### PR TITLE
nixosTests.gnome: increase autologin delay

### DIFF
--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -19,7 +19,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
           user = "alice";
         };
         # Catch GDM failures that don't happen with AutomaticLoginEnable, e.g. https://github.com/NixOS/nixpkgs/issues/149539
-        gdm.autoLogin.delay = 1;
+        gdm.autoLogin.delay = 3;
       };
 
       services.xserver.desktopManager.gnome.enable = true;


### PR DESCRIPTION
Increase the autologin delay to 3 seconds in the hope to avoid some failures, see https://github.com/NixOS/nixpkgs/pull/151105#issuecomment-1015900206