### PR TITLE
firefox: 96.0 -> 96.0.1, firefox-bin: 96.0 -> 96.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "96.0";
+  version = "96.0.1";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ach/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ach/firefox-96.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "88a69911dce4985251028b16a163b4db36fef47698ff73cd7f685ca3a1dd5243";
+      sha256 = "70d4f4ddc319315a3cae8be4174d8b80e1cde3902dee0f0ff9804b0bc0a68d4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/af/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/af/firefox-96.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "7b7cebc75eb6097a6a950599fb0b1b4e695bf12bfbc3272bbb9e79f3770e14d4";
+      sha256 = "cda4d331d55fdfebbe75d54469ca929563f1ba613026b50ac4371de001ac67e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/an/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/an/firefox-96.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "5de8de362b479fead0b4dbe0d9e81a8692465b11a63479aca012d611eff0fa14";
+      sha256 = "264f6ec85ada427027d529de8f9c5d69082e1c7306d79734cc208ccbeb771269";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ar/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ar/firefox-96.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9d45cf623e4e8fc959844174284da573a9a6bab2fb00fa9bd6511ad0941a31e7";
+      sha256 = "4d1893dc040fa7c0409fc5f6cbccc36676da8d04ebf8e7b0bdda50a65da6d5ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ast/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ast/firefox-96.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "6921a5883382c99dae6e902e079ae76e1112a86fe3aa74eed485e6c2aa5d99c1";
+      sha256 = "0c9c0597b4a78fb7b704ee7791c9e76b11a2ffa390c24aef65b4e1bdaa546d39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/az/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/az/firefox-96.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "44b78fd0f6e6feeec020ad6c71581ee875e9db5c06b55699514067a8190fc9f1";
+      sha256 = "155b331f614b9de671fd945ef186815afbbcfeb671bb2510d07e11858c74d500";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/be/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/be/firefox-96.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "abfc8a54d035fb5b8112168cabc13f48674a8a1c870096697dd648f3a801cc5e";
+      sha256 = "eb0e1589ddd53edb1cc058521a35448dbb55adf4a774906877936ac984e3c2a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bg/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/bg/firefox-96.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "7245000ff9486713add7d487e95d860cbc412fc61f292ca308553f4a447fd12b";
+      sha256 = "d59d7dada004276c55f4b0a9a4ac86b0ffbe5d565e7a2d4a0c23831c20e78e3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/bn/firefox-96.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "6186942376927d18e722575894b2337958faf2eab8ed20d092722f640eb3ae1a";
+      sha256 = "6537a4d874707fc4fad3d5deaa5459bd9dd783caae8f927ae8b2d8d74dff9e93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/br/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/br/firefox-96.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "1d4610801d2357632e469df842b70844892af9b74d4934af8a7fda5846c96116";
+      sha256 = "7a50bba797980b9413b8ea1ae6b69b59aa329a43f15a5534cfbeb242c687bca1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/bs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/bs/firefox-96.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "7ee573e4aaba51b660d25bc6a1a90659d3240d530b8baaaaba64ef989ede6be1";
+      sha256 = "a3ffb0724a224ecc211299b034d79bd9a211abdb541cf6f7d4e8e0a46aca64a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ca-valencia/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ca-valencia/firefox-96.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "c9199f12b1ea4a22d01d5a51a51a085b1b37cbc731516406b34bd7c96a4b2e8f";
+      sha256 = "fcfd42f15782b50304627f10f6e65a4f1a0aac24969c101cfbfc4b1a26513eca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ca/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ca/firefox-96.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "1527b802e525aa3a7d3edac7b2cb1fa68730d8499ee8d9904f60dc40842e2cd9";
+      sha256 = "8a3072d642dbfa2ccd2a9de29a00fd81dbfbf5a94f21120565b9db6a8a9a8d51";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cak/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/cak/firefox-96.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "77c713bbff9d83b67baeb791f551a71ee0353418e95af0b070e3806bec77e501";
+      sha256 = "bbc92e25947151f260bbea5bf81450958f1acf43c833ade6499e1de067156a40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/cs/firefox-96.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "1fdaddf381023516e4a1e476cd9f3c6d8293b2bfe755f5b35256e405956f7607";
+      sha256 = "276853dbe6865fa300059c32041cffa881dbd29012d6dfbc7516c3e5acdfe255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/cy/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/cy/firefox-96.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "782e40391e1715f39961d759323ecec10860225b65be0989c923b1ae08c3bc6a";
+      sha256 = "2a623edf9e2ca82e9c36adc115e07b1d931c6639f8416f4431033a76cb12028b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/da/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/da/firefox-96.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "68ab324a88c81b8309dd599e0a57e1553d3a7162c7d63639f5e2ad3ab4ff10e9";
+      sha256 = "8a23f262babcee651a69dc3f8089328af81a41d324039bcf4d9ffda00bf3b1a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/de/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/de/firefox-96.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "50b3677c2c6168d3d6b86b8c6d7deacd65d99d6d9ef9b91b7a1322515222b6cb";
+      sha256 = "1391338182f044f4d95b6087eefd08bfb3854f8ef8e1f95749668d6d567e8deb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/dsb/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/dsb/firefox-96.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "65f7ee8892636790e509637392583b918db56379ae05f482824217f26511288e";
+      sha256 = "79515b5ae599f4319e35861f014e26fa87ed007a39c269226e5887bdabd8a134";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/el/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/el/firefox-96.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "5fe2fa3ff7284bd6b2519736e159d31150fa13459e8203eeb7b4f2a741dd11a9";
+      sha256 = "fa35e87c066122bd077bcee9e32e48c49a6db421ab3ef4c4d42fe82c7d57b147";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-CA/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/en-CA/firefox-96.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "70aeacbae6a2f924cc63eab43857303002c2d199b1ed00b8514a1d8cb32b3c2a";
+      sha256 = "e1a0d585985c1d26db396649aaf7ea39cebec749fb42a053e44032b280fa4f45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-GB/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/en-GB/firefox-96.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "89c7f6d491021a1094c19480de5e07d2d55e869ef2027be15bfff4179047e2e3";
+      sha256 = "6cd3f585661194ebfe76fc7fa90ff8cfa173fae0304189376b291c3c398ae6c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/en-US/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/en-US/firefox-96.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "6f6cf571331e1a5f574116943b5de4cdd6c9072f6775ebec5dcb89991ed96b0a";
+      sha256 = "85143f6936bd6d5b2f55907ed6e84a91cf69bb57aa2b4427a07cf3e3e670bd30";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/eo/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/eo/firefox-96.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "11222993c2357eae6cd28e4fc31a51345088510af60545738d342ef5d3d7e62c";
+      sha256 = "e1881f2c785cbdd019d08aedc6a721a36679d490d3071b93da155de11c223c5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-AR/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/es-AR/firefox-96.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "37119a97e6bdc0d708bee83ef22642d44cd34ca02348939d7dbb8daa0f520071";
+      sha256 = "9bcd3ffbbaf67b74319026abba5a55c0e84810e980667a4a65abaa29c61e15ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-CL/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/es-CL/firefox-96.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "f6805e64b01c5cf5b35cc74449a2c4f103cad153a0a396c14cce52ead176c2ce";
+      sha256 = "0e57734b563435602bd470a74771331bea0f68bf12de70ae1fec2c72fb3a8dc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-ES/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/es-ES/firefox-96.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "e8e33a2219363c2d9a22e66a0b047848764d946b19b0f8539ab0ad9f3844d81e";
+      sha256 = "ab4a5dba1eba3cf149830f055df87c9aea4a8d97485311243d20f20686b5c050";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/es-MX/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/es-MX/firefox-96.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "5593fd719736c8d0a841a6407b5fef77a10add5e72b47cabf713ae3659c76460";
+      sha256 = "15d791514c92f5c676c8a72cf423c34f5dc491029ae9c1897907d4e945b3f441";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/et/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/et/firefox-96.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "aec0605c75e747c46ddd1d702eb84144edb6f65fbc2c9bc8dd487a8259d15344";
+      sha256 = "a3189afcbdd64a4491868712cabc80c26b8c67dab8fe41b20b47d8300e275b21";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/eu/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/eu/firefox-96.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "6d481223fd80a84369c8afda02d2223108308e4449bc8e21e5f304519c362558";
+      sha256 = "77736b1d377ea03ad43e8537aab2e5482d894082e351bbd066ba1211bdfebb59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fa/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/fa/firefox-96.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "34689658d29304e17da97121a41602399d80fa07feaea83e1647e37dac51552e";
+      sha256 = "230def61e09988d4a53af2245f59da9197a9f2e29cf88665f002d9091db34ce0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ff/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ff/firefox-96.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "6b67ea39fbf17c982ef2dd7f9ecef83d239fd43e9a6ab7ce5d41abfb8917db1b";
+      sha256 = "94fe353aa805eaef97eb1e873148eef2ab1cbf0aaec0d63fb67e2e16c043f950";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fi/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/fi/firefox-96.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "3a602bdd77f6da214f3f23a2428871ccd00b09e44d4e5aa42e1ceeb16bd36df3";
+      sha256 = "37dbe7c39420f31941b7a7e023973b20e3bf538a595e3e21a81a82a1acd7f8e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/fr/firefox-96.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "53acf00bb148595adc58fb80d9546237d662666f7cc6240fab19d393f74e1377";
+      sha256 = "9f4467c200ac3490bc9e97f814937a2c2083e133b72903ba158e3fcd275f7233";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/fy-NL/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/fy-NL/firefox-96.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "92e290420735d72e0372184d268bccffb142e154f96ad3d4a1d4e4b71b5c7050";
+      sha256 = "bea6f5cb0ef7a99823929156cc207c585a9bcba2d9554f749c5afa790f6d27c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ga-IE/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ga-IE/firefox-96.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "04423b1cc5b0f6f955e7071d7b7bc3b4989b061a85a634ee38740917e303a93e";
+      sha256 = "565c18b8a738f62b944891a472a3fd94300a3efa3b03f43896502c12b33d0d5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gd/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/gd/firefox-96.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "15ca404e594c678238369ae4e51afa46eadcda19a68b6ef2c9d465981346214b";
+      sha256 = "1af3f52d4ff3fe78e4abb7a26f52725f38214ff1dc7dc50a8b39daf2dcd250c0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/gl/firefox-96.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0397c87a2807b010256b97c1e490fe5b9c2f3c0b7642566053771ddbb34064c1";
+      sha256 = "72108446cdf29444694e4cb52f46366eb6749e51c082d25126d768d5b867be7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/gn/firefox-96.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "98987dd795dbfbe2c72a1e4e0199b1fc2a31403879920e140bd940667e79d0d1";
+      sha256 = "9ac9c828a27ba7660642b1392dcf7955c323e0e4eb9e7634a3a959cc0c62125d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/gu-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/gu-IN/firefox-96.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "7a98f3d1d4cc8974df23181383c1de9a524f02e47e0f8a6625d20fe713130e54";
+      sha256 = "3ea6ee8dd0e20229f70438172d8dbe1e8aca98776e28d6666cdd0f53c746397a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/he/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/he/firefox-96.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "1087c87aeb9465b848985c94ad647a1bc1307ade09349de6c85ae5176f32fec4";
+      sha256 = "b94fa7d26c8da38d5ee20cdc0b36f7c6a8e0186a9dc4cda359174dabfa337756";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hi-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/hi-IN/firefox-96.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "f78ef9cceec602bfb645ab15ff4546d267943403f63570a38a5153c80a721ea0";
+      sha256 = "38e7f9d934e5556a1f51d6f5fe1f0f7df6afc3620ca79b187df4e74f4bc62d83";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/hr/firefox-96.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "988a13c49fa7b1c6e3c05beb18b675c64bb6f520ed6190079d55e69cfeac6c48";
+      sha256 = "ee77fae1f428b90bfbb9f6cd5310d5268c0fd0a27c927cea16d4dbd38d0ffbb8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hsb/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/hsb/firefox-96.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "821a634c479a9b4eae5f8f706d40d256406997ba7d62bb4d29ddb4539c83a937";
+      sha256 = "a4cb2e444c0977abb2cb14030040768612837f1bc4959ab3bcec407f79092005";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hu/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/hu/firefox-96.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "da0659564688659c17b591a8844d481a86c7d2a01499e7cd785accf840012c04";
+      sha256 = "58acba6ec61a290540cebf5d21c7e422e17d4039a26a0ed66324fb809eee2255";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/hy-AM/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/hy-AM/firefox-96.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "f4404195096809fe9d652821fbfd053ee9892f28262cc9cc47db7bf160e0e824";
+      sha256 = "47fc6a81998d126745522c681244f94ff05c0c1781b35df16cdd4798e02504ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ia/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ia/firefox-96.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "d539c129c240a96cca32d4b4da252f146444c47d375d07cb5e47a1fcdb82983d";
+      sha256 = "9488d6dd3ef74028cbe6c68c7e77b5431a7c19c64abd6f17164b2c9bcb2f603c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/id/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/id/firefox-96.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "d597990b39d8cfcefe626c741750e1bdddd30db9e8a7736d244538f180f53597";
+      sha256 = "545cd0471c933319685b0d7c78aee65587106c6054919ccd0537694f7366a33d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/is/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/is/firefox-96.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "acdcabe2ecdc14804fbcb7a5f1e0b589893c90ae190a106a9988a6a60db64c89";
+      sha256 = "a0d36e32cdca56d2602f1e875836ed626e1986a59e15016c5a7581755824112b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/it/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/it/firefox-96.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "4262d0a7e6b83bad6787b48bb9aa3a31d96d4cd5a9779bfdd667ca622f9f3d2c";
+      sha256 = "9b2c57944db6c50b99ce3b4d28dbbafc1fc6ae373ae0dc5e340d8a01999c9ec0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ja/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ja/firefox-96.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5640e018babb721fd74187e6795c64a398ffc0a233ed0b48a118444f3d2104c0";
+      sha256 = "999854c3fbded0359ca01e965161f9b036de2ecb614ed01cfbae4a664feba774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ka/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ka/firefox-96.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "fb5fc8d8a1c8ab2d97a61493347c65b27709e7f725a8e7fa4f7cc3a0c793922e";
+      sha256 = "e89a4fe08e96e5e0bf05278055df4889e0e8896e069f7ff8365d88911935285a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kab/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/kab/firefox-96.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "f32255c7fba167688340d0765fd6dcf6d8d6c403dc83ee6e7e9a00d984057000";
+      sha256 = "aa07f94c15e9070dad736ab3c0575f04e1b4d97a8c883eb089416983a07cbf2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/kk/firefox-96.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "10464c863efb4697e2526481e5dc06e4222189f0c1ae389675f266f73fb70698";
+      sha256 = "a7aa1ea4c80c7b2fc206acf56f3ac5f8c7446e1ff936d00f42cf3600fe5c6939";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/km/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/km/firefox-96.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "aa01663ee6e1f15bfaaeeb9e7ff4fa33f00c7017e98dfc4316d7515940e0a8e8";
+      sha256 = "001a90e9a2b9a007006e58774ed128bd32cd3478a96e6b46f0aff8405f394b48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/kn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/kn/firefox-96.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "837347aadfe019fd8baf15fb1775f06c6ff5f1c7c099777a845317ccf24e0e6b";
+      sha256 = "d1482ad282633ce66de08a2b4418c9a8b389fd191b064aeaee392067c3f83114";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ko/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ko/firefox-96.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "18691cec2710cb89a13f5851e98951762768615ca6e45e77d9e791abad6f2132";
+      sha256 = "a8e59148929054648b4f69d4fef5465a840c75bc4bf3c534c38caebc0cadb317";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lij/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/lij/firefox-96.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "3515f22f97f7d0baa631ab2fea3335cbab3c5377a5184f73be9650fe121da728";
+      sha256 = "4f10b104007eab4b39a61a017279d93fc899816dad62c4f25dcd2ba801f4673b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lt/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/lt/firefox-96.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "ed23664bcd177dc490fdfa623d8644c34351c4a91c71465337c8b3dfb79ed726";
+      sha256 = "2c7a57aa8f16d98bea028617eaffae301f73a079486b444120948576c475b90d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/lv/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/lv/firefox-96.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "8f12bd4da0fc6506121d167090f2caff7c3cd53516f0b3d0d3a02426f40799b1";
+      sha256 = "62dc979eb6471fe4195cc18b6c3ff9abaec733fbf69071660bc5028d466f95b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/mk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/mk/firefox-96.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "33f9faf3f55aabf6c8dc1b7e2430b0de02ec5979f5100aaef88b683d3daeec35";
+      sha256 = "4226dc59168d66efb2d8d71f4232817b4c37a6b1a894767e833bc31cd0cd336f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/mr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/mr/firefox-96.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "4b57c9d1f351f3986324f3be01c2c4c8ffece6777a6f18790a02a57a53232817";
+      sha256 = "22a27cb41410cda65307215c7388ee0af259f267e7d569d961b71a99a5285b0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ms/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ms/firefox-96.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "9beb813a7781e9669d8e140e4a6279b04f9b16a0e790fcf53564e8f700ad0718";
+      sha256 = "a2ccf8df0396b342b4fd65dd8361a5de54be08e7bdd79db214457c2f85f221cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/my/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/my/firefox-96.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "3c5b78c390f3a77b490903b13ce2bdadb51f6e42b57ade221732f0c5203d052f";
+      sha256 = "47a8e92f9095f532969f8a78634f157cfbd04b2fe2562baf303ee1c41dc48980";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nb-NO/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/nb-NO/firefox-96.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "05b79768c73e6d853eccd5f8b1d85d1d1abba18c3c286c20e2c22705dfa93e37";
+      sha256 = "293900e86ccf9000ecc8344248e12cf2b1671b1f2543f60cb9f58b20a980f071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ne-NP/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ne-NP/firefox-96.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "5083d2ca8a0e46fb4b9ed6f7cc06fa5e009f2db5f7192749a273ad9294000d75";
+      sha256 = "c8e80531dc2ac9ea11a531075ca44cfdce829bed85c3fe10686ff7e89f0443f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/nl/firefox-96.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6ea95d1eaffb658f0df4ae1c3b0648fc46ceb073859315775344254dce8571a3";
+      sha256 = "5d96b46954b4b92927878f34c0f4c6af90838003ec99156e1bb29c265543ddb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/nn-NO/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/nn-NO/firefox-96.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "00c36e18988bd6a73a08bbb065f668a9f20ee06d640ff26d22da5d7410898ff7";
+      sha256 = "a2132947de63a8e825c2cff3e0855bb23dbab4ef0a654c6c2d8f8c196f4cd7bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/oc/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/oc/firefox-96.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "a77c95cc9261d717dd62ffddc6d04b1ba6538a63a7922bdec8bb0aceca8843be";
+      sha256 = "23b7a65a3e0e8a527acdd209f7ff3cd241766cfac6402c4b4b5f2ed7ad6a9f92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pa-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/pa-IN/firefox-96.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "f2b636fc5c6ee58de46cc100e5eadd74e086274284b1723af429045afa3988dd";
+      sha256 = "0433a761dcce926f09f8c8ca7e8a22d0fef7636790e41f819221e1896edeeb1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/pl/firefox-96.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "77afaeaf13c0e3c50b288fc5baf58d00cf0a4879b901a5681fecd95b6b477d2b";
+      sha256 = "884af417358344acf53296631dc4516320908b328103da968dc2c77319ea5414";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pt-BR/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/pt-BR/firefox-96.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "4e81866ec2708ea25ecaf021be1ba73e6a8314909fb2bf9814f97aeb3b8ee487";
+      sha256 = "53453485e7e3d63b436407f1c48b54f3ef6f24211bf5511e9c2a8b187b1b4bf7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/pt-PT/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/pt-PT/firefox-96.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "4fd989c61e24027f42dcaf0ae1ca9ed90bac1492683ff0c6f3acd5d22c6070cb";
+      sha256 = "0550a2585e80c3ade74fbd0e238c29d23d1648ab319e909067214997114938c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/rm/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/rm/firefox-96.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "7c433f0566a49c0141e42f3eabded921af8a286a335d17f4fac47867d17787f7";
+      sha256 = "51c246cc1b14961717fec7b8f5b9b38f11fc8883423b16d22916b8896a71dcc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ro/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ro/firefox-96.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "26ce6ad767b7be95620309310007ef2ba2cafa3b22f8f1379b70276ecaf3f3ee";
+      sha256 = "5eed24710606a6d9ae46e5086fb935b02eab1191c21fd699eb5161f9a28cbb1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ru/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ru/firefox-96.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "290a34b589bd7cf99586c9dcc1b64c65cde55a40c1851c1ce7445374523f55c8";
+      sha256 = "5202a0413f66666b167366093dfc1909b0797082f308365168050e5d4e9f0a8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sco/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sco/firefox-96.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "3a9ff8651552d7955db6d2bf3f308c3c378aa9bd6d2e0bfca014fd95a0e9b315";
+      sha256 = "66d3538be4f4225b65f4950a3df600ccb96c0869a134f72573d3c7c085f97045";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/si/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/si/firefox-96.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "e6f17fa62c22ed2144233707b0d58e53c8e0df4cc92cb5f8e202d6dcb651a34f";
+      sha256 = "b8ae8c7e6c02178e4e56ca62c67008978d05f5c40331bf011c8f68f27d001d61";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sk/firefox-96.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "6b42eef534552215fdaee354a9a259756626ad2ee96b0bc867625d958286142a";
+      sha256 = "32a7105c6ebd64511ce219e6fe07739ae801bf52d133a0c3e539acbc70d9fded";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sl/firefox-96.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d069528bbc8066bdffc8b1d0e1f91967a82e7b9698f761a2815a777b0b616878";
+      sha256 = "86b1a61a910b5e5f1c57f5eed53a9718e2c0831dec351864c3c47f8fe0c21963";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/son/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/son/firefox-96.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "567a3232153e1a249ce49da88d9576f85d783fd2ef4256180e7f09a44c520ddb";
+      sha256 = "2b090616040bbdc5192e853fd126a0d71fcb5a8b30a31b693273d0aa1581d359";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sq/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sq/firefox-96.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "7cad9d6be53e0095f41147aa373ef23729d0c5a636ae8af0680bcc054d343e5f";
+      sha256 = "21f2b20f6c035b9fd016be0c56c6bf24e6953aba3b7e045181c9f39be28855c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sr/firefox-96.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "c04396c4c313769edceb0b0c5a98a41c55fe27af973ff6fb3b9a2116e39a52d9";
+      sha256 = "c508f033013d38d53b61ae15a8cac454d3710861d1cd3434edb830440ea5e160";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/sv-SE/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/sv-SE/firefox-96.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "0a24b924e3f91b0d5e45fc8f7f1969ac52a0a3f4dc9705ff6b4186c7e4fa042d";
+      sha256 = "a99c21af9e34f737e406c13ee906ccdc71199f5a9540a116b2c706af2bc8d3fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/szl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/szl/firefox-96.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "55b2afae883c7de7fd1e33159e1c487f535f6d71f8db7e200c77e884da1c9290";
+      sha256 = "2a17020d2c8dc36efcbec724af7dd0ac92946ce68052ae5a839c3c5727433c25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ta/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ta/firefox-96.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "38abeca5e1f9e945566b8034ea3bc2c2a1cbb081f02635c152d13a8454e73bd7";
+      sha256 = "db6a6434846451666263dc805a42dc579eaccd15dfc73379609046dbb1c65067";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/te/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/te/firefox-96.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "970c4b0d5bfa24d03bac85bcccaf05d8d70e9884c2d73c7d3cad8539b46d0995";
+      sha256 = "3621ba6af69fe808027243a27e4af59c797bc0baeeb5bc880027dbc25ecbbd90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/th/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/th/firefox-96.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "7f94c556f04a78f9232c4f2ab537719e30ba6e9b5705f175768f9f41cc7921b0";
+      sha256 = "b4bd33654822a3ec1c45ea99256141458ed0c139107bf916d635fc5a99a1eb3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/tl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/tl/firefox-96.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "dbeb26032ece7026a088c8130b28dc57659816ce52f61efe31cfe5b0f4d82e78";
+      sha256 = "0136cecd5adec6cdd0b616e788c2bc8ed3d741c89fad3a1d19a3ddac40658e1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/tr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/tr/firefox-96.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "a4f95b402f158e6edeaaa4e1e5c7ecb220e88577a9e847a52c12e8d616dddef1";
+      sha256 = "3cd4f0375d20d012571422b35369c9a0e8350c2b3949f054b04ebec6e0000e29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/trs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/trs/firefox-96.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "3c22a4fa31761cd06df14e1e6a7cd7d3066287cfa9c97f34d8ceb75031fc378e";
+      sha256 = "cc11b387a1b2c0d0f1fd6ed4f18308eb5613d2c409cfb9eac9a0bbab9fd2d33c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/uk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/uk/firefox-96.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "7f6bb67e318d7c2ba322dea1636ddcb94b32180b687d4cba4c8ca885a6fbdd5a";
+      sha256 = "e6e090894c2d0926db5681fcfc875424f48002e24aac05c283a51e847eb5df6b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/ur/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/ur/firefox-96.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "253fc6fdf04d0cfa7e5304ffba9eb427cbbb76e387d94dcd5470e4556348ee20";
+      sha256 = "7b83962242d1b8550471ac607985da427e7bd839742e12fcce972bfa5e328f1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/uz/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/uz/firefox-96.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "0965894c437f9995a2cd696d87ec5da2ab21050bd3500a92558877355b07fc02";
+      sha256 = "46f7e4509fd9bede934501e7e1175912b46c25435494483c3190344f1c497da9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/vi/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/vi/firefox-96.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "abecf56f27ad4b464d881db55d8d7e455aea36f492b18863fd9eaf4195640796";
+      sha256 = "2c0fbaba7c78581e6f6810c4eba677e4d36c567dfae379a38cfc21ffcc8f436f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/xh/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/xh/firefox-96.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "e6d453b35154f0faa9c8d76808e201a9105fc6dab9158a8a688fca101d0fdb95";
+      sha256 = "3e955c713ab04ea673e284a1e7a8bebd5203ad68163a0d2c1e20e4134a1255d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/zh-CN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/zh-CN/firefox-96.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "9b32e92f96b2ba0df0d54e041bdebce747ab0815f5be9327aa6596d876321070";
+      sha256 = "85ec531c5ad72cf4737b1e09bea9cce39b103394ba4d1e4733a36f93c366f789";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-x86_64/zh-TW/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-x86_64/zh-TW/firefox-96.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "05664f6db9bfd37f09a20e37a0971cec8234f13d4480e3c02c3d280194068871";
+      sha256 = "6bf84541ff65a62039f381b134668325084647a257a7fde599eab5dcd6ad3e76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ach/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ach/firefox-96.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "775d3c5fb18f7219d1f1492c84ec2c62c188da71526a4896c139792e3b6c2d36";
+      sha256 = "7e9f42a17de2309cf2bb0c2db66149293837a2ca8bc5314962cc68bd5f00017c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/af/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/af/firefox-96.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "5781a804cd6b3205ea137ef3890ef1973240384fe2b89f4f168ecaacf5a5ea65";
+      sha256 = "a0ddd7fcc61ebccad2ac697d172cd02936c9d34ce96085415255a0282433cc79";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/an/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/an/firefox-96.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "2507de35b2d8e28b9c950256e2a5f58d9529e1f75b3a2ae3449ffdc412fcff5f";
+      sha256 = "7583e32095726fd623631b88504ec59911c56ee7f6742434a3efee1209e96cd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ar/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ar/firefox-96.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "9f340350cc9fd2af4af50b1aa1e3bb4371eccad04a567fd428c5cb5225773d6a";
+      sha256 = "57719f2beabbfb0ae0a12c8250c60edfebefddf58764e579d658ed58c3709f91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ast/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ast/firefox-96.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "0d72eddbc07dd7682ba36d731552b9e5a9eba28d10703446d1df7016783c51f7";
+      sha256 = "e3e71ac1ab5cadffd6083e243d2a4a69d743a3749e6ac7d972eae4b3f6e2825d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/az/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/az/firefox-96.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "afe6aec818678974c3590f10d32f8238c83c34311af29cbd88f847256b6c2aeb";
+      sha256 = "8d0c2a638e0f025f81b7958ac6775d35a6d46a85e8dd72e567f78cf3df354e65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/be/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/be/firefox-96.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "d3ef2a3df301eb00e769f634f413e1b7a7134e1ffd4bc5e5add9ae63b04b2060";
+      sha256 = "a8e06cdcd987d0001b69e48297beeb8e7d056ee526f9293f27e16578978a3ad0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bg/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/bg/firefox-96.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "4368ae3a9e1bc1c3b6f29e5931da3b48fde38f9289ac3b435de6d25035ecb381";
+      sha256 = "96eeafd9d1c17028b1eea7f67ca9da2e13f05ba07b846121d06a9ce9a5722bc8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/bn/firefox-96.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "4b3a502e6929c1b07ab4ba1ea436005e6b9dd8334dd262c2ae07cf12732ac8f1";
+      sha256 = "a44d8004516d0e74343df7cbfa636ed6f1675fb7fd64a49b0fd74644675513b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/br/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/br/firefox-96.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "ec1988c78c09c606f19ebc971dbb310d63f751c941f855251c1f52dc52a898d0";
+      sha256 = "40219b7179fe5e93cf81632647adc5227f141062419559a13e2c96adb619edf2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/bs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/bs/firefox-96.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "45a9ffa6b755efaa4e4cbb9d8789158f0c0da7428d60d6afda29dc49356230ec";
+      sha256 = "1a260fabd6fa3d200bcac7d59523fdd03ee7a2100386848d273c98871a9a8cd6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ca-valencia/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ca-valencia/firefox-96.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "b632eb69763a4284958be3a31bbeaf5d3a782e0c7b7a765b65e0e2b82de72d56";
+      sha256 = "0fda5a630ffae654a761361620989fdad3e395758c6ca453f7181d5594a9f430";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ca/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ca/firefox-96.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "88869f236c16676b6dfcbf86cab21224e36870ad539c4cb918ec67c6662af0b7";
+      sha256 = "6304b319a9da49492dea2a268719f6bcfd1b57313fe22a57d104c693e465b237";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cak/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/cak/firefox-96.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "857ed1a071d5f9545209272b699987645322389e7eb541617d74c4ee967567f0";
+      sha256 = "ac93bef164ede21d362db4c130ca2182239681d32aa41ceecc6040321521ac1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/cs/firefox-96.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "9c65991015af9ef40b9595e905831d0e4baf88b52ae2b678966ef56ca89dfb6f";
+      sha256 = "6ddafa9c714bac65e5a06bf459e62ba95287d540a891921d0054d485617984e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/cy/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/cy/firefox-96.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "bd4366031cd402481ac7021c2b891a9a0af34d1c8f3bc04077f22098366e8263";
+      sha256 = "247e05e6ebca3213b837dfc9d5b5cb00154eb86bb097a1c8cfa1e76f181f1492";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/da/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/da/firefox-96.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "c3900f2a4584bcb6d41a1744e4f82bf12ab451213293ec19a474750f707907cd";
+      sha256 = "e66dac7ac62ab4337b78f1bf9565044a064e88a3a5ca48a41ceb6a6288e0f25e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/de/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/de/firefox-96.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "5d29d0d70371163d751be0636b912176ae665f65d9f32bf62e01f69dc0349a91";
+      sha256 = "6b6de662320063cb030977f6c9375dfa9e5c218686333ebaff00f4ba9626ac01";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/dsb/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/dsb/firefox-96.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0682f59ce11000f78b908e063daa07a0e4f53913e9beb731f604fe372ed4f7e5";
+      sha256 = "903ee6402b4f37b87ba0ff39a7c3a903cf29555c11796021e98646b4d1584ab9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/el/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/el/firefox-96.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5418f2235bc8bd565d88f3eac49b2d2fe82a9117aa600612a68ef27c127115a2";
+      sha256 = "4b023b27b2c575f984c43308a13c86156da437bb8fd7085da3616494b39eac37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-CA/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/en-CA/firefox-96.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "d52c73155cf23a5a746ce3689571a1b9dd437ea182bdb21b556dfa0aa13818d8";
+      sha256 = "3dd23a34cfee05b0de52a50d1c0bdaef69406425bc373571e3327424a301b42d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-GB/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/en-GB/firefox-96.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "ec3fe9fca914d607f44fe048d33afd1945018e69c2fe31cc7d8d35eded88d91a";
+      sha256 = "ba26bc03bbd97169e683460ddc77cbd0404bc24f83d66b2b3c1bc1b5f0f4f993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/en-US/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/en-US/firefox-96.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "dfd82a4d8dc06cbf64b1a772dffcc7975b8cd128af2725785c68f5918ff903aa";
+      sha256 = "1108c32b4a4de68a056c44b1676db1642916ff310612b4683c126ccfc0f14cec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/eo/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/eo/firefox-96.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "9ceae21a7f36761e30debb370d0bfb97de5a489c277e8679b6f29872595d8751";
+      sha256 = "76595cb29d2d773e37e251a292c6c9dd7d5c6491c16e75fdafa638a8f753054c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-AR/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/es-AR/firefox-96.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "cdfd1b2289039eea5b2f05cd3af0c18f0c909246ec7f7c3f04e7f1485be9e894";
+      sha256 = "6f44be9c4450b438b4a1651a7190fa32aaa9a43f5fe58353f83ef7eb218a1fa7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-CL/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/es-CL/firefox-96.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "df7e0cebfb8209a29bf43af5dfdf5f496437c6017f3c8c428f0830feb17a929c";
+      sha256 = "168a389fe8a5d2b9c8898e740a13f8f48a6e7f57cc1e1cd998a8a9d26b9534d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-ES/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/es-ES/firefox-96.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "41dbe20494da17a73aeed807805cb86b70cb443bcd41aacf8fbdf2445846f58c";
+      sha256 = "762c5910b1fc6e2e64fb14326b7da6bbb1106a3bba45821d1cb7908d484d03a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/es-MX/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/es-MX/firefox-96.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "74e8c4b50e0e95a0bf95bf4436a3ee7a35df9e6e19703a8632a697f47199b545";
+      sha256 = "d215acff39e7e2d31fc0b02f820209b2874c6d75760a888abc880da2a4aa7cd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/et/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/et/firefox-96.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a2830273d08f6b0cb9d95e9875866e09b3327d411c2bc202bbf5b4c9e32ef05f";
+      sha256 = "e9ee93c11644179d9032e042bf00d9620536b846611e7b3bb9924228ea26a47c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/eu/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/eu/firefox-96.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "b1e7b452cc57b1df9bf9c4b0936a43625f88900e2682c3081b026a3842321be8";
+      sha256 = "3de1a6e07db385fce85ebdf8ed4299e5d8e95578f4e00e69abd62a24fd4ce769";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fa/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/fa/firefox-96.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "572c26e61a98706ca36760627000794f9f22c2ead6763e0e7c3d8fc4182853a9";
+      sha256 = "8d3ed0432dffd19b8b5b02ebe7bc71e6b9119a1cd8db2d8bade391286ea5da7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ff/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ff/firefox-96.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "f931798b40ad9bd538c78b7bfdb84a170cc4dd97a35ede3b90cb0b17a7dd33be";
+      sha256 = "3daca20b3c0710a5bc587bd087fc98d261a1d8bfb8b81a13ab8bd770f1e02619";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fi/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/fi/firefox-96.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "413320e2e3e339864139ea1cbd38bb35a2182a5c651491b56d6c6cc3fc16f001";
+      sha256 = "eb28ffcc96735a3d5b2e1e63b496fbec142bdde057140bbf4885e3b6dfba967d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/fr/firefox-96.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "0c98180aa71d229b8615d10f2f0d472aa9103aba961e7b72309ae4c4dbf201a8";
+      sha256 = "98cf0c26f0a81c240dded3e4e4ec1ae4fc14b6944ced9f6cf196e568f4fa8b52";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/fy-NL/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/fy-NL/firefox-96.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b79e8afc2333db64744811be301d30732efbbd5058870aea60be605356911dfa";
+      sha256 = "ed035b9763ff6d3a3bb9e6f283df2c6c7758e0dbc80124626822fb802b086215";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ga-IE/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ga-IE/firefox-96.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "5389751c882932ea285c0694dd06b02b723acea7a40494a0f5c8005613cbc31a";
+      sha256 = "96e22258417ae821ba19961da62158454d4d5b6882cab908da3dc2875ed6e4cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gd/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/gd/firefox-96.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "ecd23ae7a86a14e8a2be920ed0df8d9db7d4d9d9cebfcd1dcd31242935df437c";
+      sha256 = "6162712f9875132025088bd1d5b7288eb768cb9d666b85c37a75bd29bfa97c6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/gl/firefox-96.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "7304d29ecedb07d8b192b7c08d390ed6e59e7ecfcae3808d74ccdb24d82a5267";
+      sha256 = "eb90f192145ff258876c35c1cad609b547f1b4ae2e0819148908575092da6fce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/gn/firefox-96.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "6e4c6f2262e5bb4573c471631584a4e0421b799f643ccfe2503f7409663d4046";
+      sha256 = "4d954ad5adea89cedc31d4bd3ee06c31718c8be69e8df4fb734cb9fa0fc6666f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/gu-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/gu-IN/firefox-96.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "b484b4c95bf9ff0ff622563caa2b8efaec483b76ebf6de0b6ea5392ce6dfa687";
+      sha256 = "a3ddf64b28b0309d8c3c60a31a301cac34c70868a83517a418f68a06780d50de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/he/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/he/firefox-96.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "1e86f10829c12a635d6c8fea6afc496e440d1e91b44280befb2dbf46244091cd";
+      sha256 = "949d9dd58b170902e43a232931ae366bf2ad2d753b4dee7ddec728db4c5c2cd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hi-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/hi-IN/firefox-96.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "53fe58cc3cb8a6fff3e7870ac3435b4a096bb428c52597c75eccc11c199eb4eb";
+      sha256 = "0440859bdd04fe66811f59e0f00475bf1840a42e4af6887a70e510bbd33bc238";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/hr/firefox-96.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e03229a236dd34c9dc199afbb44d0fd10ed3b8b68b43ffa09b717ef5536bdf78";
+      sha256 = "ae452061984ae42e20b43a1c6dd2b843561f3df0a700dfcfc3a6eab1e607bbbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hsb/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/hsb/firefox-96.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "d8fa249baa33bed71e51d4e0008c4a524748e84394401f681fcdeb4ebfda93a2";
+      sha256 = "722a3f671c3ca0d9f8e894bc7150a247ce45a011db199af029354ad03b2e6961";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hu/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/hu/firefox-96.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "10eab8a65010ec5116d70739e85fbff2f9d93d336a5f8ac26c9b4621bb6adb31";
+      sha256 = "df5c83b65ebed8894c2046c6649326927f719cf754e05a90050201947aedc2c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/hy-AM/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/hy-AM/firefox-96.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "fcd08666ba84487167a7f1ba93bda53c2a01d8cea07002581a796932559589ca";
+      sha256 = "30119473a01cb79fca861bcb3d4b8edd8920367267fa356dc2349f10556fc58b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ia/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ia/firefox-96.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "8f1b6585bef3546d3450d498bc22b4111edc48a5161c613f9593dab960ea51ad";
+      sha256 = "7ffb03fe4afc58757afc7172cc58a99f88fd1f0b715ce065a4e0c05ec77d4e58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/id/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/id/firefox-96.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "fd6dadbee240001e31b0c55b290b61f6187395d6c6d92ef547552d16def9fe67";
+      sha256 = "069409053f3ed5c4d3cb3201335d9f535c84ddb38bac2e00612c1ff3b9bd5294";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/is/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/is/firefox-96.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "6813330e8fc3b04134ba91af756f7e2afab4f352f4402844032a56283948a3a6";
+      sha256 = "1a85a73f85fa25d1028c481e5e615fb0295a143e4cac2662e601e0ba01fdf6db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/it/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/it/firefox-96.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "570607d27fe8bb210bf5f6694c0cbe505d78a4e7753767a63eff5205d4cfd9ea";
+      sha256 = "0fdc8b691c06764ca4fbcb6f14dad02b095542e29d262c73916e6410b65c2b2b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ja/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ja/firefox-96.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "966b3e9d6c069d0ea2c3ca2cc1090a7ecaecc7e75a20bd06d988bfd7a1785320";
+      sha256 = "407b36c40f3c3a83232b59569edbbf75e25cea2d8ca6819b4ab89ba2b950ef06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ka/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ka/firefox-96.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "7c4efd6d06eb594b0e23031eae5a46696b629c192606ab94364b3c96a3985bd8";
+      sha256 = "21f718a2a2f1b69b49b4551382c9946ce4b5f98758c5d36e2bd14864ffcb95d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kab/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/kab/firefox-96.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "c0a044eb514c5c8dc7f670f55169df5612806ead901fc9be93b930a87c58c632";
+      sha256 = "fe5978a2f22f87fbd79dbbb8b30885e67011c5d264ea59b36449dc72e93e26ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/kk/firefox-96.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "1a10eb4f758fbb4597cdb67f7ee8e3caab41548a816d02892e34fc245748f07b";
+      sha256 = "7202218b736e5754134ea7f233748a108006b78a866abb009ed5f69049e3e2e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/km/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/km/firefox-96.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "c4d65e12d05ae7a88b86a46f86f7d562ad4e6e0d00e8f179ae5c0e02eacf3d11";
+      sha256 = "1a5ac6c5c8060187210a9b3edf827fec7581b7120c0844432d7e000ec6ab0d7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/kn/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/kn/firefox-96.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "f0db59ca26eb8ba8a2731c77ae3fba2df34d9bab7985b8bb25a0e5e085fa99e9";
+      sha256 = "a9f44a276a63e95e8bfb560306bbe063bd490b4a292d1c890e34993b4922e32e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ko/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ko/firefox-96.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "d0d1268e6e5d179e366a9be43a07eae1d595c61d322024e8829c6c0474e21c88";
+      sha256 = "087ebdad604bdbc1217101abb46792e87ad8e699b9de46c89c76bbf09eab9fd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lij/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/lij/firefox-96.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ab1ba9d76e9ea282ed34aee8656e12bc169c0725bfb1f005824a522c94f91f2c";
+      sha256 = "18658b4702781932656955581ad8274485df0cece8ea10a42351b6434ea70248";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lt/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/lt/firefox-96.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "284dfd1e39c91b86116d06743fb08ff93d63ad102930fb5dbbb759355e596d5c";
+      sha256 = "54b39021bea1cc0df72b2987f5e7f4bd22c70fee6321c0019f4f8c289ff726a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/lv/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/lv/firefox-96.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "e7f764b9cd295e3b157bbee214ba26178d8bafd3dfda7fcde7742d23e745ba4d";
+      sha256 = "ff98715d29da51180c243b5430e2b1f00195173f671371fe1ac48878e8522169";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/mk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/mk/firefox-96.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "32f6bf3ff2976393e3e1992b3f65af41ae948553bfbc015f343b2c6daa689777";
+      sha256 = "805244fa550ca460bbd2b579953e37e8c5ae80a1bc476b8f7ca88ce3efb44145";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/mr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/mr/firefox-96.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "beb39f170e77fd7a0d46b7f9cbc6cef1bdfdd83688eb0a2aeae77aa17a39dabd";
+      sha256 = "1115ed83e193a5b07235d329294ebe40e89eb51e4ce12ae8a1e9b4f532f15843";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ms/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ms/firefox-96.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c698053be91b78f6424fbcb739250e8f507f8a1de9f5a995790db533be3474d9";
+      sha256 = "b0f63831385a3861328d87204658355d15c613d21a845c5c8dc9a1c10bbc4a87";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/my/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/my/firefox-96.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "6f922f29a6ceca5ad09033df03b4683c4dee4ec9f4fb02a2bcb6275beabf706c";
+      sha256 = "8f2ce2941ed3699bc3391a772feb487bd3db8b725712e00017041ea144dad260";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nb-NO/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/nb-NO/firefox-96.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "70302578ef21d062d8d8a6fefda85827051bf66690f3f80ca68384f56045bb98";
+      sha256 = "62b2d55a7d93960136630098990f7d9bf3201adb2f83674d65c1a01f9e880661";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ne-NP/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ne-NP/firefox-96.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "d16eb28cfd200cee6066a6d03e84bc90b14dfbc0e5010f2eb2d23208b586dd35";
+      sha256 = "d9e9ebe109510bc7c682c70302d8513d1485892903c2415ce380664c64958f37";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/nl/firefox-96.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "d2269a95fc075d27c1590816f0d6b953f8435a9ef1c38af46ae30142495937bf";
+      sha256 = "3c2a208fd8041087ab7c27043c4b30b2f46fc37db63dc20d9a3e7583b53add32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/nn-NO/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/nn-NO/firefox-96.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "ec1431f428483221a89bbea288ffeb40dd28d19fff58ac988d377fe184bef032";
+      sha256 = "c17cb0d640544e6ff18b88c011f3f1cb2ff38b0100265dd171f80415fb33941b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/oc/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/oc/firefox-96.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "9541418a5d1f3feb445d1adb5b9e1a6d06d7e2cdcd0a517e321cd4ea6b72ac85";
+      sha256 = "f26d24a2d9e00cfa2d6f6e0292ae9c8e47764e686aba7bc8202e04a7a2ac2455";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pa-IN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/pa-IN/firefox-96.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "0c2e402172cbc84975bbc073e32d48ad8353b39b8eb936bc81d90d249ce7bd55";
+      sha256 = "98c13f5a1164bc6c0545f1134ab4f8a114e6ec317de3a78f1116e42cca10bb90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/pl/firefox-96.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "1b7c0b1ff2e112dae86e425aec72746e1f320c4794aae66f6cdbc0a5fbd68458";
+      sha256 = "8da390aceebd3f8ada061b955ec4f2e0b50c3e550f3fe966a0621daf19a7362d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pt-BR/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/pt-BR/firefox-96.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "c8b18b3c756614b774606693a0c74f5c91272431a8582e5a71d63dc9ea0b2c1f";
+      sha256 = "9b704bd207ec1d046e21d351e7110f01e7057350fac100b2f4afe8e92d94d5a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/pt-PT/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/pt-PT/firefox-96.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "36dcd7d573301179f47e7d073d7fe9089b703f91018ac652b7048423ae2102e0";
+      sha256 = "32610508fd9ff1b4d902f8584c9bfdcbce34ba74e2282a67195e5107043a86a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/rm/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/rm/firefox-96.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c70b472fbf5447e5eb2b2e43ddc0127fa8d1f97557ca6940c5086346c84c295b";
+      sha256 = "382dc90854525ad799b558544b6a40fe1fc9abeaa2bb231d6f7a043b99dd93c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ro/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ro/firefox-96.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "c913a3c2b05a57eacf83b4a95f6c8ef770ad632f183381750e6faad93152eb20";
+      sha256 = "2847b9c8a97d7907720b0b5d672d5eea697f34acad777da2003ff7550481d713";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ru/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ru/firefox-96.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "98db217f5f77b15f760bbab79892e3bc511ef0be3ad55d75cc1278a5fcc3dab3";
+      sha256 = "f5c0e7c12a8d6e5213cbebc929272c057617e0dfa35d999196528fafde2ab2f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sco/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sco/firefox-96.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "12f2422d485bfbe780e8db94b1cbfd187d430230c5036d4b00596d89bb64bd3c";
+      sha256 = "50809c7b9a01e970a95dfd798bd4a8d3830be773feeadb53384f79647621812f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/si/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/si/firefox-96.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "5ad07f521cc312b92ea40a3ee8f575b01524ab20be1315f5cbbe6ecdfecd64f4";
+      sha256 = "41995afb9efda0e8dfb55b4ebf50efbdf19312e0a51925385cf6a4443fd87648";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sk/firefox-96.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "a71cfb4fc3fd0a18172819763f3780a292c77c0441837aafa97d8db8736fa854";
+      sha256 = "55827591e4780395b8bd61cd3f012f28adb7b16f4947ea5a11d8baead58adb12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sl/firefox-96.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "4b3b9d9ebd5035ca309724c6980422ab0b64db3af6c9d1ba08938a7dcdd65297";
+      sha256 = "92294aa987214638a26d04df3172810840e4e3ee376a701f0e13449a86cc8dad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/son/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/son/firefox-96.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "ac7c0714a079b11894260f391330b4a5a555b5fe0274d826929f181954c1f692";
+      sha256 = "44f20f8e5ebaafd172c2c1aae53c84fdc431e8a75e16ac92f0d780d658744ffb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sq/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sq/firefox-96.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "9334c0ffb21c09c5529412d67156eb096d1fc08be0bb0360449b00ce24da25ad";
+      sha256 = "51a815d555d1fe2f4381b9e24959e654e86c5d2db331bfc37f6eafd659a6a8a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sr/firefox-96.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "a8b29a1a317566ba3b37e75d3c105008487daf44a0ab3907ce0cbc9d47d25848";
+      sha256 = "9f5413c7ea5c1cc1fa4d8830b70d7ea0ff7f5111eef0097a4597f408c51bea0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/sv-SE/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/sv-SE/firefox-96.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "05563bd29b8a89ddf517e8d4d997d177abb2e21722b14ebf0dd141d0211832af";
+      sha256 = "7ff0f61d652b0c465401bd00fbe92685582e00516eddd84724ad3eaf7e327ab6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/szl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/szl/firefox-96.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "3e49f4d70b6314bc0a92d252e2504ddfb4447c6f7d3611561c8f73065dfe770c";
+      sha256 = "b8a21ac4fcff9551249959ebf55a168a8ad8cc30be212563ed68bd3f93283fb9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ta/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ta/firefox-96.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "8b6a00cc80951cc0438d0acf05b105ad7e5ff720bfcf3b84ca96c519430b06f2";
+      sha256 = "9fd00bf87c76747832a1930c4ce526d6e280b86c5634e1b132791fbda70e9e4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/te/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/te/firefox-96.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "d988737a9e5a6afaf70ee0b8834a5b443bdb282f058f346b564fcfce0c1f2b7b";
+      sha256 = "332357b136ca53f54c5fffde603d6fb1fc4d1837b73d87717df227b490ba37a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/th/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/th/firefox-96.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "611552a0dee6a811c92ce5e90f6e85dc8685a3c015dc6fbb4816ab3ba886f31c";
+      sha256 = "1ad3f1b9f54af9e039d094e6039f77c7a3ccdfbf70b2178893bb4a91de74357d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/tl/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/tl/firefox-96.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "e8196540096bb834647e8ade99b5ce143b96e5d9157936fb9635b6e5df12e277";
+      sha256 = "2ad07a41fd029ba2d2cf84ba392e6a3ddca5df8f9ed81dd4b4d1dfe592f2f048";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/tr/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/tr/firefox-96.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "965ff28ceae8270b873b94be3a99c6363abb841e50454d5013eeba132f61bea2";
+      sha256 = "dd3dd66c7933dbd1177b7e2f435d654b4d500698536bcb41b46711f717fdb319";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/trs/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/trs/firefox-96.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "5c57ca45aa8150a8c2a723091565750593df71b8b4d4615601af61daeb5c6107";
+      sha256 = "2ad69a163f840f6be6bc6900bb7a782b7d4e851ac9f5499d2ed95eeb9aa7db20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/uk/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/uk/firefox-96.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "57789c73d243297ffad9e483a9921ce151d24ad60ba1b05caf9c6eff051b5fcf";
+      sha256 = "121946a0f845e7ed7735e5c59c1be45937052c34c7e424acb11128227d39f254";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/ur/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/ur/firefox-96.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "ff0e216802ce19e11ec239e5dd063d4bd599917442c692e6745326ea48d1570e";
+      sha256 = "e9b4b2281f9ce81065bc6a23313f545cd05966cfb6fefafbcb7ef03111ea72e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/uz/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/uz/firefox-96.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "05c07f003c18da0cc2b1087a53da126ccf53964bc4fbd79ce182e840f994aa50";
+      sha256 = "d8c224173410e8c1715e9ec36cafc055c75e56f7915c656cca9767ad0549f914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/vi/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/vi/firefox-96.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "f3df214f93b857276d412b0415f2b02b623617d4a4f9a34a17c1d5afef10f036";
+      sha256 = "0005d0f255e02cbe00395028989e6a8f500017c1e4e97541fff0a65d5f1455a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/xh/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/xh/firefox-96.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "df5e1b4a027b66fc0a6e8a68332a7b8db0180233bdf7e90d74301b82318397cb";
+      sha256 = "b987fd9b99a87fadf1103a83eba1758b2c326858e5d806cfce8c4737887edae1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/zh-CN/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/zh-CN/firefox-96.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "f3b3ee9eb3f42ec7b4d8f2bfa45f733b03c420d1b10c8719f0254feca5c482d9";
+      sha256 = "0c779c6d1e4556c032ac8f086dabe322c7b05b5f10357f82f39fe8e6090b9a28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0/linux-i686/zh-TW/firefox-96.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/96.0.1/linux-i686/zh-TW/firefox-96.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "3752ae6594afc74d8c460c7569a5467ef8f432f154256d42ae4e7e24cd8b2687";
+      sha256 = "45c9a7eb698491ba67618b3649e22357d999e0e292d71bbcad7a19a0cc4d6f9c";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    version = "96.0";
+    version = "96.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "39f553474537eb4e521f4182e38f0ddff039fa6b40b939d461937d2cef27f7182097b478f08f90d64fdcbe9c063e78f14f6863a8a82a16207ec7a1d3fdfda4ff";
+      sha512 = "c0d2ccf9ca930def63dcb9dc269e47f60fd4bbbdcbc01463df0c30e11109a543e310fb36f2334d17b90cb9c96b8dcdd97d0e2d6c589a779de5e4f197c052f9a5";
     };
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://www.mozilla.org/en-US/firefox/96.0.1/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
