### PR TITLE
net-snmp: General fixup

### DIFF
--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -1,7 +1,14 @@
 { lib, stdenv, fetchurl, fetchpatch, autoreconfHook, removeReferencesTo
-, file, openssl, perl, perlPackages, unzip, nettools, ncurses }:
+, file, openssl, perl, perlPackages, nettools, gnused
+, withPerlTools ? false }: let
 
-stdenv.mkDerivation rec {
+  perlWithPkgs = perl.withPackages (ps: with ps; [
+    JSON
+    TermReadKey
+    Tk
+  ]);
+
+in stdenv.mkDerivation rec {
   pname = "net-snmp";
   version = "5.9.1";
 
@@ -37,8 +44,9 @@ stdenv.mkDerivation rec {
     substituteInPlace testing/fulltests/support/simple_TESTCONF.sh --replace "/bin/netstat" "${nettools}/bin/netstat"
   '';
 
-  nativeBuildInputs = [ autoreconfHook nettools removeReferencesTo unzip ];
-  buildInputs = with perlPackages; [ file perl openssl ncurses JSON Tk TermReadKey ];
+  nativeBuildInputs = [ autoreconfHook nettools removeReferencesTo gnused file ];
+  buildInputs = [ openssl ]
+    ++ lib.optional withPerlTools perlWithPkgs;
 
   enableParallelBuilding = true;
   doCheck = false;  # tries to use networking
@@ -56,7 +64,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Clients and server for the SNMP network monitoring protocol";
-    homepage = "http://net-snmp.sourceforge.net/";
+    homepage = "http://www.net-snmp.org/";
     license = licenses.bsd3;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
- Remove unused inputs (unzip, ncurses)
- Make some buildInputs native
- Fix website
- Wrap the needed perl libraries using `withPackages`
- Make Perl support optional and disable it by default because it didn't
  work previously because net-snmp is built without its perl modules
  (the SNMP module to be specific) which the perl tools need

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux via pkgsCross
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
