### PR TITLE
python3Packages.demjson: only run tests on Python 2

### DIFF
--- a/pkgs/development/python-modules/demjson/default.nix
+++ b/pkgs/development/python-modules/demjson/default.nix
@@ -1,25 +1,34 @@
-{ lib, python, buildPythonPackage, fetchPypi, isPy3k }:
+{ lib
+, python
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
 
 buildPythonPackage rec {
   pname = "demjson";
   version = "2.2.4";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0ygbddpnvp5lby6mr5kz60la3hkvwwzv3wwb3z0w9ngxl0w21pii";
   };
 
-  checkPhase = lib.optionalString isPy3k ''
-    ${python.interpreter} -m lib2to3 -w test/test_demjson.py
-  '' + ''
+  doCheck = !(isPy3k);
+
+  checkPhase = ''
     ${python.interpreter} test/test_demjson.py
   '';
+
+  pythonImportsCheck = [
+    "demjson"
+  ];
 
   meta = with lib; {
     description = "Encoder/decoder and lint/validator for JSON (JavaScript Object Notation)";
     homepage = "https://github.com/dmeranda/demjson";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ bjornfor ];
-    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/163434700)

This module is only used by `nixops` which itself is also not only for Python 2.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
