### PR TITLE
nixos/borgbackup: remove literalDocBook in description

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -336,7 +336,7 @@ in {
             default = false;
             type = types.bool;
             example = true;
-            description = literalDocBook ''
+            description = ''
               Set the <literal>persistentTimer</literal> option for the
               <citerefentry><refentrytitle>systemd.timer</refentrytitle>
               <manvolnum>5</manvolnum></citerefentry>


### PR DESCRIPTION
`literalDocBook` and `literalExpression` are only for defaults and examples.

We should probably add a check for that