### PR TITLE
liberasurecode: generate man pages

### DIFF
--- a/pkgs/applications/misc/liberasurecode/default.nix
+++ b/pkgs/applications/misc/liberasurecode/default.nix
@@ -1,10 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, zlib }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, doxygen
+, installShellFiles
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "liberasurecode";
   version = "1.6.2";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "doc" ];
 
   src = fetchFromGitHub {
     owner = "openstack";
@@ -13,9 +20,26 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-qV7DL/7zrwrYOaPj6iHnChGA6KHFwYKjeaMnrGrTPrQ=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  postPatch = ''
+    substituteInPlace doc/doxygen.cfg.in \
+      --replace "GENERATE_MAN           = NO" "GENERATE_MAN           = YES"
+  '';
+
+  nativeBuildInputs = [ autoreconfHook doxygen installShellFiles ];
 
   buildInputs = [ zlib ];
+
+  configureFlags = [ "--enable-doxygen" ];
+
+  postInstall = ''
+    # remove useless man pages about directories
+    rm doc/man/man*/_*
+    installManPage doc/man/man*/*
+
+    moveToOutput share/liberasurecode/ $doc
+  '';
+
+  checkTarget = "test";
 
   meta = with lib; {
     description = "Erasure Code API library written in C with pluggable Erasure Code backends";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
