### PR TITLE
python310Packages.debugpy: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -13,11 +13,13 @@
 , pytestCheckHook
 , requests
 , isPy3k
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "debugpy";
   version = "1.5.1";
+  format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "Microsoft";
@@ -67,6 +69,7 @@ buildPythonPackage rec {
   )'';
 
   doCheck = isPy3k;
+
   checkInputs = [
     django
     flask
@@ -79,9 +82,25 @@ buildPythonPackage rec {
   ];
 
   # Override default arguments in pytest.ini
-  pytestFlagsArray = [ "--timeout=0" "-n=$NIX_BUILD_CORES" ];
+  pytestFlagsArray = [
+    "--timeout=0"
+    "-n=$NIX_BUILD_CORES"
+  ];
 
-  pythonImportsCheck = [ "debugpy" ];
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    "test_flask_breakpoint_multiproc"
+    "test_subprocess[program-launch-None]"
+    "test_systemexit[0-zero-uncaught-raised-launch(integratedTerminal)-module]"
+    "test_systemexit[0-zero-uncaught--attach_pid-program]"
+    "test_success_exitcodes[-break_on_system_exit_zero-0-attach_listen(cli)-module]"
+    "test_success_exitcodes[--0-attach_connect(api)-program]"
+    "test_run[code-attach_connect(api)]"
+    "test_subprocess[program-launch-None]"
+  ];
+
+  pythonImportsCheck = [
+    "debugpy"
+  ];
 
   meta = with lib; {
     description = "An implementation of the Debug Adapter Protocol for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163491000)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
