### PR TITLE
nsync: init at 1.24.0

### DIFF
--- a/pkgs/development/libraries/nsync/default.nix
+++ b/pkgs/development/libraries/nsync/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "google";
-    repo = "nsync";
+    repo = pname;
     rev = version;
     sha256 = "sha256-jQJtlBDR6efBe1tFOUOZ6awaMTT33qM/GbvbwiWTZxw=";
   };
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/google/nsync";
     description = "C library that exports various synchronization primitives";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.puffnfresh ];
+    maintainers = with lib.maintainers; [ puffnfresh ];
     # On macOS we get an error for some reason:
     # > mkdir: cannot create directory 'build': File exists
     platforms = lib.platforms.linux;

--- a/pkgs/development/libraries/nsync/default.nix
+++ b/pkgs/development/libraries/nsync/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nsync";
+  version = "1.24.0";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "nsync";
+    rev = version;
+    sha256 = "sha256-jQJtlBDR6efBe1tFOUOZ6awaMTT33qM/GbvbwiWTZxw=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    homepage = "https://github.com/google/nsync";
+    description = "C library that exports various synchronization primitives";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.puffnfresh ];
+    # On macOS we get an error for some reason:
+    # > mkdir: cannot create directory 'build': File exists
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3492,6 +3492,8 @@ with pkgs;
 
   nrsc5 = callPackage ../applications/misc/nrsc5 { };
 
+  nsync = callPackage ../development/libraries/nsync { };
+
   nwipe = callPackage ../tools/security/nwipe { };
 
   nx2elf = callPackage ../tools/compression/nx2elf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Library is used in various places, e.g. onnxruntime, Tensorflow

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
