### PR TITLE
nwg-drawer: 0.1.11 -> 0.2.8

### DIFF
--- a/pkgs/applications/misc/nwg-drawer/default.nix
+++ b/pkgs/applications/misc/nwg-drawer/default.nix
@@ -1,29 +1,43 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, pkg-config
 , cairo
 , gobject-introspection
 , gtk3
 , gtk-layer-shell
-}:
+, pkg-config
+, wrapGAppsHook
+, xdg-utils }:
 
 buildGoModule rec {
   pname = "nwg-drawer";
-  version = "0.1.11";
+  version = "0.2.8";
 
   src = fetchFromGitHub {
     owner = "nwg-piotr";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-aUn9zvlNUuvm7Uo0wyzbkSLXfUDcKn1uxAu3pVwq0FA=";
+    sha256 = "sha256-YhCMOktfsSb7GrKA8reZb+QHcNS/Lpd0hCaPqnWvL7w=";
   };
 
-  vendorSha256 = "sha256-HyrjquJ91ddkyS8JijHd9HjtfwSQykXCufa2wzl8RNk=";
-
-  nativeBuildInputs = [ pkg-config ];
+  vendorSha256 = "sha256-Twipdrt3XZVrzJvElEGbKaJRMnop8fIFMFnriPTSS14=";
 
   buildInputs = [ cairo gobject-introspection gtk3 gtk-layer-shell ];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
+
+  doCheck = false;
+
+  preInstall = ''
+    mkdir -p $out/share/nwg-drawer
+    cp -r desktop-directories drawer.css $out/share/nwg-drawer
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${xdg-utils}/bin
+      --prefix XDG_DATA_DIRS : $out/share
+    )
+  '';
 
   meta = with lib; {
     description = "Application drawer for sway Wayland compositor";


### PR DESCRIPTION
###### Motivation for this change

Update [nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) 0.1.11 -> ~0.2.6~ 0.2.7.

Also added a patch to refer resources under `$out/share`.
It can be changed by setting `XDG_DATA_HOME` but changing it is too risky so I ended up to create a patch.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
