### PR TITLE
libcxx: hardcode full path to <version>

### DIFF
--- a/pkgs/development/compilers/llvm/11/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/11/libcxx/default.nix
@@ -67,6 +67,12 @@ stdenv.mkDerivation {
       stdenv.hostPlatform != stdenv.buildPlatform
     ) "-DCMAKE_SYSTEM_VERSION=20.1.0";
 
+  # https://github.com/NixOS/nixpkgs/issues/155458
+  postFixup = ''
+    find "''${!outputInclude}/include/c++/v1" -type f \
+      -exec sed -i {} -e "s|^#include <version>$|#include \"''${!outputInclude}/include/c++/v1/version\"|" \;
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/12/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/12/libcxx/default.nix
@@ -48,6 +48,12 @@ stdenv.mkDerivation {
       "-DLIBCXX_ENABLE_EXCEPTIONS=OFF"
     ] ++ lib.optional (!enableShared) "-DLIBCXX_ENABLE_SHARED=OFF";
 
+  # https://github.com/NixOS/nixpkgs/issues/155458
+  postFixup = ''
+    find "''${!outputInclude}/include/c++/v1" -type f \
+      -exec sed -i {} -e "s|^#include <version>$|#include \"''${!outputInclude}/include/c++/v1/version\"|" \;
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/13/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/13/libcxx/default.nix
@@ -61,6 +61,12 @@ stdenv.mkDerivation rec {
     popd
   '';
 
+  # https://github.com/NixOS/nixpkgs/issues/155458
+  postFixup = ''
+    find "''${!outputInclude}/include/c++/v1" -type f \
+      -exec sed -i {} -e "s|^#include <version>$|#include \"''${!outputInclude}/include/c++/v1/version\"|" \;
+  '';
+
   passthru = {
     isLLVM = true;
   };

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -61,6 +61,12 @@ stdenv.mkDerivation rec {
     popd
   '';
 
+  # https://github.com/NixOS/nixpkgs/issues/155458
+  postFixup = ''
+    find "''${!outputInclude}/include/c++/v1" -type f \
+      -exec sed -i {} -e "s|^#include <version>$|#include \"''${!outputInclude}/include/c++/v1/version\"|" \;
+  '';
+
   passthru = {
     isLLVM = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes: #155458

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] `nix-build . -A llvmPackages_11.libcxx.dev -A llvmPackages_12.libcxx.dev -A llvmPackages_13.libcxx.dev -A llvmPackages_git.libcxx.dev | xargs grep -r version`
- [x] `nix-build -E 'with import ./. {}; itpp.override { stdenv = llvmPackages_git.stdenv; }'`
