### PR TITLE
npush: init at 0.7

### DIFF
--- a/pkgs/games/npush/default.nix
+++ b/pkgs/games/npush/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, stdenv
+, fetchurl
+, ncurses
+}:
+
+stdenv.mkDerivation rec {
+  pname = "npush";
+  version = "0.7";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/project/npush/${pname}/${version}/${pname}-${version}.tgz";
+    hash = "sha256-8hbSsyeehzd4T3fUhDyebyI/oTHOHr3a8ArYAquivNk=";
+  };
+
+  outputs = [ "out" "doc" ];
+
+  buildInputs = [
+    ncurses
+  ];
+
+  dontConfigure = true;
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}c++"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/npush/levels $doc/share/doc/npush
+    cp npush $out/bin/
+    cp levels/* $out/share/npush/levels
+    cp CHANGES COPYING CREDITS index.html \
+       readme.txt screenshot1.png screenshot2.png $doc/share/doc/npush/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://npush.sourceforge.net/";
+    description = "A Sokoban-like game";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ AndersonTorres ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/games/npush/run.nix
+++ b/pkgs/games/npush/run.nix
@@ -1,0 +1,31 @@
+{ runtimeShell
+, symlinkJoin
+, writeShellScriptBin
+, npush
+}:
+
+let
+  runScript = writeShellScriptBin "run-npush" ''
+    set -euo pipefail
+    CWD=$(pwd)
+
+    if [ -d "./levels" ]; then
+      echo "Directory ./levels found; skipping levelset copy"
+    else
+      echo "Directory ./levels not found; copying the official levelset to the current directory"
+      mkdir -p ./levels
+      cp ${npush}/share/npush/levels/* levels/
+      chmod 644 levels/*
+    fi
+    echo "Now calling npush"
+    exec "${npush}/bin/npush"
+  '';
+in
+symlinkJoin {
+  name = "run-npush-${npush.version}";
+
+  paths = [
+    npush
+    runScript
+  ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30902,6 +30902,9 @@ with pkgs;
 
   njam = callPackage ../games/njam { };
 
+  npush = callPackage ../games/npush { };
+  run-npush = callPackage ../games/npush/run.nix { };
+
   newtonwars = callPackage ../games/newtonwars { };
 
   nudoku = callPackage ../games/nudoku { };


### PR DESCRIPTION
Also, include a runner script to help copying level files before running the
game.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
