### PR TITLE
[21.11] python3Packages.pillow: add patches for CVE-2022-22815 CVE-2022-22816 CVE-2022-22817

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k
+{ lib, stdenv, buildPythonPackage, fetchPypi, isPyPy, isPy3k, fetchpatch
 , defusedxml, olefile, freetype, libjpeg, zlib, libtiff, libwebp, tcl, lcms2, tk, libX11
 , libxcb, openjpeg, libimagequant, pyroma, numpy, pytestCheckHook
 }@args:
@@ -13,6 +13,25 @@ import ./generic.nix (rec {
     inherit pname version;
     sha256 = "1361y215ydmdh4il1vay5831aqivmpwgzjqrphqjdiq0ipnz7qyx";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-22815.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/1e092419b6806495c683043ab3feb6ce264f3b9c.patch";
+      sha256 = "1mafa8ixh4a4nh98yjp7dhh68kk4sxbzjm468h9gjba0py8657rd";
+    })
+    (fetchpatch {
+      name = "CVE-2022-22816.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/c48271ab354db49cdbd740bc45e13be4f0f7993c.patch";
+      sha256 = "1jr25918lxqljswv1jc7m3nn370xrz0l7g39lbyh5ndjz1dmnpvv";
+    })
+    (fetchpatch {
+      name = "CVE-2022-22817.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/8531b01d6cdf0b70f256f93092caa2a5d91afc11.patch";
+      excludes = [ "docs/releasenotes/9.0.0.rst" ];
+      sha256 = "13va7lmja9bkp1d8bnwpns9nh7p31kal89cvfky4r95lx0ckrnfv";
+    })
+  ];
 
   meta = with lib; {
     homepage = "https://python-pillow.org/";

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -3,13 +3,14 @@
 , disabled
 , src
 , meta
+, patches ? []
 , ...
 }@args:
 
 with args;
 
 buildPythonPackage rec {
-  inherit pname version src meta;
+  inherit pname version src meta patches;
 
   # Disable imagefont tests, because they don't work well with infinality:
   # https://github.com/python-pillow/Pillow/issues/1259


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-22815
https://nvd.nist.gov/vuln/detail/CVE-2022-22816
https://nvd.nist.gov/vuln/detail/CVE-2022-22817

See #154825 for master.

Patches are quite trivial and come with tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
