### PR TITLE
[Backport release-21.11] sigi: init at 3.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4667,6 +4667,12 @@
     github = "higebu";
     githubId = 733288;
   };
+  hiljusti = {
+    name = "J.R. Hill";
+    email = "hiljusti@so.dang.cool";
+    github = "hiljusti";
+    githubId = 17605298;
+  };
   hinton = {
     email = "t@larkery.com";
     name = "Tom Hinton";

--- a/pkgs/applications/misc/sigi/default.nix
+++ b/pkgs/applications/misc/sigi/default.nix
@@ -1,0 +1,24 @@
+{ lib, rustPlatform, fetchFromGitHub, testVersion, sigi }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sigi";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "hiljusti";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-y0m1AQE5qoUfPZjJfo7w5h+zZ1pbz8FkLFDM13MTWvQ=";
+  };
+
+  cargoSha256 = "sha256-NTjL57Y1Uzk5F34BW3lB3xUpD60Opt0fGWuXHQU5L3g=";
+
+  passthru.tests.version = testVersion { package = sigi; };
+
+  meta = with lib; {
+    description = "CLI tool for organization and planning";
+    homepage = "https://github.com/hiljusti/sigi";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ hiljusti ];
+  };
+}

--- a/pkgs/applications/misc/sigi/default.nix
+++ b/pkgs/applications/misc/sigi/default.nix
@@ -1,24 +1,28 @@
-{ lib, rustPlatform, fetchFromGitHub, testVersion, sigi }:
+{ lib, rustPlatform, fetchCrate, installShellFiles, testVersion, sigi }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sigi";
-  version = "2.1.1";
+  version = "3.0.0";
 
-  src = fetchFromGitHub {
-    owner = "hiljusti";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-y0m1AQE5qoUfPZjJfo7w5h+zZ1pbz8FkLFDM13MTWvQ=";
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-1xZMj6NjwA9pVOEL4CDv4XHC3usu3WdjsLJuW3vgxc8=";
   };
 
-  cargoSha256 = "sha256-NTjL57Y1Uzk5F34BW3lB3xUpD60Opt0fGWuXHQU5L3g=";
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage sigi.1
+  '';
+
+  cargoSha256 = "sha256-NUWm2GkK7bASo6bAOgQgHate45iDG5l3G/KhtLrjzQ8=";
 
   passthru.tests.version = testVersion { package = sigi; };
 
   meta = with lib; {
     description = "CLI tool for organization and planning";
     homepage = "https://github.com/hiljusti/sigi";
-    license = licenses.gpl3;
+    license = licenses.gpl2;
     maintainers = with maintainers; [ hiljusti ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9420,6 +9420,8 @@ with pkgs;
 
   sigal = callPackage ../applications/misc/sigal { };
 
+  sigi = callPackage ../applications/misc/sigi { };
+
   sigil = libsForQt5.callPackage ../applications/editors/sigil { };
 
   signald = callPackage ../applications/networking/instant-messengers/signald { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a new package (A CLI tool for organization).

I cherry-picked the 3 commits leading to sigi 3.0.0 in the master branch - there is no functional difference between sigi 2.1.1 and sigi 3.0.0, it was a licensing change from GPL3+ to GPL2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
