### PR TITLE
dog-dns: init at unstable-2021-10-07

### DIFF
--- a/pkgs/tools/networking/dog-dns/default.nix
+++ b/pkgs/tools/networking/dog-dns/default.nix
@@ -1,0 +1,40 @@
+{ rustPlatform, fetchFromGitHub, lib, openssl, pkg-config, just, pandoc, installShellFiles }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "dog-dns";
+  version = "unstable-2021-10-07";
+
+  src = fetchFromGitHub {
+    owner = "ogham";
+    repo = "dog";
+    rev = "721440b12ef01a812abe5dc6ced69af6e221fad5";
+    sha256 = "sha256-y3T0vXg7631FZ4bzcbQjz3Buui/DFxh9LG8BZWwynp0=";
+  };
+
+  cargoSha256 = "sha256-3SiTA9MQ73laaURKWi+w30aH845iFiUCBS0t/UZe5jg=";
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ pkg-config just pandoc installShellFiles ];
+  buildInputs = [ openssl ];
+
+  postBuild = ''
+    just man
+  '';
+
+  postInstall = ''
+    installManPage ./target/man/*.1
+
+    for sh in bash zsh fish; do
+      installShellCompletion --cmd dog ./completions/dog."$sh"
+    done
+  '';
+
+  meta = with lib; {
+    description = "A command-line DNS client";
+    homepage = "https://github.com/ogham/dog";
+    license = licenses.eupl12;
+    maintainers = with maintainers; [ ma27 ];
+    mainProgram = "dog";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20864,6 +20864,8 @@ with pkgs;
   dnsutils = bind.dnsutils;
   dig = bind.dnsutils;
 
+  dog-dns = callPackage ../tools/networking/dog-dns { };
+
   inherit (callPackages ../servers/bird { })
     bird bird6 bird2;
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Basically a DNS lookup tool like `dig(1)`, but with a nicer, colorful
CLI interface[1].

I decided against using the latest stable release v0.1.0[2] and go for
`master` instead as it contains some useful fixes such as support for
underscores - useful for e.g. `_domainkey`-TXT records[3] - or
parser-issues for TCP responses[4].

Please note that I named it `pkgs.dog-dns` on purpose as it'd otherwise
collide with `pkgs.dog`, a `cat(1)` replacement[5], even though it seems
somewhat unmaintained. For that reason I decided to keep calling the
executable inside the package `dog`.

[1] https://dns.lookup.dog/ / https://github.com/ogham/dog
[2] https://github.com/ogham/dog/releases/tag/v0.1.0
[3] https://github.com/ogham/dog/commit/8bccd7536f0dfd4d3949175a8c652d833124be6c
[4] https://github.com/ogham/dog/commit/0094d7b6f6713c2e2293ce18c6cf1c611767a47b
[5] https://lwn.net/Articles/421072/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
