### PR TITLE
nwg-bar: init at unstable-2021-09-23

### DIFF
--- a/pkgs/applications/misc/nwg-bar/default.nix
+++ b/pkgs/applications/misc/nwg-bar/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildGoModule, fetchFromGitHub, pkg-config, gtk3, gtk-layer-shell }:
+
+buildGoModule rec {
+  pname = "nwg-bar";
+  version = "unstable-2021-09-23";
+
+  src = fetchFromGitHub {
+    owner = "nwg-piotr";
+    repo = pname;
+    rev = "7dd7df3cd9a9e78fe477e88e0f3cb97309d50ff5";
+    sha256 = "sha256-piysF19WDjb/EGI9MBepYrOrQL9C1fsoq05AP8CYN58=";
+  };
+
+  patches = [ ./fix-paths.patch ];
+  postPatch = ''
+    substituteInPlace config/bar.json --subst-var out
+    substituteInPlace tools.go --subst-var out
+  '';
+
+  vendorSha256 = "sha256-dgOwflNRb+11umFykozL8DQ50dLbhbMCmCyKmLlW7rw=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 gtk-layer-shell ];
+
+  preInstall = ''
+    mkdir -p $out/share/nwg-bar
+    cp -r config/* images $out/share/nwg-bar
+  '';
+
+  meta = with lib; {
+    description =
+      "GTK3-based button bar for sway and other wlroots-based compositors";
+    homepage = "https://github.com/nwg-piotr/nwg-bar";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/applications/misc/nwg-bar/fix-paths.patch
+++ b/pkgs/applications/misc/nwg-bar/fix-paths.patch
@@ -1,0 +1,47 @@
+diff --git a/config/bar.json b/config/bar.json
+index 6c456e7..98527cb 100644
+--- a/config/bar.json
++++ b/config/bar.json
+@@ -2,21 +2,21 @@
+   {
+     "label": "Lock",
+     "exec": "swaylock -f -c 000000",
+-    "icon": "/usr/share/nwg-bar/images/system-lock-screen.svg"
++    "icon": "@out@/share/nwg-bar/images/system-lock-screen.svg"
+   },
+   {
+     "label": "Logout",
+     "exec": "swaymsg exit",
+-    "icon": "/usr/share/nwg-bar/images/system-log-out.svg"
++    "icon": "@out@/share/nwg-bar/images/system-log-out.svg"
+   },
+   {
+     "label": "Reboot",
+     "exec": "systemctl reboot",
+-    "icon": "/usr/share/nwg-bar/images/system-reboot.svg"
++    "icon": "@out@/share/nwg-bar/images/system-reboot.svg"
+   },
+   {
+     "label": "Shutdown",
+     "exec": "systemctl -i poweroff",
+-    "icon": "/usr/share/nwg-bar/images/system-shutdown.svg"
++    "icon": "@out@/share/nwg-bar/images/system-shutdown.svg"
+   }
+ ]
+\ No newline at end of file
+diff --git a/tools.go b/tools.go
+index f97751e..987163e 100644
+--- a/tools.go
++++ b/tools.go
+@@ -45,10 +45,7 @@ func configDir() string {
+ }
+ 
+ func getDataHome() string {
+-	if os.Getenv("XDG_DATA_HOME") != "" {
+-		return os.Getenv("XDG_DATA_HOME")
+-	}
+-	return "/usr/share/"
++	return "@out@/share/"
+ }
+ 
+ func createDir(dir string) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27744,6 +27744,8 @@ with pkgs;
 
   novnc = callPackage ../applications/networking/novnc { };
 
+  nwg-bar = callPackage ../applications/misc/nwg-bar { };
+
   nwg-drawer = callPackage ../applications/misc/nwg-drawer { };
 
   nwg-launchers = callPackage ../applications/misc/nwg-launchers { };


### PR DESCRIPTION
###### Motivation for this change

Add [nwg-bar](https://github.com/nwg-piotr/nwg-bar).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
