### PR TITLE
wireplumber: 0.4.6 → 0.4.7

### DIFF
--- a/pkgs/development/libraries/pipewire/wireplumber.nix
+++ b/pkgs/development/libraries/pipewire/wireplumber.nix
@@ -26,7 +26,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wireplumber";
-  version = "0.4.6";
+  version = "0.4.7";
 
   outputs = [ "out" "dev" ] ++ lib.optional enableDocs "doc";
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     owner = "pipewire";
     repo = "wireplumber";
     rev = version;
-    sha256 = "sha256-y+Gj9EZn67W3U81zXgp+6JAFxZSZTwwT0TB3Kueb/Tw=";
+    sha256 = "sha256-yp4xtp+s+h+43LGVtYonoJ2tQaLRfwyMY4fp8z1l0CM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/pipewire/wireplumber.nix
+++ b/pkgs/development/libraries/pipewire/wireplumber.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, fetchpatch
 , nix-update-script
 , # base build deps
   meson
@@ -37,6 +38,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-yp4xtp+s+h+43LGVtYonoJ2tQaLRfwyMY4fp8z1l0CM=";
   };
+
+  patches = [
+    # backport a fix for default device selection
+    # FIXME remove this after 0.4.8
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/211f1e6b6cd4898121e4c2b821fae4dea6cc3317.patch";
+      sha256 = "sha256-EGcbJ8Rq/5ft6SV0VC+mTkhVE7Ycze4TL6AVc9KH7+M=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Big upstream release: https://gitlab.freedesktop.org/pipewire/wireplumber/-/tags/0.4.7

Notably: 

* Fixed a regression in 0.4.6 that caused the selection of the default audio sources and sinks to be delayed until some event, which effectively caused losing audio output in many circumstances
* Fixed a regression in 0.4.6 that caused the echo-cancellation pipewire module (and possibly others) to not work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
