### PR TITLE
renderdoc: 1.16 -> 1.17

### DIFF
--- a/pkgs/applications/graphics/renderdoc/default.nix
+++ b/pkgs/applications/graphics/renderdoc/default.nix
@@ -1,8 +1,25 @@
-{ lib, fetchFromGitHub, cmake, pkg-config, mkDerivation
-, qtbase, qtx11extras, qtsvg, makeWrapper
-, vulkan-loader, libglvnd, xorg, python3, python3Packages
-, bison, pcre, automake, autoconf, addOpenGLRunpath
-, waylandSupport ? false, wayland
+{ lib
+, fetchFromGitHub
+, nix-update-script
+, cmake
+, pkg-config
+, mkDerivation
+, qtbase
+, qtx11extras
+, qtsvg
+, makeWrapper
+, vulkan-loader
+, libglvnd
+, xorg
+, python3
+, python3Packages
+, bison
+, pcre
+, automake
+, autoconf
+, addOpenGLRunpath
+, waylandSupport ? false
+, wayland
 }:
 let
   custom_swig = fetchFromGitHub {
@@ -15,13 +32,13 @@ let
 in
 mkDerivation rec {
   pname = "renderdoc";
-  version = "1.16";
+  version = "1.17";
 
   src = fetchFromGitHub {
     owner = "baldurk";
     repo = "renderdoc";
     rev = "v${version}";
-    sha256 = "150d1qzjs420clqr48gickiw5ymjx4md6iyjbxmxsdml0pyxpwwn";
+    sha256 = "sha256-Zr7Av49mK48B4N+Ca2vPIgKuVNP4YLVEs4EQepukSs8=";
   };
 
   buildInputs = [
@@ -63,6 +80,10 @@ mkDerivation rec {
   postFixup = ''
     addOpenGLRunpath $out/lib/librenderdoc.so
   '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
 
   meta = with lib; {
     description = "A single-frame graphics debugger";


### PR DESCRIPTION
Also set up updateScript since there haven't been any particularly
dramatic changes requiring modifications to the expression in a while.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/baldurk/renderdoc/releases/tag/v1.17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
