### PR TITLE
wg-netmanager: init at 0.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4361,6 +4361,12 @@
     githubId = 27668;
     name = "Tobias Pflug";
   };
+  gin66 = {
+    email = "jochen@kiemes.de";
+    github = "gin66";
+    githubId = 5549373;
+    name = "Jochen Kiemes";
+  };
   giogadi = {
     email = "lgtorres42@gmail.com";
     github = "giogadi";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -906,6 +906,7 @@
   ./services/networking/vsftpd.nix
   ./services/networking/wasabibackend.nix
   ./services/networking/websockify.nix
+  ./services/networking/wg-netmanager.nix
   ./services/networking/wg-quick.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -4,18 +4,12 @@ with lib;
 
 let
   cfg = config.services.wg-netmanager;
-
 in
 {
 
-  ###### interface
-
   options = {
-
     services.wg-netmanager = {
-
       enable = mkEnableOption "Wireguard network manager";
-
       package = mkOption {
         type = types.package;
         default = pkgs.wg-netmanager;
@@ -24,14 +18,11 @@ in
           wg-netmanager derivation to use.
         '';
       };
-
     };
-
   };
 
   ###### implementation
-
-  config = mkIf cfg.enable (
+  config = mkIf cfg.enable {
 
     systemd.services.wg-netmanager = {
       description = "Wireguard network manager";
@@ -48,15 +39,11 @@ in
           "/tmp"  # wg-netmanager creates files in /tmp before deleting them after use
         ];
       unitConfig =  {
-        ConditionPathExists = "/etc/wg_netmanager/network.yaml";
-        ConditionPathExists = "/etc/wg_netmanager/peer.yaml";
+        ConditionPathExists = ["/etc/wg_netmanager/network.yaml" "/etc/wg_netmanager/peer.yaml"];
       };
     };
-
-  );
-
-  meta = {
-    maintainers = with lib.maintainers; [ gin66 ];
-    # doc = ./wg-netmanager.xml;
+   };
   };
+
+  meta.maintainers = with maintainers; [ gin66 ];
 }

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -10,20 +10,12 @@ in
   options = {
     services.wg-netmanager = {
       enable = mkEnableOption "Wireguard network manager";
-      package = mkOption {
-        type = types.package;
-        default = pkgs.wg-netmanager;
-        defaultText = literalExpression "pkgs.wg-netmanager";
-        description = ''
-          wg-netmanager derivation to use.
-        '';
-      };
     };
   };
 
   ###### implementation
   config = mkIf cfg.enable {
-
+    # NOTE: wg-netmanager runs as root
     systemd.services.wg-netmanager = {
       description = "Wireguard network manager";
       wantedBy = [ "multi-user.target" ];
@@ -31,18 +23,18 @@ in
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
-        ExecStart = "${cfg.package}/bin/wg_netmanager";
+        ExecStart = "${pkgs.wg-netmanager}/bin/wg_netmanager";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
 
         ReadWritePaths = [
           "/tmp"  # wg-netmanager creates files in /tmp before deleting them after use
         ];
+      };
       unitConfig =  {
         ConditionPathExists = ["/etc/wg_netmanager/network.yaml" "/etc/wg_netmanager/peer.yaml"];
       };
     };
-   };
   };
 
   meta.maintainers = with maintainers; [ gin66 ];

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -1,0 +1,62 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.wg-netmanager;
+
+in
+{
+
+  ###### interface
+
+  options = {
+
+    services.wg-netmanager = {
+
+      enable = mkEnableOption "Wireguard network manager";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.wg-netmanager;
+        defaultText = literalExpression "pkgs.wg-netmanager";
+        description = ''
+          wg-netmanager derivation to use.
+        '';
+      };
+
+    };
+
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable (
+
+    systemd.services.wg-netmanager = {
+      description = "Wireguard network manager";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        ExecStart = "${pkgs.wg-netmanager}/bin/wg_netmanager -c ${configFile}";
+        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        ExecStop = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+
+        ReadWritePaths = [
+          "/tmp"  # wg-netmanager creates files in /tmp before deleting them after use
+        ];
+      unitConfig =  {
+        ConditionPathExists = "/etc/wg_netmanager/network.yaml";
+        ConditionPathExists = "/etc/wg_netmanager/peer.yaml";
+      };
+    };
+
+  );
+
+  meta = {
+    maintainers = with lib.maintainers; [ gin66 ];
+    # doc = ./wg-netmanager.xml;
+  };
+}

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -20,6 +20,7 @@ in
       description = "Wireguard network manager";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      path = with pkgs; [ wireguard-tools iproute2 ];
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -31,7 +31,7 @@ in
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
-        ExecStart = "${cfg.package}/bin/wg_netmanager -c ${configFile}";
+        ExecStart = "${cfg.package}/bin/wg_netmanager";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
 

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -20,7 +20,7 @@ in
       description = "Wireguard network manager";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
-      path = with pkgs; [ wireguard-tools iproute2 ];
+      path = with pkgs; [ wireguard-tools iproute2 wireguard-go ];
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";

--- a/nixos/modules/services/networking/wg-netmanager.nix
+++ b/nixos/modules/services/networking/wg-netmanager.nix
@@ -31,7 +31,7 @@ in
       serviceConfig = {
         Type = "simple";
         Restart = "on-failure";
-        ExecStart = "${pkgs.wg-netmanager}/bin/wg_netmanager -c ${configFile}";
+        ExecStart = "${cfg.package}/bin/wg_netmanager -c ${configFile}";
         ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
         ExecStop = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
 

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,9 +1,3 @@
-# Test compilation/test with:
-#   nix build -f ~/src/nixpkgs wg-netmanager
-#
-# Test execution with:
-#   nix-env -f ~/src/nixpkgs -iA wg-netmanager
-
 { lib, stdenv, fetchFromGitHub, rustPlatform, darwin }:
 
 rustPlatform.buildRustPackage rec {
@@ -22,11 +16,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
-  # Testing this project requires sudo, Docker and network access, etc.
-  doCheck = true;
-
-  # Test 01 tries to create a wireguard interface, which requires ip.
-  # No idea, how to include ip during testing
+  # Test 01 tries to create a wireguard interface, which requires sudo.
+  doCheck = false;
   checkFlags = "--test 02_";
 
   meta = with lib; {

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -2,23 +2,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
-  version = "0.3.12";
+  version = "0.3.13";
 
   src = fetchFromGitHub {
     owner = "gin66";
     repo = "wg_netmanager";
     rev = "wg_netmanager-v${version}";
-    sha256 = "0473id4agvq5kbi34q6kx723sbczmzi7m2zfmcgq9rwdks720qq0";
+    sha256 = "x+94GSA4HXwpwlpqT+nYGOlS1lhW6Q9NRgmfj3pUjrs=";
   };
 
   # related to the Cargo.lock file
-  cargoSha256 = "1zcdjgr9z7a5mzhwd6higc4ypga4ny179r3m8g2l09iw820h9xkr";
+  cargoSha256 = "I0Mz2nh9letGdTcWWsSfXHY/4y0zmLvZwLvUopOf5Sk=";
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
   # Test 01 tries to create a wireguard interface, which requires sudo.
   doCheck = true;
-  checkFlags = "--test 02_";
+  checkFlags = "--skip device";
 
   passthru.tests = {
   };

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,24 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin, wireguard-go }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
-  version = "0.3.6";
+  version = "0.3.8";
 
   src = fetchFromGitHub {
     owner = "gin66";
     repo = "wg_netmanager";
     rev = "wg_netmanager-v${version}";
-    sha256 = "0r0c7jv06rmm8qaxiax93nq0z1lpmsblg1b3nfyxmv4fwxc00xsn";
+    sha256 = "1fbrgn1hnygfy337r52dhrq8h2lzdr0b675ys738ibiwwm6s558z";
   };
 
   # related to the Cargo.lock file
-  cargoSha256 = "0n258nycmpyb7ysrgsf0rx7mgpqjnjd3wf64dgrj12s4zphmy4as";
+  cargoSha256 = "0wj6rlj5iyzgx5xxzd4mmza2kiwfnpyi918w7gb03hqppzd2xkrr";
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
   # Test 01 tries to create a wireguard interface, which requires sudo.
   doCheck = false;
   checkFlags = "--test 02_";
+
+  passthru.tests = {
+  };
 
   meta = with lib; {
     description = "Wireguard network manager";

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "gin66";
     repo = "wg_netmanager";
     rev = "wg_netmanager-v${version}";
-    sha256 = "4tWJJLSHBDUofnkOWa89P1Ga9jKWS3hn+LnfAnnnxtw=";
+    sha256 = "AAtSSBz2zGLIEpcEMbe1mfYZikiaYEI+6KeSL5n54PE=";
   };
 
   # related to the Cargo.lock file
-  cargoSha256 = "NN1dKESyPPLAUgSt8KtcaOEhkyaw0GhlgCmNh28Ikew=";
+  cargoSha256 = "17k83QkQDq5uRCRADRLD2Q7pv7yES20lpms/N/UK+BM=";
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,0 +1,40 @@
+# Test compilation/test with:
+#   nix build -f ~/src/nixpkgs wg-netmanager
+#
+# Test execution with:
+#   nix-env -f ~/src/nixpkgs -iA wg-netmanager
+
+{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wg-netmanager";
+  version = "0.3.6";
+
+  src = fetchFromGitHub {
+    owner = "gin66";
+    repo = "wg_netmanager";
+    rev = "wg_netmanager-v${version}";
+    sha256 = "0r0c7jv06rmm8qaxiax93nq0z1lpmsblg1b3nfyxmv4fwxc00xsn";
+  };
+
+  # related to the Cargo.lock file
+  cargoSha256 = "0n258nycmpyb7ysrgsf0rx7mgpqjnjd3wf64dgrj12s4zphmy4as";
+
+  buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+
+  # Testing this project requires sudo, Docker and network access, etc.
+  doCheck = true;
+
+  # Test 01 tries to create a wireguard interface, which requires ip.
+  # No idea, how to include ip during testing
+  checkFlags = "--test 02_";
+
+  meta = with lib; {
+    description = "Wireguard network manager";
+    longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
+    homepage = "https://github.com/gin66/wg_netmanager";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gin66 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     description = "Wireguard network manager";
     longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
     homepage = "https://github.com/gin66/wg_netmanager";
-    license = licenses.mit;
+    license = [ licenses.mit licenses.asl20 licenses.bsd3 licenses.mpl20 ];
     maintainers = with maintainers; [ gin66 ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin, wireguard-go }:
+{ lib, stdenv, fetchFromGitHub, rustPlatform, darwin, wireguard-go, Security }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   # related to the Cargo.lock file
   cargoSha256 = "17k83QkQDq5uRCRADRLD2Q7pv7yES20lpms/N/UK+BM=";
 
-  buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+  buildInputs = lib.optional stdenv.isDarwin Security;
 
   # Test 01 tries to create a wireguard interface, which requires sudo.
   doCheck = true;

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
-  version = "0.3.13";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "gin66";
     repo = "wg_netmanager";
     rev = "wg_netmanager-v${version}";
-    sha256 = "x+94GSA4HXwpwlpqT+nYGOlS1lhW6Q9NRgmfj3pUjrs=";
+    sha256 = "4tWJJLSHBDUofnkOWa89P1Ga9jKWS3hn+LnfAnnnxtw=";
   };
 
   # related to the Cargo.lock file
-  cargoSha256 = "I0Mz2nh9letGdTcWWsSfXHY/4y0zmLvZwLvUopOf5Sk=";
+  cargoSha256 = "NN1dKESyPPLAUgSt8KtcaOEhkyaw0GhlgCmNh28Ikew=";
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -2,22 +2,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wg-netmanager";
-  version = "0.3.8";
+  version = "0.3.12";
 
   src = fetchFromGitHub {
     owner = "gin66";
     repo = "wg_netmanager";
     rev = "wg_netmanager-v${version}";
-    sha256 = "1fbrgn1hnygfy337r52dhrq8h2lzdr0b675ys738ibiwwm6s558z";
+    sha256 = "0473id4agvq5kbi34q6kx723sbczmzi7m2zfmcgq9rwdks720qq0";
   };
 
   # related to the Cargo.lock file
-  cargoSha256 = "0wj6rlj5iyzgx5xxzd4mmza2kiwfnpyi918w7gb03hqppzd2xkrr";
+  cargoSha256 = "1zcdjgr9z7a5mzhwd6higc4ypga4ny179r3m8g2l09iw820h9xkr";
 
   buildInputs = lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
 
   # Test 01 tries to create a wireguard interface, which requires sudo.
-  doCheck = false;
+  doCheck = true;
   checkFlags = "--test 02_";
 
   passthru.tests = {
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     description = "Wireguard network manager";
     longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";
     homepage = "https://github.com/gin66/wg_netmanager";
-    license = [ licenses.mit licenses.asl20 licenses.bsd3 licenses.mpl20 ];
+    license = with licenses; [ mit asl20 bsd3 mpl20 ];
     maintainers = with maintainers; [ gin66 ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -19,9 +19,6 @@ rustPlatform.buildRustPackage rec {
   doCheck = true;
   checkFlags = "--skip device";
 
-  passthru.tests = {
-  };
-
   meta = with lib; {
     description = "Wireguard network manager";
     longDescription = "Wireguard network manager, written in rust, simplifies the setup of wireguard nodes, identifies short connections between nodes residing in the same subnet, identifies unreachable aka dead nodes and maintains the routes between all nodes automatically. To achieve this, wireguard network manager needs to be running on each node.";

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -11,7 +11,6 @@ rustPlatform.buildRustPackage rec {
     sha256 = "AAtSSBz2zGLIEpcEMbe1mfYZikiaYEI+6KeSL5n54PE=";
   };
 
-  # related to the Cargo.lock file
   cargoSha256 = "17k83QkQDq5uRCRADRLD2Q7pv7yES20lpms/N/UK+BM=";
 
   buildInputs = lib.optional stdenv.isDarwin Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10762,7 +10762,9 @@ with pkgs;
 
   wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
 
-  wg-netmanager = callPackage ../tools/networking/wg-netmanager { };
+  wg-netmanager = callPackage ../tools/networking/wg-netmanager {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
 
   woff2 = callPackage ../development/web/woff2 { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10762,6 +10762,8 @@ with pkgs;
 
   wg-friendly-peer-names = callPackage ../tools/networking/wg-friendly-peer-names { };
 
+  wg-netmanager = callPackage ../tools/networking/wg-netmanager { };
+
   woff2 = callPackage ../development/web/woff2 { };
 
   woof = callPackage ../tools/misc/woof { };


### PR DESCRIPTION
###### Motivation for this change

New package wg-netmanager, which maintains a net connected via wireguard

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
