### PR TITLE
python3Packages.mwdblib: 3.4.1 -> 4.1.0

### DIFF
--- a/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
+++ b/pkgs/development/python-modules/karton-mwdb-reporter/default.nix
@@ -3,17 +3,21 @@
 , fetchFromGitHub
 , karton-core
 , mwdblib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "karton-mwdb-reporter";
-  version = "1.0.1";
+  version = "unstable-2022-02-22";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "0jrn5c83nhcjny4bc879wrsgcr7mbazm51jzdkxmxyqf543cc841";
+    rev = "1afa32251b4826eac4386596b4a20f295699faec";
+    hash = "sha256-dbtIjWSNIRMccrGJspZMOBUD2EzuvW7xESlEwiOhKfQ=";
   };
 
   propagatedBuildInputs = [
@@ -21,14 +25,12 @@ buildPythonPackage rec {
     mwdblib
   ];
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "mwdblib==3.4.0" "mwdblib"
-  '';
-
   # Project has no tests
   doCheck = false;
-  pythonImportsCheck = [ "karton.mwdb_reporter" ];
+
+  pythonImportsCheck = [
+    "karton.mwdb_reporter"
+  ];
 
   meta = with lib; {
     description = "Karton service that uploads analyzed artifacts and metadata to MWDB Core";

--- a/pkgs/development/python-modules/mwdblib/default.nix
+++ b/pkgs/development/python-modules/mwdblib/default.nix
@@ -8,18 +8,22 @@
 , keyring
 , python
 , python-dateutil
+, pythonOlder
 , requests
 }:
 
 buildPythonPackage rec {
   pname = "mwdblib";
-  version = "3.4.1";
+  version = "4.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-jCtK3Fk725EaA26GG6j6xqEMFH4Qq92QWrJ7sxcWRaY=";
+    sha256 = "sha256-HwJLXcYWmrEJxX2asicmM8p55ZHNS+ut3pVvOxQoNoI=";
   };
 
   propagatedBuildInputs = [
@@ -38,7 +42,9 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
-  pythonImportsCheck = [ "mwdblib" ];
+  pythonImportsCheck = [
+    "mwdblib"
+  ];
 
   meta = with lib; {
     description = "Python client library for the mwdb service";

--- a/pkgs/development/python-modules/mwdblib/default.nix
+++ b/pkgs/development/python-modules/mwdblib/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "mwdblib";
-  version = "4.0.0";
+  version = "4.1.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "CERT-Polska";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HwJLXcYWmrEJxX2asicmM8p55ZHNS+ut3pVvOxQoNoI=";
+    sha256 = "sha256-afqE6zL1uwsLNAuy5XY7OduP1e3W2ueteOOVaFJg3b0=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/CERT-Polska/mwdblib/releases/tag/v4.1.0
https://github.com/CERT-Polska/mwdblib/releases/tag/v4.0.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
