### PR TITLE
syncterm: init at 1.1

### DIFF
--- a/pkgs/applications/terminal-emulators/syncterm/default.nix
+++ b/pkgs/applications/terminal-emulators/syncterm/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchurl, pkg-config, perl, unzip, autoPatchelfHook, ncurses, SDL2, alsa-lib }:
+
+stdenv.mkDerivation rec {
+  pname = "syncterm";
+  version = "1.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${pname}/${pname}-${version}-src.tgz";
+    sha256 = "19m76bisipp1h3bc8mbq83b851rx3lbysxb0azpbr5nbqr2f8xyi";
+  };
+  sourceRoot = "${pname}-${version}/src/syncterm";
+
+  CFLAGS = [
+    "-DHAS_INTTYPES_H"
+    "-DXPDEV_DONT_DEFINE_INTTYPES"
+
+    "-Wno-unused-result"
+    "-Wformat-overflow=0"
+  ] ++ (lib.optionals stdenv.isLinux [
+    "-DUSE_ALSA_SOUND" # Don't use OSS for beeps.
+  ]);
+  makeFlags = [
+    "PREFIX=$(out)"
+    "RELEASE=1"
+    "USE_SDL_AUDIO=1"
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook pkg-config SDL2 perl unzip ]; # SDL2 for `sdl2-config`.
+  buildInputs = [ ncurses SDL2 ]
+    ++ (lib.optional stdenv.isLinux alsa-lib);
+  runtimeDependencies = [ ncurses SDL2 ]; # Both of these are dlopen()'ed at runtime.
+
+  meta = with lib; {
+    homepage = "https://syncterm.bbsdev.net/";
+    description = "BBS terminal emulator";
+    maintainers = with maintainers; [ embr ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28761,6 +28761,8 @@ with pkgs;
 
   syncplay = python3.pkgs.callPackage ../applications/networking/syncplay { };
 
+  syncterm = callPackage ../applications/terminal-emulators/syncterm { };
+
   inherit (callPackages ../applications/networking/syncthing { })
     syncthing
     syncthing-discovery


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to dial into some BBS'es - this time with XBin Image support :D

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
