### PR TITLE
gnuradio: 3.9 -> 3.10

### DIFF
--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -9,7 +9,7 @@
 , cppunit
 , orc
 , boost
-, spdlog
+, log4cpp
 , mpir
 , doxygen
 , python
@@ -18,8 +18,6 @@
 , fftwFloat
 , alsa-lib
 , libjack2
-, libiio
-, libad9361
 , CoreAudio
 , uhd
 , SDL
@@ -47,14 +45,14 @@
 , overrideSrc ? {}
 , pname ? "gnuradio"
 , versionAttr ? {
-  major = "3.10";
-  minor = "0";
+  major = "3.9";
+  minor = "5";
   patch = "0";
 }
 }:
 
 let
-  sourceSha256 = "sha256-1K8nlNiirks3MJ+9cH9bkILVFtu5OxhKkNhetGqojn4=";
+  sourceSha256 = "sha256-TWCXLoS+ImKNd2zkxMks4FXsQMvGKgcW5/MW8S1Y1TY=";
   featuresInfo = {
     # Needed always
     basic = {
@@ -66,7 +64,7 @@ let
       runtime = [
         volk
         boost
-        spdlog
+        log4cpp
         mpir
       ]
         # when gr-qtgui is disabled, icu needs to be included, otherwise
@@ -172,22 +170,6 @@ let
     };
     gr-channels = {
       cmakeEnableFlag = "GR_CHANNELS";
-    };
-    gr-pdu = {
-      cmakeEnableFlag = "GR_PDU";
-      runtime = [
-        libiio
-        libad9361
-      ];
-    };
-    gr-iio = {
-      cmakeEnableFlag = "GR_IIO";
-      runtime = [
-        libiio
-      ];
-    };
-    common-precompiled-headers = {
-      cmakeEnableFlag = "COMMON_PCH";
     };
     gr-qtgui = {
       runtime = [ qt5.qtbase libsForQt5.qwt ];

--- a/pkgs/development/gnuradio-modules/grnet/default.nix
+++ b/pkgs/development/gnuradio-modules/grnet/default.nix
@@ -52,6 +52,7 @@ mkDerivation {
   pname = "gr-grnet";
   version = version.name;
   inherit src;
+  disabledForGRafter = "3.10";
 
   buildInputs = [
     boost

--- a/pkgs/development/gnuradio-modules/limesdr/default.nix
+++ b/pkgs/development/gnuradio-modules/limesdr/default.nix
@@ -20,7 +20,6 @@ let
   version = {
     "3.7" = "2.0.0";
     "3.8" = "3.0.1";
-    "3.9" = null;
   }.${gnuradio.versionAttr.major};
   src = fetchFromGitHub {
     owner = "myriadrf";
@@ -29,7 +28,6 @@ let
     sha256 = {
       "3.7" = "0ldqvfwl0gil89l9s31fjf9d7ki0dk572i8vna336igfaz348ypq";
       "3.8" = "ffs+8TU0yr6IW1xZJ/abQ1CQWGZM+zYqPRJxy3ZvM9U=";
-      "3.9" = null;
     }.${gnuradio.versionAttr.major};
   };
 in mkDerivation {

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -24,14 +24,14 @@
 let
   version = {
     "3.7" = "0.1.5";
-    "3.8" = "0.2.2";
+    "3.8" = "0.2.3";
   }.${gnuradio.versionAttr.major};
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
     rev = "v${version}";
     sha256 = {
       "3.7" = "0bf9bnc1c3c4yqqqgmg3nhygj6rcfmyk6pybi27f7461d2cw1drv";
-      "3.8" = "HT6xlN6cJAnvF+s1g2I1uENhBJJizdADlLXeSD0rEqs=";
+      "3.8" = "sha256-ZfI8MshhZOdJ1U5FlnZKXsg2Rsvb6oKg943ZVYd/IWo=";
     }.${gnuradio.versionAttr.major};
   };
 in mkDerivation {

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -25,7 +25,6 @@ let
   version = {
     "3.7" = "0.1.5";
     "3.8" = "0.2.2";
-    "3.9" = null;
   }.${gnuradio.versionAttr.major};
   src = fetchgit {
     url = "git://git.osmocom.org/gr-osmosdr";
@@ -33,7 +32,6 @@ let
     sha256 = {
       "3.7" = "0bf9bnc1c3c4yqqqgmg3nhygj6rcfmyk6pybi27f7461d2cw1drv";
       "3.8" = "HT6xlN6cJAnvF+s1g2I1uENhBJJizdADlLXeSD0rEqs=";
-      "3.9" = null;
     }.${gnuradio.versionAttr.major};
   };
 in mkDerivation {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25373,6 +25373,38 @@ with pkgs;
       };
     };
   };
+  gnuradio3_9 = callPackage ../applications/radio/gnuradio/wrapper.nix {
+    unwrapped = callPackage ../applications/radio/gnuradio/3.9.nix {
+      inherit (darwin.apple_sdk.frameworks) CoreAudio;
+      python = python3;
+    };
+  };
+  gnuradio3_9Packages = lib.recurseIntoAttrs gnuradio.pkgs;
+  # A build without gui components and other utilites not needed for end user
+  # libraries
+  gnuradio3_9Minimal = gnuradio.override {
+    doWrap = false;
+    unwrapped = gnuradio.unwrapped.override {
+      volk = volk.override {
+        # So it will not reference python
+        enableModTool = false;
+      };
+      features = {
+        gnuradio-companion = false;
+        python-support = false;
+        examples = false;
+        gr-qtgui = false;
+        gr-utils = false;
+        gr-modtool = false;
+        gr-blocktool = false;
+        sphinx = false;
+        doxygen = false;
+        # Doesn't make it reference python eventually, but makes reverse
+        # depdendencies require python to use cmake files of GR.
+        gr-ctrlport = false;
+      };
+    };
+  };
   gnuradio3_8 = callPackage ../applications/radio/gnuradio/wrapper.nix {
     unwrapped = callPackage ../applications/radio/gnuradio/3.8.nix {
       inherit (darwin.apple_sdk.frameworks) CoreAudio;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
