### PR TITLE
nixos/prosody-filer: remove usage of literalExample

### DIFF
--- a/nixos/modules/services/web-apps/prosody-filer.nix
+++ b/nixos/modules/services/web-apps/prosody-filer.nix
@@ -21,12 +21,10 @@ in {
 
         type = settingsFormat.type;
 
-        example = literalExample ''
-          {
-            secret = "mysecret";
-            storeDir = "/srv/http/nginx/prosody-upload";
-          }
-        '';
+        example = {
+          secret = "mysecret";
+          storeDir = "/srv/http/nginx/prosody-upload";
+        };
 
         defaultText = literalExpression ''
           {


### PR DESCRIPTION
`literalExample` was deprecated in https://github.com/NixOS/nixpkgs/pull/136909 in favour of `literalExpression` (or `literalDocBook`). Since there was no use for it here, I removed it.
