### PR TITLE
clip: init at 2.1.1

### DIFF
--- a/pkgs/applications/video/clip/default.nix
+++ b/pkgs/applications/video/clip/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, mkDerivation
+, fetchFromGitLab
+, cmake
+, extra-cmake-modules
+, applet-window-buttons
+, karchive
+, kcoreaddons
+, ki18n
+, kio
+, kirigami2
+, mauikit
+, mauikit-filebrowsing
+, qtmultimedia
+, qtquickcontrols2
+, taglib
+, ffmpeg
+}:
+
+mkDerivation rec {
+  pname = "clip";
+  version = "2.1.1";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "maui";
+    repo = "clip";
+    rev = "v${version}";
+    sha256 = "sha256-vW3A0PKJSC2QNs+QVZ9w0g4aVmcndhahrpkd4wWoUko=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  buildInputs = [
+    applet-window-buttons
+    karchive
+    kcoreaddons
+    ki18n
+    kio
+    kirigami2
+    mauikit
+    mauikit-filebrowsing
+    qtmultimedia
+    qtquickcontrols2
+    taglib
+    ffmpeg
+  ];
+
+  meta = with lib; {
+    description = "Video player and video collection manager";
+    homepage = "https://invent.kde.org/maui/clip";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25366,6 +25366,8 @@ with pkgs;
 
   clightd = callPackage ../applications/misc/clight/clightd.nix { };
 
+  clip = libsForQt5.callPackage ../applications/video/clip { };
+
   clipgrab = libsForQt5.callPackage ../applications/video/clipgrab { };
 
   clipcat = callPackage ../applications/misc/clipcat { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds the convergent app [clip](https://invent.kde.org/maui/clip), a video viewer application based on [Mauikit](https://mauikit.org/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
