### PR TITLE
koka: 2.3.6 -> 2.3.8

### DIFF
--- a/pkgs/development/compilers/koka/default.nix
+++ b/pkgs/development/compilers/koka/default.nix
@@ -4,19 +4,25 @@
 , parsec, process, regex-compat, text, time }:
 
 let
-  version = "2.3.6";
+  version = "2.3.8";
   src = fetchFromGitHub {
     owner = "koka-lang";
     repo = "koka";
     rev = "v${version}";
-    sha256 = "sha256-AibS/HudJKFQZlTxGD5LfwjBawIy1xwO2Hm8qzAUP2M=";
+    sha256 = "sha256-4a9UwtiWq9eFpNHpcrlhYUwzXcr1EXFMjBmDFYP933U=";
     fetchSubmodules = true;
   };
   kklib = stdenv.mkDerivation {
     pname = "kklib";
     inherit version;
     src = "${src}/kklib";
+    patches = [ ./kklib-mimalloc-macos-fix.diff ];
     nativeBuildInputs = [ cmake ];
+    outputs = [ "out" "dev" ];
+    postInstall = ''
+      mkdir -p ''${!outputDev}/share/koka/v${version}
+      cp -a ../../kklib ''${!outputDev}/share/koka/v${version}
+    '';
   };
   inherit (pkgsHostTarget.targetPackages.stdenv) cc;
   runtimeDeps = [
@@ -40,7 +46,7 @@ mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/koka/v${version}
     cp -a lib $out/share/koka/v${version}
-    cp -a kklib $out/share/koka/v${version}
+    ln -s ${kklib.dev}/share/koka/v${version}/kklib $out/share/koka/v${version}
     wrapProgram "$out/bin/koka" \
       --set CC "${lib.getBin cc}/bin/${cc.targetPrefix}cc" \
       --prefix PATH : "${lib.makeSearchPath "bin" runtimeDeps}"

--- a/pkgs/development/compilers/koka/kklib-mimalloc-macos-fix.diff
+++ b/pkgs/development/compilers/koka/kklib-mimalloc-macos-fix.diff
@@ -1,0 +1,10 @@
+--- kklib/mimalloc/src/random.c	1969-12-31 18:00:01.000000000 -0600
++++ kklib/mimalloc/src/random.c.new	2022-01-16 19:43:54.000000000 -0600
+@@ -195,6 +195,7 @@
+ #elif defined(__APPLE__)
+ #include <AvailabilityMacros.h>
+ #if defined(MAC_OS_X_VERSION_10_10) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
++#include <CommonCrypto/CommonCryptoError.h>
+ #include <CommonCrypto/CommonRandom.h>
+ #endif
+ static bool os_random_buf(void* buf, size_t buf_len) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upgrade koka patch version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
