### PR TITLE
python3Packages.consonance: 0.1.3 -> 0.1.5

### DIFF
--- a/pkgs/development/python-modules/consonance/default.nix
+++ b/pkgs/development/python-modules/consonance/default.nix
@@ -1,29 +1,51 @@
-{ buildPythonPackage, lib, fetchFromGitHub, dissononce, python-axolotl-curve25519
-, transitions, protobuf, nose
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, dissononce
+, python-axolotl-curve25519
+, transitions
+, protobuf
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "consonance";
-  version = "0.1.3";
+  version = "0.1.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "tgalal";
     repo = "consonance";
     rev = version;
-    sha256 = "1ifs0fq6i41rdna1kszv5sf87qbqx1mn98ffyx4xhw4i9r2grrjv";
+    hash = "sha256-BhgxLxjKZ4dSL7DqkaoS+wBPCd1SYZomRKrtDLdGmYQ=";
   };
 
-  checkInputs = [ nose ];
-  checkPhase = ''
-    # skipping online test as it requires network with uplink
-    nosetests tests/test_handshakes_offline.py
-  '';
+  propagatedBuildInputs = [
+    dissononce
+    python-axolotl-curve25519
+    transitions
+    protobuf
+  ];
 
-  propagatedBuildInputs = [ dissononce python-axolotl-curve25519 transitions protobuf ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "tests/test_handshakes_offline.py"
+  ];
+
+  pythonImportsCheck = [
+    "consonance"
+  ];
 
   meta = with lib; {
-    homepage = "https://pypi.org/project/consonance/";
-    license = licenses.gpl3;
     description = "WhatsApp's handshake implementation using Noise Protocol";
+    homepage = "https://github.com/tgalal/consonance";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release

Switch to `pytestCheckHook`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
