### PR TITLE
vimPlugins: Add a few (n)vim plugins

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -4353,6 +4353,18 @@ final: prev:
     meta.homepage = "https://github.com/norcalli/nvim-colorizer.lua/";
   };
 
+  nvim-comment = buildVimPluginFrom2Nix {
+    pname = "nvim-comment";
+    version = "2022-01-04";
+    src = fetchFromGitHub {
+      owner = "terrortylor";
+      repo = "nvim-comment";
+      rev = "f670649da497de12aa3d5afc0a693d5d50b17d85";
+      sha256 = "0j3pay000yf79lz5plcnfp068fychnf7xa08cg7h5s0nx5cp5bgh";
+    };
+    meta.homepage = "https://github.com/terrortylor/nvim-comment/";
+  };
+
   nvim-compe = buildVimPluginFrom2Nix {
     pname = "nvim-compe";
     version = "2021-10-02";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -6085,6 +6085,19 @@ final: prev:
     meta.homepage = "https://github.com/keith/swift.vim/";
   };
 
+  switch-vim = buildVimPluginFrom2Nix {
+    pname = "switch.vim";
+    version = "2021-09-29";
+    src = fetchFromGitHub {
+      owner = "AndrewRadev";
+      repo = "switch.vim";
+      rev = "900c5d3ee79b1771c5e07bf7290068ea35881756";
+      sha256 = "0fqvwlf01v7bpsmb3ssqw1kbpvfrk7qvrwxsy4y1bnm60kvnqb7a";
+      fetchSubmodules = true;
+    };
+    meta.homepage = "https://github.com/AndrewRadev/switch.vim/";
+  };
+
   symbols-outline-nvim = buildVimPluginFrom2Nix {
     pname = "symbols-outline.nvim";
     version = "2021-12-09";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -3549,6 +3549,18 @@ final: prev:
     meta.homepage = "https://github.com/shaunsingh/moonlight.nvim/";
   };
 
+  Navigator-nvim = buildVimPluginFrom2Nix {
+    pname = "Navigator.nvim";
+    version = "2021-11-18";
+    src = fetchFromGitHub {
+      owner = "numToStr";
+      repo = "Navigator.nvim";
+      rev = "f7b689d72649e1d5132116c76ac2ad8b97c210d4";
+      sha256 = "17yfc7ss9yslf8dvwl0vi3mdpcxp5j1g6dc8qrz20v2dx8hjxd1q";
+    };
+    meta.homepage = "https://github.com/numToStr/Navigator.nvim/";
+  };
+
   ncm2 = buildVimPluginFrom2Nix {
     pname = "ncm2";
     version = "2021-10-08";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -531,6 +531,18 @@ final: prev:
     meta.homepage = "https://github.com/yunlingz/ci_dark/";
   };
 
+  circles-nvim = buildVimPluginFrom2Nix {
+    pname = "circles.nvim";
+    version = "2022-01-11";
+    src = fetchFromGitHub {
+      owner = "projekt0n";
+      repo = "circles.nvim";
+      rev = "3847feed23fa3ba6abecdf1b17a6c7d2022ebe65";
+      sha256 = "1wxfix1fd8qwflc7id3g0yr7838j4vgnrk1nixv5q99d7wj0hadr";
+    };
+    meta.homepage = "https://github.com/projekt0n/circles.nvim/";
+  };
+
   clang_complete = buildVimPluginFrom2Nix {
     pname = "clang_complete";
     version = "2020-09-18";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -557,6 +557,7 @@ ntpeters/vim-better-whitespace
 numirias/semshi
 numtostr/comment.nvim
 numToStr/FTerm.nvim
+numToStr/Navigator.nvim
 nvie/vim-flake8
 nvim-lua/completion-nvim
 nvim-lua/diagnostic-nvim

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -23,6 +23,7 @@ andrep/vimacs
 andreshazard/vim-logreview
 AndrewRadev/sideways.vim
 AndrewRadev/splitjoin.vim
+AndrewRadev/switch.vim
 AndrewRadev/tagalong.vim
 andsild/peskcolor.vim
 andviro/flake8-vim

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -633,6 +633,7 @@ preservim/vim-pencil
 preservim/vim-wordy
 preservim/vimux
 prettier/vim-prettier
+projekt0n/circles.nvim
 psliwka/vim-smoothie
 ptzz/lf.vim
 puremourning/vimspector

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -777,6 +777,7 @@ tami5/sqlite.lua
 tbastos/vim-lua
 tbodt/deoplete-tabnine
 ternjs/tern_for_vim
+terrortylor/nvim-comment
 terryma/vim-expand-region
 terryma/vim-multiple-cursors
 tex/vimpreviewpandoc


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds the following (n)vim plugins:

 - [AndrewRadev/switch.vim](https://github.com/AndrewRadev/switch.vim)
 - [numToStr/Navigator.nvim](https://github.com/numToStr/Navigator.nvim)
 - [projekt0n/circles.nvim](https://github.com/projekt0n/circles.nvim)
 - [terrortylor/nvim-comment](https://github.com/terrortylor/nvim-comment)
 - [~~ray-x/go.nvim~~](https://github.com/ray-x/go.nvim) - Dropped from PR as will require additional deps/setup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
