### PR TITLE
gbl: init at 0.3.1

### DIFF
--- a/pkgs/tools/archivers/gbl/default.nix
+++ b/pkgs/tools/archivers/gbl/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, fetchpatch
+, pkg-config
+, openssl
+, testVersion
+, gbl
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gbl";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "dac-gmbh";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Xzx14fvYWTZYM9Pnowf1M3D0PTPRLwsXHUj/PJskRWw=";
+  };
+
+  cargoPatches = [
+    # Upstream does not include Cargo.lock, even though this is recommended for applications.
+    # This patch adds it. https://github.com/dac-gmbh/gbl/pull/62
+    (fetchpatch {
+      url = "https://github.com/raboof/gbl/commit/99078da334c6e1ffd8189c691bbc711281fae5cc.patch";
+      sha256 = "sha256-sAKkn4//8P87ZJ6NTHm2NUJH1sAFFwfrybv2QtQ3nnM=";
+    })
+  ];
+
+  cargoSha256 = "sha256-RUZ6wswRtV8chq3+bY9LTRf6IYMbZ9/GPl2X5UcF7d8=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  passthru.tests.version =
+    testVersion { package = gbl; };
+
+  meta = with lib; {
+    description = "GBL Firmware file manipulation";
+    longDescription = ''
+      Utility to read, create and manipulate `.gbl` firmware update
+      files targeting the Silicon Labs Gecko Bootloader.
+    '';
+    homepage = "https://github.com/dac-gmbh/gbl";
+    license = licenses.mit;
+    maintainers = [ maintainers.raboof ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1753,6 +1753,8 @@ with pkgs;
 
   fxlinuxprintutil = callPackage ../tools/misc/fxlinuxprintutil { };
 
+  gbl = callPackage ../tools/archivers/gbl { };
+
   genann = callPackage ../development/libraries/genann { };
 
   genpass = callPackage ../tools/security/genpass {


### PR DESCRIPTION
###### Motivation for this change

Being able to inspect gbl firmware files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).