### PR TITLE
python3Packages.tempest: remove unittest2 requirement

### DIFF
--- a/pkgs/development/python-modules/tempest/default.nix
+++ b/pkgs/development/python-modules/tempest/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonApplication
 , fetchPypi
+, fetchpatch
 , pbr
 , cliff
 , jsonschema
@@ -20,7 +21,6 @@
 , prettytable
 , urllib3
 , debtcollector
-, unittest2
 , hacking
 , oslotest
 , bash
@@ -35,6 +35,14 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "0521d3042360c0fb469b16f99174a9abddbae8a2d2a81268cfc664f1ccfdd0f9";
   };
+
+  patches = [
+    # remove need for unittest2
+    (fetchpatch {
+      url = "https://github.com/openstack/tempest/pull/32/commits/cd3745c27b7d8fcdaffc72b965a3d803d9ee12c2.patch";
+      sha256 = "sha256-UwUmyFZokH66Xqfsj982MBHb0w7x6v4SAtXlqA5dpnk=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pbr
@@ -56,7 +64,6 @@ buildPythonApplication rec {
     prettytable
     urllib3
     debtcollector
-    unittest2
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Motivation for this change

related: https://github.com/NixOS/nixpkgs/pull/154650
related: https://github.com/NixOS/nixpkgs/pull/155005

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
