### PR TITLE
nx2elf: unstable-2020-05-26 -> unstable-2021-11-21

### DIFF
--- a/pkgs/tools/compression/nx2elf/default.nix
+++ b/pkgs/tools/compression/nx2elf/default.nix
@@ -2,23 +2,19 @@
 
 stdenv.mkDerivation rec {
   pname = "nx2elf";
-  version = "unstable-2020-05-26";
+  version = "unstable-2021-11-21";
 
   src = fetchFromGitHub {
     owner = "shuffle2";
     repo = "nx2elf";
-    rev = "7212e82a77b84fcc18ef2d050970350dbf63649b";
-    sha256 = "1j4k5s86c6ixa3wdqh4cfm31fxabwn6jcjc6pippx8mii98ac806";
+    rev = "735aaa0648a5a6c996b48add9465db86524999f6";
+    sha256 = "sha256-cS8FFIEgDWva0j9JXhS+s7Y4Oh+mNhFaKRI7BF2hqvs=";
   };
 
   buildInputs = [ lz4 ];
 
   postPatch = ''
-    # This project does not comply with C++14 standards, and compilation on that fails.
-    # This does however succesfully compile with the gnu++20 standard.
-    substituteInPlace Makefile --replace "c++14" "gnu++20"
-
-    # pkg-config is not supported, so we'll manually use a non-ancient version of lz4
+    # pkg-config is not supported, so we'll manually devendor lz4
     cp ${lz4.src}/lib/lz4.{h,c} .
   '';
 


### PR DESCRIPTION

###### Motivation for this change
They fixed the makefile on linux, so we don't need the workaround anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
