### PR TITLE
Document system.build.toplevel

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -293,6 +293,16 @@ in
       '';
     };
 
+    system.build.toplevel = mkOption {
+      type = types.package;
+      readOnly = true;
+      description = ''
+        This option contains the store path that typically represents a NixOS system.
+
+        You can read this path in a custom deployment tool for example.
+      '';
+    };
+
   };
 
 

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -139,20 +139,12 @@ in
 
 {
   imports = [
+    ../build.nix
     (mkRemovedOptionModule [ "nesting" "clone" ] "Use `specialisation.«name» = { inheritParentConfig = true; configuration = { ... }; }` instead.")
     (mkRemovedOptionModule [ "nesting" "children" ] "Use `specialisation.«name».configuration = { ... }` instead.")
   ];
 
   options = {
-
-    system.build = mkOption {
-      internal = true;
-      default = {};
-      type = types.lazyAttrsOf types.unspecified;
-      description = ''
-        Attribute set of derivations used to setup the system.
-      '';
-    };
 
     specialisation = mkOption {
       default = {};

--- a/nixos/modules/system/build.nix
+++ b/nixos/modules/system/build.nix
@@ -6,12 +6,15 @@ in
   options = {
 
     system.build = mkOption {
-      internal = true;
       default = {};
-      type = types.lazyAttrsOf types.unspecified;
       description = ''
         Attribute set of derivations used to set up the system.
       '';
+      type = types.submoduleWith {
+        modules = [{
+          freeformType = types.lazyAttrsOf types.unspecified;
+        }];
+      };
     };
 
   };

--- a/nixos/modules/system/build.nix
+++ b/nixos/modules/system/build.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+
+    system.build = mkOption {
+      internal = true;
+      default = {};
+      type = types.lazyAttrsOf types.unspecified;
+      description = ''
+        Attribute set of derivations used to set up the system.
+      '';
+    };
+
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`system.build.toplevel` isn't internal anymore, so it should be documented. For example the Flakes article on the unofficial wiki mentions it. It is a very important interface, so I don't think we should try to hide it.

Blocked on https://github.com/NixOS/nixpkgs/issues/146882

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
