### PR TITLE
bcc: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -7,7 +7,7 @@
 
 python.pkgs.buildPythonApplication rec {
   pname = "bcc";
-  version = "0.23.0";
+  version = "0.24.0";
 
   disabled = !stdenv.isLinux;
 
@@ -15,14 +15,15 @@ python.pkgs.buildPythonApplication rec {
     owner = "iovisor";
     repo = "bcc";
     rev = "v${version}";
-    sha256 = "sha256-iLVUwJTDQ8Bn38sgHOcIR8TYxIB+gIlfTgr9+gPU0gE=";
+    sha256 = "sha256-KrhbNQzdfzQaxe/V2x1Pa0kroD4YcXW1+lC+NWnLKns=";
+    fetchSubmodules = true;
   };
   format = "other";
 
   buildInputs = with llvmPackages; [
     llvm llvm.dev libclang
     elfutils luajit netperf iperf
-    flex bash libbpf
+    flex bash
   ];
 
   patches = [
@@ -39,7 +40,6 @@ python.pkgs.buildPythonApplication rec {
     "-DREVISION=${version}"
     "-DENABLE_USDT=ON"
     "-DENABLE_CPP_API=ON"
-    "-DCMAKE_USE_LIBBPF_PACKAGE=ON"
   ];
 
   # to replace this executable path:

--- a/pkgs/os-specific/linux/bpftrace/default.nix
+++ b/pkgs/os-specific/linux/bpftrace/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub
 , cmake, pkg-config, flex, bison
 , llvmPackages, elfutils
-, libelf, libbfd, libbpf, libopcodes, bcc
+, libelf, libbfd, libopcodes, bcc
 , cereal, asciidoctor
 , nixosTests
 }:
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = with llvmPackages;
     [ llvm libclang
       elfutils libelf bcc
-      libbpf libbfd libopcodes
+      libbfd libopcodes
       cereal asciidoctor
     ];
 


### PR DESCRIPTION
Switch to vendored libbpf because latest release is too old for bcc.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
