### PR TITLE
findup: init at 1.0

### DIFF
--- a/pkgs/tools/misc/findup/default.nix
+++ b/pkgs/tools/misc/findup/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, zig, testers, findup }:
+
+stdenv.mkDerivation rec {
+  pname = "findup";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "hiljusti";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-erlKIiYYlWnhoeD3FnKdxnHjfGmmJVXk44DUja5Unig=";
+  };
+
+  nativeBuildInputs = [ zig ];
+
+  # Builds and installs (at the same time) with Zig.
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Give Zig a directory for intermediate work.
+  preInstall = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    zig build -Drelease-safe -Dcpu=baseline --prefix $out
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion { package = findup; };
+
+  meta = with lib; {
+    homepage = "https://github.com/hiljusti/findup";
+    description = "Search parent directories for sentinel files";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hiljusti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6101,6 +6101,8 @@ with pkgs;
 
   findutils = callPackage ../tools/misc/findutils { };
 
+  findup = callPackage ../tools/misc/findup { };
+
   bsd-finger = callPackage ../tools/networking/bsd-finger { };
   bsd-fingerd = bsd-finger.override({ buildClient = false; });
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Imports `findup` - a utility for searching through parents.

Comes in handy when in some nested directory but you want to traverse back up.

Example: if you're deep in some npm project, instead of `cd ../../../../..` you can do something like `cd $(findup package.json)`.

Also useful for finding things like the nearest `.git` directory, nearest `.envrc` for direnv, or similar for pipenv, rbenv, asdf `.tool-versions` file, etc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
