### PR TITLE
python3Packages.tensorflow-probability: 0.8.0 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -79,8 +79,10 @@ buildPythonPackage rec {
       base_tests/test_plot_utils.py \
       base_tests/test_rcparams.py \
       base_tests/test_stats.py \
+      base_tests/test_stats_numba.py \
       base_tests/test_stats_utils.py \
       base_tests/test_utils.py \
+      base_tests/test_utils_numba.py \
       external_tests/test_data_cmdstan.py \
       external_tests/test_data_emcee.py
   '';

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -9,11 +9,12 @@
 , numpy
 , pandas
 , pytest
+, cloudpickle
 , scipy
 , setuptools
-, tensorflow-probability
+# , tensorflow-probability (incompatible version)
 , xarray
-#, h5py (used by disabled tests)
+, h5py
 #, pymc3 (broken)
 #, pyro-ppl (broken)
 #, pystan (not packaged)
@@ -50,23 +51,25 @@ buildPythonPackage rec {
     emcee
     numba
     pytest
-    tensorflow-probability
-    #h5py (used by disabled tests)
-    #pymc3 (broken)
-    #pyro-ppl (broken)
+    cloudpickle
+    #tensorflow-probability (used by disabled tests)
+    h5py
+    #pymc3 (broken, used by disabled tests)
+    #pyro-ppl (broken, used by disabled tests)
     #pystan (not packaged)
-    #numpyro (not packaged)
+    #numpyro (not packaged, used by disabled tests)
   ];
 
   # check requires pymc3 and pyro-ppl, which are currently broken, and pystan
-  # and numpyro, which are not yet packaged, some checks also need to make
+  # and numpyro, which are not yet packaged, and an incompatible (old) version
+  # of tensorflow-probability. some checks also need to make
   # directories and do not have permission to do so. So we can only check part
   # of the package
   # Additionally, there are some failures with the plots test, which revolve
   # around attempting to output .mp4 files through an interface that only wants
   # to output .html files.
   # The following test have been disabled as a result: data_cmdstanpy,
-  # data_numpyro, data_pyro, data_pystan, and plots.
+  # data_numpyro, data_pyro, data_pystan, data_tfp, data_pymc3 and plots.
   checkPhase = ''
     cd arviz/tests/
     export HOME=$TMPDIR
@@ -79,8 +82,7 @@ buildPythonPackage rec {
       base_tests/test_stats_utils.py \
       base_tests/test_utils.py \
       external_tests/test_data_cmdstan.py \
-      external_tests/test_data_emcee.py \
-      external_tests/test_data_tfp.py
+      external_tests/test_data_emcee.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -12,8 +12,10 @@
 , cloudpickle
 , scipy
 , setuptools
+, typing-extensions
 # , tensorflow-probability (incompatible version)
 , xarray
+, zarr
 , h5py
 #, pymc3 (broken)
 #, pyro-ppl (broken)
@@ -46,12 +48,18 @@ buildPythonPackage rec {
     scipy
   ];
 
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "typing_extensions>=3.7.4.3,<4" "typing_extensions>=3.7.4.3"
+  '';
+
   checkInputs = [
     bokeh
     emcee
     numba
     pytest
     cloudpickle
+    zarr
     #tensorflow-probability (used by disabled tests)
     h5py
     #pymc3 (broken, used by disabled tests)
@@ -83,6 +91,7 @@ buildPythonPackage rec {
       base_tests/test_stats_utils.py \
       base_tests/test_utils.py \
       base_tests/test_utils_numba.py \
+      base_tests/test_data_zarr.py \
       external_tests/test_data_cmdstan.py \
       external_tests/test_data_emcee.py
   '';

--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -86,5 +86,6 @@ in buildPythonPackage {
     license = licenses.asl20;
     maintainers = with maintainers; [ timokau ];
     platforms = platforms.linux;
+    broken = true; # depends on older TensorFlow version than is currently packaged
   };
 }

--- a/pkgs/development/python-modules/pymc3/default.nix
+++ b/pkgs/development/python-modules/pymc3/default.nix
@@ -68,5 +68,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/pymc-devs/pymc3";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ilya-kolpakov ];
+    # several dependencies are not declared and in the end it requires theano-pymc3
+    # instead of Theano. The former is currently not packaged.
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -1,7 +1,5 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
-, bazel_0_26
 , buildBazelPackage
 , buildPythonPackage
 , python
@@ -11,47 +9,33 @@
 , tensorflow
 , six
 , numpy
+, dm-tree
+, keras
 , decorator
 , cloudpickle
 , gast
 , hypothesis
 , scipy
+, pandas
+, mpmath
 , matplotlib
 , mock
 , pytest
 }:
 
 let
-  version = "0.8.0";
+  version = "0.15.0";
   pname = "tensorflow_probability";
 
   # first build all binaries and generate setup.py using bazel
   bazel-wheel = buildBazelPackage {
-    bazel = bazel_0_26;
-
     name = "${pname}-${version}-py2.py3-none-any.whl";
-
     src = fetchFromGitHub {
       owner = "tensorflow";
       repo = "probability";
-      rev = version;
-      sha256 = "07cm8zba8n0ihzdm3k4a4rsg5v62xxsfvcw4h0niz91c0parqjqy";
+      rev = "v" + version;
+      sha256 = "155fgmra90s08vjnp61qxdrpzq74xa3kdzhgdkavwgc25pvxn3mi";
     };
-
-    patches = [
-      (fetchpatch {
-        name = "gast-0.3.patch";
-        url = "https://github.com/tensorflow/probability/commit/ae7a9d9771771ec1e7755a3588b9325f050a84cc.patch";
-        sha256 = "0kfhx30gshm8f3945na9yjjik71r20qmjzifbigaj4l8dwd9dz1a";
-        excludes = ["testing/*"];
-      })
-      (fetchpatch {
-        name = "cloudpickle-1.2.patch";
-        url = "https://github.com/tensorflow/probability/commit/78ef12b5afe3f567d16c70b74015ed1ddff1b0c8.patch";
-        sha256 = "12ms2xcljvvrnig0j78s3wfv4yf3bm5ps4rgfgv5lg2a8mzpc1ga";
-      })
-    ];
-
     nativeBuildInputs = [
       # needed to create the output wheel in installPhase
       python
@@ -64,7 +48,7 @@ let
     bazelTarget = ":pip_pkg";
 
     fetchAttrs = {
-      sha256 = "1qw7vkwnxy45z4vm94isq5m96xiz35sigag7vjg1xb2sklbymxh8";
+      sha256 = "0sgxdlw5x3dydy53l10vbrj8smh78b7r1wff8jxcgp4w69mk8zfm";
     };
 
     buildAttrs = {
@@ -98,34 +82,31 @@ in buildPythonPackage {
     decorator
     cloudpickle
     gast
+    dm-tree
+    keras
   ];
 
   # Listed here:
-  # https://github.com/tensorflow/probability/blob/f01d27a6f256430f03b14beb14d37def726cb257/testing/run_tests.sh#L58
+  # https://github.com/tensorflow/probability/blob/f3777158691787d3658b5e80883fe1a933d48989/testing/dependency_install_lib.sh#L83
   checkInputs = [
     hypothesis
     pytest
     scipy
+    pandas
+    mpmath
     matplotlib
     mock
   ];
 
-  # actual checks currently fail because for some reason
-  # tf.enable_eager_execution is called too late. Probably because upstream
-  # intents these tests to be run by bazel, not plain pytest.
-  # checkPhase = ''
-  #   # tests need to import from other test files
-  #   export PYTHONPATH="$PWD/tensorflow-probability:$PYTHONPATH"
-  #   py.test
-  # '';
+  # Ideally, we run unit tests with pytest, but in checkPhase, only the Bazel-build wheel is available.
+  # But it seems not guaranteed that running the tests with pytest will even work, see
+  # https://github.com/tensorflow/probability/blob/c2a10877feb2c4c06a4dc58281e69c37a11315b9/CONTRIBUTING.md?plain=1#L69
+  # Ideally, tests would be run using Bazel. For now, lets's do a...
 
   # sanity check
-  checkPhase = ''
-    python -c 'import tensorflow_probability'
-  '';
+  pythonImportsCheck = [ "tensorflow_probability" ];
 
   meta = with lib; {
-    broken = true;  # tf-probability 0.8.0 is not compatible with tensorflow 2.3.2
     description = "Library for probabilistic reasoning and statistical analysis";
     homepage = "https://www.tensorflow.org/probability/";
     license = licenses.asl20;

--- a/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
@@ -2,6 +2,7 @@
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
+, pythonAtLeast
 , numpy
 , wheel
 , werkzeug
@@ -24,7 +25,7 @@ buildPythonPackage rec {
   pname = "tensorflow-tensorboard";
   version = "2.6.0";
   format = "wheel";
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
 
   src = fetchPypi {
     pname = "tensorboard";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`python3Packages.tensorflow-probability` was outdated and marked as broken because of an unpackaged dependency (`python3Packages.dm-tree`). `dm-tree` is now packaged (#152971), so I updated `tensorflow-probability` to the most current version.
Several `python3Packages` depend on `tensorflow-probability`, namely `dm-sonnet`, `arviz`, and `pymc3` and fixing `tensorflow-probability` thus potentially "unbreaks" them. Turns out that
- `arviz` tests require an older version of `tensorflow-probability`,
- `pymc3` now is broken for a different reason (missing dependencies),
- `dm-sonnet` is broken for a different reason (requires an older `tensorflow` version than the one currently packaged).

So I disabled the `arviz` tests requiring `tensorflow-probability` and marked `pymc3` and `dm-sonnet` as broken.
Furthermore, `tensorflow-tensorboard` is a dependency of `tensorflow-probability`, but is currently incompatible with Python 3.10. I thus disabled  `tensorflow-tensorboard` for Python 3.10.
I also took the liberty to add the `numba`-related tests to the list of tests run for `arviz`.

Finally, unfortunately `tensorflow-probability` is maintainerless. I would love to get engaged and maintain it, but I feel I don't have the necessary Nix skills quite yet to do / review more difficult changes , especially with regards to the Bazel tooling or the hacking likely required to run the unit tests.

This is my first PR here, so please let me know in case I am breaking any protocols or how to improve / do better next time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
