### PR TITLE
vscode-extensions.ms-ceintl: init at 1.64.3

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -1250,6 +1250,8 @@ let
         };
       };
 
+      ms-ceintl = callPackage ./language-packs.nix {}; # non-English language packs
+
       ms-dotnettools.csharp = callPackage ./ms-dotnettools-csharp { };
 
       ms-kubernetes-tools.vscode-kubernetes-tools = buildVscodeMarketplaceExtension {

--- a/pkgs/misc/vscode-extensions/language-packs.nix
+++ b/pkgs/misc/vscode-extensions/language-packs.nix
@@ -1,0 +1,89 @@
+{ lib, vscode-utils }:
+
+with vscode-utils;
+
+let
+
+  buildVscodeLanguagePack = { language, sha256 }:
+    buildVscodeMarketplaceExtension {
+      mktplcRef = {
+        name = "vscode-language-pack-${language}";
+        publisher = "MS-CEINTL";
+        version = "1.64.3";
+        inherit sha256;
+      };
+      meta = {
+        license = lib.licenses.mit;
+      };
+    };
+
+in
+
+# See list of core language packs at https://github.com/Microsoft/vscode-loc
+{
+  # French
+  vscode-language-pack-fr = buildVscodeLanguagePack {
+    language = "fr";
+    sha256 = "sha256-6ynT1sbMgKO8iZReQ6KxFpR1VL3Nuo58MvXCtp+67vA=";
+  };
+  # Italian
+  vscode-language-pack-it = buildVscodeLanguagePack {
+    language = "it";
+    sha256 = "sha256-5aNFpzNMZAZJH3n0rJevke9P6AW0au5i8+r4PXsb9Rg=";
+  };
+  # German
+  vscode-language-pack-de = buildVscodeLanguagePack {
+    language = "de";
+    sha256 = "sha256-oEaWtsgktHKw52lnZTESkpzC/TTY8LO4yX11IgtMG5U=";
+  };
+  # Spanish
+  vscode-language-pack-es = buildVscodeLanguagePack {
+    language = "es";
+    sha256 = "sha256-utLWbved3WCCk3XzqedbYzmyaKfbMrAmR0btT09GlxA=";
+  };
+  # Russian
+  vscode-language-pack-ru = buildVscodeLanguagePack {
+    language = "ru";
+    sha256 = "sha256-0Wr2ICOiaaj4jZ555bxUJcmXO/yWDyn0UmdvxUF3WSQ=";
+  };
+  # Chinese (Simplified)
+  vscode-language-pack-zh-hans = buildVscodeLanguagePack {
+    language = "zh-hans";
+    sha256 = "sha256-irTSQcVXf/V3MuZwfx4tFcvBk+xhbFZTnb7IG28s/p4=";
+  };
+  # Chinese (Traditional)
+  vscode-language-pack-zh-hant = buildVscodeLanguagePack {
+    language = "zh-hant";
+    sha256 = "sha256-3IA/VTTTEqS6jrDYv50GnLXOTSC1XAMvqOVfOuvIdIs=";
+  };
+  # Japanese
+  vscode-language-pack-ja = buildVscodeLanguagePack {
+    language = "ja";
+    sha256 = "sha256-rxod70ddrppEYYzukksVY1dTXR8osLFAsIPr1fSFZDg=";
+  };
+  # Korean
+  vscode-language-pack-ko = buildVscodeLanguagePack {
+    language = "ko";
+    sha256 = "sha256-QYFaxJz1PqKKIiLosLQ8Tu3JNXzpxLFqgIHjjRLwjA4=";
+  };
+  # Czech
+  vscode-language-pack-cs = buildVscodeLanguagePack {
+    language = "cs";
+    sha256 = "sha256-eMk+syy2h+Xb3k6QB8PqYaF4I1ydaY6eRsvOXmelh9Q=";
+  };
+  # Portuguese (Brazil)
+  vscode-language-pack-pt-br = buildVscodeLanguagePack {
+    language = "pt-BR";
+    sha256 = "sha256-7Trz38KBl4sD7608MvTs02pUsdD05oHEj3Sp1LvtI7I=";
+  };
+  # Turkish
+  vscode-language-pack-tr = buildVscodeLanguagePack {
+    language = "tr";
+    sha256 = "sha256-T4CTpbve3vrNdW4VDfHDg8U8cQEtuxPV5LvNdtKrqzA";
+  };
+  # Pseudo Language
+  vscode-language-pack-qps-ploc = buildVscodeLanguagePack {
+    language = "qps-ploc";
+    sha256 = "sha256-rPvCr3uQPfM8vwKoV7Un5aiMZClhf6TvG1PEe3xYNI0=";
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

resolves #139560 - adds non-English language packs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
