### PR TITLE
buildPerlPackage: use LINKTYPE=static when building statically

### DIFF
--- a/doc/languages-frameworks/perl.section.md
+++ b/doc/languages-frameworks/perl.section.md
@@ -157,3 +157,7 @@ The output can be pasted into `pkgs/top-level/perl-packages.nix` or wherever els
 ### Cross-compiling modules {#ssec-perl-cross-compilation}
 
 Nixpkgs has experimental support for cross-compiling Perl modules. In many cases, it will just work out of the box, even for modules with native extensions. Sometimes, however, the Makefile.PL for a module may (indirectly) import a native module. In that case, you will need to make a stub for that module that will satisfy the Makefile.PL and install it into `lib/perl5/site_perl/cross_perl/${perl.version}`. See the `postInstall` for `DBI` for an example.
+
+### Static linking {#ssec-perl-static-linking}
+
+When using `pkgsStatic` to build a perl module, the `configurePhase` will run `perl Makefile.PL` with `LINKTYPE=static` cf [ExtUtils::MakeMaker's doc](https://metacpan.org/pod/ExtUtils::MakeMaker#Static-Linking-of-a-new-Perl-Binary).

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -22,7 +22,12 @@ preConfigure() {
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    # https://metacpan.org/pod/ExtUtils::MakeMaker#Static-Linking-of-a-new-Perl-Binary
+    if [ "$LINKTYPE" = "static" ]; then
+        perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\" LINKTYPE=static
+    else
+        perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
+    fi
 }
 
 if test -n "$perlPreHook"; then

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -23,11 +23,7 @@ preConfigure() {
     done
 
     # https://metacpan.org/pod/ExtUtils::MakeMaker#Static-Linking-of-a-new-Perl-Binary
-    if [ "$LINKTYPE" = "static" ]; then
-        perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\" LINKTYPE=static
-    else
-        perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
-    fi
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\" LINKTYPE="${LINKTYPE:-dynamic}"
 }
 
 if test -n "$perlPreHook"; then

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -17,6 +17,8 @@ toPerlModule(stdenv.mkDerivation (
 
     checkTarget = "test";
 
+    LINKTYPE = if stdenv.targetPlatform.isStatic then "static" else "dynamic";
+
     # Prevent CPAN downloads.
     PERL_AUTOINSTALL = "--skipdeps";
 


### PR DESCRIPTION
###### Motivation for this change
Needed to build pkgsStatic.avahi

###### Things done
Tried to fix the static building of perlPackages. Couldn't test it because I ran out of disk memory.
Would appreciate a review from @alyssais. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
