### PR TITLE
p11-kit: 0.24.0 -> 0.24.1

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     # Hardcode paths used by Flatpak itself.
     (substituteAll {
       src = ./fix-paths.patch;
-      p11kit = "${p11-kit.dev}/bin/p11-kit";
+      p11kit = "${p11-kit.bin}/bin/p11-kit";
     })
 
     # Adapt paths exposed to sandbox for NixOS.

--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -1,34 +1,61 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, which
-, gettext, libffi, libiconv, libtasn1
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, docbook-xsl-nons
+, gtk-doc
+, installShellFiles
+, libxslt # for xsltproc
+, pkg-config
+, which
+, libffi
+, libiconv
+, libintl
+, libtasn1
 }:
 
 stdenv.mkDerivation rec {
   pname = "p11-kit";
-  version = "0.24.0";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "p11-glue";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jvUzOhMvbq05SxQ+kjKQHDDMzNwo4U6nFHu3JjygJHw=";
+    hash = "sha256-1QIMEGBZsqLYU3v5ZswD5K9VcIGLBovJlC10lBHhH7c=";
   };
 
-  outputs = [ "out" "dev"];
-  outputBin = "dev";
+  outputs = [ "out" "bin" "dev"];
 
-  # for cross platform builds of p11-kit, libtasn1 in nativeBuildInputs
+  # For cross platform builds of p11-kit, libtasn1 in nativeBuildInputs
   # provides the asn1Parser binary on the hostPlatform needed for building.
   # at the same time, libtasn1 in buildInputs provides the libasn1 library
   # to link against for the target platform.
-  # hence, libtasn1 is required in both native and build inputs.
-  nativeBuildInputs = [ autoreconfHook pkg-config which libtasn1 ];
-  buildInputs = [ gettext libffi libiconv libtasn1 ];
+  # Hence, libtasn1 is required in both native and build inputs.
+  nativeBuildInputs = [
+    autoreconfHook
+    docbook-xsl-nons
+    gtk-doc
+    installShellFiles
+    libtasn1
+    libxslt.bin
+    pkg-config
+    which
+  ];
+
+  buildInputs = [
+    libffi
+    libiconv
+    libintl
+    libtasn1
+  ];
 
   autoreconfPhase = ''
     NOCONFIGURE=1 ./autogen.sh
   '';
 
   configureFlags = [
+    "--enable-doc"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-trust-paths=${lib.concatStringsSep ":" [
@@ -53,6 +80,10 @@ stdenv.mkDerivation rec {
     "exampledir=${placeholder "out"}/etc/pkcs11"
   ];
 
+  postInstall = ''
+    installShellCompletion --bash bash-completion/{p11-kit,trust}
+  '';
+
   meta = with lib; {
     description = "Library for loading and sharing PKCS#11 modules";
     longDescription = ''
@@ -61,6 +92,10 @@ stdenv.mkDerivation rec {
       PKCS#11 modules in such a way that they're discoverable.
     '';
     homepage = "https://p11-glue.github.io/p11-glue/p11-kit.html";
+    changelog = [
+      "https://github.com/p11-glue/p11-kit/raw/${version}/NEWS"
+      "https://github.com/p11-glue/p11-kit/releases/tag/${version}"
+    ];
     platforms = platforms.all;
     license = licenses.bsd3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* version update
* move binaries into bin output (closes #90156)
* install Bash shell completions


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Changelog:

> 0.24.1 (stable)
>  * rpc: Support protocol version negotiation [PR#371, PR#385]
>  * proxy: Support copying attribute array recursively [PR#368]
>  * Link libp11-kit so that it cannot unload [PR#383]
>  * Translation improvements [PR#381]
>  * Build fixes [PR#372, PR#373, PR#375, PR#377, PR#384, PR#407]