### PR TITLE
kicad: enable i18n by default

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -22,7 +22,7 @@
 , sanitizeAddress ? false
 , sanitizeThreads ? false
 , with3d ? true
-, withI18n ? false
+, withI18n ? true
 , withPCM ? true # Plugin and Content Manager
 , srcs ? { }
 }:


### PR DESCRIPTION
without i18n
/nix/store/xgs0n52djlqqmw6qlvg6j2jxpzdpsi92-kicad-6.0.1   7269408096
/nix/store/k7ra3zkx6mp0b3ivsf0ba14mbinwws0w-kicad-unstable-33a4c9b08e   7277796352
with i18n
/nix/store/2xh82r2znqipky0sny49h9cs5fbhmh4v-kicad-6.0.1   7286672288
/nix/store/532r1f3j8xjki8g87400n0gnd594pcbm-kicad-unstable-33a4c9b08e   7294795424

###### Motivation for this change
it used to have i18n before the config for that changed to `kicad.base`
it's "only" ~17MB

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - only for `kicad-unstable`
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
