### PR TITLE
skawarePackages: fix llvm build

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -86,6 +86,8 @@ in stdenv.mkDerivation {
 
   inherit postConfigure;
 
+  makeFlags = lib.optional stdenv.cc.isClang [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ];               
+
   # TODO(Profpatsch): ensure that there is always a $doc output!
   postInstall = ''
     echo "Cleaning & moving common files"

--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -21,9 +21,9 @@
   # : lines
 , postInstall
   # : list Maintainer
-, maintainers ? []
+, maintainers ? [ ]
   # : passtrhu arguments (e.g. tests)
-, passthru ? {}
+, passthru ? { }
 
 }:
 
@@ -54,7 +54,8 @@ let
     "CONTRIBUTING"
   ];
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
@@ -73,8 +74,8 @@ in stdenv.mkDerivation {
     # This might not hold for e.g. BSD.
     "--with-sysdep-devurandom=yes"
     (if stdenv.isDarwin
-      then "--disable-shared"
-      else "--enable-shared")
+    then "--disable-shared"
+    else "--enable-shared")
   ]
     # On darwin, the target triplet from -dumpmachine includes version number,
     # but skarnet.org software uses the triplet to test binary compatibility.
@@ -82,11 +83,11 @@ in stdenv.mkDerivation {
     # binary built on a different version of darwin.
     # http://www.skarnet.org/cgi-bin/archive.cgi?1:mss:623:heiodchokfjdkonfhdph
     ++ (lib.optional stdenv.isDarwin
-         "--build=${stdenv.hostPlatform.system}");
+    "--build=${stdenv.hostPlatform.system}");
 
   inherit postConfigure;
 
-  makeFlags = lib.optional stdenv.cc.isClang [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ];               
+  makeFlags = lib.optional stdenv.cc.isClang [ "AR=${stdenv.cc.targetPrefix}ar" "RANLIB=${stdenv.cc.targetPrefix}ranlib" ];
 
   # TODO(Profpatsch): ensure that there is always a $doc output!
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

skaware packages like execline do not build correctly with llvm.
Basically all skawarePackages face this issue, so it makes sense to fix it in the build wrapper.

```
nix build nixpkgs#pkgsLLVM.skawarePackages.execline
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
