### PR TITLE
medusa: unstable-2018-12-16 -> unstable-2021-01-03

### DIFF
--- a/pkgs/tools/security/medusa/default.nix
+++ b/pkgs/tools/security/medusa/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "medusa-unstable";
-  version = "2018-12-16";
+  version = "2021-01-03";
 
   src = fetchFromGitHub {
     owner = "jmk-foofus";
     repo = "medusa";
-    rev = "292193b3995444aede53ff873899640b08129fc7";
-    sha256 = "0njlz4fqa0165wdmd5y8lfnafayf3c4la0r8pf3hixkdwsss1509";
+    rev = "bdaa2dda92ad3681387a60cc41d3bd9f077360a1";
+    sha256 = "1l90p4h5y1qqr2j2qwwr40k38sp79jrbffnl9m3ca2p1qd3mnn12";
   };
 
   outputs = [ "out" "man" ];


### PR DESCRIPTION
Among other things fixes build against -fno-common toolchains
like clang-12:

    $ nix build --impure --expr 'with import ./.{}; medusa.override { stdenv = clang12Stdenv; }' -L
    ...
    medusa-unstable> ld: ../medusa-trace.o:/build/source/src/modsrc/../../src/medusa.h:67:
      multiple definition of `ptmFileMutex'; cvs.o:/build/source/src/modsrc/./../medusa.h:67: first defined here