### PR TITLE
gpgme: add patch for Python 3.10 support

### DIFF
--- a/pkgs/development/libraries/gpgme/support-python-310.patch
+++ b/pkgs/development/libraries/gpgme/support-python-310.patch
@@ -1,0 +1,373 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -425,11 +425,12 @@
+ 	if test "$found_py" = "1" -o "$found_py3" = "1"; then
+ 	  # Reset everything, so that we can look for another Python.
+           m4_foreach([mym4pythonver],
+-                     [[2.7],[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[all]],
++                     [[2.7],[3.4],[3.5],[3.6],[3.7],[3.8],[3.9],[3.10],[all]],
+            [unset PYTHON
+ 	    unset PYTHON_VERSION
+ 	    unset PYTHON_CPPFLAGS
+ 	    unset PYTHON_LDFLAGS
++	    unset PYTHON_LIBS
+ 	    unset PYTHON_SITE_PKG
+ 	    unset PYTHON_EXTRA_LIBS
+ 	    unset PYTHON_EXTRA_LDFLAGS
+diff --git a/m4/python.m4 b/m4/python.m4
+--- a/m4/python.m4
++++ b/m4/python.m4
+@@ -1,10 +1,10 @@
+ ## ------------------------                                 -*- Autoconf -*-
+ ## Python file handling
+ ## From Andrew Dalke
+-## Updated by James Henstridge
++## Updated by James Henstridge and other contributors.
+ ## Updated by Werner Koch 2018-10-17
+-## ---------------------------------
+-# Copyright (C) 1999-2017 Free Software Foundation, Inc.
++## ------------------------
++# Copyright (C) 1999-2021 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+ # gives unlimited permission to copy and/or distribute it,
+@@ -36,13 +36,12 @@
+ # numbers and dots only.
+ AC_DEFUN([AM_PATH_PYTHON],
+  [
+-  dnl Find a Python interpreter.  Python versions prior to 2.0 are not
+-  dnl supported. (2.0 was released on October 16, 2000).  Python 3.0
+-  dnl through to Python 3.9 are also not supported.
++  dnl Find a Python interpreter.  Python versions prior to 2.7 are not
++  dnl supported. Python 3.0 through to Python 3.3 are also not supported.
+   m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
+ [python2 python2.7 dnl
+  python dnl
+- python3 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4
++ python3 python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4
+  ])
+ 
+   AC_ARG_VAR([PYTHON], [the Python interpreter])
+@@ -85,34 +84,141 @@
+   ])
+ 
+   if test "$PYTHON" = :; then
+-  dnl Run any user-specified action, or abort.
++    dnl Run any user-specified action, or abort.
+     m4_default([$3], [AC_MSG_ERROR([no suitable Python interpreter found])])
+   else
+ 
+-  dnl Query Python for its version number.  Getting [:3] seems to be
+-  dnl the best way to do this; it's what "site.py" does in the standard
+-  dnl library.
+-
++  dnl Query Python for its version number.  Although site.py simply uses
++  dnl sys.version[:3], printing that failed with Python 3.10, since the
++  dnl trailing zero was eliminated. So now we output just the major
++  dnl and minor version numbers, as numbers. Apparently the tertiary
++  dnl version is not of interest.
++  dnl
+   AC_CACHE_CHECK([for $am_display_PYTHON version], [am_cv_python_version],
+-    [am_cv_python_version=`$PYTHON -c "import sys; sys.stdout.write(sys.version[[:3]])"`])
++    [am_cv_python_version=`$PYTHON -c "import sys; print ('%u.%u' % sys.version_info[[:2]])"`])
+   AC_SUBST([PYTHON_VERSION], [$am_cv_python_version])
+ 
+-  dnl Use the values of $prefix and $exec_prefix for the corresponding
+-  dnl values of PYTHON_PREFIX and PYTHON_EXEC_PREFIX.  These are made
+-  dnl distinct variables so they can be overridden if need be.  However,
+-  dnl general consensus is that you shouldn't need this ability.
+-
+-  AC_SUBST([PYTHON_PREFIX], ['${prefix}'])
+-  AC_SUBST([PYTHON_EXEC_PREFIX], ['${exec_prefix}'])
+-
+-  dnl At times (like when building shared libraries) you may want
++  dnl At times, e.g., when building shared libraries, you may want
+   dnl to know which OS platform Python thinks this is.
+-
++  dnl
+   AC_CACHE_CHECK([for $am_display_PYTHON platform], [am_cv_python_platform],
+     [am_cv_python_platform=`$PYTHON -c "import sys; sys.stdout.write(sys.platform)"`])
+   AC_SUBST([PYTHON_PLATFORM], [$am_cv_python_platform])
+ 
+-  # Just factor out some code duplication.
++  dnl emacs-page
++  dnl If --with-python-sys-prefix is given, use the values of sys.prefix
++  dnl and sys.exec_prefix for the corresponding values of PYTHON_PREFIX
++  dnl and PYTHON_EXEC_PREFIX. Otherwise, use the GNU ${prefix} and
++  dnl ${exec_prefix} variables.
++  dnl
++  dnl The two are made distinct variables so they can be overridden if
++  dnl need be, although general consensus is that you shouldn't need
++  dnl this separation.
++  dnl
++  dnl Also allow directly setting the prefixes via configure options,
++  dnl overriding any default.
++  dnl
++  if test "x$prefix" = xNONE; then
++    am__usable_prefix=$ac_default_prefix
++  else
++    am__usable_prefix=$prefix
++  fi
++
++  # Allow user to request using sys.* values from Python,
++  # instead of the GNU $prefix values.
++  AC_ARG_WITH([python-sys-prefix],
++  [AS_HELP_STRING([--with-python-sys-prefix],
++                  [use Python's sys.prefix and sys.exec_prefix values])],
++  [am_use_python_sys=:],
++  [am_use_python_sys=false])
++
++  # Allow user to override whatever the default Python prefix is.
++  AC_ARG_WITH([python_prefix],
++  [AS_HELP_STRING([--with-python_prefix],
++                  [override the default PYTHON_PREFIX])],
++  [am_python_prefix_subst=$withval
++   am_cv_python_prefix=$withval
++   AC_MSG_CHECKING([for explicit $am_display_PYTHON prefix])
++   AC_MSG_RESULT([$am_cv_python_prefix])],
++  [
++   if $am_use_python_sys; then
++     # using python sys.prefix value, not GNU
++     AC_CACHE_CHECK([for python default $am_display_PYTHON prefix],
++     [am_cv_python_prefix],
++     [am_cv_python_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`])
++
++     dnl If sys.prefix is a subdir of $prefix, replace the literal value of
++     dnl $prefix with a variable reference so it can be overridden.
++     case $am_cv_python_prefix in
++     $am__usable_prefix*)
++       am__strip_prefix=`echo "$am__usable_prefix" | sed 's|.|.|g'`
++       am_python_prefix_subst=`echo "$am_cv_python_prefix" | sed "s,^$am__strip_prefix,\\${prefix},"`
++       ;;
++     *)
++       am_python_prefix_subst=$am_cv_python_prefix
++       ;;
++     esac
++   else # using GNU prefix value, not python sys.prefix
++     am_python_prefix_subst='${prefix}'
++     am_python_prefix=$am_python_prefix_subst
++     AC_MSG_CHECKING([for GNU default $am_display_PYTHON prefix])
++     AC_MSG_RESULT([$am_python_prefix])
++   fi])
++  # Substituting python_prefix_subst value.
++  AC_SUBST([PYTHON_PREFIX], [$am_python_prefix_subst])
++
++  # emacs-page Now do it all over again for Python exec_prefix, but with yet
++  # another conditional: fall back to regular prefix if that was specified.
++  AC_ARG_WITH([python_exec_prefix],
++  [AS_HELP_STRING([--with-python_exec_prefix],
++                  [override the default PYTHON_EXEC_PREFIX])],
++  [am_python_exec_prefix_subst=$withval
++   am_cv_python_exec_prefix=$withval
++   AC_MSG_CHECKING([for explicit $am_display_PYTHON exec_prefix])
++   AC_MSG_RESULT([$am_cv_python_exec_prefix])],
++  [
++   # no explicit --with-python_exec_prefix, but if
++   # --with-python_prefix was given, use its value for python_exec_prefix too.
++   AS_IF([test -n "$with_python_prefix"],
++   [am_python_exec_prefix_subst=$with_python_prefix
++    am_cv_python_exec_prefix=$with_python_prefix
++    AC_MSG_CHECKING([for python_prefix-given $am_display_PYTHON exec_prefix])
++    AC_MSG_RESULT([$am_cv_python_exec_prefix])],
++   [
++    # Set am__usable_exec_prefix whether using GNU or Python values,
++    # since we use that variable for pyexecdir.
++    if test "x$exec_prefix" = xNONE; then
++      am__usable_exec_prefix=$am__usable_prefix
++    else
++      am__usable_exec_prefix=$exec_prefix
++    fi
++    #
++    if $am_use_python_sys; then # using python sys.exec_prefix, not GNU
++      AC_CACHE_CHECK([for python default $am_display_PYTHON exec_prefix],
++      [am_cv_python_exec_prefix],
++      [am_cv_python_exec_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.exec_prefix)"`])
++      dnl If sys.exec_prefix is a subdir of $exec_prefix, replace the
++      dnl literal value of $exec_prefix with a variable reference so it can
++      dnl be overridden.
++      case $am_cv_python_exec_prefix in
++      $am__usable_exec_prefix*)
++        am__strip_prefix=`echo "$am__usable_exec_prefix" | sed 's|.|.|g'`
++        am_python_exec_prefix_subst=`echo "$am_cv_python_exec_prefix" | sed "s,^$am__strip_prefix,\\${exec_prefix},"`
++        ;;
++      *)
++        am_python_exec_prefix_subst=$am_cv_python_exec_prefix
++        ;;
++     esac
++   else # using GNU $exec_prefix, not python sys.exec_prefix
++     am_python_exec_prefix_subst='${exec_prefix}'
++     am_python_exec_prefix=$am_python_exec_prefix_subst
++     AC_MSG_CHECKING([for GNU default $am_display_PYTHON exec_prefix])
++     AC_MSG_RESULT([$am_python_exec_prefix])
++   fi])])
++  # Substituting python_exec_prefix_subst.
++  AC_SUBST([PYTHON_EXEC_PREFIX], [$am_python_exec_prefix_subst])
++
++  # Factor out some code duplication into this shell variable.
+   am_python_setup_sysconfig="\
+ import sys
+ # Prefer sysconfig over distutils.sysconfig, for better compatibility
+@@ -132,96 +238,95 @@
+ except ImportError:
+     pass"
+ 
+-  dnl Set up 4 directories:
++  dnl emacs-page Set up 4 directories:
+ 
+-  dnl pythondir -- where to install python scripts.  This is the
+-  dnl   site-packages directory, not the python standard library
+-  dnl   directory like in previous automake betas.  This behavior
+-  dnl   is more consistent with lispdir.m4 for example.
++  dnl 1. pythondir: where to install python scripts.  This is the
++  dnl    site-packages directory, not the python standard library
++  dnl    directory like in previous automake betas.  This behavior
++  dnl    is more consistent with lispdir.m4 for example.
+   dnl Query distutils for this directory.
+-  AC_CACHE_CHECK([for $am_display_PYTHON script directory],
+-    [am_cv_python_pythondir],
+-    [if test "x$prefix" = xNONE
+-     then
+-       am_py_prefix=$ac_default_prefix
+-     else
+-       am_py_prefix=$prefix
+-     fi
+-     am_cv_python_pythondir=`$PYTHON -c "
++  dnl
++  AC_CACHE_CHECK([for $am_display_PYTHON script directory (pythondir)],
++  [am_cv_python_pythondir],
++  [if test "x$am_cv_python_prefix" = x; then
++     am_py_prefix=$am__usable_prefix
++   else
++     am_py_prefix=$am_cv_python_prefix
++   fi
++   am_cv_python_pythondir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('purelib', vars={'base':'$am_py_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(0, 0, prefix='$am_py_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pythondir in
+-     $am_py_prefix*)
+-       am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,$PYTHON_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	  am_cv_python_pythondir=$PYTHON_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	  ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pythondir in
++   $am_py_prefix*)
++     am__strip_prefix=`echo "$am_py_prefix" | sed 's|.|.|g'`
++     am_cv_python_pythondir=`echo "$am_cv_python_pythondir" | sed "s,^$am__strip_prefix,\\${PYTHON_PREFIX},"`
++     ;;
++   *)
++     case $am_py_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pythondir="\${PYTHON_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
+-    ])
++     ;;
++   esac
++  ])
+   AC_SUBST([pythondir], [$am_cv_python_pythondir])
+ 
+-  dnl pkgpythondir -- $PACKAGE directory under pythondir.  Was
+-  dnl   PYTHON_SITE_PACKAGE in previous betas, but this naming is
+-  dnl   more consistent with the rest of automake.
+-
++  dnl 2. pkgpythondir: $PACKAGE directory under pythondir.  Was
++  dnl    PYTHON_SITE_PACKAGE in previous betas, but this naming is
++  dnl    more consistent with the rest of automake.
++  dnl
+   AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE])
+ 
+-  dnl pyexecdir -- directory for installing python extension modules
+-  dnl   (shared libraries)
++  dnl 3. pyexecdir: directory for installing python extension modules
++  dnl    (shared libraries).
+   dnl Query distutils for this directory.
+-  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory],
+-    [am_cv_python_pyexecdir],
+-    [if test "x$exec_prefix" = xNONE
+-     then
+-       am_py_exec_prefix=$am_py_prefix
+-     else
+-       am_py_exec_prefix=$exec_prefix
+-     fi
+-     am_cv_python_pyexecdir=`$PYTHON -c "
++  dnl
++  AC_CACHE_CHECK([for $am_display_PYTHON extension module directory (pyexecdir)],
++  [am_cv_python_pyexecdir],
++  [if test "x$am_cv_python_exec_prefix" = x; then
++     am_py_exec_prefix=$am__usable_exec_prefix
++   else
++     am_py_exec_prefix=$am_cv_python_exec_prefix
++   fi
++   am_cv_python_pyexecdir=`$PYTHON -c "
+ $am_python_setup_sysconfig
+ if can_use_sysconfig:
+-    sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_prefix'})
++  sitedir = sysconfig.get_path('platlib', vars={'platbase':'$am_py_exec_prefix'})
+ else:
+-    from distutils import sysconfig
+-    sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_prefix')
++  from distutils import sysconfig
++  sitedir = sysconfig.get_python_lib(1, 0, prefix='$am_py_exec_prefix')
+ sys.stdout.write(sitedir)"`
+-     case $am_cv_python_pyexecdir in
+-     $am_py_exec_prefix*)
+-       am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
+-       am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,$PYTHON_EXEC_PREFIX,"`
+-       ;;
+-     *)
+-       case $am_py_exec_prefix in
+-         /usr|/System*) ;;
+-         *)
+-	   am_cv_python_pyexecdir=$PYTHON_EXEC_PREFIX/lib/python$PYTHON_VERSION/site-packages
+-	   ;;
+-       esac
+-       ;;
++   #
++   case $am_cv_python_pyexecdir in
++   $am_py_exec_prefix*)
++     am__strip_prefix=`echo "$am_py_exec_prefix" | sed 's|.|.|g'`
++     am_cv_python_pyexecdir=`echo "$am_cv_python_pyexecdir" | sed "s,^$am__strip_prefix,\\${PYTHON_EXEC_PREFIX},"`
++     ;;
++   *)
++     case $am_py_exec_prefix in
++       /usr|/System*) ;;
++       *) am_cv_python_pyexecdir="\${PYTHON_EXEC_PREFIX}/lib/python$PYTHON_VERSION/site-packages"
++          ;;
+      esac
+-    ])
++     ;;
++   esac
++  ])
+   AC_SUBST([pyexecdir], [$am_cv_python_pyexecdir])
+ 
+-  dnl pkgpyexecdir -- $(pyexecdir)/$(PACKAGE)
+-
++  dnl 4. pkgpyexecdir: $(pyexecdir)/$(PACKAGE)
++  dnl
+   AC_SUBST([pkgpyexecdir], [\${pyexecdir}/$PACKAGE])
+ 
+   dnl Run any user-specified action.
+   $2
+   fi
+-
+ ])
+ 
+ 
+

--- a/pkgs/development/python-modules/check-manifest/default.nix
+++ b/pkgs/development/python-modules/check-manifest/default.nix
@@ -8,21 +8,20 @@
 , pep517
 , pytestCheckHook
 , toml
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "check-manifest";
   version = "0.47";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "56dadd260a9c7d550b159796d2894b6d0bcc176a94cbc426d9bb93e5e48d12ce";
+    hash = "sha256-VtrdJgqcfVULFZeW0olLbQvMF2qUy8Qm2buT5eSNEs4=";
   };
-
-  # Test requires filesystem access
-  postPatch = ''
-    substituteInPlace tests.py --replace "test_build_sdist" "no_test_build_sdist"
-  '';
 
   propagatedBuildInputs = [
     build
@@ -37,11 +36,18 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "check_manifest" ];
+  disabledTests = [
+    # Test wants to setup a venv
+    "test_build_sdist_pep517_isolated"
+  ];
+
+  pythonImportsCheck = [
+    "check_manifest"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/mgedmin/check-manifest";
     description = "Check MANIFEST.in in a Python source package for completeness";
+    homepage = "https://github.com/mgedmin/check-manifest";
     license = licenses.mit;
     maintainers = with maintainers; [ lewo ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/164507537)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
