### PR TITLE
python3Packages.google-nest-sdm: 1.3.0 -> 1.5.1

### DIFF
--- a/pkgs/development/python-modules/google-nest-sdm/default.nix
+++ b/pkgs/development/python-modules/google-nest-sdm/default.nix
@@ -1,19 +1,21 @@
 { lib
 , aiohttp
+, asynctest
 , buildPythonPackage
+, coreutils
 , fetchFromGitHub
 , google-auth
 , google-auth-oauthlib
 , google-cloud-pubsub
-, pythonOlder
-, requests_oauthlib
 , pytest-aiohttp
 , pytestCheckHook
+, pythonOlder
+, requests_oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "google-nest-sdm";
-  version = "1.3.0";
+  version = "1.5.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -22,7 +24,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "python-google-nest-sdm";
     rev = version;
-    sha256 = "sha256-E0e4lLUBzHKA3clmb/JUBE0KGciQ1xrmLTSeSkGDsWo=";
+    sha256 = "sha256-8Y3ixkDl/AmXQMOY+29og5njMh9M2qjwWBGCsiqX5PU=";
   };
 
   propagatedBuildInputs = [
@@ -34,9 +36,16 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    asynctest
+    coreutils
     pytest-aiohttp
     pytestCheckHook
   ];
+
+  postPatch = ''
+    substituteInPlace tests/event_media_test.py \
+      --replace "/bin/echo" "${coreutils}/bin/echo"
+  '';
 
   pythonImportsCheck = [
     "google_nest_sdm"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/allenporter/python-google-nest-sdm/releases/tag/1.5.1
https://github.com/allenporter/python-google-nest-sdm/releases/tag/1.5.0
https://github.com/allenporter/python-google-nest-sdm/releases/tag/1.4.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
