### PR TITLE
python3Packages.svdtools: 0.1.20 -> 0.1.21

### DIFF
--- a/pkgs/development/python-modules/svdtools/default.nix
+++ b/pkgs/development/python-modules/svdtools/default.nix
@@ -11,14 +11,21 @@
 
 buildPythonPackage rec {
   pname = "svdtools";
-  version = "0.1.20";
+  version = "0.1.21";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit version pname;
-    sha256 = "028s1bn50mfpaygf1wc2mvf06s50wqfplqrkhrjz6kx8vzrmwj72";
+    sha256 = "0qc94haqkj4dbhify1l3x0ji1dx34m79nfnsk1c7l1kl2zjvz6bz";
   };
+
+  # remove upon next release
+  # see: https://github.com/stm32-rs/svdtools/pull/96
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace 'PyYAML ~= 5.3' 'PyYAML >= 5.3'
+  '';
 
   propagatedBuildInputs = [
     braceexpand
@@ -34,7 +41,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python package to handle vendor-supplied, often buggy SVD files";
     homepage = "https://github.com/stm32-rs/svdtools";
-    changelog = "https://github.com/stm32-rs/svdtools/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/stm32-rs/svdtools/blob/v${version}/CHANGELOG-python.md";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ newam ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update svdtools to the latest version.

Changelog: https://github.com/stm32-rs/svdtools/blob/v0.1.21/CHANGELOG-python.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
