### PR TITLE
pdfstudioviewer: init at 2021.1.2

### DIFF
--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -21,7 +21,7 @@ let
   minor = "2";
 in stdenv.mkDerivation rec {
   pname = "pdfstudioviewer";
-  version = "${year}.${major}.${minor}";
+  version = "${year}.1.2";
   autoPatchelfIgnoreMissingDeps = true;
 
   src = fetchurl {

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -1,0 +1,91 @@
+{ stdenv,
+  lib,
+  makeWrapper,
+  fetchurl,
+  dpkg,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+  gst_all_1,
+  sane-backends,
+  xorg,
+  gnome2,
+  alsa-lib,
+  libgccjit,
+  jdk11
+  }:
+
+let
+  year = "2021";
+  major = "1";
+  minor = "2";
+in stdenv.mkDerivation rec {
+  pname = "pdfstudioviewer";
+  version = "${year}.${major}.${minor}";
+  autoPatchelfIgnoreMissingDeps = true;
+
+  src = fetchurl {
+    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudioViewer_v${year}_${major}_${minor}_linux64.deb";
+    sha256 = "128k3fm8m8zdykx4s30g5m2zl7cgmvs4qinf1w525zh84v56agz6";
+  };
+
+  nativeBuildInputs = [
+    gst_all_1.gst-libav
+    sane-backends
+    xorg.libXxf86vm
+    xorg.libXtst
+    gnome2.libgtkhtml
+    alsa-lib
+    libgccjit
+    autoPatchelfHook
+    makeWrapper
+    dpkg
+    copyDesktopItems
+    jdk11 # only for unpacking .jar.pack files
+  ];
+
+  desktopItems = [(makeDesktopItem {
+       name = "${pname}${year}";
+       desktopName = "PDF Studio";
+       genericName = "View and edit PDF files";
+       exec = "${pname} %f";
+       icon = "${pname}${year}";
+       comment = "Views and edits PDF files";
+       mimeType = "application/pdf";
+       categories = "Office";
+       type = "Application";
+       terminal = false;
+  })];
+
+  unpackPhase = "dpkg-deb -x $src .";
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/pixmaps
+    cp -r opt/${pname}${year} $out/share/
+    ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
+    makeWrapper $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
+
+    #Unpack jar files. Otherwise pdfstudio does this and fails due to read-only FS.
+    for pfile in $out/share/${pname}${year}/jre/lib/{,ext/}*.jar.pack; do
+      jar_file=`echo "$pfile" | awk '{ print substr($0,1,length($0)-5) }'`
+      unpack200 -r "$pfile" "$jar_file"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.qoppa.com/pdfstudio/";
+    description = "An easy to use, full-featured PDF editing software";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.pwoelfel ];
+  };
+}

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -69,7 +69,7 @@ in stdenv.mkDerivation rec {
     description = "An easy to use, full-featured PDF editing software";
     license = licenses.unfree;
     platforms = platforms.linux;
-    mainprogram = pname;
+    mainProgram = pname;
     maintainers = [ maintainers.pwoelfel ];
   };
 }

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -43,16 +43,16 @@ in stdenv.mkDerivation rec {
   ];
 
   desktopItems = [(makeDesktopItem {
-       name = "${pname}${year}";
-       desktopName = "PDF Studio";
-       genericName = "View and edit PDF files";
-       exec = "${pname} %f";
-       icon = "${pname}${year}";
-       comment = "Views and edits PDF files";
-       mimeType = "application/pdf";
-       categories = "Office";
-       type = "Application";
-       terminal = false;
+    name = "${pname}${year}";
+    desktopName = "PDF Studio";
+    genericName = "View and edit PDF files";
+    exec = "${pname} %f";
+    icon = "${pname}${year}";
+    comment = "Views and edits PDF files";
+    mimeType = "application/pdf";
+    categories = "Office";
+    type = "Application";
+    terminal = false;
   })];
 
   unpackPhase = "dpkg-deb -x $src .";
@@ -68,7 +68,8 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share/pixmaps
     cp -r opt/${pname}${year} $out/share/
     ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
-    makeWrapper $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
+    ln -s $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
+    # makeWrapper $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
 
     #Unpack jar files. Otherwise pdfstudio does this and fails due to read-only FS.
     for pfile in $out/share/${pname}${year}/jre/lib/{,ext/}*.jar.pack; do

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     mkdir -p $out/share
-    mkdir -p $out/share/applications
     mkdir -p $out/share/pixmaps
     cp -r opt/${pname}${year} $out/share/
     ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -17,8 +17,6 @@
 
 let
   year = "2021";
-  major = "1";
-  minor = "2";
 in stdenv.mkDerivation rec {
   pname = "pdfstudioviewer";
   version = "${year}.1.2";

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -1,23 +1,24 @@
-{ stdenv,
-  lib,
-  makeWrapper,
-  fetchurl,
-  dpkg,
-  makeDesktopItem,
-  copyDesktopItems,
-  autoPatchelfHook,
-  gst_all_1,
-  sane-backends,
-  xorg,
-  gnome2,
-  alsa-lib,
-  libgccjit,
-  jdk11
-  }:
+{ stdenv
+, lib
+, makeWrapper
+, fetchurl
+, dpkg
+, makeDesktopItem
+, copyDesktopItems
+, autoPatchelfHook
+, gst_all_1
+, sane-backends
+, xorg
+, gnome2
+, alsa-lib
+, libgccjit
+, jdk11
+}:
 
 let
   year = "2021";
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation rec {
   pname = "pdfstudioviewer";
   version = "${year}.1.2";
   autoPatchelfIgnoreMissingDeps = true;
@@ -42,18 +43,20 @@ in stdenv.mkDerivation rec {
     jdk11 # only for unpacking .jar.pack files
   ];
 
-  desktopItems = [(makeDesktopItem {
-    name = "${pname}${year}";
-    desktopName = "PDF Studio";
-    genericName = "View and edit PDF files";
-    exec = "${pname} %f";
-    icon = "${pname}${year}";
-    comment = "Views and edits PDF files";
-    mimeType = "application/pdf";
-    categories = "Office";
-    type = "Application";
-    terminal = false;
-  })];
+  desktopItems = [
+    (makeDesktopItem {
+      name = "${pname}${year}";
+      desktopName = "PDF Studio";
+      genericName = "View and edit PDF files";
+      exec = "${pname} %f";
+      icon = "${pname}${year}";
+      comment = "Views and edits PDF files";
+      mimeType = "application/pdf";
+      categories = "Office";
+      type = "Application";
+      terminal = false;
+    })
+  ];
 
   unpackPhase = "dpkg-deb -x $src .";
   dontConfigure = true;

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
   autoPatchelfIgnoreMissingDeps = true;
 
   src = fetchurl {
-    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudioViewer_v${year}_${major}_${minor}_linux64.deb";
+    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudioViewer_v${builtins.replaceStrings ["."] ["_"] version}_linux64.deb";
     sha256 = "128k3fm8m8zdykx4s30g5m2zl7cgmvs4qinf1w525zh84v56agz6";
   };
 

--- a/pkgs/applications/misc/pdfstudioviewer/default.nix
+++ b/pkgs/applications/misc/pdfstudioviewer/default.nix
@@ -1,11 +1,19 @@
-{ stdenv, lib, fetchurl, dpkg, makeDesktopItem, copyDesktopItems
-, autoPatchelfHook, makeWrapper, sane-backends, xorg, jdk11, gtk2, gtk3 }:
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, makeDesktopItem
+, copyDesktopItems
+, autoPatchelfHook
+, sane-backends
+, jdk11
+}:
 
 let year = "2021";
 in stdenv.mkDerivation rec {
   pname = "pdfstudioviewer";
   version = "${year}.1.2";
-  autoPatchelfIgnoreMissingDeps = true;
+  autoPatchelfIgnoreMissingDeps = false;
   strictDeps = true;
 
   src = fetchurl {
@@ -15,15 +23,15 @@ in stdenv.mkDerivation rec {
     sha256 = "128k3fm8m8zdykx4s30g5m2zl7cgmvs4qinf1w525zh84v56agz6";
   };
 
-  buildInputs =
-    [ xorg.libXrandr xorg.libXtst sane-backends xorg.libXxf86vm gtk2 gtk3 ];
+  buildInputs = [
+    sane-backends
+    jdk11
+  ];
 
   nativeBuildInputs = [
     autoPatchelfHook
     dpkg
     copyDesktopItems
-    jdk11 # for unpacking .jar.pack files
-    makeWrapper
   ];
 
   desktopItems = [
@@ -42,8 +50,11 @@ in stdenv.mkDerivation rec {
   ];
 
   unpackPhase = "dpkg-deb -x $src .";
-  dontConfigure = true;
   dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace opt/${pname}${year}/${pname}${year} --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk11.out}"
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -52,14 +63,9 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/share
     mkdir -p $out/share/pixmaps
     cp -r opt/${pname}${year} $out/share/
+    rm -rf $out/share/${pname}${year}/jre
     ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
     ln -s $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
-
-    #Unpack jar files. Otherwise pdfstudio does this and fails due to read-only FS.
-    for pfile in $out/share/${pname}${year}/jre/lib/{,ext/}*.jar.pack; do
-      jar_file=`echo "$pfile" | awk '{ print substr($0,1,length($0)-5) }'`
-      unpack200 -r "$pfile" "$jar_file"
-    done
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24211,6 +24211,8 @@ with pkgs;
 
   pdfstudio = callPackage ../applications/misc/pdfstudio { };
 
+  pdfstudioviewer = callPackage ../applications/misc/pdfstudioviewer { };
+
   aeolus = callPackage ../applications/audio/aeolus { };
 
   aewan = callPackage ../applications/editors/aewan { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

PDF Studio Viewer is a cross-platform PDF reader that can annotate PDF documents and fill interactive forms. This is the free version, which does not need a license. (For the standard / pro version, see the package `pdfstudio`.)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
