### PR TITLE
python3Packages.pony: 0.7.14 -> 0.7.15rc1

### DIFF
--- a/pkgs/development/python-modules/pony/default.nix
+++ b/pkgs/development/python-modules/pony/default.nix
@@ -1,25 +1,42 @@
-{ lib, python, buildPythonPackage, fetchPypi }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
   pname = "pony";
-  version = "0.7.14";
+  version = "0.7.15rc1";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "2f01e84e79ea7a14040225cb6c079bb266e7ba147346356c266490b18c77ce82";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "ponyorm";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-EoMpVvPCwxJbNPoeF73djcaQ4lY9jRx5nJYR2A2LXoQ=";
   };
 
-  doCheck = true;
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # stripping the tests
-  postInstall = ''
-    rm -rf $out/${python.sitePackages}/pony/orm/tests
-  '';
+  disabledTests = [
+    # Tests are outdated
+    "test_exception_msg"
+    "test_method"
+  ];
+
+  pythonImportsCheck = [
+    "pony"
+  ];
 
   meta = with lib; {
-    description = "Pony is a Python ORM with beautiful query syntax";
+    description = "Library for advanced object-relational mapping";
     homepage = "https://ponyorm.org/";
-    maintainers = with maintainers; [ d-goldin xvapx ];
     license = licenses.asl20;
+    maintainers = with maintainers; [ d-goldin xvapx ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ponyorm/pony/releases/tag/v0.7.15rc1

Fix build (https://hydra.nixos.org/build/163512274)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
