### PR TITLE
epson-201401w: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6981,6 +6981,12 @@
     githubId = 22085373;
     name = "Luis Hebendanz";
   };
+  lunarequest = {
+    email = "nullarequest@vivlaid.net";
+    github = "Lunarequest";
+    githubId = 30698906;
+    name = "Advaith Madhukar"; #this is my legal name, I prefer Luna; please keep that in mind!
+  };
   lionello = {
     email = "lio@lunesu.com";
     github = "lionello";

--- a/pkgs/misc/drivers/epson-201401w/default.nix
+++ b/pkgs/misc/drivers/epson-201401w/default.nix
@@ -1,0 +1,67 @@
+{ lib, stdenv, fetchurl, rpmextract, autoreconfHook, file, libjpeg, cups }:
+
+let
+  version = "1.0.0";
+  filterVersion = "1.0.0";
+in stdenv.mkDerivation {
+  pname = "epson-201401w";
+  inherit version;
+
+  src = fetchurl {
+    # NOTE: Don't forget to update the webarchive link too!
+    urls = [
+      "https://download3.ebz.epson.net/dsc/f/03/00/03/45/41/92e9c9254f0ee4230a069545ba27ec2858a2c457/epson-inkjet-printer-201401w-1.0.0-1lsb3.2.src.rpm"
+      "https://web.archive.org/web/20200725175832/https://download3.ebz.epson.net/dsc/f/03/00/03/45/41/92e9c9254f0ee4230a069545ba27ec2858a2c457/epson-inkjet-printer-201401w-1.0.0-1lsb3.2.src.rpm"
+    ];
+    sha256 = "0c60m1sd59s4sda38dc5nniwa7dh1b0kv1maajr0x9d38gqlyk3x";
+  };
+  patches = [ ./fixbuild.patch ];
+
+  nativeBuildInputs = [ rpmextract autoreconfHook file ];
+
+  buildInputs = [ libjpeg cups ];
+
+  unpackPhase = ''
+    rpmextract $src
+    tar -zxf epson-inkjet-printer-201401w-${version}.tar.gz
+    tar -zxf epson-inkjet-printer-filter-${filterVersion}.tar.gz
+    for ppd in epson-inkjet-printer-201401w-${version}/ppds/*; do
+      substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-201401w" "$out"
+      substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
+    done
+    cd epson-inkjet-printer-filter-${filterVersion}
+  '';
+
+  preConfigure = ''
+    chmod +x configure
+  '';
+
+  postInstall = ''
+    cd ../epson-inkjet-printer-201401w-${version}
+    cp -a lib64 resource watermark $out
+    mkdir -p $out/share/cups/model/epson-inkjet-printer-201401w
+    cp -a ppds $out/share/cups/model/epson-inkjet-printer-201401w/
+    cp -a Manual.txt $out/doc/
+    cp -a README $out/doc/README.driver
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.openprinting.org/driver/epson-201401w";
+    description =
+      "Epson printer driver (L456, L455, L366, L365, L362, L360, L312, L310, L222, L220, L132, L130)";
+    longDescription = ''
+      This software is a filter program used with the Common UNIX Printing
+      System (CUPS) under Linux. It supplies high quality printing with
+      Seiko Epson Color Ink Jet Printers.
+
+      To use the driver adjust your configuration.nix file:
+        services.printing = {
+          enable = true;
+          drivers = [ pkgs.epson-201401w ];
+        };
+    '';
+    license = with licenses; [ lgpl21 epson ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.lunarequest ];
+  };
+}

--- a/pkgs/misc/drivers/epson-201401w/fixbuild.patch
+++ b/pkgs/misc/drivers/epson-201401w/fixbuild.patch
@@ -1,0 +1,101 @@
+diff --git a/src/pagemanager/pagemanager.c b/src/pagemanager/pagemanager.c
+index 029e6d3..3c1f450 100644
+--- a/src/pagemanager/pagemanager.c
++++ b/src/pagemanager/pagemanager.c
+@@ -22,7 +22,7 @@
+ #include "epcgdef.h"
+ #include "debuglog.h"
+ #include "memory.h"
+-#include "raster.h"
++#include "raster-helper.h"
+ #include "pagemanager.h"
+
+ extern int JobCanceled;
+@@ -45,7 +45,7 @@ fetchRaster(EpsPageManager *pageManager)
+ 	int error = 0;
+ 	int did_fetch = 0;
+ 	int read_bytes = 0;
+-	int nraster;
++	size_t nraster;
+
+ 	while (error == 0 && did_fetch == 0 && JobCanceled == 0) {
+ 		eps_raster_fetch(privateData->raster_h, NULL, 0, 0, &status);
+@@ -212,7 +212,7 @@ int pageManagerGetPageRegion(EpsPageManager *pageManager, EpsPageRegion *pageReg
+ 	return EPS_OK;
+ }
+
+-int pageManagerGetRaster(EpsPageManager *pageManager, char *buf, int bufSize)
++size_t pageManagerGetRaster(EpsPageManager *pageManager, char *buf, int bufSize)
+ {
+ 	PageManagerPrivateData  *privateData = NULL;
+ 	int error = EPS_OK;
+diff --git a/src/pagemanager/pagemanager.h b/src/pagemanager/pagemanager.h
+index 87fbbd5..c9743fb 100644
+--- a/src/pagemanager/pagemanager.h
++++ b/src/pagemanager/pagemanager.h
+@@ -31,7 +31,7 @@ extern "C"
+ #define	EPS_ERROR	-1
+ #define	EPS_OK		0
+
+-typedef int (*EpsRasterSource)(char *buf, int bufSize);
++typedef size_t (*EpsRasterSource)(char *buf, int bufSize);
+
+ typedef struct {
+ 	EpsRasterSource		rasterSource;
+@@ -47,7 +47,7 @@ typedef struct {
+ EpsPageManager* pageManagerCreate(EpsPageRegion pageRegion, EpsFilterPrintOption filterPrintOption, EpsRasterSource rasterSource);
+ void pageManagerDestroy(EpsPageManager *pageManager);
+ int pageManagerGetPageRegion(EpsPageManager *pageManager, EpsPageRegion *pageRegion);
+-int pageManagerGetRaster(EpsPageManager *pageManager, char *buf, int bufSize);
++size_t pageManagerGetRaster(EpsPageManager *pageManager, char *buf, int bufSize);
+ int pageManagerIsNextPage(EpsPageManager *pageManager);
+
+ #ifdef __cplusplus
+diff --git a/src/raster/raster.c b/src/raster/raster.c
+index 7e4946b..dd5aef6 100644
+--- a/src/raster/raster.c
++++ b/src/raster/raster.c
+@@ -218,7 +218,7 @@ eps_raster_init (RASTER * handle, EpsRasterOpt * data, EpsRasterPipeline * pipel
+
+ /* if raster_p equals NULL means that it is need to flush a page. */
+ int
+-eps_raster_print (RASTER handle, char * raster_p, int raster_bytes, int pixel_num, int * outraster)
++eps_raster_print (RASTER handle, char * raster_p, int raster_bytes, int pixel_num, size_t * outraster)
+ {
+ 	EpsRaster * raster = (EpsRaster *) handle;
+ 	EpsRasterPipeline * pipeline = NULL;
+diff --git a/src/raster/raster.h b/src/raster/raster.h
+index 9be0977..cc5054d 100644
+--- a/src/raster/raster.h
++++ b/src/raster/raster.h
+@@ -143,7 +143,7 @@ typedef enum {
+ } EpsRasterFetchStatus;
+
+ int eps_raster_init (RASTER *, EpsRasterOpt *, EpsRasterPipeline *);
+-int eps_raster_print (RASTER, char *, int, int, int *);
++int eps_raster_print (RASTER, char *, int, int, size_t *);
+ int eps_raster_fetch (RASTER, char *, int, int, EpsRasterFetchStatus *);
+ int eps_raster_free (RASTER);
+
+diff --git a/src/raster_to_epson.c b/src/raster_to_epson.c
+index 6e621c8..a0811d6 100644
+--- a/src/raster_to_epson.c
++++ b/src/raster_to_epson.c
+@@ -33,7 +33,7 @@
+ #include <cups/ppd.h>
+ #include <cups/raster.h>
+
+-#include "raster.h"
++#include "raster-helper.h"
+ #include "memory.h"
+ #include "raster_to_epson.h"
+ #include "pagemanager.h"
+@@ -75,7 +75,7 @@ static int page_no = 0;
+ static int pageHeight = 0;
+ #endif
+
+-int rasterSource(char *buf, int bufSize)
++size_t rasterSource(char *buf, int bufSize)
+ {
+ 	int readBytes = 0;
+ 	if (JobCanceled == 0) {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32673,6 +32673,8 @@ with pkgs;
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };
 
+  epson-201401w = callPackage ../misc/drivers/epson-201401w { };
+
   epson-201106w = callPackage ../misc/drivers/epson-201106w { };
 
   epson-workforce-635-nx625-series = callPackage ../misc/drivers/epson-workforce-635-nx625-series { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This adds the epson-201401 printer driver which supports the following printers L456, L455, L366, L365, L362, L360, L312, L310, L222, L220, L132, L130

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
