### PR TITLE
python3Packages.pillow: 8.4.0 -> 9.0.0, python3Packages.imageio: 2.13.2 -> 2.13.5

### DIFF
--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , isPy27
 , fetchPypi
+, fetchpatch
 , imageio-ffmpeg
 , numpy
 , pillow
@@ -12,13 +13,22 @@
 
 buildPythonPackage rec {
   pname = "imageio";
-  version = "2.13.2";
+  version = "2.13.5";
   disabled = isPy27;
 
   src = fetchPypi {
-    sha256 = "5b7a55d07de88a2fd70f18a1608ca05ba2b55596a942fb2c390240201009a6c3";
+    sha256 = "0gc41aiz2i0napk1y00v9bgb4m7dd21sz3lghfm6w6s0ivjjpv67";
     inherit pname version;
   };
+
+  patches = [
+    # already present in master, remove on next bump
+    (fetchpatch {
+      name = "pillow-9-gif-rgba.patch";
+      url = "https://github.com/imageio/imageio/commit/836b7a9b077a96de8adab5b67ea53b1292048275.patch";
+      sha256 = "0rlyppa4w16n6qn5hr4wrg8xiy7ifs8c5dhmq8a9yncypx87glpv";
+    })
+  ];
 
   propagatedBuildInputs = [
     imageio-ffmpeg

--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -5,13 +5,13 @@
 
 import ./generic.nix (rec {
   pname = "Pillow";
-  version = "8.4.0";
+  version = "9.0.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed";
+    sha256 = "0gjry0yqryd2678sm47jhdnbghzxn5wk8pgyaqwr4qi7x5ijjvpf";
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-22815
https://nvd.nist.gov/vuln/detail/CVE-2022-22816
https://nvd.nist.gov/vuln/detail/CVE-2022-22817

I wouldn't consider these as severe as most pillow vulnerabilities - only moderately rare use cases would be vulnerable.

Bumped `imageio` and added a patch to fix its behaviour and tests with pillow 9.

Have also built from `python39Packages`: `kivy` `tilequant` `mahotas` `pydicom` `pilkit` `cairosvg` `piexif` `pytesseract` `bokeh` `wordcloud` `faker` `pikepdf` `imageio` `python-mapnik` `imageio` on macos 10.15 and nixos x86_64.

These vulnerabilities look quite patchable so no backport label.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
