### PR TITLE
element: 1.9.8 -> 1.9.9

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -22,7 +22,7 @@
     "lint": "yarn lint:types && yarn lint:js",
     "lint:js": "eslint --max-warnings 0 src scripts hak",
     "lint:js-fix": "eslint --fix src scripts hak",
-    "lint:types": "tsc --noEmit",
+    "lint:types": "tsc --noEmit && tsc -p scripts/hak/tsconfig.json --noEmit && tsc -p hak/tsconfig.json --noEmit",
     "build:native": "yarn run hak",
     "build:native:universal": "yarn run hak --target x86_64-apple-darwin fetchandbuild && yarn run hak --target aarch64-apple-darwin fetchandbuild && yarn run hak --target x86_64-apple-darwin --target aarch64-apple-darwin copyandlink",
     "build:32": "yarn run build:ts && yarn run build:res && electron-builder --ia32",
@@ -37,7 +37,7 @@
     "docker:install": "scripts/in-docker.sh yarn install",
     "debrepo": "scripts/mkrepo.sh",
     "clean": "rimraf webapp.asar dist packages deploys lib",
-    "hak": "node scripts/hak/index.js"
+    "hak": "ts-node scripts/hak/index.ts"
   },
   "dependencies": {
     "auto-launch": "^5.0.5",
@@ -52,6 +52,9 @@
     "@types/auto-launch": "^5.0.1",
     "@types/counterpart": "^0.18.1",
     "@types/minimist": "^1.2.1",
+    "@types/mkdirp": "^1.0.2",
+    "@types/pacote": "^11.1.1",
+    "@types/rimraf": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "allchange": "^1.0.6",
@@ -76,6 +79,7 @@
     "pacote": "^11.3.5",
     "rimraf": "^3.0.2",
     "tar": "^6.1.2",
+    "ts-node": "^10.4.0",
     "typescript": "^4.5.3"
   },
   "hakDependencies": {

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.9.8",
-  "desktopSrcHash": "o6SICu7QDdBv9WXDconkypQRj3TbrU4ZAxayO9yemvc=",
-  "desktopYarnHash": "176ih0nzzx2yds6kp3lzdsrlp0glb9nqw146z0s1az7pjp6nrf18",
-  "webHash": "141fqvh4d5lwm692yc8mfwrlvqnfixvc7vlbfis86qi557vq6ljq"
+  "version": "1.9.9",
+  "desktopSrcHash": "IMqco5HeAgsh1LMBXFH1/HnlIEFEQU0xqnHbTKwHGL4=",
+  "desktopYarnHash": "0zzr14fcyc5q2562x50nvxxda10yr5ihbr12nykzg4j534rgb55y",
+  "webHash": "1i3zka9cfn14rv5wzz969w6dz5dbkw87clrgajs8p1s2l62ac1jf"
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/vector-im/element-desktop/releases/tag/v1.9.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
