### PR TITLE
types.singleLineStr: strings that don't contain '\n'

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -300,6 +300,13 @@ rec {
       inherit (str) merge;
     };
 
+    singleLineStr = mkOptionType {
+      name = "singleLineStr";
+      description = "string that doesn't contain '\\n'";
+      check = x: str.check x && !(lib.hasInfix "\n" x);
+      inherit (str) merge;
+    };
+
     strMatching = pattern: mkOptionType {
       name = "strMatching ${escapeNixString pattern}";
       description = "string matching the pattern ${pattern}";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -300,11 +300,18 @@ rec {
       inherit (str) merge;
     };
 
-    singleLineStr = mkOptionType {
-      name = "singleLineStr";
-      description = "string that doesn't contain [\\n\\r]";
-      inherit (strMatching "[^\n\r]*") check merge;
-    };
+    # Allow a newline character at the end and trim it in the merge function.
+    singleLineStr =
+      let
+        inherit (strMatching "[^\n\r]*\n?") check merge;
+      in
+      mkOptionType {
+        name = "singleLineStr";
+        description = "string that doesn't contain [\\n\\r]";
+        inherit check;
+        merge = loc: defs:
+          lib.removeSuffix "\n" (merge loc defs);
+      };
 
     strMatching = pattern: mkOptionType {
       name = "strMatching ${escapeNixString pattern}";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -307,7 +307,7 @@ rec {
       in
       mkOptionType {
         name = "singleLineStr";
-        description = "string that doesn't contain [\\n\\r]";
+        description = "(optionally newline-terminated) single-line string";
         inherit check;
         merge = loc: defs:
           lib.removeSuffix "\n" (merge loc defs);

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -302,9 +302,8 @@ rec {
 
     singleLineStr = mkOptionType {
       name = "singleLineStr";
-      description = "string that doesn't contain '\\n'";
-      check = x: str.check x && !(lib.hasInfix "\n" x);
-      inherit (str) merge;
+      description = "string that doesn't contain [\\n\\r]";
+      inherit (strMatching "[^\n\r]*") check merge;
     };
 
     strMatching = pattern: mkOptionType {

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -30,7 +30,7 @@ let
 
     options.openssh.authorizedKeys = {
       keys = mkOption {
-        type = types.listOf types.str;
+        type = types.listOf types.singleLineStr;
         default = [];
         description = ''
           A list of verbatim OpenSSH public keys that should be added to the


### PR DESCRIPTION
###### Motivation for this change

Add a new type, inheriting `types.str`, but checking whether the value doesn't contain any newline characters.

The motivation comes from a problem with the `users.users.${u}.openssh.authorizedKeys` option.
It is easy to unintentionally insert a newline character at the end of a string, or even in the middle, for example:

```nix
restricted_ssh_keys = command: keys:
  let
    prefix = ''
      command="${command}",no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding
    '';
  in map (key: "${prefix} ${key}") keys;
```

The `prefix` string ends with a newline, which ends up in the middle of a key entry after a few manipulations.

This is problematic because the key file is built by concatenating all the keys with `concatStringsSep "\n"`, with result in two entries for the faulty key:

```nix
''
  command="...",options...
  MY_KEY
''
```

This is hard to debug and might be dangerous. This is now caught at build time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

