### PR TITLE
WIP: calcure: init at 1.7

### DIFF
--- a/pkgs/applications/misc/calcure/default.nix
+++ b/pkgs/applications/misc/calcure/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3, fetchFromGitHub }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "calcure";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "anufrievroman";
+    repo = "calcure";
+    rev = "${version}";
+    sha256 = "sha256-ciuk41DFQJfg9S/Lwf8qIANDd6DfxW8nchxYXpkQCOE=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ holidays ];
+
+  meta = with lib; {
+    description = "Calendar and task manager for Linux terminal with minimal and customizable UI";
+    homepage = "https://github.com/anufrievroman/calcure";
+    license = licenses.mit;
+    maintainers = with maintainers; [ taha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24580,6 +24580,8 @@ with pkgs;
       inherit (gnome2) libglade;
   };
 
+  calcure = callPackage ../applications/misc/calcure { };
+
   calcurse = callPackage ../applications/misc/calcurse { };
 
   calculix = callPackage ../applications/science/math/calculix {};


### PR DESCRIPTION
###### Motivation for this change

Add `calcure` software package. The reason this PR is WIP is because I'm waiting for the next tagged release (v1.7). v1.6 and earlier do not have `setup.py` which are necessary to properly build the package.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
