### PR TITLE
mimeo: 2021.2 -> 2021.11

### DIFF
--- a/pkgs/tools/misc/mimeo/default.nix
+++ b/pkgs/tools/misc/mimeo/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mimeo";
-  version = "2021.2";
+  version = "2021.11";
 
   src = fetchurl {
-    url = "https://xyne.archlinux.ca/projects/mimeo/src/${pname}-${version}.tar.xz";
-    sha256 = "113ip024ggajjdx0l406g6lwypdrddxz6k3640y6lzqjivcgybjf";
+    url = "https://xyne.dev/projects/mimeo/src/${pname}-${version}.tar.xz";
+    sha256 = "1fi8svn4hg2hmvv28j026sks1hc0v8wh974g7ixcwfcg2xda6c4p";
   };
 
   buildInputs = [ file desktop-file-utils ];
@@ -23,9 +23,14 @@ python3Packages.buildPythonApplication rec {
 
   installPhase = "install -Dm755 Mimeo.py $out/bin/mimeo";
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/mimeo --help > /dev/null
+  '';
+
   meta = with lib; {
     description = "Open files by MIME-type or file name using regular expressions";
-    homepage = "https://xyne.archlinux.ca/projects/mimeo/";
+    homepage = "https://xyne.dev/projects/mimeo/";
     license = [ licenses.gpl2 ];
     maintainers = [ maintainers.rycee ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

Bump. Also

- add install check and

- update download and homepage URLs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
