### PR TITLE
matrix-synapse-shared-secret-auth: 1.0.2 -> 2.0.1

### DIFF
--- a/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
+++ b/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
@@ -1,18 +1,19 @@
-{ buildPythonPackage, fetchFromGitHub, twisted }:
+{ buildPythonPackage, fetchFromGitHub, matrix-synapse, twisted }:
 
 buildPythonPackage rec {
   pname = "matrix-synapse-shared-secret-auth";
-  version = "1.0.2";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "devture";
     repo = "matrix-synapse-shared-secret-auth";
     rev = version;
-    sha256 = "0cnxp3bp8mmk01a0g3lzgvaawyywjg754j4nb9iwkmm3c2nqvnpz";
+    sha256 = "sha256-kaok5IwKx97FYDrVIGAtUJfExqDln5vxEKrZda2RdzE=";
   };
 
   doCheck = false;
   pythonImportsCheck = [ "shared_secret_authenticator" ];
 
+  buildInputs = [ matrix-synapse ];
   propagatedBuildInputs = [ twisted ];
 }

--- a/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
+++ b/pkgs/servers/matrix-synapse/plugins/shared-secret-auth.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchFromGitHub, matrix-synapse, twisted }:
+{ lib, buildPythonPackage, fetchFromGitHub, matrix-synapse, twisted }:
 
 buildPythonPackage rec {
   pname = "matrix-synapse-shared-secret-auth";
@@ -16,4 +16,11 @@ buildPythonPackage rec {
 
   buildInputs = [ matrix-synapse ];
   propagatedBuildInputs = [ twisted ];
+
+  meta = with lib; {
+    description = "Shared Secret Authenticator password provider module for Matrix Synapse";
+    homepage = "https://github.com/devture/matrix-synapse-shared-secret-auth";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ sumnerevans ];
+  };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/devture/matrix-synapse-shared-secret-auth/releases/tag/2.0.1

Also adds me as maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
