### PR TITLE
pinta: 2.0.1 -> 2.0.2, add translations

### DIFF
--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -11,7 +11,7 @@
 
 buildDotnetModule rec {
   pname = "Pinta";
-  version = "2.0.1";
+  version = "2.0.2";
 
   nativeBuildInputs = [
     installShellFiles
@@ -37,7 +37,7 @@ buildDotnetModule rec {
     owner = "PintaProject";
     repo = "Pinta";
     rev = version;
-    sha256 = "sha256-iOKJPB2bI/GjeDxzG7r6ew7SGIzgrJTcRXhEYzOpC9k=";
+    sha256 = "sha256-Bvzs1beq7I1+10w9pmMePqGCz2TPDp5UK5Wa9hbKERU=";
   };
 
   postFixup = ''

--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -2,10 +2,9 @@
 , buildDotnetModule
 , dotnetCorePackages
 , fetchFromGitHub
+, glibcLocales
 , gtk3
-, installShellFiles
-, librsvg
-, makeDesktopItem
+, intltool
 , wrapGAppsHook
 }:
 
@@ -14,7 +13,7 @@ buildDotnetModule rec {
   version = "2.0.2";
 
   nativeBuildInputs = [
-    installShellFiles
+    intltool
     wrapGAppsHook
   ];
 
@@ -27,7 +26,7 @@ buildDotnetModule rec {
   # How-to update deps:
   # $ nix-build -A pinta.fetch-deps
   # $ ./result
-  # $ cp /tmp/Pinta-deps.nix ./pkgs/applications/graphics/pinta/default.nix
+  # $ cp /tmp/Pinta-deps.nix ./pkgs/applications/graphics/pinta/deps.nix
   # TODO: create update script
   nugetDeps = ./deps.nix;
 
@@ -40,32 +39,38 @@ buildDotnetModule rec {
     sha256 = "sha256-Bvzs1beq7I1+10w9pmMePqGCz2TPDp5UK5Wa9hbKERU=";
   };
 
+  # https://github.com/NixOS/nixpkgs/issues/38991
+  # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+
+  # Do the autoreconf/Makefile job manually
+  # TODO: use upstream build system
+  postBuild = ''
+    # Substitute translation placeholders
+    intltool-merge -x po/ xdg/pinta.appdata.xml.in xdg/pinta.appdata.xml
+    intltool-merge -d po/ xdg/pinta.desktop.in xdg/pinta.desktop
+
+    # Build translations
+    dotnet build Pinta \
+      -p:ContinuousIntegrationBuild=true \
+      -p:Deterministic=true \
+      -target:CompileTranslations,PublishTranslations \
+      -p:BuildTranslations=true \
+      -p:PublishDir="$NIX_BUILD_TOP/source/publish"
+  '';
+
   postFixup = ''
     # Rename the binary
-    mv $out/bin/Pinta $out/bin/pinta
+    mv "$out/bin/Pinta" "$out/bin/pinta"
 
-    # Copy desktop icons
-    for size in 16x16 22x22 24x24 32x32 96x96 scalable; do
-      mkdir -p $out/share/icons/hicolor/$size/apps
-      cp xdg/$size/* $out/share/icons/hicolor/$size/apps/
-    done
-
-    # Copy runtime icons
-    cp -r Pinta.Resources/icons/hicolor/16x16/* $out/share/icons/hicolor/16x16/
-
-    # Install manpage
-    installManPage xdg/pinta.1
-
-    # Fix and copy desktop file
-    # TODO: fix this propely by using the autoreconf+pkg-config build system
-    # from upstream
-    mkdir -p $out/share/applications
-    substitute xdg/pinta.desktop.in $out/share/applications/Pinta.desktop \
-      --replace _Name Name \
-      --replace _Comment Comment \
-      --replace _GenericName GenericName \
-      --replace _X-GNOME-FullName X-GNOME-FullName \
-      --replace _Keywords Keywords
+    # Install
+    dotnet build installer/linux/install.proj \
+      -target:Install \
+      -p:ContinuousIntegrationBuild=true \
+      -p:Deterministic=true \
+      -p:SourceDir="$NIX_BUILD_TOP/source" \
+      -p:PublishDir="$NIX_BUILD_TOP/source/publish" \
+      -p:InstallPrefix="$out"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release: https://github.com/PintaProject/Pinta/releases/tag/2.0.2

Seems to fix only bugs in macOS/Windows (this package doesn't support macOS anyway), and updated translations. Minor update.

However, got the chance to finally got the translations to work. To test without changing your locale, you can do something like `LANG=pt_BR.UTF-8 pinta`:

![2022-01-16_12-39-09-screenshot](https://user-images.githubusercontent.com/844343/149666850-63d59130-c3c3-4ad5-82cf-9f5c49cbe2f8.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
