### PR TITLE
pulumi: 3.21.0 -> 3.22.0

### DIFF
--- a/pkgs/tools/admin/pulumi/data.nix
+++ b/pkgs/tools/admin/pulumi/data.nix
@@ -1,12 +1,12 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "3.21.0";
+  version = "3.22.1";
   pulumiPkgs = {
     x86_64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.21.0-linux-x64.tar.gz";
-        sha256 = "110ab7i3ynkjhbk10q150p7301prffk4xqma79rk28cxxvxf4kk3";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.22.1-linux-x64.tar.gz";
+        sha256 = "0yxjlkvyxap4c7ny5x0ch0j4d5360qapb670f6im7vnaqhc00by0";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.4.0-linux-amd64.tar.gz";
@@ -103,8 +103,8 @@
     ];
     x86_64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.21.0-darwin-x64.tar.gz";
-        sha256 = "0pd6jlrw2cc4g33kkl2dfqks5xicmc2bnbrf0cd2ymx9mdnkdaq8";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.22.1-darwin-x64.tar.gz";
+        sha256 = "0b68pfrd83x02rs2saybxycpkirjciilp4a94ps3788y1plinyih";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.4.0-darwin-amd64.tar.gz";
@@ -201,8 +201,8 @@
     ];
     aarch64-linux = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.21.0-linux-arm64.tar.gz";
-        sha256 = "0484hpbf25kfxac72r74h5rfp5r59hlkhzqib9vma3l1cz9icmyx";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.22.1-linux-arm64.tar.gz";
+        sha256 = "0551zp5n77jzh8k3jbqq75zj734faryxxdd2fvw881cxf95v39aj";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.4.0-linux-arm64.tar.gz";
@@ -296,8 +296,8 @@
     ];
     aarch64-darwin = [
       {
-        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.21.0-darwin-arm64.tar.gz";
-        sha256 = "01446r5q9a684k0z5b6d2a7gdjszy2816v09jdxkc54cg37fhmlz";
+        url = "https://get.pulumi.com/releases/sdk/pulumi-v3.22.1-darwin-arm64.tar.gz";
+        sha256 = "00jzqrnw6khbw5hsaqwi73hx9h3yxdhy2n3jn3h76az27wfjkhkz";
       }
       {
         url = "https://api.pulumi.com/releases/plugins/pulumi-resource-auth0-v2.4.0-darwin-arm64.tar.gz";

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -10,7 +10,7 @@ fi
 
 # Version of Pulumi from
 # https://www.pulumi.com/docs/get-started/install/versions/
-VERSION="3.21.0"
+VERSION="3.22.1"
 
 # An array of plugin names. The respective repository inside Pulumi's
 # Github organization is called pulumi-$name by convention.


### PR DESCRIPTION
- pulumi: 3.21.0 -> 3.22.1
- chore(pulumi): regenerate data.nix after version bump

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR bumps pulumi to the latest version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
