### PR TITLE
libsForQt5.mapbox-gl-qml: 1.7.6 -> 1.7.7.1

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -1,23 +1,23 @@
 { lib, mkDerivation, fetchFromGitHub
-, qmake, qttools, kirigami2, qtquickcontrols2, qtlocation, qtsensors
+, cmake, qttools, kirigami2, qtquickcontrols2, qtlocation, qtsensors
 , nemo-qml-plugin-dbus, mapbox-gl-qml, s2geometry
 , python3, pyotherside
 }:
 
 mkDerivation rec {
   pname = "pure-maps";
-  version = "2.6.5";
+  version = "2.9.2";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "pure-maps";
     rev = version;
-    sha256 = "17gfb7rdaadmcdba4mhish0jrz9lmiban6fpzwhyvn8z1rc43zx9";
+    hash = "sha256-pMPjY6OXR6THiSQZ4mw9Kz+tAXJaOwzJEcpPOyZ+YKI=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    qmake python3 qttools python3.pkgs.wrapPython
+    cmake python3 qttools python3.pkgs.wrapPython
   ];
 
   buildInputs = [
@@ -25,12 +25,7 @@ mkDerivation rec {
     nemo-qml-plugin-dbus pyotherside mapbox-gl-qml s2geometry
   ];
 
-  postPatch = ''
-    substituteInPlace pure-maps.pro \
-      --replace '$$[QT_HOST_BINS]/lconvert' 'lconvert'
-  '';
-
-  qmakeFlags = [ "FLAVOR=kirigami" ];
+  cmakeFlags = [ "-DFLAVOR=kirigami" ];
 
   pythonPath = with python3.pkgs; [ gpxpy ];
 

--- a/pkgs/development/libraries/mapbox-gl-qml/default.nix
+++ b/pkgs/development/libraries/mapbox-gl-qml/default.nix
@@ -11,13 +11,13 @@
 
 mkDerivation rec {
   pname = "mapbox-gl-qml";
-  version = "1.7.6";
+  version = "1.7.7.1";
 
   src = fetchFromGitHub {
     owner = "rinigus";
     repo = "mapbox-gl-qml";
     rev = version;
-    sha256 = "sha256-E6Pkr8khzDbhmJxzK943+H6cDREgwAqMnJQ3hQWU7fw=";
+    hash = "sha256-lmL9nawMY8rNNBV4zNF4N1gn9XZzIZ9Cw2ZRs9bjBaI=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
