### PR TITLE
discord{,-ptb,-canary}: add derivations for {x86_64,aarch64}-darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -1,0 +1,14 @@
+{ pname, version, src, meta, stdenv, binaryName, desktopName, undmg }:
+
+stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r "${desktopName}.app" $out/Applications
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -1,35 +1,89 @@
-{ branch ? "stable", pkgs }:
+{ branch ? "stable", pkgs, lib, stdenv }:
 let
   inherit (pkgs) callPackage fetchurl;
-in {
-  stable = callPackage ./base.nix rec {
-    pname = "discord";
-    binaryName = "Discord";
-    desktopName = "Discord";
-    version = "0.0.16";
-    src = fetchurl {
-      url = "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz";
-      sha256 = "UTVKjs/i7C/m8141bXBsakQRFd/c//EmqqhKhkr1OOk=";
+  versions = if stdenv.isLinux then {
+    stable = "0.0.16";
+    ptb = "0.0.27";
+    canary = "0.0.132";
+  } else {
+    stable = "0.0.264";
+    ptb = "0.0.58";
+    canary = "0.0.280";
+  };
+  version = versions.${branch};
+  srcs = {
+    x86_64-linux = {
+      stable = fetchurl {
+        url =
+          "https://dl.discordapp.net/apps/linux/${version}/discord-${version}.tar.gz";
+        sha256 = "UTVKjs/i7C/m8141bXBsakQRFd/c//EmqqhKhkr1OOk=";
+      };
+      ptb = fetchurl {
+        url =
+          "https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
+        sha256 = "0yphs65wpyr0ap6y24b0nbhq7sm02dg5c1yiym1fxjbynm1mdvqb";
+      };
+      canary = fetchurl {
+        url =
+          "https://dl-canary.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
+        sha256 = "1jjbd9qllgcdpnfxg5alxpwl050vzg13rh17n638wha0vv4mjhyv";
+      };
+    };
+    x86_64-darwin = {
+      stable = fetchurl {
+        url = "https://dl.discordapp.net/apps/osx/${version}/Discord.dmg";
+        sha256 = "1jvlxmbfqhslsr16prsgbki77kq7i3ipbkbn67pnwlnis40y9s7p";
+      };
+      ptb = fetchurl {
+        url =
+          "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
+        sha256 = "sha256-GwYUoPBbx9lSaRP1JwzI0UE9gEU+rV4a9BNPVSxHki0=";
+      };
+      canary = fetchurl {
+        url =
+          "https://dl-canary.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
+        sha256 = "0ccchsywry68vv81pqzzxmh1r19lnvxr429iwvgfr9y82lyjvz06";
+      };
+    };
+    # Only PTB bundles a MachO Universal binary with ARM support.
+    aarch64-darwin = {
+      ptb = fetchurl {
+        url =
+          "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
+        sha256 = "sha256-GwYUoPBbx9lSaRP1JwzI0UE9gEU+rV4a9BNPVSxHki0=";
+      };
     };
   };
-  ptb = callPackage ./base.nix rec {
-    pname = "discord-ptb";
-    binaryName = "DiscordPTB";
-    desktopName = "Discord PTB";
-    version = "0.0.27";
-    src = fetchurl {
-      url = "https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz";
-      sha256 = "0yphs65wpyr0ap6y24b0nbhq7sm02dg5c1yiym1fxjbynm1mdvqb";
+  src = srcs.${stdenv.hostPlatform.system}.${branch};
+
+  meta = with lib; {
+    description = "All-in-one cross-platform voice and text chat for gamers";
+    homepage = "https://discordapp.com/";
+    downloadPage = "https://discordapp.com/download";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ldesgoui MP2E devins2518 ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ]
+      ++ lib.optionals (branch == "ptb") [ "aarch64-darwin" ];
+  };
+  package = if stdenv.isLinux then ./linux.nix else ./darwin.nix;
+  packages = {
+    stable = callPackage package rec {
+      inherit src version meta;
+      pname = "discord";
+      binaryName = "Discord";
+      desktopName = "Discord";
+    };
+    ptb = callPackage package rec {
+      inherit src version meta;
+      pname = "discord-ptb";
+      binaryName = "DiscordPTB";
+      desktopName = "Discord PTB";
+    };
+    canary = callPackage package rec {
+      inherit src version meta;
+      pname = "discord-canary";
+      binaryName = "DiscordCanary";
+      desktopName = "Discord Canary";
     };
   };
-  canary = callPackage ./base.nix rec {
-    pname = "discord-canary";
-    binaryName = "DiscordCanary";
-    desktopName = "Discord Canary";
-    version = "0.0.132";
-    src = fetchurl {
-      url = "https://dl-canary.discordapp.net/apps/linux/${version}/discord-canary-${version}.tar.gz";
-      sha256 = "1jjbd9qllgcdpnfxg5alxpwl050vzg13rh17n638wha0vv4mjhyv";
-    };
-  };
-}.${branch}
+in packages.${branch}

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -1,17 +1,14 @@
-{ pname, version, src, binaryName, desktopName
-, autoPatchelfHook, makeDesktopItem, lib, stdenv, wrapGAppsHook
-, alsa-lib, at-spi2-atk, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig
-, freetype, gdk-pixbuf, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid
-, libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
-, libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence
-, mesa, nspr, nss, pango, systemd, libappindicator-gtk3, libdbusmenu
-, writeScript, common-updater-scripts
-}:
+{ pname, version, src, meta, binaryName, desktopName, autoPatchelfHook
+, makeDesktopItem, lib, stdenv, wrapGAppsHook, alsa-lib, at-spi2-atk
+, at-spi2-core, atk, cairo, cups, dbus, expat, fontconfig, freetype, gdk-pixbuf
+, glib, gtk3, libcxx, libdrm, libnotify, libpulseaudio, libuuid, libX11
+, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
+, libXi, libXrandr, libXrender, libXtst, libxcb, libxshmfence, mesa, nspr, nss
+, pango, systemd, libappindicator-gtk3, libdbusmenu, writeScript
+, common-updater-scripts }:
 
-let
-  inherit binaryName;
-in stdenv.mkDerivation rec {
-  inherit pname version src;
+stdenv.mkDerivation rec {
+  inherit pname version src meta;
 
   nativeBuildInputs = [
     alsa-lib
@@ -33,13 +30,45 @@ in stdenv.mkDerivation rec {
   dontWrapGApps = true;
 
   libPath = lib.makeLibraryPath [
-    libcxx systemd libpulseaudio libdrm mesa
-    stdenv.cc.cc alsa-lib atk at-spi2-atk at-spi2-core cairo cups dbus expat fontconfig freetype
-    gdk-pixbuf glib gtk3 libnotify libX11 libXcomposite libuuid
-    libXcursor libXdamage libXext libXfixes libXi libXrandr libXrender
-    libXtst nspr nss libxcb pango libXScrnSaver
-    libappindicator-gtk3 libdbusmenu
-   ];
+    libcxx
+    systemd
+    libpulseaudio
+    libdrm
+    mesa
+    stdenv.cc.cc
+    alsa-lib
+    atk
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libnotify
+    libX11
+    libXcomposite
+    libuuid
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    nspr
+    nss
+    libxcb
+    pango
+    libXScrnSaver
+    libappindicator-gtk3
+    libdbusmenu
+  ];
 
   installPhase = ''
     mkdir -p $out/{bin,opt/${binaryName},share/pixmaps}
@@ -56,7 +85,9 @@ in stdenv.mkDerivation rec {
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems
-    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${lib.strings.toLower binaryName} || true
+    ln -s $out/opt/${binaryName}/${binaryName} $out/bin/${
+      lib.strings.toLower binaryName
+    } || true
     ln -s $out/opt/${binaryName}/discord.png $out/share/pixmaps/${pname}.png
 
     ln -s "${desktopItem}/share/applications" $out/share/
@@ -76,18 +107,11 @@ in stdenv.mkDerivation rec {
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl gnugrep common-updater-scripts
     set -eou pipefail;
-    url=$(curl -sI "https://discordapp.com/api/download/${builtins.replaceStrings ["discord-" "discord"] ["" "stable"] pname}?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
+    url=$(curl -sI "https://discordapp.com/api/download/${
+      builtins.replaceStrings [ "discord-" "discord" ] [ "" "stable" ] pname
+    }?platform=linux&format=tar.gz" | grep -oP 'location: \K\S+')
     version=''${url##https://dl*.discordapp.net/apps/linux/}
     version=''${version%%/*.tar.gz}
     update-source-version ${pname} "$version" --file=./pkgs/applications/networking/instant-messengers/discord/default.nix
   '';
-
-  meta = with lib; {
-    description = "All-in-one cross-platform voice and text chat for gamers";
-    homepage = "https://discordapp.com/";
-    downloadPage = "https://discordapp.com/download";
-    license = licenses.unfree;
-    maintainers = with maintainers; [ ldesgoui MP2E ];
-    platforms = [ "x86_64-linux" ];
-  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34023,17 +34023,17 @@ with pkgs;
 
   discord = import ../applications/networking/instant-messengers/discord {
     branch = "stable";
-    inherit pkgs;
+    inherit pkgs lib stdenv;
   };
 
   discord-ptb = import ../applications/networking/instant-messengers/discord {
     branch = "ptb";
-    inherit pkgs;
+    inherit pkgs lib stdenv;
   };
 
   discord-canary = import ../applications/networking/instant-messengers/discord {
     branch = "canary";
-    inherit pkgs;
+    inherit pkgs lib stdenv;
   };
 
   golden-cheetah = libsForQt514.callPackage ../applications/misc/golden-cheetah {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Discord is not available on the macOS platform right now, and this PR addresses this. x86_64-darwin and aarch64-darwin (only PTB right now) are made available.

###### Things done
Reorganized the `discord/default.nix` file to use matrices to obtain version numbers and source urls. `discord/base.nix` has separate derivations for Darwin and linux now. Right now, `x86_64-darwin.{stable,canary}` will not build because I was not sure on how to get the hash value of the output files as I only have access to an M1 Mac. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
