### PR TITLE
discord-ptb: 0.0.58 -> 0.0.59

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -7,11 +7,16 @@ let
     canary = "0.0.132";
   } else {
     stable = "0.0.264";
-    ptb = "0.0.58";
+    ptb = "0.0.59";
     canary = "0.0.280";
   };
   version = versions.${branch};
-  srcs = {
+  srcs = let
+    darwin-ptb = fetchurl {
+      url = "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
+      sha256 = "sha256-LS7KExVXkOv8O/GrisPMbBxg/pwoDXIOo1dK9wk1yB8=";
+    };
+  in {
     x86_64-linux = {
       stable = fetchurl {
         url =
@@ -34,11 +39,7 @@ let
         url = "https://dl.discordapp.net/apps/osx/${version}/Discord.dmg";
         sha256 = "1jvlxmbfqhslsr16prsgbki77kq7i3ipbkbn67pnwlnis40y9s7p";
       };
-      ptb = fetchurl {
-        url =
-          "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
-        sha256 = "sha256-GwYUoPBbx9lSaRP1JwzI0UE9gEU+rV4a9BNPVSxHki0=";
-      };
+      ptb = darwin-ptb;
       canary = fetchurl {
         url =
           "https://dl-canary.discordapp.net/apps/osx/${version}/DiscordCanary.dmg";
@@ -46,13 +47,7 @@ let
       };
     };
     # Only PTB bundles a MachO Universal binary with ARM support.
-    aarch64-darwin = {
-      ptb = fetchurl {
-        url =
-          "https://dl-ptb.discordapp.net/apps/osx/${version}/DiscordPTB.dmg";
-        sha256 = "sha256-GwYUoPBbx9lSaRP1JwzI0UE9gEU+rV4a9BNPVSxHki0=";
-      };
-    };
+    aarch64-darwin = { ptb = darwin-ptb; };
   };
   src = srcs.${stdenv.hostPlatform.system}.${branch};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Discord-ptb 0.0.58 is broken right now because of code signing issues.

###### Things done
Bumped version

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
