### PR TITLE
ronn: make manpages reproducible

### DIFF
--- a/pkgs/development/tools/ronn/default.nix
+++ b/pkgs/development/tools/ronn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bundlerEnv, bundlerUpdateScript, makeWrapper, groff }:
+{ stdenv, lib, bundlerEnv, bundlerUpdateScript, makeWrapper, groff, callPackage }:
 
 stdenv.mkDerivation rec {
   pname = "ronn";
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.updateScript = bundlerUpdateScript "ronn";
+
+  passthru.tests.reproducible-html-manpage = callPackage ./test-reproducible-html.nix { };
 
   meta = with lib; {
     description = "markdown-based tool for building manpages";

--- a/pkgs/development/tools/ronn/gemset.nix
+++ b/pkgs/development/tools/ronn/gemset.nix
@@ -22,6 +22,11 @@
       type = "gem";
     };
     version = "2.2.0.1";
+    # Disable randomized mangling to make ronn's outputs reproducible
+    dontBuild = false;
+    postPatch = ''
+      substituteInPlace ext/generate.c --replace '#if DEBIAN_GLITCH' '#if 1'
+    '';
   };
   ronn = {
     source = {

--- a/pkgs/development/tools/ronn/test-reproducible-html.nix
+++ b/pkgs/development/tools/ronn/test-reproducible-html.nix
@@ -1,0 +1,30 @@
+{ runCommand
+, diffutils
+, ronn
+}:
+runCommand "ronn-test-reproducible-html" { } ''
+  set -euo pipefail
+
+  cat > aprog.1.ronn << EOF
+  aprog
+  =====
+
+  ## AUTHORS
+
+  Vincent Haupert <veehaitch@users.noreply.github.com>
+  EOF
+
+  # We have to repeat the manpage generation a few times to be confident
+  # it is in fact reproducible.
+  for i in {1..20}; do
+    ${ronn}/bin/ronn --html --pipe aprog.1.ronn > aprog.1.html-1
+    ${ronn}/bin/ronn --html --pipe aprog.1.ronn > aprog.1.html-2
+
+    ${diffutils}/bin/diff -q aprog.1.html-1 aprog.1.html-2 \
+      || (printf 'The HTML manpage is not reproducible (round %d)' "$i" && exit 1)
+  done
+
+  echo 'The HTML manpage appears reproducible'
+
+  mkdir $out
+''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`ronn`'s dependency `rdiscount` uses a randomized mangle routine for
certain strings like the email address. As a result, `ronn`'s outputs
are not always reproducible; this particularly affects the HTML output.

This commit disables the randomized mangling in favor of a deterministic
approach. `rdiscount` has builtin support for this through the
`DEBIAN_GLITCH` flag.

Unfortunately, setting `buildFlags = [ "-DDEBIAN_GLITCH=1" ]` isn't
properly propagated to the (r)discount C code. Therefore, the commit
patches the source to achieve the same result.

Also adds a test to make sure the HTML output is in fact reproducible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
