### PR TITLE
[21.11] rustc: add patch for CVE-2022-21658

### DIFF
--- a/pkgs/development/compilers/rust/1_56.nix
+++ b/pkgs/development/compilers/rust/1_56.nix
@@ -17,6 +17,7 @@
 , makeRustPlatform
 , llvmPackages_11
 , llvmPackages_13, llvm_13
+, fetchpatch
 } @ args:
 
 import ./default.nix {
@@ -57,6 +58,23 @@ import ./default.nix {
   selectRustPackage = pkgs: pkgs.rust_1_56;
 
   rustcPatches = [
+    # Patch 0001 was skipped as it doesn't apply cleanly and affects Windows-only code.
+    (fetchpatch {
+      name = "0002-CVE-2022-21658.patch";
+      url = "https://raw.githubusercontent.com/rust-lang/wg-security-response/240384a5fd494d4f8167c0ffa8ef566661003d8a/patches/CVE-2022-21658/0002-Fix-CVE-2022-21658-for-UNIX-like.patch";
+      sha256 = "0gwjp7clh52mg2pps44awwpdq9zq2nci8q97jaljis7h16yx3ra7";
+    })
+    (fetchpatch {
+      name = "0003-CVE-2022-21658.patch";
+      url = "https://raw.githubusercontent.com/rust-lang/wg-security-response/240384a5fd494d4f8167c0ffa8ef566661003d8a/patches/CVE-2022-21658/0003-Fix-CVE-2022-21658-for-WASI.patch";
+      sha256 = "01d77a15gikzkql4q6y43bx1cx8hy8n71v1qmlnzp7wg40v78xrp";
+    })
+    (fetchpatch {
+      name = "0004-CVE-2022-21658.patch";
+      url = "https://raw.githubusercontent.com/rust-lang/wg-security-response/240384a5fd494d4f8167c0ffa8ef566661003d8a/patches/CVE-2022-21658/0004-Update-std-fs-remove_dir_all-documentation.patch";
+      sha256 = "08afz21m1k12245q1jg813cnwl8gc95ajbzqn6mwlppqhhi4wdq2";
+    })
+    # Patch 0005 was skipped as it doesn't apply cleanly and only affects platforms that aren't Linux.
   ];
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixing a security vulnerability.

Patch `0001-Fix-CVE-2022-21658-for-Windows.patch` is not applied as it doesn't merge cleanly, but considering it's for Windows it's likely not a big issue.

Not submitting this to unstable staging as rustc 1.58.1 will be released soon. (EDIT: created #155961)

@ofborg build fd

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
