### PR TITLE
variety: use runtimeShell instead of stdenv.shell

### DIFF
--- a/pkgs/applications/misc/variety/default.nix
+++ b/pkgs/applications/misc/variety/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, lib, fetchFromGitHub
-, python3Packages
+{ lib
+, stdenv
+, fetchFromGitHub
+, gexiv2
+, gobject-introspection
+, gtk3
+, hicolor-icon-theme
+, intltool
+, libnotify
+, librsvg
+, python3
+, runtimeShell
+, wrapGAppsHook
 , fehSupport ? false, feh
 , imagemagickSupport ? true, imagemagick
-, intltool
-, gtk3
-, gexiv2
-, libnotify
-, gobject-introspection
-, hicolor-icon-theme
-, librsvg
-, wrapGAppsHook
-, makeWrapper
 }:
 
-with python3Packages;
-
-buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "variety";
   version = "0.8.5";
 
@@ -26,9 +26,34 @@ buildPythonApplication rec {
     sha256 = "sha256-6dLz4KXavXwnk5GizBH46d2EHMHPjRo0WnnUuVMtI1M=";
   };
 
-  nativeBuildInputs = [ makeWrapper intltool wrapGAppsHook ];
+  nativeBuildInputs = [
+    intltool
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ distutils_extra ];
+  propagatedBuildInputs = [
+   gexiv2
+   gobject-introspection
+   gtk3
+   hicolor-icon-theme
+   libnotify
+   librsvg
+  ]
+  ++ (with python3.pkgs; [
+    beautifulsoup4
+    configobj
+    dbus-python
+    distutils_extra
+    httplib2
+    lxml
+    pillow
+    pycairo
+    pygobject3
+    requests
+    setuptools
+  ])
+  ++ lib.optional fehSupport feh
+  ++ lib.optional imagemagickSupport imagemagick;
 
   doCheck = false;
 
@@ -38,32 +63,13 @@ buildPythonApplication rec {
 
   prePatch = ''
     substituteInPlace variety_lib/varietyconfig.py \
-      --replace "__variety_data_directory__ = \"../data\"" "__variety_data_directory__ = \"$out/share/variety\""
+      --replace "__variety_data_directory__ = \"../data\"" \
+                "__variety_data_directory__ = \"$out/share/variety\""
     substituteInPlace data/scripts/set_wallpaper \
-      --replace /bin/bash ${stdenv.shell}
+      --replace /bin/bash ${runtimeShell}
     substituteInPlace data/scripts/get_wallpaper \
-      --replace /bin/bash ${stdenv.shell}
+      --replace /bin/bash ${runtimeShell}
   '';
-
-  propagatedBuildInputs = [
-    beautifulsoup4
-    configobj
-    dbus-python
-    gexiv2
-    gobject-introspection
-    gtk3
-    hicolor-icon-theme
-    httplib2
-    libnotify
-    librsvg
-    lxml
-    pillow
-    pycairo
-    pygobject3
-    requests
-    setuptools
-  ] ++ lib.optional fehSupport feh
-    ++ lib.optional imagemagickSupport imagemagick;
 
   meta = with lib; {
     homepage = "https://github.com/varietywalls/variety";
@@ -80,8 +86,7 @@ buildPythonApplication rec {
       Variety also includes a range of image effects, such as oil painting and
       blur, as well as options to layer quotes and a clock onto the background.
     '';
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ p3psi AndersonTorres zfnmxt ];
-    platforms = with platforms; linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Old code pulling my leg. Fixes https://github.com/NixOS/nixpkgs/issues/154840

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
