### PR TITLE
rhvoice: unstable-2018-02-10 -> 1.8.0

### DIFF
--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -1,35 +1,49 @@
-{ stdenv, lib, pkg-config, fetchFromGitHub, sconsPackages
-, glibmm, libpulseaudio, libao }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, ensureNewerSourcesForZipFilesHook
+, pkg-config
+, scons
+, glibmm
+, libpulseaudio
+, libao
+, speechd
+}:
 
-let
-  version = "unstable-2018-02-10";
-in stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "rhvoice";
-  inherit version;
+  version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "Olga-Yakovleva";
+    owner = "RHVoice";
     repo = "RHVoice";
-    rev = "7a25a881b0465e47a12d8029b56f3b71a1d02312";
-    sha256 = "1gkrlmv7msh9qlm0gkjqpl9gswghpclfdwszr1p85v8vk6m63v0b";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-5iq+St/fqGMeJu2XaiCmgzBpxqE9IQLnKlfZErd1fPs=";
   };
 
+  patches = [
+    # SConstruct patch
+    #     Scons creates an independent environment that assumes standard POSIX paths.
+    #     The patch is needed to push the nix environment.
+    #     - PATH
+    #     - PKG_CONFIG_PATH, to find available (sound) libraries
+    #     - RPATH, to link to the newly built libraries
+    ./honor_nix_environment.patch
+  ];
+
   nativeBuildInputs = [
-    sconsPackages.scons_3_1_2 pkg-config
+    ensureNewerSourcesForZipFilesHook
+    pkg-config
+    scons
   ];
 
   buildInputs = [
-    glibmm libpulseaudio libao
+    glibmm
+    libpulseaudio
+    libao
+    speechd
   ];
-
-  # SConstruct patch
-  #     Scons creates an independent environment that assumes standard POSIX paths.
-  #     The patch is needed to push the nix environment.
-  #     - PATH
-  #     - PKG_CONFIG_PATH, to find available (sound) libraries
-  #     - RPATH, to link to the newly built libraries
-
-  patches = [ ./honor_nix_environment.patch ];
 
   meta = {
     description = "A free and open source speech synthesizer for Russian language and others";

--- a/pkgs/applications/audio/rhvoice/default.nix
+++ b/pkgs/applications/audio/rhvoice/default.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "rhvoice";
-  version = "1.6.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "RHVoice";
     repo = "RHVoice";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-5iq+St/fqGMeJu2XaiCmgzBpxqE9IQLnKlfZErd1fPs=";
+    hash = "sha256-G5886rjBaAp0AXcr07O0q7K1OXTayfIbd4zniKwDiLw=";
   };
 
   patches = [

--- a/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
+++ b/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
@@ -1,14 +1,26 @@
 diff --git a/SConstruct b/SConstruct
-index 2421399..ba39254 100644
+index b29168f..d507b95 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -147,6 +147,9 @@ def create_base_env(vars):
+@@ -93,6 +93,8 @@ def CheckWiX(context):
+ 
+ def get_spd_module_dir():
+     env = Environment()
++    env.PrependENVPath("PATH", os.environ["PATH"])
++    env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
+     return env.ParseConfig("pkg-config speech-dispatcher --variable=modulebindir", passthru)
+ 
+ def validate_spd_version(key,val,env):
+@@ -202,9 +204,9 @@ def create_base_env(user_vars):
      env_args["package_name"]="RHVoice"
      env_args["CPPDEFINES"]=[("RHVOICE","1")]
      env=Environment(**env_args)
+-    if env["dev"]:
+-        env["prefix"]=os.path.abspath("local")
+-        env["RPATH"]=env.Dir("$libdir").abspath
 +    env.PrependENVPath("PATH", os.environ["PATH"])
 +    env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
-+    env["RPATH"]=env["libdir"]
++    env["RPATH"]=env.Dir("$libdir").abspath
      env["package_version"]=get_version(env["release"])
      env.Append(CPPDEFINES=("PACKAGE",env.subst(r'\"$package_name\"')))
-     env.Append(CPPDEFINES=("VERSION",env.subst(r'\"$package_version\"')))
+     if env["PLATFORM"]=="win32":

--- a/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
+++ b/pkgs/applications/audio/rhvoice/honor_nix_environment.patch
@@ -1,17 +1,22 @@
 diff --git a/SConstruct b/SConstruct
-index b29168f..d507b95 100644
+index 3ad4d9a..fb02365 100644
 --- a/SConstruct
 +++ b/SConstruct
-@@ -93,6 +93,8 @@ def CheckWiX(context):
+@@ -94,11 +94,8 @@ def CheckWiX(context):
+     return result
  
  def get_spd_module_dir():
-     env = Environment()
-+    env.PrependENVPath("PATH", os.environ["PATH"])
-+    env["ENV"]["PKG_CONFIG_PATH"]=os.environ["PKG_CONFIG_PATH"]
-     return env.ParseConfig("pkg-config speech-dispatcher --variable=modulebindir", passthru)
+-    env = Environment()
+-    try:
+-        return env.ParseConfig("pkg-config speech-dispatcher --variable=modulebindir", passthru)
+-    except:
+-        return False
++    # cannot write to ${speechd}/libexec/speech-dispatcher-modules
++    return os.path.join(os.environ["out"], "libexec/speech-dispatcher-modules")
  
  def validate_spd_version(key,val,env):
-@@ -202,9 +204,9 @@ def create_base_env(user_vars):
+     m=re.match(r"^\d+\.\d+",val)
+@@ -208,9 +205,9 @@ def create_base_env(user_vars):
      env_args["package_name"]="RHVoice"
      env_args["CPPDEFINES"]=[("RHVOICE","1")]
      env=Environment(**env_args)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#148779 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
