### PR TITLE
Provide NSS modules globally, make nscd unnecessary (v2)

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -14,14 +14,17 @@ with lib;
       internal = true;
       default = [];
       description = ''
-        Search path for NSS (Name Service Switch) modules.  This allows
-        several DNS resolution methods to be specified via
+        Path containing NSS (Name Service Switch) modules.
+        This allows several DNS resolution methods to be specified via
         <filename>/etc/nsswitch.conf</filename>.
       '';
       apply = list:
         {
           inherit list;
-          path = makeLibraryPath list;
+          path = pkgs.symlinkJoin {
+            name = "nss-modules";
+            paths = list;
+          };
         };
     };
 

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -33,9 +33,6 @@ let
       ${smbToString (map shareConfig (attrNames cfg.shares))}
     '');
 
-  # This may include nss_ldap, needed for samba if it has to use ldap.
-  nssModulesPath = config.system.nssModules.path;
-
   daemonService = appName: args:
     { description = "Samba Service Daemon ${appName}";
 
@@ -44,7 +41,6 @@ let
       partOf = [ "samba.target" ];
 
       environment = {
-        LD_LIBRARY_PATH = nssModulesPath;
         LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       };
 

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -264,10 +264,6 @@ in
       wantedBy = [ "multi-user.target" ];
       requires = [ "avahi-daemon.socket" ];
 
-      # Make NSS modules visible so that `avahi_nss_support ()' can
-      # return a sensible value.
-      environment.LD_LIBRARY_PATH = config.system.nssModules.path;
-
       path = [ pkgs.coreutils pkgs.avahi ];
 
       serviceConfig = {

--- a/nixos/modules/services/networking/ssh/lshd.nix
+++ b/nixos/modules/services/networking/ssh/lshd.nix
@@ -137,10 +137,6 @@ in
 
       wantedBy = [ "multi-user.target" ];
 
-      environment = {
-        LD_LIBRARY_PATH = config.system.nssModules.path;
-      };
-
       preStart = ''
         test -d /etc/lsh || mkdir -m 0755 -p /etc/lsh
         test -d /var/spool/lsh || mkdir -m 0755 -p /var/spool/lsh

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -24,8 +24,6 @@ let
   cfg  = config.services.openssh;
   cfgc = config.programs.ssh;
 
-  nssModulesPath = config.system.nssModules.path;
-
   userOptions = {
 
     options.openssh.authorizedKeys = {
@@ -425,7 +423,6 @@ in
             after = [ "network.target" ];
             stopIfChanged = false;
             path = [ cfgc.package pkgs.gawk ];
-            environment.LD_LIBRARY_PATH = nssModulesPath;
 
             restartTriggers = optionals (!cfg.startWhenNeeded) [
               config.environment.etc."ssh/sshd_config".source

--- a/nixos/modules/services/system/dbus.nix
+++ b/nixos/modules/services/system/dbus.nix
@@ -122,7 +122,6 @@ in
       # Don't restart dbus-daemon. Bad things tend to happen if we do.
       reloadIfChanged = true;
       restartTriggers = [ configDir ];
-      environment = { LD_LIBRARY_PATH = config.system.nssModules.path; };
     };
 
     systemd.user = {

--- a/nixos/modules/services/system/nscd.conf
+++ b/nixos/modules/services/system/nscd.conf
@@ -1,11 +1,3 @@
-# We basically use nscd as a proxy for forwarding nss requests to appropriate
-# nss modules, as we run nscd with LD_LIBRARY_PATH set to the directory
-# containing all such modules
-# Note that we can not use `enable-cache no` As this will actually cause nscd
-# to just reject the nss requests it receives, which then causes glibc to
-# fallback to trying to handle the request by itself. Which won't work as glibc
-# is not aware of the path in which the nss modules live.  As a workaround, we
-# have `enable-cache yes` with an explicit ttl of 0
 server-user             nscd
 
 enable-cache            passwd          yes

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -48,7 +48,8 @@ in
     environment.etc."nscd.conf".text = cfg.config;
 
     systemd.services.nscd =
-      { description = "Name Service Cache Daemon";
+      {
+        description = "Name Service Cache Daemon";
 
         before = [ "nss-lookup.target" "nss-user-lookup.target" ];
         wants = [ "nss-lookup.target" "nss-user-lookup.target" ];
@@ -69,14 +70,16 @@ in
         # files. So prefix the ExecStart command with "!" to prevent systemd
         # from dropping privileges early. See ExecStart in systemd.service(5).
         serviceConfig =
-          { ExecStart = "!@${nscd}/sbin/nscd nscd";
+          {
+            ExecStart = "!@${nscd}/sbin/nscd nscd";
             Type = "forking";
             DynamicUser = true;
             RuntimeDirectory = "nscd";
             PIDFile = "/run/nscd/nscd.pid";
             Restart = "always";
             ExecReload =
-              [ "${nscd}/sbin/nscd --invalidate passwd"
+              [
+                "${nscd}/sbin/nscd --invalidate passwd"
                 "${nscd}/sbin/nscd --invalidate group"
                 "${nscd}/sbin/nscd --invalidate hosts"
               ];

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
 
-  nssModulesPath = config.system.nssModules.path;
   cfg = config.services.nscd;
 
   nscd = if pkgs.stdenv.hostPlatform.libc == "glibc"
@@ -26,8 +25,10 @@ in
         default = true;
         description = ''
           Whether to enable the Name Service Cache Daemon.
-          Disabling this is strongly discouraged, as this effectively disables NSS Lookups
-          from all non-glibc NSS modules, including the ones provided by systemd.
+
+          When this option is disabled, NSS lookups from non-glibc NSS modules are disabled for:
+          - binaries that use a glibc version different from the system glibc
+          - 32-bit binaries on 64-bit hosts.
         '';
       };
 
@@ -54,8 +55,6 @@ in
         before = [ "nss-lookup.target" "nss-user-lookup.target" ];
         wants = [ "nss-lookup.target" "nss-user-lookup.target" ];
         wantedBy = [ "multi-user.target" ];
-
-        environment = { LD_LIBRARY_PATH = nssModulesPath; };
 
         restartTriggers = [
           config.environment.etc.hosts.source

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -139,7 +139,6 @@ in
 
     users.users.systemd-resolve.group = "systemd-resolve";
 
-    # add resolve to nss hosts database if enabled and nscd enabled
     # system.nssModules is configured in nixos/modules/system/boot/systemd.nix
     # added with order 501 to allow modules to go before with mkBefore
     system.nssDatabases.hosts = (mkOrder 501 ["resolve [!UNAVAIL=return]"]);

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -335,6 +335,7 @@ in
   nomad = handleTest ./nomad.nix {};
   novacomd = handleTestOn ["x86_64-linux"] ./novacomd.nix {};
   nsd = handleTest ./nsd.nix {};
+  nssmodules-without-nscd = handleTest ./nssmodules-without-nscd.nix {};
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};

--- a/nixos/tests/nssmodules-without-nscd.nix
+++ b/nixos/tests/nssmodules-without-nscd.nix
@@ -1,0 +1,21 @@
+# Ensure that NSS modules are accessible by glibc client binaries when
+# nscd is disabled
+
+import ./make-test-python.nix ({ lib, ... } : {
+  name = "nssmodules-without-nscd";
+
+  meta = with lib.maintainers; {
+    maintainers = [ earvstedt flokli ];
+  };
+
+  nodes.node = {
+    services.nscd.enable = false;
+  };
+
+  # Test dynamic user resolution via `libnss_systemd.so` which is only available
+  # through `system.nssModules`
+  testScript = ''
+    node.succeed("systemd-run --property=DynamicUser=yes --property=User=testuser sleep infinity")
+    node.succeed("getent passwd testuser")
+  '';
+})

--- a/pkgs/development/libraries/glibc/add-extra-module-load-path.patch
+++ b/pkgs/development/libraries/glibc/add-extra-module-load-path.patch
@@ -1,0 +1,47 @@
+Add NSS module load path /run/nss-modules-${word_size}-${glibc_version}/lib
+as a fallback. Previously, glibc only looked for NSS modules in ${glibc.out}/lib and
+LD_LIBRARY_PATH.
+
+On NixOS, this removes the dependency on nscd for enabling NSS functionality in
+glibc clients.
+nscd has caching bugs and leaks DNS requests across network namespaces.
+
+The module load path is only used by binaries that use the same glibc
+version and word size as the NSS modules. This avoids failures due to ABI
+incompatibilities. Incompatible binaries can still be served by nscd.
+
+On non-NixOS systems, this patch doesn't change behaviour, as the path
+doesn't exist there.
+
+diff --git a/nss/nss_module.c b/nss/nss_module.c
+index 6c5f341f..80b6eac0 100644
+--- a/nss/nss_module.c
++++ b/nss/nss_module.c
+@@ -133,5 +133,27 @@ module_load (struct nss_module *module)
+       return false;
+ 
+     handle = __libc_dlopen (shlib_name);
++
++    /* After loading from the default locations, try loading from
++       the NixOS module load path. */
++    if (handle == NULL) {
++
++      #define STR_(x) #x
++      #define STR(x) STR_(x)
++
++      const char nix_nss_path[] = "/run/nss-modules-" STR(__WORDSIZE) "-"
++        STR(__GLIBC__) "." STR(__GLIBC_MINOR__) "/lib/";
++      char shlib_path[1024];
++      size_t nix_nss_path_len = sizeof(nix_nss_path) - 1;
++      size_t shlib_name_len = strlen(shlib_name);
++      size_t shlib_path_len = nix_nss_path_len + shlib_name_len;
++
++      if (shlib_path_len < sizeof(shlib_path)) {
++        memcpy(&shlib_path[0], nix_nss_path, nix_nss_path_len);
++        memcpy(&shlib_path[nix_nss_path_len], shlib_name, shlib_name_len + 1);
++        handle = __libc_dlopen(shlib_path);
++      }
++    }
++
+     free (shlib_name);
+   }

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -125,6 +125,8 @@ stdenv.mkDerivation ({
 
       /* https://github.com/NixOS/nixpkgs/pull/137601 */
       ./nix-nss-open-files.patch
+
+      ./add-extra-module-load-path.patch
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./fix-rpc-types-musl-conflicts.patch
     ++ lib.optional stdenv.buildPlatform.isDarwin ./darwin-cross-build.patch;


### PR DESCRIPTION
This is a follow-up to https://github.com/NixOS/nixpkgs/pull/138178 ([diff](https://gist.github.com/erikarvstedt/9362ee4b7961129ea618e8e39c5b1b41)) which fixes the binary incompatibilities of the original PR.

This PR allows glibc client binaries to access NSS modules configured via `system.nssModules` without nscd.
nscd has significant caching bugs and causes friction in general (#95107, #154928).
For details about nscd bugs, see issue [`DNS responses are cached`](https://github.com/NixOS/nixpkgs/issues/135888) and the [Fedora nscd deprecation notes](https://fedoraproject.org/wiki/Changes/DeprecateNSCD#Benefit_to_Fedora).

Some services set `LD_LIBRARY_PATH` to allow running them without nscd. These workarounds are now obsolete and are removed by this PR.

### Implementation

Provide global NSS modules at `/run/nss-modules-${word_size}-${glibc_version}/lib` (e.g. `/run/nss-modules-64-2.34/lib`) and patch glibc to use this path.
The versioning suffix ensures that only binary compatible glibc client binaries will use this path.

Repo [erikarvstedt/check-glibc-compatibilities](https://github.com/erikarvstedt/check-glibc-compatibilities/) shows that different NSS modules and glibc clients are compatible with each other, as long as they share the same minor glibc release (e.g. `2.34`).

Because the patched code region is never inlined, the patch affects all binaries that dynamically link glibc. This includes binaries prebuilt with a non-nixpkgs libc that are processed with `patchelf` (like `slack`).

### Todo
- nscd is still enabled to provide NSS modules for binaries with non-system glibc versions and for 32-bit binaries on 64-bit hosts.
  In light of its defects and lack of maintenance, it might be sensible to disable nscd by default.
  Note: `unscd` is no replacement for nscd because it [doesn't implement](https://github.com/bytedance/unscd/blob/3a4df8de6723bc493e9cd94bb3e3fd831e48b8ca/nscd.c#L615-L621) all nsswitch functions ([src thread](https://github.com/NixOS/nixpkgs/pull/124019#issuecomment-856228888)).
- We'll add release notes for this PR as soon as it reaches community consensus.
- To support 32-bit binaries on 64-bit hosts without nscd, we could add options analogous to [`opengl.driSupport32Bit`](https://github.com/NixOS/nixpkgs/blob/610d4ea2750e064bf34b33fa38cb671edd893d3d/nixos/modules/hardware/opengl.nix#L60) and [`opengl.extraPackages32`](https://github.com/NixOS/nixpkgs/blob/610d4ea2750e064bf34b33fa38cb671edd893d3d/nixos/modules/hardware/opengl.nix#L99). As a minimum, `systemd` NSS modules should be provided. This can be addressed in another PR.

### Appendix
Fixes: #135888
Fixes: #105353
Fixes: #55276
Cc: [#52411 (comment)](https://github.com/NixOS/nixpkgs/issues/52411#issuecomment-757347201)
Closes: #111194

This PR is co-authored by @flokli.