### PR TITLE
bukut: init at 0.11

### DIFF
--- a/pkgs/applications/misc/bukut/default.nix
+++ b/pkgs/applications/misc/bukut/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3, fetchFromGitHub }:
+
+with python3.pkgs; buildPythonApplication rec {
+  pname = "bukut";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "peterjschroeder";
+    repo = "bukut";
+    rev = "v${version}";
+    sha256 = "sha256-MCAyMvzXnC7QSpWeG7qorK4JmRBMzG3eGsp5YpKmVjg=";
+  };
+
+  propagatedBuildInputs = [
+    asciimatics
+    beautifulsoup4
+    natsort
+    pyperclip
+    pyxdg
+  ];
+
+  meta = with lib; {
+    description = "Text user interface for buku bookmark manager";
+    homepage = "https://github.com/peterjschroeder/bukut";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ taha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3938,6 +3938,8 @@ with pkgs;
 
   buku = callPackage ../applications/misc/buku { };
 
+  bukut = callPackage ../applications/misc/bukut { };
+
   byzanz = callPackage ../applications/video/byzanz {};
 
   ori = callPackage ../tools/backup/ori { };


### PR DESCRIPTION
###### Motivation for this change

Add `bukut` TUI program to nixpkgs.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
