### PR TITLE
python3Packages.pygal: 2.4.0 -> 3.0.0

### DIFF
--- a/pkgs/development/python-modules/pygal/default.nix
+++ b/pkgs/development/python-modules/pygal/default.nix
@@ -15,22 +15,14 @@
 
 buildPythonPackage rec {
   pname = "pygal";
-  version = "2.4.0";
+  version = "3.0.0";
 
   doCheck = !isPyPy; # one check fails with pypy
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9204f05380b02a8a32f9bf99d310b51aa2a932cba5b369f7a4dc3705f0a4ce83";
+    sha256 = "sha256-KSP5XS5RWTCqWplyGdzO+/PZK36vX8HJ/ruVsJk1/bI=";
   };
-  patches = [
-    # Fixes compatibility with latest pytest. October 12, 2020.
-    # Should be included in the next release after 2.4.0
-    (fetchpatch {
-      url = "https://github.com/Kozea/pygal/commit/19e5399be18a054b3b293f4a8a2777d2df4f9c18.patch";
-      sha256 = "1j0hpcvd2mhi449wmlr0ml9gw4cakqk3av1j79bi2qy86dyrss2l";
-    })
-  ];
 
   buildInputs = [
     flask


### PR DESCRIPTION
###### Motivation for this change
failing build spotted in #154961

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
