### PR TITLE
pixinsight: init at 1.8.8-12

### DIFF
--- a/pkgs/applications/graphics/pixinsight/default.nix
+++ b/pkgs/applications/graphics/pixinsight/default.nix
@@ -1,0 +1,132 @@
+{ stdenv, lib, requireFile, wrapQtAppsHook, autoPatchelfHook, makeWrapper, unixtools, fakeroot
+, mime-types, libGL, libpulseaudio, alsa-lib, nss, gd, gst_all_1, nspr, expat, fontconfig
+, dbus, glib, zlib, openssl, libdrm, cups, avahi-compat, xorg, wayland, libudev0-shim
+# Qt 5 subpackages
+, qtbase, qtgamepad, qtserialport, qtserialbus, qtvirtualkeyboard, qtmultimedia, qtwebkit, qt3d, mlt
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pixinsight";
+  version = "1.8.8-12";
+
+  src = requireFile rec {
+    name = "PI-linux-x64-${version}-20211229-c.tar.xz";
+    url = "https://pixinsight.com/";
+    sha256 = "7095b83a276f8000c9fe50caadab4bf22a248a880e77b63e0463ad8d5469f617";
+    message = ''
+      PixInsight is available from ${url} and requires a commercial (or trial) license.
+      After a license has been obtained, PixInsight can be downloaded from the software distribution
+      (choose Linux 64bit).
+      The PixInsight tarball must be added to the nix-store, i.e. via
+        nix-prefetch-url --type sha256 file:///path/to/${name}
+    '';
+  };
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    unixtools.script
+    fakeroot
+    wrapQtAppsHook
+    autoPatchelfHook
+    mime-types
+    libudev0-shim
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    stdenv.cc
+    libGL
+    libpulseaudio
+    alsa-lib
+    nss
+    gd
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    nspr
+    expat
+    fontconfig
+    dbus
+    glib
+    zlib
+    openssl
+    libdrm
+    wayland
+    cups
+    avahi-compat
+    # Qt stuff
+    qt3d
+    mlt
+    qtbase
+    qtgamepad
+    qtserialport
+    qtserialbus
+    qtvirtualkeyboard
+    qtmultimedia
+    qtwebkit
+  ] ++ (with xorg; [
+    libX11
+    libXdamage
+    xrandr
+    libXtst
+    libXcomposite
+    libXext
+    libXfixes
+    libXrandr
+  ]);
+
+  postPatch = ''
+    patchelf ./installer \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${stdenv.cc.cc.lib}/lib
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/opt/PixInsight $out/share/{applications,mime/packages,icons/hicolor}
+
+    fakeroot script -ec "./installer \
+      --yes \
+      --install-dir=$out/opt/PixInsight \
+      --install-desktop-dir=$out/share/applications \
+      --install-mime-dir=$out/share/mime \
+      --install-icons-dir=$out/share/icons/hicolor \
+      --no-bin-launcher \
+      --no-remove"
+
+    rm -rf $out/opt/PixInsight-old-0
+    ln -s $out/opt/PixInsight/bin/PixInsight $out/bin/.
+  '';
+
+  # Some very exotic Qt libraries are not available in nixpkgs
+  autoPatchelfIgnoreMissingDeps = true;
+
+  # This mimics what is happening in PixInsight.sh and adds on top the libudev0-shim, which
+  # without PixInsight crashes at startup.
+  qtWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${libudev0-shim}/lib"
+    "--set LC_ALL en_US.utf8"
+    "--set AVAHI_COMPAT_NOWARN 1"
+    "--set QT_PLUGIN_PATH $out/opt/PixInsight/bin/lib/qt-plugins"
+    "--set QT_QPA_PLATFORM_PLUGIN_PATH $out/opt/PixInsight/bin/lib/qt-plugins/platforms"
+    "--set QT_AUTO_SCREEN_SCALE_FACTOR 0"
+    "--set QT_ENABLE_HIGHDPI_SCALING 0"
+    "--set QT_SCALE_FACTOR 1"
+    "--set QT_LOGGING_RULES '*=false'"
+    "--set QTWEBENGINEPROCESS_PATH $out/opt/PixInsight/bin/libexec/QtWebEngineProcess"
+  ];
+  dontWrapQtApps = true;
+  postFixup = ''
+    wrapProgram $out/opt/PixInsight/bin/PixInsight ${builtins.toString qtWrapperArgs}
+  '';
+
+  meta = with lib; {
+    description = "Scientific image processing program for astrophotography";
+    homepage = "https://pixinsight.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+    mainProgram = "PixInsight";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26400,6 +26400,8 @@ with pkgs;
 
   pixeluvo = callPackage ../applications/graphics/pixeluvo { };
 
+  pixinsight = libsForQt5.callPackage ../applications/graphics/pixinsight { };
+
   pmbootstrap = python3Packages.callPackage ../tools/misc/pmbootstrap { };
 
   shepherd = nodePackages."@nerdwallet/shepherd";


### PR DESCRIPTION
###### Motivation for this change
Addition of the PixInsight image processing software for astrophotography. See also https://discourse.nixos.org/t/faking-root-in-build-sandbox/17089/10?u=sheepforce

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
