### PR TITLE
python3Packages.socketio-client: init at 0.7.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9719,6 +9719,13 @@
     githubId = 1016742;
     name = "Rafael García";
   };
+  raitobezarius = {
+    email = "ryan@lahfa.xyz";
+    matrix = "@raitobezarius:matrix.org";
+    github = "RaitoBezarius";
+    githubId = 314564;
+    name = "Ryan Lahfa";
+  };
   raquelgb = {
     email = "raquel.garcia.bautista@gmail.com";
     github = "raquelgb";

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -25,10 +25,6 @@ buildPythonPackage rec {
     requests
   ];
 
-  checkInputs = [
-    coverage
-    nose
-  ];
 
   # Perform networking tests.
   doCheck = false;

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -29,7 +29,9 @@ buildPythonPackage rec {
   # Perform networking tests.
   doCheck = false;
 
-  passthru.updateScript = ./update.sh;
+  pythonImportsCheck = [
+    "socketIO_client"
+  ];
 
   meta = with lib; {
     description = "A socket.io client library for protocol 1.x";

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A socket.io client library for protocol 1.x";
     homepage = "https://github.com/invisibleroads/socketIO-client";
-    license = licenses.gpl3;
+    license = licenses.mit;
     maintainers = with maintainers; [ raitobezarius ];
   };
 }

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -3,8 +3,6 @@
 , requests
 , six
 , websocket-client
-, coverage
-, nose
 , fetchFromGitHub
 }:
 
@@ -24,7 +22,6 @@ buildPythonPackage rec {
     websocket-client
     requests
   ];
-
 
   # Perform networking tests.
   doCheck = false;

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -5,7 +5,9 @@
 , websocket-client
 , coverage
 , nose
-, fetchFromGitHub }:
+, fetchFromGitHub
+}:
+
 buildPythonPackage rec {
   pname = "socketio-client";
   version = "0.7.2";

--- a/pkgs/development/python-modules/socketio-client/default.nix
+++ b/pkgs/development/python-modules/socketio-client/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, requests
+, six
+, websocket-client
+, coverage
+, nose
+, fetchFromGitHub }:
+buildPythonPackage rec {
+  pname = "socketio-client";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "invisibleroads";
+    repo = "socketio-client";
+    rev = version;
+    sha256 = "sha256-71sjiGJDDYElPGUNCH1HaVdvgMt8KeD/kXVDpF615ho=";
+  };
+
+  propagatedBuildInputs = [
+    six
+    websocket-client
+    requests
+  ];
+
+  checkInputs = [
+    coverage
+    nose
+  ];
+
+  # Perform networking tests.
+  doCheck = false;
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "A socket.io client library for protocol 1.x";
+    homepage = "https://github.com/invisibleroads/socketIO-client";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/socketio-client/update.sh
+++ b/pkgs/development/python-modules/socketio-client/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update python3Packages.socketio-client

--- a/pkgs/development/python-modules/socketio-client/update.sh
+++ b/pkgs/development/python-modules/socketio-client/update.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix-update
-set -eu -o pipefail
-
-nix-update python3Packages.socketio-client

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9013,6 +9013,8 @@ in {
     usePython = true;
   });
 
+  socketio-client = callPackage ../development/python-modules/socketio-client { };
+
   socialscan = callPackage ../development/python-modules/socialscan { };
 
   socid-extractor =  callPackage ../development/python-modules/socid-extractor { };


### PR DESCRIPTION
###### Motivation for this change

This socket.io client library is a dependency for ripe-atlas-cousteau (https://github.com/RIPE-NCC/ripe-atlas-cousteau) which is a Python client library for RIPE Atlas API (see #155267 for more context).

Tests cannot be enabled because they will use localhost networking for websockets actual tests.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
tes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).