### PR TITLE
accountsservice: build with systemd to allow user switching

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -41,12 +41,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     polkit
+    systemd
   ];
 
   mesonFlags = [
     "-Dadmin_group=wheel"
     "-Dlocalstatedir=/var"
     "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "-Dsystemd=true"
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Currently Gnome (and I presume other desktops relying on the same mechanism) does not allow user switching. You need to log out and log back in. With this fix the user switcher now shows up and works.


###### Things done

The reason the user switcher does not show up is because seat IDs in accountsservice are not populated as a result of accountsservice not being built with systemd support. Without seat IDs accountsservice doesn't expose the user switching
capability. This fix builds accountsservice with systemd support enabled.

Similar to the following fix in Fedora: https://src.fedoraproject.org/rpms/accountsservice/c/a472b4ede59ecdb505851c42639f67d980a7bc5b

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
