### PR TITLE
vimUtils: deprecate configure.pathogen

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -277,9 +277,6 @@ my-vim =
        copy paste output2 here
     ];
 
-    # Pathogen would be
-    # vimrcConfig.pathogen.knownPlugins = plugins; # plugins
-    # vimrcConfig.pathogen.pluginNames = ["tlib"];
   };
 ```
 

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -121,6 +121,14 @@
           this version for the entire lifecycle of the 22.11 release.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          (Neo)Vim can not be configured with
+          <literal>configure.pathogen</literal> anymore to reduce
+          maintainance burden. Use <literal>configure.packages</literal>
+          instead.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.11-notable-changes">

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -50,6 +50,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 - PHP 7.4 is no longer supported due to upstream not supporting this
   version for the entire lifecycle of the 22.11 release.
 
+- (Neo)Vim can not be configured with `configure.pathogen` anymore to reduce maintainance burden.
+Use `configure.packages` instead.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Other Notable Changes {#sec-release-22.11-notable-changes}

--- a/pkgs/applications/editors/neovim/tests.nix
+++ b/pkgs/applications/editors/neovim/tests.nix
@@ -150,8 +150,8 @@ rec {
   # and do `:call deoplete#enable()`. It will print an error if the remote
   # plugin is not registered.
   test_nvim_with_remote_plugin = neovim.override {
-    extraName = "-pathogen-remote";
-    configure.pathogen.pluginNames = with vimPlugins; [ deoplete-nvim ];
+    extraName = "-remote";
+    configure.packages.foo.start = with vimPlugins; [ deoplete-nvim ];
   };
 
   # only neovim makes use of `requiredPlugins`, test this here

--- a/pkgs/applications/editors/vim/plugins/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/vim-utils.nix
@@ -51,9 +51,6 @@ vim-with-plugins in PATH:
       # full documentation at github.com/MarcWeber/vim-addon-manager
     ];
 
-    # there is a pathogen implementation as well, but its startup is slower and [VAM] has more feature
-    # vimrcConfig.pathogen.knownPlugins = vimPlugins; # optional
-    # vimrcConfig.pathogen.pluginNames = ["vim-addon-nix"];
   };
 
 WHAT IS A VIM PLUGIN?
@@ -103,7 +100,7 @@ It might happen than a plugin is not known by vim-pi yet. We encourage you to
 contribute to vim-pi so that plugins can be updated automatically.
 
 
-CREATING DERVITATIONS AUTOMATICALLY BY PLUGIN NAME
+CREATING DERIVATIONS AUTOMATICALLY BY PLUGIN NAME
 ==================================================
 Most convenient is to use a ~/.vim-scripts file putting a plugin name into each line
 as documented by [VAM]'s README.md
@@ -277,24 +274,18 @@ let
   }:
 
     let
-      /* pathogen mostly can set &rtp at startup time. Its used very commonly.
+      /* pathogen mostly can set &rtp at startup time. Deprecated.
       */
       pathogenImpl = let
         knownPlugins = pathogen.knownPlugins or vimPlugins;
 
         plugins = findDependenciesRecursively (map (pluginToDrv knownPlugins) pathogen.pluginNames);
 
-        pluginsEnv = buildEnv {
-          name = "pathogen-plugin-env";
-          paths = map (x: "${x}/${rtpPath}") plugins;
+        pathogenPackages.pathogen = lib.warn "'pathogen' attribute is deprecated. Use 'packages' instead in your vim configuration" {
+          start = plugins;
         };
       in
-      ''
-        let &rtp.=(empty(&rtp)?"":',')."${vimPlugins.vim-pathogen.rtp}"
-        execute pathogen#infect('${pluginsEnv}/{}')
-
-        filetype indent plugin on | syn on
-      '';
+        nativeImpl pathogenPackages;
 
       /* vim-plug is an extremely popular vim plugin manager.
       */

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -23,11 +23,6 @@ in
     vimrcConfig.vam.pluginDictionaries = [{name = "vim-nix"; }];
   };
 
-  test_vim_with_vim_nix_using_pathogen = vim_configurable.customize {
-    name = "vim-with-vim-addon-nix-using-pathogen";
-    vimrcConfig.pathogen.pluginNames = [ "vim-nix" ];
-  };
-
   test_vim_with_vim_nix_using_plug = vim_configurable.customize {
     name = "vim-with-vim-addon-nix-using-plug";
     vimrcConfig.plug.plugins = with vimPlugins; [ vim-nix ];


### PR DESCRIPTION

###### Motivation for this change
I've never used pathogen but looks like it does not bring any value compared to vim native packages so
remove it to ease maintainance burden.

Follow up on this issue:
https://github.com/NixOS/nixpkgs/pull/154560#issuecomment-1010584832

I have no idea if there are nix+pathogen users out there, and I am happy to close this if it's an issue. Would be nice in such a case if any such user could look into fixing https://github.com/NixOS/nixpkgs/pull/154560#issuecomment-1010584832

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
