### PR TITLE
(k)vdo: init

### DIFF
--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -7,17 +7,18 @@ in {
   options.services.lvm = {
     package = mkOption {
       type = types.package;
-      default = if cfg.dmeventd.enable then pkgs.lvm2_dmeventd else pkgs.lvm2;
+      default = pkgs.lvm2;
       internal = true;
       defaultText = literalExpression "pkgs.lvm2";
       description = ''
         This option allows you to override the LVM package that's used on the system
         (udev rules, tmpfiles, systemd services).
-        Defaults to pkgs.lvm2, or pkgs.lvm2_dmeventd if dmeventd is enabled.
+        Defaults to pkgs.lvm2, pkgs.lvm2_dmeventd if dmeventd or pkgs.lvm2_vdo if vdo is enabled.
       '';
     };
     dmeventd.enable = mkEnableOption "the LVM dmevent daemon";
     boot.thin.enable = mkEnableOption "support for booting from ThinLVs";
+    boot.vdo.enable = mkEnableOption "support for booting from VDOLVs";
   };
 
   config = mkMerge [
@@ -40,6 +41,7 @@ in {
       environment.etc."lvm/lvm.conf".text = ''
         dmeventd/executable = "${cfg.package}/bin/dmeventd"
       '';
+      services.lvm.package = mkDefault pkgs.lvm2_dmeventd;
     })
     (mkIf cfg.boot.thin.enable {
       boot.initrd = {
@@ -61,6 +63,32 @@ in {
       environment.etc."lvm/lvm.conf".text = concatMapStringsSep "\n"
         (bin: "global/${bin}_executable = ${pkgs.thin-provisioning-tools}/bin/${bin}")
         [ "thin_check" "thin_dump" "thin_repair" "cache_check" "cache_dump" "cache_repair" ];
+
+      environment.systemPackages = [ pkgs.thin-provisioning-tools ];
+    })
+    (mkIf cfg.boot.vdo.enable {
+      boot = {
+        initrd = {
+          kernelModules = [ "kvdo" ];
+
+          extraUtilsCommands = ''
+            for BIN in ${pkgs.vdo}/bin/*; do
+              copy_bin_and_libs $BIN
+            done
+          '';
+
+          extraUtilsCommandsTest = ''
+            ls ${pkgs.vdo}/bin/ | while read BIN; do
+              $out/bin/$(basename $BIN) --help > /dev/null
+            done
+          '';
+        };
+        extraModulePackages = [ config.boot.kernelPackages.kvdo ];
+      };
+
+      services.lvm.package = mkOverride 999 pkgs.lvm2_vdo;  # this overrides mkDefault
+
+      environment.systemPackages = [ pkgs.vdo ];
     })
     (mkIf (cfg.dmeventd.enable || cfg.boot.thin.enable) {
       boot.initrd.preLVMCommands = ''

--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -72,13 +72,13 @@ in {
           kernelModules = [ "kvdo" ];
 
           extraUtilsCommands = ''
-            for BIN in ${pkgs.vdo}/bin/*; do
-              copy_bin_and_libs $BIN
+            ls ${pkgs.vdo}/bin/ | grep -v adaptLVMVDO | while read BIN; do
+              copy_bin_and_libs ${pkgs.vdo}/bin/$BIN
             done
           '';
 
           extraUtilsCommandsTest = ''
-            ls ${pkgs.vdo}/bin/ | while read BIN; do
+            ls ${pkgs.vdo}/bin/ | grep -v adaptLVMVDO | while read BIN; do
               $out/bin/$(basename $BIN) --help > /dev/null
             done
           '';

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -274,6 +274,7 @@ in
   login = handleTest ./login.nix {};
   logrotate = handleTest ./logrotate.nix {};
   loki = handleTest ./loki.nix {};
+  lvm2 = handleTest ./lvm2 {};
   lxd = handleTest ./lxd.nix {};
   lxd-image = handleTest ./lxd-image.nix {};
   lxd-nftables = handleTest ./lxd-nftables.nix {};

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -5,6 +5,7 @@
 , kernelVersionsToTest ? [ "4.19" "5.4" "5.10" "5.15" "latest" ]
 }:
 
+# For quickly running a test, the nixosTests.lvm2.lvm-thinpool-linux-latest attribute is recommended
 let
   tests = let callTest = p: lib.flip (import p) { inherit system pkgs; }; in {
     thinpool = { test = callTest ./thinpool.nix; kernelFilter = lib.id; };

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -1,0 +1,26 @@
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../../.. { inherit system config; }
+, lib ? pkgs.lib
+, kernelVersionsToTest ? [ "4.19" "5.4" "5.10" "5.15" "latest" ]
+}:
+
+let
+  tests = let callTest = p: lib.flip (import p) { inherit system pkgs; }; in {
+    thinpool = { test = callTest ./thinpool.nix; kernelFilter = lib.id; };
+    # we would like to test all versions, but the kernel module currently does not compile against the other versions
+    vdo = { test = callTest ./vdo.nix; kernelFilter = lib.filter (v: v == "5.15"); };
+  };
+in
+lib.listToAttrs (
+  lib.filter (x: x.value != {}) (
+    lib.flip lib.concatMap kernelVersionsToTest (version:
+      let
+        v' = lib.replaceStrings [ "." ] [ "_" ] version;
+      in
+      lib.flip lib.mapAttrsToList tests (name: t:
+        lib.nameValuePair "lvm-${name}-linux-${v'}" (lib.optionalAttrs (builtins.elem version (t.kernelFilter kernelVersionsToTest)) (t.test { kernelPackages = pkgs."linuxPackages_${v'}"; }))
+      )
+    )
+  )
+)

--- a/nixos/tests/lvm2/thinpool.nix
+++ b/nixos/tests/lvm2/thinpool.nix
@@ -1,0 +1,32 @@
+{ kernelPackages ? null }:
+import ../make-test-python.nix ({ pkgs, ... }: {
+  name = "lvm2-thinpool";
+  meta.maintainers = with pkgs.lib.maintainers; [ ajs124 ];
+
+  nodes.machine = { pkgs, lib, ... }: {
+    virtualisation.emptyDiskImages = [ 4096 ];
+    services.lvm = {
+      boot.thin.enable = true;
+      dmeventd.enable = true;
+    };
+    environment.systemPackages = with pkgs; [ xfsprogs ];
+    environment.etc."lvm/lvm.conf".text = ''
+      activation/thin_pool_autoextend_percent = 10
+      activation/thin_pool_autoextend_threshold = 80
+    '';
+    boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  };
+
+  testScript = ''
+    machine.succeed("vgcreate test_vg /dev/vdb")
+    machine.succeed("lvcreate -L 512M -T test_vg/test_thin_pool")
+    machine.succeed("lvcreate -n test_lv -V 16G --thinpool test_thin_pool test_vg")
+    machine.succeed("mkfs.xfs /dev/test_vg/test_lv")
+    machine.succeed("mkdir /mnt; mount /dev/test_vg/test_lv /mnt")
+    assert "/dev/mapper/test_vg-test_lv" == machine.succeed("findmnt -no SOURCE /mnt").strip()
+    machine.succeed("dd if=/dev/zero of=/mnt/empty.file bs=1M count=1024")
+    machine.succeed("journalctl -u dm-event.service | grep \"successfully resized\"")
+    machine.succeed("umount /mnt")
+    machine.succeed("vgchange -a n")
+  '';
+})

--- a/nixos/tests/lvm2/vdo.nix
+++ b/nixos/tests/lvm2/vdo.nix
@@ -1,0 +1,27 @@
+{ kernelPackages ? null }:
+import ../make-test-python.nix ({ pkgs, ... }: {
+  name = "lvm2-thinpool";
+  meta.maintainers = with pkgs.lib.maintainers; [ ajs124 ];
+
+  nodes.machine = { pkgs, lib, ... }: {
+    # Minimum required size for VDO volume: 5063921664 bytes
+    virtualisation.emptyDiskImages = [ 8192 ];
+    services.lvm = {
+      boot.vdo.enable = true;
+      dmeventd.enable = true;
+    };
+    environment.systemPackages = with pkgs; [ xfsprogs ];
+    boot = lib.mkIf (kernelPackages != null) { inherit kernelPackages; };
+  };
+
+  testScript = ''
+    machine.succeed("vgcreate test_vg /dev/vdb")
+    machine.succeed("lvcreate --type vdo -n vdo_lv -L 6G -V 12G test_vg/vdo_pool_lv")
+    machine.succeed("mkfs.xfs -K /dev/test_vg/vdo_lv")
+    machine.succeed("mkdir /mnt; mount /dev/test_vg/vdo_lv /mnt")
+    assert "/dev/mapper/test_vg-vdo_lv" == machine.succeed("findmnt -no SOURCE /mnt").strip()
+    machine.succeed("umount /mnt")
+    machine.succeed("vdostats")
+    machine.succeed("vgchange -a n")
+  '';
+})

--- a/nixos/tests/lvm2/vdo.nix
+++ b/nixos/tests/lvm2/vdo.nix
@@ -1,6 +1,6 @@
 { kernelPackages ? null }:
 import ../make-test-python.nix ({ pkgs, ... }: {
-  name = "lvm2-thinpool";
+  name = "lvm2-vdo";
   meta.maintainers = with pkgs.lib.maintainers; [ ajs124 ];
 
   nodes.machine = { pkgs, lib, ... }: {

--- a/pkgs/os-specific/linux/kvdo/default.nix
+++ b/pkgs/os-specific/linux/kvdo/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub, vdo, kernel }:
+
+stdenv.mkDerivation rec {
+  inherit (vdo) version;
+  pname = "kvdo";
+
+  src = fetchFromGitHub {
+    owner = "dm-vdo";
+    repo = "kvdo";
+    rev = version;
+    sha256 = "1plzvw68x16q8a65cyy0pbycajrl03siyh3yh7qr8kmd2i1p1mxc";
+  };
+
+  dontConfigure = true;
+  enableParallelBuilding = true;
+
+  KSRC = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  INSTALL_MOD_PATH = placeholder "out";
+
+  preBuild = ''
+    makeFlags="$makeFlags -C ${KSRC} M=$(pwd)"
+'';
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    inherit (vdo.meta) license maintainers;
+    homepage = "https://github.com/dm-vdo/kvdo";
+    description = "A pair of kernel modules which provide pools of deduplicated and/or compressed block storage";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/kvdo/default.nix
+++ b/pkgs/os-specific/linux/kvdo/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "dm-vdo";
     repo = "kvdo";
     rev = version;
-    sha256 = "1plzvw68x16q8a65cyy0pbycajrl03siyh3yh7qr8kmd2i1p1mxc";
+    sha256 = "1xl7dwcqx00w1gbpb6vlkn8nchyfj1fsc8c06vgda0sgxp7qs5gn";
   };
 
   dontConfigure = true;

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -11,6 +11,7 @@
 , enableDmeventd ? false
 , udevSupport ? !stdenv.hostPlatform.isStatic, udev ? null
 , onlyLib ? stdenv.hostPlatform.isStatic
+, enableVDO ? false, vdo ? null
 , nixosTests
 }:
 
@@ -18,7 +19,7 @@
 assert enableDmeventd -> enableCmdlib;
 
 stdenv.mkDerivation rec {
-  pname = "lvm2" + lib.optionalString enableDmeventd "-with-dmeventd";
+  pname = "lvm2" + lib.optionalString enableDmeventd "-with-dmeventd" + lib.optionalString enableVDO "-with-vdo";
   inherit version;
 
   src = fetchurl {
@@ -33,6 +34,8 @@ stdenv.mkDerivation rec {
     udev
   ] ++ lib.optionals (!onlyLib) [
     libuuid
+  ] ++ lib.optionals enableVDO [
+    vdo
   ];
 
   configureFlags = [
@@ -58,6 +61,8 @@ stdenv.mkDerivation rec {
     "--enable-udev_sync"
   ] ++ lib.optionals stdenv.hostPlatform.isStatic [
     "--enable-static_link"
+  ] ++  lib.optionals enableVDO [
+    "--enable-vdo"
   ];
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/vdo/default.nix
+++ b/pkgs/os-specific/linux/vdo/default.nix
@@ -1,0 +1,64 @@
+{ lib, stdenv
+, fetchFromGitHub
+, installShellFiles
+, libuuid
+, lvm2_dmeventd  # <libdevmapper-event.h>
+, zlib
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vdo";
+  version = "8.1.1.287";  # kvdo uses this!
+
+  src = fetchFromGitHub {
+    owner = "dm-vdo";
+    repo = pname;
+    rev = version;
+    sha256 = "1dmfz1rfc7hzqbqmhlk0x4vsp7jivww19gmj5z1gg4fsl9g26wn8";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    libuuid
+    lvm2_dmeventd
+    zlib
+    python3.pkgs.wrapPython
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyyaml
+  ];
+
+  pythonPath = propagatedBuildInputs;
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "INSTALLOWNER="
+    # all of these paths are relative to DESTDIR and have defaults that don't work for us
+    "bindir=/bin"
+    "defaultdocdir=/share/doc"
+    "mandir=/share/man"
+    "python3_sitelib=${python3.sitePackages}"
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    installShellCompletion --bash $out/bash_completion.d/*
+    rm -r $out/bash_completion.d
+
+    wrapPythonPrograms
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/dm-vdo/vdo";
+    description = "A set of userspace tools for managing pools of deduplicated and/or compressed block storage";
+    platforms = platforms.linux;
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ ajs124 ];
+  };
+}

--- a/pkgs/os-specific/linux/vdo/default.nix
+++ b/pkgs/os-specific/linux/vdo/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vdo";
-  version = "8.1.1.287";  # kvdo uses this!
+  version = "8.1.1.360";  # kvdo uses this!
 
   src = fetchFromGitHub {
     owner = "dm-vdo";
     repo = pname;
     rev = version;
-    sha256 = "1dmfz1rfc7hzqbqmhlk0x4vsp7jivww19gmj5z1gg4fsl9g26wn8";
+    sha256 = "1zp8aaw0diramnlx5z96jcpbm6x0r204xf1vwq6k21rzcazczkwv";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22978,6 +22978,9 @@ with pkgs;
     enableDmeventd = true;
     enableCmdlib = true;
   };
+  lvm2_vdo = lvm2_dmeventd.override {
+    enableVDO = true;
+  };
 
   maddy = callPackage ../servers/maddy { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23554,6 +23554,8 @@ with pkgs;
 
   vndr = callPackage ../development/tools/vndr { };
 
+  vdo = callPackage ../os-specific/linux/vdo { };
+
   windows = callPackages ../os-specific/windows {};
 
   wirelesstools = callPackage ../os-specific/linux/wireless-tools { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -317,6 +317,8 @@ in {
 
     ena = callPackage ../os-specific/linux/ena {};
 
+    kvdo = callPackage ../os-specific/linux/kvdo {};
+
     liquidtux = callPackage ../os-specific/linux/liquidtux {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
###### Motivation for this change
I'm thinking about using this (cc @mr-pi)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
