### PR TITLE
python39Packages.sphinx: 4.3.1 -> 4.4.0, add sphinx maintainer team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -278,6 +278,13 @@ with lib.maintainers; {
     scope = "Maintain SageMath and the dependencies that are likely to break it.";
   };
 
+  sphinx = {
+    members = [
+      SuperSandro2000
+    ];
+    scope = "Maintain Sphinx related packages.";
+  };
+
   serokell = {
     # Verify additions by approval of an already existing member of the team.
     members = [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -8,11 +8,11 @@
 , alabaster
 , docutils
 , imagesize
+, importlib-metadata
 , jinja2
 , packaging
 , pygments
 , requests
-, setuptools
 , snowballstemmer
 , sphinxcontrib-applehelp
 , sphinxcontrib-devhelp
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "sphinx";
-  version = "4.3.2";
+  version = "4.4.0";
   disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "sphinx-doc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-ze6+iGGWSDljb8SPc1Z9UcPfUrleDTeaol5ZDGj1iYg=";
+    sha256 = "sha256-Q4CqPO08AfR+CDB02al65A+FHRFUDUfFTba0u8YQx+8=";
     extraPostFetch = ''
       cd $out
       mv tests/roots/test-images/testimäge.png \
@@ -54,7 +54,6 @@ buildPythonPackage rec {
     packaging
     pygments
     requests
-    setuptools
     snowballstemmer
     sphinxcontrib-applehelp
     sphinxcontrib-devhelp
@@ -64,6 +63,8 @@ buildPythonPackage rec {
     sphinxcontrib-serializinghtml
     # extra[docs]
     sphinxcontrib-websupport
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
   ];
 
   checkInputs = [
@@ -114,6 +115,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://www.sphinx-doc.org";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = teams.sphinx.members;
   };
 }

--- a/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-applehelp/default.nix
@@ -14,14 +14,13 @@ buildPythonPackage rec {
     sha256 = "a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-applehelp";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }

--- a/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-devhelp/default.nix
@@ -12,14 +12,13 @@ buildPythonPackage rec {
     sha256 = "ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document.";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-devhelp";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }

--- a/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-htmlhelp/default.nix
@@ -14,14 +14,13 @@ buildPythonPackage rec {
     sha256 = "f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "Sphinx extension which renders HTML help files";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-htmlhelp";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }

--- a/pkgs/development/python-modules/sphinxcontrib-jsmath/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-jsmath/default.nix
@@ -14,14 +14,13 @@ buildPythonPackage rec {
     sha256 = "a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "sphinxcontrib-jsmath is a sphinx extension which renders display math in HTML via JavaScript.";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-jsmath";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }

--- a/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-qthelp/default.nix
@@ -14,14 +14,13 @@ buildPythonPackage rec {
     sha256 = "4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document.";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-qthelp";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }

--- a/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-serializinghtml/default.nix
@@ -14,14 +14,13 @@ buildPythonPackage rec {
     sha256 = "aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952";
   };
 
-
   # Check is disabled due to circular dependency of sphinx
   doCheck = false;
 
   meta = with lib; {
     description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle).";
-    homepage = "http://sphinx-doc.org/";
+    homepage = "https://github.com/sphinx-doc/sphinxcontrib-serializinghtml";
     license = licenses.bsd0;
+    maintainers = teams.sphinx.members;
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I hacked a while on sphinx today for #155973 and thought this would be a good idea. If someone is interested feel free to create a PR to add yourself to the team and give me a ping. If someone wants to move some more sphinx things to the team please do the same.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
