### PR TITLE
fetch-rebar-deps: fix bad use of prePhases

### DIFF
--- a/pkgs/development/beam-modules/fetch-rebar-deps.nix
+++ b/pkgs/development/beam-modules/fetch-rebar-deps.nix
@@ -17,8 +17,9 @@ stdenv.mkDerivation ({
   dontConfigure = true;
   dontBuild = true;
   dontFixup = true;
+  prePhases = [ "downloadPhase" ];
 
-  prePhases = ''
+  downloadPhase = ''
     cp ${src} .
     HOME='.' DEBUG=1 ${rebar3}/bin/rebar3 get-deps
   '';


### PR DESCRIPTION
###### Motivation for this change

This was introduced in 50dd4a6cb2c8003d995459db7c9e8d8eee59cc08

'prePhases' is a list of phase names, so this failed trying to run 'cp'
with no arguments.

It would be nice if this could be tested automatically, but that's hard for fixed-output derivations like this. Here's an example that exercises it:

```nix
let
  nixpkgs = import ./path/to/nixpkgs/default.nix {};
  lockfile = ''
    {"1.2.0",
    [{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.8.0">>},1}]}.
    [
    {pkg_hash,[
     {<<"cowlib">>, <<"FD0FF1787DB84AC415B8211573E9A30A3EBE71B5CBFF7F720089972B2319C8A4">>}]},
    {pkg_hash_ext,[
     {<<"cowlib">>, <<"79F954A7021B302186A950A32869DBC185523D99D3E44CE430CD1F3289F41ED4">>}]}
    ].
  '';
in
  nixpkgs.beam.packages.erlang.fetchRebar3Deps {
    name = "test";
    version = "test";
    src = nixpkgs.writeText "rebar.lock" lockfile;
    sha256 = "0lryhy18d2x90piq7kpia97izg7lsq4jvx0mfqj820gnpk0pls14";
  }
```

It would be good to have this in 21.11 if possible -- it's trivial as there has been no changes since.

Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
