### PR TITLE
networkmanager-openvpn/-l2tp: add dependency if built without Gnome

### DIFF
--- a/pkgs/tools/networking/networkmanager/l2tp/default.nix
+++ b/pkgs/tools/networking/networkmanager/l2tp/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, substituteAll, fetchFromGitHub, autoreconfHook, libtool, intltool, pkg-config
 , file, findutils
 , gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret
-, withGnome ? true, libnma }:
+, withGnome ? true, libnma, glib }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ networkmanager ppp ]
+  buildInputs = [ networkmanager ppp glib ]
     ++ lib.optionals withGnome [ gtk3 libsecret libnma ];
 
   nativeBuildInputs = [ autoreconfHook libtool intltool pkg-config file findutils ];

--- a/pkgs/tools/networking/networkmanager/openvpn/default.nix
+++ b/pkgs/tools/networking/networkmanager/openvpn/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, substituteAll, openvpn, intltool, libxml2, pkg-config, file, networkmanager, libsecret
-, gtk3, withGnome ? true, gnome, kmod, libnma }:
+, glib, gtk3, withGnome ? true, gnome, kmod, libnma }:
 
 let
   pname = "NetworkManager-openvpn";
@@ -19,7 +19,7 @@ in stdenv.mkDerivation {
     })
   ];
 
-  buildInputs = [ openvpn networkmanager ]
+  buildInputs = [ openvpn networkmanager glib ]
     ++ lib.optionals withGnome [ gtk3 libsecret libnma ];
 
   nativeBuildInputs = [ intltool pkg-config file libxml2 ];


### PR DESCRIPTION
###### Motivation for this change

Fix builds of `networkmanager-openvpn` and `networkmanager-l2tp` if `withGnome=false`.

Build errors without the proposed fix:

```console
$ nix-build -E 'with import <nixpkgs> {}; map (v: v.override { withGnome=false; }) [ networkmanager-l2tp networkmanager-openvpn ]' --keep-going
...
error: builder for '/nix/store/cfwn6i1klcdb28rnbqyil4y93rvh6zxk-NetworkManager-openvpn-1.8.16.drv' failed with exit code 1;
       last 10 log lines:
       > configure: error: Package requirements (glib-2.0 >= 2.32) were not met:
       >
       > No package 'glib-2.0' found
       >
       > Consider adjusting the PKG_CONFIG_PATH environment variable if you
       > installed software in a non-standard prefix.
       >
       > Alternatively, you may set the environment variables GLIB_CFLAGS
       > and GLIB_LIBS to avoid the need to call pkg-config.
       > See the pkg-config man page for more details.
       For full logs, run 'nix log /nix/store/cfwn6i1klcdb28rnbqyil4y93rvh6zxk-NetworkManager-openvpn-1.8.16.drv'.
error: builder for '/nix/store/pf4j32ps1jji4yg524p0k2mry87kmvw3-NetworkManager-l2tp-1.2.12.drv' failed with exit code 1;
       last 10 log lines:
       > ./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
       > configure.ac:54: the top level
       > configure.ac:88: warning: The macro `AC_HEADER_TIME' is obsolete.
       > configure.ac:88: You should run autoupdate.
       > ./lib/autoconf/headers.m4:743: AC_HEADER_TIME is expanded from...
       > configure.ac:88: the top level
       > configure.ac:131: error: possibly undefined macro: AM_GLIB_GNU_GETTEXT
       >       If this token and others are legitimate, please use m4_pattern_allow.
       >       See the Autoconf documentation.
       > autoreconf: error: /nix/store/ff171rsg3598vhjrpz2nh6x0l2882pz6-autoconf-2.71/bin/autoconf failed with exit status: 1
       For full logs, run 'nix log /nix/store/pf4j32ps1jji4yg524p0k2mry87kmvw3-NetworkManager-l2tp-1.2.12.drv'.
error: build of '/nix/store/cfwn6i1klcdb28rnbqyil4y93rvh6zxk-NetworkManager-openvpn-1.8.16.drv', '/nix/store/pf4j32ps1jji4yg524p0k2mry87kmvw3-NetworkManager-l2tp-1.2.12.drv' failed
```

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  > Nothing to be built.

  ... because variants with `withGnome=false` are normally not built.
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
