### PR TITLE
rivercarro: init at 0.1.1

### DIFF
--- a/pkgs/applications/misc/rivercarro/default.nix
+++ b/pkgs/applications/misc/rivercarro/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, zig
+, river
+, wayland
+, pkg-config
+, scdoc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rivercarro";
+  version = "0.1.1";
+
+  src = fetchFromSourcehut {
+    owner = "~novakane";
+    repo = pname;
+    fetchSubmodules = true;
+    rev = "v${version}";
+    sha256 = "0h1wvl6rlrpr67zl51x71hy7nwkfd5kfv5p2mql6w5fybxxyqnpm";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    river
+    scdoc
+    wayland
+    zig
+  ];
+
+  dontConfigure = true;
+
+  preBuild = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    zig build -Drelease-safe -Dcpu=baseline -Dman-pages --prefix $out install
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://git.sr.ht/~novakane/rivercarro";
+    description = "A layout generator for river Wayland compositor, fork of rivertile";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kraem ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3600,6 +3600,8 @@ with pkgs;
     zig = zig_0_8_1;
   };
 
+  rivercarro = callPackage ../applications/misc/rivercarro { };
+
   rmapi = callPackage ../applications/misc/remarkable/rmapi { };
 
   rmview = libsForQt5.callPackage ../applications/misc/remarkable/rmview { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
