### PR TITLE
lightly-qt: init at 0.4.1

### DIFF
--- a/pkgs/data/themes/lightly-qt/default.nix
+++ b/pkgs/data/themes/lightly-qt/default.nix
@@ -1,13 +1,12 @@
-{
-  mkDerivation,
-  lib,
-  fetchFromGitHub,
-  cmake,
-  extra-cmake-modules,
-  kdecoration,
-  plasma-workspace,
-  qtbase,
-  qt5
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, kdecoration
+, plasma-workspace
+, qtbase
+, qt5
 }:
 
 mkDerivation rec {

--- a/pkgs/data/themes/lightly-qt/default.nix
+++ b/pkgs/data/themes/lightly-qt/default.nix
@@ -35,7 +35,7 @@ mkDerivation rec {
   meta = {
     description = "A fork of breeze theme style that aims to be visually modern and minimalistic";
     homepage = "https://github.com/Luwx/Lightly";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ pwoelfel ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/data/themes/lightly-qt/default.nix
+++ b/pkgs/data/themes/lightly-qt/default.nix
@@ -36,7 +36,7 @@ mkDerivation rec {
     description = "A fork of breeze theme style that aims to be visually modern and minimalistic";
     homepage = "https://github.com/Luwx/Lightly";
     license = lib.licenses.gpl2;
-    maintainers = [ lib.maintainers.pwoelfel ];
+    maintainers = with lib.maintainers; [ pwoelfel ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/data/themes/lightly-qt/default.nix
+++ b/pkgs/data/themes/lightly-qt/default.nix
@@ -1,0 +1,43 @@
+{
+  mkDerivation,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  extra-cmake-modules,
+  kdecoration,
+  plasma-workspace,
+  qtbase,
+  qt5
+}:
+
+mkDerivation rec {
+  pname = "lightly-qt";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "Luwx";
+    repo = "Lightly";
+    rev = "v${version}";
+    sha256 = "0qkjzgjplgwczhk6959iah4ilvazpprv7yb809jy75kkp1jw8mwk";
+  };
+
+  buildInputs = [
+    kdecoration
+    plasma-workspace
+    qtbase
+    qt5.qtx11extras
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  meta = {
+    description = "A fork of breeze theme style that aims to be visually modern and minimalistic";
+    homepage = "https://github.com/Luwx/Lightly";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.pwoelfel ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/data/themes/lightly-qt/default.nix
+++ b/pkgs/data/themes/lightly-qt/default.nix
@@ -32,11 +32,11 @@ mkDerivation rec {
     extra-cmake-modules
   ];
 
-  meta = {
+  meta = with lib; {
     description = "A fork of breeze theme style that aims to be visually modern and minimalistic";
     homepage = "https://github.com/Luwx/Lightly";
-    license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ pwoelfel ];
-    platforms = lib.platforms.all;
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.pwoelfel ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23621,6 +23621,8 @@ with pkgs;
 
   libre-franklin = callPackage ../data/fonts/libre-franklin { };
 
+  lightly-qt = libsForQt5.callPackage ../data/themes/lightly-qt { };
+
   line-awesome = callPackage ../data/fonts/line-awesome { };
 
   linux-manual = callPackage ../data/documentation/linux-manual { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a package for the KDE application style "Lightly". This is the top-rated application style at https://store.kde.org

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
