### PR TITLE
python3Packages.python-kasa: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/development/python-modules/python-kasa/default.nix
+++ b/pkgs/development/python-modules/python-kasa/default.nix
@@ -2,7 +2,6 @@
 , asyncclick
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , importlib-metadata
 , poetry-core
 , pytest-asyncio
@@ -14,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "python-kasa";
-  version = "0.4.0";
+  version = "0.4.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -23,7 +22,7 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "08blmz5kg826l08pf6yrvl8gc8iz3hfb6wsfqih606dal08kdhdi";
+    sha256 = "sha256-4e9jpUDorZlKCYwWtqrba61zbkJl57oWUhEpFcaS9ak=";
   };
 
   nativeBuildInputs = [
@@ -42,26 +41,14 @@ buildPythonPackage rec {
     voluptuous
   ];
 
-  patches = [
-    # Switch to poetry-core, https://github.com/python-kasa/python-kasa/pull/226
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/python-kasa/python-kasa/commit/05c2a4a7dedbd60038e177b4d3f5ac5798544d11.patch";
-      sha256 = "0cla11yqx88wj2s50s3xxxhv4nz4h3wd9pi12v79778hzdlg58rr";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'asyncclick = "^7"' 'asyncclick = "*"'
-  '';
-
   disabledTestPaths = [
     # Skip the examples tests
     "kasa/tests/test_readme_examples.py"
   ];
 
-  pythonImportsCheck = [ "kasa" ];
+  pythonImportsCheck = [
+    "kasa"
+  ];
 
   meta = with lib; {
     description = "Python API for TP-Link Kasa Smarthome products";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/python-kasa/python-kasa/releases/tag/0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
