### PR TITLE
libxls: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/libxls/default.nix
+++ b/pkgs/development/libraries/libxls/default.nix
@@ -1,21 +1,31 @@
-{ lib, stdenv, fetchurl, unzip }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, autoconf-archive }:
 
 stdenv.mkDerivation rec {
   pname = "libxls";
   version = "1.6.2";
 
-  src = fetchurl {
-    url = "https://github.com/libxls/libxls/releases/download/v${version}/libxls-${version}.tar.gz";
-    sha256 = "sha256-XazDTZS/IRWSbIDG+2nk570u1kA9Uc/0kEGpQXL143E=";
+  src = fetchFromGitHub {
+    owner = "libxls";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vjmYByk+IDBon8xGR1+oNaEQTiJK+IVpDXsG1IyVNoY=";
   };
 
-  nativeBuildInputs = [ unzip ];
+  patches = [
+    # Fix cross-compilation
+    (fetchpatch {
+      url = "https://github.com/libxls/libxls/commit/007e63c1f5e19bc73292f267c85d7dd14e9ecb38.patch";
+      sha256 = "sha256-PjPHuXth4Yaq9nVfk5MYJMRo5B0R6YA1KEqgwfjF3PM=";
+    })
+  ];
+
+  nativeBuildInputs = [ autoreconfHook autoconf-archive ];
 
   enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Extract Cell Data From Excel xls files";
-    homepage = "https://sourceforge.net/projects/libxls/";
+    homepage = "https://github.com/libxls/libxls";
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ abbradar ];


### PR DESCRIPTION
###### Motivation for this change
Fix cross-compilation

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
