### PR TITLE
live555: 2019.11.22 -> 2022.01.21

### DIFF
--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -188,6 +188,16 @@ stdenv.mkDerivation rec {
       url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/4250fe8f28c220d883db454cec2b2c76a07473eb/trunk/vlc-3.0.11.1-srt_1.4.2.patch";
       sha256 = "53poWjZfwq/6l316sqiCp0AtcGweyXBntcLDFPSokHQ=";
     })
+    # patches to build with recent live555
+    # upstream issue: https://code.videolan.org/videolan/vlc/-/issues/25473
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/vlc/uploads/3c84ea58d7b94d7a8d354eaffe4b7d55/0001-Get-addr-by-ref.-from-getConnectionEndpointAddress.patch";
+      sha256 = "171d3qjl9a4dm13sqig3ra8s2zcr76wfnqz4ba4asg139cyc1axd";
+    })
+    (fetchpatch {
+      url = "https://code.videolan.org/videolan/vlc/uploads/eb1c313d2d499b8a777314f789794f9d/0001-Add-lssl-and-lcrypto-to-liblive555_plugin_la_LIBADD.patch";
+      sha256 = "0kyi8q2zn2ww148ngbia9c7qjgdrijf4jlvxyxgrj29cb5iy1kda";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -1,20 +1,23 @@
-{ stdenv, fetchurl, lib, darwin }:
+{ stdenv, fetchurl, lib, darwin, openssl }:
 
 # Based on https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD
 stdenv.mkDerivation rec {
   pname = "live555";
-  version = "2019.11.22";
+  version = "2022.01.21";
 
   src = fetchurl { # the upstream doesn't provide a stable URL
     urls = [
       "mirror://sourceforge/slackbuildsdirectlinks/live.${version}.tar.gz"
       "https://download.videolan.org/contrib/live555/live.${version}.tar.gz"
     ];
-    sha256 = "144y2wsfpaclkj7srx85f3y3parzn7vbjmzc2afc62wdsb9gn46d";
+    sha256 = "03m9wgw06vs93nbd55yq8qjpm92mcg9j7cih8j6blfnv8b0pj9bn";
   };
 
   postPatch = ''
     sed 's,/bin/rm,rm,g' -i genMakefiles
+    substituteInPlace config.macosx-catalina \
+      --replace '/usr/lib/libssl.46.dylib' "${openssl.out}/lib/libssl.dylib" \
+      --replace '/usr/lib/libcrypto.44.dylib' "${openssl.out}/lib/libcrypto.dylib"
     sed \
       -e 's/$(INCLUDES) -I. -O2 -DSOCKLEN_T/$(INCLUDES) -I. -O2 -I. -fPIC -DRTSPCLIENT_SYNCHRONOUS_INTERFACE=1 -DSOCKLEN_T/g' \
       -i config.linux
@@ -27,7 +30,7 @@ stdenv.mkDerivation rec {
     runHook preConfigure
 
     ./genMakefiles ${{
-      x86_64-darwin = "macosx";
+      x86_64-darwin = "macosx-catalina";
       i686-linux = "linux";
       x86_64-linux = "linux-64bit";
       aarch64-linux = "linux-64bit";
@@ -49,6 +52,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = lib.optional stdenv.isDarwin darwin.cctools;
+
+  buildInputs = [ openssl ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Fix #138686.

###### Things done
Tested that playing RTSP streams in VLC still works.

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of packages that depend on this change: live555 and vlc
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).