### PR TITLE
promescale: 0.7.1 -> 0.8.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/promscale/default.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale/default.nix
@@ -29,7 +29,16 @@ buildGoModule rec {
     "-X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}"
   ];
 
-  doCheck = false; # Requires access to a docker daemon
+  checkPhase = ''
+    runHook preCheck
+
+    # some checks requires access to a docker daemon
+    for pkg in $(getGoDirs test | grep -Ev 'testhelpers|upgrade_tests|end_to_end_tests|util'); do
+      buildGoDir test $checkFlags "$pkg"
+    done
+
+    runHook postCheck
+  '';
 
   passthru.tests.version = testVersion {
     package = promscale;

--- a/pkgs/servers/monitoring/prometheus/promscale/default.nix
+++ b/pkgs/servers/monitoring/prometheus/promscale/default.nix
@@ -7,22 +7,27 @@
 
 buildGoModule rec {
   pname = "promscale";
-  version = "0.7.1";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
     rev = version;
-    sha256 = "sha256-OMDl8RGFOMW+KNX2tNHusJY/6gLZxuWCI3c0E/oqrfE=";
+    sha256 = "sha256-h76NHEPY3ABq2NbRQXNR+zSkriBasi550rfSkl3Xdas=";
   };
 
   patches = [
     ./0001-remove-jaeger-test-dep.patch
   ];
 
-  vendorSha256 = "sha256-IwHngKiQ+TangEj5PcdiGoLxQJrt/Y3EtbSYZYmfUOE=";
+  vendorSha256 = "sha256-PxmTS8fSh21BcLS4PsSfHhKOXWWJLboPR6E8/Jx/UGY=";
 
-  ldflags = [ "-s" "-w" "-X github.com/timescale/promscale/pkg/version.Version=${version}" "-X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/timescale/promscale/pkg/version.Version=${version}"
+    "-X github.com/timescale/promscale/pkg/version.CommitHash=${src.rev}"
+  ];
 
   doCheck = false; # Requires access to a docker daemon
 
@@ -34,6 +39,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "An open-source analytical platform for Prometheus metrics";
     homepage = "https://github.com/timescale/promscale";
+    changelog = "https://github.com/timescale/promscale/blob/${version}/CHANGELOG.md";
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ _0x4A6F ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [0.8.0](https://github.com/timescale/promscale/releases/tag/0.8.0) incorporating these [changes](https://github.com/timescale/promscale/compare/0.7.1...0.8.0).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
