### PR TITLE
firejail: fix examples

### DIFF
--- a/nixos/modules/programs/firejail.nix
+++ b/nixos/modules/programs/firejail.nix
@@ -40,7 +40,7 @@ in {
           executable = mkOption {
             type = types.path;
             description = "Executable to run sandboxed";
-            example = literalExpression ''"''${lib.getBin pkgs.firefox}/bin/firefox"'';
+            example = literalExpression ''"''${pkgs.lib.getBin pkgs.firefox}/bin/firefox"'';
           };
           profile = mkOption {
             type = types.nullOr types.path;
@@ -60,11 +60,11 @@ in {
       example = literalExpression ''
         {
           firefox = {
-            executable = "''${lib.getBin pkgs.firefox}/bin/firefox";
+            executable = "''${pkgs.lib.getBin pkgs.firefox}/bin/firefox";
             profile = "''${pkgs.firejail}/etc/firejail/firefox.profile";
           };
           mpv = {
-            executable = "''${lib.getBin pkgs.mpv}/bin/mpv";
+            executable = "''${pkgs.lib.getBin pkgs.mpv}/bin/mpv";
             profile = "''${pkgs.firejail}/etc/firejail/mpv.profile";
           };
         }


### PR DESCRIPTION
pkgs is not always global in the nix configuration file

###### Motivation for this change

In a relatively default configuration.nix file, the snippets found in configuration.nix man page are not working because `pkgs` is not "global".

```
error: undefined variable 'lib'
       at /etc/nixos/configuration.nix:25:27:
           24|       firefox = {
           25|           executable = "${lib.getBin pkgs.firefox}/bin/firefox";
             |                           ^
           26|           profile = "${pkgs.firejail}/etc/firejail/firefox.profile";
       … while evaluating 'isFunction'
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
