### PR TITLE
xiphos: clean up

### DIFF
--- a/pkgs/applications/misc/xiphos/0001-Add-dbus-glib-dependency-to-main.patch
+++ b/pkgs/applications/misc/xiphos/0001-Add-dbus-glib-dependency-to-main.patch
@@ -1,0 +1,38 @@
+From 0e9e686c902935c0f00afdf9d0d45f9635995988 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sat, 15 Jan 2022 05:00:37 +0100
+Subject: [PATCH] Add dbus-glib dependency to main
+
+It is required through the ipc header and the build will fail without it on Nix:
+
+	In file included from /build/source/src/main/search_sidebar.cc:48:
+	/build/source/src/gui/ipc.h:26:10: fatal error: dbus/dbus-glib.h: No such file or directory
+	   26 | #include <dbus/dbus-glib.h>
+	      |          ^~~~~~~~~~~~~~~~~~
+	compilation terminated.
+---
+ src/main/CMakeLists.txt | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/main/CMakeLists.txt b/src/main/CMakeLists.txt
+index 49b86371..bb8e4bb6 100644
+--- a/src/main/CMakeLists.txt
++++ b/src/main/CMakeLists.txt
+@@ -74,3 +74,14 @@ target_link_libraries(main
+   PkgConfig::Sword
+   PkgConfig::Biblesync
+   )
++
++IF (DBUS)
++  target_include_directories (main
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
++    PkgConfig::DBus
++    )
++  target_link_libraries(main
++    PRIVATE
++    PkgConfig::DBus
++    )
++ENDIF (DBUS)
+-- 
+2.34.1
+

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -1,5 +1,5 @@
-{ lib
-, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , fetchpatch
 , appstream-glib
@@ -60,14 +60,26 @@ stdenv.mkDerivation rec {
     hash = "sha256-H5Q+azE2t3fgu77C9DxrkeUCJ7iJz3Cc91Ln4dqLvD8=";
   };
 
+  patches = [
+    # GLIB_VERSION_MIN_REQUIRED is not defined.
+    # https://github.com/crosswire/xiphos/issues/1083#issuecomment-820304874
+    (fetchpatch {
+      name ="xiphos-glibc.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/xiphos-glibc.patch?h=xiphos";
+      sha256 = "sha256-0WadztJKXW2adqsDP8iSAYVShbdqHoDvP+aVJC0cQB0=";
+    })
+  ];
+
+  patchFlags = [ "-p0" ];
+
   nativeBuildInputs = [
-    appstream-glib
+    appstream-glib # for appstream-util
     cmake
-    desktop-file-utils
+    desktop-file-utils # for desktop-file-validate
     itstool
     pkg-config
     wrapGAppsHook
-    yelp-tools
+    yelp-tools # for yelp-build
   ];
 
   buildInputs = [
@@ -107,12 +119,10 @@ stdenv.mkDerivation rec {
     sqlite
     sword
     webkitgtk
+    xorg.libXdmcp
+    xorg.libXtst
     zip
-  ]
-  ++ (with xorg; [
-    libXdmcp
-    libXtst
-  ]);
+  ];
 
   cmakeFlags = [
     "-DDBUS=OFF"
@@ -126,18 +136,6 @@ stdenv.mkDerivation rec {
     export CLUCENE_HOME=${clucene_core};
     export SWORD_HOME=${sword};
   '';
-
-  patchFlags = [ "-p0" ];
-
-  patches = [
-    # GLIB_VERSION_MIN_REQUIRED is not defined.
-    # https://github.com/crosswire/xiphos/issues/1083#issuecomment-820304874
-    (fetchpatch {
-      name ="xiphos-glibc.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/xiphos-glibc.patch?h=xiphos";
-      sha256 = "sha256-0WadztJKXW2adqsDP8iSAYVShbdqHoDvP+aVJC0cQB0=";
-    })
-  ];
 
   meta = with lib; {
     description = "A GTK Bible study tool";

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -3,47 +3,27 @@
 , fetchFromGitHub
 , fetchpatch
 , appstream-glib
-, at-spi2-core
 , biblesync
-, brotli
 , cmake
-, dbus
 , dbus-glib
 , desktop-file-utils
 , docbook2x
 , docbook_xml_dtd_412
-, enchant
-, gconf
+, enchant2
 , glib
-, gnome-doc-utils
-, gtk2
+, gtk3
 , gtkhtml
 , icu
 , intltool
 , isocodes
 , itstool
-, libdatrie
-, libepoxy
-, libglade
-, libgsf
-, libpsl
-, libselinux
-, libsepol
-, libsysprof-capture
-, libthai
 , libuuid
-, libxkbcommon
 , libxslt
 , minizip
-, pcre
 , pkg-config
-, python
-, scrollkeeper
-, sqlite
 , sword
 , webkitgtk
 , wrapGAppsHook
-, xorg
 , yelp-tools
 , zip
 }:
@@ -68,61 +48,44 @@ stdenv.mkDerivation rec {
       sha256 = "he3U7phU2/QCrZidHviupA7YwzudnQ9Jbb8eMZw6/ck=";
       extraPrefix = "";
     })
+
+    # Fix D-Bus build
+    # https://github.com/crosswire/xiphos/pull/1103
+    ./0001-Add-dbus-glib-dependency-to-main.patch
   ];
 
   nativeBuildInputs = [
     appstream-glib # for appstream-util
     cmake
     desktop-file-utils # for desktop-file-validate
+    docbook2x
+    docbook_xml_dtd_412
+    intltool
     itstool
+    libxslt
     pkg-config
     wrapGAppsHook
     yelp-tools # for yelp-build
+    zip # for building help epubs
   ];
 
   buildInputs = [
-    at-spi2-core
     biblesync
-    brotli
-    dbus
     dbus-glib
-    docbook2x
-    docbook_xml_dtd_412
-    enchant
-    gconf
+    enchant2
     glib
-    gnome-doc-utils
-    gtk2
+    gtk3
     gtkhtml
     icu
-    intltool
     isocodes
-    libdatrie
-    libepoxy
-    libglade
-    libgsf
-    libpsl
-    libselinux
-    libsepol
-    libsysprof-capture
-    libthai
     libuuid
-    libxkbcommon
-    libxslt
     minizip
-    pcre
-    python
-    scrollkeeper
-    sqlite
     sword
     webkitgtk
-    xorg.libXdmcp
-    xorg.libXtst
-    zip
   ];
 
   cmakeFlags = [
-    "-DDBUS=OFF"
+    # WebKit-based editor does not build.
     "-DGTKHTML=ON"
   ];
 

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -6,7 +6,6 @@
 , at-spi2-core
 , biblesync
 , brotli
-, clucene_core
 , cmake
 , dbus
 , dbus-glib
@@ -85,7 +84,6 @@ stdenv.mkDerivation rec {
     at-spi2-core
     biblesync
     brotli
-    clucene_core
     dbus
     dbus-glib
     docbook2x
@@ -132,7 +130,6 @@ stdenv.mkDerivation rec {
     # The build script won't continue without the version saved locally.
     echo "${version}" > cmake/source_version.txt
 
-    export CLUCENE_HOME=${clucene_core};
     export SWORD_HOME=${sword};
   '';
 

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -65,12 +65,11 @@ stdenv.mkDerivation rec {
     # https://github.com/crosswire/xiphos/issues/1083#issuecomment-820304874
     (fetchpatch {
       name ="xiphos-glibc.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/xiphos-glibc.patch?h=xiphos";
-      sha256 = "sha256-0WadztJKXW2adqsDP8iSAYVShbdqHoDvP+aVJC0cQB0=";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/xiphos-glibc.patch?h=xiphos&id=bb816f43ba764ffac1287ab1e2a649c2443e3ce8";
+      sha256 = "he3U7phU2/QCrZidHviupA7YwzudnQ9Jbb8eMZw6/ck=";
+      extraPrefix = "";
     })
   ];
-
-  patchFlags = [ "-p0" ];
 
   nativeBuildInputs = [
     appstream-glib # for appstream-util

--- a/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
+++ b/pkgs/desktops/gnome-2/platform/gtkhtml/4.x.nix
@@ -12,11 +12,6 @@ stdenv.mkDerivation rec {
     rev = "master";
     sha256 = "sha256-jL8YADvhW0o6I/2Uo5FNARMAnSbvtmFp+zWH1yCVvQk=";
   };
-  propagatedBuildInputs = [ gsettings-desktop-schemas gtk3 gnome-icon-theme GConf ];
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ intltool enchant isocodes autoreconfHook ];
-
-  patchFlags = [ "-p0" ];
 
   patches = [
     # Enables enchant2 support.
@@ -24,7 +19,12 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name ="enchant-2.patch";
       url = "https://aur.archlinux.org/cgit/aur.git/plain/enchant-2.patch?h=gtkhtml4&id=0218303a63d64c04d6483a6fe9bb55063fcfaa43";
-      sha256 = "sha256-jkA/GgIiJZmxkbcBGQ26OZ1nuI502BMPwbPhsZkbgbY=";
+      sha256 = "f0OToWGHZwxvqf+0qosfA9FfwJ/IXfjIPP5/WrcvArI=";
+      extraPrefix = "";
     })
   ];
+
+  propagatedBuildInputs = [ gsettings-desktop-schemas gtk3 gnome-icon-theme GConf ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ intltool enchant isocodes autoreconfHook ];
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29748,11 +29748,7 @@ with pkgs;
   };
 
   xiphos = callPackage ../applications/misc/xiphos {
-    gconf = gnome2.GConf;
-    inherit (gnome2) libglade scrollkeeper;
     gtkhtml = gnome2.gtkhtml4;
-    python = python27;
-    enchant = enchant2;
   };
 
   xournal = callPackage ../applications/graphics/xournal {


### PR DESCRIPTION
###### Motivation for this change
Clean up and do not use ancient libraries when not necessary.

cc @AndersonTorres @dasj19 @piegamesde

Follow up to #154899 and #154796.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
