### PR TITLE
gopass: 1.13.0 → 1.13.1, gopass-summon-provider: init at 1.12.0

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -13,7 +13,7 @@
 
 buildGoModule rec {
   pname = "gopass";
-  version = "1.13.0";
+  version = "1.13.1";
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
@@ -21,7 +21,7 @@ buildGoModule rec {
     owner = "gopasspw";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-MBpk84H3Ng/+rCjW2Scm/su0/5kgs7IzvFk/bFLNzXY=";
+    sha256 = "sha256-g/ICT489uW3a5EnsxJPYOnV+yeOFfaFPMowdIK0M1Fc=";
   };
 
   vendorSha256 = "sha256-HGc6jUp4WO5P5dwfa0r7+X78a8us9fWrf+/IOotZHqk=";

--- a/pkgs/tools/security/gopass/summon.nix
+++ b/pkgs/tools/security/gopass/summon.nix
@@ -1,0 +1,39 @@
+{ lib
+, makeWrapper
+, buildGoModule
+, fetchFromGitHub
+, gopass
+}:
+
+buildGoModule rec {
+  pname = "gopass-summon-provider";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "gopasspw";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-mRZXczIlW1s0VGZJ+KQue4Dz6XCXGfl56+g6iRv2lZg=";
+  };
+
+  vendorSha256 = "sha256-fiV4rtel2jOw6y/ukOZHeFuNVqxHS3rnYhXJ6JZ+a/8=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}"
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/gopass-summon-provider --prefix PATH : "${lib.makeBinPath [ gopass ]}"
+  '';
+
+  meta = with lib; {
+    description = "Gopass Summon Provider";
+    homepage = "https://www.gopass.pw/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1939,6 +1939,8 @@ with pkgs;
 
   git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix { };
 
+  gopass-summon-provider = callPackage ../tools/security/gopass/summon.nix { };
+
   gosh = callPackage ../tools/security/gosh { };
 
   gospider = callPackage ../tools/security/gospider { };


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/gopasspw/gopass/releases/tag/v1.13.1)

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Relase notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
