### PR TITLE
linuxPackages.kvmfr: patch for 5.16

### DIFF
--- a/pkgs/os-specific/linux/kvmfr/default.nix
+++ b/pkgs/os-specific/linux/kvmfr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, kernel, kmod, looking-glass-client }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, kernel, kmod, looking-glass-client }:
 
 stdenv.mkDerivation rec {
   pname = "kvmfr";
@@ -8,6 +8,13 @@ stdenv.mkDerivation rec {
   sourceRoot = "source/module";
   hardeningDisable = [ "pic" "format" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  patches = lib.optional (kernel.kernelAtLeast "5.16") (fetchpatch {
+    name = "kvmfr-5.16.patch";
+    url = "https://github.com/gnif/LookingGlass/commit/a9b5302a517e19d7a2da114acf71ef1e69cfb497.patch";
+    sha256 = "017nxlk2f7kyjp6llwa74dbczdb1jk8v791qld81dxhzkm9dyqqx";
+    stripLen = 1;
+  });
 
   makeFlags = [
     "KVER=${kernel.modDirVersion}"
@@ -28,6 +35,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ j-brn ];
     platforms = [ "x86_64-linux" ];
-    broken = kernel.kernelOlder "5.3" || kernel.kernelAtLeast "5.16";
+    broken = kernel.kernelOlder "5.3";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

 #154240

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).