### PR TITLE
vulkan: 1.2.189.1 -> 1.2.198.0

### DIFF
--- a/pkgs/development/compilers/glslang/default.nix
+++ b/pkgs/development/compilers/glslang/default.nix
@@ -6,69 +6,29 @@
 , python3
 , spirv-headers
 , spirv-tools
-, argSpirv-tools ? null
-, argSpirv-headers ? null
 }:
-# glslang requires custom versions of spirv-tools and spirb-headers.
-# The exact versions are taken from:
-# https://github.com/KhronosGroup/glslang/blob/${version}/known_good.json
-
-let
-  localSpirv-tools = if argSpirv-tools == null
-    then spirv-tools.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Tools";
-        rev = "b27b1afd12d05bf238ac7368bb49de73cd620a8e";
-        sha256 = "0v26ws6qx23jn4dcpsq6rqmdxgyxpl5pcvfm90wb3nz6iqbqx294";
-      };
-    })
-    else argSpirv-tools;
-
-  localSpirv-headers = if argSpirv-headers == null
-    then spirv-headers.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Headers";
-        rev = "f027d53ded7e230e008d37c8b47ede7cd308e19d";
-        sha256 = "12gp2mqcar6jj57jw9isfr62yn72kmvdcl0zga4gvrlyfhnf582q";
-      };
-    })
-    else argSpirv-headers;
-in
-
 stdenv.mkDerivation rec {
   pname = "glslang";
-  version = "11.1.0";
+  version = "1.2.198.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = version;
-    sha256 = "1j81pghy7whyr8ygk7lx6g6qph61rky7fkkc8xp87c7n695a48rw";
+    rev = "sdk-${version}";
+    sha256 = "sha256-FRiqsfoyjUW2kbbphxcy0Hn0TLVaszatM/nnWBrchRY=";
   };
 
   # These get set at all-packages, keep onto them for child drvs
   passthru = {
-    spirv-tools = localSpirv-tools;
-    spirv-headers = localSpirv-headers;
+    spirv-tools = spirv-tools;
+    spirv-headers = spirv-headers;
   };
 
   nativeBuildInputs = [ cmake python3 bison jq ];
 
   postPatch = ''
-    cp --no-preserve=mode -r "${localSpirv-tools.src}" External/spirv-tools
-    ln -s "${localSpirv-headers.src}" External/spirv-tools/external/spirv-headers
-  '';
-
-  # Ensure spirv-headers and spirv-tools match exactly to what is expected
-  preConfigure = ''
-    HEADERS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools/external/spirv-headers"))[0].commit')
-    TOOLS_COMMIT=$(jq -r < known_good.json '.commits|map(select(.name=="spirv-tools"))[0].commit')
-    if [ "$HEADERS_COMMIT" != "${localSpirv-headers.src.rev}" ] || [ "$TOOLS_COMMIT" != "${localSpirv-tools.src.rev}" ]; then
-      echo "ERROR: spirv-tools commits do not match expected versions: expected tools at $TOOLS_COMMIT, headers at $HEADERS_COMMIT";
-      exit 1;
-    fi
+    cp --no-preserve=mode -r "${spirv-tools.src}" External/spirv-tools
+    ln -s "${spirv-headers.src}" External/spirv-tools/external/spirv-headers
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/spirv-headers/default.nix
+++ b/pkgs/development/libraries/spirv-headers/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-headers";
-  version = "unstable-2021-08-11";
+  version = "1.2.198.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "e71feddb3f17c5586ff7f4cfb5ed1258b800574b";
-    sha256 = "sha256-9m0EBcgdya+KCNJHC3x+YV2sXoSNToTcgDkpeKzId6U=";
+    rev = "sdk-${version}";
+    sha256 = "sha256-cdEiRSCoX0New8ecUh7UTDz/is2v29zhf6Il2N1j3mw=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, cmake }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.2.189.1";
+  version = "1.2.198.0";
 
   nativeBuildInputs = [ cmake ];
 
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "sdk-${version}";
-    sha256 = "1qggc7dv9jr83xr9w2h375wl3pz3rfgrk9hnrjmylkg9gz4p9q03";
+    sha256 = "sha256-SvC0AX1wIZWLzws3ZS8Wi8fbNUw1+An/PRlFIfNj24Y=";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -3,14 +3,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-loader";
-  version = "1.2.189.1";
+  version = "1.2.198.0";
 
   src = (assert version == vulkan-headers.version;
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-Loader";
       rev = "sdk-${version}";
-      sha256 = "1745fdzi0n5qj2s41q6z1y52cq8pwswvh1a32d3n7kl6bhksagp6";
+      sha256 = "sha256-k3eCdZqCjFxpKa0pZ0K4XcORxdSOlr1dFa7C3Qzi04Y=";
     });
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/development/tools/spirv-tools/default.nix
+++ b/pkgs/development/tools/spirv-tools/default.nix
@@ -2,14 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "spirv-tools";
-  # Update spirv-headers rev in lockstep according to DEPs file
-  version = "2021.3";
+  version = "1.2.198.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "v${version}";
-    sha256 = "sha256-skpsxpgl6hR5uiKfphKFQJfh+LJvhGvDW/t2u5AhXzk=";
+    rev = "sdk-${version}";
+    sha256 = "sha256-8EJbTPY5dvsqx32POf2HcCV3j2fA68GtGZA66l9V4TI=";
   };
 
   nativeBuildInputs = [ cmake python3 ];

--- a/pkgs/development/tools/vulkan-validation-layers/default.nix
+++ b/pkgs/development/tools/vulkan-validation-layers/default.nix
@@ -13,38 +13,6 @@
 }:
 
 let
-  # vulkan-validation-layers requires a custom glslang & robin-hood-hashing
-  # version, while glslang requires custom versions for spirv-tools and spirv-headers.
-  #
-  # The git hashes required for all of these deps is documented upstream here:
-  # https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/master/scripts/known_good.json
-  # and https://github.com/KhronosGroup/glslang/blob/master/known_good.json
-  localSpirvHeaders = spirv-headers.overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "KhronosGroup";
-      repo = "SPIRV-Headers";
-      rev = "449bc986ba6f4c5e10e32828783f9daef2a77644"; # pin
-      sha256 = "1249pvk4iz09caxm3kwckzwcx2hbw97cr2h8h770l6c061kb14z5";
-    };
-  });
-  localGlslang = (glslang.override {
-    argSpirv-tools = spirv-tools.overrideAttrs (_: {
-      src = fetchFromGitHub {
-        owner = "KhronosGroup";
-        repo = "SPIRV-Tools";
-        rev = "1fbed83c8aab8517d821fcb4164c08567951938f"; # pin
-        sha256 = "0faz468bnxpvbg1np13gnbwf35s0hl9ad7r2p9wi9si5k336qjmj";
-      };
-    });
-    argSpirv-headers = localSpirvHeaders;
-  }).overrideAttrs (_: {
-    src = fetchFromGitHub {
-      owner = "KhronosGroup";
-      repo = "glslang";
-      rev = "2fb89a0072ae7316af1c856f22663fde4928128a"; # pin
-      sha256 = "04kkmphv0a5mb5javhmkc4kab8r0n107kb7djakj5h238ni2j7q9";
-    };
-  });
   robin-hood-hashing = fetchFromGitHub {
     owner = "martinus";
     repo = "robin-hood-hashing";
@@ -54,19 +22,19 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.2.189.1";
+  version = "1.2.198.0";
 
   # If we were to use "dev" here instead of headers, the setupHook would be
   # placed in that output instead of "out".
   outputs = ["out" "headers"];
   outputInclude = "headers";
 
-  src = (assert version == vulkan-headers.version;
+  src = (assert (lib.all (pkg: pkg.version == version) [vulkan-headers glslang spirv-tools spirv-headers]);
     fetchFromGitHub {
       owner = "KhronosGroup";
       repo = "Vulkan-ValidationLayers";
       rev = "sdk-${version}";
-      sha256 = "0a5plvvffidgnqh5ymq315xscl08w298sn9da48b3x2rdbdqgw90";
+      sha256 = "sha256-/pnXT55EQZcnjOzY2vBwp+gM6l2hktZHwB9yKP8vVTU=";
     });
 
   # Include absolute paths to layer libraries in their associated
@@ -88,8 +56,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DGLSLANG_INSTALL_DIR=${localGlslang}"
-    "-DSPIRV_HEADERS_INSTALL_DIR=${localSpirvHeaders}"
+    "-DGLSLANG_INSTALL_DIR=${glslang}"
+    "-DSPIRV_HEADERS_INSTALL_DIR=${spirv-headers}"
     "-DROBIN_HOOD_HASHING_INSTALL_DIR=${robin-hood-hashing}"
     "-DBUILD_LAYER_SUPPORT_FILES=ON"
     # Hide dev warnings that are useless for packaging


### PR DESCRIPTION
Upstream has established rigorous tagging practices, allowing us to simplify things considerably.

###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/147667 and cleans up substantial duplication thanks to upstream tagging.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
