### PR TITLE
lighttpd: 1.4.59 -> 1.4.63, add patch for CVE-2022-22707

### DIFF
--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -13,17 +13,21 @@
 
 stdenv.mkDerivation rec {
   pname = "lighttpd";
-  version = "1.4.59";
+  version = "1.4.63";
 
   src = fetchurl {
     url = "https://download.lighttpd.net/lighttpd/releases-${lib.versions.majorMinor version}.x/${pname}-${version}.tar.xz";
-    sha256 = "sha256-+5U9snPa7wjttuICVWyuij0H7tYIHJa9mQPblX0QhNU=";
+    sha256 = "1fgasvif13gvzz4rf5mjpy28cbw9fs4ymhx18494mxgb080pzvra";
   };
 
   postPatch = ''
     patchShebangs tests
     # Linux sandbox has an empty hostname and not /etc/hosts, which fails some tests
     sed -ire '/[$]self->{HOSTNAME} *=/i     if(length($name)==0) { $name = "127.0.0.1" }' tests/LightyTest.pm
+    # it's difficult to prevent this test from trying to use /var/tmp (which
+    # the sandbox doesn't have) so until libredirect has support for mkstemp
+    # calls it's easiest to disable it
+    sed -i '/test_mod_ssi/d' src/t/test_mod.c
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/servers/http/lighttpd/default.nix
+++ b/pkgs/servers/http/lighttpd/default.nix
@@ -9,6 +9,7 @@
 , enableWebDAV ? false, sqlite, libuuid
 , enableExtendedAttrs ? false, attr
 , perl
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +20,14 @@ stdenv.mkDerivation rec {
     url = "https://download.lighttpd.net/lighttpd/releases-${lib.versions.majorMinor version}.x/${pname}-${version}.tar.xz";
     sha256 = "1fgasvif13gvzz4rf5mjpy28cbw9fs4ymhx18494mxgb080pzvra";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-22707.patch";
+      url = "https://github.com/lighttpd/lighttpd1.4/commit/8c62a890e23f5853b1a562b03fe3e1bccc6e7664.patch";
+      sha256 = "0zm2khgllsd1ivh9m7sisfsyrdfz45zsmiwl963wf0gn8m100gzk";
+    })
+  ];
 
   postPatch = ''
     patchShebangs tests


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-22707

Fix not available in a release yet. Still, I bumped to the latest available to keep up.

I'm quite happy with the validity of patching - it's an identical patch to what debian are using for `lighttpd` back to 1.4.53.

Had to disable one new test which is being quite painful in insisting on using `/var/tmp`. I would normally use `libredirect` in cases like this but the access is through `mkstemp` which libredirect doesn't support yet (opened #155154 for this).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
