### PR TITLE
mopidy-ytmusic: 0.3.2 -> 0.3.5

### DIFF
--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -25,6 +25,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Mopidy extension for playing music from YouTube Music";
+    homepage = "https://github.com/OzymandiasTheGreat/mopidy-ytmusic";
     license = licenses.asl20;
     maintainers = [ maintainers.nickhu ];
   };

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -10,6 +10,11 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0pncyxfqxvznb9y4ksndbny1yf5mxh4089ak0yz86dp2qi5j99iv";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'ytmusicapi>=0.20.0,<0.21.0' 'ytmusicapi>=0.20.0'
+  '';
+
   propagatedBuildInputs = [
     mopidy
     python3Packages.ytmusicapi
@@ -20,11 +25,6 @@ python3Packages.buildPythonApplication rec {
 
   # has no tests
   doCheck = false;
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace 'ytmusicapi>=0.20.0,<0.21.0' 'ytmusicapi>=0.20.0'
-  '';
 
   meta = with lib; {
     description = "Mopidy extension for playing music from YouTube Music";

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -21,8 +21,6 @@ python3Packages.buildPythonApplication rec {
       --replace 'ytmusicapi>=0.20.0,<0.21.0' 'ytmusicapi>=0.20.0'
   '';
 
-  doCheck = true;
-
   meta = with lib; {
     description = "Mopidy extension for playing music from YouTube Music";
     homepage = "https://github.com/OzymandiasTheGreat/mopidy-ytmusic";

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -16,6 +16,11 @@ python3Packages.buildPythonApplication rec {
     python3Packages.pytube
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'ytmusicapi>=0.19.1,<0.20.0' 'ytmusicapi>=0.19.1'
+  '';
+  
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mopidy-ytmusic";
-  version = "0.3.2";
+  version = "0.3.5";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "Mopidy-YTMusic";
-    sha256 = "sha256-BZtW+qHsTnOMj+jdAFI8ZMwGxJc9lNosgPJZGbt4JgU=";
+    sha256 = "0pncyxfqxvznb9y4ksndbny1yf5mxh4089ak0yz86dp2qi5j99iv";
   };
 
   propagatedBuildInputs = [
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'ytmusicapi>=0.19.1,<0.20.0' 'ytmusicapi>=0.19.1'
+      --replace 'ytmusicapi>=0.20.0,<0.21.0' 'ytmusicapi>=0.20.0'
   '';
 
   doCheck = true;

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -20,8 +20,8 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace setup.py \
       --replace 'ytmusicapi>=0.19.1,<0.20.0' 'ytmusicapi>=0.19.1'
   '';
-  
-  doCheck = false;
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Mopidy extension for playing music from YouTube Music";

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -16,6 +16,11 @@ python3Packages.buildPythonApplication rec {
     python3Packages.pytube
   ];
 
+  pythonImportsCheck = [ "mopidy_ytmusic" ];
+
+  # has no tests
+  doCheck = false;
+
   postPatch = ''
     substituteInPlace setup.py \
       --replace 'ytmusicapi>=0.20.0,<0.21.0' 'ytmusicapi>=0.20.0'


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/164542129

###### Things done

- Relaxed ytmusicapi requirements
- Enabled tests

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
