### PR TITLE
nixosTests.xmonad: avoid sleep()

### DIFF
--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -90,8 +90,7 @@ in {
 
     # original config has a keybinding that creates somefile
     machine.send_key("alt-ctrl-t")
-    machine.sleep(1)
-    machine.succeed("stat /tmp/somefile")
+    machine.wait_for_file("/tmp/somefile")
 
     # set up the new config
     machine.succeed("mkdir -p ${user.home}/.xmonad")
@@ -103,15 +102,13 @@ in {
 
     # new config has a keybinding that deletes somefile
     machine.send_key("alt-ctrl-r")
-    machine.sleep(1)
-    machine.fail("stat /tmp/somefile")
+    machine.wait_until_fails("stat /tmp/somefile", timeout=30)
 
     # restart with the old config, and confirm the old keybinding is back
     machine.succeed("rm /tmp/oldXMonad")
     machine.send_key("alt-q")
     machine.wait_for_file("/tmp/oldXMonad")
     machine.send_key("alt-ctrl-t")
-    machine.sleep(1)
-    machine.succeed("stat /tmp/somefile")
+    machine.wait_for_file("/tmp/somefile")
   '';
 })

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -52,7 +52,7 @@ let
 in {
   name = "xmonad";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ nequissimus ];
+    maintainers = [ nequissimus ivanbrennan ];
   };
 
   machine = { pkgs, ... }: {


### PR DESCRIPTION
###### Motivation for this change

Relying on `sleep()` in the xmonad test could lead to failures if running on a very congested build system. Where possible, eliminate the need for `sleep()` by using `wait_for_file()` and `wait_until_fails()`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
