### PR TITLE
llvmPackages_{12,13,git}: don't try to patch non-existing _LIBCPP_USE_AVAILABILITY_APPLE

### DIFF
--- a/pkgs/development/compilers/llvm/12/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxx/default.nix
@@ -23,12 +23,6 @@ stdenv.mkDerivation {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
-  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
-  postPatch = ''
-    substituteInPlace include/__config \
-      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
-  '';
-
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -25,12 +25,6 @@ stdenv.mkDerivation rec {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
-  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
-  postPatch = ''
-    substituteInPlace include/__config \
-      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
-  '';
-
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -25,12 +25,6 @@ stdenv.mkDerivation rec {
     ../../libcxx-0001-musl-hacks.patch
   ];
 
-  # Prevent errors like "error: 'foo' is unavailable: introduced in macOS yy.zz"
-  postPatch = ''
-    substituteInPlace include/__config \
-      --replace "#    define _LIBCPP_USE_AVAILABILITY_APPLE" ""
-  '';
-
   preConfigure = lib.optionalString stdenv.hostPlatform.isMusl ''
     patchShebangs utils/cat_files.py
   '';


### PR DESCRIPTION
    substituteStream(): WARNING: pattern '#    define _LIBCPP_USE_AVAILABILITY_APPLE' doesn't match anything in file 'include/__config'

The new mechanism for those is a cmake option
LIBCXX_ENABLE_VENDOR_AVAILABILITY_ANNOTATIONS that is off by default:
https://reviews.llvm.org/D90843

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
