### PR TITLE
python3Packages.flask-gravatar: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/flask-gravatar/default.nix
+++ b/pkgs/development/python-modules/flask-gravatar/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flask
+, pytestCheckHook
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "flask-gravatar";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    pname = "Flask-Gravatar";
+    inherit version;
+    sha256 = "YGZfMcLGEokdto/4Aek+06CIHGyOw0arxk0qmSP1YuE=";
+  };
+
+
+  postPatch = ''
+    sed -i setup.py \
+     -e "s|tests_require=tests_require,||g" \
+     -e "s|extras_require=extras_require,||g" \
+     -e "s|setup_requires=setup_requires,||g"
+    # pep8 is deprecated and cov not needed
+    substituteInPlace pytest.ini \
+     --replace "--pep8" "" \
+     --replace "--cov=flask_gravatar --cov-report=term-missing" ""
+  '';
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pygments
+  ];
+
+  pythonImportsCheck = [ "flask_gravatar" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/zzzsochi/Flask-Gravatar";
+    description = "Small and simple integration of gravatar into flask";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/development/python-modules/flask-gravatar/default.nix
+++ b/pkgs/development/python-modules/flask-gravatar/default.nix
@@ -16,7 +16,6 @@ buildPythonPackage rec {
     sha256 = "YGZfMcLGEokdto/4Aek+06CIHGyOw0arxk0qmSP1YuE=";
   };
 
-
   postPatch = ''
     sed -i setup.py \
      -e "s|tests_require=tests_require,||g" \

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2888,6 +2888,8 @@ in {
 
   flask_elastic = callPackage ../development/python-modules/flask-elastic { };
 
+  flask-gravatar = callPackage ../development/python-modules/flask-gravatar { };
+
   flask-httpauth = callPackage ../development/python-modules/flask-httpauth { };
 
   flask-jwt-extended = callPackage ../development/python-modules/flask-jwt-extended { };


### PR DESCRIPTION
Init of Flask-Gravatar

###### Motivation for this change
needed for pgadmin4 init
https://github.com/NixOS/nixpkgs/pull/154764

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) 
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
