### PR TITLE
python3Packages.rflink: 0.0.58 -> 0.0.62

### DIFF
--- a/pkgs/development/python-modules/rflink/default.nix
+++ b/pkgs/development/python-modules/rflink/default.nix
@@ -8,18 +8,19 @@
 , pyserial-asyncio
 , setuptools
 , pytestCheckHook
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "rflink";
-  version = "0.0.58";
+  version = "0.0.62";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "aequitas";
     repo = "python-rflink";
     rev = version;
-    sha256 = "1zab55lsw419gg0jfrl69ap6128vbi3wdmg5z7qin65ijpjdhasc";
+    hash = "sha256-dEzkYE8xtUzvdsnPaSiQR8960WLOEcr/QhwDiQlobcs=";
   };
 
   propagatedBuildInputs = [
@@ -32,15 +33,6 @@ buildPythonPackage rec {
 
   checkInputs = [
     pytestCheckHook
-  ];
-
-  patches = [
-    # Remove loop, https://github.com/aequitas/python-rflink/pull/61
-    (fetchpatch {
-      name = "remove-loop.patch";
-      url = "https://github.com/aequitas/python-rflink/commit/777e19b5bde3398df5b8f142896c34a01ae18d52.patch";
-      sha256 = "sJmihxY3fNSfZVFhkvQ/+9gysQup/1jklKDMyDDLOs8=";
-    })
   ];
 
   postPatch = ''
@@ -57,5 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/aequitas/python-rflink";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
+    broken = pythonAtLeast "3.10"; # https://github.com/aequitas/python-rflink/issues/65
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
