### PR TITLE
onionshare: 2.4 -> 2.5

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -8,7 +8,7 @@
 , flask
 , flask-httpauth
 , flask-socketio
-, stem
+, cepa
 , psutil
 , pyqt5
 , pycrypto
@@ -21,15 +21,16 @@
 , unidecode
 , tor
 , obfs4
+, snowflake
 }:
 
 let
-  version = "2.4";
+  version = "2.5";
   src = fetchFromGitHub {
     owner = "onionshare";
     repo = "onionshare";
     rev = "v${version}";
-    sha256 = "sha256-Lclm7mIkaAkQpWcNILTRJtLA43dpiyHtWAeHS2r3+ZQ=";
+    sha256 = "xCAM+tjjyDg/gqAXr4YNPhM8R3n9r895jktisAGlpZo=";
   };
   meta = with lib; {
     description = "Securely and anonymously send and receive files";
@@ -55,16 +56,9 @@ let
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ lourkeur ];
   };
-  stem' = stem.overridePythonAttrs (_: rec {
-    version = "1.8.1";
 
-    src = fetchFromGitHub {
-      owner = "onionshare";
-      repo = "stem";
-      rev = version;
-      sha256 = "Dzpvx7CgAr5OtGmfubWAYDLqq5LkGqcwjr3bxpfL/3A=";
-    };
-  });
+  # TODO: package meek https://support.torproject.org/glossary/meek/
+  meek = "/meek-not-available";
 
 in
 rec {
@@ -76,7 +70,7 @@ rec {
       # hardcode store paths of dependencies
       (substituteAll {
         src = ./fix-paths.patch;
-        inherit tor obfs4;
+        inherit tor meek obfs4 snowflake;
         inherit (tor) geoip;
       })
     ];
@@ -86,7 +80,7 @@ rec {
       flask
       flask-httpauth
       flask-socketio
-      stem'
+      cepa
       psutil
       pycrypto
       pynacl
@@ -109,8 +103,6 @@ rec {
     '';
 
     disabledTests = [
-      "test_firefox_like_behavior"
-      "test_if_unmodified_since"
       "test_get_tor_paths_linux"  # expects /usr instead of /nix/store
     ] ++ lib.optionals stdenv.isDarwin [
       # on darwin (and only on darwin) onionshare attempts to discover
@@ -123,12 +115,12 @@ rec {
   onionshare-gui = buildPythonApplication {
     pname = "onionshare";
     inherit version meta;
-    src = "${src}/desktop/src";
+    src = "${src}/desktop";
     patches = [
       # hardcode store paths of dependencies
       (substituteAll {
         src = ./fix-paths-gui.patch;
-        inherit tor obfs4;
+        inherit tor meek obfs4 snowflake;
         inherit (tor) geoip;
       })
     ];

--- a/pkgs/applications/networking/onionshare/fix-paths-gui.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths-gui.patch
@@ -1,25 +1,46 @@
 --- a/onionshare/gui_common.py
 +++ b/onionshare/gui_common.py
-@@ -391,29 +391,10 @@ class GuiCommon:
+@@ -410,52 +410,12 @@ class GuiCommon:
          }
  
      def get_tor_paths(self):
 -        if self.common.platform == "Linux":
--            tor_path = shutil.which("tor")
--            obfs4proxy_file_path = shutil.which("obfs4proxy")
--            prefix = os.path.dirname(os.path.dirname(tor_path))
--            tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
--            tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
--        elif self.common.platform == "Windows":
+-            base_path = self.get_resource_path("tor")
+-            if base_path and os.path.isdir(base_path):
+-                self.common.log(
+-                    "GuiCommon", "get_tor_paths", "using paths in resources"
+-                )
+-                tor_path = os.path.join(base_path, "tor")
+-                tor_geo_ip_file_path = os.path.join(base_path, "geoip")
+-                tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
+-                obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy")
+-                snowflake_file_path = os.path.join(base_path, "snowflake-client")
+-                meek_client_file_path = os.path.join(base_path, "meek-client")
+-            else:
+-                # Fallback to looking in the path
+-                self.common.log("GuiCommon", "get_tor_paths", "using paths from PATH")
+-                tor_path = shutil.which("tor")
+-                obfs4proxy_file_path = shutil.which("obfs4proxy")
+-                snowflake_file_path = shutil.which("snowflake-client")
+-                meek_client_file_path = shutil.which("meek-client")
+-                prefix = os.path.dirname(os.path.dirname(tor_path))
+-                tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
+-                tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
+-
+-        if self.common.platform == "Windows":
 -            base_path = self.get_resource_path("tor")
 -            tor_path = os.path.join(base_path, "Tor", "tor.exe")
 -            obfs4proxy_file_path = os.path.join(base_path, "Tor", "obfs4proxy.exe")
+-            snowflake_file_path = os.path.join(base_path, "Tor", "snowflake-client.exe")
+-            meek_client_file_path = os.path.join(base_path, "Tor", "meek-client.exe")
 -            tor_geo_ip_file_path = os.path.join(base_path, "Data", "Tor", "geoip")
 -            tor_geo_ipv6_file_path = os.path.join(base_path, "Data", "Tor", "geoip6")
 -        elif self.common.platform == "Darwin":
 -            base_path = self.get_resource_path("tor")
 -            tor_path = os.path.join(base_path, "tor")
 -            obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy")
+-            snowflake_file_path = os.path.join(base_path, "snowflake-client")
+-            meek_client_file_path = os.path.join(base_path, "meek-client")
 -            tor_geo_ip_file_path = os.path.join(base_path, "geoip")
 -            tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
 -        elif self.common.platform == "BSD":
@@ -27,10 +48,14 @@
 -            tor_geo_ip_file_path = "/usr/local/share/tor/geoip"
 -            tor_geo_ipv6_file_path = "/usr/local/share/tor/geoip6"
 -            obfs4proxy_file_path = "/usr/local/bin/obfs4proxy"
+-            meek_client_file_path = "/usr/local/bin/meek-client"
+-            snowflake_file_path = "/usr/local/bin/snowflake-client"
 +        tor_path = "@tor@/bin/tor"
 +        tor_geo_ip_file_path = "@geoip@/share/tor/geoip"
 +        tor_geo_ipv6_file_path = "@geoip@/share/tor/geoip6"
 +        obfs4proxy_file_path = "@obfs4@/bin/obfs4proxy"
++        meek_client_file_path = "@meek@/bin/meek-client"
++        snowflake_file_path = "@snowflake@/bin/snowflake-client"
  
          return (
              tor_path,

--- a/pkgs/applications/networking/onionshare/fix-paths.patch
+++ b/pkgs/applications/networking/onionshare/fix-paths.patch
@@ -1,41 +1,76 @@
 --- a/onionshare_cli/common.py
 +++ b/onionshare_cli/common.py
-@@ -308,33 +308,10 @@ class Common:
+@@ -318,67 +318,12 @@ class Common:
          return path
-
+ 
      def get_tor_paths(self):
 -        if self.platform == "Linux":
 -            tor_path = shutil.which("tor")
 -            if not tor_path:
 -                raise CannotFindTor()
 -            obfs4proxy_file_path = shutil.which("obfs4proxy")
+-            snowflake_file_path = shutil.which("snowflake-client")
+-            meek_client_file_path = shutil.which("meek-client")
 -            prefix = os.path.dirname(os.path.dirname(tor_path))
 -            tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
 -            tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
 -        elif self.platform == "Windows":
+-            # In Windows, the Tor binaries are in the onionshare package, not the onionshare_cli package
 -            base_path = self.get_resource_path("tor")
+-            base_path = base_path.replace("onionshare_cli", "onionshare")
 -            tor_path = os.path.join(base_path, "Tor", "tor.exe")
+-
+-            # If tor.exe isn't there, mayber we're running from the source tree
+-            if not os.path.exists(tor_path):
+-                base_path = os.path.join(os.getcwd(), "onionshare", "resources", "tor")
+-
+-                tor_path = os.path.join(base_path, "Tor", "tor.exe")
+-                if not os.path.exists(tor_path):
+-                    raise CannotFindTor()
+-
 -            obfs4proxy_file_path = os.path.join(base_path, "Tor", "obfs4proxy.exe")
+-            snowflake_file_path = os.path.join(base_path, "Tor", "snowflake-client.exe")
+-            meek_client_file_path = os.path.join(base_path, "Tor", "meek-client.exe")
 -            tor_geo_ip_file_path = os.path.join(base_path, "Data", "Tor", "geoip")
 -            tor_geo_ipv6_file_path = os.path.join(base_path, "Data", "Tor", "geoip6")
+-
 -        elif self.platform == "Darwin":
--            tor_path = shutil.which("tor")
--            if not tor_path:
--                raise CannotFindTor()
--            obfs4proxy_file_path = shutil.which("obfs4proxy")
--            prefix = os.path.dirname(os.path.dirname(tor_path))
--            tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
--            tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
+-            # Let's see if we have tor binaries in the onionshare GUI package
+-            base_path = self.get_resource_path("tor")
+-            base_path = base_path.replace("onionshare_cli", "onionshare")
+-            tor_path = os.path.join(base_path, "tor")
+-            if os.path.exists(tor_path):
+-                obfs4proxy_file_path = os.path.join(base_path, "obfs4proxy")
+-                snowflake_file_path = os.path.join(base_path, "snowflake-client")
+-                meek_client_file_path = os.path.join(base_path, "meek-client")
+-                tor_geo_ip_file_path = os.path.join(base_path, "geoip")
+-                tor_geo_ipv6_file_path = os.path.join(base_path, "geoip6")
+-            else:
+-                # Fallback to looking in the path
+-                tor_path = shutil.which("tor")
+-                if not os.path.exists(tor_path):
+-                    raise CannotFindTor()
+-
+-                obfs4proxy_file_path = shutil.which("obfs4proxy")
+-                snowflake_file_path = shutil.which("snowflake-client")
+-                meek_client_file_path = shutil.which("meek-client")
+-                prefix = os.path.dirname(os.path.dirname(tor_path))
+-                tor_geo_ip_file_path = os.path.join(prefix, "share/tor/geoip")
+-                tor_geo_ipv6_file_path = os.path.join(prefix, "share/tor/geoip6")
+-
 -        elif self.platform == "BSD":
 -            tor_path = "/usr/local/bin/tor"
 -            tor_geo_ip_file_path = "/usr/local/share/tor/geoip"
 -            tor_geo_ipv6_file_path = "/usr/local/share/tor/geoip6"
 -            obfs4proxy_file_path = "/usr/local/bin/obfs4proxy"
+-            snowflake_file_path = "/usr/local/bin/snowflake-client"
+-            meek_client_file_path = "/usr/local/bin/meek-client"
 +        tor_path = "@tor@/bin/tor"
 +        tor_geo_ip_file_path = "@geoip@/share/tor/geoip"
 +        tor_geo_ipv6_file_path = "@geoip@/share/tor/geoip6"
 +        obfs4proxy_file_path = "@obfs4@/bin/obfs4proxy"
-
++        snowflake_file_path = "@snowflake@/bin/snowflake-client"
++        meek_client_file_path = "@meek@/bin/meek-client"
+ 
          return (
              tor_path,
-

--- a/pkgs/development/python-modules/cepa/default.nix
+++ b/pkgs/development/python-modules/cepa/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchPypi, python, mock }:
+
+buildPythonPackage rec {
+  pname = "cepa";
+  version = "1.8.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "HcbwsyTTei7SyidGSOzo/SyWodL0QPWMDKF6/Ute3no=";
+  };
+
+  postPatch = ''
+    rm test/unit/installation.py
+    sed -i "/test.unit.installation/d" test/settings.cfg
+    # https://github.com/torproject/stem/issues/56
+    sed -i '/MOCK_VERSION/d' run_tests.py
+  '';
+
+  checkInputs = [ mock ];
+
+  checkPhase = ''
+    touch .gitignore
+    ${python.interpreter} run_tests.py -u
+  '';
+
+  meta = with lib; {
+    description = "Controller library that allows applications to interact with Tor";
+    homepage = "https://github.com/onionshare/cepa";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ lourkeur ];
+  };
+}

--- a/pkgs/tools/networking/snowflake/default.nix
+++ b/pkgs/tools/networking/snowflake/default.nix
@@ -1,0 +1,21 @@
+{ lib, buildGoModule, fetchgit }:
+
+buildGoModule rec {
+  pname = "snowflake";
+  version = "2.0.1";
+
+  src = fetchgit {
+    url = "https://git.torproject.org/pluggable-transports/${pname}";
+    rev = "v${version}";
+    hash = "sha256-ULkqsh0DeFI1GsaVaHGSjoEY38EktvDVC52Sx6cQLOE=";
+  };
+
+  vendorSha256 = "D5A19UHL1WEE1ODT80jKT+PJ5CTXPjc9Eg6v2Nfm4aw=";
+
+  meta = with lib; {
+    description = "System to defeat internet censorship";
+    homepage = "https://snowflake.torproject.org/";
+    maintainers = with maintainers; [ lourkeur ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1166,6 +1166,8 @@ with pkgs;
   mcaimi-st = callPackage ../applications/terminal-emulators/st/mcaimi-st.nix { };
   siduck76-st = callPackage ../applications/terminal-emulators/st/siduck76-st.nix { };
 
+  snowflake = callPackage ../tools/networking/snowflake { };
+
   stupidterm = callPackage ../applications/terminal-emulators/stupidterm {
     gtk = gtk3;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1495,6 +1495,8 @@ in {
 
   coqpit = callPackage ../development/python-modules/coqpit { };
 
+  cepa = callPackage ../development/python-modules/cepa { };
+
   cerberus = callPackage ../development/python-modules/cerberus { };
 
   cert-chain-resolver = callPackage ../development/python-modules/cert-chain-resolver { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/onionshare/onionshare/releases/tag/v2.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### TODO
- [ ] ~package `meek`~
- [x] package `snowflake`
- [x] package `cepa` properly