### PR TITLE
python3Packages.amqtt: 0.10.0 -> unstable-2022-01-11

### DIFF
--- a/pkgs/development/python-modules/amqtt/default.nix
+++ b/pkgs/development/python-modules/amqtt/default.nix
@@ -2,9 +2,11 @@
 , buildPythonPackage
 , docopt
 , fetchFromGitHub
+, fetchpatch
 , hypothesis
 , passlib
 , poetry-core
+, pytest-logdog
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
@@ -15,24 +17,21 @@
 
 buildPythonPackage rec {
   pname = "amqtt";
-  version = "0.10.0";
+  version = "unstable-2022-01-11";
   format = "pyproject";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Yakifo";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-27LmNR1KC8w3zRJ7YBlBolQ4Q70ScTPqypMCpU6fO+I=";
+    rev = "8961b8fff57007a5d9907b98bc555f0519974ce9";
+    hash = "sha256-3uwz4RSoa6KRC8mlVfeIMLPH6F2kOJjQjjXCrnVX0Jo=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'websockets = "^9.0"' 'websockets = "^10.0"' \
-      --replace 'PyYAML = "^5.4.0"' 'PyYAML = "*"' \
-  '';
-
-  nativeBuildInputs = [ poetry-core ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     docopt
@@ -44,9 +43,15 @@ buildPythonPackage rec {
 
   checkInputs = [
     hypothesis
+    pytest-logdog
     pytest-asyncio
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'PyYAML = "^5.4.0"' 'PyYAML = "*"'
+  '';
 
   disabledTestPaths = [
     # Test are not ported from hbmqtt yet
@@ -54,12 +59,14 @@ buildPythonPackage rec {
     "tests/test_client.py"
   ];
 
-  disabledTests = [
-    # Requires network access
-    "test_connect_tcp"
-  ];
+  preCheck = ''
+    # Some tests need amqtt
+    export PATH=$out/bin:$PATH
+  '';
 
-  pythonImportsCheck = [ "amqtt" ];
+  pythonImportsCheck = [
+    "amqtt"
+  ];
 
   meta = with lib; {
     description = "Python MQTT client and broker implementation";

--- a/pkgs/development/python-modules/pytest-logdog/default.nix
+++ b/pkgs/development/python-modules/pytest-logdog/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, pytestCheckHook
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-logdog";
+  version = "0.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ods";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Tmoq+KAGzn0MMj29rukDfAc4LSIwC8DoMTuBAppV32I=";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pytest_logdog"
+  ];
+
+  meta = with lib; {
+    description = "Pytest plugin to test logging";
+    homepage = "https://github.com/ods/pytest-logdog";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/roombapy/default.nix
+++ b/pkgs/development/python-modules/roombapy/default.nix
@@ -37,6 +37,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    # hbmqtt was replaced by amqtt
+    substituteInPlace tests/test_roomba_integration.py \
+      --replace "from hbmqtt.broker import Broker" "from amqtt.broker import Broker"
+  '';
+
   disabledTestPaths = [
     # Requires network access
     "tests/test_discovery.py"

--- a/pkgs/development/python-modules/transitions/default.nix
+++ b/pkgs/development/python-modules/transitions/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 , six
 , pygraphviz
 , pytestCheckHook
@@ -13,6 +14,7 @@
 buildPythonPackage rec {
   pname = "transitions";
   version = "0.8.10";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -35,6 +37,16 @@ buildPythonPackage rec {
     export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
     export HOME=$TMPDIR
   '';
+
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    # https://github.com/pytransitions/transitions/issues/563
+    "test_multiple_models"
+    "test_timeout"
+  ];
+
+  pythonImportsCheck = [
+    "transitions"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/pytransitions/transitions";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7678,6 +7678,8 @@ in {
 
   pytest-localserver = callPackage ../development/python-modules/pytest-localserver { };
 
+  pytest-logdog = callPackage ../development/python-modules/pytest-logdog{ };
+
   pytest-metadata = callPackage ../development/python-modules/pytest-metadata { };
 
   pytest-mock = callPackage ../development/python-modules/pytest-mock { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/164497056)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
