### PR TITLE
ocamlPackages.z3: fix build

### DIFF
--- a/pkgs/development/ocaml-modules/z3/default.nix
+++ b/pkgs/development/ocaml-modules/z3/default.nix
@@ -1,9 +1,18 @@
-{ stdenv, ocaml, findlib, zarith, z3 }:
+{ stdenv, lib, ocaml, findlib, zarith, z3 }:
 
-let z3-with-ocaml = z3.override {
+if !lib.versionAtLeast ocaml.version "4.07"
+then throw "z3 is not available for OCaml ${ocaml.version}"
+else
+
+let z3-with-ocaml = (z3.override {
   ocamlBindings = true;
   inherit ocaml findlib zarith;
-}; in
+}).overrideAttrs (o: {
+  patches = (o.patches or []) ++ [
+    # Fix build; see: https://github.com/Z3Prover/z3/issues/5776
+    ./ocamlfind.patch
+  ];
+}); in
 
 stdenv.mkDerivation {
 

--- a/pkgs/development/ocaml-modules/z3/ocamlfind.patch
+++ b/pkgs/development/ocaml-modules/z3/ocamlfind.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/mk_util.py b/scripts/mk_util.py
+index 042e6af46..1e105b002 100644
+--- a/scripts/mk_util.py
++++ b/scripts/mk_util.py
+@@ -1995,7 +1995,7 @@ class MLComponent(Component):
+ 
+             LIBZ3 = LIBZ3 + ' ' + ' '.join(map(lambda x: '-cclib ' + x, LDFLAGS.split()))
+ 
+-            stubs_install_path = '$$(%s printconf path)/stublibs' % OCAMLFIND
++            stubs_install_path = '$$(%s printconf destdir)/stublibs' % OCAMLFIND
+             if not STATIC_LIB:
+                 loadpath = '-ccopt -L' + stubs_install_path
+                 dllpath = '-dllpath ' + stubs_install_path


### PR DESCRIPTION
###### Motivation for this change

Build is currently broken.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
