### PR TITLE
python310Packages.unittest2: mark broken, minor formatting

### DIFF
--- a/pkgs/development/python-modules/unittest2/default.nix
+++ b/pkgs/development/python-modules/unittest2/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , six
 , traceback2
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -16,14 +17,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ six traceback2 ];
 
-  # # 1.0.0 and up create a circle dependency with traceback2/pbr
+  # 1.0.0 and up create a circle dependency with traceback2/pbr
   doCheck = false;
 
   postPatch = ''
     # argparse is needed for python < 2.7, which we do not support anymore.
     substituteInPlace setup.py --replace "argparse" ""
 
-    # # fixes a transient error when collecting tests, see https://bugs.launchpad.net/python-neutronclient/+bug/1508547
+    # fixes a transient error when collecting tests, see https://bugs.launchpad.net/python-neutronclient/+bug/1508547
     sed -i '510i\        return None, False' unittest2/loader.py
     # https://github.com/pypa/packaging/pull/36
     sed -i 's/version=VERSION/version=str(VERSION)/' setup.py
@@ -31,8 +32,9 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "A backport of the new features added to the unittest testing framework";
-    homepage = "https://pypi.python.org/pypi/unittest2";
+    homepage = "https://pypi.org/project/unittest2/";
     license = licenses.bsd0;
+    # AttributeError: module 'collections' has no attribute 'MutableMapping'
+    broken = pythonAtLeast "3.10";
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
