### PR TITLE
[staging] sconsPackages.*: use python3

### DIFF
--- a/pkgs/development/tools/build-managers/scons/common.nix
+++ b/pkgs/development/tools/build-managers/scons/common.nix
@@ -1,8 +1,8 @@
 { version, sha256 }:
 
-{ fetchurl, python, lib }:
+{ fetchurl, python3, lib }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "scons";
   inherit version;
 
@@ -32,7 +32,7 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     # expose the used python version so tools using this (and extensing scos with other python modules)
     # can use the exact same python version.
-    inherit python;
+    python = python3;
   };
 
   meta = with lib; {

--- a/pkgs/development/tools/build-managers/scons/default.nix
+++ b/pkgs/development/tools/build-managers/scons/default.nix
@@ -1,18 +1,16 @@
-{ callPackage, python2, python3 }:
+{ callPackage, python3 }:
 
 let
-  mkScons = args: callPackage (import ./common.nix args) {
-    python = python3;
-  };
+  mkScons = args: callPackage (import ./common.nix args) { };
 in {
-  scons_3_0_1 = (mkScons {
+  scons_3_0_1 = mkScons {
     version = "3.0.1";
     sha256 = "0wzid419mlwqw9llrg8gsx4nkzhqy16m4m40r0xnh6cwscw5wir4";
-  }).override { python = python2; };
-  scons_3_1_2 = (mkScons {
+  };
+  scons_3_1_2 = mkScons {
     version = "3.1.2";
     sha256 = "1yzq2gg9zwz9rvfn42v5jzl3g4qf1khhny6zfbi2hib55zvg60bq";
-  }).override { python = python2; };
+  };
   scons_latest = mkScons {
     version = "4.1.0";
     sha256 = "11axk03142ziax6i3wwy9qpqp7r3i7h5jg9y2xzph9i15rv8vlkj";

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -17,7 +17,7 @@ let
             mozjsVersion = "60";
             mozjsReplace = "defined(HAVE___SINCOS)";
           }
-    else rec { python = scons.python.withPackages (ps: with ps; [ pyyaml typing cheetah ]);
+    else rec { python = scons.python.withPackages (ps: with ps; [ pyyaml typing cheetah3 setuptools ]);
             scons = sconsPackages.scons_3_1_2;
             mozjsVersion = "45";
             mozjsReplace = "defined(HAVE_SINCOS)";


### PR DESCRIPTION
###### Motivation for this change
Attempt to use python3 for all scons builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
