### PR TITLE
python310Packages.cssutils: fix tests

### DIFF
--- a/pkgs/development/python-modules/cssutils/default.nix
+++ b/pkgs/development/python-modules/cssutils/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , pythonOlder
+, fetchpatch
 , fetchPypi
 , setuptools-scm
 , toml
@@ -21,6 +23,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-stOxYEfKroLlxZADaTW6+htiHPRcLziIWvS+SDjw/QA=";
   };
+
+  patches = lib.optionals (pythonAtLeast "3.10") [
+    # fix tests for python3.10
+    (fetchpatch {
+      url = "https://github.com/jaraco/cssutils/pull/17/commits/355b1795dde77bd4b49d8df35377230fdb503802.patch";
+      sha256 = "sha256-hwe8oeZO2rq00cs079lje3wjQDEczAu3Tfy/X/M9+GQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     setuptools-scm


### PR DESCRIPTION
###### Motivation for this change
spotted in #154947

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
