### PR TITLE
python310Packages.aspell-python: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/aspell-python/default.nix
+++ b/pkgs/development/python-modules/aspell-python/default.nix
@@ -1,29 +1,57 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, aspell, aspellDicts, python }:
+{ lib
+, aspell
+, aspellDicts
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, pytestCheckHook
+, pythonAtLeast
+}:
 
 buildPythonPackage rec {
   pname = "aspell-python";
   version = "1.15";
+  format = "setuptools";
+
   disabled = isPy27;
 
   src = fetchPypi {
-    inherit version;
     pname = "aspell-python-py3";
+    inherit version;
     extension = "tar.bz2";
-    sha256 = "13dk3jrvqmfvf2w9b8afj37d8bh32kcx295lyn3z7r8qch792hi0";
+    hash = "sha256-IEKRDmQY5fOH9bQk0dkUAy7UzpBOoZW4cNtVvLMcs40=";
   };
 
-  buildInputs = [ aspell ];
+  buildInputs = [
+    aspell
+  ];
 
-  checkPhase = ''
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
     export ASPELL_CONF="dict-dir ${aspellDicts.en}/lib/aspell"
     export HOME=$(mktemp -d)
-    ${python.interpreter} test/unittests.py
   '';
 
-  pythonImportsCheck = [ "aspell" ];
+  pytestFlagsArray = [
+    "test/unittests.py"
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    # https://github.com/WojciechMula/aspell-python/issues/22
+    "test_add"
+    "test_get"
+    "test_saveall"
+  ];
+
+  pythonImportsCheck = [
+    "aspell"
+  ];
 
   meta = with lib; {
-    description = "Python wrapper for aspell (C extension and python version)";
+    description = "Python wrapper for aspell (C extension and Python version)";
     homepage = "https://github.com/WojciechMula/aspell-python";
     license = licenses.bsd3;
     maintainers = with maintainers; [ SuperSandro2000 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163533994)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
