### PR TITLE
python3Packages.celery: 5.2.1 -> 5.2.3

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -129,9 +129,11 @@ let
               version = "5.0.0";
               src = oldAttrs.src.override {
                 inherit version;
-                sha256 = "sha256-MTkw/d3nA9jjcCmjBL+RQpzRGu72PFfebayp2Vjh8lU=";
+                hash = "sha256-MTkw/d3nA9jjcCmjBL+RQpzRGu72PFfebayp2Vjh8lU=";
               };
-              doCheck = false;
+              disabledTestPaths = [
+                "t/unit/backends/test_mongodb.py"
+              ];
             });
           }
         )

--- a/pkgs/development/python-modules/amqp/default.nix
+++ b/pkgs/development/python-modules/amqp/default.nix
@@ -1,24 +1,46 @@
-{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, case, vine }:
+{ lib
+, buildPythonPackage
+, case
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, vine
+}:
 
 buildPythonPackage rec {
   pname = "amqp";
-  version = "5.0.6";
+  version = "5.0.9";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "03e16e94f2b34c31f8bf1206d8ddd3ccaa4c315f7f6a1879b7b1210d229568c2";
+    hash = "sha256-Hl9wdCTlRAeMoZbnKuahSIfOdOAr0Sa+VLfAPJcb7xg=";
   };
 
-  propagatedBuildInputs = [ vine ];
+  propagatedBuildInputs = [
+    vine
+  ];
 
-  checkInputs = [ pytestCheckHook case ];
+  checkInputs = [
+    case
+    pytestCheckHook
+  ];
+
   disabledTests = [
-    "test_rmq.py" # requires network access
+    # Requires network access
+    "test_rmq.py"
+  ];
+
+  pythonImportsCheck = [
+    "amqp"
   ];
 
   meta = with lib; {
     homepage = "https://github.com/celery/py-amqp";
     description = "Python client for the Advanced Message Queuing Procotol (AMQP). This is a fork of amqplib which is maintained by the Celery project";
-    license = licenses.lgpl21;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -2,6 +2,7 @@
 , billiard
 , boto3
 , buildPythonPackage
+, case
 , click
 , click-didyoumean
 , click-plugins
@@ -45,6 +46,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     boto3
+    case
     dnspython
     moto
     pymongo

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -2,11 +2,11 @@
 , billiard
 , boto3
 , buildPythonPackage
-, case
 , click
 , click-didyoumean
 , click-plugins
 , click-repl
+, dnspython
 , fetchPypi
 , kombu
 , moto
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "celery";
-  version = "5.2.1";
+  version = "5.2.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b41a590b49caf8e6498a57db628e580d5f8dc6febda0f42de5d783aed5b7f808";
+    hash = "sha256-4s1BZnrZfU9qL0Zy0cam662hlMYZJTBYtfI3BKqtqoI=";
   };
 
   propagatedBuildInputs = [
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   checkInputs = [
     boto3
-    case
+    dnspython
     moto
     pymongo
     pytest-celery
@@ -53,6 +53,11 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace requirements/default.txt \
+      --replace "setuptools>=59.1.1,<59.7.0" "setuptools"
+  '';
 
   disabledTestPaths = [
     # test_eventlet touches network
@@ -75,6 +80,6 @@ buildPythonPackage rec {
     description = "Distributed task queue";
     homepage = "https://github.com/celery/celery/";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/kombu/default.nix
+++ b/pkgs/development/python-modules/kombu/default.nix
@@ -1,27 +1,28 @@
 { lib
-, buildPythonPackage
-, pythonOlder
-, fetchPypi
 , amqp
-, vine
-, cached-property
-, importlib-metadata
 , azure-servicebus
+, buildPythonPackage
+, cached-property
 , case
+, fetchPypi
+, importlib-metadata
 , Pyro4
 , pytestCheckHook
+, pythonOlder
 , pytz
+, vine
 }:
 
 buildPythonPackage rec {
   pname = "kombu";
-  version = "5.2.2";
+  version = "5.2.3";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f5d0763fb916808f617b886697b2be28e6bc35026f08e679697fc814b48a608";
+    hash = "sha256-gakMHel+CNPbN9vxY+qvZnRF4QaMmL/YnwUaQOn2270=";
   };
 
   propagatedBuildInputs = [
@@ -40,9 +41,14 @@ buildPythonPackage rec {
     pytz
   ];
 
+  pythonImportsCheck = [
+    "kombu"
+  ];
+
   meta = with lib; {
     description = "Messaging library for Python";
-    homepage    = "https://github.com/celery/kombu";
-    license     = licenses.bsd3;
+    homepage = "https://github.com/celery/kombu";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }

--- a/pkgs/development/python-modules/vine/default.nix
+++ b/pkgs/development/python-modules/vine/default.nix
@@ -1,22 +1,36 @@
-{ lib, buildPythonPackage, fetchPypi
-, case, pytest, pythonOlder }:
+{ lib
+, buildPythonPackage
+, case
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "vine";
   version = "5.0.0";
+  format = "setuptools";
 
-  disable = pythonOlder "2.7";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e";
+    hash = "sha256-fTsWJKlT2oLvY0YgE7vScdPrdXUUifmAdZjo80C9Y34=";
   };
 
-  buildInputs = [ case pytest ];
+  checkInputs = [
+    case
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "vine"
+  ];
 
   meta = with lib; {
     description = "Python promises";
     homepage = "https://github.com/celery/vine";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/celery/celery/releases/tag/v5.2.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
