### PR TITLE
chipsec: 1.6.1 -> 1.8.1

### DIFF
--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -10,7 +10,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "chipsec";
-  version = "1.8.0";
+  version = "1.8.1";
 
   disabled = !stdenv.isLinux;
 
@@ -18,7 +18,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "chipsec";
     repo = "chipsec";
     rev = version;
-    hash = "sha256-6Wzh1cEQoVl4FSlqni1bRbVWZIjovaAMeozuxKvvSqA=";
+    hash = "sha256-bK8wlwhP0pi8rOs8ysbSZ+0aZOaX4mckfH/p4OLGnes=";
   };
 
   patches = lib.optionals withDriver [ ./ko-path.diff ./compile-ko.diff ];

--- a/pkgs/tools/security/chipsec/default.nix
+++ b/pkgs/tools/security/chipsec/default.nix
@@ -10,14 +10,15 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "chipsec";
-  version = "1.6.1";
+  version = "1.8.0";
+
   disabled = !stdenv.isLinux;
 
   src = fetchFromGitHub {
     owner = "chipsec";
     repo = "chipsec";
     rev = version;
-    sha256 = "01sp24z63r3nqxx57zc4873b8i5dqipy7yrxzrwjns531vznhiy2";
+    hash = "sha256-6Wzh1cEQoVl4FSlqni1bRbVWZIjovaAMeozuxKvvSqA=";
   };
 
   patches = lib.optionals withDriver [ ./ko-path.diff ./compile-ko.diff ];
@@ -29,9 +30,9 @@ python3.pkgs.buildPythonApplication rec {
     nasm
   ];
 
-  checkInputs = [
-    python3.pkgs.distro
-    python3.pkgs.pytestCheckHook
+  checkInputs = with python3.pkgs; [
+    distro
+    pytestCheckHook
   ];
 
   preBuild = lib.optionalString withDriver ''
@@ -45,10 +46,15 @@ python3.pkgs.buildPythonApplication rec {
       $out/${python3.pkgs.python.sitePackages}/drivers/linux/chipsec.ko
   '';
 
-  setupPyBuildFlags = [ "--build-lib=$CHIPSEC_BUILD_LIB" ]
-                   ++ lib.optional (!withDriver) "--skip-driver";
+  setupPyBuildFlags = [
+    "--build-lib=$CHIPSEC_BUILD_LIB"
+  ] ++ lib.optional (!withDriver) [
+    "--skip-driver"
+  ];
 
-  pythonImportsCheck = [ "chipsec" ];
+  pythonImportsCheck = [
+    "chipsec"
+  ];
 
   meta = with lib; {
     description = "Platform Security Assessment Framework";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/chipsec/chipsec/releases/tag/1.8.1
https://github.com/chipsec/chipsec/releases/tag/1.8.0
https://github.com/chipsec/chipsec/releases/tag/v1.7.3
https://github.com/chipsec/chipsec/releases/tag/1.7.2
https://github.com/chipsec/chipsec/releases/tag/1.7.1
https://github.com/chipsec/chipsec/releases/tag/1.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
