### PR TITLE
kodi.packages.trakt: init at 3.5.0 

### DIFF
--- a/pkgs/applications/video/kodi/addons/arrow/default.nix
+++ b/pkgs/applications/video/kodi/addons/arrow/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, dateutil, typing_extensions }:
+buildKodiAddon rec {
+  pname = "arrow";
+  namespace = "script.module.arrow";
+  version = "1.0.3.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "0xa16sb2hls59l4gsg1xwb1qbkhcvbykq02l05n5rcm0alg80l3l";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    typing_extensions
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.arrow";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/razzeee/script.module.arrow";
+    description = "Better dates & times for Python";
+    license = licenses.asl20;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/trakt-module/default.nix
+++ b/pkgs/applications/video/kodi/addons/trakt-module/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, requests, six, arrow }:
+buildKodiAddon rec {
+  pname = "trakt-module";
+  namespace = "script.module.trakt";
+  version = "4.4.0+matrix.1";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "19kjhrykx92sy67cajxjckzdwgq47ipwml0bx9vmdr9d191h14p8";
+  };
+
+  propagatedBuildInputs = [
+    requests
+    six
+    arrow
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.trakt-module";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/Razzeee/script.module.trakt";
+    description = "Python trakt.py library packed for Kodi";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/trakt/default.nix
+++ b/pkgs/applications/video/kodi/addons/trakt/default.nix
@@ -1,0 +1,30 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript, trakt-module, dateutil }:
+buildKodiAddon rec {
+  pname = "trakt";
+  namespace = "script.trakt";
+  version = "3.5.0";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "07fb0wjcr8ggidswrjs1r1hzi6grykiyi855bgm7pjzzk95kl99v";
+  };
+
+  propagatedBuildInputs = [
+    dateutil
+    trakt-module
+  ];
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.trakt";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://kodi.wiki/view/Add-on:Trakt";
+    description = "Trakt.tv movie and TV show scrobbler for Kodi";
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/applications/video/kodi/addons/typing_extensions/default.nix
+++ b/pkgs/applications/video/kodi/addons/typing_extensions/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildKodiAddon, fetchzip, addonUpdateScript }:
+buildKodiAddon rec {
+  pname = "typing_extensions";
+  namespace = "script.module.typing_extensions";
+  version = "3.7.4.3";
+
+  src = fetchzip {
+    url = "https://mirrors.kodi.tv/addons/matrix/${namespace}/${namespace}-${version}.zip";
+    sha256 = "0p28hchj05hmccs6b2836kh4vqdqnl169409f2845d0nw9y4wkqq";
+  };
+
+  passthru = {
+    pythonPath = "lib";
+    updateScript = addonUpdateScript {
+      attrPath = "kodi.packages.typing_extensions";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/python/typing/tree/master/typing_extensions";
+    description = "Python typing extensions";
+    license = licenses.psfl;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -166,4 +166,5 @@ let self = rec {
 
   typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
 
+  arrow = callPackage ../applications/video/kodi/addons/arrow { };
 }; in self

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -169,4 +169,6 @@ let self = rec {
   arrow = callPackage ../applications/video/kodi/addons/arrow { };
 
   trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
+
+  trakt = callPackage ../applications/video/kodi/addons/trakt { };
 }; in self

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -164,4 +164,6 @@ let self = rec {
 
   xbmcswift2 = callPackage ../applications/video/kodi/addons/xbmcswift2 { };
 
+  typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
+
 }; in self

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -167,4 +167,6 @@ let self = rec {
   typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
 
   arrow = callPackage ../applications/video/kodi/addons/arrow { };
+
+  trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
 }; in self


### PR DESCRIPTION
###### Motivation for this change

A kodi addon I've been missing for a while

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
