### PR TITLE
yaml-merge: unstable-2016-02-16 -> unstable-2022-01-12

### DIFF
--- a/pkgs/tools/text/yaml-merge/default.nix
+++ b/pkgs/tools/text/yaml-merge/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "yaml-merge";
-  version = "unstable-2016-02-16";
+  version = "unstable-2022-01-12";
 
   src = fetchFromGitHub {
     owner = "abbradar";
     repo = "yaml-merge";
-    rev = "4eef7b68632d79dec369b4eff5a8c63f995f81dc";
-    sha256 = "0mwda2shk43i6f22l379fcdchmb07fm7nf4i2ii7fk3ihkhb8dgp";
+    rev = "2f0174fe92fc283dd38063a3a14f7fe71db4d9ec";
+    sha256 = "sha256-S2eZw+FOZvOn0XupZDRNcolUPd4PhvU1ziu+kx2AwnY=";
   };
 
   pythonPath = with python3Packages; [ pyyaml ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
yaml-merge does not currently work, because its dependency is pyyaml, which is now at 6.0
But the old commit that was used did not support pyyaml 6.0, and caused error:
```
Traceback (most recent call last):
  File "/nix/store/4d263m2v4clf88dpkig7d5nygp1pixsn-yaml-merge-unstable-2016-02-16/bin/.yaml-merge-wrapped", line 28, in <module>
    file1 = yaml.load(f)
TypeError: load() missing 1 required positional argument: 'Loader'
```
When used normally like `yaml-merge a.yaml b.yaml`

I noticed yaml-merge have gotten new commits which now supports pyyaml 6.0.
Using overlays to bump this for my personal configs, and it works for me.

The adguardhome module is having some issues now, and one of the issues:
https://github.com/NixOS/nixpkgs/pull/154791#issuecomment-1012685720
seen in this comment, I also had, but it dissapears when bumping yaml-merge to newest commit.

###### Things done
Bumped yaml-merge from the ancient commit, to the newest.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
