### PR TITLE
far2l: 2020-12-30 → 2.4.0, enable on darwin

### DIFF
--- a/pkgs/applications/misc/far2l/default.nix
+++ b/pkgs/applications/misc/far2l/default.nix
@@ -1,79 +1,79 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, cmake, pkg-config, wxGTK30, glib, pcre, m4, bash
-, xdg-utils, gvfs, zip, unzip, gzip, bzip2, gnutar, p7zip, xz, imagemagick
-, libuchardet, spdlog, xercesc, openssl, libssh, samba, neon, libnfs, libarchive }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, cmake, ninja, pkg-config, m4, bash
+, xdg-utils, zip, unzip, gzip, bzip2, gnutar, p7zip, xz
+, IOKit, Carbon, Cocoa, AudioToolbox, OpenGL
+, withTTYX ? true, libX11
+, withGUI ? true, wxGTK30, wxmac
+, withUCD ? true, libuchardet
 
+# Plugins
+, withColorer ? true, spdlog, xercesc
+, withMultiArc ? true, libarchive, pcre
+, withNetRocks ? true, openssl, libssh, samba, libnfs, neon
+, withPython ? false, python3Packages
+}:
+
+let
+  wxWidgets = (if stdenv.isDarwin then wxmac else wxGTK30);
+in
 stdenv.mkDerivation rec {
   pname = "far2l";
-  version = "2020-12-30.git${builtins.substring 0 7 src.rev}";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "elfmz";
     repo = "far2l";
-    rev = "52c1372441443aafd1a7dff6f17969a6ec19885d";
-    sha256 = "0s7427fgxzj5zkyy6mhb4y5hqa6adsr30m0bigycp12b0495ryx0";
+    rev = "v_${version}";
+    sha256 = "sha256-nfoAElPLQ97lj65MBX4JMEdgTFbkdEbR1BazYZgV/lg=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config m4 makeWrapper imagemagick ];
+  patches = [ ./python_prebuild.patch ];
 
-  buildInputs = [ wxGTK30 glib pcre libuchardet spdlog xercesc ] # base requirements of the build
-    ++ [ openssl libssh samba neon libnfs libarchive ]; # optional feature packages, like protocol support for Network panel, or archive formats
-    #++ lib.optional stdenv.isDarwin Cocoa # Mac support -- disabled, see "meta.broken" below
+  nativeBuildInputs = [ cmake ninja pkg-config m4 makeWrapper ];
 
-  postPatch = lib.optionalString stdenv.isLinux ''
-    substituteInPlace far2l/bootstrap/trash.sh \
-      --replace 'gvfs-trash'  '${gvfs}/bin/gvfs-trash'
-  '' + lib.optionalString stdenv.isDarwin ''
-    substituteInPlace far2l/CMakeLists.txt \
-      --replace "-framework System" -lSystem
-  '' + ''
-    echo 'echo ${version}' > far2l/bootstrap/scripts/vbuild.sh
-    substituteInPlace far2l/bootstrap/open.sh              \
-      --replace 'xdg-open'    '${xdg-utils}/bin/xdg-open'
-    substituteInPlace far2l/vtcompletor.cpp                \
+  buildInputs = lib.optional withTTYX libX11
+    ++ lib.optional withGUI wxWidgets
+    ++ lib.optional withUCD libuchardet
+    ++ lib.optionals withColorer [ spdlog xercesc ]
+    ++ lib.optionals withMultiArc [ libarchive pcre ]
+    ++ lib.optionals withNetRocks [ openssl libssh libnfs neon ]
+    ++ lib.optional (withNetRocks && !stdenv.isDarwin) samba # broken on darwin
+    ++ lib.optionals withPython (with python3Packages; [ python cffi debugpy pcpp ])
+    ++ lib.optionals stdenv.isDarwin [ IOKit Carbon Cocoa AudioToolbox OpenGL ];
+
+  postPatch = ''
+    patchShebangs python/src/prebuild.sh
+    substituteInPlace far2l/src/vt/vtcompletor.cpp \
       --replace '"/bin/bash"' '"${bash}/bin/bash"'
-    substituteInPlace multiarc/src/formats/zip/zip.cpp     \
-      --replace '"unzip '     '"${unzip}/bin/unzip '       \
-      --replace '"zip '       '"${zip}/bin/zip '
-    substituteInPlace multiarc/src/formats/7z/7z.cpp       \
-      --replace '"^7z '       '"^${p7zip}/lib/p7zip/7z '   \
-      --replace '"7z '        '"${p7zip}/lib/p7zip/7z '
-    substituteInPlace multiarc/src/formats/targz/targz.cpp \
-      --replace '"xz '        '"${xz}/bin/xz '             \
-      --replace '"gzip '      '"${gzip}/bin/gzip '         \
-      --replace '"bzip2 '     '"${bzip2}/bin/bzip2 '       \
-      --replace '"tar '       '"${gnutar}/bin/tar '
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/scalable/apps
-    cp -dpR install $out/share/far2l
-    mv $out/share/far2l/far2l $out/bin/
-    ln -s -r --force $out/bin/far2l $out/share/far2l/far2l_askpass
-    ln -s -r --force $out/bin/far2l $out/share/far2l/far2l_sudoapp
-
-    cp ../far2l/DE/far2l.desktop $out/share/applications/far2l.desktop
-    substituteInPlace $out/share/applications/far2l.desktop --replace \''${CMAKE_INSTALL_PREFIX} "$out"
-
-    cp ../far2l/DE/icons/hicolor/1024x1024/apps/far2l.svg $out/share/icons/hicolor/scalable/apps/
-    convert -size 128x128 ../far2l/DE/icons/far2l.svg $out/share/icons/far2l.png
-    for size in 16x16 24x24 32x32 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512 1024x1024; do
-      mkdir -p $out/share/icons/hicolor/$size/apps
-      convert -size $size ../far2l/DE/icons/hicolor/$size/apps/far2l.svg $out/share/icons/hicolor/$size/apps/far2l.png
-    done
+    substituteInPlace far2l/src/cfg/config.cpp \
+      --replace '"/bin/bash"' '"${bash}/bin/bash"'
   '' + lib.optionalString stdenv.isDarwin ''
-    wrapProgram $out/bin/far2l --argv0 $out/bin/far2l
+    substituteInPlace WinPort/src/Backend/WX/CMakeLists.txt \
+      --replace "-framework System" -lSystem
   '';
 
-  stripDebugList = [ "bin" "share" ];
+  cmakeFlags = lib.mapAttrsToList (k: v: "-D${k}=${if v then "yes" else "no"}") {
+    TTYX = withTTYX;
+    USEWX = withGUI;
+    USEUCD = withUCD;
+    COLORER = withColorer;
+    MULTIARC = withMultiArc;
+    NETROCKS = withNetRocks;
+    PYTHON = withPython;
+  };
+
+  runtimeDeps = [ unzip zip p7zip xz gzip bzip2 gnutar xdg-utils ];
+
+  postInstall = ''
+    wrapProgram $out/bin/far2l \
+      --argv0 $out/bin/far2l \
+      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+  '';
 
   meta = with lib; {
     description = "Linux port of FAR Manager v2, a program for managing files and archives in Windows operating systems";
     homepage = "https://github.com/elfmz/far2l";
     license = licenses.gpl2Plus; # NOTE: might change in far2l repo soon, check next time
     maintainers = with maintainers; [ volth hypersw ];
-    platforms = platforms.all;
-    # fails to compile with:
-    # error: no member named 'st_ctim' in 'stat'
-    broken = stdenv.isDarwin;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/far2l/python_prebuild.patch
+++ b/pkgs/applications/misc/far2l/python_prebuild.patch
@@ -1,0 +1,20 @@
+diff --git i/python/src/prebuild.sh w/python/src/prebuild.sh
+index d2847ee5..aa1ecc53 100755
+--- i/python/src/prebuild.sh
++++ w/python/src/prebuild.sh
+@@ -12,9 +12,6 @@ mkdir -p "$DST/incpy"
+ if [ ! -f "$DST/python/.prepared" ]; then
+ 	echo "Preparing python virtual env at $DST/python using $PYTHON"
+ 	mkdir -p "$DST/python"
+-	$PYTHON -m venv --system-site-packages "$DST/python"
+-	"$DST/python/bin/python" -m pip install --upgrade pip || true
+-	"$DST/python/bin/python" -m pip install --ignore-installed cffi debugpy pcpp
+ 	$PREPROCESSOR "$SRC/python/src/consts.gen" | sh > "${DST}/incpy/consts.h"
+ 
+ 	echo "1" > "$DST/python/.prepared"
+@@ -26,4 +23,4 @@ cp -f -R \
+ 	"$SRC/python/configs/plug/far2l/"* \
+ 	"$DST/incpy/"
+ 
+-"$DST/python/bin/python" "$SRC/python/src/pythongen.py" "${SRC}" "${DST}/incpy"
++"python" "$SRC/python/src/pythongen.py" "${SRC}" "${DST}/incpy"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16331,6 +16331,7 @@ with pkgs;
 
   far2l = callPackage ../applications/misc/far2l {
     stdenv = if stdenv.cc.isClang then llvmPackages.stdenv else stdenv;
+    inherit (darwin.apple_sdk.frameworks) IOKit Carbon Cocoa AudioToolbox OpenGL;
   };
 
   farbfeld = callPackage ../development/libraries/farbfeld { };


### PR DESCRIPTION
###### Motivation for this change
* v2.4.0 BETA released
* enable on darwin

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
