### PR TITLE
nixosTests.gnome: Revert "add autologin delay to catch GDM failures"

### DIFF
--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -18,8 +18,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
           enable = true;
           user = "alice";
         };
-        # Catch GDM failures that don't happen with AutomaticLoginEnable, e.g. https://github.com/NixOS/nixpkgs/issues/149539
-        gdm.autoLogin.delay = 1;
       };
 
       services.xserver.desktopManager.gnome.enable = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#150980

Unfortunately, because of a [bug](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2116) in gnome-shell this causes more [failures](https://hydra.nixos.org/build/164881244/nixlog/23) than it catches at the moment.