### PR TITLE
python3Packages.entrypoint2: 0.2.4 -> 1.0

### DIFF
--- a/pkgs/development/python-modules/entrypoint2/default.nix
+++ b/pkgs/development/python-modules/entrypoint2/default.nix
@@ -1,31 +1,17 @@
-{ lib, buildPythonPackage, fetchPypi, EasyProcess, pathpy, pytest }:
+{ lib, buildPythonPackage, fetchPypi, EasyProcess, pathpy, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "entrypoint2";
-  version = "0.2.4";
+  version = "1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4770c3afcf3865c606a6e5f7cfcc5c59212f555fcee9b2540270399149c1dde3";
+    sha256 = "sha256-Z+kG9q2VjYP0i07ewo192CZw6SYZiPa0prY6vJ+zvlY=";
   };
-
-  propagatedBuildInputs = [ ];
 
   pythonImportsCheck = [ "entrypoint2" ];
 
-  # argparse is part of the standardlib
-  prePatch = ''
-    substituteInPlace setup.py --replace "argparse" ""
-  '';
-
-  checkInputs = [ EasyProcess pathpy pytest ];
-
-  # 0.2.1 has incompatible pycache files included
-  # https://github.com/ponty/entrypoint2/issues/8
-  checkPhase = ''
-    rm -rf tests/__pycache__
-    pytest tests
-  '';
+  checkInputs = [ EasyProcess pathpy pytestCheckHook ];
 
   meta = with lib; {
     description = "Easy to use command-line interface for python modules";


### PR DESCRIPTION
###### Motivation for this change

Routine upgrade, remove some no longer needed workarounds.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).