### PR TITLE
libpinyin: 2.3.0 -> 2.6.1

### DIFF
--- a/pkgs/development/libraries/libpinyin/default.nix
+++ b/pkgs/development/libraries/libpinyin/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
 , autoreconfHook
 , glib
 , db
@@ -7,32 +10,37 @@
 
 let
   modelData = fetchurl {
-    url    = "mirror://sourceforge/libpinyin/models/model17.text.tar.gz";
-    sha256 = "1kb2nswpsqlk2qm5jr7vqcp97f2dx7nvpk24lxjs1g12n252f5z0";
+    url = "mirror://sourceforge/libpinyin/models/model19.text.tar.gz";
+    sha256 = "02zml6m8sj5q97ibpvaj9s9yz3gfj0jnjrfhkn02qv4nwm72lhjn";
   };
 in
 stdenv.mkDerivation rec {
   pname = "libpinyin";
-  version = "2.3.0";
+  version = "2.6.1";
 
   src = fetchFromGitHub {
-    owner  = "libpinyin";
-    repo   = "libpinyin";
-    rev    = version;
-    sha256 = "14fkpp16s5k0pbw5wwd24pqr0qbdjgbl90n9aqwx72m03n7an40l";
+    owner = "libpinyin";
+    repo = "libpinyin";
+    rev = version;
+    sha256 = "0izisma5g9a7mxfxs177pi1d7v9dklm0ar4z404nf2s8x4wcg3ib";
   };
 
   postUnpack = ''
     tar -xzf ${modelData} -C $sourceRoot/data
   '';
 
-  nativeBuildInputs = [ autoreconfHook glib db pkg-config ];
+  nativeBuildInputs = [
+    autoreconfHook
+    glib
+    db
+    pkg-config
+  ];
 
   meta = with lib; {
     description = "Library for intelligent sentence-based Chinese pinyin input method";
-    homepage    = "https://sourceforge.net/projects/libpinyin";
-    license     = licenses.gpl2;
-    maintainers = with maintainers; [ ericsagnes ];
-    platforms   = platforms.linux;
+    homepage = "https://sourceforge.net/projects/libpinyin";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ linsui ericsagnes ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@ericsagnes