### PR TITLE
[21.11] blightmud: init at 3.5.0

### DIFF
--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -1,0 +1,79 @@
+{ stdenv, lib, fetchFromGitHub, rustPlatform, pkg-config, alsa-lib, openssl
+, withTTS ? false, llvmPackages, speechd }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "blightmud";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-DaICzwBew90YstV42wiY0IbvR1W4Hm8dzo3xY2qlMGQ=";
+  };
+
+  cargoSha256 = "sha256-BamMTPh+GN9GG4puxyTauPhjCC8heCu1wsgFaw98s9U=";
+
+  buildFeatures = lib.optional withTTS "tts";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ alsa-lib openssl ] ++ lib.optional withTTS [ speechd ];
+
+  # Building the speech-dispatcher-sys crate for TTS support requires setting
+  # LIBCLANG_PATH.
+  LIBCLANG_PATH = lib.optionalString withTTS "${llvmPackages.libclang.lib}/lib";
+
+  preBuild = lib.optionalString withTTS ''
+    # When building w/ TTS the speech-dispatcher-sys crate's build.rs uses
+    # rust-bindgen with libspeechd. This bypasses the normal nixpkgs CC wrapper
+    # so we have to adapt the BINDGEN_EXTRA_CLANG_ARGS env var to compensate. See
+    # this blog post[0] for more information.
+    #
+    # [0]: https://hoverbear.org/blog/rust-bindgen-in-nix/
+
+    export BINDGEN_EXTRA_CLANG_ARGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
+      $(< ${stdenv.cc}/nix-support/cc-cflags) \
+      -isystem ${llvmPackages.libclang.lib}/lib/clang/${
+        lib.getVersion llvmPackages.clang
+      }/include \
+      -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${
+        lib.getVersion stdenv.cc.cc
+      }/include \
+      -idirafter ${speechd}/include"
+  '';
+
+  checkFlags = let
+    # Most of Blightmud's unit tests pass without trouble in the isolated
+    # Nixpkgs build env. The following tests need to be skipped.
+    skipList = [
+      "test_connect"
+      "test_gmcp_negotiation"
+      "test_ttype_negotiation"
+      "test_reconnect"
+      "test_mud"
+      "test_server"
+      "test_lua_script"
+      "timer_test"
+      "validate_assertion_fail"
+    ];
+    skipFlag = test: "--skip " + test;
+  in builtins.concatStringsSep " " (builtins.map skipFlag skipList);
+
+  meta = with lib; {
+    description = "A terminal MUD client written in Rust";
+    longDescription = ''
+      Blightmud is a terminal client for connecting to Multi User Dungeon (MUD)
+      games. It is written in Rust and supports TLS, GMCP, MSDP, MCCP2, tab
+      completion, text searching and a split view for scrolling. Blightmud can
+      be customized with Lua scripting for aliases, triggers, timers, customized
+      status bars, and more. Blightmud supports several accessibility features
+      including an optional built-in text-to-speech engine and a screen reader
+      friendly mode.
+    '';
+    homepage = "https://github.com/Blightmud/Blightmud";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ cpu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30344,6 +30344,10 @@ with pkgs;
     lua = lua5_1;
   };
 
+  blightmud = callPackage ../games/blightmud { };
+
+  blightmud-tts = callPackage ../games/blightmud { withTTS = true; };
+
   n2048 = callPackage ../games/n2048 { };
 
   naev = callPackage ../games/naev { };


### PR DESCRIPTION
###### Motivation for this change

_This is a backport of a new package, Blightmud, merged to master in https://github.com/NixOS/nixpkgs/pull/154058_

Blightmud is a terminal client for connecting to Multi User Dungeon (MUD) games. It is written in Rust and supports TLS, GMCP, MSDP, MCCP2, tab completion, text searching and a split view for scrolling. Blightmud can be customized with Lua scripting for aliases, triggers, timers, customized status bars, and more. Blightmud supports several accessibility features including an optional built-in text-to-speech engine and a screen reader friendly mode.

Since the TTS support brings in heavy dependencies, but is a useful accessibility feature, the Blightmud derivation is added to `all-packages.nix` twice:

1. the `blightmud` attribute builds a configuration without TTS support.
2. the `blightmud-tts` attribute builds a configuration _with_ TTS support.

(cherry picked from commit ae1bee344a09129db2c13d5564e632934b68cdaf)

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
