### PR TITLE
qpdfview: refactor

### DIFF
--- a/pkgs/applications/misc/qpdfview/default.nix
+++ b/pkgs/applications/misc/qpdfview/default.nix
@@ -1,30 +1,40 @@
-{lib, mkDerivation, fetchurl, qmake, qtbase, qtsvg, pkg-config, poppler, djvulibre, libspectre, cups
-, file, ghostscript
+{ lib
+, mkDerivation
+, fetchurl
+, qmake
+, qtbase
+, qtsvg
+, pkg-config
+, poppler
+, djvulibre
+, libspectre
+, cups
+, file
+, ghostscript
 }:
-let
-  s = # Generated upstream information
-  rec {
-    baseName="qpdfview";
-    version = "0.4.18";
-    name="${baseName}-${version}";
-    url="https://launchpad.net/qpdfview/trunk/${version}/+download/qpdfview-${version}.tar.gz";
+mkDerivation rec {
+  pname = "qpdfview";
+  version = "0.4.18";
+
+  src = fetchurl {
+    url = "https://launchpad.net/qpdfview/trunk/${version}/+download/qpdfview-${version}.tar.gz";
     sha256 = "0v1rl126hvblajnph2hkansgi0s8vjdc5yxrm4y3faa0lxzjwr6c";
   };
-  nativeBuildInputs = [ qmake pkg-config ];
-  buildInputs = [
-    qtbase qtsvg poppler djvulibre libspectre cups file ghostscript
-  ];
+
   # apply upstream fix for qt5.15 https://bazaar.launchpad.net/~adamreichold/qpdfview/trunk/revision/2104
   patches = [ ./qpdfview-qt515-compat.patch ];
-in
-mkDerivation {
-  pname = s.baseName;
-  inherit (s) version;
-  inherit nativeBuildInputs buildInputs patches;
-  src = fetchurl {
-    inherit (s) url sha256;
-  };
 
+  nativeBuildInputs = [ qmake pkg-config ];
+  buildInputs = [
+    qtbase
+    qtsvg
+    poppler
+    djvulibre
+    libspectre
+    cups
+    file
+    ghostscript
+  ];
   preConfigure = ''
     qmakeFlags+=(*.pro)
   '';
@@ -39,13 +49,11 @@ mkDerivation {
     "APPDATA_INSTALL_PATH=${placeholder "out"}/share/appdata"
   ];
 
-  meta = {
-    inherit (s) version;
+  meta = with lib; {
     description = "A tabbed document viewer";
-    license = lib.licenses.gpl2Plus;
-    maintainers = [lib.maintainers.raskin];
-    platforms = lib.platforms.linux;
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     homepage = "https://launchpad.net/qpdfview";
-    updateWalker = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
