### PR TITLE
resholve: work around nixpkgs aarch64-darwin issues

### DIFF
--- a/pkgs/development/misc/resholve/oildev.nix
+++ b/pkgs/development/misc/resholve/oildev.nix
@@ -79,8 +79,8 @@ rec {
     patchSrc = fetchFromGitHub {
       owner = "abathur";
       repo = "nix-py-dev-oil";
-      rev = "v0.8.12.1";
-      hash = "sha256-7JVnosdcvmVFN3h6SIeeqcJFcyFkai//fFuzi7ThNMY=";
+      rev = "v0.8.12.2";
+      hash = "sha256-+dVxzPKMGNKFE+7Ggzx9iWjjvwW2Ow3UqmjjUud9Mqo=";
     };
     patches = [
       "${patchSrc}/0001-add_setup_py.patch"
@@ -88,6 +88,7 @@ rec {
       "${patchSrc}/0004-disable-internal-py-yajl-for-nix-built.patch"
       "${patchSrc}/0006-disable_failing_libc_tests.patch"
       "${patchSrc}/0007-namespace_via_init.patch"
+      "${patchSrc}/0009-avoid_nix_arch64_darwin_toolchain_bug.patch"
     ];
 
     buildInputs = [ readline cmark py-yajl ];

--- a/pkgs/development/misc/resholve/resholve.nix
+++ b/pkgs/development/misc/resholve/resholve.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , callPackage
 , python27Packages
 , installShellFiles
@@ -17,7 +18,18 @@ python27Packages.buildPythonApplication {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  propagatedBuildInputs = [ oildev python27Packages.configargparse ];
+  propagatedBuildInputs = [
+    oildev
+    /*
+    Disable configargparse's tests on aarch64-darwin.
+    Several of py27 scandir's tests fail on aarch64-darwin. Chain:
+    configargparse -> pytest-check-hook -> pytest -> pathlib2 -> scandir
+    TODO: drop if https://github.com/NixOS/nixpkgs/issues/156807 resolves?
+    */
+    (python27Packages.configargparse.overridePythonAttrs (old: {
+      doCheck = stdenv.hostPlatform.system != "aarch64-darwin";
+    }))
+  ];
 
   patchPhase = ''
     for file in resholve; do


### PR DESCRIPTION
These are hopefully both just short-term workarounds.
- add an oil-dev patch to work around build failure documented in NixOS#154203
- override configargparse to disable tests and work around failure reported in NixOS#156807

The OfBorg results should clarify whether this works.