### PR TITLE
sfxr-qt: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -2,6 +2,7 @@
 , mkDerivation
 , fetchFromGitHub
 , cmake
+, extra-cmake-modules
 , qtbase
 , qtquickcontrols2
 , SDL
@@ -10,18 +11,22 @@
 
 mkDerivation rec {
   pname = "sfxr-qt";
-  version = "1.3.0";
+  version = "1.4.0";
+
   src = fetchFromGitHub {
     owner = "agateau";
     repo = "sfxr-qt";
     rev = version;
-    sha256 = "15yjgjl1c5k816mnpc09104zq0ack2a3mjsxmhcik7cmjkfiipr5";
+    sha256 = "sha256-Mn+wcwu70BwsTLFlc12sOOe6U1AJ8hR7bCIPlPnCooE=";
     fetchSubmodules = true;
   };
+
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     (python3.withPackages (pp: with pp; [ pyyaml jinja2 setuptools ]))
   ];
+
   buildInputs = [
     qtbase
     qtquickcontrols2
@@ -36,4 +41,3 @@ mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-


### PR DESCRIPTION
And some formatting

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
