### PR TITLE
yex-lang: minor adjustements

### DIFF
--- a/pkgs/development/interpreters/yex-lang/default.nix
+++ b/pkgs/development/interpreters/yex-lang/default.nix
@@ -1,24 +1,24 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   pname = "yex-lang";
   version = "unstable-2021-12-25";
 
   src = fetchFromGitHub {
-    owner = "nonamesc";
+    owner = "nonamescm";
     repo = "yex-lang";
     rev = "a97def1431b73b8693700f530ec023f1776eaf83";
-    sha256 = "074x9j0ihjpaghnwywq5zyxfad2h6m57c2i58wkz6chma6vcjk08";
-    fetchSubmodules = true;
+    hash = "sha256-CEzJtlEVMvMnRyUKdko1UDTluv8Fc88tfOpKGIFMnRw=";
   };
 
-  cargoSha256 = "017nszw07gzd2awadasxqyzx4zpb3y6db1zykcixddqxlyg1wwwq";
+  cargoSha256 = "sha256-mHMenqcdt9Yjm/6H1Ywf637Sv8ddq6a4Eu2/A/jX9gQ=";
 
   meta = with lib; {
+    homepage = "https://github.com/nonamesc/yex-lang";
     description = "A cool functional scripting language written in rust";
-    homepage = "https://github.com/yex-lang/yex-lang";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.all;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = platforms.unix;
+    broken = stdenv.isAarch64 && stdenv.isLinux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
