### PR TITLE
giara: 0.3 -> 1.0

### DIFF
--- a/pkgs/applications/networking/giara/default.nix
+++ b/pkgs/applications/networking/giara/default.nix
@@ -1,22 +1,24 @@
 { lib
 , fetchFromGitLab
+, fetchpatch
 , meson
 , gobject-introspection
 , pkg-config
 , ninja
 , python3
-, wrapGAppsHook
-, gtk3
+, wrapGAppsHook4
+, gtk4
 , gdk-pixbuf
 , webkitgtk
-, gtksourceview4
-, libhandy
+, gtksourceview5
 , glib-networking
+, libadwaita
+, appstream
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "giara";
-  version = "0.3";
+  version = "1.0";
 
   format = "other";
 
@@ -25,24 +27,25 @@ python3.pkgs.buildPythonApplication rec {
     owner = "World";
     repo = pname;
     rev = version;
-    sha256 = "004qmkfrgd37axv0b6hfh6v7nx4pvy987k5yv4bmlmkj9sbqm6f9";
+    hash = "sha256-xDIzgr8zYal0r0sASWqiSZANCMC52LrVmLjlnGAd2Mg=";
   };
 
   nativeBuildInputs = [
+    appstream
     meson
     gobject-introspection
     pkg-config
     ninja
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    gtk3
+    gtk4
     gdk-pixbuf
     webkitgtk
-    gtksourceview4
-    libhandy
+    gtksourceview5
     glib-networking
+    libadwaita
   ];
 
   pythonPath = with python3.pkgs; [
@@ -54,6 +57,21 @@ python3.pkgs.buildPythonApplication rec {
     mistune
     beautifulsoup4
   ];
+
+  patches = [
+    # Proper support for gtk4 and libadwaita
+    # @TODO: Remove when bumping the version.
+    (fetchpatch {
+      name = "giara-gtk4-libadwaita.patch";
+      url = "https://gitlab.gnome.org/World/giara/-/commit/6204427f8b8e3d8c72b669717a3f129ffae401d9.patch";
+      sha256 = "sha256-E8kbVsACPD2gkfNrzYUy0+1U7+/pIkUu4rCkX+xY0us=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace meson_post_install.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+  '';
 
   # Fix setup-hooks https://github.com/NixOS/nixpkgs/issues/56943
   strictDeps = false;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump to 1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
