### PR TITLE
python3Packages.flask-security-too: init at 4.1.2

### DIFF
--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flask
+, blinker
+, setuptools
+, itsdangerous
+, flask_principal
+, passlib
+, email_validator
+, flask_wtf
+, flask_login
+, pytestCheckHook
+, flask_mail
+, sqlalchemy
+, flask_sqlalchemy
+, flask-mongoengine
+, peewee
+, pony
+, zxcvbn
+, mongoengine
+, cryptography
+, pyqrcode
+, phonenumbers
+, bleach
+, mongomock
+}:
+
+buildPythonPackage rec {
+  pname = "flask-security-too";
+  version = "4.1.2";
+
+  src = fetchPypi {
+    pname = "Flask-Security-Too";
+    inherit version;
+    sha256 = "16ws5n08vm7wsa2f7lrkxvc7jl3ah1xfylhhyzb4vvqmlk7x9hw8";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    flask_login
+    flask_principal
+    flask_wtf
+    email_validator
+    itsdangerous
+    passlib
+    blinker
+    setuptools
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    flask_mail
+    sqlalchemy
+    flask_sqlalchemy
+    flask-mongoengine
+    peewee
+    pony
+    zxcvbn
+    mongoengine
+    cryptography
+    pyqrcode
+    phonenumbers
+    bleach
+    mongomock
+  ];
+
+  pythonImportsCheck = [ "flask_security" ];
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/Flask-Security-Too/";
+    description = "Simple security for Flask apps (fork)";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2930,6 +2930,8 @@ in {
 
   flask-session = callPackage ../development/python-modules/flask-session { };
 
+  flask-security-too = callPackage ../development/python-modules/flask-security-too { };
+
   flask-silk = callPackage ../development/python-modules/flask-silk { };
 
   flask-socketio = callPackage ../development/python-modules/flask-socketio { };


### PR DESCRIPTION
Init of Flask-security-too

###### Motivation for this change
needed for pgadmin4 init
https://github.com/NixOS/nixpkgs/pull/154764

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) 
**NOTE: Due to a pony requirement (python 3.3-3.9), this package fails to build in Python3.10**
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
