### PR TITLE
python3Packages.gevent: 20.9.0 -> 21.12.0

### DIFF
--- a/pkgs/development/python-modules/gevent-socketio/default.nix
+++ b/pkgs/development/python-modules/gevent-socketio/default.nix
@@ -1,29 +1,48 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, versiontools
+, gevent
 , gevent-websocket
 , mock
-, pytest
-, gevent
+, versiontools
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "gevent-socketio";
   version = "0.3.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zra86hg2l1jcpl9nsnqagy3nl3akws8bvrbpgdxk15x7ywllfak";
+    hash = "sha256-UzlKuT+9hNnbuyvvhTSfalA7/FPYapvoZTJQ8aBBKv8=";
   };
 
-  buildInputs = [ versiontools gevent-websocket mock pytest ];
-  propagatedBuildInputs = [ gevent ];
+  nativeBuildInputs = [
+    versiontools
+  ];
+
+  buildInputs = [
+    gevent-websocket
+  ];
+
+  propagatedBuildInputs = [
+    gevent
+  ];
+
+  # Tests are not ported to Python 3
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "socketio"
+  ];
 
   meta = with lib; {
+    description = "SocketIO server based on the Gevent pywsgi server";
     homepage = "https://github.com/abourget/gevent-socketio";
-    description = "SocketIO server based on the Gevent pywsgi server, a Python network library";
     license = licenses.bsd0;
+    maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/gevent-websocket/default.nix
+++ b/pkgs/development/python-modules/gevent-websocket/default.nix
@@ -3,29 +3,37 @@
 , fetchPypi
 , gevent
 , gunicorn
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "gevent-websocket";
   version = "0.10.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1c2zv2rahp1gil3cj66hfsqgy0n35hz9fny3ywhr2319d0lz7bky";
+    hash = "sha256-fq7zKWgpDJEh98Nblz4swwL/sHbQGMkGjS9cqLLYX7A=";
   };
 
-  propagatedBuildInputs = [ gevent gunicorn ];
+  propagatedBuildInputs = [
+    gevent
+    gunicorn
+  ];
 
-  # zero tests run
+  # Module has no test
   doCheck = false;
 
-  pythonImportsCheck = [ "geventwebsocket" ];
+  pythonImportsCheck = [
+    "geventwebsocket"
+  ];
 
   meta = with lib; {
+    description = "Websocket handler for the gevent pywsgi server";
     homepage = "https://www.gitlab.com/noppo/gevent-websocket";
-    description = "Websocket handler for the gevent pywsgi server, a Python network library";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };
-
 }

--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -1,35 +1,50 @@
-{ lib, fetchPypi, buildPythonPackage, isPyPy, python, libev, greenlet
+{ lib
+, fetchPypi
+, buildPythonPackage
+, isPyPy
+, python
+, libev
+, greenlet
+, zope_event
 , zope_interface
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "gevent";
-  version = "20.9.0";
+  version = "21.12.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "13aw9x6imsy3b369kfjblqiwfni69pp32m4r13n62r9k3l2lhvaz";
+    hash = "sha256-9ItkV4w2e5H6eTv46qr0mVy5PIvEWGDkc7+GgHCtCU4=";
   };
 
-  buildInputs = [ libev ];
-  propagatedBuildInputs = [
-    zope_interface
-  ] ++ lib.optionals (!isPyPy) [ greenlet ];
+  buildInputs = [
+    libev
+  ];
 
-  checkPhase = ''
-    cd greentest
-    ${python.interpreter} testrunner.py
-  '';
+  propagatedBuildInputs = [
+    zope_event
+    zope_interface
+  ] ++ lib.optionals (!isPyPy) [
+    greenlet
+  ];
 
   # Bunch of failures.
   doCheck = false;
+
+  pythonImportsCheck = [
+    "gevent"
+  ];
 
   meta = with lib; {
     description = "Coroutine-based networking library";
     homepage = "http://www.gevent.org/";
     license = licenses.mit;
-    platforms = platforms.unix;
     maintainers = with maintainers; [ bjornfor ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/python-modules/geventhttpclient/default.nix
+++ b/pkgs/development/python-modules/geventhttpclient/default.nix
@@ -1,23 +1,25 @@
 { lib
-, buildPythonPackage
-, pythonOlder
-, fetchPypi
-, backports_ssl_match_hostname
 , brotli
+, buildPythonPackage
 , certifi
-, gevent
-, six
 , dpkt
+, fetchPypi
+, gevent
 , pytestCheckHook
+, pythonOlder
+, six
 }:
 
 buildPythonPackage rec {
   pname = "geventhttpclient";
   version = "1.5.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d80ec9ff42b7219f33558185499d0b4365597fc55ff886207b45f5632e099780";
+    hash = "sha256-2A7J/0K3IZ8zVYGFSZ0LQ2VZf8Vf+IYge0X1Yy4Jl4A=";
   };
 
   propagatedBuildInputs = [
@@ -25,8 +27,6 @@ buildPythonPackage rec {
     certifi
     gevent
     six
-  ] ++ lib.optionals (pythonOlder "3.7") [
-    backports_ssl_match_hostname
   ];
 
   checkInputs = [
@@ -45,11 +45,14 @@ buildPythonPackage rec {
     "test_multi_queries_greenlet_safe"
   ];
 
+  pythonImportsCheck = [
+    "geventhttpclient"
+  ];
+
   meta = with lib; {
     homepage = "https://github.com/gwik/geventhttpclient";
     description = "HTTP client library for gevent";
     license = licenses.mit;
     maintainers = with maintainers; [ koral ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/gevent/gevent/blob/master/CHANGES.rst#21120-2021-12-11


Also, cleanup and `pythonImportsCheck`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
