### PR TITLE
(r)discount: use deterministic mangling

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -26,7 +26,7 @@
 , file, libvirt, glib, vips, taglib, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
 , bison, flex, pango, python3, patchelf, binutils, freetds, wrapGAppsHook, atk
 , bundler, libsass, libexif, libselinux, libsepol, shared-mime-info, libthai, libdatrie
-, CoreServices, DarwinTools, cctools, libtool
+, CoreServices, DarwinTools, cctools, libtool, discount
 }@args:
 
 let
@@ -133,6 +133,17 @@ in
 
   digest-sha3 = attrs: {
     hardeningDisable = [ "format" ];
+  };
+
+  rdiscount = attrs: {
+    # Use discount from nixpkgs instead of vendored version
+    dontBuild = false;
+    buildInputs = [ discount ];
+    patches = [
+      # Adapted from Debian:
+      # https://sources.debian.org/data/main/r/ruby-rdiscount/2.1.8-1/debian/patches/01_use-system-libmarkdown.patch
+      ./rdiscount-use-nixpkgs-libmarkdown.patch
+    ];
   };
 
   ethon = attrs: {

--- a/pkgs/development/ruby-modules/gem-config/rdiscount-use-nixpkgs-libmarkdown.patch
+++ b/pkgs/development/ruby-modules/gem-config/rdiscount-use-nixpkgs-libmarkdown.patch
@@ -1,0 +1,14 @@
+diff --git a/ext/extconf.rb b/ext/extconf.rb
+index 30764cb..b87ac2b 100644
+--- a/ext/extconf.rb
++++ b/ext/extconf.rb
+@@ -46,4 +46,9 @@ if /mswin/.match RbConfig::CONFIG['host_os']
+   $defs.push("-Dinline=__inline")
+ end
+ 
++$srcs = %w[
++  rdiscount.c
++]
++have_library('markdown')
++
+ create_makefile('rdiscount')

--- a/pkgs/development/tools/ronn/default.nix
+++ b/pkgs/development/tools/ronn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, bundlerEnv, bundlerUpdateScript, makeWrapper, groff }:
+{ stdenv, lib, bundlerEnv, bundlerUpdateScript, makeWrapper, groff, callPackage }:
 
 stdenv.mkDerivation rec {
   pname = "ronn";
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.updateScript = bundlerUpdateScript "ronn";
+
+  passthru.tests.reproducible-html-manpage = callPackage ./test-reproducible-html.nix { };
 
   meta = with lib; {
     description = "markdown-based tool for building manpages";

--- a/pkgs/development/tools/ronn/test-reproducible-html.nix
+++ b/pkgs/development/tools/ronn/test-reproducible-html.nix
@@ -1,0 +1,30 @@
+{ runCommand
+, diffutils
+, ronn
+}:
+runCommand "ronn-test-reproducible-html" { } ''
+  set -euo pipefail
+
+  cat > aprog.1.ronn << EOF
+  aprog
+  =====
+
+  ## AUTHORS
+
+  Vincent Haupert <veehaitch@users.noreply.github.com>
+  EOF
+
+  # We have to repeat the manpage generation a few times to be confident
+  # it is in fact reproducible.
+  for i in {1..20}; do
+    ${ronn}/bin/ronn --html --pipe aprog.1.ronn > aprog.1.html-1
+    ${ronn}/bin/ronn --html --pipe aprog.1.ronn > aprog.1.html-2
+
+    ${diffutils}/bin/diff -q aprog.1.html-1 aprog.1.html-2 \
+      || (printf 'The HTML manpage is not reproducible (round %d)' "$i" && exit 1)
+  done
+
+  echo 'The HTML manpage appears reproducible'
+
+  mkdir $out
+''

--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -33,6 +33,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   doCheck = true;
 
+  postFixup = lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libmarkdown.dylib $out/lib/libmarkdown.dylib
+  '';
+
   meta = with lib; {
     description = "Implementation of Markdown markup language in C";
     homepage = "http://www.pell.portland.or.us/~orc/Code/discount/";

--- a/pkgs/tools/text/discount/default.nix
+++ b/pkgs/tools/text/discount/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
     "--pkg-config"
     "--shared"
     "--with-fenced-code"
+    # Use deterministic mangling
+    "--debian-glitch"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`ronn`'s HTML manpage is not reproducible due to `(r)discount`.

`discount` (aka `libmarkdown`) offers [a mangling function](https://github.com/Orc/discount/blob/c2617280f9fc5faf4db5742fb8f95aebc7f9a5a7/generate.c#L839-L849) which by default produces non-deterministic results, hence, harming reproducibility. This PR uses the `--debian-glitch` configuration option to make the results deterministic.

The Ruby package `rdiscount` uses a vendored version of `discount`. Instead of patching the vendored source, the PR patches `rdiscount` to use the library from `discount`. This seems to work fine (Debian does this as well).

Also adds a test for `ronn` to make sure the changes result in the reproducibility of HTML manpages.

Supersedes #155363.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
