### PR TITLE
nixos/virtualisation/linode-image: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5446,6 +5446,13 @@
     githubId = 25618740;
     name = "Vincent Cui";
   };
+  houstdav000 = {
+    email = "houstdav000@gmail.com";
+    github = "houstdav000";
+    githubId = 17628961;
+    matrix = "@houstdav000:gh0st.ems.host";
+    name = "David Houston";
+  };
   hoverbear = {
     email = "operator+nix@hoverbear.org";
     matrix = "@hoverbear:matrix.org";

--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -137,6 +137,13 @@
       </listitem>
       <listitem>
         <para>
+          An image configuration and generator has been added for Linode
+          images, largely based on the present GCE configuration and
+          image.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>hardware.nvidia</literal> has a new option
           <literal>open</literal> that can be used to opt in the
           opensource version of NVIDIA kernel driver. Note that the

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -55,6 +55,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - OpenSSL now defaults to OpenSSL 3, updated from 1.1.1.
 
+- An image configuration and generator has been added for Linode images, largely based on the present GCE configuration and image.
+
 - `hardware.nvidia` has a new option `open` that can be used to opt in the opensource version of NVIDIA kernel driver. Note that the driver's support for GeForce and Workstation GPUs is still alpha quality, see [NVIDIA Releases Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-releases-open-source-gpu-kernel-modules/) for the official announcement.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -1,0 +1,77 @@
+{ config, lib, pkgs, ... }:
+with lib;
+{
+  imports = [ ../profiles/qemu-guest.nix ];
+
+  ### Allow Root logins only using SSH keys
+  services.openssh = {
+    enable = true;
+
+    permitRootLogin = "prohibit-password";
+    passwordAuthentication = mkDefault false;
+  };
+
+  ### Set networking config
+  #
+  networking = {
+    usePredictableInterfaceNames = false;
+    useDHCP = false;
+    interfaces.eth0.useDHCP = true;
+  };
+
+  ### Install diagnostic tools for Linode support
+  #
+  environment.systemPackages = with pkgs; [
+    inetutils
+    mtr
+    sysstat
+  ];
+
+  fileSystems."/" = {
+    fsType = "ext4";
+    device = "/dev/sda";
+    autoResize = true;
+  };
+
+  swapDevices = mkDefault [{ device = "/dev/sdb"; }];
+
+  ### Enable LISH and Linode Booting w/ GRUB
+  #
+  boot = {
+    ### Add Required Kernel Modules
+    # NOTE: These are not documented in the install guide
+    #
+    initrd.availableKernelModules = [
+      "virtio_pci"
+      "virtio_scsi"
+      "ahci"
+      "sd_mod"
+    ];
+
+    ### Set Up LISH Serial Connection
+    #
+    kernelParams = [ "console=ttyS0,19200n8" ];
+    kernelModules = [ "virtio_net" ];
+
+    loader = {
+      ### Increase Timeout to Allow LISH Connection
+      # NOTE: The image generator tries to set a timeout of 0, so we must force
+      #
+      timeout = lib.mkForce 10;
+
+      grub = {
+        enable = true;
+        version = 2;
+        forceInstall = true;
+        device = "nodev";
+
+        # Allow serial connection for GRUB to be able to use LISH
+        extraConfig = ''
+          serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
+          terminal_input serial;
+          terminal_output serial
+        '';
+      };
+    };
+  };
+}

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -3,7 +3,7 @@ with lib;
 {
   imports = [ ../profiles/qemu-guest.nix ];
 
-  ### Allow Root logins only using SSH keys
+  # Allow Root logins only using SSH keys
   services.openssh = {
     enable = true;
 
@@ -11,16 +11,14 @@ with lib;
     passwordAuthentication = mkDefault false;
   };
 
-  ### Set networking config
-  #
+  # Set networking config
   networking = {
     usePredictableInterfaceNames = false;
     useDHCP = false;
     interfaces.eth0.useDHCP = true;
   };
 
-  ### Install diagnostic tools for Linode support
-  #
+  # Install diagnostic tools for Linode support
   environment.systemPackages = with pkgs; [
     inetutils
     mtr
@@ -35,12 +33,10 @@ with lib;
 
   swapDevices = mkDefault [{ device = "/dev/sdb"; }];
 
-  ### Enable LISH and Linode Booting w/ GRUB
-  #
+  # Enable LISH and Linode Booting w/ GRUB
   boot = {
-    ### Add Required Kernel Modules
+    # Add Required Kernel Modules
     # NOTE: These are not documented in the install guide
-    #
     initrd.availableKernelModules = [
       "virtio_pci"
       "virtio_scsi"
@@ -48,15 +44,13 @@ with lib;
       "sd_mod"
     ];
 
-    ### Set Up LISH Serial Connection
-    #
+    # Set Up LISH Serial Connection
     kernelParams = [ "console=ttyS0,19200n8" ];
     kernelModules = [ "virtio_net" ];
 
     loader = {
-      ### Increase Timeout to Allow LISH Connection
+      # Increase Timeout to Allow LISH Connection
       # NOTE: The image generator tries to set a timeout of 0, so we must force
-      #
       timeout = lib.mkForce 10;
 
       grub = {

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -3,7 +3,6 @@ with lib;
 {
   imports = [ ../profiles/qemu-guest.nix ];
 
-  # Allow Root logins only using SSH keys
   services.openssh = {
     enable = true;
 
@@ -11,7 +10,6 @@ with lib;
     passwordAuthentication = mkDefault false;
   };
 
-  # Set networking config
   networking = {
     usePredictableInterfaceNames = false;
     useDHCP = false;

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -13,7 +13,13 @@ with lib;
   networking = {
     usePredictableInterfaceNames = false;
     useDHCP = false;
-    interfaces.eth0.useDHCP = true;
+    interfaces.eth0 = {
+      useDHCP = true;
+
+      # Linode expects IPv6 privacy extensions to be disabled, so disable them
+      # See: https://www.linode.com/docs/guides/manual-network-configuration/#static-vs-dynamic-addressing
+      tempAddress = "disabled";
+    };
   };
 
   # Install diagnostic tools for Linode support

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -61,4 +61,6 @@ in
       inherit config lib pkgs;
     };
   };
+
+  meta.maintainers = with maintainers; [ houstdav000 ];
 }

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -36,7 +36,7 @@ in
     };
 
     virtualisation.linodeImage.compressionLevel = mkOption {
-      type = types.int;
+      type = types.ints.between 1 9;
       default = 6;
       description = ''
         GZIP compression level of the resulting disk image (1-9).

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -16,7 +16,7 @@ in
 
   options = {
     virtualisation.linodeImage.diskSize = mkOption {
-      type = with types; either (enum (singleton "auto")) int;
+      type = with types; either (enum (singleton "auto")) ints.positive;
       default = "auto";
       example = 1536;
       description = ''

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -1,0 +1,63 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.virtualisation.linodeImage;
+  defaultConfigFile = pkgs.writeText "configuration.nix" ''
+    _: {
+      imports = [
+        <nixpkgs/nixos/modules/virtualisation/linode-image.nix>
+      ];
+    }
+  '';
+in
+{
+  imports = [ ./linode-config.nix ];
+
+  options = {
+    virtualisation.linodeImage.diskSize = mkOption {
+      type = with types; either (enum (singleton "auto")) int;
+      default = "auto";
+      example = 1536;
+      description = ''
+        Size of disk image in MB.
+      '';
+    };
+
+    virtualisation.linodeImage.configFile = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        A path to a configuration file which will be placed at `/etc/nixos/configuration.nix`
+        and be used when switching to a new configuration.
+        If set to `null`, a default configuration is used, where the only import is
+        `<nixpkgs/nixos/modules/virtualisation/linode-image.nix>`
+      '';
+    };
+
+    virtualisation.linodeImage.compressionLevel = mkOption {
+      type = types.int;
+      default = 6;
+      description = ''
+        GZIP compression level of the resulting disk image (1-9).
+      '';
+    };
+  };
+
+  config = {
+    system.build.linodeImage = import ../../lib/make-disk-image.nix {
+      name = "linode-image";
+      postVM = ''
+        PATH=$PATH:${with pkgs; lib.makeBinPath [ gzip ]}
+        gzip -${toString cfg.compressionLevel} -c -- $diskImage > \
+        $out/nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img.gz
+        rm $diskImage
+      '';
+      format = "raw";
+      partitionTableType = "none";
+      configFile = if cfg.configFile == null then defaultConfigFile else cfg.configFile;
+      inherit (cfg) diskSize;
+      inherit config lib pkgs;
+    };
+  };
+}

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -48,8 +48,7 @@ in
     system.build.linodeImage = import ../../lib/make-disk-image.nix {
       name = "linode-image";
       postVM = ''
-        PATH=$PATH:${with pkgs; lib.makeBinPath [ gzip ]}
-        gzip -${toString cfg.compressionLevel} -c -- $diskImage > \
+        ${pkgs.gzip}/bin/gzip -${toString cfg.compressionLevel} -c -- $diskImage > \
         $out/nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img.gz
         rm $diskImage
       '';

--- a/nixos/modules/virtualisation/linode-image.nix
+++ b/nixos/modules/virtualisation/linode-image.nix
@@ -47,6 +47,8 @@ in
   config = {
     system.build.linodeImage = import ../../lib/make-disk-image.nix {
       name = "linode-image";
+      # NOTE: Linode specifically requires images to be `gzip`-ed prior to upload
+      # See: https://www.linode.com/docs/products/tools/images/guides/upload-an-image/#requirements-and-considerations
       postVM = ''
         ${pkgs.gzip}/bin/gzip -${toString cfg.compressionLevel} -c -- $diskImage > \
         $out/nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img.gz


### PR DESCRIPTION
Create both a configuration and image definition file for Linode, which
uses a QEMU-based configuration but without partition tables for some
reason. Largely bases most of the configuration and image generation on the current GCE configuration.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to easily be able to use NixOS in Linode, so I wrote a configuration and image builder configuration for it. It seems to work based on my testing of local building and pushing and running a simple image in Linode and doing so with Terranix.

Will require adding an interface to [nix-community/nixos-generators](https://github.com/nix-community/nixos-generators), but I can pr one easily with this added to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
