### PR TITLE
spice-up: 1.8.2 -> 1.9.1

### DIFF
--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -1,65 +1,59 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , nix-update-script
-, fetchpatch
-, cmake
-, gdk-pixbuf
-, gtk3
-, vala
-, gettext
+, meson
 , ninja
-, pantheon
 , pkg-config
+, python3
+, vala
+, wrapGAppsHook
+, glib
+, gtk3
 , json-glib
-, libgudev
 , libevdev
 , libgee
+, libgudev
 , libsoup
-, wrapGAppsHook
+, pantheon
 }:
 
 stdenv.mkDerivation rec {
   pname = "spice-up";
-  version = "1.8.2";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "Philip-Scott";
     repo = "Spice-up";
     rev = version;
-    sha256 = "1pix911l4ddn50026a5sbpqfzba6fmw40m1yzbknmkgd2ny28f0m";
+    sha256 = "sha256-FI6YMbqZfaU19k8pS2eoNCnX8O8F99SHHOxMwHC5fTc=";
   };
 
-  USER = "pbuilder";
-
   nativeBuildInputs = [
-    cmake
-    gettext
+    meson
     ninja
     pkg-config
+    python3
     vala
     wrapGAppsHook
   ];
 
   buildInputs = [
-    pantheon.elementary-icon-theme
-    pantheon.granite
-    gdk-pixbuf
+    glib
     gtk3
     json-glib
     libevdev
     libgee
     libgudev
     libsoup
+    pantheon.elementary-icon-theme
+    pantheon.granite
   ];
 
-  patches = [
-    # Fix build with Vala 0.46
-    # https://github.com/Philip-Scott/Spice-up/pull/288
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/Philip-Scott/Spice-up/pull/288.patch";
-      sha256 = "0kyfd8v2sk4cvcq1j8ysp64snfjhnpr3iz7l04lx7if7h372xj39";
-    })
-  ];
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
 
   passthru = {
     updateScript = nix-update-script {
@@ -74,6 +68,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     # The COPYING file has GPLv3; some files have GPLv2+ and some have GPLv3+
     license = licenses.gpl3Plus;
-    mainProgram = "com.github.philip-scott.spice-up";
+    mainProgram = "com.github.philip_scott.spice-up";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/Philip-Scott/Spice-up/releases/tag/1.9.0
https://github.com/Philip-Scott/Spice-up/releases/tag/1.9.1
https://github.com/Philip-Scott/Spice-up/compare/1.8.2...1.9.1

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
