### PR TITLE
nixos/nscd: start in early boot

### DIFF
--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -50,11 +50,19 @@ in
     systemd.services.nscd =
       { description = "Name Service Cache Daemon";
 
-        before = [ "nss-lookup.target" "nss-user-lookup.target" ];
-        wants = [ "nss-lookup.target" "nss-user-lookup.target" ];
-        wantedBy = [ "multi-user.target" ];
-
         environment = { LD_LIBRARY_PATH = nssModulesPath; };
+
+        # We need system users to be resolveable in late-boot.  nscd is the proxy between
+        # nss-modules in NixOS and thus if you have nss-modules providing system users
+        # (e.g. when using DynamicUser) then nscd needs to be available before late-boot is ready
+        # We add a dependency of sysinit.target to nscd to ensure
+        # these units are started after nscd is fully started.
+        unitConfig.DefaultDependencies = false;
+        wantedBy = [ "sysinit.target" ];
+        before = [ "sysinit.target" "shutdown.target" ];
+        conflicts = [ "shutdown.target" ];
+        wants = [ "local-fs.target" ];
+        after = [ "local-fs.target" ];
 
         restartTriggers = [
           config.environment.etc.hosts.source
@@ -68,20 +76,19 @@ in
         # privileges after all the NSS modules have read their configuration
         # files. So prefix the ExecStart command with "!" to prevent systemd
         # from dropping privileges early. See ExecStart in systemd.service(5).
-        serviceConfig =
-          { ExecStart = "!@${nscd}/sbin/nscd nscd";
-            Type = "forking";
-            DynamicUser = true;
-            RuntimeDirectory = "nscd";
-            PIDFile = "/run/nscd/nscd.pid";
-            Restart = "always";
-            ExecReload =
-              [ "${nscd}/sbin/nscd --invalidate passwd"
-                "${nscd}/sbin/nscd --invalidate group"
-                "${nscd}/sbin/nscd --invalidate hosts"
-              ];
-          };
+        serviceConfig = {
+          ExecStart = "!@${nscd}/sbin/nscd nscd";
+          Type = "forking";
+          DynamicUser = true;
+          RuntimeDirectory = "nscd";
+          PIDFile = "/run/nscd/nscd.pid";
+          Restart = "always";
+          ExecReload = [
+            "${nscd}/sbin/nscd --invalidate passwd"
+            "${nscd}/sbin/nscd --invalidate group"
+            "${nscd}/sbin/nscd --invalidate hosts"
+          ];
+        };
       };
-
   };
 }


### PR DESCRIPTION
Services that have dynamic users require nscd to resolve users
via pam_systemd. Those services might not even create
their own dynamic users itself i.e. iptables.
To make sure nscd is always started when this is happening we move
nscd to sysinit.target and make sure that it is always started before
starting/reloading/restarting any other service.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This pr was original opened here: https://github.com/NixOS/nixpkgs/pull/106336

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
