### PR TITLE
onnxruntime: init at 1.10.0 (resurrected)

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -1,0 +1,135 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, runCommand
+, patchutils
+, pkg-config
+, glibcLocales
+, cmake
+, python3
+, libpng
+, zlib
+, eigen
+, protobuf
+, nsync
+, flatbuffers
+, howard-hinnant-date
+, re2
+, nlohmann_json
+, boost
+, oneDNN
+}:
+
+let
+  externals = {
+    pytorch_cpuinfo = fetchFromGitHub {
+      owner = "pytorch";
+      repo = "cpuinfo";
+      rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
+      sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
+    };
+    onnx = fetchFromGitHub {
+      owner = "onnx";
+      repo = "onnx";
+      rev = "be76ca7148396176784ba8733133b9fb1186ea0d";
+      sha256 = "sha256-WwbfUijV67LL69RPgz+4m6EcwSyBNFweGUe0jkYRpbg=";
+    };
+    "SafeInt/safeint" = fetchFromGitHub {
+      owner = "dcleblanc";
+      repo = "SafeInt";
+      rev = "a104e0cf23be4fe848f7ef1f3e8996fe429b06bb";
+      sha256 = "sha256-LmQNIoHPqvl8asn86P33SDn+lCg8LpLfxUmoG9CGEdc=";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "onnxruntime";
+  version = "1.10.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime";
+    rev = "v${version}";
+    sha256 = "sha256-kWl0xrbTQL2FBSvpiqTcaj8uZV+ZV8gJJvj4/I0jopw=";
+  };
+
+  preConfigure = lib.concatStringsSep "\n" (lib.mapAttrsToList (name: path: ''
+    rmdir cmake/external/${name}
+    ln -s ${path} cmake/external/${name}
+  '') externals);
+
+  patches = [
+    # Exclude the flatbuffers change which breaks things
+    (runCommand "filtered" {
+      AUR_PATCH = fetchpatch {
+        name = "aur-build-fixes.patch";
+        url = "https://aur.archlinux.org/cgit/aur.git/plain/build-fixes.patch?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
+        sha256 = "sha256-bAJWThTbECQaoqDdkjHLneg6I1BshGMyCWaj7nfACvA=";
+      };
+    } ''
+      ${patchutils}/bin/filterdiff --hunks 1,2 $AUR_PATCH > $out
+    '')
+    (fetchpatch {
+      name = "system-dnnl.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/system-dnnl.diff?h=python-onnxruntime&id=0185531906bda3a9aba93bbb0f3dcfeb0ae671ad";
+      sha256 = "sha256-58RBrQnAWNtc/1pmFs+PkZ6qCsL1LfMY3P0exMKzotA=";
+    })
+  ];
+
+  # TODO: build server, and move .so's to lib output
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    libpng
+    zlib
+    protobuf
+    nsync
+    flatbuffers
+    howard-hinnant-date
+    re2
+    nlohmann_json
+    boost
+    oneDNN
+  ];
+
+  cmakeDir = "../cmake";
+
+  cmakeFlags = [
+    "-Donnxruntime_PREFER_SYSTEM_LIB=ON"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_ENABLE_LTO=ON"
+    "-Donnxruntime_BUILD_UNIT_TESTS=OFF"
+    "-Donnxruntime_USE_PREINSTALLED_EIGEN=ON"
+    "-Donnxruntime_USE_MPI=ON"
+    "-Deigen_SOURCE_PATH=${eigen.src}"
+    "-Donnxruntime_USE_DNNL=YES"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Cross-platform, high performance scoring engine for ML models";
+    longDescription = ''
+      ONNX Runtime is a performance-focused complete scoring engine
+      for Open Neural Network Exchange (ONNX) models, with an open
+      extensible architecture to continually address the latest developments
+      in AI and Deep Learning. ONNX Runtime stays up to date with the ONNX
+      standard with complete implementation of all ONNX operators, and
+      supports all ONNX releases (1.2+) with both future and backwards
+      compatibility.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime";
+    changelog = "https://github.com/microsoft/onnxruntime/releases";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = lib.platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jonringer puffnfresh ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -688,7 +688,6 @@ mapAliases ({
   opensans-ttf = open-sans; # added 2018-12-04
   openssh_with_kerberos = openssh; # added 2018-01-28
   orchis = orchis-theme; # added 2021-06-09
-  onnxruntime = throw "onnxruntime has been removed due to poor maintainability"; # added 2020-12-04
   osquery = throw "osquery has been removed."; # added 2019-11-24
   osxfuse = macfuse-stubs; # added 2021-03-20
   otter-browser = throw "otter-browser has been removed from nixpkgs, as it was unmaintained"; # added 2020-02-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3496,6 +3496,8 @@ with pkgs;
 
   oneshot = callPackage ../tools/networking/oneshot { };
 
+  onnxruntime = callPackage ../development/libraries/onnxruntime { };
+
   xkbd = callPackage ../applications/misc/xkbd { };
 
   libpsm2 = callPackage ../os-specific/linux/libpsm2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Includes nsync package from PR #155042 

The onnxruntime package was removed in #105951 because it didn't work well with package managers at the time. It's still not great but it is a lot better. Now we are able to provide standard nixpkgs versions of Boost, Eigen, Protobuf, re2, nsync, JSON, etc.

~It's still a big repo to pull down and most of the submodules aren't used now. At some point we should try to exclude the submodules and replace just the few that are used with Nix versions.~ Fixed

@blitz @jonringer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
