### PR TITLE
aws-c-common: emit unwind information for RISC-V

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF" # for tests
+  ] ++ lib.optionals stdenv.hostPlatform.isRiscV [
+    "-DCMAKE_C_FLAGS=-fasynchronous-unwind-tables"
   ];
 
   # aws-c-common misuses cmake modules, so we need


### PR DESCRIPTION
###### Motivation for this change

The test suite for `aws-c-common` fails on RISC-V due to libgcc `backtrace()` returning 0, which in turn triggers a segfault due to underflow (see https://github.com/awslabs/aws-c-common/pull/873).

This is fairly easy to reproduce:

```
#include <execinfo.h>
#include <stdio.h>

int main(int argc, char **argv[])
{
	void *buf[128];
	int n;

	n = backtrace(buf, 128);
	printf("backtrace() = %d\n", n);

	return 0;
}
```

Compile:
```
# riscv64-unknown-linux-gnu-gcc test.c && ./a.out 
backtrace() = 0
```

Passing `-fasynchronous-unwind-tables` helps. Note *gcc_s* needs to be explicitly linked to avoid runtime `dlopen()` failure:

```
# riscv64-unknown-linux-gnu-gcc -fasynchronous-unwind-tables test.c -lgcc_s && ./a.out 
backtrace() = 3
```

###### Notes

This appears to be gcc default for AArch64: [[AArch64] Turn on -fasynchronous-unwind-tables and -funwind-tables by default.
](https://patchwork.ozlabs.org/project/gcc/patch/7b28c03a-c032-6cec-c127-1c12cbe98eeb@foss.arm.com/) and on `x86_64` it works out of the box as well, so an alternate approach would be to patch the toolchain instead. If this doesn't turn out to be a widespread issue, just patching up this package works for me.

###### Resolution

Pass -fasynchronous-unwind-tables in CFLAGS for RISC-V.

This fixes functionality which depends on backtrace() and enables
running the test suite without error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
