### PR TITLE
ratman: init at 0.3.1

### DIFF
--- a/pkgs/tools/networking/ratman/default.nix
+++ b/pkgs/tools/networking/ratman/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchurl
+, installShellFiles
+, libsodium
+, pkg-config
+, protobuf
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ratman";
+  version = "0.3.1";
+
+  src = fetchurl {
+    url = "https://git.irde.st/we/irdest/-/archive/${pname}-${version}/irdest-${pname}-${version}.tar.gz";
+    sha256 = "0x1wvhsmf7m55j9hmirkz75qivsg33xab1sil6nbv8fby428fpq6";
+  };
+
+  cargoSha256 = "1dkfyy1z34qaavyd3f20hrrrb3kjsdfkyzd535xlds9wivgchmd0";
+
+  nativeBuildInputs = [ protobuf pkg-config installShellFiles ];
+
+  cargoBuildFlags = [ "--all-features" "-p" "ratman" ];
+  cargoTestFlags = cargoBuildFlags;
+
+  buildInputs = [ libsodium ];
+
+  postInstall = ''
+    installManPage docs/man/ratmand.1
+  '';
+
+  SODIUM_USE_PKG_CONFIG = 1;
+
+  meta = with lib; {
+    description = "A modular decentralised peer-to-peer packet router and associated tools";
+    homepage = "https://git.irde.st/we/irdest";
+    platforms = platforms.unix;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ spacekookie yuka ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9124,6 +9124,8 @@ with pkgs;
 
   rarian = callPackage ../development/libraries/rarian { };
 
+  ratman = callPackage ../tools/networking/ratman { };
+
   ratools = callPackage ../tools/networking/ratools { };
 
   ratt = callPackage ../applications/misc/ratt { };


### PR DESCRIPTION


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
