### PR TITLE
aplwrap: init at version 2.4

### DIFF
--- a/pkgs/applications/editors/aplwrap/default.nix
+++ b/pkgs/applications/editors/aplwrap/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, autoreconfHook
+, fetchFromGitHub
+, gnuapl
+, gsettings-desktop-schemas
+, gtk3
+, makeWrapper
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "aplwrap";
+  version = "2.4";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "ChrisMoller";
+      repo = "aplwrap";
+      rev = "773228a8107a0850bf0589cda234cb538b163818";
+      hash = "sha256-gvajdcU+ZXe5X9S/jnU5C8tkE9yFBd3g7JF4UQttgCk=";
+    })
+    # aplwrap requires gnuapl sources to compile
+    gnuapl.src
+  ];
+
+  # Because we have multple sources, we need to tell nix where
+  # the build should be based out of
+  sourceRoot = "source";
+
+  # Do not make this target since all it does is to run fc-cache,
+  # which we don't need and also leads to errors.
+  preConfigurePhases = [ "removeInstallDataHook" ];
+  removeInstallDataHook = ''
+    substituteInPlace Makefile.am \
+      --replace 'fc-cache' 'echo skipping fc-cache'
+  '';
+
+  preBuildPhases = [ "patchBuildInfo" ];
+  patchBuildInfo = ''
+    patchShebangs src/buildinfo
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config makeWrapper ];
+  buildInputs = [ gnuapl gtk3 gsettings-desktop-schemas ];
+
+  # Because aplwrap starts the apl binary using "apl", we need to add gnuapl
+  # to path in the context of aplwrap
+  # We need to set XDG_DATA_DIRS the error
+  # 'No GSettings schemas are installed on the system' when changing settings
+  postInstall = ''
+    wrapProgram "$out/bin/aplwrap" \
+      --suffix XDG_DATA_DIRS ':' "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}" \
+      --suffix PATH ':' "${gnuapl}/bin"
+  '';
+
+  meta = {
+    description = "A GTK+-based wrapper for GNU APL";
+    homepage = "https://github.com/ChrisMoller/aplwrap";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ wchresta ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1262,6 +1262,8 @@ with pkgs;
 
   apfsprogs = callPackage ../tools/filesystems/apfsprogs { };
 
+  aplwrap = callPackage ../applications/editors/aplwrap { };
+
   apk-tools = callPackage ../tools/package-management/apk-tools {
     lua = lua5_3;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

aplwrap is missing, so we're adding it

###### Things done

Created new package. Tested with:

```
$ nix run .#aplwrap

(aplwrap:77558): Gtk-WARNING **: 21:54:12.304: Theme parsing error: <data>:1:10: not a number

(aplwrap:77558): Gtk-WARNING **: 21:54:12.304: Theme parsing error: <data>:1:23: Using Pango syntax for the font: style property is deprecated; please use CSS syntax

(aplwrap:77558): Gtk-WARNING **: 21:54:12.304: Theme parsing error: <data>:1:86: 'ed2' is not a valid color name

(aplwrap:77558): Gtk-WARNING **: 21:54:17.343: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.
```

Played around within aplwrap (executed some APL commands) and works as expected. Gtk icons seem to work, too (after installing them in my profile).

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
