### PR TITLE
python3Packages.s3transfer: ignore test_compat on darwin

### DIFF
--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -1,13 +1,5 @@
-{ lib
-, botocore
-, buildPythonPackage
-, docutils
-, fetchFromGitHub
-, mock
-, pytestCheckHook
-, pythonOlder
-, wheel
-}:
+{ lib, botocore, buildPythonPackage, docutils, fetchFromGitHub, mock
+, pytestCheckHook, pythonOlder, stdenv, wheel }:
 
 buildPythonPackage rec {
   pname = "s3transfer";
@@ -42,11 +34,13 @@ buildPythonPackage rec {
     "tests/integration/test_processpool.py"
     "tests/integration/test_s3transfer.py"
     "tests/integration/test_upload.py"
-  ];
+  ] ++
+    # There was a change in python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
+    # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.
+    # I suspect the underlying issue here is that upstream tests aren't compatible with spawn multiprocessing, and pass on linux where the default is still fork
+    lib.optionals stdenv.isDarwin [ "tests/unit/test_compat.py" ];
 
-  pythonImportsCheck = [
-    "s3transfer"
-  ];
+  pythonImportsCheck = [ "s3transfer" ];
 
   meta = with lib; {
     description = "Library for managing Amazon S3 transfers";

--- a/pkgs/development/python-modules/s3transfer/default.nix
+++ b/pkgs/development/python-modules/s3transfer/default.nix
@@ -1,5 +1,14 @@
-{ lib, botocore, buildPythonPackage, docutils, fetchFromGitHub, mock
-, pytestCheckHook, pythonOlder, stdenv, wheel }:
+{ lib
+, botocore
+, buildPythonPackage
+, docutils
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, pythonOlder
+, stdenv
+, wheel
+}:
 
 buildPythonPackage rec {
   pname = "s3transfer";
@@ -15,16 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-0Dl7oKB2xxq/a8do3HgBUIGay88yOGBUdOGo+QCtnUE=";
   };
 
-  propagatedBuildInputs = [
-    botocore
-  ];
+  propagatedBuildInputs = [ botocore ];
 
-  buildInputs = [
-    docutils
-    mock
-    pytestCheckHook
-    wheel
-  ];
+  buildInputs = [ docutils mock pytestCheckHook wheel ];
 
   disabledTestPaths = [
     # Requires network access
@@ -35,10 +37,10 @@ buildPythonPackage rec {
     "tests/integration/test_s3transfer.py"
     "tests/integration/test_upload.py"
   ] ++
-    # There was a change in python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
-    # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.
-    # I suspect the underlying issue here is that upstream tests aren't compatible with spawn multiprocessing, and pass on linux where the default is still fork
-    lib.optionals stdenv.isDarwin [ "tests/unit/test_compat.py" ];
+  # There was a change in python 3.8 that defaults multiprocessing to spawn instead of fork on macOS
+  # See https://bugs.python.org/issue33725 and https://github.com/python/cpython/pull/13603.
+  # I suspect the underlying issue here is that upstream tests aren't compatible with spawn multiprocessing, and pass on linux where the default is still fork
+  lib.optionals stdenv.isDarwin [ "tests/unit/test_compat.py" ];
 
   pythonImportsCheck = [ "s3transfer" ];
 


### PR DESCRIPTION
This tests fails on darwin due to a switch on python 3.8 on MacOS from
fork to spawn. See https://github.com/NixOS/nixpkgs/pull/154280 for more information.

cc @fabaff
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
