### PR TITLE
bottles: 2022.1.14-trento-4 -> 2022.2.14-trento

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9863,6 +9863,12 @@
     githubId = 20524473;
     name = "Psyanticy";
   };
+  psydvl = {
+    email = "psydvl@fea.st";
+    github = "psydvl";
+    githubId = 43755002;
+    name = "Dmitriy P";
+  };
   ptival = {
     email = "valentin.robert.42@gmail.com";
     github = "Ptival";

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -100,7 +100,7 @@ python3Packages.buildPythonApplication rec {
     description = "An easy-to-use wineprefix manager";
     homepage = "https://usebottles.com/";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ bloomvdomino shamilton ];
+    maintainers = with maintainers; [ bloomvdomino psydvl shamilton ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -2,20 +2,32 @@
 , meson, ninja, pkg-config, wrapGAppsHook
 , desktop-file-utils, gsettings-desktop-schemas, libnotify, libhandy, webkitgtk
 , python3Packages, gettext
-, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gnome
-, steam-run, xdg-utils, pciutils, cabextract, wineWowPackages
+, appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gtksourceview4, gnome
+, steam, xdg-utils, pciutils, cabextract, wineWowPackages
 , freetype, p7zip, gamemode
+, bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
+, bottlesExtraPkgs ? pkgs: [ ] # extra packages to add to steam.run targetPkgs
 }:
 
+let
+  steam-run = (steam.override {
+    # required by wine runner `caffe`
+    extraLibraries = pkgs: with pkgs; [ libunwind libusb1 ]
+      ++ bottlesExtraLibraries pkgs;
+    extraPkgs = pkgs: [ ]
+      ++ bottlesExtraPkgs pkgs;
+  }).run;
+in
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2021.12.28-treviso";
+  version = "2022.2.14-trento";
+  sha256 = "GtVC3JfVoooJ+MuF9r1W3J8RfXNKalaIgecv1ner7GA=";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = pname;
     rev = version;
-    sha256 = "lZbSLLBg7XM6PuOmu5rJ15dg+QHHRcjijRYE6u3WT9Y=";
+    inherit sha256;
   };
 
   postPatch = ''
@@ -40,6 +52,7 @@ python3Packages.buildPythonApplication rec {
     gsettings-desktop-schemas
     gspell
     gtk3
+    gtksourceview4
     libhandy
     libnotify
     webkitgtk
@@ -75,8 +88,8 @@ python3Packages.buildPythonApplication rec {
 
   preConfigure = ''
     patchShebangs build-aux/meson/postinstall.py
-    substituteInPlace src/backend/runner.py \
-      --replace "{Paths.runners}" "${steam-run}/bin/steam-run {Paths.runners}"
+    substituteInPlace src/backend/wine/winecommand.py \
+      --replace '= f"{Paths.runners}' '= f"${steam-run}/bin/steam-run {Paths.runners}'
   '';
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change
`bottles` updated from 2021.12.28-treviso to 2022.2.14-trento
~`bottles` updated from 2021.12.28-treviso to 2022.1.28-trento-4~
~`bottles` updated from 2021.12.28-treviso to 2022.1.14-trento-4~
~`bottles` updated from 2021.12.28-treviso to 2022.1.14-trento-2~

Add me as maintainer for this package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
