### PR TITLE
mongodb: fix 3.4 evaluation, mark others < 4.2 as broken

### DIFF
--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -54,11 +54,11 @@ in stdenv.mkDerivation rec {
     libyamlcpp
     openssl
     pcre-cpp
-    variants.python
     sasl
     snappy
     zlib
-  ] ++ lib.optionals stdenv.isDarwin [ Security CoreFoundation cctools ];
+  ] ++ lib.optionals stdenv.isDarwin [ Security CoreFoundation cctools ]
+  ++ lib.optional (versionAtLeast version "3.6") [ variants.python ] ;
 
   # MongoDB keeps track of its build parameters, which tricks nix into
   # keeping dependencies to build inputs in the final output.

--- a/pkgs/servers/nosql/mongodb/mongodb.nix
+++ b/pkgs/servers/nosql/mongodb/mongodb.nix
@@ -8,6 +8,7 @@ with lib;
 
 { version, sha256, patches ? []
 , license ? lib.licenses.sspl
+, broken ? false
 }@args:
 
 let
@@ -129,6 +130,7 @@ in stdenv.mkDerivation rec {
     description = "A scalable, high-performance, open source NoSQL database";
     homepage = "http://www.mongodb.org";
     inherit license;
+    broken = broken;
 
     maintainers = with maintainers; [ bluescreen303 offline cstrahan ];
     platforms = subtractLists systems.doubles.i686 systems.doubles.unix;

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -13,4 +13,5 @@ in buildMongoDB {
   sha256 = "0j6mvgv0jnsnvgkl8505bl88kbxkba66qijlpi1la0dd5pd1imfr";
   patches = [ ./forget-build-dependencies-3-4.patch ];
   license = lib.licenses.agpl3;
+  broken = true;
 }

--- a/pkgs/servers/nosql/mongodb/v3_4.nix
+++ b/pkgs/servers/nosql/mongodb/v3_4.nix
@@ -13,5 +13,4 @@ in buildMongoDB {
   sha256 = "0j6mvgv0jnsnvgkl8505bl88kbxkba66qijlpi1la0dd5pd1imfr";
   patches = [ ./forget-build-dependencies-3-4.patch ];
   license = lib.licenses.agpl3;
-  broken = true;
 }

--- a/pkgs/servers/nosql/mongodb/v3_6.nix
+++ b/pkgs/servers/nosql/mongodb/v3_6.nix
@@ -13,4 +13,5 @@ in buildMongoDB {
   sha256 = "sha256-EJpIerW4zcGJvHfqJ65fG8yNsLRlUnRkvYfC+jkoFJ4=";
   patches = [ ./forget-build-dependencies.patch ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
+  broken = true;
 }

--- a/pkgs/servers/nosql/mongodb/v4_0.nix
+++ b/pkgs/servers/nosql/mongodb/v4_0.nix
@@ -14,4 +14,5 @@ in buildMongoDB {
   patches =
     [ ./forget-build-dependencies.patch ./mozjs-45_fix-3-byte-opcode.patch ]
     ++ lib.optionals stdenv.isDarwin [ ./asio-no-experimental-string-view.patch ];
+  broken = true;
 }


### PR DESCRIPTION
###### Motivation for this change
MongoDB was broken by the removal of pyyaml for python2. However it turns out that version 3.4 does not need python2 in the buildInputs at all, so remove it there and mark the other versions which depend on python2 and the pyyaml module as broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
