### PR TITLE
ripe-atlas-tools: init at 2.3.0

### DIFF
--- a/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-cousteau/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, python-dateutil
+, python-socketio
+, requests
+, jsonschema
+, pythonOlder
+, pytestCheckHook
+, buildPythonPackage
+, fetchFromGitHub
+}:
+buildPythonPackage rec {
+  pname = "ripe-atlas-cousteau";
+  version = "1.5.1";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-EHZt9Po/1wDwDacXUCVGcuVSOwcIkPCT2JCKGchu8G4=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'python-socketio[client]<5' 'python-socketio[client]<6'
+  '';
+
+  propagatedBuildInputs = [
+    python-dateutil
+    requests
+    python-socketio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "ripe.atlas.cousteau"
+  ];
+
+  meta = with lib; {
+    description = "A Python client library for RIPE ATLAS API";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-cousteau";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
+++ b/pkgs/development/python-modules/ripe-atlas-sagan/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, python-dateutil
+, pytz
+, cryptography
+, pytest
+, pytestCheckHook
+, fetchFromGitHub
+}:
+
+buildPythonPackage rec {
+  pname = "ripe-atlas-sagan";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-xIBIKsQvDmVBa/C8/7Wr3WKeepHaGhoXlgatXSUtWLA=";
+  };
+
+  propagatedBuildInputs = [
+    python-dateutil
+    pytz
+    cryptography
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/*.py" ];
+
+  disabledTests = [
+    "test_invalid_country_code"  # This test fail for unknown reason, I suspect it to be flaky.
+  ];
+
+  pythonImportsCheck = [
+    "ripe.atlas.sagan"
+  ];
+
+  meta = with lib; {
+    description = "A parsing library for RIPE Atlas measurements results";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-sagan";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -25,12 +25,9 @@ python3.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python3.pkgs; [
     ripe-atlas-cousteau
     ripe-atlas-sagan
-
     ujson
-
     sphinx
     sphinx_rtd_theme
-
     ipy
     python-dateutil
     requests

--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -16,7 +16,6 @@ python3.pkgs.buildPythonApplication rec {
 
   checkInputs = with python3.pkgs; [
     sphinx
-    flake8
     pytestCheckHook
   ];
 

--- a/pkgs/tools/networking/ripe-atlas-tools/default.nix
+++ b/pkgs/tools/networking/ripe-atlas-tools/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "ripe-atlas-tools";
+  version = "3.0.2";
+
+  src = fetchFromGitHub {
+    owner = "RIPE-NCC";
+    repo = "ripe-atlas-tools";
+    rev = "v${version}";
+    sha256 = "sha256-5AMqBXxJZOtI0/2NrEjrUfNXWKc7sn6kZX26766LBUM=";
+  };
+
+  checkInputs = with python3.pkgs; [
+    sphinx
+    flake8
+    pytestCheckHook
+  ];
+
+  # TODO(raitobezarius): cannot import during tests ripe.atlas.cousteau/ripe.atlas.sagan, I do not know why.
+  doCheck = false;
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ripe-atlas-cousteau
+    ripe-atlas-sagan
+
+    ujson
+
+    sphinx
+    sphinx_rtd_theme
+
+    ipy
+    python-dateutil
+    requests
+    tzlocal
+    pyyaml
+    pyopenssl
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "RIPE ATLAS project tools";
+    homepage = "https://github.com/RIPE-NCC/ripe-atlas-tools";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ raitobezarius ];
+  };
+}

--- a/pkgs/tools/networking/ripe-atlas-tools/update.sh
+++ b/pkgs/tools/networking/ripe-atlas-tools/update.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix-update
-set -eu -o pipefail
-
-nix-update ripe-atlas-tools

--- a/pkgs/tools/networking/ripe-atlas-tools/update.sh
+++ b/pkgs/tools/networking/ripe-atlas-tools/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+set -eu -o pipefail
+
+nix-update ripe-atlas-tools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4588,6 +4588,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) AppKit Security;
   };
 
+  ripe-atlas-tools = callPackage ../tools/networking/ripe-atlas-tools { };
+
   roundcube = callPackage ../servers/roundcube { };
 
   roundcubePlugins = dontRecurseIntoAttrs (callPackage ../servers/roundcube/plugins { });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9458,6 +9458,8 @@ in {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  ripe-atlas-cousteau = callPackage ../development/python-modules/ripe-atlas-cousteau { };
+
   ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
 
   riprova = callPackage ../development/python-modules/riprova { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9458,6 +9458,8 @@ in {
 
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
+  ripe-atlas-sagan = callPackage ../development/python-modules/ripe-atlas-sagan { };
+
   riprova = callPackage ../development/python-modules/riprova { };
 
   ripser = callPackage ../development/python-modules/ripser { };


### PR DESCRIPTION
Depends on #155267 and #155270

###### Motivation for this change

RIPE Atlas tools are command line tooling for the RIPE Atlas measurements project: https://atlas.ripe.net/measurements/ which is very useful to measure state of services across multiple point of presence.

I am unable to properly run the unit tests as it is complaining about ripe.atlas.sagan/cousteau failing imports but I am able to use the binaries nevertheless, if anyone has an idea, I'd be glad to implement it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
