### PR TITLE
python3Packages.pytorch-bin: enable on darwin (cpu build)

### DIFF
--- a/pkgs/development/python-modules/pytorch/bin.nix
+++ b/pkgs/development/python-modules/pytorch/bin.nix
@@ -11,6 +11,7 @@
 , patchelf
 , pyyaml
 , requests
+, setuptools
 , typing-extensions
 }:
 
@@ -41,6 +42,7 @@ in buildPythonPackage {
     numpy
     pyyaml
     requests
+    setuptools
     typing-extensions
   ];
 
@@ -72,7 +74,7 @@ in buildPythonPackage {
     # https://docs.nvidia.com/cuda/eula/index.html
     # https://www.intel.com/content/www/us/en/developer/articles/license/onemkl-license-faq.html
     license = licenses.bsd3;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ junjihashimoto ];
   };
 }

--- a/pkgs/development/python-modules/pytorch/binary-hashes.nix
+++ b/pkgs/development/python-modules/pytorch/binary-hashes.nix
@@ -22,5 +22,30 @@ version : builtins.getAttr version {
       url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
       hash = "sha256-w8UJDh4b5cgDu7ZSvDoKzNH4hiXEyRfvpycNOg+wJOg=";
     };
+    x86_64-darwin-37 = {
+      name = "torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-RJkFVUcIfX736KdU8JwsTxRwKXrj5UkDY9umbHVQGyE=";
+    };
+    x86_64-darwin-38 = {
+      name = "torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-rvevti6bF0tODl4eSkLjurO4SQpmjWZvYvfUUXVZ+/I=";
+    };
+    x86_64-darwin-39 = {
+      name = "torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-1u+HRwtE35lw6EVCVH1bp3ILuJYWYCRB31VaObEk4rw=";
+    };
+    aarch64-darwin-38 = {
+      name = "torch-1.10.0-cp38-none-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_11_0_arm64.whl";
+      hash = "sha256-1hhYJ7KFeAZTzdgdd6Cf3KdqWxkNWYbVUr4qXEQs+qQ=";
+    };
+    aarch64-darwin-39 = {
+      name = "torch-1.10.0-cp39-none-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp39-none-macosx_11_0_arm64.whl";
+      hash = "sha256-7qZ17AHsS0oGVf0phPFmpco7kz2uatTrTlLrpwJtwXY=";
+    };
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- this PR enables pytorch-bin on darwin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
