### PR TITLE
bukut: fix incorrect sha256 hash

### DIFF
--- a/pkgs/applications/misc/bukut/default.nix
+++ b/pkgs/applications/misc/bukut/default.nix
@@ -8,7 +8,7 @@ with python3.pkgs; buildPythonApplication rec {
     owner = "peterjschroeder";
     repo = "bukut";
     rev = "v${version}";
-    sha256 = "sha256-MCAyMvzXnC7QSpWeG7qorK4JmRBMzG3eGsp5YpKmVjg=";
+    sha256 = "sha256-Hp9/tSdRNAoll/fYNJuhYC7cgy5AK3PUtYUsS6zsz1Y=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

In the previous [PR](https://github.com/NixOS/nixpkgs/pull/155783) to add `bukut`, after switching to the tag, I forgot to update the sha256 hash.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@legendofmiracles