### PR TITLE
python3Packages.glom: switch to pytestCheckHook

### DIFF
--- a/pkgs/development/python-modules/boltons/default.nix
+++ b/pkgs/development/python-modules/boltons/default.nix
@@ -3,40 +3,53 @@
 , fetchFromGitHub
 , fetchpatch
 , pytestCheckHook
+, pythonAtLeast
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "boltons";
   version = "20.2.1";
+  format = "setuptools";
 
-  # No tests in PyPi Tarball
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "mahmoud";
     repo = "boltons";
     rev = version;
-    sha256 = "0vw0h0z81gfxgjfijqiza92ic0siv9xy65mklgj5d0dzr1k9waw8";
+    hash = "sha256-iCueZsi/gVbko7MW43vaUQMWRVI/YhmdfN29gD6AgG8=";
   };
 
-  patches = [
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  patches = lib.optionals (pythonAtLeast "3.10") [
+    # pprint has no attribute _safe_repr, https://github.com/mahmoud/boltons/issues/294
     (fetchpatch {
-      url = "https://github.com/mahmoud/boltons/commit/754afddf141ea26956c88c7e13fe5e7ca7942654.patch";
-      sha256 = "14kcq8pl4pmgcnlnmj1sh1yrksgym0kn0kgz2648g192svqkbpz8";
+      name = "fix-pprint-attribute.patch";
+      url = "https://github.com/mahmoud/boltons/commit/270e974975984f662f998c8f6eb0ebebd964de82.patch";
+      sha256 = "sha256-pZLfr6SRCw2aLwZeYaX7bzfJeZC4cFUILEmnVsKR6zc=";
     })
   ];
 
-  checkInputs = [ pytestCheckHook ];
   disabledTests = [
-    # This test is broken without this PR, which has not yet been merged
+    # This test is broken without this PR. Merged but not released
     # https://github.com/mahmoud/boltons/pull/283
-    "test_frozendict_ior"
+    "test_frozendict"
+  ];
+
+  pythonImportsCheck = [
+    "boltons"
   ];
 
   meta = with lib; {
     homepage = "https://github.com/mahmoud/boltons";
-    description = "220+ constructs, recipes, and snippets extending (and relying on nothing but) the Python standard library";
+    description = "Constructs, recipes, and snippets extending the Python standard library";
     longDescription = ''
-      Boltons is a set of over 220 BSD-licensed, pure-Python utilities
-      in the same spirit as — and yet conspicuously missing from — the
+      Boltons is a set of over 200 BSD-licensed, pure-Python utilities
+      in the same spirit as - and yet conspicuously missing from - the
       standard library, including:
 
       - Atomic file saving, bolted on with fileutils

--- a/pkgs/development/python-modules/glom/default.nix
+++ b/pkgs/development/python-modules/glom/default.nix
@@ -4,24 +4,47 @@
 , boltons
 , attrs
 , face
-, pytest
+, pytestCheckHook
 , pyyaml
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "glom";
   version = "20.11.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "54051072bccc9cdb3ebbd8af0559195137a61d308f04bff19678e4b61350eb12";
+    hash = "sha256-VAUQcrzMnNs+u9ivBVkZUTemHTCPBL/xlnjkthNQ6xI=";
   };
 
-  propagatedBuildInputs = [ boltons attrs face ];
+  propagatedBuildInputs = [
+    boltons
+    attrs
+    face
+  ];
 
-  checkInputs = [ pytest pyyaml ];
-  # test_cli.py checks the output of running "glom"
-  checkPhase = "PATH=$out/bin:$PATH pytest glom/test";
+  checkInputs = [
+    pytestCheckHook
+    pyyaml
+  ];
+
+  preCheck = ''
+    # test_cli.py checks the output of running "glom"
+    export PATH=$out/bin:$PATH
+  '';
+
+  disabledTests = [
+    # Test is outdated (was made for PyYAML 3.x)
+    "test_main_yaml_target"
+  ];
+
+  pythonImportsCheck = [
+    "glom"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/mahmoud/glom";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163442515, https://hydra.nixos.org/build/163443655)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
