### PR TITLE
gpuvis: 20210220 -> 20211204

### DIFF
--- a/pkgs/development/tools/misc/gpuvis/default.nix
+++ b/pkgs/development/tools/misc/gpuvis/default.nix
@@ -12,17 +12,16 @@
 
 stdenv.mkDerivation rec {
   pname = "gpuvis";
-  version = "20210220";
+  version = "20211204";
 
   src = fetchFromGitHub {
     owner = "mikesart";
     repo = pname;
-    rev = "216f7d810e182a89fd96ab9fad2a5c2b1e425ea9";
-    sha256 = "15pj7gy0irlp849a85z68n184jksjri0xhihgh56rs15kq333mwz";
+    rev = "7f47419470687c7ecbdf086b81f5bafdb05d1bef";
+    sha256 = "sha256-29Bv+y0zWzn7QtpsjRV6hr19bCeyVJusPcYiAIEIluk=";
   };
 
   # patch dlopen path for gtk3
-  # python2 is wrongly added in the meson file, upstream PR: https://github.com/mikesart/gpuvis/pull/62
   postPatch = ''
     substituteInPlace src/hook_gtk3.h \
       --replace "libgtk-3.so" "${lib.getLib gtk3}/lib/libgtk-3.so"


### PR DESCRIPTION

###### Motivation for this change
Package bump. Also remove the note on python2 support, upstream merged the PR removing
it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
