### PR TITLE
sambamba: 0.8.1 -> 0.8.2

### DIFF
--- a/pkgs/applications/science/biology/sambamba/default.nix
+++ b/pkgs/applications/science/biology/sambamba/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , python3
 , which
 , ldc

--- a/pkgs/applications/science/biology/sambamba/default.nix
+++ b/pkgs/applications/science/biology/sambamba/default.nix
@@ -1,27 +1,28 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, python3, which, ldc, zlib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, python3
+, which
+, ldc
+, zlib
+, lz4
+}:
 
 stdenv.mkDerivation rec {
   pname = "sambamba";
-  version = "0.8.1";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "biod";
     repo = "sambamba";
     rev = "v${version}";
-    sha256 = "0f4qngnys2zjb0ri54k6kxqnssg938mnnscs4z9713hjn41rk7yd";
+    sha256 = "sha256-FEa9QjQoGNUOAtMNMZcqpTKMKVtXoBuOomTy0mpos/0=";
     fetchSubmodules = true;
   };
 
-  patches = [
-    # make ldc 1.27.1 compatible
-    (fetchpatch {
-      url = "https://github.com/biod/sambamba/pull/480/commits/b5c80feb62683d24ec0529f685a1d7a36962a1d4.patch";
-      sha256 = "0yr9baxqbhyb4scwcwczk77z8gazhkl60jllhz9dnrb7p5qsvs7r";
-    })
-  ];
-
   nativeBuildInputs = [ which python3 ldc ];
-  buildInputs = [ zlib ];
+  buildInputs = [ zlib lz4 ];
 
   # Upstream's install target is broken; copy manually
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Sambamba update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
