### PR TITLE
ocamlPackages.progress: 0.1.1 → 0.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/index/default.nix
+++ b/pkgs/development/ocaml-modules/index/default.nix
@@ -6,14 +6,14 @@
 
 buildDunePackage rec {
   pname = "index";
-  version = "1.4.0";
+  version = "1.4.1";
 
   src = fetchurl {
     url = "https://github.com/mirage/index/releases/download/${version}/index-${version}.tbz";
-    sha256 = "13xd858c50fs651p1y8x70323ff0gzbf6zgc0a25f6xh3rsmkn4c";
+    sha256 = "sha256:01i24m1xh7vn44sq7gsxg1z0jxa6rg80bpjcp3cvg6zfjpsl7sfx";
   };
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
   useDune2 = true;
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/progress/default.nix
+++ b/pkgs/development/ocaml-modules/progress/default.nix
@@ -1,23 +1,20 @@
-{ lib, buildDunePackage, fetchurl
-, mtime, terminal_size, alcotest, astring, fmt
+{ lib, buildDunePackage
+, fmt, logs, mtime, optint, terminal, vector
+, alcotest, astring
 }:
 
 buildDunePackage rec {
   pname = "progress";
-  version = "0.1.1";
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
   useDune2 = true;
 
-  src = fetchurl {
-    url = "https://github.com/CraigFe/progress/releases/download/${version}/progress-${version}.tbz";
-    sha256 = "90c6bec19d014a4c6b0b67006f08bdfcf36981d2176769bebe0ccd75d6785a32";
-  };
+  inherit (terminal) version src;
 
-  propagatedBuildInputs = [ mtime terminal_size ];
+  propagatedBuildInputs = [ fmt logs mtime optint terminal vector ];
 
   doCheck = true;
-  checkInputs = [ alcotest astring fmt ];
+  checkInputs = [ alcotest astring ];
 
   meta = with lib; {
     description = "Progress bar library for OCaml";

--- a/pkgs/development/ocaml-modules/terminal/default.nix
+++ b/pkgs/development/ocaml-modules/terminal/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildDunePackage, fetchurl, ocaml
+, stdlib-shims, uutf, uucp
+, alcotest, fmt
+}:
+
+buildDunePackage rec {
+  pname = "terminal";
+  version = "0.2.1";
+
+  minimalOCamlVersion = "4.03";
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/CraigFe/progress/releases/download/${version}/terminal-${version}.tbz";
+    sha256 = "sha256:0vjqkvmpyi8kvmb4vrx3f0994rph8i9pvlrz1dyi126vlb2zbrvs";
+  };
+
+  propagatedBuildInputs = [ stdlib-shims uutf uucp ];
+
+  doCheck = lib.versionAtLeast ocaml.version "4.05";
+  checkInputs = [ alcotest fmt ];
+
+  meta = with lib; {
+    description = "Basic utilities for interacting with terminals";
+    homepage = "https://github.com/CraigFe/progress";
+    license = licenses.mit;
+    maintainers = [ maintainers.vbgl ];
+  };
+}
+

--- a/pkgs/development/ocaml-modules/vector/default.nix
+++ b/pkgs/development/ocaml-modules/vector/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, fetchurl }:
+
+buildDunePackage rec {
+  pname = "vector";
+  version = "1.0.0";
+
+  useDune2 = true;
+
+  src = fetchurl {
+    url = "https://github.com/backtracking/vector/releases/download/${version}/vector-${version}.tbz";
+    sha256 = "sha256:0hb6prpada4c5z07sxf5ayj5xbahsnwall15vaqdwdyfjgbd24pj";
+  };
+
+  doCheck = true;
+
+  meta = {
+    description = "Resizable arrays for OCaml";
+    license = lib.licenses.lgpl2Only;
+    homepage = "https://github.com/backtracking/vector";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1281,6 +1281,8 @@ let
 
     tcslib = callPackage ../development/ocaml-modules/tcslib { };
 
+    terminal = callPackage ../development/ocaml-modules/terminal { };
+
     terminal_size = callPackage ../development/ocaml-modules/terminal_size { };
 
     tezos-010-PtGRANAD-test-helpers = callPackage ../development/ocaml-modules/tezos/010-PtGRANAD-test-helpers.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1374,6 +1374,8 @@ let
 
     vchan = callPackage ../development/ocaml-modules/vchan { };
 
+    vector = callPackage ../development/ocaml-modules/vector { };
+
     vg = callPackage ../development/ocaml-modules/vg { };
 
     vlq = callPackage ../development/ocaml-modules/vlq { };


### PR DESCRIPTION
###### Motivation for this change

#154901

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @sternenseemann