### PR TITLE
pgcli: 3.3.0 -> 3.3.1

### DIFF
--- a/pkgs/development/python-modules/cli-helpers/default.nix
+++ b/pkgs/development/python-modules/cli-helpers/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "cli_helpers";
-  version = "2.2.0";
+  version = "2.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "733f65d8c921e0cffa8f7ae4c8735bd7ecdffec383c5246f647ddd0fddb33448";
+    sha256 = "sha256-DMwc/Noaxk3H7YPXATBVzxnll50p5Wwh87aS3gFVWq4=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -20,13 +20,13 @@
 
 buildPythonApplication rec {
   pname = "pgcli";
-  version = "3.3.0";
+  version = "3.3.1";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-PQ7UDfaR1gJUzLTVZUpSwcY3P3fSs89qkK6m7pn+pDk=";
+    sha256 = "sha256-/MyeVcpopK0Ih6z6KZGvs7ivk/PM6a2iSeatiYeZM6E=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Update to latest release https://github.com/dbcli/pgcli/releases/tag/v3.3.1

Also needed to update `cli-helpers`: https://github.com/dbcli/pgcli/commit/a981564f9d0d67e9b583e2bff8f24f613084fbba

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
6 packages updated:
litecli mycli pgcli pgcli python310Packages.cli-helpers (2.2.0 → 2.2.1) python39Packages.cli-helpers (2.2.0 → 2.2.1)

6 packages built:
litecli mycli pgcli python310Packages.cli-helpers python310Packages.pgcli python39Packages.cli-helpers
```