### PR TITLE
canon-cups-ufr2: fix library patching and use proot to enable cnsetuputil2

### DIFF
--- a/pkgs/misc/cups/drivers/canon/default.nix
+++ b/pkgs/misc/cups/drivers/canon/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, stdenv_32bit
 , fetchurl
 , unzip
 , autoconf
@@ -10,10 +11,18 @@
 , jbigkit
 , glib
 , gtk3
+, gdk-pixbuf
+, pango
+, cairo
+, coreutils
+, atk
 , pkg-config
 , gnome2
 , libxml2
+, runtimeShell
+, proot
 , ghostscript
+, pkgs
 , pkgsi686Linux
 , zlib
 }:
@@ -21,6 +30,12 @@
 let
 
   i686_NIX_GCC = pkgsi686Linux.callPackage ({ gcc }: gcc) { };
+  ld32 =
+    if stdenv.hostPlatform.system == "x86_64-linux" then "${stdenv.cc}/nix-support/dynamic-linker-m32"
+    else if stdenv.hostPlatform.system == "i686-linux" then "${stdenv.cc}/nix-support/dynamic-linker"
+    else throw "Unsupported platform for Canon UFR2 Drivers: ${stdenv.hostPlatform.system}";
+  ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
+  libs = pkgs: lib.makeLibraryPath buildInputs;
 
   version = "5.40";
   dl = "6/0100009236/10";
@@ -31,10 +46,12 @@ let
     sha256 = "sha256:069z6ijmql62mcdyxnzc9mf0dxa6z1107cd0ab4i1adk8kr3d75k";
   };
 
+  buildInputs = [ cups zlib jbigkit glib gtk3 pkg-config gnome2.libglade libxml2 gdk-pixbuf pango cairo atk ];
+
 in
 
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "canon-cups-ufr2";
   inherit version;
   src = src_canon;
@@ -59,7 +76,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper unzip autoconf automake libtool_1_5 ];
 
-  buildInputs = [ cups zlib jbigkit glib gtk3 pkg-config gnome2.libglade libxml2 ];
+  inherit buildInputs;
 
   installPhase = ''
     runHook preInstall
@@ -78,6 +95,9 @@ stdenv.mkDerivation {
       cd cnrdrvcups-lb-${version}
       ./allgen.sh
       make install
+
+      mkdir -p $out/share/cups/model
+      install -m 644 ppd/*.ppd $out/share/cups/model/
     )
     (
       cd lib
@@ -111,7 +131,7 @@ stdenv.mkDerivation {
       install -m 755 libs64/intel/cnpkbidir $out/bin
       install -m 755 libs64/intel/cnpkmoduleufr2r $out/bin
       install -m 755 libs64/intel/cnrsdrvufr2 $out/bin
-      install -m 755 libs64/intel/cnsetuputil2 $out/bin
+      install -m 755 libs64/intel/cnsetuputil2 $out/bin/cnsetuputil2
 
       mkdir -p $out/share/cnpkbidir
       install -m 644 libs64/intel/cnpkbidir_info* $out/share/cnpkbidir
@@ -123,27 +143,47 @@ stdenv.mkDerivation {
     (
       cd $out/lib32
       ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so
+      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so.1
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so.1
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so.1
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so.1
+
+      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${stdenv_32bit.glibc.out}/lib:${pkgsi686Linux.libxml2.out}/lib:$out/lib32" libcanonufr2r.so.1.0.0
+      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${stdenv_32bit.glibc.out}/lib" libcaepcmufr2.so.1.0
+      patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib:${libs pkgsi686Linux}:${stdenv_32bit.glibc.out}/lib" libColorGearCufr2.so.2.0.0
     )
 
     (
       cd $out/lib
       ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so
+      ln -sf libcaepcmufr2.so.1.0 libcaepcmufr2.so.1
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so
       ln -sf libcaiowrapufr2.so.1.0.0 libcaiowrapufr2.so.1
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so
       ln -sf libcanon_slimufr2.so.1.0.0 libcanon_slimufr2.so.1
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so
       ln -sf libufr2filterr.so.1.0.0 libufr2filterr.so.1
+
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64:$out/lib" libcanonufr2r.so.1.0.0
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" libcaepcmufr2.so.1.0
+      patchelf --set-rpath "$(cat $NIX_CC/nix-support/orig-cc)/lib:${libs pkgs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" libColorGearCufr2.so.2.0.0
     )
 
-    # Perhaps patch the lib64 version as well???
-    patchelf --set-rpath "$(cat ${i686_NIX_GCC}/nix-support/orig-cc)/lib" $out/lib32/libColorGearCufr2.so.2.0.0
+    (
+      cd $out/bin
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" cnsetuputil2
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64" cnpdfdrv
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64:$out/lib" cnpkbidir
+      patchelf --set-interpreter "$(cat ${ld64})" --set-rpath "${lib.makeLibraryPath buildInputs}:${stdenv.cc.cc.lib}/lib64:${stdenv.glibc.out}/lib64:$out/lib" cnrsdrvufr2
+
+      mv cnsetuputil2 cnsetuputil2.wrapped
+      echo "#!${runtimeShell} -e" > cnsetuputil2
+      echo "exec ${proot}/bin/proot -b $out/usr/share/cnsetuputil2:/usr/share/cnsetuputil2 -b ${coreutils}/bin/ls:/bin/ls -b ${cups}/share:/usr/share/cups $out/bin/cnsetuputil2.wrapped" > cnsetuputil2
+      chmod +x cnsetuputil2
+    )
 
     (
       cd lib/data/ufr2
@@ -154,8 +194,11 @@ stdenv.mkDerivation {
       install -m 644 CnLB* $out/share/caepcm
     )
 
-    mkdir -p $out/share/cups/model
-    install -m 644 cnrdrvcups-lb-${version}/ppd/*.ppd $out/share/cups/model/
+    (
+      cd cnrdrvcups-utility-${version}/data
+      mkdir -p $out/usr/share/cnsetuputil2
+      install -m 644 cnsetuputil* $out/usr/share/cnsetuputil2
+    )
 
     makeWrapper "${ghostscript}/bin/gs" "$out/bin/gs" \
       --prefix LD_LIBRARY_PATH ":" "$out/lib" \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The new version update to 5.40 packages a non-working cnsetuputil2.  This fixes that binary by using proot, rather than the previous version which used a manual loader for the gui program that was included (not cnsetuputil2)

Fixes issue  #156089 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
