### PR TITLE
apt-cacher-ng: 3.6.3 -> 3.7.4

### DIFF
--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -11,19 +11,20 @@
 , systemd
 , tcp_wrappers
 , zlib
+, c-ares
 }:
 
 stdenv.mkDerivation rec {
   pname = "apt-cacher-ng";
-  version = "3.6.3";
+  version = "3.7.4";
 
   src = fetchurl {
     url = "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
-    sha256 = "sha256-P4ArWpxjOjBi9EiDp/ord17GfUOFwpiTKGvSEuZljGA=";
+    sha256 = "0pwsj9rf6a6q7cnfbpcrfq2gjcy7sylqzqqr49g2zi39lrrh8533";
   };
 
   nativeBuildInputs = [ cmake doxygen pkg-config ];
-  buildInputs = [ bzip2 fuse libevent xz openssl systemd tcp_wrappers zlib ];
+  buildInputs = [ bzip2 fuse libevent xz openssl systemd tcp_wrappers zlib c-ares ];
 
   meta = with lib; {
     description = "A caching proxy specialized for linux distribution files";

--- a/pkgs/servers/http/apt-cacher-ng/default.nix
+++ b/pkgs/servers/http/apt-cacher-ng/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "3.7.4";
 
   src = fetchurl {
-    url = "http://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
+    url = "https://ftp.debian.org/debian/pool/main/a/apt-cacher-ng/apt-cacher-ng_${version}.orig.tar.xz";
     sha256 = "0pwsj9rf6a6q7cnfbpcrfq2gjcy7sylqzqqr49g2zi39lrrh8533";
   };
 
@@ -27,9 +27,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ bzip2 fuse libevent xz openssl systemd tcp_wrappers zlib c-ares ];
 
   meta = with lib; {
-    description = "A caching proxy specialized for linux distribution files";
+    description = "A caching proxy specialized for Linux distribution files";
     homepage = "https://www.unix-ag.uni-kl.de/~bloch/acng/";
-    license = licenses.gpl2;
+    license = licenses.bsdOriginal;
     platforms = platforms.linux;
     maintainers = [ maintainers.makefu ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bumping outdated packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
