### PR TITLE
python310Packages.serverlessrepo: relax dependency constraints

### DIFF
--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -1,16 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, pytest
+, pytestCheckHook
 , boto3
 , six
 , pyyaml
 , mock
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "serverlessrepo";
   version = "0.1.10";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
@@ -23,11 +27,24 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  checkInputs = [ pytest mock ];
+  checkInputs = [
+    pytestCheckHook
+    mock
+  ];
 
-  checkPhase = ''
-    pytest tests/unit
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pyyaml~=5.1" "pyyaml" \
+      --replace "boto3~=1.9, >=1.9.56" "boto3"
   '';
+
+  pytestFlagsArray = [
+    "tests/unit"
+  ];
+
+  pythonImportsCheck = [
+    "serverlessrepo"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/awslabs/aws-serverlessrepo-python";
@@ -36,7 +53,7 @@ buildPythonPackage rec {
       A Python library with convenience helpers for working with the
       AWS Serverless Application Repository.
     '';
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     maintainers = with maintainers; [ dhkl ];
   };
 }

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -5,15 +5,12 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "1.36.0";
+  version = "1.37.0";
 
   src = python3.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-GJbBhe1l25ZHGWVu1o2oJvd/BNv8dv7aIYor/ebFl9U=";
+    hash = "sha256-XE3g2mKwAiaJvi0ShVScnCKrmz7ujaQgOeFXuYwtP4g=";
   };
-
-  # Tests are not included in the PyPI package
-  doCheck = false;
 
   propagatedBuildInputs = with python3.pkgs; [
     aws-lambda-builders
@@ -42,17 +39,21 @@ python3.pkgs.buildPythonApplication rec {
   # fix over-restrictive version bounds
   postPatch = ''
     substituteInPlace requirements/base.txt \
+      --replace "aws_lambda_builders==" "aws-lambda-builders #" \
       --replace "click~=7.1" "click~=8.0" \
-      --replace "Flask~=1.1.2" "Flask~=2.0" \
       --replace "dateparser~=1.0" "dateparser>=0.7" \
       --replace "docker~=4.2.0" "docker>=4.2.0" \
-      --replace "requests==" "requests #" \
-      --replace "watchdog==" "watchdog #" \
-      --replace "aws_lambda_builders==" "aws-lambda-builders #" \
-      --replace "typing_extensions==" "typing-extensions #" \
+      --replace "Flask~=1.1.2" "Flask~=2.0" \
+      --replace "PyYAML~=5.3" "PyYAML" \
       --replace "regex==" "regex #" \
-      --replace "tzlocal==3.0" "tzlocal"
+      --replace "requests==" "requests #" \
+      --replace "typing_extensions==" "typing-extensions #" \
+      --replace "tzlocal==3.0" "tzlocal" \
+      --replace "watchdog==" "watchdog #"
   '';
+
+  # Tests are not included in the PyPI package
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://github.com/awslabs/aws-sam-cli";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163901884)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
