### PR TITLE
python310Packages.bibtexparser: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/batchgenerators/default.nix
+++ b/pkgs/development/python-modules/batchgenerators/default.nix
@@ -1,12 +1,12 @@
 { lib
 , buildPythonPackage
-, isPy27
+, pythonOlder
 , fetchFromGitHub
 , pytestCheckHook
-, unittest2
 , future
 , numpy
 , pillow
+, fetchpatch
 , scipy
 , scikit-learn
 , scikitimage
@@ -16,27 +16,53 @@
 buildPythonPackage rec {
   pname = "batchgenerators";
   version = "0.21";
+  format = "setuptools";
 
-  disabled = isPy27;
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "MIC-DKFZ";
     repo = pname;
     rev = "v${version}";
-    sha256 = "16bk4r0q3m2c9fawpmj4l7kz0x3fyv1spb92grf44gmyricq3jdb";
-
+    hash = "sha256-q8mBWcy+PkJcfiKtq8P2bnTw56FE1suVS0zUgUEmc5k=";
   };
 
   propagatedBuildInputs = [
-    future numpy pillow scipy scikit-learn scikitimage threadpoolctl
+    future
+    numpy
+    pillow
+    scipy
+    scikit-learn
+    scikitimage
+    threadpoolctl
   ];
 
-  checkInputs = [ pytestCheckHook unittest2 ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  meta = {
+  patches = [
+    # Remove deprecated unittest2, https://github.com/MIC-DKFZ/batchgenerators/pull/78
+    (fetchpatch {
+      name = "remove-unittest2.patch";
+      url = "https://github.com/MIC-DKFZ/batchgenerators/commit/87a9437057df8a7550aa3b3eaf840871cc0d5cef.patch";
+      sha256 = "sha256-vozBK7g2dLxx9din/R2vU28Mm+LoGAO/BmQlt/ShmEo=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace '"unittest2",' ""
+  '';
+
+  pythonImportsCheck = [
+    "batchgenerators"
+  ];
+
+  meta = with lib; {
     description = "2D and 3D image data augmentation for deep learning";
     homepage = "https://github.com/MIC-DKFZ/batchgenerators";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ bcdarwin ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
   };
 }

--- a/pkgs/development/python-modules/bibtexparser/default.nix
+++ b/pkgs/development/python-modules/bibtexparser/default.nix
@@ -1,33 +1,49 @@
 { lib
-, buildPythonPackage, fetchFromGitHub
-, future, pyparsing
-, glibcLocales, nose, unittest2
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, pyparsing
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "bibtexparser";
-  version = "1.1.0";
+  version = "1.2.0";
+  format = "setuptools";
 
-  # PyPI tarball does not ship tests
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "sciunto-org";
     repo = "python-${pname}";
     rev = "v${version}";
-    sha256 = "1yj3hqnmkjh0sjjhmlm4097mmz98kna8rn0dd9g8zaw9g1a35h8c";
+    hash = "sha256-M9fDI28Yq0uUHPx51wiuRPmRTLkjVqj7ixapbSftnJc=";
   };
 
-  propagatedBuildInputs = [ future pyparsing ];
+  propagatedBuildInputs = [
+    future
+    pyparsing
+  ];
 
-  checkInputs = [ nose unittest2 glibcLocales ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    LC_ALL="en_US.UTF-8" nosetests
+  postPatch = ''
+    # https://github.com/sciunto-org/python-bibtexparser/pull/259
+    substituteInPlace bibtexparser/tests/test_crossref_resolving.py \
+      --replace "import unittest2 as unittest" "import unittest"
   '';
 
-  meta = {
-    description = "Bibtex parser for python 2.7 and 3.3 and newer";
+  pythonImportsCheck = [
+    "bibtexparser"
+  ];
+
+  meta = with lib; {
+    description = "Bibtex parser for Python";
     homepage = "https://github.com/sciunto-org/python-bibtexparser";
-    license = with lib.licenses; [ gpl3 bsd3 ];
-    maintainers = with lib.maintainers; [ fridh ];
+    license = with licenses; [ lgpl3Only /* or */ bsd3 ];
+    maintainers = with maintainers; [ fridh ];
   };
 }

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,53 +1,55 @@
 { lib
-, fetchPypi
 , buildPythonPackage
-, isPy27
-, isPy3k
+, dask
+, fetchPypi
+, fsspec
+, lxml
 , numpy
-, imagecodecs-lite
-, enum34 ? null
-, futures ? null
-, pathlib ? null
-, pytest
+, pytestCheckHook
+, pythonOlder
+, zarr
 }:
 
 buildPythonPackage rec {
   pname = "tifffile";
   version = "2021.11.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "153e31fa1d892f482fabb2ae9f2561fa429ee42d01a6f67e58cee13637d9285b";
+    hash = "sha256-FT4x+h2JL0gvq7KunyVh+kKe5C0BpvZ+WM7hNjfZKFs=";
   };
-
-  patches = lib.optional isPy27 ./python2-regex-compat.patch;
-
-  # Missing dependencies: imagecodecs, czifile, cmapfile, oiffile, lfdfiles
-  # and test data missing from PyPI tarball
-  doCheck = false;
-
-  checkInputs = [
-    pytest
-  ];
-
-  checkPhase = ''
-    pytest
-  '';
 
   propagatedBuildInputs = [
     numpy
-  ] ++ lib.optionals isPy3k [
-    imagecodecs-lite
-  ] ++ lib.optionals isPy27 [
-    futures
-    enum34
-    pathlib
+  ];
+
+  checkInputs = [
+    dask
+    fsspec
+    lxml
+    pytestCheckHook
+    zarr
+  ];
+
+  disabledTests = [
+    # Test require network access
+    "test_class_omexml"
+    "test_write_ome"
+    # Test file is missing
+    "test_write_predictor"
+  ];
+
+  pythonImportsCheck = [
+    "tifffile"
   ];
 
   meta = with lib; {
-    description = "Read and write image data from and to TIFF files.";
-    homepage = "https://www.lfd.uci.edu/~gohlke/";
-    maintainers = [ maintainers.lebastr ];
+    description = "Read and write image data from and to TIFF files";
+    homepage = "https://github.com/cgohlke/tifffile/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [ lebastr ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163504135, https://hydra.nixos.org/build/163523665, https://hydra.nixos.org/build/164496223)

Preparation to fix `papis`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
