### PR TITLE
openjfx17: init at 17.0.0.1+1

### DIFF
--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -1,0 +1,106 @@
+{ stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless, gradle_7
+, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst, libXxf86vm, glib, alsa-lib
+, ffmpeg, python3, ruby, icu68 }:
+
+let
+  major = "17";
+  update = ".0.0.1";
+  build = "+1";
+  repover = "${major}${update}${build}";
+  gradle_ = (gradle_7.override {
+    java = openjdk17_headless;
+  });
+
+  makePackage = args: stdenv.mkDerivation ({
+    version = "${major}${update}${build}";
+
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jfx";
+      rev = repover;
+      sha256 = "sha256-PSiE9KbF/4u9VyBl9PAMLGzKyGFB86/XByeh7vhL6Kw=";
+    };
+
+    buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg icu68 ];
+    nativeBuildInputs = [ gradle_ perl pkg-config cmake gperf python3 ruby ];
+
+    dontUseCmakeConfigure = true;
+
+    config = writeText "gradle.properties" (''
+      CONF = Release
+      JDK_HOME = ${openjdk17_headless.home}
+    '' + args.gradleProperties or "");
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      ln -s $config gradle.properties
+      export NIX_CFLAGS_COMPILE="$(pkg-config --cflags glib-2.0) $NIX_CFLAGS_COMPILE"
+      gradle --no-daemon $gradleFlags sdk
+
+      runHook postBuild
+    '';
+  } // args);
+
+  # Fake build to pre-download deps into fixed-output derivation.
+  # We run nearly full build because I see no other way to download everything that's needed.
+  # Anyone who knows a better way?
+  deps = makePackage {
+    pname = "openjfx-deps";
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME -type f -regex '.*/modules.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+      rm -rf $out/tmp
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-dV7/U5GpFxhI13smZ587C6cVE4FRNPY0zexZkYK4Yqo=";
+  };
+
+in makePackage {
+  pname = "openjfx-modular-sdk";
+
+  gradleProperties = ''
+    COMPILE_MEDIA = true
+    COMPILE_WEBKIT = false
+  '';
+
+  preBuild = ''
+    swtJar="$(find ${deps} -name org.eclipse.swt\*.jar)"
+    substituteInPlace build.gradle \
+      --replace 'mavenCentral()' 'mavenLocal(); maven { url uri("${deps}") }' \
+      --replace 'name: SWT_FILE_NAME' "files('$swtJar')"
+  '';
+
+  installPhase = ''
+    cp -r build/modular-sdk $out
+  '';
+
+  stripDebugList = [ "." ];
+
+  postFixup = ''
+    # Remove references to bootstrap.
+    export openjdkOutPath='${openjdk17_headless.outPath}'
+    find "$out" -name \*.so | while read lib; do
+      new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
+      patchelf --set-rpath "$new_refs" "$lib"
+    done
+  '';
+
+  disallowedReferences = [ openjdk17_headless ];
+
+  passthru.deps = deps;
+
+  meta = with lib; {
+    homepage = "http://openjdk.java.net/projects/openjfx/";
+    license = licenses.gpl2;
+    description = "The next-generation Java client toolkit";
+    maintainers = with maintainers; [ abbradar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -3,7 +3,7 @@
 rec {
   gen =
 
-    { version, nativeVersion, sha256, defaultJava ? jdk8 }:
+    { version, nativeVersion, sha256, defaultJava ? jdk8, supportedPlatforms ? null }:
 
     { lib, stdenv, fetchurl, makeWrapper, unzip, java ? defaultJava
     , javaToolchains ? [ ], ncurses5, ncurses6 }:
@@ -87,7 +87,7 @@ rec {
         changelog = "https://docs.gradle.org/${version}/release-notes.html";
         downloadPage = "https://gradle.org/next-steps/?version=${version}";
         license = licenses.asl20;
-        platforms = platforms.unix;
+        platforms = if (supportedPlatforms != null) then supportedPlatforms else platforms.unix;
         maintainers = with maintainers; [ lorenzleutgeb liff ];
       };
     };
@@ -100,6 +100,9 @@ rec {
     nativeVersion = "0.22-milestone-21";
     sha256 = "00h3z0vxc4hv31sc71gb88r8yabyqgz304wpr0bxhbx2d14f11mm";
     defaultJava = jdk17;
+    # Gradle 7 ships some binaries that are only available for some platforms
+    # See https://github.com/gradle/native-platform#supported-platforms
+    supportedPlatforms =  [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" "x86_64-cygwin" "x86_64-windows" "i686-windows"  ];
   };
 
   gradle_6 = gen {
@@ -107,6 +110,9 @@ rec {
     nativeVersion = "0.22-milestone-20";
     sha256 = "13qyk3f6namw27ynh6nxljxpk9r3l12vxl3f0qpglprdf3c6ydcb";
     defaultJava = jdk11;
+    # Gradle 6 ships some binaries that are only available for some platforms
+    # See https://github.com/gradle/native-platform#supported-platforms
+    supportedPlatforms =  [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" "x86_64-cygwin" "x86_64-windows" "i686-windows"  ];
   };
 
   # NOTE: No GitHub Release for the following versions. `update.sh` will not work.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12417,8 +12417,8 @@ with pkgs;
 
   hugs = callPackage ../development/interpreters/hugs { };
 
-  inherit (javaPackages) openjfx11 openjfx15;
-  openjfx = openjfx15;
+  inherit (javaPackages) openjfx11 openjfx15 openjfx17;
+  openjfx = openjfx17;
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;
   openjdk8 = javaPackages.compiler.openjdk8;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -8,9 +8,10 @@ let
 
   openjfx11 = callPackage ../development/compilers/openjdk/openjfx/11.nix { };
   openjfx15 = callPackage ../development/compilers/openjdk/openjfx/15.nix { };
+  openjfx17 = callPackage ../development/compilers/openjdk/openjfx/17.nix { };
 
 in {
-  inherit mavenbuild fetchMaven openjfx11 openjfx15;
+  inherit mavenbuild fetchMaven openjfx11 openjfx15 openjfx17;
 
   compiler = let
 
@@ -170,7 +171,7 @@ in {
       ../development/compilers/openjdk/darwin/17.nix
       {
         inherit openjdk17-bootstrap;
-        openjfx = openjfx15;
+        openjfx = openjfx17;
       };
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add the OpenJFX17 to go along with OpenJDK17.
This is required to update cryptomator to a newer version.

It's currently only buildable on 64bit linux due to gradle >= 6 not supporting 32bit linux anymore.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
