### PR TITLE
pluginupdate.py: fix regression with plugin line splitting

### DIFF
--- a/maintainers/scripts/pluginupdate.py
+++ b/maintainers/scripts/pluginupdate.py
@@ -470,10 +470,10 @@ def parse_plugin_line(line: str) -> PluginDesc:
     alias = None
     uri = line
     if " as " in uri:
-        uri, alias = line.split(" as ")
+        uri, alias = uri.split(" as ")
         alias = alias.strip()
-    if "@" in line:
-        uri, branch = line.split("@")
+    if "@" in uri:
+        uri, branch = uri.split("@")
 
     repo = make_repo(uri.strip(), branch.strip(), alias)
 


### PR DESCRIPTION
###### Motivation for this change

Before 46c68ad both "`@`" and "` as `" could be used in the same line like
the following:

    vimwiki/vimwiki@dev as vimwiki-dev

After 46c68ad this gives an error due to the split URI still erroneously
including the "` as [name]`" at the end, due to splitting from the wrong
variable.

<details>
  <summary>Actual Python error</summary>

  ```
  vimwiki-dev: URL can't contain control characters. '/vimwiki/vimwiki/commits/dev as vimwiki-dev.atom' (found at least ' ')
  Traceback (most recent call last):
    File "/home/lily/src/foosteros/scripts/pluginupdate.py", line 573, in prefetch
      plugin, redirect = prefetch_plugin(pluginDesc, cache)
    File "/home/lily/src/foosteros/scripts/pluginupdate.py", line 421, in prefetch_plugin
      commit, date = repo.latest_commit()
    File "/home/lily/src/foosteros/scripts/pluginupdate.py", line 86, in f_retry
      return f(*args, **kwargs)
    File "/home/lily/src/foosteros/scripts/pluginupdate.py", line 188, in latest_commit
      with urllib.request.urlopen(commit_req, timeout=10) as req:
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 214, in urlopen
      return opener.open(url, data, timeout)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 517, in open
      response = self._open(req, data)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 534, in _open
      result = self._call_chain(self.handle_open, protocol, protocol +
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 494, in _call_chain
      result = func(*args)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 1389, in https_open
      return self.do_open(http.client.HTTPSConnection, req,
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/urllib/request.py", line 1346, in do_open
      h.request(req.get_method(), req.selector, req.data, headers,
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/http/client.py", line 1285, in request
      self._send_request(method, url, body, headers, encode_chunked)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/http/client.py", line 1296, in _send_request
      self.putrequest(method, url, **skips)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/http/client.py", line 1130, in putrequest
      self._validate_path(url)
    File "/nix/store/dn4fwp0yx6nsa85cr20cwvdmg64xwmcy-python3-3.9.9/lib/python3.9/http/client.py", line 1230, in _validate_path
      raise InvalidURL(f"URL can't contain control characters. {url!r} "
  http.client.InvalidURL: URL can't contain control characters. '/vimwiki/vimwiki/commits/dev as vimwiki-dev.atom' (found at least ' ')</code>
  ```
</details>


###### Things done

To fix it, I changed the variable to split from to the one that would consume "` as `" then "`@`" during parsing. I tested this change by running `pkgs/misc/vim-plugins/update.py` and it worked fine.


ref: #154695
cc: @teto

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
