### PR TITLE
mesa: 21.3.3 -> 21.3.4

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -33,7 +33,7 @@ with lib;
 let
   # Release calendar: https://www.mesa3d.org/release-calendar.html
   # Release frequency: https://www.mesa3d.org/releasing.html#schedule
-  version = "21.3.3";
+  version = "21.3.4";
   branch  = versions.major version;
 
 self = stdenv.mkDerivation {
@@ -47,18 +47,20 @@ self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
     ];
-    sha256 = "08c118j440xpfbjjxmwzm6dfnv4y35q540mmzkchhpbwx89lczxd";
+    sha256 = "0zd6skf9qcwlk1k1ljgwijwlyz5si3pgi0h97gd6kkivm7a4y43p";
   };
 
   # TODO:
   #  revive ./dricore-gallium.patch when it gets ported (from Ubuntu), as it saved
   #  ~35 MB in $drivers; watch https://launchpad.net/ubuntu/+source/mesa/+changelog
   patches = [
-    # fixes pkgsMusl.mesa build
+    # To fix flickering on Intel GPUs (iris), see https://github.com/NixOS/nixpkgs/issues/153377:
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/b9f58f303ae23754c95d5d1fe87a98b5a2d8f271/srcpkgs/mesa/patches/musl.patch";
-      sha256 = "sha256-Jyl7ILLhn8hBJG7afnEjE8H56Wz/1bxkvlqfrXK5U7I=";
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/07dc3d4238e57901ccf98e0b506d9aad2c86b9d9.diff";
+      sha256 = "sha256-3fa1qHJes3x1/iXsxfjgy9HnEGlOyFtJatSkU1a3XDI=";
     })
+    # fixes pkgsMusl.mesa build
+    ./musl.patch
     (fetchpatch {
       url = "https://raw.githubusercontent.com/void-linux/void-packages/b9f58f303ae23754c95d5d1fe87a98b5a2d8f271/srcpkgs/mesa/patches/musl-endian.patch";
       sha256 = "sha256-eRc91qCaFlVzrxFrNUPpAHd1gsqKsLCCN0IW8pBQcqk=";

--- a/pkgs/development/libraries/mesa/musl.patch
+++ b/pkgs/development/libraries/mesa/musl.patch
@@ -1,0 +1,59 @@
+diff --git a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
+index 06ca90564f0..bb244f8f358 100644
+--- a/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
++++ b/src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
+@@ -30,6 +30,7 @@
+ 
+ #include <amdgpu.h>
+ #include <pthread.h>
++#include <sys/types.h>
+ #include "util/list.h"
+ #include "util/rwlock.h"
+ #include "ac_gpu_info.h"
+diff --git a/src/gallium/drivers/freedreno/freedreno_util.h b/src/gallium/drivers/freedreno/freedreno_util.h
+index 22f99c41909..2f3195926be 100644
+--- a/src/gallium/drivers/freedreno/freedreno_util.h
++++ b/src/gallium/drivers/freedreno/freedreno_util.h
+@@ -108,6 +108,8 @@ extern bool fd_binning_enabled;
+ #include <sys/types.h>
+ #include <sys/syscall.h>
+ 
++#define gettid() ((pid_t)syscall(SYS_gettid))
++
+ #define DBG(fmt, ...)                                                          \
+    do {                                                                        \
+       if (FD_DBG(MSGS))                                                        \
+diff --git a/src/gallium/frontends/nine/nine_debug.c b/src/gallium/frontends/nine/nine_debug.c
+index f3a6a945025..f4a6c41a612 100644
+--- a/src/gallium/frontends/nine/nine_debug.c
++++ b/src/gallium/frontends/nine/nine_debug.c
+@@ -65,7 +65,7 @@ _nine_debug_printf( unsigned long flag,
+ {
+     static boolean first = TRUE;
+     static unsigned long dbg_flags = DBG_ERROR | DBG_WARN;
+-    unsigned long tid = 0;
++    pthread_t tid = 0;
+ 
+     if (first) {
+         first = FALSE;
+@@ -74,7 +74,7 @@ _nine_debug_printf( unsigned long flag,
+ 
+ #if defined(HAVE_PTHREAD)
+     if (dbg_flags & DBG_TID)
+-        tid = (unsigned long)pthread_self();
++        tid = pthread_self();
+ #endif
+ 
+     if (dbg_flags & flag) {
+diff --git a/src/util/rand_xor.c b/src/util/rand_xor.c
+index 81b64f1ea71..56ebd2eccdf 100644
+--- a/src/util/rand_xor.c
++++ b/src/util/rand_xor.c
+@@ -28,6 +28,7 @@
+ #if defined(HAVE_GETRANDOM)
+ #include <sys/random.h>
+ #endif
++#include <sys/types.h>         /* size_t, ssize_t */
+ #include <unistd.h>
+ #include <fcntl.h>
+ #endif


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
