### PR TITLE
barcode: pull upstream fix for -fno-common toolchains

### DIFF
--- a/pkgs/tools/graphics/barcode/default.nix
+++ b/pkgs/tools/graphics/barcode/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, fetchpatch }:
 
 stdenv.mkDerivation rec {
   version = "0.99";
@@ -7,6 +7,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
     sha256 = "1indapql5fjz0bysyc88cmc54y8phqrbi7c76p71fgjp45jcyzp8";
   };
+  patches = [
+    # Pull upstream patch for -fno-common toolchains.
+    (fetchpatch {
+      name = "fno-common.patch";
+      url = "http://git.savannah.gnu.org/cgit/barcode.git/patch/?id=4654f68706a459c9602d9932b56a56e8930f7d53";
+      sha256 = "15kclzcwlh0ymr7m48vc0m8z98q0wf4xbfcky4g1y8yvvpvvrfgc";
+    })
+  ];
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
Without the change build fails as:

    $ nix build --impure --expr 'with import ./.{}; barcode.override { stdenv = clang12Stdenv; }' -L
    ...
    barcode> ld: barcode.h:126: multiple definition of `streaming';
      main.o:/build/barcode-0.99/./barcode.h:126: first defined here