### PR TITLE
ace-of-penguins: init at 1.4

### DIFF
--- a/pkgs/games/ace-of-penguins/default.nix
+++ b/pkgs/games/ace-of-penguins/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, fetchurl
+, copyDesktopItems
+, libX11
+, libXpm
+, libpng
+, makeDesktopItem
+, zlib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ace-of-penguins";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "http://www.delorie.com/store/ace/ace-${version}.tar.gz";
+    hash = "sha256-H+47BTOSGkKHPAYj8z2HOgZ7HuxY8scMAUSRRueaTM4=";
+  };
+
+  patches = [
+    # Fixes a bunch of miscompilations in modern environments
+    ./fixup-miscompilations.patch
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libX11
+    libXpm
+    libpng
+    zlib
+  ];
+
+  desktopItems = let
+    generateItem = gameName: {
+      name = "${pname}-${gameName}";
+      exec = "${placeholder "out"}/bin/${gameName}";
+      comment = "Ace of Penguins ${gameName} Card Game";
+      desktopName = gameName;
+      genericName = gameName;
+    };
+  in
+    map (x: makeDesktopItem (generateItem x)) [
+      "canfield"
+      "freecell"
+      "golf"
+      "mastermind"
+      "merlin"
+      "minesweeper"
+      "pegged"
+      "penguins"
+      "solitaire"
+      "spider"
+      "taipedit"
+      "taipei"
+      "thornq"
+    ];
+
+  meta = with lib; {
+    homepage = "http://www.delorie.com/store/ace/";
+    description = "Solitaire games in X11";
+    longDescription = ''
+      The Ace of Penguins is a set of Unix/X solitaire games based on the ones
+      available for Windows(tm) but with a number of enhancements that my wife
+      says make my versions better :-)
+
+      The latest version includes clones of freecell, golf, mastermind, merlin,
+      minesweeper, pegged, solitaire, taipei (with editor!), and thornq (by
+      Martin Thornquist).
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/games/ace-of-penguins/fixup-miscompilations.patch
+++ b/pkgs/games/ace-of-penguins/fixup-miscompilations.patch
@@ -1,0 +1,80 @@
+--- ace-1.4/lib/xwin.c	
++++ ace-1.4/lib/xwin.c	
+@@ -89,10 +89,10 @@
+ /* Motif window hints */
+ typedef struct
+ {
+-  unsigned flags;
+-  unsigned functions;
+-  unsigned decorations;
+-  int inputMode;
++  unsigned long flags;
++  unsigned long functions;
++  unsigned long decorations;
++  long inputMode;
+ } PropMotifWmHints;
+ 
+ typedef PropMotifWmHints        PropMwmHints;
+@@ -841,13 +841,13 @@
+   png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+   info_ptr = png_create_info_struct (png_ptr);
+ 
+-  if (setjmp (png_ptr->jmpbuf)) {
++  if (setjmp (png_jmpbuf (png_ptr))) {
+     fprintf(stderr, "Invalid PNG image!\n");
+     return;
+   }
+ 
+   file_bytes = src->file_data;
+-  png_set_read_fn (png_ptr, (voidp)&file_bytes, (png_rw_ptr)png_reader);
++  png_set_read_fn (png_ptr, (void *)&file_bytes, (png_rw_ptr)png_reader);
+ 
+   png_read_info (png_ptr, info_ptr);
+ 
+--- ace-1.4/lib/make-imglib.c	
++++ ace-1.4/lib/make-imglib.c	
+@@ -86,7 +86,7 @@
+     png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+     info_ptr = png_create_info_struct (png_ptr);
+ 
+-    if (setjmp (png_ptr->jmpbuf)) {
++    if (setjmp (png_jmpbuf (png_ptr))) {
+       fclose (f);
+       continue;
+     }
+
+--- ace-1.4/lib/Makefile.am	
++++ ace-1.4/lib/Makefile.am
+@@ -6,7 +6,7 @@
+ CLEANFILES = images.c images.d
+ 
+ INCLUDES = $(X_CFLAGS) @PDA@
+-AM_LDFLAGS = $(X_LIBS)
++AM_LDFLAGS = $(X_LIBS) -lpng -lz -lm
+ 
+ BUILD_CC = @BUILD_CC@
+ AR = @AR@
+
+--- ace-1.4/lib/xwin.c  2020-10-07 02:07:59.000000000 +0300
++++ ace-1.4/lib/xwin.c    2020-10-07 02:15:05.941784967 +0300
+@@ -55,7 +55,6 @@
+   { "-visual", OPTION_INTEGER, &visual_id },
+   { 0, 0, 0 }
+ };
+-OptionDesc *xwin_options = xwin_options_list;
+
+ Display *display=0;
+ int screen=0;
+--- ace-1.4/config.guess	2012-03-24 19:00:49.000000000 +0100
++++ ace-1.4/config.guess	2021-07-05 11:02:16.685843793 +0200
+@@ -882,6 +882,9 @@
+ 	    echo ${UNAME_MACHINE}-unknown-linux-gnueabi
+ 	fi
+ 	exit ;;
++    aarch64*:Linux:*:*)
++	echo ${UNAME_MACHINE}-unknown-linux-gnu
++	exit ;;
+     avr32*:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-unknown-linux-gnu
+ 	exit ;;
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30235,6 +30235,8 @@ with pkgs;
 
   _90secondportraits = callPackage ../games/90secondportraits { love = love_0_10; };
 
+  ace-of-penguins = callPackage ../games/ace-of-penguins { };
+
   among-sus = callPackage ../games/among-sus { };
 
   antsimulator = callPackage ../games/antsimulator { };


### PR DESCRIPTION
Plus patches!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
