### PR TITLE
Pdfstudio change java

### DIFF
--- a/pkgs/applications/misc/pdfstudio/default.nix
+++ b/pkgs/applications/misc/pdfstudio/default.nix
@@ -1,82 +1,77 @@
-{ stdenv,
-  lib,
-  makeWrapper,
-  fetchurl,
-  dpkg,
-  makeDesktopItem,
-  copyDesktopItems,
-  autoPatchelfHook,
-  gst_all_1,
-  sane-backends,
-  xorg,
-  gnome2,
-  alsa-lib,
-  libgccjit,
-  jdk11
-  }:
+{ stdenv
+, lib
+, fetchurl
+, libgccjit
+, dpkg
+, makeDesktopItem
+, copyDesktopItems
+, autoPatchelfHook
+, sane-backends
+, jdk11
+}:
 
-let
-  year = "2021";
-  major = "1";
-  minor = "2";
-in stdenv.mkDerivation rec {
+# See also package 'pdfstudioviewer'
+# Differences are ${pname}, Download directory name (PDFStudio / PDFStudioViewer),
+# sha256, and libgccjit (not needed for PDFStudioViewer)
+let year = "2021";
+in
+stdenv.mkDerivation rec {
   pname = "pdfstudio";
-  version = "${year}.${major}.${minor}";
-  autoPatchelfIgnoreMissingDeps = true;
+  version = "${year}.1.2";
+  strictDeps = true;
 
   src = fetchurl {
-    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudio_v${year}_${major}_${minor}_linux64.deb";
+    url = "https://download.qoppa.com/${pname}/v${year}/PDFStudio_v${
+        builtins.replaceStrings [ "." ] [ "_" ] version
+      }_linux64.deb";
     sha256 = "1188ll2qz58rr2slavqxisbz4q3fdzidpasb1p33926z0ym3rk45";
   };
 
-  nativeBuildInputs = [
-    gst_all_1.gst-libav
-    sane-backends
-    xorg.libXxf86vm
-    xorg.libXtst
-    gnome2.libgtkhtml
-    alsa-lib
-    libgccjit
-    autoPatchelfHook
-    makeWrapper
-    dpkg
-    copyDesktopItems
-    jdk11 # only for unpacking .jar.pack files
+  buildInputs = [
+    libgccjit #for libstdc++.so.6 and libgomp.so.1
+    sane-backends #for libsane.so.1
+    jdk11
   ];
 
-  desktopItems = [(makeDesktopItem {
-       name = "${pname}${year}";
-       desktopName = "PDF Studio";
-       genericName = "View and edit PDF files";
-       exec = "${pname} %f";
-       icon = "${pname}${year}";
-       comment = "Views and edits PDF files";
-       mimeType = "application/pdf";
-       categories = "Office";
-       type = "Application";
-       terminal = false;
-  })];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "${pname}${year}";
+      desktopName = "PDF Studio";
+      genericName = "View and edit PDF files";
+      exec = "${pname} %f";
+      icon = "${pname}${year}";
+      comment = "Views and edits PDF files";
+      mimeType = "application/pdf";
+      categories = "Office";
+      type = "Application";
+      terminal = false;
+    })
+  ];
 
   unpackPhase = "dpkg-deb -x $src .";
-  dontConfigure = true;
   dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace opt/${pname}${year}/${pname}${year} --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk11.out}"
+    substituteInPlace opt/${pname}${year}/updater --replace "# INSTALL4J_JAVA_HOME_OVERRIDE=" "INSTALL4J_JAVA_HOME_OVERRIDE=${jdk11.out}"
+  '';
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
     mkdir -p $out/share
-    mkdir -p $out/share/applications
     mkdir -p $out/share/pixmaps
     cp -r opt/${pname}${year} $out/share/
+    rm -rf $out/share/${pname}${year}/jre
     ln -s $out/share/${pname}${year}/.install4j/${pname}${year}.png  $out/share/pixmaps/
-    makeWrapper $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
-
-    #Unpack jar files. Otherwise pdfstudio does this and fails due to read-only FS.
-    for pfile in $out/share/${pname}${year}/jre/lib/{,ext/}*.jar.pack; do
-      jar_file=`echo "$pfile" | awk '{ print substr($0,1,length($0)-5) }'`
-      unpack200 -r "$pfile" "$jar_file"
-    done
+    ln -s $out/share/${pname}${year}/${pname}${year} $out/bin/${pname}
 
     runHook postInstall
   '';
@@ -86,6 +81,7 @@ in stdenv.mkDerivation rec {
     description = "An easy to use, full-featured PDF editing software";
     license = licenses.unfree;
     platforms = platforms.linux;
+    mainProgram = pname;
     maintainers = [ maintainers.pwoelfel ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- makes the package almost identically to the package `pdfstudioviewer`, for ease of maintenance. 
- fixes update script (checking for updates from preferences does not silently fail anymore)
- starts pdfstudio with Java from `jdk11` instead of the JRE from the source. This allows at least the print menu to be opened (and printing to a file seems to work), but printing to printers is still broken (it seems `/usr/bin/lpr` is hardcoded in the binary). Fonts also look nicer (at least on my system)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
