### PR TITLE
wluma: 2.0.1 -> 3.0.0

### DIFF
--- a/pkgs/tools/wayland/wluma/default.nix
+++ b/pkgs/tools/wayland/wluma/default.nix
@@ -1,29 +1,54 @@
 { lib
+, stdenv
 , fetchFromGitHub
 , makeWrapper
 , rustPlatform
 , vulkan-loader
+, pkg-config
+, udev
+, v4l-utils
+, llvmPackages
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wluma";
-  version = "2.0.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "maximbaz";
     repo = "wluma";
     rev = version;
-    sha256 = "sha256-fqBEJS+SQoPNNEw6jyoiZjq/chY73bQ+cM21F8RdNPE=";
+    sha256 = "sha256-H5ohAawHTvZoFq4t5dUgP4Tr5qNyXEP4SG738Bo8mxc=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+    v4l-utils.lib
+  ];
+
+  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+
+  # Works around the issue with rust-bindgen and the Nix gcc wrapper:
+  # https://hoverbear.org/blog/rust-bindgen-in-nix/
+  preBuild = ''
+    export BINDGEN_EXTRA_CLANG_ARGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
+    $(< ${stdenv.cc}/nix-support/cc-cflags) \
+    -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include \
+    -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include \
+    -idirafter ${v4l-utils.dev}/include"
+  '';
 
   postInstall = ''
     wrapProgram $out/bin/wluma \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ vulkan-loader ]}"
   '';
 
-  cargoSha256 = "sha256-dZBA6VeJRHmqpazRwjLP1kYcYYN5LCFWkIaXqp4/RkQ=";
+  cargoSha256 = "sha256-xLmDDy6qKXo0mLW3R4hQfZssg6lpo0G018TonF1uS14=";
 
   meta = with lib; {
     description = "Automatic brightness adjustment based on screen contents and ALS";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated the package version from 2.0.1 to 3.0.0. This is quite a significant update, adding support for using webcams as ALS, which, in turn, adds some additional native dependencies, for which the workaround specified in https://hoverbear.org/blog/rust-bindgen-in-nix/ was utilized.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
