### PR TITLE
waterfox: init at G4.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13666,4 +13666,15 @@
       fingerprint = "3586 3350 BFEA C101 DB1A 4AF0 1F81 112D 62A9 ADCE";
     }];
   };
+  jcdickinson = {
+    name = "Jonathan Dickinson";
+    email = "oss@jonathan.dickinson.id";
+    matrix = "@jonathan:dickinson.id";
+    github = "jcdickinson";
+    githubId = 522465;
+    keys = [{
+      longkeyid = "ed25519/509F0352FA9D7E45";
+      fingerprint = "4B01 D0E1 FC12 D8AF 737E  60A0 509F 0352 FA9D 7E45";
+    }];
+  };
 }

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -564,6 +564,11 @@
           </listitem>
         </itemizedlist>
       </listitem>
+      <listitem>
+        <para>
+          The <literal>waterfox-bin</literal> package has been added.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -189,3 +189,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The `zrepl` package has been updated from 0.4.0 to 0.5:
     * The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.
     * A bug involving encrypt-on-receive has been fixed.  Read the [zrepl documentation](https://zrepl.github.io/configuration/sendrecvoptions.html#job-recv-options-placeholder) and check the output of `zfs get -r encryption,zrepl:placeholder PATH_TO_ROOTFS` on the receiver.
+
+- The `waterfox-bin` package has been added.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -514,6 +514,7 @@ in
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
   vscodium = discoverTests (import ./vscodium.nix);
   wasabibackend = handleTest ./wasabibackend.nix {};
+  waterfox = handleText ./waterfox.nix {};
   wiki-js = handleTest ./wiki-js.nix {};
   wireguard = handleTest ./wireguard {};
   without-nix = handleTest ./without-nix.nix {};

--- a/nixos/tests/waterfox.nix
+++ b/nixos/tests/waterfox.nix
@@ -1,0 +1,116 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "waterfox";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ jcdickinson ];
+  };
+
+  machine =
+    { pkgs, ... }:
+
+    { imports = [ ./common/x11.nix ];
+      environment.systemPackages = [
+        pkgs.waterfox-bin
+        pkgs.xdotool
+      ];
+
+      # Create a virtual sound device, with mixing
+      # and all, for recording audio.
+      boot.kernelModules = [ "snd-aloop" ];
+      sound.enable = true;
+      sound.extraConfig = ''
+        pcm.!default {
+          type plug
+          slave.pcm pcm.dmixer
+        }
+        pcm.dmixer {
+          type dmix
+          ipc_key 1
+          slave {
+            pcm "hw:Loopback,0,0"
+            rate 48000
+            periods 128
+            period_time 0
+            period_size 1024
+            buffer_size 8192
+          }
+        }
+        pcm.recorder {
+          type hw
+          card "Loopback"
+          device 1
+          subdevice 0
+        }
+      '';
+
+      systemd.services.audio-recorder = {
+        description = "Record NixOS test audio to /tmp/record.wav";
+        script = "${pkgs.alsa-utils}/bin/arecord -D recorder -f S16_LE -r48000 /tmp/record.wav";
+      };
+
+    };
+
+  testScript = ''
+      from contextlib import contextmanager
+
+
+      @contextmanager
+      def audio_recording(machine: Machine) -> None:
+          """
+          Perform actions while recording the
+          machine audio output.
+          """
+          machine.systemctl("start audio-recorder")
+          yield
+          machine.systemctl("stop audio-recorder")
+
+
+      def wait_for_sound(machine: Machine) -> None:
+          """
+          Wait until any sound has been emitted.
+          """
+          machine.wait_for_file("/tmp/record.wav")
+          while True:
+              # Get at most 2M of the recording
+              machine.execute("tail -c 2M /tmp/record.wav > /tmp/last")
+              # Get the exact size
+              size = int(machine.succeed("stat -c '%s' /tmp/last").strip())
+              # Compare it against /dev/zero using `cmp` (skipping 50B of WAVE header).
+              # If some non-NULL bytes are found it returns 1.
+              status, output = machine.execute(
+                  f"cmp -i 50 -n {size - 50} /tmp/last /dev/zero 2>&1"
+              )
+              if status == 1:
+                  break
+              machine.sleep(2)
+
+
+      machine.wait_for_x()
+
+      with subtest("Wait until Waterfox has finished loading the Valgrind docs page"):
+          machine.execute(
+              "xterm -e 'waterfox file://${pkgs.valgrind.doc}/share/doc/valgrind/html/index.html' >&2 &"
+          )
+          machine.wait_for_window("Valgrind")
+          machine.sleep(40)
+
+      with subtest("Check whether Waterfox can play sound"):
+          with audio_recording(machine):
+              machine.succeed(
+                  "waterfox file://${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo/phone-incoming-call.oga >&2 &"
+              )
+              wait_for_sound(machine)
+          machine.copy_from_vm("/tmp/record.wav")
+
+      with subtest("Close sound test tab"):
+          machine.execute("xdotool key ctrl+w")
+
+      with subtest("Close default browser prompt"):
+          machine.execute("xdotool key space")
+
+      with subtest("Wait until Waterfox draws the developer tool panel"):
+          machine.sleep(10)
+          machine.succeed("xwininfo -root -tree | grep Valgrind")
+          machine.screenshot("screen")
+    '';
+
+})

--- a/pkgs/applications/networking/browsers/waterfox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/waterfox-bin/default.nix
@@ -1,0 +1,208 @@
+{ lib, stdenv, fetchurl, config, wrapGAppsHook
+, alsa-lib
+, atk
+, cairo
+, curl
+, cups
+, dbus-glib
+, dbus
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, glibc
+, gtk2
+, gtk3
+, libkrb5
+, libX11
+, libXScrnSaver
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrender
+, libXrandr
+, libXt
+, libXtst
+, libcanberra
+, libnotify
+, adwaita-icon-theme
+, libGLU, libGL
+, nspr
+, nss
+, pango
+, pipewire
+, pciutils
+, libheimdal
+, libpulseaudio
+, systemd
+, generated
+, writeScript
+, writeText
+, xidel
+, coreutils
+, gnused
+, gnugrep
+, gnupg
+, ffmpeg
+, runtimeShell
+, mesa
+, systemLocale ? config.i18n.defaultLocale or "en_US"
+}:
+
+let
+
+  inherit (generated) version sources;
+
+  waterfoxPlatforms = {
+    x86_64-linux = "linux-x86_64";
+  };
+
+  arch = waterfoxPlatforms.${stdenv.hostPlatform.system};
+
+  isPrefixOf = prefix: string:
+    builtins.substring 0 (builtins.stringLength prefix) string == prefix;
+
+  sourceMatches = locale: source:
+      (isPrefixOf source.locale locale) && source.arch == arch;
+
+  policies = {
+    DisableAppUpdate = true;
+  } // config.waterfox.policies or {};
+
+  policiesJson = writeText "waterfox-policies.json" (builtins.toJSON { inherit policies; });
+
+  defaultSource = lib.findFirst (sourceMatches "en-US") {} sources;
+
+  mozLocale =
+    if systemLocale == "ca_ES@valencia"
+    then "ca-valencia"
+    else lib.replaceStrings ["_"] ["-"] systemLocale;
+
+  source = lib.findFirst (sourceMatches mozLocale) defaultSource sources;
+
+  pname = "waterfox-bin-unwrapped";
+
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchurl { inherit (source) url sha256; };
+
+  libPath = lib.makeLibraryPath
+    [ stdenv.cc.cc
+      alsa-lib
+      atk
+      cairo
+      curl
+      cups
+      dbus-glib
+      dbus
+      fontconfig
+      freetype
+      gdk-pixbuf
+      glib
+      glibc
+      gtk2
+      gtk3
+      libkrb5
+      mesa
+      libX11
+      libXScrnSaver
+      libXcomposite
+      libXcursor
+      libxcb
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXinerama
+      libXrender
+      libXrandr
+      libXt
+      libXtst
+      libcanberra
+      libnotify
+      libGLU libGL
+      nspr
+      nss
+      pango
+      pipewire
+      pciutils
+      libheimdal
+      libpulseaudio
+      systemd
+      ffmpeg
+    ] + ":" + lib.makeSearchPathOutput "lib" "lib64" [
+      stdenv.cc.cc
+    ];
+
+  inherit gtk3;
+
+  buildInputs = [ wrapGAppsHook gtk3 adwaita-icon-theme ];
+
+  # "strip" after "patchelf" may break binaries.
+  # See: https://github.com/NixOS/patchelf/issues/10
+  dontStrip = true;
+  dontPatchELF = true;
+
+  patchPhase = ''
+    # Don't download updates from Waterfox directly
+    echo 'pref("app.update.auto", "false");' >> defaults/pref/channel-prefs.js
+  '';
+
+  installPhase =
+    ''
+      mkdir -p "$prefix/usr/lib/waterfox-bin-${version}"
+      cp -r * "$prefix/usr/lib/waterfox-bin-${version}"
+
+      mkdir -p "$out/bin"
+      ln -s "$prefix/usr/lib/waterfox-bin-${version}/waterfox" "$out/bin/"
+
+      for executable in \
+        waterfox waterfox-bin plugin-container \
+        updater crashreporter webapprt-stub
+      do
+        if [ -e "$out/usr/lib/waterfox-bin-${version}/$executable" ]; then
+          patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+            "$out/usr/lib/waterfox-bin-${version}/$executable"
+        fi
+      done
+
+      find . -executable -type f -exec \
+        patchelf --set-rpath "$libPath" \
+          "$out/usr/lib/waterfox-bin-${version}/{}" \;
+
+      # wrapWaterfox expects "$out/lib" instead of "$out/usr/lib"
+      ln -s "$out/usr/lib" "$out/lib"
+
+      gappsWrapperArgs+=(--argv0 "$out/bin/.waterfox-wrapped")
+
+      # See: https://github.com/mozilla/policy-templates/blob/master/README.md
+      mkdir -p "$out/lib/waterfox-bin-${version}/distribution";
+      ln -s ${policiesJson} "$out/lib/waterfox-bin-${version}/distribution/policies.json";
+    '';
+
+  passthru.execdir = "/bin";
+  passthru.ffmpegSupport = true;
+  passthru.gssSupport = true;
+  # update with:
+  # $ nix-shell maintainers/scripts/update.nix --argstr package firefox-bin-unwrapped
+  passthru.updateScript = import ./update.nix {
+    inherit pname writeScript xidel coreutils gnused gnugrep gnupg curl runtimeShell;
+    baseUrl = "https://github.com/WaterfoxCo/Waterfox/archive/refs/tags/";
+  };
+  meta = with lib; {
+    description = "Waterfox, striking the perfect balance between privacy and usability. (binary package)";
+    homepage = "http://www.waterfox.net";
+    license = licenses.mpl20;
+    platforms = builtins.attrNames waterfoxPlatforms;
+    hydraPlatforms = [];
+    maintainers = with maintainers; [ jcdickinson ];
+  };
+}

--- a/pkgs/applications/networking/browsers/waterfox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/waterfox-bin/release_sources.nix
@@ -1,0 +1,10 @@
+{
+  version = "G4.0.6";
+  sources = [
+    { url = "https://github.com/WaterfoxCo/Waterfox/releases/download/G4.0.6/waterfox-G4.0.6.en-US.linux-x86_64.tar.bz2";
+      locale = "en-US";
+      arch = "linux-x86_64";
+      sha256 = "9de8a5e19bd42d33fc70c7d0a9a24192ff1b01b0ae14cd3628694d10fd3e73d2";
+    }
+  ];
+}

--- a/pkgs/applications/networking/browsers/waterfox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/waterfox/wrapper.nix
@@ -1,0 +1,358 @@
+{ stdenv, lib, makeDesktopItem, makeWrapper, lndir, config
+, replace, fetchurl, zip, unzip, jq, xdg-utils, writeText
+
+## various stuff that can be plugged in
+, ffmpeg, xorg, alsa-lib, libpulseaudio, libcanberra-gtk3, libglvnd, libnotify, opensc
+, gnome/*.gnome-shell*/
+, browserpass, chrome-gnome-shell, uget-integrator, plasma5Packages, bukubrow, pipewire
+, tridactyl-native
+, fx_cast_bridge
+, udev
+, libkrb5
+, libva
+, mesa
+, cups
+}:
+
+## configurability of the wrapper itself
+
+browser:
+
+let
+  wrapper =
+    { applicationName ? browser.applicationName or (lib.getName browser)
+    , pname ? applicationName
+    , version ? lib.getVersion browser
+    , desktopName ? # applicationName with first letter capitalized
+      (lib.toUpper (lib.substring 0 1 applicationName) + lib.substring 1 (-1) applicationName)
+    , nameSuffix ? ""
+    , icon ? applicationName
+    , extraNativeMessagingHosts ? []
+    , pkcs11Modules ? []
+    , forceWayland ? false
+    , useGlvnd ? true
+    , cfg ? config.${applicationName} or {}
+
+    ## Following options are needed for extra prefs & policies
+    # For more information about anti tracking (german website)
+    # visit https://wiki.kairaven.de/open/app/firefox
+    , extraPrefs ? ""
+    # For more information about policies visit
+    # https://github.com/mozilla/policy-templates#enterprisepoliciesenabled
+    , extraPolicies ? {}
+    , libName ? "waterfox" # Important for tor package or the like
+    , nixExtensions ? null
+    }:
+
+    let
+      ffmpegSupport = browser.ffmpegSupport or false;
+      gssSupport = browser.gssSupport or false;
+      alsaSupport = browser.alsaSupport or false;
+      pipewireSupport = browser.pipewireSupport or false;
+      # PCSC-Lite daemon (services.pcscd) also must be enabled for waterfox to access smartcards
+      smartcardSupport = cfg.smartcardSupport or false;
+
+      nativeMessagingHosts =
+        ([ ]
+          ++ lib.optional (cfg.enableBrowserpass or false) (lib.getBin browserpass)
+          ++ lib.optional (cfg.enableBukubrow or false) bukubrow
+          ++ lib.optional (cfg.enableTridactylNative or false) tridactyl-native
+          ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
+          ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
+          ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma5Packages.plasma-browser-integration
+          ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
+          ++ extraNativeMessagingHosts
+        );
+      libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups ]
+            ++ lib.optional (pipewireSupport && lib.versionAtLeast version "83") pipewire
+            ++ lib.optional ffmpegSupport ffmpeg
+            ++ lib.optional gssSupport libkrb5
+            ++ lib.optional useGlvnd libglvnd
+            ++ lib.optionals (cfg.enableQuakeLive or false)
+            (with xorg; [ stdenv.cc libX11 libXxf86dga libXxf86vm libXext libXt alsa-lib zlib ])
+            ++ lib.optional (config.pulseaudio or true) libpulseaudio
+            ++ lib.optional alsaSupport alsa-lib
+            ++ lib.optional smartcardSupport opensc
+            ++ pkcs11Modules;
+      gtk_modules = [ libcanberra-gtk3 ];
+
+      #########################
+      #                       #
+      #   EXTRA PREF CHANGES  #
+      #                       #
+      #########################
+      policiesJson = writeText "policies.json" (builtins.toJSON enterprisePolicies);
+
+      usesNixExtensions = nixExtensions != null;
+
+      nameArray = builtins.map(a: a.name) (if usesNixExtensions then nixExtensions else []);
+
+      # Check that every extension has a unqiue .name attribute
+      # and an extid attribute
+      extensions = if nameArray != (lib.unique nameArray) then
+        throw "Waterfox addon name needs to be unique"
+      else builtins.map (a:
+        if ! (builtins.hasAttr "extid" a) then
+        throw "nixExtensions has an invalid entry. Missing extid attribute. Please use fetchfirefoxaddon"
+        else
+        a
+      ) (if usesNixExtensions then nixExtensions else []);
+
+      enterprisePolicies =
+      {
+        policies = lib.optionalAttrs usesNixExtensions  {
+          DisableAppUpdate = true;
+        } //
+        lib.optionalAttrs usesNixExtensions {
+          ExtensionSettings = {
+            "*" = {
+                blocked_install_message = "You can't have manual extension mixed with nix extensions";
+                installation_mode = "blocked";
+              };
+
+          } // lib.foldr (e: ret:
+              ret // {
+                "${e.extid}" = {
+                  installation_mode = "allowed";
+                };
+              }
+            ) {} extensions;
+          } // lib.optionalAttrs usesNixExtensions {
+            Extensions = {
+              Install = lib.foldr (e: ret:
+                ret ++ [ "${e.outPath}/${e.extid}.xpi" ]
+                ) [] extensions;
+            };
+          } // lib.optionalAttrs smartcardSupport {
+            SecurityDevices = {
+              "OpenSC PKCS#11 Module" = "onepin-opensc-pkcs11.so";
+            };
+          }
+        // extraPolicies;
+      };
+
+      waterfoxCfg =  writeText "waterfox.cfg" ''
+        // First line must be a comment
+
+        // Disables addon signature checking
+        // to be able to install addons that do not have an extid
+        // Security is maintained because only user whitelisted addons
+        // with a checksum can be installed
+        ${ lib.optionalString usesNixExtensions ''lockPref("xpinstall.signatures.required", false)'' };
+        ${extraPrefs}
+      '';
+
+      #############################
+      #                           #
+      #   END EXTRA PREF CHANGES  #
+      #                           #
+      #############################
+
+      # TODO: remove this after the next release (21.03)
+      configPlugins = lib.filter (a: builtins.hasAttr a cfg) [
+        "enableAdobeFlash"
+        "enableAdobeReader"
+        "enableBluejeans"
+        "enableDjvu"
+        "enableFriBIDPlugin"
+        "enableGoogleTalkPlugin"
+        "enableMPlayer"
+        "enableVLC"
+        "icedtea"
+        "jre"
+      ];
+      pluginsError =
+        "Your configuration mentions ${lib.concatMapStringsSep ", " (p: applicationName + "." + p) configPlugins}. All plugin related options have been removed.";
+
+    in if configPlugins != [] then throw pluginsError else
+      (stdenv.mkDerivation {
+      inherit pname version;
+
+      desktopItem = makeDesktopItem {
+        name = applicationName;
+        exec = "${applicationName}${nameSuffix} %U";
+        inherit icon;
+        comment = "";
+        desktopName = "${desktopName}${nameSuffix}${lib.optionalString forceWayland " (Wayland)"}";
+        genericName = "Web Browser";
+        categories = "Network;WebBrowser;";
+        mimeType = lib.concatStringsSep ";" [
+          "text/html"
+          "text/xml"
+          "application/xhtml+xml"
+          "application/vnd.mozilla.xul+xml"
+          "x-scheme-handler/http"
+          "x-scheme-handler/https"
+          "x-scheme-handler/ftp"
+        ];
+      };
+
+      nativeBuildInputs = [ makeWrapper lndir replace ];
+      buildInputs = [ browser.gtk3 ];
+
+
+      buildCommand = lib.optionalString stdenv.isDarwin ''
+        mkdir -p $out/Applications
+        cp -R --no-preserve=mode,ownership ${browser}/Applications/${applicationName}.app $out/Applications
+        rm -f $out${browser.execdir or "/bin"}/${applicationName}
+      '' + ''
+        if [ ! -x "${browser}${browser.execdir or "/bin"}/${applicationName}" ]
+        then
+            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            exit 1
+        fi
+
+        #########################
+        #                       #
+        #   EXTRA PREF CHANGES  #
+        #                       #
+        #########################
+        # Link the runtime. The executable itself has to be copied,
+        # because it will resolve paths relative to its true location.
+        # Any symbolic links have to be replicated as well.
+        cd "${browser}"
+        find . -type d -exec mkdir -p "$out"/{} \;
+
+        find . -type f \( -not -name "${applicationName}" \) -exec ln -sT "${browser}"/{} "$out"/{} \;
+
+        find . -type f -name "${applicationName}" -print0 | while read -d $'\0' f; do
+          cp -P --no-preserve=mode,ownership "${browser}/$f" "$out/$f"
+          chmod a+rwx "$out/$f"
+        done
+
+        # fix links and absolute references
+        cd "${browser}"
+
+        find . -type l -print0 | while read -d $'\0' l; do
+          target="$(readlink "$l" | replace-literal -es -- "${browser}" "$out")"
+          ln -sfT "$target" "$out/$l"
+        done
+
+        # This will not patch binaries, only "text" files.
+        # Its there for the wrapper mostly.
+        cd "$out"
+        replace-literal -esfR -- "${browser}" "$out"
+
+        # create the wrapper
+
+        executablePrefix="$out${browser.execdir or "/bin"}"
+        executablePath="$executablePrefix/${applicationName}"
+
+        if [ ! -x "$executablePath" ]
+        then
+            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            exit 1
+        fi
+
+        if [ ! -L "$executablePath" ]
+        then
+          # Careful here, the file at executablePath may already be
+          # a wrapper. That is why we postfix it with -old instead
+          # of -wrapped.
+          oldExe="$executablePrefix"/".${applicationName}"-old
+          mv "$executablePath" "$oldExe"
+        else
+          oldExe="$(readlink -v --canonicalize-existing "$executablePath")"
+        fi
+
+        if [ ! -x "${browser}${browser.execdir or "/bin"}/${applicationName}" ]
+        then
+            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            exit 1
+        fi
+
+        makeWrapper "$oldExe" \
+          "$out${browser.execdir or "/bin"}/${applicationName}${nameSuffix}" \
+            --prefix LD_LIBRARY_PATH ':' "$libs" \
+            --suffix-each GTK_PATH ':' "$gtk_modules" \
+            --prefix PATH ':' "${xdg-utils}/bin" \
+            --suffix PATH ':' "$out${browser.execdir or "/bin"}" \
+            --set MOZ_APP_LAUNCHER "${applicationName}${nameSuffix}" \
+            --set MOZ_SYSTEM_DIR "$out/lib/waterfox" \
+            --set MOZ_LEGACY_PROFILES 1 \
+            --set MOZ_ALLOW_DOWNGRADE 1 \
+            --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
+            --suffix XDG_DATA_DIRS : '${gnome.adwaita-icon-theme}/share' \
+            ${lib.optionalString forceWayland ''
+              --set MOZ_ENABLE_WAYLAND "1" \
+            ''}
+        #############################
+        #                           #
+        #   END EXTRA PREF CHANGES  #
+        #                           #
+        #############################
+
+        if [ -e "${browser}/share/icons" ]; then
+            mkdir -p "$out/share"
+            ln -s "${browser}/share/icons" "$out/share/icons"
+        else
+            for res in 16 32 48 64 128; do
+            mkdir -p "$out/share/icons/hicolor/''${res}x''${res}/apps"
+            icon=$( find "${browser}/lib/" -name "default''${res}.png" )
+              if [ -e "$icon" ]; then ln -s "$icon" \
+                "$out/share/icons/hicolor/''${res}x''${res}/apps/${applicationName}.png"
+              fi
+            done
+        fi
+
+        install -D -t $out/share/applications $desktopItem/share/applications/*
+
+        mkdir -p $out/lib/waterfox/native-messaging-hosts
+        for ext in ${toString nativeMessagingHosts}; do
+            ln -sLt $out/lib/waterfox/native-messaging-hosts $ext/lib/waterfox/native-messaging-hosts/*
+        done
+
+        mkdir -p $out/lib/waterfox/pkcs11-modules
+        for ext in ${toString pkcs11Modules}; do
+            ln -sLt $out/lib/waterfox/pkcs11-modules $ext/lib/waterfox/pkcs11-modules/*
+        done
+
+
+        #########################
+        #                       #
+        #   EXTRA PREF CHANGES  #
+        #                       #
+        #########################
+        # user customization
+        mkdir -p $out/lib/${libName}
+
+        # creating policies.json
+        mkdir -p "$out/lib/${libName}/distribution"
+
+        POL_PATH="$out/lib/${libName}/distribution/policies.json"
+        rm -f "$POL_PATH"
+        cat ${policiesJson} >> "$POL_PATH"
+
+        # preparing for autoconfig
+        mkdir -p "$out/lib/${libName}/defaults/pref"
+
+        echo 'pref("general.config.filename", "waterfox.cfg");' > "$out/lib/${libName}/defaults/pref/autoconfig.js"
+        echo 'pref("general.config.obscure_value", 0);' >> "$out/lib/${libName}/defaults/pref/autoconfig.js"
+
+        cat > "$out/lib/${libName}/waterfox.cfg" < ${waterfoxCfg}
+
+        mkdir -p $out/lib/${libName}/distribution/extensions
+
+        #############################
+        #                           #
+        #   END EXTRA PREF CHANGES  #
+        #                           #
+        #############################
+      '';
+
+      preferLocalBuild = true;
+
+      libs = lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
+      gtk_modules = map (x: x + x.gtkModule) gtk_modules;
+
+      passthru = { unwrapped = browser; };
+
+      disallowedRequisites = [ stdenv.cc ];
+
+      meta = browser.meta // {
+        description = browser.meta.description;
+        hydraPlatforms = [];
+        priority = (browser.meta.priority or 0) - 1; # prefer wrapper over the package
+      };
+    });
+in lib.makeOverridable wrapper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26297,6 +26297,19 @@ with pkgs;
     wlroots = wlroots_0_14;
   };
 
+  wrapWaterfox = callPackage ../applications/networking/browsers/waterfox/wrapper.nix { };
+
+  waterfox-bin-unwrapped = callPackage ../applications/networking/browsers/waterfox-bin {
+    inherit (gnome) adwaita-icon-theme;
+    generated = import ../applications/networking/browsers/waterfox-bin/release_sources.nix;
+  };
+
+  waterfox-bin = wrapWaterfox waterfox-bin-unwrapped {
+    applicationName = "waterfox";
+    pname = "waterfox-bin";
+    desktopName = "Waterfox";
+  };
+
   workstyle = callPackage ../applications/window-managers/i3/workstyle.nix { };
 
   windowchef = callPackage ../applications/window-managers/windowchef { };


### PR DESCRIPTION
###### Motivation for this change

This introduces waterfox-bin, which is derived from the official Waterfox releases.

###### Remarks

I heavily based this on the Firefox nixfiles, including the stubbed `waterfox` package (that only contains the wrapper script). I hope to add the full build once I become more adept with nixfiles.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- N/A For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [X] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
