### PR TITLE
Update my maintainership

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6604,7 +6604,7 @@
   };
   kylesferrazza = {
     name = "Kyle Sferrazza";
-    email = "kyle.sferrazza@gmail.com";
+    email = "nixpkgs@kylesferrazza.com";
 
     github = "kylesferrazza";
     githubId = 6677292;

--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation {
     homepage = "http://www.canon.com/";
     license = licenses.unfree;
     maintainers = with maintainers; [
-      kylesferrazza
+      # please consider maintaining if you are updating this package
     ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I would like to update my email address, and I no longer have a Canon printer for testing, so I removed myself from `canon-cups-ufr2`.