### PR TITLE
flake.nix: expose forAllSystems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
     in
     {
       lib = lib.extend (final: prev: {
+        inherit forAllSystems;
         nixosSystem = { modules, ... } @ args:
           import ./nixos/lib/eval-config.nix (args // {
             modules =


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`forAllSystems` is a handy little function. It'd save me pulling in flake-utils just for the `eachDefaultSystem` function

Any thoughts? It is a quite short and sweet function people could just copy past if we're against adding extra flake "lib" stuff

cc: @edolstra @zimbatm @roberth

