### PR TITLE
opensupaplex: init at 7.1.2

### DIFF
--- a/pkgs/games/opensupaplex/default.nix
+++ b/pkgs/games/opensupaplex/default.nix
@@ -1,0 +1,89 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, makeDesktopItem
+, copyDesktopItems
+, testVersion
+, opensupaplex
+, SDL2
+, SDL2_mixer
+}:
+
+let
+  # Doesn't seem to be included in tagged releases, but does exist on master.
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/sergiou87/open-supaplex/b102548699cf16910b59559f689ecfad88d2a7d2/open-supaplex.svg";
+    sha256 = "sha256-nKeSBUGjSulbEP7xxc6smsfCRjyc/xsLykH0o3Rq5wo=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "opensupaplex";
+  version = "7.1.2";
+
+  src = fetchFromGitHub {
+    owner = "sergiou87";
+    repo = "open-supaplex";
+    rev = "v${version}";
+    sha256 = "sha256-hP8dJlLXE5J/oxPhRkrrBl1Y5e9MYbJKi8OApFM3+GU=";
+  };
+
+  nativeBuildInputs = [
+    SDL2 # For "sdl2-config"
+    copyDesktopItems
+  ];
+  buildInputs = [ SDL2_mixer ];
+
+  enableParallelBuilding = true;
+
+  NIX_CFLAGS_COMPILE = [
+    "-DFILE_DATA_PATH=${placeholder "out"}/lib/opensupaplex"
+    "-DFILE_FHS_XDG_DIRS"
+  ];
+
+  preBuild = ''
+    # Makefile is located in this directory
+    pushd linux
+  '';
+
+  postBuild = ''
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib,share/icons/hicolor/scalable/apps}
+
+    install -D ./linux/opensupaplex $out/bin/opensupaplex
+    cp -R ./resources $out/lib/opensupaplex
+    cp ${icon} $out/share/icons/hicolor/scalable/apps/open-supaplex.svg
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testVersion {
+    package = opensupaplex;
+    command = "opensupaplex --help";
+    version = "v${version}";
+  };
+
+  desktopItems = [(makeDesktopItem {
+    name = "opensupaplex";
+    exec = meta.mainProgram;
+    icon = "open-supaplex";
+    desktopName = "OpenSupaplex";
+    comment = meta.description;
+    categories = "Application;Game;";
+  })];
+
+  meta = with lib; {
+    description = "A decompilation of Supaplex in C and SDL";
+    homepage = "https://github.com/sergiou87/open-supaplex";
+    changelog = "https://github.com/sergiou87/open-supaplex/blob/master/changelog/v${version}.txt";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.ivar ];
+    platforms = platforms.linux; # Many more are supported upstream, but only linux is tested.
+    mainProgram = "opensupaplex";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19225,6 +19225,8 @@ with pkgs;
 
   opensubdiv = callPackage ../development/libraries/opensubdiv { };
 
+  opensupaplex = callPackage ../games/opensupaplex { };
+
   open-wbo = callPackage ../applications/science/logic/open-wbo {};
 
   openwsman = callPackage ../development/libraries/openwsman {};


### PR DESCRIPTION
###### Motivation for this change
Closes: https://github.com/NixOS/nixpkgs/issues/155439

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (cross from x84 linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
