### PR TITLE
python3Packages.attrdict: refactor for Python 3.10

### DIFF
--- a/pkgs/development/python-modules/attrdict/default.nix
+++ b/pkgs/development/python-modules/attrdict/default.nix
@@ -1,19 +1,56 @@
-{ lib, buildPythonPackage, fetchPypi, coverage, nose, six }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, coverage
+, pythonOlder
+, nose
+, pytestCheckHook
+, six
+}:
 
 buildPythonPackage rec {
   pname = "attrdict";
   version = "2.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "35c90698b55c683946091177177a9e9c0713a0860f0e049febd72649ccd77b70";
+    hash = "sha256-NckGmLVcaDlGCRF3F3qenAcToIYPDgSf69cmSczXe3A=";
   };
 
-  propagatedBuildInputs = [ coverage nose six ];
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    coverage
+    nose
+  ];
+
+  postPatch = ''
+    substituteInPlace attrdict/merge.py \
+      --replace "from collections" "from collections.abc"
+    substituteInPlace attrdict/mapping.py \
+      --replace "from collections" "from collections.abc"
+    substituteInPlace attrdict/default.py \
+      --replace "from collections" "from collections.abc"
+    substituteInPlace attrdict/mixins.py \
+      --replace "from collections" "from collections.abc"
+  '';
+
+  # Tests are not shipped and source is not tagged
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "attrdict"
+  ];
 
   meta = with lib; {
     description = "A dict with attribute-style access";
     homepage = "https://github.com/bcj/AttrDict";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/wavedrom/default.nix
+++ b/pkgs/development/python-modules/wavedrom/default.nix
@@ -1,8 +1,8 @@
 { lib
-, buildPythonPackage
-, fetchPypi
 , attrdict
+, buildPythonPackage
 , cairosvg
+, fetchPypi
 , pillow
 , pytestCheckHook
 , setuptools-scm
@@ -14,9 +14,11 @@
 buildPythonPackage rec {
   pname = "wavedrom";
   version = "2.0.3.post2";
+  format = "setuptools";
+
   src = fetchPypi {
     inherit pname version;
-    sha256 = "239b3435ff116b09007d5517eed755fc8591891b7271a1cd40db9e400c02448d";
+    hash = "sha256-I5s0Nf8RawkAfVUX7tdV/IWRiRtycaHNQNueQAwCRI0=";
   };
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
@@ -32,22 +34,25 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    cairosvg
+    pillow
     pytestCheckHook
     xmldiff
-    pillow
-    cairosvg
   ];
 
   disabledTests = [
-    "test_upstream"  # requires to clone a full git repository
+    # Requires to clone a full git repository
+    "test_upstream"
   ];
 
-  pythonImportsCheck = [ "wavedrom" ];
+  pythonImportsCheck = [
+    "wavedrom"
+  ];
 
-  meta = {
+  meta = with lib; {
     description = "WaveDrom compatible Python command line";
     homepage = "https://github.com/wallento/wavedrompy";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ airwoodix ];
+    license = licenses.mit;
+    maintainers = with maintainers; [ airwoodix ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163433425)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
