### PR TITLE
 thunderbird, thunderbird-bin: 91.4.1 -> 91.5.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.4.1";
+  version = "91.5.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/af/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/af/thunderbird-91.5.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "7af2c19b46daf1869af49289c1ab080559f8640c6dfc21cdae1ff48cdc26bf1f";
+      sha256 = "20272a9fbf08651ca804f324aca1c0c7b6b04351b0a773790510a69d56ef19fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ar/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ar/thunderbird-91.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "dfabb7336f9b5929041c43997ad7ac34fca0750d70293dacdc32f9048de2fc7d";
+      sha256 = "208937e2b22db6a159b2c744d9ad6d9e96fddf21f753673d9006b2576e5ddd24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ast/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ast/thunderbird-91.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3aade12867be4da3fb890214a7cd8551e12e962fb2a66b7e76da20a06755d045";
+      sha256 = "a8b078c5699d174db89c4adbcce45c4add38d88561d1154dcaff56be4731b29d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/be/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/be/thunderbird-91.5.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "8bb288330b957d8361880738b7d5e5833602dd81aad580a96f1031e88bd963f4";
+      sha256 = "91be973a0658dc7a284cde429b537bc70db88143abe42fd6ce6c4a0a450353ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/bg/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/bg/thunderbird-91.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "fcd8bbef82a24b146f4473da351cbd5262f8286d5b7ea78265516e815c7c84da";
+      sha256 = "bdb25d9c1e3ed725d667b9b613a425a3f1c18bd6ff78417a32f04fc6257c7b66";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/br/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/br/thunderbird-91.5.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c1d331f6621fc120076d49015046f22ff898b089af8cac5226491bbe82391b9a";
+      sha256 = "b8cf6f6f490a3f7a06a036bf84d71cdcdfb21e4e253190d2c8c648df8f7af931";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ca/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ca/thunderbird-91.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "7b2a63bd30d1e47db16f64ea077623dfca965d71b2aa7f7ce56f8940a2f59301";
+      sha256 = "5a55055b5eb29e209e02b2980895719883bfc9929910d0f336e431ebea870856";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/cak/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/cak/thunderbird-91.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "f22de3c4bc4237610e7826ed6d46f84f8a02d5370e7d0675932abd98ee24256e";
+      sha256 = "fe192c81dd6f04d37c4f603c3e0367d462c5dc6effe7c8a07a030d5584118c58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/cs/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/cs/thunderbird-91.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "8dd685427622c1bc710d8056e527d5766f7e5f0c47ca7e170b8e48ed01e8c5a5";
+      sha256 = "bce9c7bd093631e2f0096ac3c8c2cdb19d9567d5233d912169c238e33372da1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/cy/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/cy/thunderbird-91.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "d98ebd1787b29a6ee785a4b7cfaa2283b836f23214c3c27d4fbb3e7154c1e9e5";
+      sha256 = "4128f704289b9267316eb373a3142305096897b37a2daa79a84f4448aea54b14";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/da/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/da/thunderbird-91.5.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "202729a6f4813bb3760a5ae834731a019593dbcd5d66173999f5cbbedf277f00";
+      sha256 = "39e5239860b450079cc10179e215bef63d77957c47bc3690c16c086a30e01317";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/de/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/de/thunderbird-91.5.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "c035ce2cb81b7083d0c6fc859ee259afce5440bc8f2c8e1ca1db02ce97f0b237";
+      sha256 = "0bc2cabac439734fdddfcfc1426696559ac1ee3e9a7bad1182329d83fb47d8cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/dsb/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/dsb/thunderbird-91.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "413eda01d4390e41f6d859def75c5972c4595b453fc9da948415e8e38f4766c0";
+      sha256 = "2c4d8fc6ae4c9a2adabe0a1593d7289596b97dd7b9e39b44da926f925f754ef2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/el/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/el/thunderbird-91.5.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "b238ee1b8dbf54ab0aa4c6f23a646e037a48e31d77749698744dc122bf38608a";
+      sha256 = "07e10b923d0829e6cddc35bd56fe51afd07b35664b4feb725dfedbd51e99029a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/en-CA/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/en-CA/thunderbird-91.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "4ef51ab9fdcd3c6ab1323a402253f5cd8682fa100f3b05fa62bf1153bbc04c28";
+      sha256 = "7f583ea36dc9d8a1a2136343773a8e7434d466f31ddf50f5f7da7675a08dbd03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/en-GB/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/en-GB/thunderbird-91.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "3ee22d3b5c23bfba703d36e58185ef139ccfa923c1877f983fed90419e7fdf8b";
+      sha256 = "46bd4e13d215bd9be875ebe3f999da3927a480401aa4a2e51f0388d3cf28a3a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/en-US/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/en-US/thunderbird-91.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "6bd3bbcf3d92efe04b19bb45c0d9ac3abe8dd68fc84e255b76467b37ea5918b1";
+      sha256 = "f6d62b3161d1b7cf665fdb965526632fc4eefcaf1727ece7986e956c7575cf0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/es-AR/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/es-AR/thunderbird-91.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "14b7fac461e90c4dd1790f6095e291e1ba510561d51655b16bda4ad7050dca8e";
+      sha256 = "4f190b4d64db8fe9accafe1941e3f949ba21488b4411a506f6f61d437f17d61e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/es-ES/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/es-ES/thunderbird-91.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "ee910bc3415e314d5f3b072608d61089ae55e969a138ee446377edf0e5ba710a";
+      sha256 = "61065d0c72451cebbf5d83c92e460e240e7f477322531a3f4d082b3c0e6c213e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/et/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/et/thunderbird-91.5.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "a643d96e71123c554a8af69bc875515113ffd30ab621d5f3b5678c33931cfab0";
+      sha256 = "cba4afe259ccd7c6619f4ee0adf167659eb4f80e9355b25138d9f370ecbcf932";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/eu/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/eu/thunderbird-91.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "b910976d8e940331d46ac92f82f56aff61f8d91137bae9c869715cb371309f9e";
+      sha256 = "4e8569190b2702ad6e10156b434100cdf879dfb3a5ee798c876fc46871e1abf3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/fi/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/fi/thunderbird-91.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "a8dd93299fde700cf1419187da06405093b3f010e7fdd327742fbddcef1721a0";
+      sha256 = "93e3b7624d6de0b77f87bb192384437e006530abd03bdc5589dc0dc47e0af304";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/fr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/fr/thunderbird-91.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "526f4f4feae5f6a0b9f1d80b0f76a7f26af7456e1eb09e36eadd51fc8d4115ed";
+      sha256 = "a35c370b69a977160a83ffc4d24f5a9a9f1000e1012c71fcd1e7adc6c16c68b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/fy-NL/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/fy-NL/thunderbird-91.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "df5320f98ecd32439273b18237a742c34590e5b533a7da9471cfd37921725108";
+      sha256 = "c392fb2f59d13f912e757be716a4bfc464a0cb2f69f8af780bbaec8e6bbcdf0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ga-IE/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ga-IE/thunderbird-91.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "c13529036ec2186e0e3088f63e351086bee21b0f8a3479586420c6a2701ee8f1";
+      sha256 = "210aeb0fe2c3214f82948ef39205416e4c50750be0226fa56b2c5548ed06a182";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/gd/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/gd/thunderbird-91.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "f6c2c7cf6c8a39997e272d9aae5c7ab4620f426e2be96b4e90c3641db672a6ea";
+      sha256 = "c02818558da950caa540cc73597bb2ba1cbfcf02240b085856776df5155b59eb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/gl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/gl/thunderbird-91.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "ba0d17f99ca15bc81631201057509694c5dc656176a03e67d5f89371a4200eda";
+      sha256 = "5704fa5d4efb470e516c23a6f15d238ebaeaa7ad1ce14f49b7a5a3bd19524f92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/he/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/he/thunderbird-91.5.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "c71bf27c55ad5b6c7981a434d598eeab8a927dbfc0510d4d68df357cb1abff9f";
+      sha256 = "c366556e481757da8f48b89f1ef54492e5d5e41a45d9ec55f5e81081de4d8b58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/hr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/hr/thunderbird-91.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "9cf92e922329ec46ed68f352284de30c78aa2d25f040da4e1289d5ea0226bc3a";
+      sha256 = "47a713172ea17582ec988fdef33cab24f3245274badefbefee7f665af7e9e917";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/hsb/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/hsb/thunderbird-91.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "e4d6baa0d92fbe7f40071045fcdb20f59944a0c1422c1095b946019461013242";
+      sha256 = "019271fd8d9343581783dcd6a59698de726fdeca39e4e71226b7361a42e7478b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/hu/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/hu/thunderbird-91.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "cea2f9b614e0b7cec709947ff75b9eb6abe6600b76d642b60910e2de1788f09b";
+      sha256 = "bbdd56ba0a2f1079d2dfe63f2cbf56dc98f5f0675c73413880aba147d797d1c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/hy-AM/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/hy-AM/thunderbird-91.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "8708acca6f1e4088f10f94f8c26a7790913fe55acbf0ab555e22b1256b74a866";
+      sha256 = "8393fdba3c2d7024c1ad5d017853c1a13fec47a29e31db4ba0f38c5ee49843ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/id/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/id/thunderbird-91.5.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "745ecb2038a84b1571e326ed0e6d38e7519bcf5b7f2bacf6ef053c9a88926c77";
+      sha256 = "51ff83923eda81e69d5c74bd49878c17eb3552072b196e2fc933b3dbf89a7513";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/is/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/is/thunderbird-91.5.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "e04b6fc88ddd46e6e6cbe47eb681acce91b47df355847f65e793d92419dc4204";
+      sha256 = "9f6bdf8f9a97788137e698464e391f6942e3cbff5870e8b4f534597f0b582f5d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/it/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/it/thunderbird-91.5.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "e23eb2075bcac5abc195b1abffe64b8e1a409c855699c6d5bcbd102c19a2ad4b";
+      sha256 = "33b0169fec2ba8822c086837fce0ed59d77676f6fe804948dfd0ad0c328e1cc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ja/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ja/thunderbird-91.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a79711803c46b6ab95f654d5b9dffafe85733b6c839238de8f76d30f9757553c";
+      sha256 = "bf93f1e234aa13edb416912377a23ffb370de5a249cc66ec13587632493f0efc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ka/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ka/thunderbird-91.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "3076defee6dadfad4560800ecf2b3556fcf8f4dd5a8795bb578ee73bbbccf72f";
+      sha256 = "dee6e5c984c0dafa66476bd4342385beedeb826a947991b2b4bc3a0e1d7bafd4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/kab/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/kab/thunderbird-91.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "65f796d71d02118794b79d5460ef9db06e3d172e5d15ff350eff52cc214587dc";
+      sha256 = "fcf175d175327f8a6c76d0e81062a967813f486e8005aafa7998fa682542e5db";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/kk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/kk/thunderbird-91.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "f8df25990df8b577e224551f1af44fb87c867b7d7622931214bbceeec3699646";
+      sha256 = "22e2bff84795a512eaa486acb11440afa51afddd5feb6828c025bfdd796cc5e8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ko/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ko/thunderbird-91.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "77d6e16972f9ddb553d9bd19627a0725d25d42a0ad6d1e665d249b094b137dc9";
+      sha256 = "a3c8fb1b1cfc7e68ad177fce78a8751c86cb4d95965d05abeff384c19f470bce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/lt/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/lt/thunderbird-91.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "208eb06ba9e8b1cd391a7694552af6e7ba3ead33567d51fda82d70e024378f56";
+      sha256 = "5aaa95d61662a69d3d92cad9d5cbf24a348a7c6d7db1440412a324799167bd7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/lv/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/lv/thunderbird-91.5.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "a4a85c3f969dc40149ad82d0dbc4e1089de67ba3c6d7495f5c45196e8c7083a8";
+      sha256 = "ec61d867216b50649e2900e8922603f38ebd4c67596b29984c60c1933f1f00a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ms/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ms/thunderbird-91.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e5f3259e002b31d9a2738ad81826d59dd464aa34532441e9092e976efe8be7b4";
+      sha256 = "27bf8b301dc1c05a22c413559f833d522fb42934c136be126de90d3519df7c1d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/nb-NO/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/nb-NO/thunderbird-91.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "33fa29d2490c7618d1f9bbaceb34b898d150e57fc9b96b957a5b348b6fe47cfc";
+      sha256 = "587b27872162ac8e7580183b362192f7c2439a4a7a783aa4fc6ae81e87e7b4bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/nl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/nl/thunderbird-91.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "726962fd26948726230b49736f2d1e6c6daa562a4389e0fa0069ab737304cbac";
+      sha256 = "be970367d664bcc2a5e6a0805d0b63fc991221c41497ccfa1a1ce5102b20450a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/nn-NO/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/nn-NO/thunderbird-91.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "09bab6f8061400413e7167693e4c2f14caa4aba0ac68c7cfeaf9ed2dfa44ea0a";
+      sha256 = "92e168f3db1bef0c2fd33dd8da8f2ba8732e63c1b36aeb0e01f3478e67dafba2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/pa-IN/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/pa-IN/thunderbird-91.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "2203476872b140a1fec867435bf1a006b63a7ffc018eb466ea164597474a2083";
+      sha256 = "485d231b5153fde23d9a35154c713b97dbcf96a8f1058399b09796210c831391";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/pl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/pl/thunderbird-91.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "3cc4fa964b4deaef9d901fd9fba597059f638b1b8322515ac02cbb97f5a5c28b";
+      sha256 = "112240a352a3d833de9df127ab0118841b88e67c4496a17c8cc63abbd19f1166";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/pt-BR/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/pt-BR/thunderbird-91.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "c68055c96551a1b529bdf81659231ec5244c4c68255d88f581c378046bbb5e84";
+      sha256 = "7388f54dc99de6498af19f0a6e7b80bf2c7465c68d94c4e04ca5038a2e087960";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/pt-PT/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/pt-PT/thunderbird-91.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "36c9b2170aff5e6f58377efd53f679e9e823f45b67d7407cb3c34d72f676625a";
+      sha256 = "1ca7c9a460e8603d0daadbc07fd12fe6d0d07ef288144ba5da389fdbb5ccf4e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/rm/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/rm/thunderbird-91.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "2f00df17c29128e2b135136fe700930ff0078e8896e1cb4f7c34b44af0cfd8f2";
+      sha256 = "954516da6b44ad4dfc56f3b837e45bc0816498fe426ae3aa4d3363621cb2c289";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ro/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ro/thunderbird-91.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "ed93041b32a711e04de6737c5d6fbcf6b598ca9eccefe5ab0e02cf3cacba5ffa";
+      sha256 = "e5d83482c7381d89445d49b5c85b5645533dae173010f2ebfcf706c01337f4e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/ru/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/ru/thunderbird-91.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "206ccfcb5d6a9d70f4258ddeff0cc79c38e801d860a05bf6214c03b24e2f9057";
+      sha256 = "51db5bfaca6c9404eddb71cc6559c7c83534fbe57bf27da14c35b4b268cdfc98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/sk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/sk/thunderbird-91.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "aa8e6dd53d5b741bee345d1f7a5b03866121619f54993233cb4239c6107eb3e6";
+      sha256 = "5803d8547bddaffa6a9532eb6abd2f66f6936c6614a1c322a8065a01e6c831c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/sl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/sl/thunderbird-91.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "95f3a97adc32abb33c0a7579c19247595f6f27c7da0cf06bf1fa9d8270b41996";
+      sha256 = "2837b957b89184978c0ead48e7a2d58a7ee140ed280be8d744fac929d66cfd0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/sq/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/sq/thunderbird-91.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fe8255e55081a6cae15085cfcf793c4094de55a2b12d3732c7e75ce567b85716";
+      sha256 = "fd98ce5bb9bccfc8c9ae022cdf0416848e3564b59ccaf3ce8888eb7d4d02f0ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/sr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/sr/thunderbird-91.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f889e1ff38542aae19d6ebaf827a2c6d6f8dbd6e16a80966bc311588e4e10ffc";
+      sha256 = "d9c1ec7df7e66e1b4e28a68c9ed74e8ea17a166dee2d2aaf7c9be616bfde97a0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/sv-SE/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/sv-SE/thunderbird-91.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "2f90c95bbdcb6bfd59cee40013cc1c498e50f5cc0209799dfe1dfc57afbc37ad";
+      sha256 = "e9e8ea82bf5fdb900c36ef22afda90d518ac52a4fadff5a3f1afbb09b4d1ebe4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/th/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/th/thunderbird-91.5.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "3fa19fef25c76f49f9e6ee9edc2f24cd02c2b589b8e2cea270f4aa71f1a1a621";
+      sha256 = "4a58f3d88283cbe83bc6f9ff26c5b621bde3a52a8e5cda283f9bac6fa329e2a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/tr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/tr/thunderbird-91.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "7de3ccbe109401dab260ed1c8ae9fc360e5392c81111df930d0c7f7d46211f83";
+      sha256 = "489e5d4448c25310ae14c6a74405d582b50113a73c394aa51776c2c3b37104ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/uk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/uk/thunderbird-91.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "967020d05810d1514be84635cb56162b83f7f28a2bea221ad21ecb4ebd960968";
+      sha256 = "cefeaf9df2e5fab13cf131d597393b83c1101d83b6dda04207c4428abbb62d15";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/uz/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/uz/thunderbird-91.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "371d60bc164552f04cf680a29af5992f1ac353e8bb30af62a5cdadf744576c71";
+      sha256 = "7a330fa612f09f1337c3c775d0c0447dd2878e79c2555c7e1a13f611e2712720";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/vi/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/vi/thunderbird-91.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "600cc9d18a18ebc13bd8371140b573723b913e100937b3bb22ab04cf7846e1e7";
+      sha256 = "c1c11ce007f1e8cdfd039c8b9dbc73e879adafc40d6ef11dbf82134ff76c8d48";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/zh-CN/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/zh-CN/thunderbird-91.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "ae59930a4c609e4ce0562338019db1202c3eafc2e3dabd90888076ece4fe8ee5";
+      sha256 = "041aa19e78aad8be563bf4466572deb8bbd16f3a74c24f297da0667dfc65739f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-x86_64/zh-TW/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-x86_64/zh-TW/thunderbird-91.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2cd58c1fb54b572e6a2f63b9881f53ee65d9992d75c0905ea2e1047afabd08a9";
+      sha256 = "dee8d2dea78128f250054d5f8aaf948b19d3e43acc228a0c751df84d601ce76c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/af/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/af/thunderbird-91.5.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "bbf9e3a8856f66ed2d263b05d5520a9be26719f45380a5f29e6cf27c891c3e23";
+      sha256 = "6e19fa5338b63c3aa163cbb9d84953a0f1bc4bb593cbc685cf4e59249425f948";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ar/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ar/thunderbird-91.5.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "0df457c90aedef53adca7dafe34dc95847b77603362b27f814f4e88d40311ccb";
+      sha256 = "2b35a83198c30bc9838849260477b4846dbd35b82607261534e05336911129c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ast/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ast/thunderbird-91.5.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "b97a3fc046dcd75e2703629e01abbe2c7a81bc98746fdd96ac195b2508e396b7";
+      sha256 = "01712e869983cb089f9e98449ae215c95aa59e70ad2a7e61a17788f74c50c905";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/be/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/be/thunderbird-91.5.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "158495d87e2bc8c2b257d055fc9096580bbb7dcc126b3b83a4aa0f3deaae9cf7";
+      sha256 = "e7cfd5b52f0a809c514ac17f29bf30d2aa1959193020f742b8e907fc4772eb8b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/bg/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/bg/thunderbird-91.5.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "77497a922cd441a3ed791d6f497586b2d3b286a64cf057cf34b07e38b6c1f5f2";
+      sha256 = "e74a5073ec17e2ac75c81e9dbe418167932d53d47fb1449a919b7a6824f7ace3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/br/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/br/thunderbird-91.5.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "862629fb07c7743a2bc909883ebe19347fea71fc91b8df927d846054ce2b1b08";
+      sha256 = "a8b13e933e1767d6f42fa4e02892d99ef5d8da14c9aad51e2089d16c2b935c6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ca/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ca/thunderbird-91.5.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "33ab06809f5982036b849aed5ec46d7271c217cb7330149f4783fd308c19ef46";
+      sha256 = "047e158f5b81c5c5837c583e63f1852e94ab65365e7551dc14dee4e91711ee89";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/cak/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/cak/thunderbird-91.5.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "6bd1cd49eb18ce7bb88e4e023063bf03e2c2078f7c3ccf0f1c477d712b4e67fb";
+      sha256 = "1175e2c893f720fd128de26ff7832367e2e8792d1a0fb968c23cf0c2971d87a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/cs/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/cs/thunderbird-91.5.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "528aba25c407f52e728361e5174cb232f2583ef5ff62bf47386d4766f776566d";
+      sha256 = "9c80c6afa31ed73ccb2e1c813acabc3be484e00f6c498dece19e095d5fc7e1ab";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/cy/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/cy/thunderbird-91.5.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "efd1490cd2a357c1d61d5225a8d1b1b9a61be5c25805b26496ea3ad946d4cbcc";
+      sha256 = "79418720066cdeca5abee231952b3b26f1209eaf59ceab0882f798ba86305aee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/da/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/da/thunderbird-91.5.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "00e9e787a8bf21caebcd1b21889c5534d38d14d8eb2e10b297b320e71455910f";
+      sha256 = "4797af3b1d72199565fafe269d5514042420d3ffd276fb94b3bdda5cea2191f2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/de/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/de/thunderbird-91.5.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "1c93e59e8d55ff671e630dc86091b1503b73e8b92f7bf0b6726d3b9829bfa8d1";
+      sha256 = "c15470c0a61190749d88c857d1a4490e331fc0046cd7aa18fffa5d23b33c1460";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/dsb/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/dsb/thunderbird-91.5.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "d8de15bf2699fa44b82aab0872b966d20dae733b46404b03a1e8c41e28b2c4dd";
+      sha256 = "64c176f0c64d877a505006b03eb0d685042b7120293b733de029868a3ae562ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/el/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/el/thunderbird-91.5.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "1ecb81092cd8bdae878792f2be7a32edc378d3691ca696bcfe3899e81ace7cd7";
+      sha256 = "b220e7f82cbd674b5e98d082766b06a52bc69e18c7d1c91bb0a9dc6d2f129c99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/en-CA/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/en-CA/thunderbird-91.5.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "68836e09adf5f9d2b5c9f3b96ed5b05f56931faa33bbb17c578436c13c5cc4ee";
+      sha256 = "0cc5344d19e62fc86843d71792a59b310be9604ba2bc1ea633d71d6f54ea7eae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/en-GB/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/en-GB/thunderbird-91.5.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b20a74cc35abd3d066384f57b5d2f7a6a1dd24193b720fedce693d8b864058b6";
+      sha256 = "04285f839530ce6917a1918d557cc86448debbd8910d54ca051b9f1b63749b7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/en-US/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/en-US/thunderbird-91.5.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "8f3bffb289081a898f9e77c291ef1ce63af8c0e966894b54a3c533741b655aa9";
+      sha256 = "fa96eb80909cc7f485abda8fdc093f0ef1e2e5fe69f4919bdeeea27651fa264c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/es-AR/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/es-AR/thunderbird-91.5.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "b1c26f4dd600995a88ad960f55fbf6026ad2ff93b94ac12af991440ada44a54a";
+      sha256 = "5affd961efe6b8d6b7616ef1103095c068627f6d3c571aaf71924bc8f8bc58ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/es-ES/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/es-ES/thunderbird-91.5.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "a28fb5020e2e5a577958f4702cd3f15dadf4fcc62c3bfc954d5df3777ef4152a";
+      sha256 = "1dae610383b6dd35e4d6e7d0f8a757b98ab98c6b587940818c239c95f7829e24";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/et/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/et/thunderbird-91.5.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "9a8fc8ba9df9aa179ca6b18d412ee0395c54ed3e2394d951c1cb85d4cb656808";
+      sha256 = "3b2979496032f3f140460295fcae7ff6b08b7970c18eff6bd83df6f582c20651";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/eu/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/eu/thunderbird-91.5.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "56b10b3f9a824fbd91d1107db46e085b45d2c7d78a67a9eb8554afa7aab881a9";
+      sha256 = "a10fddb7405cb311d0a8c69dafca4dce66084c64f68fc7dabbdd7292d265d528";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/fi/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/fi/thunderbird-91.5.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "ef41d1f5a985f1bf98790f76cd9dc9cf8d02614b0d780c59f95fe30224678f02";
+      sha256 = "edc8f3c7368126e3678f8ea6c22e8e575cd34054a94e21b1eac0a44f44689790";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/fr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/fr/thunderbird-91.5.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "2af9a88a1bf2bc0932ef0131a53b2ab3fda256ceaf3e8f256e41f648153eea8f";
+      sha256 = "bae7f4e7cd6d72c3e8270f12483f382c939f3012df6597bb3233af9a3d0bab03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/fy-NL/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/fy-NL/thunderbird-91.5.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "3406057ce9f70c9f1a2efce979fd9b1bffa2ad7fe63bb90e541ea539a2eb071f";
+      sha256 = "dd38566e30d30d1a15283ef1c4382d350cfd4afe8cdaeefc38b995cc82045964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ga-IE/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ga-IE/thunderbird-91.5.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "ee6a8941da6093a7b342da1f124ab5d82cfc9ed288a7385c2ce33e5d95370fb6";
+      sha256 = "7b16826113f3c46601465dbc3b44a24b5e62d9a6a0639d4f74b6314250f24224";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/gd/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/gd/thunderbird-91.5.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "9b57c51af6dbdb9c654e0fc96fe086c04f4dc482fa3528c9658261b9710bc229";
+      sha256 = "4287667e5ff7a6ff39c74066a7c22229736ce503fad749293710a25cf74b5836";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/gl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/gl/thunderbird-91.5.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "d2d12a17334c0b74904fd5a64294c0ca86430d79ebd765d7118b3451cb361819";
+      sha256 = "bcca84aaab4c48e8842f1c921ac398f56eaa569cda6ffa6b5aa3cd0ec709e42e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/he/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/he/thunderbird-91.5.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "da8791864ea612b37839075a85ed446aecd4be941c4f624ed212fa1e4d322768";
+      sha256 = "fd9be0e774dde17d5c2b5d1887c9e9ab75fcb7c797f5b6d59c991679eeb870a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/hr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/hr/thunderbird-91.5.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "11ef3a9c2b7555ef144cc0689265f928c29b01fccded781d76a3f2105d15ed67";
+      sha256 = "4dbc9d9a2d9409688c2f67f5c73fbb31fd1027ee787527f437f95582103c728a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/hsb/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/hsb/thunderbird-91.5.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "bce0ebbaa3e19912d74e5a9754a45a93948f41d5fa9dfab77aea03856ea70ef4";
+      sha256 = "5cf4fc68d7d9464d55686dbac2dba4a38ca50bb36e6661ed4d58b91726f0b312";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/hu/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/hu/thunderbird-91.5.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "dd1b5a48fb175be82967f3b9ca72ea86b2797ebb68285fee143c77ae72a9e659";
+      sha256 = "dd1b4a5f2498eb2e3a3956fdf6379cdde04f0eb60efc201c86237f07dfc01a2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/hy-AM/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/hy-AM/thunderbird-91.5.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "cc172a84b6c586a786a7691eb728e8bce5af253316cec64b989fe2f10f253f95";
+      sha256 = "4e717d157784d865f4de4dd8b14718d39103ce24be1d72c5720629c74d74ae94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/id/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/id/thunderbird-91.5.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "6ac4c494569bb7d5a9948d1e19cb273135638b3b0fa487a535d36f2b70c86bfa";
+      sha256 = "a705929998084e28016cc60df3b7ae6a1f70929270be16307e9be89f1324de2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/is/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/is/thunderbird-91.5.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "e98642ccc27cc77180a83b34a55a59f9b653beb993e80647b76b1c2d1fec003a";
+      sha256 = "48d7eb8c949e9590699031c45bcdd746d1e86ed8dd893bb3afa7025f7bc4c247";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/it/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/it/thunderbird-91.5.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "bada535c73a41318650acb3e744771beea09bf192b3f88e6e8be0de0f9c15b4f";
+      sha256 = "0278a174914da7f874a974847a30bc52851496e79690a8ccde2c3a0a24e9aa39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ja/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ja/thunderbird-91.5.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "dc30bc5943518dbde7b213df3fdd0b454550612d741e167003efc0463b3fd2ae";
+      sha256 = "243e610020c892cf44de3d76b27539e57c5c9eeaef6c5d8298af59ee4be8b448";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ka/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ka/thunderbird-91.5.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "747b850fdb8cad7607b807bf402e2b6d9b58006c9d8323947c2c991d3d775d1e";
+      sha256 = "c641e2f92c87a7454603d059dc34dd2719aefe9b10548dba9e4b95e728583181";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/kab/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/kab/thunderbird-91.5.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "fd063bc5e41bec78ad7d006370ecc0be0644a63bb0f5d6cfdda7148790113059";
+      sha256 = "a47675e0ec44e8bb94dd950e5282f26f0ee878be90a87c0cffe50fe74adc754a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/kk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/kk/thunderbird-91.5.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f853aeb878ed181070b192f1b27dd985a6f0b2318500373b23358c53a56c3d97";
+      sha256 = "1a4cc1087fd9fd0f9cb303c1a0de438d95ec9a665360d9c9915af4269af6f5e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ko/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ko/thunderbird-91.5.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "7444d40c6db9b592d3831115e981208567311a58d47606da6947217e58650e90";
+      sha256 = "f45540f54fab28b107c2938b91191a65f2051fbf435e00530d343f076cb84373";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/lt/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/lt/thunderbird-91.5.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "c7f1cf8b583e6659ec84a0546a3e7828626bae3664de35bc9bcd9fbbb97b56ba";
+      sha256 = "be4d02c3b07aab05e82de8d167ae22269ca5c5ee020a6d8cad0e53a433135160";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/lv/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/lv/thunderbird-91.5.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "30671983c35bb5c112b2b9755e56a1c36afe5bd03c0f09ba930095880b7ab25a";
+      sha256 = "76e3c3c943d4f3598f6f49b51ab9c8625322ad78b6809418905e8d0c7d586ee7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ms/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ms/thunderbird-91.5.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "233464fc722e9deba822c3cec0c7ebf5b1b72295a6847a3203410784e8e33f0f";
+      sha256 = "e125a89ea9d9f013ddd2f816ab10c6916b514ff329011f54e517e2d6e5edb865";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/nb-NO/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/nb-NO/thunderbird-91.5.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "299f50b9d2077ea8300959cd90aaf3113b5fc5da77fa66617533d2b6d4a11f72";
+      sha256 = "f1645ab9430323efefff6751696e1fe601063eef5c5ac70b90889620f6bd9680";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/nl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/nl/thunderbird-91.5.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "4374b5d175d4c990d706241083886e9459f9aa51b1c9862dc02c5134df6a8523";
+      sha256 = "2c1cc1a8ed006e45d4649fa89d5446a9df2e95e2656e9a18130556c42ee0db78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/nn-NO/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/nn-NO/thunderbird-91.5.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "786c23053df9dedb177bd22ab3cf78e3083b73b9bd11b45c17bae35921f8c762";
+      sha256 = "089e6cb230da93b30aac8a81d22f6ac97233d20f6a0e50e96ef8675acfcc407c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/pa-IN/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/pa-IN/thunderbird-91.5.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "cc3df207d658cdc6b13e8d67dec598afa477520d81d6c4bda23bfa0a3bdfe9f7";
+      sha256 = "6ca6b68ac5ab40966b8bc13d6a8f1ef26730d8065cad27f93bd3139295b5fcbc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/pl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/pl/thunderbird-91.5.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "9471ddfc7086cf21222eb1de8c5de76f61f0d9479d6691fa4cce16ea4a481361";
+      sha256 = "93f94b83a17569b5b626277af71651a607d74c32fa17fc35896ac42556075d2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/pt-BR/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/pt-BR/thunderbird-91.5.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "0e466b0a1a0e258b9d3b5288902dcf4fc114a192ba156d956d8be9bbcea1a42a";
+      sha256 = "9c7e02da587136eebf6111fe4e25687f904b8db7629be251c84ab25b6adfd2e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/pt-PT/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/pt-PT/thunderbird-91.5.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "83b0e2bfe657f16b88906f2a70a0d954b73d053c01b545812e40d02f343b50ef";
+      sha256 = "8666b71ac2fa83da6175c8c26ab73a957f19dcc6b36cca7f980407aa7a42111d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/rm/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/rm/thunderbird-91.5.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "507059e7cad7c0665c0468436e334a3c2cef258751fe97e90a731d067e0cc672";
+      sha256 = "f278f045fe7c941b4545ea452152859960d952704f2d666d39bb6a91175c7027";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ro/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ro/thunderbird-91.5.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "61e4d4652ecbce03421dab02aa15f49e4a782cf63380d76207173afd07dc6183";
+      sha256 = "2c43f39a8fcd557efde852eb7f859eff048672806ec23620037a28d4d98da99a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/ru/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/ru/thunderbird-91.5.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "b3c1d07ace631bc8117d1003029216a5579a64f7e83a4289877fe5101c0b261b";
+      sha256 = "63041d68d0072699dfc7e3fa448ac9a3bf065795c455dd3f5671cae97d5d121a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/sk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/sk/thunderbird-91.5.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "ec8949eec7a001e075888500749f7b0211996afe4d25dc081df34e20a214e835";
+      sha256 = "be1cdf0cd47f788d736c9bfae340b6cf9edd661293e5ce5b5bca6b2aa169438c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/sl/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/sl/thunderbird-91.5.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "026a55fbb143621ba98d2218ff72c5eea2491ea74e3abbf46dc4d8405a7df327";
+      sha256 = "128a46d7df356375536a432d7bd13bdea8d4932b105cdf4b8288af3dfa878b7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/sq/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/sq/thunderbird-91.5.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "0a22abf8961874edc88fb7654d8b66694050f98ed4440eb7aabbf7a4969bd993";
+      sha256 = "6a8fa0c4806240a886393c51f63992e567524264c821ccf4f12e202f4f30e7ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/sr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/sr/thunderbird-91.5.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "4304ac8a1283065aabc63b39734cd7d023a82b590cc1d255093d73cc1155e30c";
+      sha256 = "e2639022166d0be0d30846a269c08940652475e77ef114089e22c9d5ddf61f98";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/sv-SE/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/sv-SE/thunderbird-91.5.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "b2196727748a1d42bc67fcde4df47e7e1661a446e0620e11c64dcc1a7db0da06";
+      sha256 = "d8a419a6c8105fbf6ee29a38cba3e40729ef8f12743d87ce2a623e8707ba0414";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/th/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/th/thunderbird-91.5.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "de52a8a1a64b26d29721be3843c12df6bdb732354c9263782f989918a51dee2a";
+      sha256 = "ac2926a73937c0789ba63d6ecce8a17dcf5a65a7fca5dd439618384588c0dce5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/tr/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/tr/thunderbird-91.5.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "bba119fb7749350c06760d6885a89efa0632098e593f22a23451a592dbea9e1d";
+      sha256 = "efcf840a32ab0264484c7f1fa2b3a0961cdd1e8ff37f4f83126ab0626c19834b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/uk/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/uk/thunderbird-91.5.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "34198ab171b0783d0ac592e0a72ea355aae75b950f2569d2e6ed30a9b1a5d2f8";
+      sha256 = "e1fabb41564ebd683cf298bb3bc13e3478dfef6522f6524a7c2ab69c64d59251";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/uz/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/uz/thunderbird-91.5.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "1adcedb12bb9485da32b47558352d5fa9182fd8411450386d9ac8a528b40cca4";
+      sha256 = "2dac221764006b5db352416159311849cfa62c67894ec40a2914caf3191c79d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/vi/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/vi/thunderbird-91.5.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "c22cd41206fd7e4d80c6855c7217071be3890e84460cd030f4029a910c672bb2";
+      sha256 = "fb482c3579b6bde18214ca68fa731d50ac254152dc51c5d13e283f16559f0886";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/zh-CN/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/zh-CN/thunderbird-91.5.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "744515522d16884b4067a75412977243753baece132c4d5c815ac60d5a26bd7b";
+      sha256 = "4e596742711f72eae50621fbc0b329bdf736267c753c51ab8dd1713cc0860285";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.4.1/linux-i686/zh-TW/thunderbird-91.4.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.0/linux-i686/zh-TW/thunderbird-91.5.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "21fcb4c30b76c607e215363688966ea92ae1f3cd658ce7c9118f3d0f2cfff729";
+      sha256 = "c97873b840540297f08ad866479789f2f7cc8baa48de6bdf9eb4b945a5c135c4";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -10,12 +10,12 @@ in
 rec {
   thunderbird = common rec {
     pname = "thunderbird";
-    version = "91.4.1";
+    version = "91.5.0";
     application = "comm/mail";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "aa442ef886277f5091ebadff907a29451a0ee6542f24adb5c1fb4223193d719c2cb01474d3ccd96067695b19ce3cbf042893b0beaaeb7c65e0660ab5072bf82e";
+      sha512 = "e1cafbd99e67e8fef346e936890a22aeadded4aa8be604607535ae933251bc1b2a3b56c2b62045b3d37ecb09999adb746157df188d1a32dfe75685f3af959b7d";
     };
     patches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- High security fixes
- Other fixes

https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird91.5
https://www.thunderbird.net/en-US/thunderbird/91.5.0/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
