### PR TITLE
openbgpd: 6.8p0 -> 7.2

### DIFF
--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -1,37 +1,31 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, m4, bison }:
 
-let
-  openbsd_version =
-    "OPENBSD_6_8"; # This has to be equal to ${src}/OPENBSD_BRANCH
-  openbsd = fetchFromGitHub {
-    name = "portable";
-    owner = "openbgpd-portable";
-    repo = "openbgpd-openbsd";
-    rev = openbsd_version;
-    sha256 = "sha256-vCVK5k4g6aW2z2fg7Kv0uvkX7f34aRc8K2myb3jjl6w=";
-  };
-in stdenv.mkDerivation rec {
-  pname = "opengpd";
-  version = "6.8p0";
+stdenv.mkDerivation rec {
+  pname = "openbgpd";
+  version = "7.2";
 
   src = fetchFromGitHub {
     owner = "openbgpd-portable";
     repo = "openbgpd-portable";
     rev = version;
-    sha256 = "sha256-TKs6tt/SCWes6kYAGIrSShZgOLf7xKh26xG3Zk7wCCw=";
+    sha256 = "sha256-Q0hnDeGcCOhXAe1j3VRKt7q6hRcjgt8dqa3EoxTuHiI=";
   };
 
   nativeBuildInputs = [ autoconf automake libtool m4 bison ];
 
-  preConfigure = ''
+  # Merge the OpenBSD and portable trees and apply portablity patches.
+  preConfigure = let
+    openbsd-src = fetchFromGitHub {
+      name = "portable";
+      owner = "openbgpd-portable";
+      repo = "openbgpd-openbsd";
+      rev = "openbgpd-${version}";
+      sha256 = "sha256-kflTy6+2TrkP/hn4xjyeSeTbDLGvCKoJ8n5toRkAYFw=";
+    };
+  in ''
     mkdir ./openbsd
-    cp -r ${openbsd}/* ./openbsd/
+    cp -r ${openbsd-src}/* ./openbsd/
     chmod -R +w ./openbsd
-    openbsd_version=$(cat ./OPENBSD_BRANCH)
-    if [ "$openbsd_version" != "${openbsd_version}" ]; then
-      echo "OPENBSD VERSION does not match"
-      exit 1
-    fi
     ./autogen.sh
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Version bump. I didn't end up using the software, but 6.8p0 had a crashing bug in v6-only mode which is fixed by 7.2.

- Fix typo in pname.

- OPENBSD_BRANCH is gone, and I couldn't find an obvious replacement
  ("VERSION" is now .gitignore'd) so we can't rely on this to check
  consistency. Instead, derive the fetched version from a single
  variable.

- We make that variable the "version" of the derivation so that bots can
  figure out what to bump when a new release is out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
