### PR TITLE
wine: Remove bundled libraries

### DIFF
--- a/pkgs/misc/emulators/wine/base.nix
+++ b/pkgs/misc/emulators/wine/base.nix
@@ -43,16 +43,11 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   buildInputs = toBuildInputs pkgArches (with supportFlags; (pkgs:
   [ pkgs.freetype pkgs.perl ]
   ++ lib.optional stdenv.isLinux         pkgs.libcap
-  ++ lib.optional pngSupport             pkgs.libpng
-  ++ lib.optional jpegSupport            pkgs.libjpeg
   ++ lib.optional cupsSupport            pkgs.cups
-  ++ lib.optional colorManagementSupport pkgs.lcms2
   ++ lib.optional gettextSupport         pkgs.gettext
   ++ lib.optional dbusSupport            pkgs.dbus
-  ++ lib.optional mpg123Support          pkgs.mpg123
   ++ lib.optional openalSupport          pkgs.openal
   ++ lib.optional cairoSupport           pkgs.cairo
-  ++ lib.optional tiffSupport            pkgs.libtiff
   ++ lib.optional odbcSupport            pkgs.unixODBC
   ++ lib.optional netapiSupport          pkgs.samba4
   ++ lib.optional cursesSupport          pkgs.ncurses
@@ -60,7 +55,6 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional pcapSupport            pkgs.libpcap
   ++ lib.optional v4lSupport             pkgs.libv4l
   ++ lib.optional saneSupport            pkgs.sane-backends
-  ++ lib.optional gsmSupport             pkgs.gsm
   ++ lib.optional gphoto2Support         pkgs.libgphoto2
   ++ lib.optional ldapSupport            pkgs.openldap
   ++ lib.optional fontconfigSupport      pkgs.fontconfig
@@ -70,14 +64,12 @@ stdenv.mkDerivation ((lib.optionalAttrs (buildScript != null) {
   ++ lib.optional udevSupport            pkgs.udev
   ++ lib.optional vulkanSupport          pkgs.vulkan-loader
   ++ lib.optional sdlSupport             pkgs.SDL2
-  ++ lib.optional faudioSupport          pkgs.faudio
   ++ vkd3dArches
   ++ lib.optionals gstreamerSupport      (with pkgs.gst_all_1;
     [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-ugly gst-libav
     (gst-plugins-bad.override { enableZbar = false; }) ])
   ++ lib.optionals gtkSupport    [ pkgs.gtk3 pkgs.glib ]
   ++ lib.optionals openclSupport [ pkgs.opencl-headers pkgs.ocl-icd ]
-  ++ lib.optionals xmlSupport    [ pkgs.libxml2 pkgs.libxslt ]
   ++ lib.optionals tlsSupport    [ pkgs.openssl pkgs.gnutls ]
   ++ lib.optionals (openglSupport && !stdenv.isDarwin) [ pkgs.libGLU pkgs.libGL pkgs.mesa.osmesa pkgs.libdrm ]
   ++ lib.optionals stdenv.isDarwin (with pkgs.buildPackages.darwin.apple_sdk.frameworks; [

--- a/pkgs/misc/emulators/wine/default.nix
+++ b/pkgs/misc/emulators/wine/default.nix
@@ -9,9 +9,6 @@
 { lib, stdenv, callPackage,
   wineRelease ? "stable",
   wineBuild ? if stdenv.hostPlatform.system == "x86_64-linux" then "wineWow" else "wine32",
-  pngSupport ? false,
-  jpegSupport ? false,
-  tiffSupport ? false,
   gettextSupport ? false,
   fontconfigSupport ? false,
   alsaSupport ? false,
@@ -20,9 +17,7 @@
   tlsSupport ? false,
   gstreamerSupport ? false,
   cupsSupport ? false,
-  colorManagementSupport ? false,
   dbusSupport ? false,
-  mpg123Support ? false,
   openalSupport ? false,
   openclSupport ? false,
   cairoSupport ? false,
@@ -33,16 +28,13 @@
   pcapSupport ? false,
   v4lSupport ? false,
   saneSupport ? false,
-  gsmSupport ? false,
   gphoto2Support ? false,
   ldapSupport ? false,
   pulseaudioSupport ? false,
   udevSupport ? false,
   xineramaSupport ? false,
-  xmlSupport ? false,
   vulkanSupport ? false,
   sdlSupport ? false,
-  faudioSupport ? false,
   vkd3dSupport ? false,
   mingwSupport ? wineRelease != "stable",
   waylandSupport ? wineRelease == "wayland",
@@ -53,13 +45,13 @@ let wine-build = build: release:
       lib.getAttr build (callPackage ./packages.nix {
         wineRelease = release;
         supportFlags = {
-          inherit pngSupport jpegSupport cupsSupport colorManagementSupport gettextSupport
-                  dbusSupport mpg123Support openalSupport cairoSupport tiffSupport odbcSupport
-                  netapiSupport cursesSupport vaSupport pcapSupport v4lSupport saneSupport
-                  gsmSupport gphoto2Support ldapSupport fontconfigSupport alsaSupport
-                  pulseaudioSupport xineramaSupport gtkSupport openclSupport xmlSupport tlsSupport
-                  openglSupport gstreamerSupport udevSupport vulkanSupport sdlSupport faudioSupport
-                  vkd3dSupport mingwSupport waylandSupport embedInstallers;
+          inherit
+            cupsSupport gettextSupport dbusSupport openalSupport cairoSupport
+            odbcSupport netapiSupport cursesSupport vaSupport pcapSupport
+            v4lSupport saneSupport gphoto2Support ldapSupport fontconfigSupport
+            alsaSupport pulseaudioSupport xineramaSupport gtkSupport openclSupport
+            tlsSupport openglSupport gstreamerSupport udevSupport vulkanSupport
+            sdlSupport vkd3dSupport mingwSupport waylandSupport embedInstallers;
         };
       });
 

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -8,9 +8,6 @@ rec {
   };
 
   base = minimal.override {
-    pngSupport = true;
-    jpegSupport = true;
-    tiffSupport = true;
     gettextSupport = true;
     fontconfigSupport = true;
     alsaSupport = true;
@@ -25,7 +22,6 @@ rec {
     pulseaudioSupport = config.pulseaudio or stdenv.isLinux;
     udevSupport = true;
     xineramaSupport = true;
-    xmlSupport = true;
     sdlSupport = true;
     mingwSupport = true;
   };
@@ -33,8 +29,6 @@ rec {
   full = base.override {
     gtkSupport = true;
     gstreamerSupport = true;
-    colorManagementSupport = true;
-    mpg123Support = true;
     openalSupport = true;
     openclSupport = true;
     odbcSupport = true;
@@ -42,10 +36,8 @@ rec {
     vaSupport = true;
     pcapSupport = true;
     v4lSupport = true;
-    gsmSupport = true;
     gphoto2Support = true;
     ldapSupport = true;
-    faudioSupport = true;
     vkd3dSupport = true;
     embedInstallers = true;
   };


### PR DESCRIPTION
###### Motivation for this change

From the 7.0 release notes:

```
*** External dependencies

- The following libraries are bundled in the source tree and built as PE
  libraries, so they are no longer required at the Unix level:
   - Faudio
   - GSM
   - LCMS2
   - LibJPEG
   - LibJXR
   - LibMPG123
   - LibPng
   - LibTiff
   - LibXml2
   - LibXslt
   - Zlib

- The libraries above can still be imported as external libraries instead of
  using the bundled copy, provided that they are available in PE format. This
  behavior is requested with the '--with-system-dllpath' configure option,
  which specifies the Unix search path for such dependencies.
```

Not sure if we want to still provide them as external libraries or if we can clean them up and let Wine do its thing?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
