### PR TITLE
dbxfs: init at 1.0.58

### DIFF
--- a/pkgs/tools/filesystems/dbxfs/default.nix
+++ b/pkgs/tools/filesystems/dbxfs/default.nix
@@ -1,0 +1,94 @@
+{ lib, fetchgit, python3Packages, fusePackages }:
+
+let
+  block-tracing = python3Packages.buildPythonPackage rec {
+    pname = "block_tracing";
+    version = "1.0.1";
+
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "9faa009a702a8f2f605ebb78314d5ca2a2a93543d061038a3d3a978c93385e68";
+    };
+  };
+  privy = python3Packages.buildPythonPackage rec {
+    pname = "privy";
+    version = "6.0.0";
+    format = "wheel";
+
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      format = "wheel";
+      sha256 = "e68679bb4006ce83206d9a7af1158cf4d56a2ed6861ee39276907be618dfb8d9";
+    };
+
+    propagatedBuildInputs = [
+      python3Packages.cryptography
+      python3Packages.argon2_cffi
+    ];
+  };
+  fusepyng = python3Packages.buildPythonPackage rec {
+    pname = "fusepyng";
+    version = "1.0.7";
+
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-i09u+B6GAPI9p1CRaayyYVWC7xFtRqKhrUt+Uw2PiZ8=";
+    };
+
+  };
+  userspacefs = python3Packages.buildPythonPackage rec {
+    pname = "userspacefs";
+    version = "2.0.5";
+
+    src = python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-XW9f+m05SI8cdDfF6q6Pq/SRbKzqtIOjFzoY5nibGGw=";
+    };
+
+    buildInputs = [
+      fusePackages.fuse_2
+    ];
+
+    # crashes looking for libfuse in build_ext (?)
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      fusepyng
+    ];
+  };
+in
+python3Packages.buildPythonApplication rec {
+  pname = "dbxfs";
+  version = "1.0.58";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-vDuv5QPwAMFaDxgObdqRMCymdqSYmCI9gSFlZjiTIxs=";
+  };
+
+  # IndentationError at dbxfs/macos_proxies_crash_fix.py", line 15
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    python3Packages.keyring
+    python3Packages.keyrings-alt
+    python3Packages.dropbox
+    python3Packages.appdirs
+    python3Packages.sentry-sdk
+    block-tracing
+    privy
+    userspacefs
+  ];
+
+  buildInputs = [
+    fusePackages.fuse_2
+  ];
+
+  meta = with lib; {
+    description = "Mounts a Dropbox folder as if it were a local filesystem or SMB share";
+    homepage = "https://thelig.ht/code/dbxfs/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mausch ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33011,6 +33011,8 @@ with pkgs;
 
   darling-dmg = callPackage ../tools/filesystems/darling-dmg { };
 
+  dbxfs = callPackage ../tools/filesystems/dbxfs { };
+
   depotdownloader = callPackage ../tools/misc/depotdownloader { };
 
   desmume = callPackage ../applications/emulators/desmume { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#154173

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
