### PR TITLE
optifinePackages: init

### DIFF
--- a/pkgs/tools/games/minecraft/optifine/default.nix
+++ b/pkgs/tools/games/minecraft/optifine/default.nix
@@ -1,39 +1,67 @@
-{ lib
-, stdenv
-, fetchurl
-, makeWrapper
-, jre }:
+{ recurseIntoAttrs
+, callPackage
+}:
 
-stdenv.mkDerivation rec {
-  pname = "optifine";
-  version = "1.18.1_HD_U_H4";
+recurseIntoAttrs rec {
+  optifine-latest = optifine_1_18_1;
 
-  src = fetchurl {
-    url = "https://optifine.net/download?f=OptiFine_${version}.jar";
-    sha256 = "325168569b21a2dcde82999876f69ec9d8af75202a7021691f2abede4d81dcec";
+  optifine_1_18_1 = callPackage ./generic.nix {
+    version = "1.18.1_HD_U_H4";
+    sha256 = "sha256-MlFoVpshotzegpmYdvaeydivdSAqcCFpHyq+3k2B3Ow=";
   };
 
-  dontUnpack = true;
+  optifine_1_17_1 = callPackage ./generic.nix {
+    version = "1.17.1_HD_U_H1";
+    sha256 = "sha256-HHt747bIHYY/WNAx19mNgvnLrLCqaKIqwXmmB7A895M=";
+  };
 
-  nativeBuildInputs = [ jre makeWrapper ];
+  optifine_1_16_5 = callPackage ./generic.nix {
+    version = "1.16.5_HD_U_G8";
+    sha256 = "sha256-PHa8kO1EvOVnzufCDrLENhkm8jqG5TZ9WW9uYk0LSU8=";
+  };
 
-  installPhase = ''
-    mkdir -p $out/{bin,lib/optifine}
-    cp $src $out/lib/optifine/optifine.jar
+  optifine_1_15_2 = callPackage ./generic.nix {
+    version = "1.16.5_HD_U_G8";
+    sha256 = "sha256-PHa8kO1EvOVnzufCDrLENhkm8jqG5TZ9WW9uYk0LSU8=";
+  };
 
-    makeWrapper ${jre}/bin/java $out/bin/optifine \
-      --add-flags "-jar $out/lib/optifine/optifine.jar"
-  '';
+  optifine_1_14_4 = callPackage ./generic.nix {
+    version = "1.14.4_HD_U_G5";
+    sha256 = "sha256-I+65vQO6yG4AQ0ZLAfX73ImsFKAQkTyrIOnQHldTibs=";
+  };
 
-  meta = with lib; {
-    homepage = "https://optifine.net/";
-    description = "A Minecraft optimization mod";
-    longDescription = ''
-      OptiFine is a Minecraft optimization mod.
-      It allows Minecraft to run faster and look better with full support for HD textures and many configuration options.
-    '';
-    license = licenses.unfree;
-    maintainers = [ maintainers.ivar ];
-    platforms = platforms.unix;
+  optifine_1_13_2 = callPackage ./generic.nix {
+    version = "1.13.2_HD_U_G5";
+    sha256 = "sha256-sjUQot8fPdbZTiLqt+exbF5T8kI5bLQevu7atW9Xu3E=";
+  };
+
+  optifine_1_12_2 = callPackage ./generic.nix {
+    version = "1.12.2_HD_U_G5";
+    sha256 = "sha256-OwAGeXdx/rl/LQ0pCK58mnjO+y5zCvHC6F0IqDm6Jx4=";
+  };
+
+  optifine_1_11_2 = callPackage ./generic.nix {
+    version = "1.11.2_HD_U_G5";
+    sha256 = "sha256-1sLUBtM5e5LDTUFCRZf9UeH6WOA8zY6TAmB9PCS5iv4=";
+  };
+
+  optifine_1_10 = callPackage ./generic.nix {
+    version = "1.10_HD_U_I5";
+    sha256 = "sha256-oKOsaNFnOKfhWLDDYG/0Z4h/ZCDtyJWS9LXPaKAApc0=";
+  };
+
+  optifine_1_9_4 = callPackage ./generic.nix {
+    version = "1.9.4_HD_U_I5";
+    sha256 = "sha256-t+OxIf0Tl/NZxUTl+LGnWRUhEwZ+vxiZfhclxEAf6yI=";
+  };
+
+  optifine_1_8_9 = callPackage ./generic.nix {
+    version = "1.8.9_HD_U_M5";
+    sha256 = "sha256-Jzl2CnD8pq5cfcgXvMYoPxj1Xjj6I3eNp/OHprckssQ=";
+  };
+
+  optifine_1_7_10 = callPackage ./generic.nix {
+    version = "1.7.10_HD_U_E7";
+    sha256 = "sha256-i82dg94AGgWR9JgQXzafBwxH0skZJ3TVpbafZG5E+rQ=";
   };
 }

--- a/pkgs/tools/games/minecraft/optifine/generic.nix
+++ b/pkgs/tools/games/minecraft/optifine/generic.nix
@@ -1,0 +1,44 @@
+{ version
+, sha256
+, lib
+, runCommand
+, fetchurl
+, makeWrapper
+, jre
+}:
+
+let
+  mcVersion = builtins.head (lib.splitString "_" version);
+in
+runCommand "optifine-${mcVersion}" {
+  pname = "optifine";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://optifine.net/download?f=OptiFine_${version}.jar";
+    inherit sha256;
+    name = "OptiFine_${version}.jar";
+  };
+
+  nativeBuildInputs = [ jre makeWrapper ];
+
+  meta = with lib; {
+    homepage = "https://optifine.net/";
+    description = "A Minecraft ${mcVersion} optimization mod";
+    longDescription = ''
+      OptiFine is a Minecraft optimization mod.
+      It allows Minecraft to run faster and look better with full support for HD textures and many configuration options.
+      This is for version ${mcVersion} of Minecraft.
+    '';
+    license = licenses.unfree;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.unix;
+    mainProgram = "optifine";
+  };
+} ''
+  mkdir -p $out/{bin,lib/optifine}
+  cp $src $out/lib/optifine/optifine.jar
+
+  makeWrapper ${jre}/bin/java $out/bin/optifine \
+    --add-flags "-jar $out/lib/optifine/optifine.jar"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8451,7 +8451,9 @@ with pkgs;
 
   openvswitch-lts = callPackage ../os-specific/linux/openvswitch/lts.nix { };
 
-  optifine = callPackage ../tools/games/minecraft/optifine { };
+  optifinePackages = callPackage ../tools/games/minecraft/optifine { };
+
+  optifine = optifinePackages.optifine-latest;
 
   optipng = callPackage ../tools/graphics/optipng {
     libpng = libpng12;


### PR DESCRIPTION
###### Motivation for this change
Since old versions of this game are still played a lot because of their mod support, we want all versions supported by upstream available in nixpkgs. These were all recently updated, I'm guessing to fix the log4j vulnerability.

I was unfortunately not able to find a version list to write an update script, but I think this should be fine. Updates are rather infrequent anyway, especially for older versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
