### PR TITLE
amdvlk: 2021.Q4.3 -> 2022.Q1.1

### DIFF
--- a/pkgs/development/libraries/amdvlk/default.nix
+++ b/pkgs/development/libraries/amdvlk/default.nix
@@ -22,13 +22,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "amdvlk";
-  version = "2021.Q4.3";
+  version = "2022.Q1.1";
 
   src = fetchRepoProject {
     name = "${pname}-src";
     manifest = "https://github.com/GPUOpen-Drivers/AMDVLK.git";
     rev = "refs/tags/v-${version}";
-    sha256 = "M+58gJjP33yOuq6RYN73HG7wACPaYRz7WFC/AFFGMzw=";
+    sha256 = "jdAFIC2JYPqCADx/73KM6E3rLFWF4SlEdY9lCK1NOhU=";
   };
 
   buildInputs = [
@@ -87,11 +87,11 @@ in stdenv.mkDerivation rec {
     #!nix-shell -i bash -p coreutils curl gnused jq common-updater-scripts
 
     function setHash() {
-      sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's,sha256 = "[^.'"'"']*",sha256 = "'"$1"'",'
+      sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's,sha256 = "[^'"'"'"]*",sha256 = "'"$1"'",'
     }
 
     version="$(curl -sL "https://api.github.com/repos/GPUOpen-Drivers/AMDVLK/releases?per_page=1" | jq '.[0].tag_name | split("-") | .[1]' --raw-output)"
-    sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's/version = "[^.'"'"']*"/version = "'"$version"'"/'
+    sed -i "pkgs/development/libraries/amdvlk/default.nix" -e 's/version = "[^'"'"'"]*"/version = "'"$version"'"/'
 
     setHash "$(nix-instantiate --eval -A lib.fakeSha256 | xargs echo)"
     hash="$(nix to-base64 $(nix-build -A amdvlk 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true))"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
2022.Q1.1 was published: https://github.com/GPUOpen-Drivers/AMDVLK/releases/tag/v-2022.Q1.1

**Edit:** Pushed `/nix/store/l9sc5d1cbsacmsksd2dfqgbbd3x1vxx3-amdvlk-2022.Q1.1` to cachix: https://app.cachix.org/cache/flakebi

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested vkcube
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
