### PR TITLE
drush: 6.1.0 -> 8.4.10

### DIFF
--- a/pkgs/development/tools/misc/drush/default.nix
+++ b/pkgs/development/tools/misc/drush/default.nix
@@ -2,40 +2,30 @@
 
 stdenv.mkDerivation rec {
   pname = "drush";
-  version = "6.1.0";
+  version = "8.4.10";
 
-  meta = with lib; {
-    description = "Command-line shell and Unix scripting interface for Drupal";
-    homepage    = "https://github.com/drush-ops/drush";
-    license     = licenses.gpl2;
-    maintainers = with maintainers; [ lovek323 ];
-    platforms   = platforms.all;
+  src = fetchurl {
+    url = "https://github.com/drush-ops/drush/releases/download/${version}/drush.phar";
+    sha256 = "sha256-yXSoTDFLsjDiYkRfrIxv2WTVdHzgxZRvtn3Pht5XF4k=";
   };
 
-  src = fetchFromGitHub {
-    owner = "drush-ops";
-    repo  = pname;
-    rev = version;
-    sha256 = "sha256-0nf/m+xJmfHsFLuordiMp8UyrGGXuS70+zFHkIxLWhU=";
-  };
-
-  consoleTable = fetchurl {
-    url    = "http://download.pear.php.net/package/Console_Table-1.1.3.tgz";
-    sha256 = "07gbjd7m1fj5dmavr0z20vkqwx1cz2522sj9022p257jifj1yl76";
-  };
+  dontUnpack = true;
 
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
-    # install libraries
-    cd lib
-    tar -xf ${consoleTable}
-    cd ..
-
-    mkdir -p "$out"
-    cp -r . "$out/src"
-    mkdir "$out/bin"
-    wrapProgram "$out/src/drush" --prefix PATH : "${lib.makeBinPath [ which php bash coreutils ncurses ]}"
-    ln -s "$out/src/drush" "$out/bin/drush"
+    mkdir -p $out/bin
+    install -D $src $out/libexec/drush/drush.phar
+    makeWrapper ${php}/bin/php $out/bin/drush \
+      --add-flags "$out/libexec/drush/drush.phar" \
+      --prefix PATH : "${lib.makeBinPath [ which php bash coreutils ncurses ]}"
   '';
+
+  meta = with lib; {
+    description = "Command-line shell and Unix scripting interface for Drupal";
+    homepage = "https://github.com/drush-ops/drush";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ lovek323 ];
+    platforms = platforms.all;
+  };
 }


### PR DESCRIPTION
Drush 6.x is unsupported, and not compatible with any PHP version we
ship in nixpkgs.

Drush 8.x still supports Drupal 6, 7 and 8.

I switched to using the released .phar, instead of trying to nixify the
composer dependencies.

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/155690

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
