### PR TITLE
hut: init at unstable-2022-01-18

### DIFF
--- a/pkgs/applications/version-management/hut/default.nix
+++ b/pkgs/applications/version-management/hut/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromSourcehut
+, installShellFiles
+, scdoc
+}:
+
+buildGoModule rec {
+  pname = "hut";
+  version = "unstable-2022-01-18";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "hut";
+    rev = "c039cb53135a5e9fdd4bc66e2626e3ae6e857a34";
+    sha256 = "0gfl6zdvdiip9bzvya98sln4b7bd3g1isrqfrwpcwap49xbczc3f";
+  };
+
+  vendorSha256 = "sha256-6CgHc2ASaci5ybxAvUGJHjtTFllr4RghPw8RIsGmHdo=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    scdoc
+  ];
+
+  postBuild = ''
+    scdoc < doc/hut.1.scd > hut.1
+    installManPage hut.1
+  '';
+
+  meta = with lib; {
+    description = "A CLI tool for sr.ht";
+    homepage = "https://sr.ht/~emersion/hut/";
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ _0x4A6F ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9848,6 +9848,8 @@ with pkgs;
 
   sourcehut = callPackage ../applications/version-management/sourcehut { };
 
+  hut = callPackage ../applications/version-management/hut { };
+
   sshfs-fuse = callPackage ../tools/filesystems/sshfs-fuse { };
   sshfs = sshfs-fuse; # added 2017-08-14
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [hut](https://sr.ht/~emersion/hut/), a command line utility for [sourcehut](https://sourcehut.org/) instances.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
