### PR TITLE
python3Packages.testfixtures: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/connexion/default.nix
+++ b/pkgs/development/python-modules/connexion/default.nix
@@ -7,7 +7,6 @@
 , clickclick
 , decorator
 , fetchFromGitHub
-, fetchpatch
 , flask
 , inflection
 , jsonschema
@@ -23,14 +22,16 @@
 
 buildPythonPackage rec {
   pname = "connexion";
-  version = "2.9.0";
+  version = "2.10.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "zalando";
     repo = pname;
     rev = version;
-    sha256 = "13smcg2w24zr2sv1968g9p9m6f18nqx688c96qdlmldnszgzf5ik";
+    sha256 = "sha256-a1wj72XpjXvhWCxRLrGeDatS8a4ij9YAm9FGhTBq/i8=";
   };
 
   propagatedBuildInputs = [
@@ -55,16 +56,20 @@ buildPythonPackage rec {
     testfixtures
   ];
 
-  patches = [
-    # No minor release for later versions, https://github.com/zalando/connexion/pull/1402
-    (fetchpatch {
-      name = "allow-later-flask-and-werkzeug-releases.patch";
-      url = "https://github.com/zalando/connexion/commit/4a225d554d915fca17829652b7cb8fe119e14b37.patch";
-      sha256 = "0dys6ymvicpqa3p8269m4yv6nfp58prq3fk1gcx1z61h9kv84g1k";
-    })
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "PyYAML>=5.1,<6" "PyYAML>=5.1" \
+      --replace "jsonschema>=2.5.1,<4" "jsonschema>=2.5.1"
+  '';
+
+  disabledTests = [
+    # We have a later PyYAML release
+    "test_swagger_yaml"
   ];
 
-  pythonImportsCheck = [ "connexion" ];
+  pythonImportsCheck = [
+    "connexion"
+  ];
 
   meta = with lib; {
     description = "Swagger/OpenAPI First framework on top of Flask";

--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -1,9 +1,10 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
 , mock
 , pytestCheckHook
+, pythonAtLeast
+, pythonOlder
 , sybil
 , twisted
 , zope_component
@@ -12,6 +13,9 @@
 buildPythonPackage rec {
   pname = "testfixtures";
   version = "6.18.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -19,29 +23,42 @@ buildPythonPackage rec {
   };
 
   checkInputs = [
-    pytestCheckHook
     mock
+    pytestCheckHook
     sybil
-    zope_component
     twisted
+    zope_component
   ];
-
-  doCheck = !isPy27;
 
   disabledTestPaths = [
     # Django is too much hasle to setup at the moment
     "testfixtures/tests/test_django"
   ];
 
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    # https://github.com/simplistix/testfixtures/issues/168
+    "test_invalid_communicate_call"
+    "test_invalid_kill"
+    "test_invalid_parameters"
+    "test_invalid_poll"
+    "test_invalid_send_signal"
+    "test_invalid_terminate"
+    "test_invalid_wait_call"
+    "test_replace_delattr_cant_remove"
+    "test_replace_delattr_cant_remove_not_strict"
+  ];
+
   pytestFlagsArray = [
     "testfixtures/tests"
   ];
 
-  pythonImportsCheck = [ "testfixtures" ];
+  pythonImportsCheck = [
+    "testfixtures"
+  ];
 
   meta = with lib; {
+    description = "Collection of helpers and mock objects for unit tests and doc tests";
     homepage = "https://github.com/Simplistix/testfixtures";
-    description = "A collection of helpers and mock objects for unit tests and doc tests";
     license = licenses.mit;
     maintainers = with maintainers; [ siriobalmelli ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/164070798)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
