### PR TITLE
google-chrome: add /run/opengl-driver/share/vulkan/icd.d/ to path

### DIFF
--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -44,7 +44,7 @@
 , libvaSupport ? true, libva
 
 # For Vulkan support (--enable-features=Vulkan)
-, vulkanSupport ? true, vulkan-loader
+, addOpenGLRunpath
 }:
 
 with lib;
@@ -70,7 +70,6 @@ let
     libxkbcommon pipewire wayland
   ] ++ optional pulseSupport libpulseaudio
     ++ optional libvaSupport libva
-    ++ optional vulkanSupport vulkan-loader
     ++ [ gtk3 ];
 
   suffix = if channel != "stable" then "-" + channel else "";
@@ -143,7 +142,7 @@ in stdenv.mkDerivation {
     makeWrapper "$out/share/google/$appname/google-$appname" "$exe" \
       --prefix LD_LIBRARY_PATH : "$rpath" \
       --prefix PATH            : "$binpath" \
-      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+      --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
       --add-flags ${escapeShellArg commandLineArgs}
 
     for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
NixOS stores ICDs at ` /run/opengl-driver/share/vulkan/icd.d/`, while Chrome is searching these paths:
```
DRIVER: Searching for driver manifest files
DRIVER:    In following folders:
DRIVER:       /home/bweeks/.config/vulkan/icd.d
DRIVER:       /etc/xdg/vulkan/icd.d
DRIVER:       /home/bweeks/.nix-profile/etc/xdg/vulkan/icd.d
DRIVER:       /etc/profiles/per-user/bweeks/etc/xdg/vulkan/icd.d
DRIVER:       /nix/var/nix/profiles/default/etc/xdg/vulkan/icd.d
DRIVER:       /run/current-system/sw/etc/xdg/vulkan/icd.d
DRIVER:       /etc/vulkan/icd.d
DRIVER:       /home/bweeks/.local/share/vulkan/icd.d
DRIVER:       /nix/store/z4p55yy4i15l5cppid37yih6gvrbczvy-cups-2.3.3op2/share/vulkan/icd.d
DRIVER:       /nix/store/ydckdz6qc010fclx3hrksa62yjphrl19-gtk+3-3.24.30/share/vulkan/icd.d
DRIVER:       /nix/store/zszg84zmq95fmka2xmb29j80p8y8671j-adwaita-icon-theme-41.0/share/vulkan/icd.d
DRIVER:       /nix/store/6pwg357yyh43aklmxnh2zlwi21dbwfv2-hicolor-icon-theme-0.17/share/vulkan/icd.d
DRIVER:       /nix/store/0rhbw783qcjxv3cqln1760i1lmz2yb67-gsettings-desktop-schemas-41.0/share/gsettings-schemas/gsettings-desktop-schemas-41.0/vulkan/icd.d
DRIVER:       /nix/store/ydckdz6qc010fclx3hrksa62yjphrl19-gtk+3-3.24.30/share/gsettings-schemas/gtk+3-3.24.30/vulkan/icd.d
DRIVER:       /nix/store/hnnlhlsn0qbf166b88kr5kynq4dxal13-patchelf-0.13/share/vulkan/icd.d
DRIVER:       /nix/store/jbi6kbiilbg7mxy2y8ydklbgz7r8iyqj-desktops/share/vulkan/icd.d
DRIVER:       /home/bweeks/.nix-profile/share/vulkan/icd.d
DRIVER:       /etc/profiles/per-user/bweeks/share/vulkan/icd.d
DRIVER:       /nix/var/nix/profiles/default/share/vulkan/icd.d
DRIVER:       /run/current-system/sw/share/vulkan/icd.d
```

Tested by running `VK_LOADER_DEBUG=all google-chrome-unstable --enable-features=Vulkan` and navigating to chrome://gpu.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
