### PR TITLE
python310Packages.sqlalchemy-migrate: fix build by removing unittest2…

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-migrate/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, buildPythonPackage, fetchPypi, fetchpatch, python
-, unittest2, scripttest, pytz, mock
-, testtools, pbr, tempita, decorator, sqlalchemy
+, scripttest, pytz, pbr, tempita, decorator, sqlalchemy
 , six, sqlparse, testrepository
 }:
+
 buildPythonPackage rec {
   pname = "sqlalchemy-migrate";
   version = "0.13.0";
@@ -13,21 +13,27 @@ buildPythonPackage rec {
   };
 
   # See: https://review.openstack.org/#/c/608382/
-  patches = [ (fetchpatch {
-    url = "https://github.com/openstack/sqlalchemy-migrate/pull/18.patch";
-    sha256 = "1qyfq2m7w7xqf0r9bc2x42qcra4r9k9l9g1jy5j0fvlb6bvvjj07";
-  }) ];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/openstack/sqlalchemy-migrate/pull/18.patch";
+      sha256 = "1qyfq2m7w7xqf0r9bc2x42qcra4r9k9l9g1jy5j0fvlb6bvvjj07";
+    })
+  ];
 
-  checkInputs = [ unittest2 scripttest pytz mock testtools testrepository ];
+  postPatch = ''
+    substituteInPlace test-requirements.txt \
+      --replace "ibm_db_sa>=0.3.0;python_version<'3.0'" "" \
+      --replace "ibm-db-sa-py3;python_version>='3.0'" "" \
+      --replace "tempest-lib>=0.1.0" "" \
+      --replace "testtools>=0.9.34,<0.9.36" "" \
+      --replace "pylint" ""
+  '';
+
+  checkInputs = [ scripttest pytz testrepository ];
   propagatedBuildInputs = [ pbr tempita decorator sqlalchemy six sqlparse ];
 
   doCheck = !stdenv.isDarwin;
 
-  prePatch = ''
-    sed -i -e /tempest-lib/d \
-           -e /testtools/d \
-      test-requirements.txt
-  '';
   checkPhase = ''
     export PATH=$PATH:$out/bin
     echo sqlite:///__tmp__ > test_db.cfg
@@ -41,9 +47,9 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/openstack/sqlalchemy-migrate";
+    homepage = "https://opendev.org/x/sqlalchemy-migrate";
     description = "Schema migration tools for SQLAlchemy";
     license = licenses.asl20;
-    maintainers = with maintainers; [ makefu ];
+    maintainers = teams.openstack.members ++ (with maintainers; [ makefu ]);
   };
 }


### PR DESCRIPTION
…, adopt into openstack team, minor cleanups

~~This should fix most of the openstack things for python 3.10.~~ Nope, more incoming.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
