### PR TITLE
more terraform cleanup

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -7,34 +7,40 @@
 , cdrtools # libvirt
 }:
 let
-  list = lib.importJSON ./providers.json;
-
-  buildWithGoModule = data:
+  # Our generic constructor to build new providers.
+  #
+  # Is designed to combine with the terraform.withPlugins implementation.
+  mkProvider =
+    { owner
+    , repo
+    , rev
+    , version
+    , sha256
+    , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
+    , deleteVendor ? false
+    , proxyVendor ? false
+    , provider-source-address
+    }@attrs:
     buildGoModule {
-      pname = data.repo;
-      inherit (data) vendorSha256 version;
+      pname = repo;
+      inherit vendorSha256 version deleteVendor proxyVendor;
       subPackages = [ "." ];
       doCheck = false;
       # https://github.com/hashicorp/terraform-provider-scaffolding/blob/a8ac8375a7082befe55b71c8cbb048493dd220c2/.goreleaser.yml
       # goreleaser (used for builds distributed via terraform registry) requires that CGO is disabled
       CGO_ENABLED = 0;
-      ldflags = [ "-s" "-w" "-X main.version=${data.version}" "-X main.commit=${data.rev}" ];
+      ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${rev}" ];
       src = fetchFromGitHub {
-        inherit (data) owner repo rev sha256;
+        inherit owner repo rev sha256;
       };
-      deleteVendor = data.deleteVendor or false;
-      proxyVendor = data.proxyVendor or false;
 
       # Terraform allow checking the provider versions, but this breaks
       # if the versions are not provided via file paths.
-      postBuild = "mv $NIX_BUILD_TOP/go/bin/${data.repo}{,_v${data.version}}";
-      passthru = data;
+      postBuild = "mv $NIX_BUILD_TOP/go/bin/${repo}{,_v${version}}";
+      passthru = attrs;
     };
 
-  # Our generic constructor to build new providers
-  mkProvider = attrs:
-    (if (lib.hasAttr "vendorSha256" attrs) then buildWithGoModule else throw /* added 2022/01 */ "vendorSha256 missing: please use `buildGoModule`")
-      attrs;
+  list = lib.importJSON ./providers.json;
 
   # These providers are managed with the ./update-all script
   automated-providers = lib.mapAttrs (_: attrs: mkProvider attrs) list;

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -40,49 +40,58 @@ let
   automated-providers = lib.mapAttrs (_: attrs: mkProvider attrs) list;
 
   # These are the providers that don't fall in line with the default model
-  special-providers = let archived = throw "the provider has been archived by upstream"; in {
-    # Packages that don't fit the default model
-    gandi = callPackage ./gandi { };
-    # mkisofs needed to create ISOs holding cloud-init data,
-    # and wrapped to terraform via deecb4c1aab780047d79978c636eeb879dd68630
-    libvirt = automated-providers.libvirt.overrideAttrs (_: { propagatedBuildInputs = [ cdrtools ]; });
-    teleport = callPackage ./teleport { };
-    vpsadmin = callPackage ./vpsadmin { };
-  } // (lib.optionalAttrs (config.allowAliases or false) {
-    arukas = archived; # added 2022/01
-    bitbucket = archived; # added 2022/01
-    chef = archived; # added 2022/01
-    cherryservers = archived; # added 2022/01
-    clc = archived; # added 2022/01
-    cloudstack = throw "removed from nixpkgs"; # added 2022/01
-    cobbler = archived; # added 2022/01
-    cohesity = archived; # added 2022/01
-    dyn = archived; # added 2022/01
-    genymotion = archived; # added 2022/01
-    hedvig = archived; # added 2022/01
-    ignition = archived; # added 2022/01
-    incapsula = archived; # added 2022/01
-    influxdb = archived; # added 2022/01
-    jdcloud = archived; # added 2022/01
-    kubernetes-alpha = throw "This has been merged as beta into the kubernetes provider. See https://www.hashicorp.com/blog/beta-support-for-crds-in-the-terraform-provider-for-kubernetes for details";
-    librato = archived; # added 2022/01
-    logentries = archived; # added 2022/01
-    metalcloud = archived; # added 2022/01
-    mysql = archived; # added 2022/01
-    nixos = archived; # added 2022/01
-    oneandone = archived; # added 2022/01
-    packet = archived; # added 2022/01
-    profitbricks = archived; # added 2022/01
-    pureport = archived; # added 2022/01
-    rancher = archived; # added 2022/01
-    rightscale = archived; # added 2022/01
-    runscope = archived; # added 2022/01
-    segment = throw "removed from nixpkgs"; # added 2022/01
-    softlayer = archived; # added 2022/01
-    telefonicaopencloud = archived; # added 2022/01
-    terraform = archived; # added 2022/01
-    ultradns = archived; # added 2022/01
-    vthunder = throw "provider was renamed to thunder"; # added 2022/01
-  });
+  special-providers =
+    {
+      # Packages that don't fit the default model
+      gandi = callPackage ./gandi { };
+      # mkisofs needed to create ISOs holding cloud-init data,
+      # and wrapped to terraform via deecb4c1aab780047d79978c636eeb879dd68630
+      libvirt = automated-providers.libvirt.overrideAttrs (_: { propagatedBuildInputs = [ cdrtools ]; });
+      teleport = callPackage ./teleport { };
+      vpsadmin = callPackage ./vpsadmin { };
+    };
+
+  # Put all the providers we not longer support in this list.
+  removed-providers =
+    let
+      archived = date: throw "the provider has been archived by upstream on ${date}";
+      removed = date: throw "removed from nixpkgs on ${date}";
+    in
+    lib.optionalAttrs (config.allowAliases or false) {
+      arukas = archived "2022/01";
+      bitbucket = archived "2022/01";
+      chef = archived "2022/01";
+      cherryservers = archived "2022/01";
+      clc = archived "2022/01";
+      cloudstack = removed "2022/01";
+      cobbler = archived "2022/01";
+      cohesity = archived "2022/01";
+      dyn = archived "2022/01";
+      genymotion = archived "2022/01";
+      hedvig = archived "2022/01";
+      ignition = archived "2022/01";
+      incapsula = archived "2022/01";
+      influxdb = archived "2022/01";
+      jdcloud = archived "2022/01";
+      kubernetes-alpha = throw "This has been merged as beta into the kubernetes provider. See https://www.hashicorp.com/blog/beta-support-for-crds-in-the-terraform-provider-for-kubernetes for details";
+      librato = archived "2022/01";
+      logentries = archived "2022/01";
+      metalcloud = archived "2022/01";
+      mysql = archived "2022/01";
+      nixos = archived "2022/01";
+      oneandone = archived "2022/01";
+      packet = archived "2022/01";
+      profitbricks = archived "2022/01";
+      pureport = archived "2022/01";
+      rancher = archived "2022/01";
+      rightscale = archived "2022/01";
+      runscope = archived "2022/01";
+      segment = removed "2022/01";
+      softlayer = archived "2022/01";
+      telefonicaopencloud = archived "2022/01";
+      terraform = archived "2022/01";
+      ultradns = archived "2022/01";
+      vthunder = throw "provider was renamed to thunder on 2022/01";
+    };
 in
-automated-providers // special-providers // { inherit mkProvider; }
+automated-providers // special-providers // removed-providers // { inherit mkProvider; }

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -160,20 +160,6 @@ rec {
   # Constructor for other terraform versions
   mkTerraform = attrs: pluggable (generic attrs);
 
-  terraform_0_12 = mkTerraform {
-    version = "0.12.31";
-    sha256 = "03p698xdbk5gj0f9v8v1fpd74zng3948dyy4f2hv7zgks9hid7fg";
-    patches = [
-      ./provider-path.patch
-      (fetchpatch {
-        name = "fix-mac-mojave-crashes.patch";
-        url = "https://github.com/hashicorp/terraform/commit/cd65b28da051174a13ac76e54b7bb95d3051255c.patch";
-        sha256 = "1k70kk4hli72x8gza6fy3vpckdm3sf881w61fmssrah3hgmfmbrs";
-      })
-    ];
-    passthru = { inherit plugins; };
-  };
-
   terraform_0_13 = mkTerraform {
     version = "0.13.7";
     sha256 = "1cahnmp66dk21g7ga6454yfhaqrxff7hpwpdgc87cswyq823fgjn";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -972,6 +972,7 @@ mapAliases ({
   telepathy_salut = telepathy-salut; # added 2018-02-25
   telnet = inetutils; # added 2018-05-15
   terminus = throw "terminus has been removed, it was unmaintained in nixpkgs"; # added 2021-08-21
+  terraform_0_12 = throw "terraform_0_12 has been removed from nixpkgs on 2021/01";
   terraform_1_0_0 = throw "terraform_1_0_0 has been renamed to terraform_1"; # added 2021-06-15
   terraform_1_0 = throw "terraform_1_0 has been renamed to terraform_1"; # added 2021-12-08
   terraform-provider-ibm = terraform-providers.ibm; # added 2018-09-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33589,7 +33589,6 @@ with pkgs;
     buildGoModule = buildGo117Module;
   })
     mkTerraform
-    terraform_0_12
     terraform_0_13
     terraform_0_14
     terraform_0_15


### PR DESCRIPTION
###### Motivation for this change

Clean and remove old code. Prepare to make it compatible with [nixpkgs-terraform-providers-bin](https://github.com/numtide/nixpkgs-terraform-providers-bin)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).