### PR TITLE
(nixos/system/boot): make stage-2 respect `boot.initrd.verbose` flag

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -1,9 +1,15 @@
 #! @shell@
 
 systemConfig=@systemConfig@
+verbose="@verbose@"
 
 export HOME=/root PATH="@path@"
 
+info() {
+    if [[ -n "$verbose" ]]; then
+        echo -e "$@"
+    fi
+}
 
 # Process the kernel command line.
 for o in $(</proc/cmdline); do
@@ -21,9 +27,9 @@ done
 
 
 # Print a greeting.
-echo
-echo -e "\e[1;32m<<< NixOS Stage 2 >>>\e[0m"
-echo
+info ""
+info "\e[1;32m<<< NixOS Stage 2 >>>\e[0m"
+info ""
 
 
 # Normally, stage 1 mounts the root filesystem read/writable.
@@ -103,7 +109,7 @@ ln -s /run/lock /var/lock
 
 # Clear the resume device.
 if test -n "$resumeDevice"; then
-    mkswap "$resumeDevice" || echo 'Failed to clear saved image.'
+    mkswap "$resumeDevice" || info 'Failed to clear saved image.'
 fi
 
 
@@ -129,7 +135,7 @@ fi
 
 # Run the script that performs all configuration activation that does
 # not have to be done at boot time.
-echo "running activation script..."
+info "running activation script..."
 $systemConfig/activate
 
 
@@ -168,7 +174,7 @@ exec {logOutFd}>&- {logErrFd}>&-
 
 
 # Start systemd.
-echo "starting systemd..."
+info "starting systemd..."
 
 PATH=/run/current-system/systemd/lib/systemd:@fsPackagesPath@ \
     LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive @systemdUnitPathEnvVar@ \


### PR DESCRIPTION
Fixes #32555

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This should remove any output of the stage 2 boot script, making boots silent. A lot of people have asked for silent boots for some time now.

##### Things that need to be done

I think there still needs to be a `boot.verbose` flag added to `stage-2.nix`, similar to how it's done in [stage-1.nix](https://github.com/NixOS/nixpkgs/blob/b77b529e4bb68ef34f1b4d770baf0159c7477bdd/nixos/modules/system/boot/stage-1.nix#L624). Maybe it's a good idea to re-use the value of `boot.initrd.verbose`? I left this change out to get some feedback!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
