### PR TITLE
rucredstash: init at 0.9.0

### DIFF
--- a/pkgs/tools/security/rucredstash/default.nix
+++ b/pkgs/tools/security/rucredstash/default.nix
@@ -1,0 +1,31 @@
+{ lib, rustPlatform, fetchFromGitHub, pkg-config, openssl, stdenv, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rucredstash";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "psibi";
+    repo = "rucredstash";
+    rev = "v${version}";
+    sha256 = "1jwsj2y890nxpgmlfbr9hms2raspp5h89ykzsh014mf7lb3yxzwg";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ]
+    ++ lib.optional stdenv.isDarwin Security;
+
+  # Disable tests since it requires network access and relies on the
+  # presence of certain AWS infrastructure
+  doCheck = false;
+
+  cargoSha256 = "0qnfrwpdvjksc97iiwn1r6fyqaqn0q3ckbdzswf9flvwshqzb6ih";
+
+  meta = with lib; {
+    description =
+      "Rust port for credstash. Manages credentials securely in AWS cloud";
+    homepage = "https://github.com/psibi/rucredstash";
+    license = licenses.mit;
+    maintainers = with maintainers; [ psibi ];
+  };
+}

--- a/pkgs/tools/security/rucredstash/default.nix
+++ b/pkgs/tools/security/rucredstash/default.nix
@@ -22,8 +22,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "0qnfrwpdvjksc97iiwn1r6fyqaqn0q3ckbdzswf9flvwshqzb6ih";
 
   meta = with lib; {
-    description =
-      "Rust port for credstash. Manages credentials securely in AWS cloud";
+    description = "Rust port for credstash. Manages credentials securely in AWS cloud";
     homepage = "https://github.com/psibi/rucredstash";
     license = licenses.mit;
     maintainers = with maintainers; [ psibi ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28402,6 +28402,10 @@ with pkgs;
 
   rubyripper = callPackage ../applications/audio/rubyripper {};
 
+  rucredstash = callPackage ../tools/security/rucredstash {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   runc = callPackage ../applications/virtualization/runc {};
 
   rymcast = callPackage ../applications/audio/rymcast {


### PR DESCRIPTION
Rust port of credstash. Helps to store credentials securely in AWS.

Tested it locally on a NixOS machine:

``` shellsession
❯ /nix/store/rcnqj388k0lrfza48m9f09ksp7h1is8c-rucredstash-0.9.0/bin/rucredstash --help
rucredstash 0.9.0
Sibi Prabakaran
A credential/secret storage system

USAGE:
    rucredstash [OPTIONS] [SUBCOMMAND]

OPTIONS:
    -a, --arn <ARN>                  AWS IAM ARN for AssumeRole
    -h, --help                       Print help information
    -m, --mfa_serial <MFA_SERIAL>    Optional MFA hardware device serial number or virtual device
                                     ARN
    -p, --profile <PROFILE>          Boto config profile to use when connecting to AWS
    -r, --region <REGION>            the AWS region in which to operate. If a region is not
                                     specified, credstash will use the value of the
                                     AWS_DEFAULT_REGION env variable, or if that is not set, the
                                     value in `~/.aws/config`. As a last resort, it will use us-
                                     east-1
    -t, --table <TABLE>              DynamoDB table to use for credential storage. If not specified,
                                     credstash will use the value of the CREDSTASH_DEFAULT_TABLE env
                                     variable, or if that is not set, the value `credential-store`
                                     will be used
    -V, --version                    Print version information

SUBCOMMANDS:
    delete    Delete a credential from the store
    get       Get a credential from the store
    getall    Get all credentials from the store
    help      Print this message or the help of the given subcommand(s)
    keys      List all keys in the store
    list      List credentials and their versions
    put       Put a credential into the store
    putall    Put credentials from json or file into the store
    setup     setup the credential store
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
