### PR TITLE
ombi: 4.0.1468 -> 4.3.3

### DIFF
--- a/pkgs/servers/ombi/default.nix
+++ b/pkgs/servers/ombi/default.nix
@@ -10,14 +10,14 @@ let
     "Unsupported system: ${stdenv.hostPlatform.system}");
 
   hash = {
-    x64-linux_hash = "sha256-4kvcBRMMH4AnTKSES5Cpst/omTRXVRq1V1y/z5njKJI=";
-    arm64-linux_hash = "sha256-NLsf0ldvlKSrHJyAXv5Ar2zIetoga6iZPOGTxFOqoQQ=";
-    x64-osx_hash = "sha256-tjvGuShz/fv3qUknFVKJ+tE/bVtIyPZ7dr4JfTEcDJY=";
+    x64-linux_hash = "sha256-BLtoT6UHsur+jFp4KBlE10/Z/V6RDy0k16H10IC98WQ=";
+    arm64-linux_hash = "sha256-s8EV/VqiUXWRTNxacx4sy6r+TIAqkqhESAYYa9s0uAQ=";
+    x64-osx_hash = "sha256-woXFYmX+499NTtWmmGBpZ12PxTUazJ8klA6IPQIDjLE=";
   }."${arch}-${os}_hash";
 
 in stdenv.mkDerivation rec {
   pname = "ombi";
-  version = "4.0.1468";
+  version = "4.3.3";
 
   sourceRoot = ".";
 

--- a/pkgs/servers/ombi/update.sh
+++ b/pkgs/servers/ombi/update.sh
@@ -15,7 +15,7 @@ updateHash()
 
     url="https://github.com/Ombi-app/Ombi/releases/download/v$version/$os-$arch.tar.gz"
     hash=$(nix-prefetch-url --type sha256 $url)
-    sriHash="$(nix hash to-sri --type sha256 $hash)"
+    sriHash="$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $hash)"
 
     sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
 }

--- a/pkgs/servers/ombi/update.sh
+++ b/pkgs/servers/ombi/update.sh
@@ -15,7 +15,7 @@ updateHash()
 
     url="https://github.com/Ombi-app/Ombi/releases/download/v$version/$os-$arch.tar.gz"
     hash=$(nix-prefetch-url --type sha256 $url)
-    sriHash="$(nix to-sri --type sha256 $hash)"
+    sriHash="$(nix hash to-sri --type sha256 $hash)"
 
     sed -i "s|$hashKey = \"[a-zA-Z0-9\/+-=]*\";|$hashKey = \"$sriHash\";|g" "$dirname/default.nix"
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
