### PR TITLE
python3Packages.eventlet: switch to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , dnspython
 , greenlet
@@ -10,22 +10,35 @@
 , nose
 , pyopenssl
 , iana-etc
+, pytestCheckHook
 , libredirect
 }:
 
 buildPythonPackage rec {
   pname = "eventlet";
   version = "0.33.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "80144f489c1bb273a51b6f96ff9785a382d2866b9bab1f5bd748385019f4141f";
+  src = fetchFromGitHub {
+    owner = "eventlet";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-kE/eYBbaTt1mPGoUIMhonvFBlQOdAfPU5GvCvPaRHvs=";
   };
 
-  propagatedBuildInputs = [ dnspython greenlet pyopenssl six ]
-    ++ lib.optional (pythonOlder "3.5") monotonic;
+  propagatedBuildInputs = [
+    dnspython
+    greenlet
+    pyopenssl
+    six
+  ] ++ lib.optional (pythonOlder "3.5") [
+    monotonic
+  ];
 
-  checkInputs = [ nose ];
+  checkInputs = [
+    pytestCheckHook
+    nose
+  ];
 
   doCheck = !stdenv.isDarwin;
 
@@ -37,23 +50,48 @@ buildPythonPackage rec {
     export EVENTLET_IMPORT_VERSION_ONLY=0
   '';
 
-  checkPhase = ''
-    runHook preCheck
+  disabledTests = [
+    # Tests requires network access
+    "test_017_ssl_zeroreturnerror"
+    "test_getaddrinfo"
+    "test_hosts_no_network"
+    "test_leakage_from_tracebacks"
+    "test_patcher_existing_locks_locked"
+  ];
 
-    # test_fork-after_monkey_patch fails on aarch64 on hydra only
-    #   AssertionError: Expected single line "pass" in stdout
-    nosetests --exclude test_getaddrinfo --exclude test_hosts_no_network --exclude test_fork_after_monkey_patch
-
-    runHook postCheck
-  '';
+  disabledTestPaths = [
+    # Tests are out-dated
+    "tests/stdlib/test_asynchat.py"
+    "tests/stdlib/test_asyncore.py"
+    "tests/stdlib/test_ftplib.py"
+    "tests/stdlib/test_httplib.py"
+    "tests/stdlib/test_httpservers.py"
+    "tests/stdlib/test_os.py"
+    "tests/stdlib/test_queue.py"
+    "tests/stdlib/test_select.py"
+    "tests/stdlib/test_SimpleHTTPServer.py"
+    "tests/stdlib/test_socket_ssl.py"
+    "tests/stdlib/test_socket.py"
+    "tests/stdlib/test_socketserver.py"
+    "tests/stdlib/test_ssl.py"
+    "tests/stdlib/test_subprocess.py"
+    "tests/stdlib/test_thread__boundedsem.py"
+    "tests/stdlib/test_thread.py"
+    "tests/stdlib/test_threading_local.py"
+    "tests/stdlib/test_threading.py"
+    "tests/stdlib/test_timeout.py"
+    "tests/stdlib/test_urllib.py"
+    "tests/stdlib/test_urllib2_localnet.py"
+    "tests/stdlib/test_urllib2.py"
+  ];
 
   # unfortunately, it needs /etc/protocol to be present to not fail
   # pythonImportsCheck = [ "eventlet" ];
 
   meta = with lib; {
-    homepage = "https://github.com/eventlet/eventlet/";
     description = "A concurrent networking library for Python";
-    maintainers = with maintainers; [ SuperSandro2000 ];
+    homepage = "https://github.com/eventlet/eventlet/";
     license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163455973)

Closes #154879

Switch to `pytestCheckHook` and disable all tests which look remote like made for Python 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
