### PR TITLE
nixos: use `uniq` in the type of system.build

### DIFF
--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -148,7 +148,7 @@ in
     system.build = mkOption {
       internal = true;
       default = {};
-      type = types.lazyAttrsOf types.unspecified;
+      type = with types; lazyAttrsOf (uniq unspecified);
       description = ''
         Attribute set of derivations used to setup the system.
       '';


### PR DESCRIPTION
`unspecified` will happily concatenate strings together from two unrelated modules, causing spurious errors (see #155925).

Ideally we could make system.build a submodule with a few distinguished options like installBootLoader, but I don't think this is necessary right now.

I've tested this by running a vm with `build-vm-with-bootloader`.