### PR TITLE
[21.11] hostapd/wpa_supplicant: SAE/EAP-pwd side-channel attack update 2

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -49,6 +49,29 @@ stdenv.mkDerivation rec {
       url = "https://w1.fi/cgit/hostap/patch/?id=a0541334a6394f8237a4393b7372693cd7e96f15";
       sha256 = "1gbhlz41x1ar1hppnb76pqxj6vimiypy7c4kq6h658637s4am3xg";
     })
+    # SAE/EAP-pwd side-channel attack update 2
+    # https://w1.fi/security/2022-1/
+    (fetchurl {
+      name = "0001-crypto-Add-more-bignum-EC-helper-functions.patch";
+      url = "https://w1.fi/security/2022-1/0001-crypto-Add-more-bignum-EC-helper-functions.patch";
+      sha256 = "0gq14p4vrg4sn8dhqylidjrcm2y4v1pj758k6zin61nvfy9b9xrl";
+    })
+    (fetchurl {
+      name = "0002-dragonfly-Add-sqrt-helper-function.patch";
+      url = "https://w1.fi/security/2022-1/0002-dragonfly-Add-sqrt-helper-function.patch";
+      sha256 = "0jwdrb3lvazryahr4vkp4mgfx9699c63bknllvaw4kkc0ashvql4";
+    })
+    (fetchurl {
+      name = "0003-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch";
+      url = "https://w1.fi/security/2022-1/0003-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch";
+      sha256 = "09fmnvnl64gp17hxf1kz6aza6zjn2zxvmp7i917yssjc27n3ag6f";
+    })
+    (fetchurl {
+      name = "0004-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch";
+      url = "https://w1.fi/security/2022-1/0004-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch";
+      sha256 = "17lya82bq923lvxafnb80xvmw0v1z8l56dbgnbllwz79zzzsxdfn";
+    })
+
   ];
 
   outputs = [ "out" "man" ];

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -47,6 +47,28 @@ stdenv.mkDerivation rec {
       url = "https://w1.fi/cgit/hostap/patch/?id=a0541334a6394f8237a4393b7372693cd7e96f15";
       sha256 = "1gbhlz41x1ar1hppnb76pqxj6vimiypy7c4kq6h658637s4am3xg";
     })
+    # SAE/EAP-pwd side-channel attack update 2
+    # https://w1.fi/security/2022-1/
+    (fetchurl {
+      name = "0001-crypto-Add-more-bignum-EC-helper-functions.patch";
+      url = "https://w1.fi/security/2022-1/0001-crypto-Add-more-bignum-EC-helper-functions.patch";
+      sha256 = "0gq14p4vrg4sn8dhqylidjrcm2y4v1pj758k6zin61nvfy9b9xrl";
+    })
+    (fetchurl {
+      name = "0002-dragonfly-Add-sqrt-helper-function.patch";
+      url = "https://w1.fi/security/2022-1/0002-dragonfly-Add-sqrt-helper-function.patch";
+      sha256 = "0jwdrb3lvazryahr4vkp4mgfx9699c63bknllvaw4kkc0ashvql4";
+    })
+    (fetchurl {
+      name = "0003-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch";
+      url = "https://w1.fi/security/2022-1/0003-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch";
+      sha256 = "09fmnvnl64gp17hxf1kz6aza6zjn2zxvmp7i917yssjc27n3ag6f";
+    })
+    (fetchurl {
+      name = "0004-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch";
+      url = "https://w1.fi/security/2022-1/0004-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch";
+      sha256 = "17lya82bq923lvxafnb80xvmw0v1z8l56dbgnbllwz79zzzsxdfn";
+    })
   ] ++ lib.optionals readOnlyModeSSIDs [
     # Allow read-only networks
     ./0001-Implement-read-only-mode-for-ssids.patch


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://w1.fi/security/2022-1/sae-eap-pwd-side-channel-attack-update-2.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
