### PR TITLE
darwin.diskdev_cmds: fix build on m1 by bumping xnu version

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -288,7 +288,9 @@ developerToolsPackages_11_3_1 // macosPackages_11_0_1 // {
     adv_cmds        = applePackage "adv_cmds"          "osx-10.11.6"    "12gbv35i09aij9g90p6b3x2f3ramw43qcb2gjrg8lzkzmwvcyw9q" {};
     basic_cmds      = applePackage "basic_cmds"        "osx-10.11.6"     "0hvab4b1v5q2x134hdkal0rmz5gsdqyki1vb0dbw4py1bqf0yaw9" {};
     developer_cmds  = applePackage "developer_cmds"    "osx-10.11.6"     "1r9c2b6dcl22diqf90x58psvz797d3lxh4r2wppr7lldgbgn24di" {};
-    diskdev_cmds    = applePackage "diskdev_cmds"      "osx-10.11.6"     "1ssdyiaq5m1zfy96yy38yyknp682ki6bvabdqd5z18fa0rv3m2ar" {};
+    diskdev_cmds    = applePackage "diskdev_cmds"      "osx-10.11.6"     "1ssdyiaq5m1zfy96yy38yyknp682ki6bvabdqd5z18fa0rv3m2ar" {
+      macosPackages_11_0_1 = macosPackages_11_0_1;
+    };
     network_cmds    = applePackage "network_cmds"      "osx-10.11.6"     "0lhi9wz84qr1r2ab3fb4nvmdg9gxn817n5ldg7zw9gnf3wwn42kw" {};
     file_cmds       = applePackage "file_cmds"         "osx-10.11.6"     "1zfxbmasps529pnfdjvc13p7ws2cfx8pidkplypkswyff0nff4wp" {};
     shell_cmds      = applePackage "shell_cmds"        "osx-10.11.6"     "0084k271v66h4jqp7q7rmjvv7w4mvhx3aq860qs8jbd30canm86n" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/diskdev_cmds/default.nix
@@ -1,7 +1,10 @@
-{ lib, appleDerivation, xcbuildHook
-, Libc, xnu, libutil }:
+{ lib, appleDerivation, xcbuildHook, Libc, stdenv, macosPackages_11_0_1, xnu
+, fetchurl, libutil }:
 
-appleDerivation {
+let
+  xnu-src = if stdenv.isAarch64 then macosPackages_11_0_1.xnu.src else xnu.src;
+  arch = if stdenv.isAarch64 then "arm" else "i386";
+in appleDerivation {
   nativeBuildInputs = [ xcbuildHook ];
   buildInputs = [ libutil ];
 
@@ -11,11 +14,11 @@ appleDerivation {
     # ugly hacks for missing headers
     # most are bsd related - probably should make this a drv
     unpackFile ${Libc.src}
-    unpackFile ${xnu.src}
-    mkdir System sys machine i386
+    unpackFile ${xnu-src}
+    mkdir System sys machine ${arch}
     cp xnu-*/bsd/sys/disklabel.h sys
     cp xnu-*/bsd/machine/disklabel.h machine
-    cp xnu-*/bsd/i386/disklabel.h i386
+    cp xnu-*/bsd/${arch}/disklabel.h ${arch}
     cp -r xnu-*/bsd/sys System
     cp -r Libc-*/uuid System
     substituteInPlace diskdev_cmds.xcodeproj/project.pbxproj \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`diskdev_cmds` failed to build, causing issues with nix-darwin configurations. 

###### Things done
Bumped `xnu` version and copied over `arm/` headers for `diskdev_cmds`.

`xnu` still fails to build, and I'm not sure how to fix it. This might be relevant to m1 only as the error is
```
clang-11: error: cannot use 'cpp-output' output with multiple -arch options`.
mig: fatal: "<no name yet>", line -1: no SubSystem declaration
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
