### PR TITLE
python3Packages.can: 3.3.4 -> unstable-2022-01-11

### DIFF
--- a/pkgs/development/python-modules/can/default.nix
+++ b/pkgs/development/python-modules/can/default.nix
@@ -1,39 +1,75 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, pythonOlder
-, aenum
-, wrapt
-, typing ? null
-, pyserial
-, nose
-, mock
-, hypothesis
+, fetchFromGitHub
 , future
-, pytest
- }:
+, hypothesis
+, parameterized
+, msgpack
+, pyserial
+, pytest-timeout
+, pytestCheckHook
+, pythonOlder
+, typing-extensions
+, wrapt
+}:
 
 buildPythonPackage rec {
   pname = "python-can";
-  version = "3.3.4";
+  version = "unstable-2022-01-11";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "2d3c223b7adc4dd46ce258d4a33b7e0dbb6c339e002faa40ee4a69d5fdce9449";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "hardbyte";
+    repo = pname;
+    rev = "2e24af08326ecd69fba9f02fed7b9c26f233c92b";
+    hash = "sha256-ZP5qtbjDtBZ2uT9DOSvSnfHyTlirr0oCEXhiLO1ydz0=";
   };
 
-  propagatedBuildInputs = [ wrapt pyserial aenum ] ++ lib.optional (pythonOlder "3.5") typing;
-  checkInputs = [ nose mock pytest hypothesis future ];
+  propagatedBuildInputs = [
+    msgpack
+    pyserial
+    typing-extensions
+    wrapt
+  ];
 
-  # Add the scripts to PATH
-  checkPhase = ''
-    PATH=$out/bin:$PATH pytest -c /dev/null
+  checkInputs = [
+    future
+    hypothesis
+    parameterized
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace tox.ini \
+      --replace " --cov=can --cov-config=tox.ini --cov-report=xml --cov-report=term" ""
   '';
 
+  disabledTestPaths = [
+    # We don't support all interfaces
+    "test/test_interface_canalystii.py"
+  ];
+
+  disabledTests = [
+    # Tests require access socket
+    "BasicTestUdpMulticastBusIPv4"
+    "BasicTestUdpMulticastBusIPv6"
+  ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin";
+  '';
+
+  pythonImportsCheck = [
+    "can"
+  ];
+
   meta = with lib; {
-    homepage = "https://github.com/hardbyte/python-can";
     description = "CAN support for Python";
-    license = licenses.lgpl3;
-    maintainers = with maintainers; [ sorki ];
+    homepage = "python-can.readthedocs.io";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ fab sorki ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163431953)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
