### PR TITLE
modules/nixos-containers: add forceHostPath option for bindMounts

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -168,7 +168,14 @@ let
         ${containerInit cfg} "''${SYSTEM_PATH:-/nix/var/nix/profiles/system}/init"
     '';
 
-  preStartScript = cfg:
+  preStartScript = let
+    mkForceHostPath = d: "mkdir -p ${d.hostPath}";
+    mkForceHostPaths = bs:
+      concatStringsSep "\n"
+        (map mkForceHostPath
+          (lib.filter (d: d.hostPath != null && d.forceHostPath)
+            (lib.attrValues bs)));
+  in cfg:
     ''
       # Clean up existing machined registration and interfaces.
       machinectl terminate "$INSTANCE" 2> /dev/null || true
@@ -184,6 +191,9 @@ let
           "ip link del dev ${name} 2> /dev/null || true "
         ) cfg.extraVeths
       )}
+
+      # Mkdir all hostPath-binds when forceHostPath is set
+      ${mkForceHostPaths cfg.bindMounts}
    '';
 
   postStartScript = (cfg:
@@ -295,6 +305,11 @@ let
         example = "/home/alice";
         type = types.nullOr types.str;
         description = "Location of the host path to be mounted.";
+      };
+      forceHostPath = mkOption {
+        default = false;
+        type = types.bool;
+        description = "Determine whether the host path should be created if non-existent.";
       };
       isReadOnly = mkOption {
         default = true;
@@ -426,6 +441,7 @@ let
   dummyConfig =
     {
       extraVeths = {};
+      bindMounts = {};
       additionalCapabilities = [];
       ephemeral = false;
       timeoutStartSec = "1min";


### PR DESCRIPTION
###### Motivation for this change
I have a service that communicates with host's other service with a unix domain socket in `/run/myservice/myservice.sock`.
For security purposes, I didn't want to bindMount the entire `/run` directory (I actually tried anyway and nix refuses because of some special folders) so I tried to only mount `/run/myservice` directory.

Problem is that this is in `/run` so it gets deleted at reboot. And it doesn't exist anymore when rebooting the container.

So nixos-container complains about the hostPath of the bindMount being non-existent and fails.

###### Things done
Added an option `containers.<name>.bindMounts.<name>.forceHostPath` to force the container's preStartScript to create the hostPath if non-existent.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
