### PR TITLE
whitebophir: pin to nodejs-14_x to unbreak the build

### DIFF
--- a/pkgs/servers/web-apps/whitebophir/default.nix
+++ b/pkgs/servers/web-apps/whitebophir/default.nix
@@ -1,11 +1,14 @@
 { stdenv
 , pkgs
 , lib
-, nodejs
+, nodejs-14_x
 , runtimeShell
 }:
 
 let
+  # nodejs-16_x fails with ENOTCACHED
+  nodejs = nodejs-14_x;
+
   nodePackages = import ./node-packages.nix {
     inherit pkgs nodejs;
     inherit (stdenv.hostPlatform) system;

--- a/pkgs/servers/web-apps/whitebophir/generate.sh
+++ b/pkgs/servers/web-apps/whitebophir/generate.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i bash -p nodePackages.node2nix
+
+# Run this script not via `./generate.sh`, but via `$PWD/generate.sh`.
+# Else `nix-shell` will not find this script.
+
 set -euo pipefail
+
+cd -- "$(dirname -- "$BASH_SOURCE[0]")"
 
 node2nix \
      --input node-packages.json \

--- a/pkgs/servers/web-apps/whitebophir/node-packages-generated.nix
+++ b/pkgs/servers/web-apps/whitebophir/node-packages-generated.nix
@@ -49,13 +49,13 @@ let
         sha512 = "vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==";
       };
     };
-    "@types/node-17.0.0" = {
+    "@types/node-17.0.8" = {
       name = "_at_types_slash_node";
       packageName = "@types/node";
-      version = "17.0.0";
+      version = "17.0.8";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz";
-        sha512 = "eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==";
+        url = "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz";
+        sha512 = "YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==";
       };
     };
     "accept-language-parser-1.5.0" = {
@@ -193,13 +193,13 @@ let
         sha1 = "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59";
       };
     };
-    "engine.io-6.1.0" = {
+    "engine.io-6.1.1" = {
       name = "engine.io";
       packageName = "engine.io";
-      version = "6.1.0";
+      version = "6.1.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz";
-        sha512 = "ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==";
+        url = "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz";
+        sha512 = "AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==";
       };
     };
     "engine.io-parser-5.0.2" = {
@@ -256,13 +256,13 @@ let
         sha1 = "18282b27d08a267cb3030cd2b8b4b0f212af752a";
       };
     };
-    "graceful-fs-4.2.8" = {
+    "graceful-fs-4.2.9" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.8";
+      version = "4.2.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz";
-        sha512 = "qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz";
+        sha512 = "NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==";
       };
     };
     "handlebars-4.7.7" = {
@@ -535,13 +535,13 @@ let
         sha512 = "E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==";
       };
     };
-    "socket.io-4.4.0" = {
+    "socket.io-4.4.1" = {
       name = "socket.io";
       packageName = "socket.io";
-      version = "4.4.0";
+      version = "4.4.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz";
-        sha512 = "bnpJxswR9ov0Bw6ilhCvO38/1WPtE3eA2dtxi2Iq4/sFebiDJQzgKNYA7AuVVdGW09nrESXd90NbZqtDd9dzRQ==";
+        url = "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz";
+        sha512 = "s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==";
       };
     };
     "socket.io-adapter-2.3.3" = {
@@ -715,7 +715,7 @@ in
       sources."@types/component-emitter-1.2.11"
       sources."@types/cookie-0.4.1"
       sources."@types/cors-2.8.12"
-      sources."@types/node-17.0.0"
+      sources."@types/node-17.0.8"
       sources."accept-language-parser-1.5.0"
       sources."accepts-1.3.7"
       sources."async-mutex-0.3.2"
@@ -734,7 +734,7 @@ in
       sources."destroy-1.0.4"
       sources."ee-first-1.1.1"
       sources."encodeurl-1.0.2"
-      (sources."engine.io-6.1.0" // {
+      (sources."engine.io-6.1.1" // {
         dependencies = [
           sources."debug-4.3.3"
           sources."ms-2.1.2"
@@ -746,7 +746,7 @@ in
       sources."fresh-0.5.2"
       sources."from2-2.3.0"
       sources."from2-string-1.1.0"
-      sources."graceful-fs-4.2.8"
+      sources."graceful-fs-4.2.9"
       sources."handlebars-4.7.7"
       sources."http-errors-1.8.1"
       sources."inherits-2.0.4"
@@ -775,7 +775,7 @@ in
       sources."send-0.17.2"
       sources."serve-static-1.14.2"
       sources."setprototypeof-1.2.0"
-      (sources."socket.io-4.4.0" // {
+      (sources."socket.io-4.4.1" // {
         dependencies = [
           sources."debug-4.3.3"
           sources."ms-2.1.2"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

On current nixpkgs-unstable and nixpkgs-master, whitebophir fails to build with "ENOTCACHED". Thanks to @ilkecan's insightful comment [over at our Discourse](https://discourse.nixos.org/t/node2nix-enotcached-when-using-callpackage-instead-of-import/17157), I was able to fix this issue by pinning to nodejs-14_x.

I also took the liberty of regenerating node-packages-generated.nix so we use newer versions of some dependencies. I'm the maintainer of this package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
