### PR TITLE
nitter: unstable-2021-12-31 -> unstable-2022-01-32

### DIFF
--- a/pkgs/development/nim-packages/jsony/default.nix
+++ b/pkgs/development/nim-packages/jsony/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildNimPackage, fetchFromGitHub }:
+
+buildNimPackage rec {
+  pname = "jsony";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "treeform";
+    repo = pname;
+    rev = version;
+    hash = "sha256-jtUCoqwCmE536Kpv/vZxGgqiHyReZf1WOiBdUzmMhM4=";
+  };
+
+  doCheck = true;
+
+  meta = with lib;
+    src.meta // {
+      description = "A loose, direct to object json parser with hooks";
+      license = [ licenses.mit ];
+      maintainers = [ maintainers.erdnaxe ];
+    };
+}

--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -2,32 +2,29 @@
 
 nimPackages.buildNimPackage rec {
   pname = "nitter";
-  version = "unstable-2021-12-31";
+  version = "unstable-2022-01-32";
   nimBinOnly = true;
 
   src = fetchFromGitHub {
     owner = "zedeus";
     repo = "nitter";
-    rev = "9d117aa15b3c3238cee79acd45d655eeb0e46293";
-    sha256 = "06hd3r1kgxx83sl5ss90r39v815xp2ki72fc8p64kid34mcn57cz";
+    rev = "cdb4efadfeb5102b501c7ff79261fefc7327edb9";
+    sha256 = "sha256-kNK0UQd1whkaZwj98b2JYtYwjUSE1qBcAYytqnSaK1o=";
   };
 
   buildInputs = with nimPackages; [
     jester
     karax
     sass
-    regex
-    unicodedb
-    unicodeplus
-    segmentation
     nimcrypto
     markdown
     packedjson
     supersnappy
     redpool
-    flatty
-    zippy
     redis
+    zippy
+    flatty
+    jsony
   ];
 
   postBuild = ''

--- a/pkgs/top-level/nim-packages.nix
+++ b/pkgs/top-level/nim-packages.nix
@@ -30,6 +30,8 @@ lib.makeScope newScope (self:
 
     jsonschema = callPackage ../development/nim-packages/jsonschema { };
 
+    jsony = callPackage ../development/nim-packages/jsony { };
+
     karax = callPackage ../development/nim-packages/karax { };
 
     lscolors = callPackage ../development/nim-packages/lscolors { };


### PR DESCRIPTION
###### Motivation for this change

This fixes Nitter global timeline error due to Twitter API change (since 2022/01/32).

I am running this version on my own server and it is working well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
