### PR TITLE
pythonPackages.py3nvml: init at 0.2.6

### DIFF
--- a/pkgs/development/python-modules/py3nvml/default.nix
+++ b/pkgs/development/python-modules/py3nvml/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, nvidia_x11
+, pytestCheckHook
+, pythonOlder
+, substituteAll
+, xmltodict
+}:
+
+buildPythonPackage rec {
+  pname = "py3nvml";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "fbcotter";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-k6ErpDpXg6eKSMLDHVgfl7M25nhERLX+w4ney371EGs=";
+  };
+
+  disabled = pythonOlder "3.5";
+
+  patches = [
+    (substituteAll {
+      src = ./fix_shared_object_paths.patch;
+      inherit nvidia_x11;
+    })
+  ];
+
+  buildInputs = [ xmltodict ];
+
+  checkInputs = [ pytestCheckHook numpy ];
+
+  pythonImportsCheck = [ "py3nvml" ];
+
+  meta = with lib; {
+    description = "Python 3 compatible bindings to the NVIDIA Management Library";
+    homepage = "https://github.com/fbcotter/py3nvml";
+    maintainers = with maintainers; [ rhoriguchi ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/py3nvml/fix_shared_object_paths.patch
+++ b/pkgs/development/python-modules/py3nvml/fix_shared_object_paths.patch
@@ -1,0 +1,26 @@
+diff --git a/py3nvml/py3nvml.py b/py3nvml/py3nvml.py
+index 56b1fd0..2b97191 100644
+--- a/py3nvml/py3nvml.py
++++ b/py3nvml/py3nvml.py
+@@ -1128,7 +1128,7 @@ def _LoadNvmlLibrary():
+                             nvmlLib = CDLL(nvmlPath)
+                     else:
+                         # assume linux
+-                        nvmlLib = CDLL("libnvidia-ml.so.1")
++                        nvmlLib = CDLL("@nvidia_x11@/lib/libnvidia-ml.so.1")
+                 except OSError as ose:
+                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
+                 if (nvmlLib == None):
+diff --git a/tests/out.py b/tests/out.py
+index 70eea98..8338ef4 100644
+--- a/tests/out.py
++++ b/tests/out.py
+@@ -1121,7 +1121,7 @@ def _LoadNvmlLibrary():
+                         nvmlLib = CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
+                     else:
+                         # assume linux
+-                        nvmlLib = CDLL("libnvidia-ml.so.1")
++                        nvmlLib = CDLL("@nvidia_x11@/lib/libnvidia-ml.so.1")
+                 except OSError as ose:
+                     _nvmlCheckReturn(NVML_ERROR_LIBRARY_NOT_FOUND)
+                 if (nvmlLib == None):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6411,6 +6411,8 @@ in {
 
   py3exiv2 = callPackage ../development/python-modules/py3exiv2 { };
 
+  py3nvml = callPackage ../development/python-modules/py3nvml { inherit (pkgs.linuxPackages) nvidia_x11; };
+
   py3status = callPackage ../development/python-modules/py3status { };
 
   py3to2 = callPackage ../development/python-modules/3to2 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
