### PR TITLE
teamspeak5_client: init at 5.0.0-beta70

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client5.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client5.nix
@@ -1,0 +1,109 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, atk
+, cairo
+, cups
+, dbus
+, gcc-unwrapped
+, gdk-pixbuf
+, glib
+, gtk3
+, libdrm
+, libnotify
+, libpulseaudio
+, libxkbcommon
+, mesa
+, nss
+, udev
+, xorg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "teamspeak5-client";
+  version = "5.0.0-beta70";
+
+  src = fetchurl {
+    # check https://teamspeak.com/en/downloads/#ts5 for version and checksum
+    url = "https://files.teamspeak-services.com/pre_releases/client/${version}/teamspeak-client.tar.gz";
+    sha256 = "44f1a29b915c3930e7385ce32b13e363a7be04c1e341226d0693600818411c6e";
+  };
+
+  sourceRoot = ".";
+
+  propagatedBuildInputs = [
+    alsa-lib
+    at-spi2-atk
+    atk
+    cairo
+    cups.lib
+    dbus
+    gcc-unwrapped.lib
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libnotify
+    libpulseaudio
+    libxkbcommon
+    mesa.drivers
+    nss
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXdamage
+    xorg.libXfixes
+    xorg.libxshmfence
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "TeamSpeak";
+      exec = "TeamSpeak";
+      icon = pname;
+      desktopName = pname;
+      comment = "TeamSpeak Voice Communication Client";
+      categories = ["Audio" "AudioVideo" "Chat" "Network"];
+    })
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/${pname} $out/share/icons/hicolor/64x64/apps/
+
+    cp -a * $out/share/${pname}
+    cp logo-256.png $out/share/icons/hicolor/64x64/apps/${pname}.png
+
+    makeWrapper $out/share/${pname}/TeamSpeak $out/bin/TeamSpeak \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ udev ]}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The TeamSpeak voice communication tool (beta version)";
+    homepage = "https://teamspeak.com/";
+    license = {
+      fullName = "Teamspeak client license";
+      url = "https://www.teamspeak.com/en/privacy-and-terms/";
+      free = false;
+    };
+    maintainers = with maintainers; [ jojosch ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30697,6 +30697,7 @@ with pkgs;
   teams = callPackage ../applications/networking/instant-messengers/teams { };
 
   teamspeak_client = libsForQt5.callPackage ../applications/networking/instant-messengers/teamspeak/client.nix { };
+  teamspeak5_client = callPackage ../applications/networking/instant-messengers/teamspeak/client5.nix { };
   teamspeak_server = callPackage ../applications/networking/instant-messengers/teamspeak/server.nix { };
 
   taskell = haskell.lib.compose.justStaticExecutables haskellPackages.taskell;


### PR DESCRIPTION
###### Motivation for this change

Add the TeamSpeak 5 Beta client (currently in closed beta, open beta coming soon™).

Currently an account (https://beta.teamspeak.com/) is required to use the new client.

The client runs, voice is transmitted and I haven't found any obvious breakages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
