### PR TITLE
Some Coq 8.15 package updates

### DIFF
--- a/pkgs/development/coq-modules/coq-ext-lib/default.nix
+++ b/pkgs/development/coq-modules/coq-ext-lib/default.nix
@@ -5,13 +5,15 @@ with lib; mkCoqDerivation rec {
   owner = "coq-ext-lib";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.8" "8.15"; out = "0.11.6"; }
     { case = range "8.8" "8.14"; out = "0.11.4"; }
     { case = range "8.8" "8.13"; out = "0.11.3"; }
     { case = "8.7";              out = "0.9.7"; }
     { case = "8.6";              out = "0.9.5"; }
     { case = "8.5";              out = "0.9.4"; }
   ] null;
-  release."0.11.4".sha256 = "sha256:0yp8mhrhkc498nblvhq1x4j6i9aiidkjza4wzvrkp9p8rgx5g5y3";
+  release."0.11.6".sha256 = "0w6iyrdszz7zc8kaybhy3mwjain2d2f83q79xfd5di0hgdayh7q7";
+  release."0.11.4".sha256 = "0yp8mhrhkc498nblvhq1x4j6i9aiidkjza4wzvrkp9p8rgx5g5y3";
   release."0.11.3".sha256 = "1w99nzpk72lffxis97k235axss5lmzhy5z3lga2i0si95mbpil42";
   release."0.11.2".sha256 = "0iyka81g26x5n99xic7kqn8vxqjw8rz7vw9rs27iw04lf137vzv6";
   release."0.10.3".sha256 = "0795gs2dlr663z826mp63c8h2zfadn541dr8q0fvnvi2z7kfyslb";

--- a/pkgs/development/coq-modules/coq-record-update/default.nix
+++ b/pkgs/development/coq-modules/coq-record-update/default.nix
@@ -5,10 +5,11 @@ with lib; mkCoqDerivation rec {
   owner = "tchajed";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.14";  out = "0.3.0"; }
+    { case = range "8.10" "8.15";  out = "0.3.0"; }
   ] null;
   release."0.3.0".sha256 = "1ffr21dd6hy19gxnvcd4if2450iksvglvkd6q5713fajd72hmc0z";
   releaseRev = v: "v${v}";
+  buildFlags = "NO_TEST=1";
   meta = {
     description = "Library to create Coq record update functions";
     maintainers = with maintainers; [ ineol ];

--- a/pkgs/development/coq-modules/deriving/default.nix
+++ b/pkgs/development/coq-modules/deriving/default.nix
@@ -9,7 +9,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.11" "8.14"; out = "0.1.0"; }
+    { case = range "8.11" "8.15"; out = "0.1.0"; }
   ] null;
 
   releaseRev = v: "v${v}";

--- a/pkgs/development/coq-modules/equations/default.nix
+++ b/pkgs/development/coq-modules/equations/default.nix
@@ -6,8 +6,9 @@ with lib; mkCoqDerivation {
   repo = "Coq-Equations";
   inherit version;
   defaultVersion = switch coq.coq-version [
-    { case = "8.14"; out = "1.3-8.14"; }
-    { case = "8.13"; out = "1.3-8.13"; }
+    { case = "8.15"; out = "1.3+8.15"; }
+    { case = "8.14"; out = "1.3+8.14"; }
+    { case = "8.13"; out = "1.3+8.13"; }
     { case = "8.12"; out = "1.2.4+coq8.12"; }
     { case = "8.11"; out = "1.2.4+coq8.11"; }
     { case = "8.10"; out = "1.2.1+coq8.10-2"; }
@@ -44,10 +45,12 @@ with lib; mkCoqDerivation {
     release."1.2.4+coq8.12".sha256    = "1n0w8is464qcq8mk2mv7amaf0khbjz5mpc9phf0rhpjm0lb22cb3";
     release."1.2.4+coq8.13".rev       = "v1.2.4-8.13";
     release."1.2.4+coq8.13".sha256    = "0i014lshsdflzw6h0qxra9d2f0q82vffxv2f29awbb9ad0p4rq4q";
-    release."1.3-8.13".rev            = "v1.3-8.13";
-    release."1.3-8.13".sha256         = "1jwjbkkkk4bwf6pz4zzz8fy5bb17aqyf4smkja59rgj9ya6nrdhg";
-    release."1.3-8.14".rev            = "v1.3-8.14";
-    release."1.3-8.14".sha256         = "19bj9nncd1r9g4273h5qx35gs3i4bw5z9bhjni24b413hyj55hkv";
+    release."1.3+8.13".rev            = "v1.3-8.13";
+    release."1.3+8.13".sha256         = "1jwjbkkkk4bwf6pz4zzz8fy5bb17aqyf4smkja59rgj9ya6nrdhg";
+    release."1.3+8.14".rev            = "v1.3-8.14";
+    release."1.3+8.14".sha256         = "19bj9nncd1r9g4273h5qx35gs3i4bw5z9bhjni24b413hyj55hkv";
+    release."1.3+8.15".rev            = "v1.3-8.15";
+    release."1.3+8.15".sha256         = "1vfcfpsp9zyj0sw0cwibk76nj6n0r6gwh8m1aa3lbvc0b1kbm32k";
 
   mlPlugin = true;
   preBuild = "coq_makefile -f _CoqProject -o Makefile";

--- a/pkgs/development/coq-modules/reglang/default.nix
+++ b/pkgs/development/coq-modules/reglang/default.nix
@@ -10,7 +10,7 @@ mkCoqDerivation {
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.14"; out = "1.1.2"; }
+    { case = range "8.10" "8.15"; out = "1.1.2"; }
   ] null;
 
 


### PR DESCRIPTION
###### Motivation for this change

Mostly based on recent similar updates to the opam-coq-archive.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
