### PR TITLE
terraform.withPlugins: load providers from libexec

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -391,6 +391,24 @@
       </listitem>
       <listitem>
         <para>
+          The terraform 0.12 compatibility has been removed and the
+          <literal>terraform.withPlugins</literal> and
+          <literal>terraform-providers.mkProvider</literal>
+          implementations simplified. Providers now need to be stored
+          under
+          <literal>$out/libexec/terraform-providers/&lt;registry&gt;/&lt;owner&gt;/&lt;name&gt;/&lt;version&gt;/&lt;os&gt;_&lt;arch&gt;/terraform-provider-&lt;name&gt;_v&lt;version&gt;</literal>
+          (which mkProvider does).
+        </para>
+        <para>
+          This breaks back-compat so it’s not possible to mix-and-match
+          with previous versions of nixpkgs. In exchange, it now becomes
+          possible to use the providers from
+          <link xlink:href="https://github.com/numtide/nixpkgs-terraform-providers-bin">nixpkgs-terraform-providers-bin</link>
+          directly.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.noto-fonts-cjk</literal> is now deprecated in
           favor of <literal>pkgs.noto-fonts-cjk-sans</literal> and
           <literal>pkgs.noto-fonts-cjk-serif</literal> because they each

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -120,6 +120,11 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - MultiMC has been replaced with the fork PolyMC due to upstream developers being hostile to 3rd party package maintainers. PolyMC removes all MultiMC branding and is aimed at providing proper 3rd party packages like the one contained in Nixpkgs. This change affects the data folder where game instances and other save and configuration files are stored. Users with existing installations should rename `~/.local/share/multimc` to `~/.local/share/polymc`. The main config file's path has also moved from `~/.local/share/multimc/multimc.cfg` to `~/.local/share/polymc/polymc.cfg`.
 
+- The terraform 0.12 compatibility has been removed and the `terraform.withPlugins` and `terraform-providers.mkProvider` implementations simplified. Providers now need to be stored under
+`$out/libexec/terraform-providers/<registry>/<owner>/<name>/<version>/<os>_<arch>/terraform-provider-<name>_v<version>` (which mkProvider does).
+
+  This breaks back-compat so it's not possible to mix-and-match with previous versions of nixpkgs. In exchange, it now becomes possible to use the providers from [nixpkgs-terraform-providers-bin](https://github.com/numtide/nixpkgs-terraform-providers-bin) directly.
+
 - `pkgs.noto-fonts-cjk` is now deprecated in favor of `pkgs.noto-fonts-cjk-sans`
   and `pkgs.noto-fonts-cjk-serif` because they each have different release
   schedules. To maintain compatibility with prior releases of Nixpkgs,

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -19,7 +19,8 @@ let
     , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
     , deleteVendor ? false
     , proxyVendor ? false
-    , provider-source-address
+    , # Looks like "registry.terraform.io/vancluever/acme"
+      provider-source-address
     }@attrs:
     buildGoModule {
       pname = repo;
@@ -34,9 +35,15 @@ let
         inherit owner repo rev sha256;
       };
 
-      # Terraform allow checking the provider versions, but this breaks
-      # if the versions are not provided via file paths.
-      postBuild = "mv $NIX_BUILD_TOP/go/bin/${repo}{,_v${version}}";
+      # Move the provider to libexec
+      postInstall = ''
+        dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/''${GOOS}_''${GOARCH}
+        mkdir -p "$dir"
+        mv $out/bin/* "$dir/terraform-provider-$(basename ${provider-source-address})_${version}"
+        rmdir $out/bin
+      '';
+
+      # Keep the attributes around for later consumption
       passthru = attrs;
     };
 

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, buildEnv
 , buildGoModule
 , fetchFromGitHub
 , makeWrapper
@@ -62,9 +63,9 @@ let
           babariviere
           kalbasit
           marsam
+          maxeaubrey
           timstott
           zimbatm
-          maxeaubrey
           zowoq
         ];
       };
@@ -75,39 +76,6 @@ let
       withPlugins = plugins:
         let
           actualPlugins = plugins terraform.plugins;
-
-          # Make providers available in Terraform 0.13 and 0.12 search paths.
-          pluginDir = lib.concatMapStrings
-            (pl:
-              let
-                inherit (pl) version GOOS GOARCH;
-
-                pname = pl.pname or (throw "${pl.name} is missing a pname attribute");
-
-                # This is just the name, without the terraform-provider- prefix
-                plugin_name = lib.removePrefix "terraform-provider-" pname;
-
-                slug = pl.passthru.provider-source-address or "registry.terraform.io/nixpkgs/${plugin_name}";
-
-                shim = writeText "shim" ''
-                  #!${runtimeShell}
-                  exec ${pl}/bin/${pname}_v${version} "$@"
-                '';
-              in
-              ''
-                TF_0_13_PROVIDER_PATH=$out/plugins/${slug}/${version}/${GOOS}_${GOARCH}/${pname}_v${version}
-                mkdir -p "$(dirname $TF_0_13_PROVIDER_PATH)"
-
-                cp ${shim} "$TF_0_13_PROVIDER_PATH"
-                chmod +x "$TF_0_13_PROVIDER_PATH"
-
-                TF_0_12_PROVIDER_PATH=$out/plugins/${pname}_v${version}
-
-                cp ${shim} "$TF_0_12_PROVIDER_PATH"
-                chmod +x "$TF_0_12_PROVIDER_PATH"
-              ''
-            )
-            actualPlugins;
 
           # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
           wrapperInputs = lib.unique (lib.flatten
@@ -134,18 +102,16 @@ let
           terraform.overrideAttrs
             (orig: { passthru = orig.passthru // passthru; })
         else
-          lib.appendToName "with-plugins" (stdenv.mkDerivation {
+          lib.appendToName "with-plugins" (buildEnv {
             inherit (terraform) name meta;
+            paths = actualPlugins;
             nativeBuildInputs = [ makeWrapper ];
-
-            buildCommand = pluginDir + ''
-              mkdir -p $out/bin/
+            postBuild = ''
+              mkdir -p $out/bin
               makeWrapper "${terraform}/bin/terraform" "$out/bin/terraform" \
-                --set NIX_TERRAFORM_PLUGIN_DIR $out/plugins \
+                --set NIX_TERRAFORM_PLUGIN_DIR $out/libexec/terraform-providers \
                 --prefix PATH : "${lib.makeBinPath wrapperInputs}"
             '';
-
-            inherit passthru;
           });
     in
     withPlugins (_: [ ]);


### PR DESCRIPTION
Now that the terraform 0.12 compatibility is removed, we can clean how
terraform.withPlugins is implemented, and simplify to a simple buildEnv.

On the other side, providers are now asked to be stored in
$out/libexec/terraform-providers/<registry>/<name>_<version>/<arch>_<os>

This breaks back-compat so it's not possible to mix-and-match with
previous versions of nixpkgs. In exchange, it now becomes possible to
use the providers from
[nixpkgs-terraform-providers-bin](https://github.com/numtide/nixpkgs-terraform-providers-bin)
directly.


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).