### PR TITLE
python3Packages.mutmut: init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/mutmut/default.nix
+++ b/pkgs/development/python-modules/mutmut/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, fetchFromGitHub
+, buildPythonApplication
+, click
+, glob2
+, parso
+, pony
+, junit-xml
+, pythonOlder
+, testVersion
+}:
+
+let self = buildPythonApplication rec {
+  pname = "mutmut";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "boxed";
+    rev = version;
+    hash = "sha256-G+OL/9km2iUeZ1QCpU73CIWVWMexcs3r9RdCnAsESnY=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt --replace 'junit-xml==1.8' 'junit-xml==1.9'
+  '';
+
+  disabled = pythonOlder "3.7";
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ click glob2 parso pony junit-xml ];
+
+  passthru.tests.version = testVersion { package = self; };
+
+  meta = with lib; {
+    description = "mutation testing system for Python, with a strong focus on ease of use";
+    homepage = "https://github.com/boxed/mutmut";
+    changelog = "https://github.com/boxed/mutmut/blob/${version}/HISTORY.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ synthetica ];
+  };
+};
+in self

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5181,6 +5181,8 @@ in {
 
   mutf8 = callPackage ../development/python-modules/mutf8 { };
 
+  mutmut = callPackage ../development/python-modules/mutmut { };
+
   mujson = callPackage ../development/python-modules/mujson { };
 
   mwclient = callPackage ../development/python-modules/mwclient { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
