### PR TITLE
fftw: convert to pname+version, use https for fetching, expose withDo…

### DIFF
--- a/pkgs/development/libraries/fftw/default.nix
+++ b/pkgs/development/libraries/fftw/default.nix
@@ -3,7 +3,7 @@
 , lib
 , gfortran
 , perl
-, llvmPackages ? null
+, llvmPackages
 , precision ? "double"
 , enableAvx ? stdenv.hostPlatform.avxSupport
 , enableAvx2 ? stdenv.hostPlatform.avx2Support
@@ -11,24 +11,20 @@
 , enableFma ? stdenv.hostPlatform.fmaSupport
 , enableMpi ? false
 , mpi
+, withDoc ? stdenv.cc.isGNU
 }:
 
 with lib;
 
-assert stdenv.cc.isClang -> llvmPackages != null;
 assert elem precision [ "single" "double" "long-double" "quad-precision" ];
 
-let
+stdenv.mkDerivation rec {
+  pname = "fftw-${precision}";
   version = "3.3.10";
-  withDoc = stdenv.cc.isGNU;
-in
-
-stdenv.mkDerivation {
-  name = "fftw-${precision}-${version}";
 
   src = fetchurl {
     urls = [
-      "http://fftw.org/fftw-${version}.tar.gz"
+      "https://fftw.org/fftw-${version}.tar.gz"
       "ftp://ftp.fftw.org/pub/fftw/fftw-${version}.tar.gz"
     ];
     sha256 = "sha256-VskyVJhSzdz6/as4ILAgDHdCZ1vpIXnlnmIVs0DiZGc=";


### PR DESCRIPTION
…c, remove ? null from inputs

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
