### PR TITLE
mepo: init at 0.2

### DIFF
--- a/pkgs/applications/misc/mepo/default.nix
+++ b/pkgs/applications/misc/mepo/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, pkg-config
+, zig
+, curl
+, SDL2
+, SDL2_image
+, SDL2_ttf
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mepo";
+  version = "0.2";
+
+  src = fetchFromSourcehut {
+    owner = "~mil";
+    repo = pname;
+    rev = version;
+    hash = "sha256-ECq748GpjOjvchzAWlGA7H7HBvKNxY9d43+PTOWopiM=";
+  };
+
+  nativeBuildInputs = [ pkg-config zig ];
+
+  buildInputs = [ curl SDL2 SDL2_image SDL2_ttf ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$TMPDIR
+    zig build -Drelease-safe=true -Dcpu=baseline
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    zig build test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 zig-out/bin/mepo -t $out/bin
+    install -Dm755 scripts/mepo_* $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Fast, simple, and hackable OSM map viewer";
+    homepage = "https://sr.ht/~mil/mepo/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin; # See https://github.com/NixOS/nixpkgs/issues/86299
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27081,6 +27081,10 @@ with pkgs;
 
   merkaartor = libsForQt5.callPackage ../applications/misc/merkaartor { };
 
+  mepo = callPackage ../applications/misc/mepo {
+    zig = zig_0_8_1;
+  };
+
   meshcentral = callPackage ../tools/admin/meshcentral { };
 
   meshlab = libsForQt5.callPackage ../applications/graphics/meshlab { };


### PR DESCRIPTION
###### Motivation for this change
[**Mepo**](https://git.sr.ht/~mil/mepo) - fast, simple, and hackable OSM map viewer for Linux.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
