### PR TITLE
chromium: Backport important fixes for Wayland

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -161,13 +161,23 @@ let
       ./patches/no-build-timestamps.patch
       # For bundling Widevine (DRM), might be replaceable via bundle_widevine_cdm=true in gnFlags:
       ./patches/widevine-79.patch
-    ] ++ lib.optionals (versionRange "98" "99") [
+    ] ++ lib.optionals (versionRange "97" "98") [
       # A critical Ozone/Wayland fix:
+      # (Note: The patch for surface_augmenter.cc doesn't apply on M97 so we extract that part.)
+      (fetchpatch {
+        # [linux/wayland] Fixed terminate caused by binding to wrong version.
+        url = "https://github.com/chromium/chromium/commit/dd4c3ddadbb9869f59cee201a38e9ca3b9154f4d.patch";
+        excludes = [ "ui/ozone/platform/wayland/host/surface_augmenter.cc" ];
+        sha256 = "sha256-lp4kxPNAkafdE9NfD3ittTCpomRpX9Hqhtt9GFf4Ntw=";
+      })
+      ./patches/m97-ozone-wayland-fix-surface_augmenter.patch
+    ] ++ lib.optionals (versionRange "98" "99") [
       (githubPatch {
         # [linux/wayland] Fixed terminate caused by binding to wrong version.
         commit = "dd4c3ddadbb9869f59cee201a38e9ca3b9154f4d";
         sha256 = "sha256-FH7lBQTruMzkBT2XQ+kgADmJA0AxJfaV/gvtoqfQ4a4=";
       })
+    ] ++ lib.optionals (versionRange "97" "99") [
       (githubPatch {
         # [linux/wayland] Fixed terminate caused by binding to wrong version. (fixup)
         commit = "a84b79daa8897b822336b8f348ef4daaae07af37";

--- a/pkgs/applications/networking/browsers/chromium/patches/m97-ozone-wayland-fix-surface_augmenter.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/m97-ozone-wayland-fix-surface_augmenter.patch
@@ -1,0 +1,31 @@
+diff --git a/ui/ozone/platform/wayland/host/surface_augmenter.cc b/ui/ozone/platform/wayland/host/surface_augmenter.cc
+index d971d15e71426..6e5408398bcea 100644
+--- a/ui/ozone/platform/wayland/host/surface_augmenter.cc
++++ b/ui/ozone/platform/wayland/host/surface_augmenter.cc
+@@ -13,7 +13,8 @@
+ namespace ui {
+ 
+ namespace {
+-constexpr uint32_t kMaxSurfaceAugmenterVersion = 1;
++constexpr uint32_t kMinVersion = 1;
++constexpr uint32_t kMaxVersion = 1;
+ }
+ 
+ // static
+@@ -27,11 +28,13 @@ void SurfaceAugmenter::Instantiate(WaylandConnection* connection,
+                                    uint32_t version) {
+   DCHECK_EQ(interface, kInterfaceName);
+ 
+-  if (connection->surface_augmenter_)
++  if (connection->surface_augmenter_ ||
++      !wl::CanBind(interface, version, kMinVersion, kMaxVersion)) {
+     return;
++  }
+ 
+-  auto augmenter = wl::Bind<surface_augmenter>(
+-      registry, name, std::min(version, kMaxSurfaceAugmenterVersion));
++  auto augmenter = wl::Bind<surface_augmenter>(registry, name,
++                                               std::min(version, kMaxVersion));
+   if (!augmenter) {
+     LOG(ERROR) << "Failed to bind surface_augmenter";
+     return;


### PR DESCRIPTION
This is 843508dad46 for M97 (upstream didn't backport them so far).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
