### PR TITLE
python3Packages.scrapy: disable failing test

### DIFF
--- a/pkgs/development/python-modules/logfury/default.nix
+++ b/pkgs/development/python-modules/logfury/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-EwpdrOq5rVNJJCUt33BIKqLJZmKzo4JafTCYHQO3aiY=";
+    hash = "sha256-EwpdrOq5rVNJJCUt33BIKqLJZmKzo4JafTCYHQO3aiY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/logfury/default.nix
+++ b/pkgs/development/python-modules/logfury/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, funcsigs
 , setuptools-scm
 , pytestCheckHook
 , pythonOlder
@@ -11,6 +10,7 @@
 buildPythonPackage rec {
   pname = "logfury";
   version = "1.0.1";
+  format = "setuptools";
 
   disabled = pythonOlder "3.5";
 
@@ -21,10 +21,6 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools-scm
-  ];
-
-  propagatedBuildInputs = [
-    funcsigs
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -86,9 +86,10 @@ buildPythonPackage rec {
 
   LC_ALL = "en_US.UTF-8";
 
-  # Disable doctest plugin because it causes pytest to hang
   preCheck = ''
-    substituteInPlace pytest.ini --replace "--doctest-modules" ""
+    # Disable doctest plugin because it causes pytest to hang
+    substituteInPlace pytest.ini \
+      --replace "--doctest-modules" ""
   '';
 
   disabledTestPaths = [
@@ -116,6 +117,7 @@ buildPythonPackage rec {
     "test_peek_fifo"
     "test_peek_one_element"
     "test_peek_lifo"
+    "test_callback_kwargs"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_xmliter_encoding"
     "test_download"
@@ -127,7 +129,9 @@ buildPythonPackage rec {
     install -m 644 -D extras/scrapy_zsh_completion $out/share/zsh/site-functions/_scrapy
   '';
 
-  pythonImportsCheck = [ "scrapy" ];
+  pythonImportsCheck = [
+    "scrapy"
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/164070567)

Follow up of #154937

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
