### PR TITLE
vimPlugins.sniprun: init at 1.1.2

### DIFF
--- a/pkgs/misc/vim-plugins/patches/sniprun/fix-paths.patch
+++ b/pkgs/misc/vim-plugins/patches/sniprun/fix-paths.patch
@@ -1,0 +1,36 @@
+diff --git a/lua/sniprun.lua b/lua/sniprun.lua
+index aa39e0b..188d54a 100644
+--- a/lua/sniprun.lua
++++ b/lua/sniprun.lua
+@@ -4,9 +4,7 @@ M.custom_highlight=false
+ M.info_floatwin = {}
+ 
+ -- See https://github.com/tjdevries/rofl.nvim/blob/632c10f2ec7c56882a3f7eda8849904bcac6e8af/lua/rofl.lua
+-local binary_path = vim.fn.fnamemodify(
+-  vim.api.nvim_get_runtime_file("lua/sniprun.lua", false)[1], ":h:h")
+-  .. "/target/release/sniprun"
++local binary_path = "@sniprun_bin@/bin/sniprun"
+ 
+ local sniprun_path = vim.fn.fnamemodify( vim.api.nvim_get_runtime_file("lua/sniprun.lua", false)[1], ":p:h") .. "/.."
+ 
+diff --git a/ressources/init_repl.sh b/ressources/init_repl.sh
+index 2e6264d..0eab1c6 100644
+--- a/ressources/init_repl.sh
++++ b/ressources/init_repl.sh
+@@ -23,7 +23,7 @@ mkfifo $working_dir/$pipe
+ touch $working_dir/$out
+ sleep 36000 > $working_dir/$pipe &
+ 
+-echo "/bin/cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
++echo "cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
+ chmod +x $working_dir/real_launcher.sh
+ 
+ echo $repl " process started at $(date +"%F %T")." >> $working_dir/log
+diff --git a/ressources/launcher_repl.sh b/ressources/launcher_repl.sh
+index feaa91e..749c55e 100755
+--- a/ressources/launcher_repl.sh
++++ b/ressources/launcher_repl.sh
+@@ -1,2 +1,2 @@
+ #!/bin/bash
+-/bin/cat $1 > $2
++cat $1 > $2


### PR DESCRIPTION
###### Motivation for this change

Add [sniprun](https://github.com/michaelb/sniprun) with `sniprun` executable.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
