### PR TITLE
python3Packages.sigrok: init at 0.5.1 

### DIFF
--- a/pkgs/development/python-modules/sigrok/default.nix
+++ b/pkgs/development/python-modules/sigrok/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, stdenv
+, libsigrok
+, toPythonModule
+, python
+, autoreconfHook
+, pythonImportsCheckHook
+, pythonCatchConflictsHook
+, swig
+, setuptools
+, numpy
+, pygobject3
+}:
+
+# build libsigrok plus its Python bindings. Unfortunately it does not appear
+# to be possible to build them separately, at least not easily.
+toPythonModule ((libsigrok.override {
+  inherit python;
+}).overrideAttrs (orig: {
+  pname = "${python.libPrefix}-sigrok";
+
+  patches = orig.patches or [] ++ [
+    # Makes libsigrok install the bindings into site-packages properly (like
+    # we expect) instead of making a version-specific *.egg subdirectory.
+    ./python-install.patch
+  ];
+
+  nativeBuildInputs = orig.nativeBuildInputs or [] ++ [
+    autoreconfHook
+    setuptools
+    swig
+    numpy
+  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    pythonImportsCheckHook
+    pythonCatchConflictsHook
+  ];
+
+  buildInputs = orig.buildInputs or [] ++ [
+    pygobject3 # makes headers available the configure script checks for
+  ];
+
+  propagatedBuildInputs = orig.propagatedBuildInputs or [] ++ [
+    pygobject3
+    numpy
+  ];
+
+  postInstall = ''
+    ${orig.postInstall or ""}
+
+    # for pythonImportsCheck
+    export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
+  '';
+
+  pythonImportsCheck = [ "sigrok" "sigrok.core" ];
+
+  meta = orig.meta // {
+    description = "Python bindings for libsigrok";
+    maintainers = orig.meta.maintainers ++ [
+      lib.maintainers.sternenseemann
+    ];
+  };
+}))

--- a/pkgs/development/python-modules/sigrok/python-install.patch
+++ b/pkgs/development/python-modules/sigrok/python-install.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile.am b/Makefile.am
+index 280cf64d..e10eb79f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -888,8 +888,9 @@ $(PDIR)/timestamp: $(PDIR)/sigrok/core/classes.i \
+ 
+ python-install:
+ 	$(AM_V_at)$(MKDIR_P) "$(DESTDIR)$(prefix)" "$(DESTDIR)$(exec_prefix)"
+-	destdir='$(DESTDIR)'; $(setup_py) install $${destdir:+"--root=$$destdir"} \
+-		--prefix "$(prefix)" --exec-prefix "$(exec_prefix)"
++	destdir='$(DESTDIR)'; $(setup_py) install --root=$${destdir:-/} \
++		--prefix "$(prefix)" --exec-prefix "$(exec_prefix)" \
++		--single-version-externally-managed
+ 
+ python-clean:
+ 	-$(AM_V_at)rm -f $(PDIR)/timestamp

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, libzip, glib, libusb1, libftdi1, check
-, libserialport, librevisa, doxygen, glibmm, python3
+, libserialport, librevisa, doxygen, glibmm, python
 , version ? "0.5.1", sha256 ? "171b553dir5gn6w4f7n37waqk62nq2kf1jykx4ifjacdz5xdw3z4", doInstallCheck ? true
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "14sd8xqph4kb109g073daiavpadb20fcz7ch1ipn0waz7nlly4sw";
   };
 
-  nativeBuildInputs = [ doxygen pkg-config python3 ];
+  nativeBuildInputs = [ doxygen pkg-config python ];
   buildInputs = [ libzip glib libusb1 libftdi1 check libserialport librevisa glibmm ];
 
   strictDeps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14529,9 +14529,12 @@ with pkgs;
 
   libstdcxx5 = callPackage ../development/libraries/gcc/libstdc++/5.nix { };
 
-  libsigrok = callPackage ../development/tools/libsigrok { };
+  libsigrok = callPackage ../development/tools/libsigrok {
+    python = python3;
+  };
   # old version:
   libsigrok_0_3 = libsigrok.override {
+    python = python3;
     version = "0.3.0";
     sha256 = "0l3h7zvn3w4c1b9dgvl3hirc4aj1csfkgbk87jkpl7bgl03nk4j3";
     doInstallCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8925,6 +8925,8 @@ in {
 
   signedjson = callPackage ../development/python-modules/signedjson { };
 
+  sigrok = callPackage ../development/python-modules/sigrok { };
+
   sigtools = callPackage ../development/python-modules/sigtools { };
 
   simanneal = callPackage ../development/python-modules/simanneal { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`nix-shell -p "python3.withPackages (p: [ p.sigrok ])" --run "python -c 'import sigrok'" -I nixpkgs=.`

cc @cyber-murmel

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
