### PR TITLE
python39Packages.python-openstackclient, cliff: generate and install man page

### DIFF
--- a/pkgs/development/python-modules/cliff/default.nix
+++ b/pkgs/development/python-modules/cliff/default.nix
@@ -3,11 +3,14 @@
 , fetchPypi
 , autopage
 , cmd2
+, installShellFiles
+, openstackdocstheme
 , pbr
 , prettytable
 , pyparsing
 , pyyaml
 , stevedore
+, sphinx
 , callPackage
 }:
 
@@ -26,6 +29,12 @@ buildPythonPackage rec {
     rm test-requirements.txt
   '';
 
+  nativeBuildInputs = [
+    installShellFiles
+    openstackdocstheme
+    sphinx
+  ];
+
   propagatedBuildInputs = [
     autopage
     cmd2
@@ -35,6 +44,11 @@ buildPythonPackage rec {
     pyyaml
     stevedore
   ];
+
+  postInstall = ''
+    sphinx-build -a -E -d doc/build/doctrees -b man doc/source doc/build/man
+    installManPage doc/build/man/cliff.1
+  '';
 
   # check in passthru.tests.pytest to escape infinite recursion with stestr
   doCheck = false;

--- a/pkgs/development/python-modules/openstackdocstheme/default.nix
+++ b/pkgs/development/python-modules/openstackdocstheme/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, dulwich
+, pbr
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "openstackdocstheme";
+  version = "2.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-zzWgAozJrYMFyGWzoDLYbeoY+IPlgzmVhnX7lgM6BXs=";
+  };
+
+  postPatch = ''
+    # only a small portion of the listed packages are actually needed for running the tests
+    # so instead of removing them one by one remove everything
+    rm test-requirements.txt
+  '';
+
+  propagatedBuildInputs = [ dulwich pbr sphinx ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "openstackdocstheme" ];
+
+  meta = with lib; {
+    description = "Sphinx theme for RST-sourced documentation published to docs.openstack.org";
+    homepage = "https://github.com/openstack/openstackdocstheme";
+    license = licenses.asl20;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -2,12 +2,15 @@
 , buildPythonPackage
 , fetchPypi
 , ddt
+, installShellFiles
+, openstackdocstheme
 , osc-lib
 , pbr
 , python-cinderclient
 , python-keystoneclient
 , python-novaclient
 , requests-mock
+, sphinx
 , stestr
 }:
 
@@ -20,6 +23,12 @@ buildPythonPackage rec {
     sha256 = "c65e3d51018f193cce2daf3d0fd69daa36003bdb2b85df6b07b973e4c39e2f92";
   };
 
+  nativeBuildInputs = [
+    installShellFiles
+    openstackdocstheme
+    sphinx
+  ];
+
   propagatedBuildInputs = [
     osc-lib
     pbr
@@ -27,6 +36,11 @@ buildPythonPackage rec {
     python-keystoneclient
     python-novaclient
   ];
+
+  postInstall = ''
+    sphinx-build -a -E -d doc/build/doctrees -b man doc/source doc/build/man
+    installManPage doc/build/man/openstack.1
+  '';
 
   checkInputs = [
     ddt

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -14,6 +14,7 @@
 , pygments
 , requests
 , snowballstemmer
+, sphinxcontrib-apidoc
 , sphinxcontrib-applehelp
 , sphinxcontrib-devhelp
 , sphinxcontrib-htmlhelp
@@ -63,6 +64,9 @@ buildPythonPackage rec {
     sphinxcontrib-serializinghtml
     # extra[docs]
     sphinxcontrib-websupport
+
+    # extra plugins which are otherwise not found by sphinx-build
+    sphinxcontrib-apidoc
   ] ++ lib.optionals (pythonOlder "3.10") [
     importlib-metadata
   ];

--- a/pkgs/development/python-modules/sphinxcontrib-apidoc/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-apidoc/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pbr
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-apidoc";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-cpv1ks97fdV8TAV5T3MtwCYScnXXhcKlSUUh/d53P7k=";
+  };
+
+  postPatch = ''
+    # break infite recursion, remove pytest 4 requirement
+    rm test-requirements.txt requirements.txt
+  '';
+
+  propagatedBuildInputs = [
+    pbr
+  ];
+
+  # Check is disabled due to circular dependency of sphinx
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Sphinx extension for running sphinx-apidoc on each build";
+    homepage = "https://github.com/sphinx-contrib/apidoc";
+    license = licenses.bsd2;
+    maintainers = teams.openstack.members;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5636,6 +5636,8 @@ in {
 
   opensimplex = callPackage ../development/python-modules/opensimplex { };
 
+  openstackdocstheme = callPackage ../development/python-modules/openstackdocstheme { };
+
   openstacksdk = callPackage ../development/python-modules/openstacksdk { };
 
   opentimestamps = callPackage ../development/python-modules/opentimestamps { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9234,6 +9234,8 @@ in {
 
   sphinxcontrib-actdiag = callPackage ../development/python-modules/sphinxcontrib-actdiag { };
 
+  sphinxcontrib-apidoc = callPackage ../development/python-modules/sphinxcontrib-apidoc { };
+
   sphinxcontrib-applehelp = callPackage ../development/python-modules/sphinxcontrib-applehelp { };
 
   sphinxcontrib-autoapi = callPackage ../development/python-modules/sphinxcontrib-autoapi { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

have man pages

###### Things to do after this got merged
- check all other openstack packages and do similar things

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
