### PR TITLE
Pantheon: prepare for meson 0.61

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-camera/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -33,6 +34,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-xIv+mOlZV58XD0Z6Vc2wA1EQUxT5BaQ0zhYc9v+ne1w=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/camera/pull/216
+    (fetchpatch {
+      url = "https://github.com/elementary/camera/commit/ead143b7e3246c5fa9bb37c95d491fb07cea9e04.patch";
+      sha256 = "sha256-2zGigUi6DpjJx8SEvAE3Q3jrm7MggOvLc72lAPMPvs4=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream

--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -37,6 +38,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-AXmMcPj2hf33G5v3TUg+eZwaKOdVlRvoVXglMJFHRjw=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/code/pull/1165
+    (fetchpatch {
+      url = "https://github.com/elementary/code/commit/a2607cce3a6b1bb62d02456456d3cbc3c6530bb0.patch";
+      sha256 = "sha256-VKR83IOUYsQhBRlU9JUTlMJtXWv/AyG4wDsjMU2vmU8=";
+    })
+  ];
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -42,6 +43,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-5TSzV8MQG81aCCR8yiCPhKJaLrp/fwf4mjP32KkcbbY=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/files/pull/1973
+    (fetchpatch {
+      url = "https://github.com/elementary/files/commit/28428fbda905ece59d3427a3a40e986fdf71a916.patch";
+      sha256 = "sha256-GZTHAH9scQWrBqdrDI14cj57f61HD8o79zFcPCXjKmc=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils

--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -33,6 +34,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-wOu9jvvwG53vzcNa38nk4eREZWW7Cin8el4qApQ8gI8=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/mail/pull/751
+    (fetchpatch {
+      url = "https://github.com/elementary/mail/commit/bbadc56529276d8e0ff98e9df7d9bb1bf8fc5783.patch";
+      sha256 = "sha256-lJEnX5/G6e8PdKy1XGlwFIoCeSy6SR5p68tS4noj+44=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -50,6 +50,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/elementary/music/commit/aea97103d59afd213467403a48788e476e47c4c3.patch";
       sha256 = "1ayj8l6lb19hhl9bhsdfbq7jgchfmpjx0qkljnld90czcksn95yx";
     })
+    # Fix build with meson 0.61
+    # https://github.com/elementary/music/pull/674
+    (fetchpatch {
+      url = "https://github.com/elementary/music/commit/fb3d840049c1e2e0bf8fdddea378a2db647dd096.patch";
+      sha256 = "sha256-tQZv7hZExLqbkGXahZxDfg7bkgwCKYbDholC2zuwlNw=";
+    })
   ];
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-screenshot/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -27,6 +28,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-n+L08C/W5YnHZ5P3F1NGUYE2SH94sc4+kr1x+wXZ+cw=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/screenshot/pull/241
+    (fetchpatch {
+      url = "https://github.com/elementary/screenshot/commit/80a5d942e813dd098e1ef0f6629b81d2ccef05ae.patch";
+      sha256 = "sha256-jOQuzUJvsjqytplLcW9BeIxzi9+/k2GFa4hHVZ3+wts=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils

--- a/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -31,6 +32,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-4q7YQ4LxuiM/TRae1cc3ncmw7QwE1soC2Sh+GZ+Gpq0=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/terminal/pull/649
+    (fetchpatch {
+      url = "https://github.com/elementary/terminal/commit/15e3ace08cb25e53941249fa1ee680a1e2f871b4.patch";
+      sha256 = "sha256-XVs+kq5qbX5KlxtkqxwJnatNYNeJiVLBec7sLjQsUxg=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream

--- a/pkgs/desktops/pantheon/apps/switchboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/default.nix
@@ -60,6 +60,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/elementary/switchboard/commit/8d6b5f4cbbaf134880252afbf1e25d70033e6402.patch";
       sha256 = "0gwq3wwj45jrnlhsmxfclbjw6xjr8kf6pp3a84vbnrazw76lg5nc";
     })
+    # Fix build with meson 0.61
+    # https://github.com/elementary/switchboard/pull/226
+    (fetchpatch {
+      url = "https://github.com/elementary/switchboard/commit/ecf2a6c42122946cc84150f6927ef69c1f67c909.patch";
+      sha256 = "sha256-J62tMeDfOpliBLHMSa3uBGTc0RBNzC6eDjDBDYySL+0=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , linkFarm
 , substituteAll
@@ -89,6 +90,12 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./hardcode-fallback-background.patch;
       default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
+    })
+    # Fix build with meson 0.61
+    # https://github.com/elementary/greeter/pull/590
+    (fetchpatch {
+      url = "https://github.com/elementary/greeter/commit/a4b25244058fce794a9f13f6b22a8ff7735ebde9.patch";
+      sha256 = "sha256-qPXhdvmYG8YMDU/CjbEkfZ0glgRzxnu0TsOPtvWHxLY=";
     })
   ];
 

--- a/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-shortcut-overlay/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -21,14 +22,21 @@ stdenv.mkDerivation rec {
   pname = "elementary-shortcut-overlay";
   version = "1.2.1";
 
-  repoName = "shortcut-overlay";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "shortcut-overlay";
     rev = version;
     sha256 = "sha256-qmqzGCM3cVM6y80pzjm5CCyG6BO6XlKZiODAAEnwVrM=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/shortcut-overlay/pull/113
+    (fetchpatch {
+      url = "https://github.com/elementary/shortcut-overlay/commit/130f78eb4b7770586ea98ba0a5fdbbf5bb116f3f.patch";
+      sha256 = "sha256-XXWq9CEv3Z2B8ogcFQAJZCfy19XxNHs3c8NToE2m/aA=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils

--- a/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -21,14 +22,21 @@ stdenv.mkDerivation rec {
   pname = "elementary-capnet-assist";
   version = "2.4.0";
 
-  repoName = "capnet-assist";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "capnet-assist";
     rev = version;
     sha256 = "sha256-UdkS+w61c8z2TCJyG7YsDb0n0b2LOpFyaHzMbdCJsZI=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://github.com/elementary/capnet-assist/pull/76
+    (fetchpatch {
+      url = "https://github.com/elementary/capnet-assist/commit/0e77bf8023ba1b35e3a5badb72c246cabf6552b9.patch";
+      sha256 = "sha256-B/KEs/TCxR+i3uQSRtWxTi2+cu0n6QLcfKCbMCvSsvs=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
###### Motivation for this change

I am not sure whether upstream will make some release for these fixes before elementary OS 7 so I opened this just to make sure if someone wants to bump meson, it won't break Pantheon. To build Pantheon with meson 0.61, apply [this patch](https://gist.github.com/bobby285271/078f88b6f9f9ba85bd68ff942f82d5a2) on top of this PR.

Packages mostly fails with "Function does not take positional arguments" when using meson 0.61. As what upstream change says, `i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.61, and actually this has been marked as deprecated in 0.60. So it is still a good idea to fetch these fixes in advance.

To make sure at least nixosTests.pantheon passes:

- [x] https://github.com/elementary/screenshot/commit/80a5d942e813dd098e1ef0f6629b81d2ccef05ae
- [x] https://github.com/elementary/capnet-assist/commit/0e77bf8023ba1b35e3a5badb72c246cabf6552b9
- [x] https://github.com/elementary/files/commit/28428fbda905ece59d3427a3a40e986fdf71a916
- [x] https://github.com/elementary/camera/commit/ead143b7e3246c5fa9bb37c95d491fb07cea9e04
- [x] https://github.com/elementary/code/commit/a2607cce3a6b1bb62d02456456d3cbc3c6530bb0
- [x] https://github.com/elementary/mail/commit/bbadc56529276d8e0ff98e9df7d9bb1bf8fc5783
- [x] https://github.com/elementary/music/commit/fb3d840049c1e2e0bf8fdddea378a2db647dd096
- [x] https://github.com/elementary/terminal/commit/15e3ace08cb25e53941249fa1ee680a1e2f871b4
- [x] https://github.com/elementary/switchboard/commit/ecf2a6c42122946cc84150f6927ef69c1f67c909
- [x] https://github.com/elementary/greeter/commit/a4b25244058fce794a9f13f6b22a8ff7735ebde9
- [x] https://github.com/elementary/shortcut-overlay/commit/130f78eb4b7770586ea98ba0a5fdbbf5bb116f3f

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
