### PR TITLE
mtr: 0.94 -> 0.95

### DIFF
--- a/pkgs/tools/networking/mtr/default.nix
+++ b/pkgs/tools/networking/mtr/default.nix
@@ -1,27 +1,26 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config
-, libcap, ncurses, jansson
-, withGtk ? false, gtk3 }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, pkg-config
+, libcap
+, ncurses
+, jansson
+, withGtk ? false
+, gtk3
+}:
 
 stdenv.mkDerivation rec {
   pname = "mtr${lib.optionalString withGtk "-gui"}";
-  version = "0.94";
+  version = "0.95";
 
   src = fetchFromGitHub {
     owner = "traviscross";
     repo = "mtr";
     rev = "v${version}";
-    sha256 = "0wnz87cr2lcl74bj8qxq9xgai40az3pk9k0z893scyc8svd61xz6";
+    sha256 = "sha256-f5bL3IdXibIc1xXCuZHwcEV5vhypRE2mLsS3A8HW2QM=";
   };
-
-  patches = [
-    # pull patch to fix build failure against ncurses-6.3:
-    #  https://github.com/traviscross/mtr/pull/411
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/traviscross/mtr/commit/aeb493e08eabcb4e6178bda0bb84e9cd01c9f213.patch";
-      sha256 = "1qk8lf4sha18g36mr84vbdvll2s8khgbzyyq0as3ifx44lv0qlf2";
-    })
-  ];
 
   # we need this before autoreconfHook does its thing
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
