### PR TITLE
compactor: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   ];
   enableParallelBuilding = true;
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin; # check-dnstap.sh failing on Darwin
   checkInputs = [
     cbor-diag
     cddl

--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -1,28 +1,36 @@
-{ autoconf, automake, boost, cbor-diag, cddl, fetchFromGitHub, file, libctemplate, libmaxminddb
-, libpcap, libtins, libtool, xz, openssl, pkg-config, lib, stdenv, tcpdump, wireshark-cli
+{ lib, stdenv, fetchFromGitHub
+, asciidoctor, autoreconfHook, pkg-config
+, boost, libctemplate, libmaxminddb, libpcap, libtins, openssl, protobuf, xz, zlib
+, cbor-diag, cddl, diffutils, file, mktemp, netcat, tcpdump, wireshark-cli
 }:
 
 stdenv.mkDerivation rec {
   pname = "compactor";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "dns-stats";
     repo = pname;
     rev = version;
-    sha256 = "0qykdnwi2q9sajkkc2sl5f00lvxjfymqjzqm0limsziykanh87c0";
+    fetchSubmodules = true;
+    hash = "sha256-AUNPUk70VwJ0nZgMPLMU258nqkL4QP6km0USrZi2ea0=";
   };
 
-  # cbor-diag, cddl and wireshark-cli are only used for tests.
-  nativeBuildInputs = [ autoconf automake libtool pkg-config cbor-diag cddl wireshark-cli ];
+  nativeBuildInputs = [
+    asciidoctor
+    autoreconfHook
+    pkg-config
+  ];
   buildInputs = [
     boost
-    libpcap
-    openssl
-    libtins
-    xz
     libctemplate
     libmaxminddb
+    libpcap
+    libtins
+    openssl
+    protobuf
+    xz
+    zlib
   ];
 
   prePatch = ''
@@ -30,11 +38,10 @@ stdenv.mkDerivation rec {
   '';
 
   preConfigure = ''
-    ${stdenv.shell} autogen.sh
     substituteInPlace configure \
       --replace "/usr/bin/file" "${file}/bin/file"
   '';
-  CXXFLAGS = "-std=c++11";
+
   configureFlags = [
     "--with-boost-libdir=${boost.out}/lib"
     "--with-boost=${boost.dev}"
@@ -42,18 +49,23 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
-  preCheck = ''
-    substituteInPlace test-scripts/check-live-pcap.sh \
-      --replace "/usr/sbin/tcpdump" "${tcpdump}/bin/tcpdump"
-    rm test-scripts/same-tshark-output.sh
-  ''; # TODO: https://github.com/dns-stats/compactor/issues/49  (failing test)
+  checkInputs = [
+    cbor-diag
+    cddl
+    diffutils
+    file
+    mktemp
+    netcat
+    tcpdump
+    wireshark-cli
+  ];
 
   meta = with lib; {
     description = "Tools to capture DNS traffic and record it in C-DNS files";
-    homepage    = "http://dns-stats.org/";
+    homepage    = "https://dns-stats.org/";
     changelog   = "https://github.com/dns-stats/${pname}/raw/${version}/ChangeLog.txt";
-    license     = [ licenses.boost licenses.mpl20 licenses.openssl ];
+    license     = licenses.mpl20;
     maintainers = with maintainers; [ fdns ];
-    platforms   = lib.platforms.unix;
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  prePatch = ''
+  postPatch = ''
     patchShebangs test-scripts/
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
