### PR TITLE
extlinux-conf-builder: specialisations entries

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -141,7 +141,13 @@ if [ "$numGenerations" -gt 0 ]; then
             | sort -n -r \
             | head -n $numGenerations); do
         link=/nix/var/nix/profiles/system-$generation-link
-        addEntry $link $generation
+        addEntry $link "${generation}-default"
+        for specialisation in $(
+            ls /nix/var/nix/profiles/system-$generation-link/specialisation \
+            | sort -n -r); do
+            link=/nix/var/nix/profiles/system-$generation-link/specialisation/$specialisation
+            addEntry $link "${generation}-${specialisation}"
+        done
     done >> $tmpFile
 fi
 


### PR DESCRIPTION
###### Motivation for this change

Add entries to the generated extlinux config for sub-generations (specialisations).

Example output after this commit:

```                                                                                
Retrieving file: /extlinux/extlinux.conf                                                                                         
10981 bytes read in 1 ms (10.5 MiB/s)                                                                                            
------------------------------------------------------------                                                                     
1:      NixOS - Default                                                                                                          
2:      NixOS - Configuration 334-default (2022-01-13 15:07 - 22.05.20220113.dirty)                                              
3:      NixOS - Configuration 334-foundation (2022-01-13 13:46 - 22.05pre-git)                                                   
4:      NixOS - Configuration 333-default (2022-01-13 15:03 - 22.05.20220113.dirty)                                              
5:      NixOS - Configuration 333-foundation (2022-01-13 13:46 - 22.05pre-git)                                                   
6:      NixOS - Configuration 332-default (2022-01-13 14:59 - 22.05.20220113.dirty)                                              
7:      NixOS - Configuration 332-foundation (2022-01-13 13:46 - 22.05pre-git)                                                   
8:      NixOS - Configuration 331-default (2022-01-13 14:52 - 22.05.20220113.dirty)                                              
9:      NixOS - Configuration 331-foundation (2022-01-13 13:46 - 22.05pre-git)                                                   
10:     NixOS - Configuration 330-default (2022-01-13 13:56 - 22.05.20220113.c9d0820)                                            
11:     NixOS - Configuration 330-foundation (2022-01-13 13:56 - 22.05pre-git)                                                   
12:     NixOS - Configuration 329-default (2022-01-13 13:46 - 22.05.20220113.c9d0820)                                            
13:     NixOS - Configuration 329-foundation (2022-01-13 13:46 - 22.05pre-git)                                                   
14:     NixOS - Configuration 328-default (2022-01-13 13:12 - 22.05.20220113.c9d0820)                                            
15:     NixOS - Configuration 328-foundation (2022-01-13 13:06 - 22.05pre-git)                                                   
```

Particularly, this shows a "foundation" specialisation that represents a different kernel configuration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
