### PR TITLE
ffmpeg_5: init at 5.0

### DIFF
--- a/pkgs/development/libraries/ffmpeg/0001-fate-ffmpeg-add-missing-samples-dependency-to-fate-s.patch
+++ b/pkgs/development/libraries/ffmpeg/0001-fate-ffmpeg-add-missing-samples-dependency-to-fate-s.patch
@@ -1,0 +1,27 @@
+From a66b58d61caaae452785a2d69f5de9259ab27138 Mon Sep 17 00:00:00 2001
+From: James Almer <jamrial@gmail.com>
+Date: Sun, 16 Jan 2022 00:32:52 -0300
+Subject: [PATCH] fate/ffmpeg: add missing samples dependency to fate-shortest
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+(cherry picked from commit b1ef5882e35d1a95e9c4838d0933084773055345)
+---
+ tests/fate/ffmpeg.mak | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/fate/ffmpeg.mak b/tests/fate/ffmpeg.mak
+index 0b00bb5b23..b80467d02e 100644
+--- a/tests/fate/ffmpeg.mak
++++ b/tests/fate/ffmpeg.mak
+@@ -86,7 +86,7 @@ fate-unknown_layout-ac3: CMD = md5 -auto_conversion_filters \
+   -guess_layout_max 0 -f s32le -ac 1 -ar 44100 -i $(TARGET_PATH)/$(AREF) \
+   -f ac3 -flags +bitexact -c ac3_fixed
+ 
+-FATE_FFMPEG-$(call ALLYES, FILE_PROTOCOL LAVFI_INDEV RAWVIDEO_DEMUXER      \
++FATE_SAMPLES_FFMPEG-$(call ALLYES, FILE_PROTOCOL LAVFI_INDEV RAWVIDEO_DEMUXER \
+                            SINE_FILTER PCM_S16LE_DECODER RAWVIDEO_DECODER  \
+                            ARESAMPLE_FILTER AMIX_FILTER MPEG4_ENCODER      \
+                            AC3_FIXED_ENCODER FRAMECRC_MUXER PIPE_PROTOCOL) \
+-- 
+2.33.1
+

--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -1,0 +1,14 @@
+{ callPackage
+# Darwin frameworks
+, Cocoa, CoreMedia, VideoToolbox
+, ...
+}@args:
+
+callPackage ./generic.nix (rec {
+  version = "5.0";
+  branch = version;
+  sha256 = "1ndy6a2bhl6nvz9grmcaakh4xi0vss455466s47l6qy7na6hn4y0";
+  darwinFrameworks = [ Cocoa CoreMedia VideoToolbox ];
+
+  patches = [ ./0001-fate-ffmpeg-add-missing-samples-dependency-to-fate-s.patch ];
+} // args)

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -54,6 +54,8 @@ let
 
   ifMinVer = minVer: flag: if reqMin minVer then flag else null;
 
+  ifVerOlder = maxVer: flag: if (lib.versionOlder branch maxVer) then flag else null;
+
   # Version specific fix
   verFix = withoutFix: fixVer: withFix: if reqMatch fixVer then withFix else withoutFix;
 
@@ -121,7 +123,7 @@ stdenv.mkDerivation rec {
       (ifMinVer "0.6" "--enable-avdevice")
       "--enable-avfilter"
       (ifMinVer "0.6" "--enable-avformat")
-      (ifMinVer "1.0" "--enable-avresample")
+      (ifMinVer "1.0" (ifVerOlder "5.0" "--enable-avresample"))
       (ifMinVer "1.1" "--enable-avutil")
       "--enable-postproc"
       (ifMinVer "0.9" "--enable-swresample")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16350,6 +16350,9 @@ with pkgs;
   ffmpeg_4 = callPackage ../development/libraries/ffmpeg/4.nix {
     inherit (darwin.apple_sdk.frameworks) Cocoa CoreMedia VideoToolbox;
   };
+  ffmpeg_5 = callPackage ../development/libraries/ffmpeg/5.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreMedia VideoToolbox;
+  };
 
   # Aliases
   ffmpeg_3 = ffmpeg_3_4;


### PR DESCRIPTION
###### Motivation for this change

Packaging FFmpeg 5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
