### PR TITLE
h2: 1.4.199 -> 2.1.210

### DIFF
--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -1,13 +1,14 @@
 { lib, stdenv, fetchzip, jre, makeWrapper }:
 stdenv.mkDerivation rec {
   pname = "h2";
-
   version = "2.1.210";
 
   src = fetchzip {
-    url = "https://github.com/h2database/h2database/releases/download/version-2.1.210/h2-2022-01-17.zip";
+    url = "https://github.com/h2database/h2database/releases/download/version-${version}/h2-2022-01-17.zip";
     sha256 = "0zcjblhjj98dsj954ia3by9vx5w7mix1dzi85jnvp18kxmbldmf4";
   };
+
+  outputs = [ "out" "doc" ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -24,8 +25,9 @@ stdenv.mkDerivation rec {
         fi
       '';
     in ''
-      mkdir -p $out
-      cp -R * $out
+      mkdir -p $out $doc/share/doc/
+      cp -R bin $out/
+      cp -R docs $doc/share/doc/h2
 
       echo '${h2ToolScript}' > $out/bin/h2tool.sh
 

--- a/pkgs/servers/h2/default.nix
+++ b/pkgs/servers/h2/default.nix
@@ -2,11 +2,11 @@
 stdenv.mkDerivation rec {
   pname = "h2";
 
-  version = "1.4.199";
+  version = "2.1.210";
 
   src = fetchzip {
-    url = "https://h2database.com/h2-2019-03-13.zip";
-    sha256 = "0pdvbnx7nqfqs7x1zkwz2q34331l55jknpk6arf6dksvnd71hinj";
+    url = "https://github.com/h2database/h2database/releases/download/version-2.1.210/h2-2022-01-17.zip";
+    sha256 = "0zcjblhjj98dsj954ia3by9vx5w7mix1dzi85jnvp18kxmbldmf4";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#155329 (CVE-2021-23463)

Also pull out docs (and drop `src` + non-`bin/` stuff) since they're nearly 4x the size of the actual app (9.7 megs of docs v. 2.5 megs of app). (I'll un-push this if it's controversial somehow)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
