### PR TITLE
mojave-gtk-theme: 2021-07-20 -> unstable-2021-12-20

### DIFF
--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -10,10 +10,25 @@
 , optipng
 , sassc
 , which
+, buttonSizeVariants ? [] # default to standard
+, buttonVariants ? [] # default to all
+, colorVariants ? [] # default to all
+, opacityVariants ? [] # default to all
+, themeVariants ? [] # default to MacOS blue
+, wallpapers ? false
 }:
 
-stdenv.mkDerivation rec {
+let
   pname = "mojave-gtk-theme";
+in
+lib.checkListOfEnum "${pname}: button size variants" [ "standard" "small" ] buttonSizeVariants
+lib.checkListOfEnum "${pname}: button variants" [ "standard" "alt" ] buttonVariants
+lib.checkListOfEnum "${pname}: color variants" [ "light" "dark" ] colorVariants
+lib.checkListOfEnum "${pname}: opacity variants" [ "standard" "solid" ] opacityVariants
+lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
+
+stdenv.mkDerivation rec {
+  inherit pname;
   version = "unstable-2021-12-20";
 
   srcs = [
@@ -23,11 +38,14 @@ stdenv.mkDerivation rec {
       rev = "c148646ccab382f7a2d5fdc421fc32d843cb4172";
       sha256 = "sha256-h4MSSh8cu9M81bM+WJSyl1SQ7CVth1DvjIVOUJXqpxs";
     })
+  ]
+  ++
+  lib.optional wallpapers
     (fetchurl {
       url = "https://github.com/vinceliuice/Mojave-gtk-theme/raw/11741a99d96953daf9c27e44c94ae50a7247c0ed/macOS_Mojave_Wallpapers.tar.xz";
       sha256 = "18zzkwm1kqzsdaj8swf0xby1n65gxnyslpw4lnxcx1rphip0rwf7";
     })
-  ];
+  ;
 
   sourceRoot = "source";
 
@@ -77,9 +95,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    name= ./install.sh --theme all --dest $out/share/themes
+    name= ./install.sh \
+      ${lib.optionalString (buttonSizeVariants != []) "--small " + builtins.toString buttonSizeVariants} \
+      ${lib.optionalString (buttonVariants != []) "--alt " + builtins.toString buttonVariants} \
+      ${lib.optionalString (colorVariants != []) "--color " + builtins.toString colorVariants} \
+      ${lib.optionalString (opacityVariants != []) "--opacity " + builtins.toString opacityVariants} \
+      ${lib.optionalString (themeVariants != []) "--theme " + builtins.toString themeVariants} \
+      --dest $out/share/themes
 
-    install -D -t $out/share/wallpapers ../"macOS Mojave Wallpapers"/*
+    ${lib.optionalString wallpapers ''
+      install -D -t $out/share/wallpapers ../"macOS Mojave Wallpapers"/*
+    ''}
 
     # Replace duplicate files with hardlinks to the first file in each
     # set of duplicates, reducing the installed size in about 53%

--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -14,14 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "mojave-gtk-theme";
-  version = "2021-07-20";
+  version = "unstable-2021-12-20";
 
   srcs = [
     (fetchFromGitHub {
       owner = "vinceliuice";
       repo = pname;
-      rev = version;
-      sha256 = "08j70kmjhvh06c3ahcracarrfq4vpy0zsp6zkcivbw4nf3bzp2zc";
+      rev = "c148646ccab382f7a2d5fdc421fc32d843cb4172";
+      sha256 = "sha256-h4MSSh8cu9M81bM+WJSyl1SQ7CVth1DvjIVOUJXqpxs";
     })
     (fetchurl {
       url = "https://github.com/vinceliuice/Mojave-gtk-theme/raw/11741a99d96953daf9c27e44c94ae50a7247c0ed/macOS_Mojave_Wallpapers.tar.xz";

--- a/pkgs/data/themes/mojave/default.nix
+++ b/pkgs/data/themes/mojave/default.nix
@@ -76,9 +76,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     name= ./install.sh --theme all --dest $out/share/themes
+
     install -D -t $out/share/wallpapers ../"macOS Mojave Wallpapers"/*
-    jdupes -l -r $out/share
+
+    # Replace duplicate files with hardlinks to the first file in each
+    # set of duplicates, reducing the installed size in about 53%
+    jdupes -L -r $out/share
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- mojave-gtk-theme: 2021-07-20 -> [unstable-2021-12-20](https://www.pling.com/p/1275087/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
