### PR TITLE
Add Xyce 7.4 (second attempt)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3893,6 +3893,12 @@
     githubId = 1276854;
     name = "Florian Peter";
   };
+  fbeffa = {
+    email = "beffa@fbengineering.ch";
+    github = "fedeinthemix";
+    githubId = 7670450;
+    name = "Federico Beffa";
+  };
   fbrs = {
     email = "yuuki@protonmail.com";
     github = "cideM";

--- a/pkgs/applications/science/electronics/xyce/default.nix
+++ b/pkgs/applications/science/electronics/xyce/default.nix
@@ -1,0 +1,182 @@
+{ stdenv
+, fetchFromGitHub
+, fetchgit
+, lib
+, autoconf
+, automake
+, bison
+, blas
+, flex
+, fftw
+, gfortran
+, lapack
+, libtool_2
+, mpi
+, suitesparse
+, trilinos
+, withMPI ? false
+  # for doc
+, texlive
+, pandoc
+, enableDocs ? true
+  # for tests
+, bash
+, bc
+, openssh # required by MPI
+, perl
+, perlPackages
+, python3
+, enableTests ? true
+}:
+
+assert withMPI -> trilinos.withMPI;
+
+stdenv.mkDerivation rec {
+  pname = "xyce";
+  version = "7.4.0";
+
+  srcs = [
+    # useing fetchurl or fetchFromGitHub doesn't include the manuals
+    # due to .gitattributes files
+    (fetchgit {
+      url = "https://github.com/Xyce/Xyce.git";
+      rev = "Release-${version}";
+      sha256 = "sha256-sOHjQEo4FqlDseTtxFVdLa0SI/VAf2OkwQV7QSL7SNM=";
+    })
+    (fetchFromGitHub {
+      owner = "Xyce";
+      repo = "Xyce_Regression";
+      rev = "Release-${version}";
+      sha256 = "sha256-kSGUaFarOHDNJ8kA/TAGkmzicm9O7cfJ7mGFZcbqCZM=";
+    })
+  ];
+
+  sourceRoot = "./Xyce";
+
+  preConfigure = "./bootstrap";
+
+  configureFlags = [
+    "CXXFLAGS=-O3"
+    "--enable-xyce-shareable"
+    "--enable-shared"
+    "--enable-stokhos"
+    "--enable-amesos2"
+  ] ++ lib.optionals withMPI [
+    "--enable-mpi"
+    "CXX=mpicxx"
+    "CC=mpicc"
+    "F77=mpif77"
+  ];
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gfortran
+    libtool_2
+  ] ++ lib.optionals enableDocs [
+    (texlive.combine {
+      inherit (texlive)
+        scheme-medium
+        koma-script
+        optional
+        framed
+        enumitem
+        multirow
+        preprint;
+    })
+  ];
+
+  buildInputs = [
+    bison
+    blas
+    flex
+    fftw
+    lapack
+    suitesparse
+    trilinos
+  ] ++ lib.optionals withMPI [ mpi ];
+
+  doCheck = enableTests;
+
+  postPatch = ''
+    pushd ../source
+    find Netlists -type f -regex ".*\.sh\|.*\.pl" -exec chmod ugo+x {} \;
+    # some tests generate new files, some overwrite netlists
+    find . -type d -exec chmod u+w {} \;
+    find . -type f -name "*.cir" -exec chmod u+w {} \;
+    patchShebangs Netlists/ TestScripts/
+    # patch script generating functions
+    sed -i -E 's|/usr/bin/env perl|${lib.escapeRegex perl.outPath}/bin/perl|'  \
+      TestScripts/XyceRegression/Testing/Netlists/RunOptions/runOptions.cir.sh
+    sed -i -E 's|/bin/sh|${lib.escapeRegex bash.outPath}/bin/sh|' \
+      TestScripts/XyceRegression/Testing/Netlists/RunOptions/runOptions.cir.sh
+    popd
+  '';
+
+  checkInputs = [
+    bc
+    perl
+    perlPackages.DigestMD5
+    (python3.withPackages (ps: with ps; [ numpy scipy ]))
+  ] ++ lib.optionals withMPI [ mpi openssh ];
+
+  checkPhase = ''
+    XYCE_BINARY="$(pwd)/src/Xyce"
+    EXECSTRING="${lib.optionalString withMPI "mpirun -np 2 "}$XYCE_BINARY"
+    TEST_ROOT="$(pwd)/../source"
+
+    # Honor the TMP variable
+    sed -i -E 's|/tmp|\$TMP|' $TEST_ROOT/TestScripts/suggestXyceTagList.sh
+
+    EXLUDE_TESTS_FILE=$TMP/exclude_tests.$$
+    # Gold standard has additional ":R" suffix in result column label
+    echo "Output/HB/hb-step-tecplot.cir" >> $EXLUDE_TESTS_FILE
+    # This test makes Xyce access /sys/class/net when run with MPI
+    ${lib.optionalString withMPI "echo \"CommandLine/command_line.cir\" >> $EXLUDE_TESTS_FILE"}
+
+    $TEST_ROOT/TestScripts/run_xyce_regression \
+      --output="$(pwd)/Xyce_Test" \
+      --xyce_test="''${TEST_ROOT}" \
+      --taglist="$($TEST_ROOT/TestScripts/suggestXyceTagList.sh "$XYCE_BINARY" | sed -E -e 's/TAGLIST=([^ ]+).*/\1/' -e '2,$d')" \
+      --resultfile="$(pwd)/test_results" \
+      --excludelist="$EXLUDE_TESTS_FILE" \
+      "''${EXECSTRING}"
+  '';
+
+  outputs = [ "out" "doc" ];
+
+  postInstall = lib.optionalString enableDocs ''
+    local docFiles=("doc/Users_Guide/Xyce_UG"
+      "doc/Reference_Guide/Xyce_RG"
+      "doc/Release_Notes/Release_Notes_${lib.versions.majorMinor version}/Release_Notes_${lib.versions.majorMinor version}")
+
+    # Release notes refer to an image not in the repo.
+    sed -i -E 's/\\includegraphics\[height=(0.5in)\]\{snllineblubrd\}/\\mbox\{\\rule\{0mm\}\{\1\}\}/' ''${docFiles[2]}.tex
+
+    install -d $doc/share/doc/${pname}-${version}/
+    for d in ''${docFiles[@]}; do
+      # Use a public document class
+      sed -i -E 's/\\documentclass\[11pt,report\]\{SANDreport\}/\\documentclass\[11pt,letterpaper\]\{scrreprt\}/' $d.tex
+      sed -i -E 's/\\usepackage\[sand\]\{optional\}/\\usepackage\[report\]\{optional\}/' $d.tex
+      pushd $(dirname $d)
+      make
+      install -t $doc/share/doc/${pname}-${version}/ $(basename $d.pdf)
+      popd
+    done
+  '';
+
+  meta = with lib; {
+    description = "High-performance analog circuit simulator";
+    longDescription = ''
+      Xyce is a SPICE-compatible, high-performance analog circuit simulator,
+      capable of solving extremely large circuit problems by supporting
+      large-scale parallel computing platforms.
+    '';
+    homepage = "https://xyce.sandia.gov";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/science/math/trilinos/default.nix
+++ b/pkgs/development/libraries/science/math/trilinos/default.nix
@@ -1,0 +1,100 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, blas
+, boost
+, cmake
+, gfortran
+, lapack
+, mpi
+, suitesparse
+, swig
+, withMPI ? false
+}:
+
+# NOTE: Not all packages are enabled.  We specifically enable the ones
+# required to build Xyce. If the need comes, we can enable more of them.
+
+let
+  flagsBase = ''
+    -G "Unix Makefiles"
+    -DBUILD_SHARED_LIBS=ON
+    -DCMAKE_CXX_FLAGS="-O3 -fPIC"
+    -DCMAKE_C_FLAGS="-O3 -fPIC"
+    -DCMAKE_Fortran_FLAGS="-O3 -fPIC"
+    -DTrilinos_ENABLE_NOX=ON
+    -DNOX_ENABLE_LOCA=ON
+    -DTrilinos_ENABLE_EpetraExt=ON
+    -DEpetraExt_BUILD_BTF=ON
+    -DEpetraExt_BUILD_EXPERIMENTAL=ON
+    -DEpetraExt_BUILD_GRAPH_REORDERINGS=ON
+    -DTrilinos_ENABLE_TrilinosCouplings=ON
+    -DTrilinos_ENABLE_Ifpack=ON
+    -DTrilinos_ENABLE_AztecOO=ON
+    -DTrilinos_ENABLE_Belos=ON
+    -DTrilinos_ENABLE_Teuchos=ON
+    -DTeuchos_ENABLE_COMPLEX=ON
+    -DTrilinos_ENABLE_Amesos=ON
+    -DAmesos_ENABLE_KLU=ON
+    -DTrilinos_ENABLE_Amesos2=ON
+    -DAmesos2_ENABLE_KLU2=ON
+    -DAmesos2_ENABLE_Basker=ON
+    -DTrilinos_ENABLE_Sacado=ON
+    -DTrilinos_ENABLE_Stokhos=ON
+    -DTrilinos_ENABLE_Kokkos=ON
+    -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF
+    -DTrilinos_ENABLE_CXX11=ON
+    -DTPL_ENABLE_AMD=ON
+    -DTPL_ENABLE_BLAS=ON
+    -DTPL_ENABLE_LAPACK=ON
+  '';
+  flagsParallel = ''
+    -DCMAKE_C_COMPILER=mpicc
+    -DCMAKE_CXX_COMPILER=mpic++
+    -DCMAKE_Fortran_COMPILER=mpif77
+    -DTrilinos_ENABLE_Isorropia=ON
+    -DTrilinos_ENABLE_Zoltan=ON
+    -DTPL_ENABLE_MPI=ON
+  '';
+in
+stdenv.mkDerivation rec {
+  pname = "trilinos";
+  version = "12.12.1"; # Xyce 7.4 requires version 12.12.1
+
+  src = fetchFromGitHub {
+    owner = "trilinos";
+    repo = "Trilinos";
+    rev = "${pname}-release-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    sha256 = "sha256-Nqjr7RAlUHm6vs87a1P84Y7BIZEL0Vs/A1Z6dykfv+o=";
+  };
+
+  nativeBuildInputs = [ cmake gfortran swig ];
+
+  buildInputs = [ blas boost lapack suitesparse ] ++ lib.optionals withMPI [ mpi ];
+
+  preConfigure =
+    if withMPI then ''
+      cmakeFlagsArray+=(${flagsBase} ${flagsParallel})
+    ''
+    else ''
+      cmakeFlagsArray+=(${flagsBase})
+    '';
+
+  passthru = {
+    inherit withMPI;
+  };
+
+  meta = with lib; {
+    description = "Engineering and scientific problems algorithms";
+    longDescription = ''
+      The Trilinos Project is an effort to develop algorithms and enabling
+      technologies within an object-oriented software framework for the
+      solution of large-scale, complex multi-physics engineering and scientific
+      problems.
+    '';
+    homepage = "https://trilinos.org";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32256,6 +32256,12 @@ with pkgs;
 
   xoscope = callPackage ../applications/science/electronics/xoscope { };
 
+  xyce = callPackage ../applications/science/electronics/xyce { };
+
+  xyce-parallel = callPackage ../applications/science/electronics/xyce {
+    withMPI = true;
+    trilinos = trilinos-mpi;
+  };
 
   ### SCIENCE / MATH
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31884,6 +31884,10 @@ with pkgs;
 
   sympow = callPackage ../development/libraries/science/math/sympow { };
 
+  trilinos = callPackage ../development/libraries/science/math/trilinos {};
+
+  trilinos-mpi = callPackage ../development/libraries/science/math/trilinos { withMPI = true; };
+
   ipopt = callPackage ../development/libraries/science/math/ipopt { };
 
   gmsh = callPackage ../applications/science/math/gmsh { };


### PR DESCRIPTION
###### Motivation for this change
Added the analog circuit simulator Xyce previously not present in `nixpkgs`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
