### PR TITLE
input-remapper: init at unstable-2022-02-09 (and add nixos module)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7058,6 +7058,12 @@
     githubId = 30698906;
     name = "Luna D Dragon";
   };
+  LunNova = {
+    email = "nixpkgs-maintainer@lunnova.dev";
+    github = "LunNova";
+    githubId = 782440;
+    name = "Luna Nova";
+  };
   lionello = {
     email = "lio@lunesu.com";
     github = "lionello";

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -116,6 +116,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/sezanzeb/input-remapper">input-remapper</link>,
+          an easy to use tool to change the mapping of your input device
+          buttons. Available at
+          <link xlink:href="options.html#opt-services.input-remapper.enable">services.input-remapper</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://invoiceplane.com">InvoicePlane</link>,
           web application for managing and creating invoices. Available
           at

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -37,6 +37,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [PowerDNS-Admin](https://github.com/ngoduykhanh/PowerDNS-Admin), a web interface for the PowerDNS server. Available at [services.powerdns-admin](options.html#opt-services.powerdns-admin.enable).
 
+- [input-remapper](https://github.com/sezanzeb/input-remapper), an easy to use tool to change the mapping of your input device buttons. Available at [services.input-remapper](options.html#opt-services.input-remapper.enable).
+
 - [InvoicePlane](https://invoiceplane.com), web application for managing and creating invoices. Available at [services.invoiceplane](options.html#opt-services.invoiceplane.enable).
 
 - [maddy](https://maddy.email), a composable all-in-one mail server. Available as [services.maddy](options.html#opt-services.maddy.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/misc/greenclip.nix
   ./services/misc/home-assistant.nix
   ./services/misc/ihaskell.nix
+  ./services/misc/input-remapper.nix
   ./services/misc/irkerd.nix
   ./services/misc/jackett.nix
   ./services/misc/jellyfin.nix

--- a/nixos/modules/services/misc/input-remapper.nix
+++ b/nixos/modules/services/misc/input-remapper.nix
@@ -1,0 +1,29 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+let cfg = config.services.input-remapper; in
+{
+  options = {
+    services.input-remapper = {
+      enable = mkEnableOption "input-remapper, an easy to use tool to change the mapping of your input device buttons.";
+      package = mkOption {
+        type = types.package;
+        default = pkgs.input-remapper;
+        defaultText = literalExpression "pkgs.input-remapper";
+        description = ''
+          The input-remapper package to use.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # FIXME: udev rule hangs sometimes when lots of devices connected, so let's not use it
+    # config.services.udev.packages = mapper-pkg;
+    services.dbus.packages = cfg.package;
+    systemd.packages = cfg.package;
+    environment.systemPackages = cfg.package;
+    systemd.services.input-remapper.wantedBy = [ "graphical.target" ];
+  };
+}

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -1,0 +1,157 @@
+{ lib
+, python3
+, pkgconfig
+, wrapGAppsHook
+, gettext
+, gtk3
+, glib
+, dbus
+, gobject-introspection
+, xmodmap
+, pygobject3
+, setuptools
+, evdev
+, pydantic
+, pydbus
+, psutil
+, fetchFromGitHub
+, buildPythonApplication
+, procps
+, gtksourceview4
+  # Change the default log level to debug for easier debugging of package issues
+, withDebugLogLevel ? false
+  # Xmodmap is an optional dependency
+  # If you use Xmodmap to set keyboard mappings (or your DE does)
+  # it is required to correctly map keys
+, withXmodmap ? true
+  # Version and rev and hash are package arguments to allow overriding
+  # while ensuring the values in prePatch and src match
+  # https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7
+  # The names are prefixed with input_remapper to avoid potential
+  # collisions with package names
+, input_remapper_version ? "unstable-2022-02-09"
+, input_remapper_src_rev ? "55227e0b5a28d21d7333c6c8ea1c691e56fd35c4"
+, input_remapper_src_hash ? "sha256-kzGlEaYN/JfAgbI0aMLr5mwObYOL43X7QU/ihDEBQFg="
+}:
+
+let
+  maybeXmodmap = lib.optional withXmodmap xmodmap;
+in
+buildPythonApplication {
+  pname = "input-remapper";
+  version = input_remapper_version;
+
+  src = fetchFromGitHub {
+    rev = input_remapper_src_rev;
+    owner = "sezanzeb";
+    repo = "input-remapper";
+    hash = input_remapper_src_hash;
+  };
+
+  # Fixes error
+  # Couldn’t recognize the image file format for file "*.svg"
+  # at startup, see https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  prePatch = ''
+    # set revision for --version output
+    echo "COMMIT_HASH = '${input_remapper_src_rev}'" > inputremapper/commit_hash.py
+
+    # fix FHS paths
+    substituteInPlace inputremapper/configs/data.py \
+      --replace "/usr/share/input-remapper"  "$out/usr/share/input-remapper"
+  '' + (lib.optionalString (withDebugLogLevel) ''
+    # if debugging
+    substituteInPlace inputremapper/logger.py --replace "logger.setLevel(logging.INFO)"  "logger.setLevel(logging.DEBUG)"
+  '');
+
+  doCheck = true;
+  checkInputs = [
+    psutil
+  ];
+  pythonImportsCheck = [
+    "evdev"
+    "inputremapper"
+  ];
+
+  # Custom test script, can't use plain pytest / pytestCheckHook
+  # We only run tests in the unit folder, integration tests require UI
+  # To allow tests which access the system and session DBUS to run, we start a dbus session
+  # and bind it to both the system and session buses
+  installCheckPhase = ''
+    echo "<busconfig>
+      <type>session</type>
+      <listen>unix:tmpdir=$TMPDIR</listen>
+      <listen>unix:path=/build/system_bus_socket</listen>
+      <standard_session_servicedirs/>
+      <policy context=\"default\">
+        <!-- Allow everything to be sent -->
+        <allow send_destination=\"*\" eavesdrop=\"true\"/>
+        <!-- Allow everything to be received -->
+        <allow eavesdrop=\"true\"/>
+        <!-- Allow anyone to own anything -->
+        <allow own=\"*\"/>
+      </policy>
+    </busconfig>" > dbus.cfg
+    PATH=${lib.makeBinPath ([ dbus procps ] ++ maybeXmodmap)}:$PATH \
+      USER="$(id -u -n)" \
+      DBUS_SYSTEM_BUS_ADDRESS=unix:path=/build/system_bus_socket \
+      ${dbus}/bin/dbus-run-session --config-file dbus.cfg \
+      python tests/test.py --start-dir unit
+  '';
+
+  # Nixpkgs 15.9.4.3. When using wrapGAppsHook with special derivers you can end up with double wrapped binaries.
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : "${lib.makeBinPath maybeXmodmap}"
+    )
+  '';
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gettext # needed to build translations
+    gtk3
+    glib
+    gobject-introspection
+    pygobject3
+  ] ++ maybeXmodmap;
+
+  propagatedBuildInputs = [
+    setuptools # needs pkg_resources
+    pygobject3
+    evdev
+    pkgconfig
+    pydantic
+    pydbus
+    gtksourceview4
+  ];
+
+  postInstall = ''
+    sed -r "s#RUN\+\=\"/bin/input-remapper-control#RUN\+\=\"$out/bin/input-remapper-control#g" -i data/99-input-remapper.rules
+    sed -r "s#ExecStart\=/usr/bin/input-remapper-service#ExecStart\=$out/bin/input-remapper-service#g" -i data/input-remapper.service
+
+    chmod +x data/*.desktop
+
+    install -D -t $out/share/applications/ data/*.desktop
+    install -D -t $out/share/polkit-1/actions/ data/input-remapper.policy
+    install -D data/99-input-remapper.rules $out/etc/udev/rules.d/99-input-remapper.rules
+    install -D data/input-remapper.service $out/lib/systemd/system/input-remapper.service
+    install -D data/input-remapper.policy $out/share/polkit-1/actions/input-remapper.policy
+    install -D data/inputremapper.Control.conf $out/etc/dbus-1/system.d/inputremapper.Control.conf
+    install -D -t $out/usr/share/input-remapper/ data/*
+
+    # Only install input-remapper prefixed binaries, we don't care about deprecated key-mapper ones
+    install -m755 -D -t $out/bin/ bin/input-remapper*
+  '';
+
+  meta = with lib; {
+    description = "An easy to use tool to change the mapping of your input device buttons";
+    homepage = "https://github.com/sezanzeb/input-remapper";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ LunNova ];
+    mainProgram = "input-remapper-gtk";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6611,6 +6611,8 @@ with pkgs;
 
   innoextract = callPackage ../tools/archivers/innoextract { };
 
+  input-remapper = python3Packages.callPackage ../tools/inputmethods/input-remapper { };
+
   input-utils = callPackage ../os-specific/linux/input-utils { };
 
   inql = callPackage ../tools/security/inql { };


### PR DESCRIPTION
###### Motivation for this change
Add [input-remapper](https://github.com/sezanzeb/input-remapper) package and module to allow remapping keys on most input devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (but emulated)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
