### PR TITLE
python3Packages.ripe-atlas-cousteau: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -8,6 +8,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 }:
+
 buildPythonPackage rec {
   pname = "ripe-atlas-cousteau";
   version = "1.5.1";

--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, python-dateutil
+, python-socketio
+, requests
+, jsonschema
+, pythonOlder
+, pytestCheckHook
+, buildPythonPackage
+, fetchFromGitHub
+}:
+buildPythonPackage rec {
+  pname = "ripe-atlas-cousteau";
+  version = "1.5.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-EHZt9Po/1wDwDacXUCVGcuVSOwcIkPCT2JCKGchu8G4=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'python-socketio[client]<5' 'python-socketio[client]<6'
+  '';
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+    python-socketio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "ripe.atlas.cousteau"
+  ];
+
+  meta = with lib; {
+    description = "Python client library for RIPE ATLAS API";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-cousteau";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9458,6 +9458,8 @@ in {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };


### PR DESCRIPTION
Depends on #155269

###### Motivation for this change

This adds the client library for RIPE ATLAS API, which is necessary for `ripe-atlas-tools`, see #155267 for context.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
