### PR TITLE
love: updates, fetch from GitHub, refactor name to pname + version, etc

### DIFF
--- a/pkgs/development/interpreters/love/0.10.nix
+++ b/pkgs/development/interpreters/love/0.10.nix
@@ -1,17 +1,15 @@
-{ lib, stdenv, fetchFromBitbucket, pkg-config, SDL2, libGLU, libGL, openal, luajit,
-  libdevil, freetype, physfs, libmodplug, mpg123, libvorbis, libogg,
-  libtheora, which, autoconf, automake, libtool
+{ lib, stdenv, fetchFromGitHub, pkg-config
+, SDL2, libGLU, libGL, openal, luajit
+, libdevil, freetype, physfs, libmodplug, mpg123, libvorbis, libogg
+, libtheora, which, autoconf, automake, libtool
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "love";
   version = "0.10.2";
-in
 
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
-  src = fetchFromBitbucket {
-    owner = "rude";
+  src = fetchFromGitHub {
+    owner = "love2d";
     repo = "love";
     rev = version;
     sha256 = "19yfmlcx6w8yi4ndm5lni8lrsvnn77bxw5py0dc293nzzlaqa9ym";
@@ -32,7 +30,7 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
 
   meta = {
-    homepage = "http://love2d.org";
+    homepage = "https://love2d.org";
     description = "A Lua-based 2D game engine/scripting language";
     license = lib.licenses.zlib;
     platforms = lib.platforms.linux;

--- a/pkgs/development/interpreters/love/0.7.nix
+++ b/pkgs/development/interpreters/love/0.7.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.7.2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/rude/love/downloads/love-${version}-linux-src.tar.gz";
+    url = "https://github.com/love2d/love/releases/download/${version}/love-${version}-linux-src.tar.gz";
     sha256 = "0s7jywkvydlshlgy11ilzngrnybmq5xlgzp2v2dhlffwrfqdqym5";
   };
 
@@ -48,10 +48,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "http://love2d.org";
+    homepage = "https://love2d.org";
     description = "A Lua-based 2D game engine/scripting language";
     license = lib.licenses.zlib;
-
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.raskin ];
   };

--- a/pkgs/development/interpreters/love/0.8.nix
+++ b/pkgs/development/interpreters/love/0.8.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "0.8.0";
 
   src = fetchurl {
-    url = "https://bitbucket.org/rude/love/downloads/${pname}-${version}-linux-src.tar.gz";
+    url = "https://github.com/love2d/love/releases/download/${version}/love-${version}-linux-src.tar.gz";
     sha256 = "1k4fcsa8zzi04ja179bmj24hvqcbm3icfvrvrzyz2gw9qwfclrwi";
   };
 
@@ -45,10 +45,9 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "http://love2d.org";
+    homepage = "https://love2d.org";
     description = "A Lua-based 2D game engine/scripting language";
     license = lib.licenses.zlib;
-
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.raskin ];
   };

--- a/pkgs/development/interpreters/love/0.9.nix
+++ b/pkgs/development/interpreters/love/0.9.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "love";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchurl {
-    url = "https://bitbucket.org/rude/love/downloads/love-${version}-linux-src.tar.gz";
-    sha256 = "1pikd0bzb44r4bf0jbgn78whz1yswpq1n5jc8nf87v42pm30kp84";
+    url = "https://github.com/love2d/love/releases/download/${version}/love-${version}-linux-src.tar.gz";
+    sha256 = "0wn1npr5gal5b1idh4a5fwc3f5c36lsbjd4r4d699rqlviid15d9";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -26,10 +26,9 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-DluaL_reg=luaL_Reg" ]; # needed since luajit-2.1.0-beta3
 
   meta = {
-    homepage = "http://love2d.org";
+    homepage = "https://love2d.org";
     description = "A Lua-based 2D game engine/scripting language";
     license = lib.licenses.zlib;
-
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.raskin ];
     broken = true;

--- a/pkgs/development/interpreters/love/11.nix
+++ b/pkgs/development/interpreters/love/11.nix
@@ -1,20 +1,18 @@
-{ lib, stdenv, fetchFromBitbucket, pkg-config, SDL2, libGLU, libGL, openal, luajit,
-  libdevil, freetype, physfs, libmodplug, mpg123, libvorbis, libogg,
-  libtheora, which, autoconf, automake, libtool
+{ lib, stdenv, fetchFromGitHub, pkg-config
+, SDL2, libGLU, libGL, openal, luajit
+, libdevil, freetype, physfs, libmodplug, mpg123, libvorbis, libogg
+, libtheora, which, autoconf, automake, libtool
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "love";
-  version = "11.3";
-in
+  version = "11.4";
 
-stdenv.mkDerivation {
-  name = "${pname}-${version}";
-  src = fetchFromBitbucket {
-    owner = "rude";
+  src = fetchFromGitHub {
+    owner = "love2d";
     repo = "love";
     rev = version;
-    sha256 = "18gfp65ngb8k8g7hgbw2bhrwk2i7m56m21d39pk4484q9z8p4vm7";
+    sha256 = "0kpdp6v8m8j0r7ppyy067shr0lfgrlh0dwb7ccws76d389vizwhb";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -32,7 +30,7 @@ stdenv.mkDerivation {
   NIX_CFLAGS_COMPILE = "-DluaL_reg=luaL_Reg"; # needed since luajit-2.1.0-beta3
 
   meta = {
-    homepage = "http://love2d.org";
+    homepage = "https://love2d.org";
     description = "A Lua-based 2D game engine/scripting language";
     license = lib.licenses.zlib;
     platforms = lib.platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13530,7 +13530,7 @@ with pkgs;
   love_0_8 = callPackage ../development/interpreters/love/0.8.nix { lua=lua5_1; };
   love_0_9 = callPackage ../development/interpreters/love/0.9.nix { };
   love_0_10 = callPackage ../development/interpreters/love/0.10.nix { };
-  love_11 = callPackage ../development/interpreters/love/11.1.nix { };
+  love_11 = callPackage ../development/interpreters/love/11.nix { };
   love = love_0_10;
 
   wabt = callPackage ../development/tools/wabt { };


### PR DESCRIPTION
Changes:

- `love_0_9`: 0.9.1 -> 0.9.2
- `love_11`: 11.3 -> 11.4
- Updated the `src` of each package to fetch from [GitHub](https://github.com/love2d/love) rather than
  Bitbucket as the repository moved
- Changed `name` to `pname` + `version` (#103997)
- Moved `11.1.nix` to `11.nix` to fit the others and because the version is
  no longer 11.1
- Changed all the homepage links from `http` to `https` just because
- `love_0_9` is still broken unfortunately

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A lot of this stuff hasn't been updated for a while.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
