### PR TITLE
dockutil: new package for darwin

### DIFF
--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -18,8 +18,12 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     install -Dm755 usr/local/bin/dockutil -t $out/bin
+
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchurl, libarchive, p7zip }:
+
+stdenv.mkDerivation rec {
+  pname = "dockutil";
+  version = "2.0.5";
+
+  src = fetchurl {
+    url = "https://github.com/kcrawford/dockutil/releases/download/${version}/dockutil-${version}.pkg";
+    sha256 = "sha256-kZ7dOG8SSh25DgcbvkgPvEFGZIVz4fv0kWN41pbeNlw=";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ libarchive p7zip ];
+
+  unpackPhase = ''
+    7z x $src
+    bsdtar -xf Payload~
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -Dm755 usr/local/bin/dockutil -t $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Tool for managing dock items";
+    homepage = "https://github.com/kcrawford/dockutil";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ tboerger ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -1,27 +1,23 @@
-{ lib, stdenv, fetchurl, libarchive, p7zip }:
+{ lib, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "dockutil";
   version = "2.0.5";
 
-  src = fetchurl {
-    url = "https://github.com/kcrawford/dockutil/releases/download/${version}/dockutil-${version}.pkg";
-    sha256 = "sha256-kZ7dOG8SSh25DgcbvkgPvEFGZIVz4fv0kWN41pbeNlw=";
+  src = fetchFromGitHub {
+    owner  = "kcrawford";
+    repo   = "dockutil";
+    rev    = version;
+    sha256 = "sha256-8tDkueCTCtvxc7owp3K9Tsrn4hL79CM04zBNv7AcHgA=";
   };
 
   dontBuild = true;
-  nativeBuildInputs = [ libarchive p7zip ];
-
-  unpackPhase = ''
-    7z x $src
-    bsdtar -xf Payload~
-  '';
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
-    install -Dm755 usr/local/bin/dockutil -t $out/bin
+    install -Dm755 scripts/dockutil -t $out/bin
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33016,6 +33016,8 @@ with pkgs;
 
   dell-530cdn = callPackage ../misc/drivers/dell-530cdn {};
 
+  dockutil = callPackage ../os-specific/darwin/dockutil { };
+
   dosbox = callPackage ../applications/emulators/dosbox { };
 
   dosbox-staging = callPackage ../applications/emulators/dosbox-staging { };


### PR DESCRIPTION
###### Motivation for this change

I would like to contribute a module to nix-darwin to configure the macOS applications displayed within the Dock, the tool dockutil helps to script the Dock items.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
