### PR TITLE
python3Packages.wtforms: 2.3.3 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/wtforms/default.nix
+++ b/pkgs/development/python-modules/wtforms/default.nix
@@ -2,21 +2,29 @@
 , buildPythonPackage
 , fetchPypi
 , markupsafe
+, Babel
+, pytestCheckHook
+, email_validator
 }:
 
 buildPythonPackage rec {
-  version = "2.3.3";
+  version = "3.0.1";
   pname = "WTForms";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "81195de0ac94fbc8368abbaf9197b88c4f3ffd6c2719b5bf5fc9da744f3d829c";
+    sha256 = "1g654ghavds387hqxmhg9s8x222x89wbq1ggzxbsyn6x2axindbb";
   };
 
-  propagatedBuildInputs = [ markupsafe ];
+  propagatedBuildInputs = [ markupsafe Babel ];
 
-  # Django tests are broken "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."
-  doCheck = false;
+
+  checkInputs = [
+    pytestCheckHook
+    email_validator
+  ];
+
+  pythonImportsCheck = [ "wtforms" ];
 
   meta = with lib; {
     description = "A flexible forms validation and rendering library for Python";


### PR DESCRIPTION
update of wtforms to 3.0.1

###### Motivation for this change
needed for pgadmin4 init
https://github.com/NixOS/nixpkgs/pull/154764

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) 
  **Several packages break:**
  - [ ] wtf-peewee: [Fix committed](https://github.com/coleifer/wtf-peewee/commit/b1764f4474c73a9a2b34ae6b7db61274f5252a7f) upstream, but no new release published
  - [ ] flask-admin fails due to a dependency on wtf-peewee
  - [ ] buku fails due to flask-admin
  - [ ] ihatemoney with `ERROR: No matching distribution found for WTForms<2.4,>=2.3.1` [Upstream is working on it](https://github.com/spiral-project/ihatemoney/pull/916)
  - [ ] flask-appbuilder fails and [Upstream is working on it](https://github.com/dpgaspar/Flask-AppBuilder/pull/1734)
  - [ ] apache-airflow fails due to a dependency on flask-appbuilder


- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Maybe we should add wtforms > 3 separately until all breakage is fixed?

I want to add the wtforms>=3 version due to its hard build requirement in pgadmin4. 