### PR TITLE
wpa_supplicant_gui: fixup build after update in PR #155266

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, openssl, pkg-config, libnl
-, nixosTests
+, nixosTests, wpa_supplicant_gui
 , withDbus ? true, dbus
 , withReadline ? true, readline
 , withPcsclite ? true, pcsclite
@@ -113,6 +113,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     inherit (nixosTests) wpa_supplicant;
+    inherit wpa_supplicant_gui; # inherits the src+version updates
   };
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/wpa_supplicant/gui.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/gui.nix
@@ -2,18 +2,7 @@
 
 mkDerivation {
   pname = "wpa_gui";
-  version = wpa_supplicant.version;
-
-  inherit (wpa_supplicant) src;
-
-  patches = [
-    # Fix build with Inkscape 1.0
-    # https://github.com/NixOS/nixpkgs/issues/86930
-    (fetchpatch {
-      url = "https://w1.fi/cgit/hostap/patch/?id=0388992905a5c2be5cba9497504eaea346474754";
-      sha256 = "05hs74qawa433adripzhycm45g7yvxr6074nd4zcl4gabzp9hd30";
-    })
-  ];
+  inherit (wpa_supplicant) version src;
 
   buildInputs = [ qtbase ];
   nativeBuildInputs = [ qmake inkscape imagemagick ];


### PR DESCRIPTION
<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
