### PR TITLE
retroarch: 1.9.14 -> 1.10.0;  libretro: unstable-2021-12-06 -> unstable-2022-01-21;  libretro.citra-canary: init at unstable-2022-01-21 

### DIFF
--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -8,7 +8,6 @@
 , cmake
 , curl
 , fetchFromGitHub
-, fetchpatch
 , ffmpeg
 , fluidsynth
 , gettext
@@ -56,7 +55,7 @@ let
     , license
     , src ? (getCoreSrc core)
     , broken ? false
-    , version ? "unstable-2021-12-06"
+    , version ? "unstable-2022-01-21"
     , platforms ? retroarch.meta.platforms
       # The resulting core file is based on core name
       # Setting `normalizeCore` to `true` will convert `-` to `_` on the core filename
@@ -245,14 +244,6 @@ in
     description = "Port of bsnes to libretro";
     license = lib.licenses.gpl3Only;
     makefile = "Makefile";
-    # https://github.com/libretro/bsnes-libretro/issues/10
-    patches = [
-      (fetchpatch {
-        name = "added-missing-GB_VERSION-define.patch";
-        url = "https://github.com/nE0sIghT/bsnes-libretro/commit/97fd8b486f9a9046277a580b238b6673a98f7f72.patch";
-        sha256 = "sha256-gCiy6sqc9sixT6Appr5ZCfHyBE2jYhPb0KvI63nfmEc=";
-      })
-    ];
   };
 
   bsnes-hd =
@@ -865,6 +856,7 @@ in
       "-DBUILD_SDL=OFF"
       "-DBUILD_SOKOL=OFF"
     ];
+    preConfigure = "cd core";
     postBuild = "cd lib";
   };
 

--- a/pkgs/misc/emulators/retroarch/cores.nix
+++ b/pkgs/misc/emulators/retroarch/cores.nix
@@ -313,6 +313,24 @@ in
     postBuild = "cd src/citra_libretro";
   };
 
+  citra-canary = mkLibRetroCore {
+    core = "citra-canary";
+    description = "Port of Citra Canary/Experimental to libretro";
+    license = lib.licenses.gpl2Plus;
+    extraNativeBuildInputs = [ cmake pkg-config ];
+    extraBuildInputs = [ libGLU libGL boost ];
+    makefile = "Makefile";
+    cmakeFlags = [
+      "-DENABLE_LIBRETRO=ON"
+      "-DENABLE_QT=OFF"
+      "-DENABLE_SDL2=OFF"
+      "-DENABLE_WEB_SERVICE=OFF"
+      "-DENABLE_DISCORD_PRESENCE=OFF"
+    ];
+    preConfigure = "sed -e '77d' -i externals/cmake-modules/GetGitRevisionDescription.cmake";
+    postBuild = "cd src/citra_libretro";
+  };
+
   desmume = mkLibRetroCore {
     core = "desmume";
     description = "libretro wrapper for desmume NDS emulator";

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -113,6 +113,7 @@ stdenv.mkDerivation rec {
     description = "Multi-platform emulator frontend for libretro cores";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
+    changelog = "https://github.com/libretro/RetroArch/blob/v${version}/CHANGES.md";
     maintainers = with maintainers; [ MP2E edwtjo matthewbauer kolbycrouch thiagokokada ];
     # FIXME: exits with error on macOS:
     # No Info.plist file in application bundle or no NSPrincipalClass in the Info.plist file, exiting

--- a/pkgs/misc/emulators/retroarch/default.nix
+++ b/pkgs/misc/emulators/retroarch/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , enableNvidiaCgToolkit ? false
+, withGamemode ? stdenv.isLinux
 , withVulkan ? stdenv.isLinux
 , alsa-lib
 , AppKit
@@ -8,6 +9,7 @@
 , ffmpeg
 , Foundation
 , freetype
+, gamemode
 , libdrm
 , libGL
 , libGLU
@@ -26,23 +28,22 @@
 , pkg-config
 , python3
 , SDL2
-, substituteAll
 , udev
 , vulkan-loader
 , wayland
 , which
 }:
 
-with lib;
-
 let
-  version = "1.9.14";
-  libretroSuperSrc = fetchFromGitHub {
+  version = "1.10.0";
+  libretroCoreInfo = fetchFromGitHub {
     owner = "libretro";
     repo = "libretro-core-info";
-    sha256 = "sha256-C2PiBcN5r9NDxFWFE1pytSGR1zq9E5aVt6QUf5aJ7I0=";
+    sha256 = "sha256-3j7fvcfbgyk71MmbUUKYi+/0cpQFNbYXO+DMDUjDqkQ=";
     rev = "v${version}";
   };
+  runtimeLibs = lib.optional withVulkan vulkan-loader
+    ++ lib.optional withGamemode gamemode.lib;
 in
 stdenv.mkDerivation rec {
   pname = "retroarch-bare";
@@ -51,7 +52,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    sha256 = "sha256-H2fCA1sM8FZfVnLxBjnKe7RjHJNAn/Antxlos5oFFSY=";
+    sha256 = "sha256-bpTSzODVRKRs1OW6JafjbU3e/AqdQeGzWcg1lb9SIyo=";
     rev = "v${version}";
   };
 
@@ -70,42 +71,44 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config ] ++
-    optional stdenv.isLinux wayland ++
-    optional withVulkan makeWrapper;
+    lib.optional stdenv.isLinux wayland ++
+    lib.optional (runtimeLibs != [ ]) makeWrapper;
 
   buildInputs = [ ffmpeg freetype libxml2 libGLU libGL python3 SDL2 which ] ++
-    optional enableNvidiaCgToolkit nvidia_cg_toolkit ++
-    optional withVulkan vulkan-loader ++
-    optionals stdenv.isDarwin [ libobjc AppKit Foundation ] ++
-    optionals stdenv.isLinux [
+    lib.optional enableNvidiaCgToolkit nvidia_cg_toolkit ++
+    lib.optional withVulkan vulkan-loader ++
+    lib.optionals stdenv.isDarwin [ libobjc AppKit Foundation ] ++
+    lib.optionals stdenv.isLinux [
       alsa-lib
-      libdrm
-      libpulseaudio
-      libv4l
       libX11
       libXdmcp
       libXext
       libXxf86vm
+      libdrm
+      libpulseaudio
+      libv4l
+      libxkbcommon
       mesa
       udev
       wayland
-      libxkbcommon
     ];
 
   enableParallelBuilding = true;
 
   configureFlags = lib.optionals stdenv.isLinux [ "--enable-kms" "--enable-egl" ];
 
-  postInstall = optionalString withVulkan ''
+  postInstall = ''
     mkdir -p $out/share/libretro/info
     # TODO: ideally each core should have its own core information
-    cp -r ${libretroSuperSrc}/* $out/share/libretro/info
-    wrapProgram $out/bin/retroarch --prefix LD_LIBRARY_PATH ':' ${vulkan-loader}/lib
+    cp -r ${libretroCoreInfo}/* $out/share/libretro/info
+  '' + lib.optionalString (runtimeLibs != [ ]) ''
+    wrapProgram $out/bin/retroarch \
+      --prefix LD_LIBRARY_PATH ':' ${lib.makeLibraryPath runtimeLibs}
   '';
 
   preFixup = "rm $out/bin/retroarch-cg2glsl";
 
-  meta = {
+  meta = with lib; {
     homepage = "https://libretro.com";
     description = "Multi-platform emulator frontend for libretro cores";
     license = licenses.gpl3Plus;

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -3,120 +3,103 @@
         "owner": "libretro",
         "repo": "libretro-atari800",
         "rev": "478a8ec99a7f8436a39d5ac193c5fe313233ee7b",
-        "sha256": "LJpRegJVR2+sS1UmTTpVest0rMrNDBMXmj/jRFVglWI=",
-        "fetchSubmodules": false
+        "sha256": "LJpRegJVR2+sS1UmTTpVest0rMrNDBMXmj/jRFVglWI="
     },
     "beetle-gba": {
         "owner": "libretro",
         "repo": "beetle-gba-libretro",
         "rev": "38182572571a48cb58057cde64b915237c4e2d58",
-        "sha256": "4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo=",
-        "fetchSubmodules": false
+        "sha256": "4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo="
     },
     "beetle-lynx": {
         "owner": "libretro",
         "repo": "beetle-lynx-libretro",
-        "rev": "24ca629d50de752861684a83cc9bcee96313f9e1",
-        "sha256": "LPt3JT0lyKK73yNIxvR1eUuzOkLKa8IkRA4cchhfljA=",
-        "fetchSubmodules": false
+        "rev": "8930e88a4342945c023cbf713031a65de11a8e75",
+        "sha256": "bg/a+9ZJNTUIuEHKrFIss8sia3JWMWXIXbxha5qKVeI="
     },
     "beetle-ngp": {
         "owner": "libretro",
         "repo": "beetle-ngp-libretro",
         "rev": "f7c393184e5228c3d3807ee74c951c4c549107d8",
-        "sha256": "7vki8VkwOzxwMZcUxekg1DFSskV7VNQ1SRaU3M1xHZ0=",
-        "fetchSubmodules": false
+        "sha256": "7vki8VkwOzxwMZcUxekg1DFSskV7VNQ1SRaU3M1xHZ0="
     },
     "beetle-pce-fast": {
         "owner": "libretro",
         "repo": "beetle-pce-fast-libretro",
-        "rev": "6f63eab86abab335c1e337d4e8c1582bceda5708",
-        "sha256": "QRw7FDd7rOTsTW4qGr2isvFHmobz7GgXUt84q0x2S/c=",
-        "fetchSubmodules": false
+        "rev": "0f43fd4dc406e7da6bbdc13b6eb1c105d6072f8a",
+        "sha256": "u1lOgXEYuGAF4sOLdsBzcA4/A5Yz1b82TjFBiM57yE4="
     },
     "beetle-pcfx": {
         "owner": "libretro",
         "repo": "beetle-pcfx-libretro",
         "rev": "6d2b11e17ad5a95907c983e7c8a70e75508c2d41",
-        "sha256": "WG2YpCYdL/MxW5EbiP2+1VtAjbX7yYDIcLXhb+YySI4=",
-        "fetchSubmodules": false
+        "sha256": "WG2YpCYdL/MxW5EbiP2+1VtAjbX7yYDIcLXhb+YySI4="
     },
     "beetle-psx": {
         "owner": "libretro",
         "repo": "beetle-psx-libretro",
-        "rev": "39be47bc9958258cf3b6f3c68d9485ea99971cf8",
-        "sha256": "q6aKSfG1A2AV2MppZFujDwqqZu26R7b0t9KyAETQTyU=",
-        "fetchSubmodules": false
+        "rev": "297970e4ff080ea80a5670209aeea4fde8059020",
+        "sha256": "6kZher3/+5ywXyC3n9R9JVA4IVLZBaSfAcWEKp2SsDE="
     },
     "beetle-saturn": {
         "owner": "libretro",
         "repo": "beetle-saturn-libretro",
         "rev": "e6ba71f8bcc647b646d94dec812b24d00c41cf3f",
-        "sha256": "tDbV+CsDr4bowBbJ/C8J9scfCryTAXxz58pGaUHU5yU=",
-        "fetchSubmodules": false
+        "sha256": "tDbV+CsDr4bowBbJ/C8J9scfCryTAXxz58pGaUHU5yU="
     },
     "beetle-snes": {
         "owner": "libretro",
         "repo": "beetle-bsnes-libretro",
         "rev": "bc867656d7438aaffc6818b3b92350587bc78a47",
-        "sha256": "TyUCRGK+uyXowDjXW9/4m+zL8Vh/3GGsX1eznrTCbAg=",
-        "fetchSubmodules": false
+        "sha256": "TyUCRGK+uyXowDjXW9/4m+zL8Vh/3GGsX1eznrTCbAg="
     },
     "beetle-supergrafx": {
         "owner": "libretro",
         "repo": "beetle-supergrafx-libretro",
-        "rev": "cd800d701f0b8f4dcb1654a5cb5b24ee09dd9257",
-        "sha256": "vnskn2+65cKQjaXO9GJnKNppi8TWHUO+uZdt2BYGN9Y=",
-        "fetchSubmodules": false
+        "rev": "7bae6fb1a238f1e66b129c7c70c7cb6dbdc09fa1",
+        "sha256": "OAJ86XrwjDrgCjrk0RHMn8sHYaJFhJhLaQnhaEVXN38="
     },
     "beetle-vb": {
         "owner": "libretro",
         "repo": "beetle-vb-libretro",
         "rev": "aa77198c6c60b935503b5ea2149b8ff7598344da",
-        "sha256": "ShsMYc2vjDoiN1yCCoSl91P5ecYJDj/V+VWUYuYVxas=",
-        "fetchSubmodules": false
+        "sha256": "ShsMYc2vjDoiN1yCCoSl91P5ecYJDj/V+VWUYuYVxas="
     },
     "beetle-wswan": {
         "owner": "libretro",
         "repo": "beetle-wswan-libretro",
-        "rev": "ea00c1d8eb9894538dd8758975cd9d6ae99ead1e",
-        "sha256": "0ptDbq3X8EGNwPePr4H0VQkgmXXIP50dNpITX8DX6w8=",
-        "fetchSubmodules": false
+        "rev": "5717c101b314f64d4c384c23b1934d09fcbf82bb",
+        "sha256": "Nfezb6hja1qHv1fMGU9HMbbb56GHAfe/zIgRqrzz334="
     },
     "blastem": {
         "owner": "libretro",
         "repo": "blastem",
         "rev": "0786858437ed71996f43b7af0fbe627eb88152fc",
-        "sha256": "uEP5hSgLAle1cLv/EM7D11TJMAggu7pqWxfrUt3rhEg=",
-        "fetchSubmodules": false
+        "sha256": "uEP5hSgLAle1cLv/EM7D11TJMAggu7pqWxfrUt3rhEg="
     },
     "bluemsx": {
         "owner": "libretro",
         "repo": "bluemsx-libretro",
-        "rev": "cfc1df4d026387883f21994bcce603c4a6be8730",
-        "sha256": "ix/AyYNer1R73ZJW1reXyj7geBr3ThrqXf5Ki5yrz9A=",
-        "fetchSubmodules": false
+        "rev": "5dfdb75106e10ef8bc21b8bcea1432ecbd590b2a",
+        "sha256": "0D0xufIt3qmQ+/UjyWynoLyLDSza8cTrFp3UwGWBXko="
     },
     "bsnes": {
         "owner": "libretro",
         "repo": "bsnes-libretro",
-        "rev": "44d97b17d06a10ae17d97a91a48e5acd10ec6db4",
-        "sha256": "VNSeTRryrX2/V38GGXTRLuDEQqDUmX2DUOHAKLxJezU=",
-        "fetchSubmodules": false
+        "rev": "1b2987ab1e9caf5c8d7550da01ffa08edff2f128",
+        "sha256": "l6Jvn0ZgFaKSWjiV2bN9aemxLyfnNEQFc+HS1/MuiaY="
     },
     "bsnes-hd": {
         "owner": "DerKoun",
         "repo": "bsnes-hd",
         "rev": "65f24e56c37f46bb752190024bd4058e64ad77d1",
-        "sha256": "1dk2i71NOLeTTOZjVll8wrkr5dIH5bGSGUeeHqWjZHE=",
-        "fetchSubmodules": false
+        "sha256": "1dk2i71NOLeTTOZjVll8wrkr5dIH5bGSGUeeHqWjZHE="
     },
     "bsnes-mercury": {
         "owner": "libretro",
         "repo": "bsnes-mercury",
         "rev": "d232c6ea90552f5921fec33a06626f08d3e18b24",
-        "sha256": "fpl7hmqz+Ca+9ZeM6E1JSikbiu+NJUU8xXtyl6Dd9Gg=",
-        "fetchSubmodules": false
+        "sha256": "fpl7hmqz+Ca+9ZeM6E1JSikbiu+NJUU8xXtyl6Dd9Gg="
     },
     "citra": {
         "owner": "libretro",
@@ -131,434 +114,377 @@
         "owner": "libretro",
         "repo": "desmume",
         "rev": "7ea0fc96804fcd9c8d33e8f76cf64b1be50cc5ea",
-        "sha256": "4S/CirRVOBN6PVbato5X5fu0tBn3Fu5FEAbdf3TBqng=",
-        "fetchSubmodules": false
+        "sha256": "4S/CirRVOBN6PVbato5X5fu0tBn3Fu5FEAbdf3TBqng="
     },
     "desmume2015": {
         "owner": "libretro",
         "repo": "desmume2015",
         "rev": "cd89fb7c48c735cb321311fbce7e6e9889dda1ce",
-        "sha256": "9Ou/n6pxRjJOp/Ybpyg4+Simosj2X26kLZCMEqeVL6U=",
-        "fetchSubmodules": false
+        "sha256": "9Ou/n6pxRjJOp/Ybpyg4+Simosj2X26kLZCMEqeVL6U="
     },
     "dolphin": {
         "owner": "libretro",
         "repo": "dolphin",
-        "rev": "48066c84560322219be4080bca125cc03d48f411",
-        "sha256": "IPKcqges/BX6KFQSirLpmsI2+7/cjcrySK+YWaA1cuo=",
-        "fetchSubmodules": false
+        "rev": "3b19e6d1781584f3e1fd2922b48b8ae6b3bcb686",
+        "sha256": "EcgJhkMzdZfYRwSpU1OcsJqQyq4V8dq5PndVufZFy7k="
     },
     "dosbox": {
         "owner": "libretro",
         "repo": "dosbox-libretro",
         "rev": "aa71b67d54eaaf9e41cdd3cb5153d9cff0ad116e",
-        "sha256": "L0Y67UROjldnXUlLQ+Xbd7RHLb96jDxlB/k+LR9Kbas=",
-        "fetchSubmodules": false
+        "sha256": "L0Y67UROjldnXUlLQ+Xbd7RHLb96jDxlB/k+LR9Kbas="
     },
     "eightyone": {
         "owner": "libretro",
         "repo": "81-libretro",
-        "rev": "7e8153cd5b88cd5cb23fb0c03c04e7c7d8a73159",
-        "sha256": "Y+RU3T4qUmV44IZ5OBNhtC+f/DX6njOCF0tsl8MN4qM=",
-        "fetchSubmodules": false
+        "rev": "86d7d5afe98f16006d4b1fdb99d281f1d7ea6b2f",
+        "sha256": "QN7anzqv1z8SgY8dlkjr8Ns7reGWc7hTneiRmorXZSk="
     },
     "fbalpha2012": {
         "owner": "libretro",
         "repo": "fbalpha2012",
         "rev": "23f98fc7cf4f2f216149c263cf5913d2e28be8d4",
-        "sha256": "dAInW6tTV7oXcPhKMnHWcmQaWQCTqRrYHD2yuaI1I1w=",
-        "fetchSubmodules": false
+        "sha256": "dAInW6tTV7oXcPhKMnHWcmQaWQCTqRrYHD2yuaI1I1w="
     },
     "fbneo": {
         "owner": "libretro",
         "repo": "fbneo",
-        "rev": "8e9f73ab28fc6176f0bde53eac0f0b561b065e16",
-        "sha256": "gv1Yuo0wFB6MmCtnajM71EK2GEzd5X29VYY2yFcB6Uk=",
-        "fetchSubmodules": false
+        "rev": "4ecf2782a4eee042d1e126d1671e5231b6437b6e",
+        "sha256": "15MYI03r45mmRsXCwzWnjfBdtzSaHLp7DfmcACQFTvU="
     },
     "fceumm": {
         "owner": "libretro",
         "repo": "libretro-fceumm",
-        "rev": "02b5bbf26981b5ae0da81a9f312cb51ed64112b8",
-        "sha256": "zsY0RyWLJD2Zf1qDzuMbbNxV630TAIt3KqjLWXR4lgQ=",
-        "fetchSubmodules": false
+        "rev": "eb06d17e7912780a3ee117ae73bc50c3948c761c",
+        "sha256": "aBqskJtK1bFBjwaoo9hilr33fyAWsdj5+hFC3WY3sKk="
     },
     "flycast": {
         "owner": "libretro",
         "repo": "flycast",
-        "rev": "041297cc6c266b1185a4414271a10732c946239c",
-        "sha256": "htuUfzwlSbhh8CxMEeE8HqNqaJupav4cBfXMwMEKim8=",
-        "fetchSubmodules": false
+        "rev": "0d8c6a2e717c002bc76ce26a152353b004fb15e7",
+        "sha256": "t2RGHAyYXeHVqTqqhayOUWx/msFN9q/Z9P2wXJUtQTI="
     },
     "fmsx": {
         "owner": "libretro",
         "repo": "fmsx-libretro",
-        "rev": "cd2d59a9b820a0abf038fa7e279965da34132960",
-        "sha256": "8mOcTTETgDWGDV5q9n3UupMsbPXEqv0AbQGdgOSKfBk=",
-        "fetchSubmodules": false
+        "rev": "dfcda056896576c6a1c75c002a82d0e6c1160ccc",
+        "sha256": "9ANZ1suAQcYOhqSchQ20Yuqvgw06j5Sd3Z1fjrp2UFc="
     },
     "freeintv": {
         "owner": "libretro",
         "repo": "freeintv",
-        "rev": "0058a09492c5c17a4fa59ebb3601ce66844b3b25",
-        "sha256": "DA6eAl9ZR84Ow8rH9q/DVbEU83nmidwMy3kqk+hWWLQ=",
-        "fetchSubmodules": false
+        "rev": "d58caf23ed1438a1db58f8d6ac24ca521b411d3b",
+        "sha256": "nUV+A3Zh66M1K5NDK0ksNF5H1HS3AQdeYLaGfaA34n4="
     },
     "gambatte": {
         "owner": "libretro",
         "repo": "gambatte-libretro",
-        "rev": "eb6f26a57ff6c35154950da20f83ddf1d44d4ca6",
-        "sha256": "boPCbMX1o1i+rL0dnY0M3pzY1D6uzoYRN21C1zXXOJw=",
-        "fetchSubmodules": false
+        "rev": "79bb2e56d034c30d8dcac02b6c34a59ec8fe91bc",
+        "sha256": "H+Hkeep18whaSYbyG8DcaJqsVVu7DEX9T28pkfXfyCg="
     },
     "genesis-plus-gx": {
         "owner": "libretro",
         "repo": "Genesis-Plus-GX",
-        "rev": "8a7d4c87d2e6936d64c1251c6f968a93cc87cce5",
-        "sha256": "SX0jA8VuN4LNVhR/aw3gF0uF7+c9McEiHnNmxbPtE5g=",
-        "fetchSubmodules": false
+        "rev": "88c9ad000ba553b9c819d9eb259f741fabd877bb",
+        "sha256": "8ZCMq8/sk5TqwTNWMfDevZHRPSOM1PJ57kiZZ7qfQxA="
     },
     "gpsp": {
         "owner": "libretro",
         "repo": "gpsp",
-        "rev": "be3fdfd0b4e0529d7e00c4e16eb26d92fe0559a6",
-        "sha256": "GX3iAVNfznxa/3aIHuopFFNsdz2b22BiQyycioH1TGw=",
-        "fetchSubmodules": false
+        "rev": "e554360dd3ed283696fc607877024a219248b735",
+        "sha256": "ImsqB89XmjF8nvs7j8IZVvFltgZRYvF2L7LTcJG/xCU="
     },
     "gw": {
         "owner": "libretro",
         "repo": "gw-libretro",
         "rev": "0f1ccca156388880bf4507ad44741f80945dfc6f",
-        "sha256": "BVpx8pL224J2u9W6UDrxzfEv4qIsh6wrf3bDdd1R850=",
-        "fetchSubmodules": false
+        "sha256": "BVpx8pL224J2u9W6UDrxzfEv4qIsh6wrf3bDdd1R850="
     },
     "handy": {
         "owner": "libretro",
         "repo": "libretro-handy",
-        "rev": "ebcbb8be5d174306ffb091b7657637b910fc35d2",
-        "sha256": "mkPgOFfYDICmFu0nZ+9kfbrmSmPpNdC9lvci0MsXIwo=",
-        "fetchSubmodules": false
+        "rev": "3b02159ba32aa37c1b93d7f7eac56b28e3715645",
+        "sha256": "mBKK+pdWgkxYkV4OOiBrlWbLAMugDX0fd6QRh0D7JYU="
     },
     "hatari": {
         "owner": "libretro",
         "repo": "hatari",
-        "rev": "cea06eebf695b078fadc0e78bb0f2b2baaca799f",
-        "sha256": "Z05IGubwdgg7X/e2ZG49zVfXuITM59HW/1gicdpDXls=",
-        "fetchSubmodules": false
+        "rev": "79d128888ca3efdd27d639a35edf72a9bc81a798",
+        "sha256": "du2xORgAXTSQArqNuFa5gjticgZ+weqySFHVz2Y2qzI="
     },
     "mame": {
         "owner": "libretro",
         "repo": "mame",
-        "rev": "031ac783585e7d5156a6f87a9ba20d88caf94ad6",
-        "sha256": "hLMQw5jvJTxojGwCY7iUDHcJdLZjcLzEDhW576TerJI=",
-        "fetchSubmodules": false
+        "rev": "2f9c793a77222ae46266c71f64d491cf7870dc1e",
+        "sha256": "WAhm6QMMVbnuSIK4PW7Ek+AAkMs7s95gGb6ERzlon0w="
     },
     "mame2000": {
         "owner": "libretro",
         "repo": "mame2000-libretro",
         "rev": "4793742b457945afb74053c8a895e6ff0b36b033",
-        "sha256": "DA9fZTic/jlYzSAIiOjfhohyEyQZiBNdIa8YCZoKZNs=",
-        "fetchSubmodules": false
+        "sha256": "DA9fZTic/jlYzSAIiOjfhohyEyQZiBNdIa8YCZoKZNs="
     },
     "mame2003": {
         "owner": "libretro",
         "repo": "mame2003-libretro",
-        "rev": "80a4ca5c0db69be9fe9b65dcaa7ad45930c989b8",
-        "sha256": "ZViVX+Z40ctxWGiQtfmRUDbUT7EYHqTNDhwWbKBjTEQ=",
-        "fetchSubmodules": false
+        "rev": "dbda6ddacdd8962cfea25000421dba398e551aef",
+        "sha256": "RSL3iZZEJCxOtsJqjnM5ZiT0yM2nAgg/Ujq6FBLMHkk="
     },
     "mame2003-plus": {
         "owner": "libretro",
         "repo": "mame2003-plus-libretro",
-        "rev": "8dc4cfa741db8136e43c4a0eabdc1977fd88ccdb",
-        "sha256": "gcsL2xfF+q5ECN9u4JaKR8rimCXLt/bVSzybLo2ln3Q=",
-        "fetchSubmodules": false
+        "rev": "9c0c954f0f88730f44abdd4d414691fef6b1cd7c",
+        "sha256": "NLdHc0VuZhqQhAzv+8kipc0mhqT2BNaJeLYZUx7DwRU="
     },
     "mame2010": {
         "owner": "libretro",
         "repo": "mame2010-libretro",
         "rev": "932e6f2c4f13b67b29ab33428a4037dee9a236a8",
-        "sha256": "HSZRSnc+0300UE9fPcUOMrXABlxHhTewkFPTqQ4Srxs=",
-        "fetchSubmodules": false
+        "sha256": "HSZRSnc+0300UE9fPcUOMrXABlxHhTewkFPTqQ4Srxs="
     },
     "mame2015": {
         "owner": "libretro",
         "repo": "mame2015-libretro",
-        "rev": "ef41361dc9c88172617f7bbf6cd0ead4516a3c3f",
-        "sha256": "HZrw9KKwYAJyU4NH1BEvuod/TK/nqjN03qJuSX8JP8o=",
-        "fetchSubmodules": false
+        "rev": "e6a7aa4d53726e61498f68d6b8e2c092a2169fa2",
+        "sha256": "IgiLxYYuUIn3YE+kQCXzgshES2VNpUHn0Qjsorw0w/s="
     },
     "mame2016": {
         "owner": "libretro",
         "repo": "mame2016-libretro",
-        "rev": "69711c25c14f990b05fdce87fb92f3b5c312ec1e",
-        "sha256": "QdSgWcZIMDnmYAKAnvwNRPBYRaSMTcRpI7Vd04Xv3Is=",
-        "fetchSubmodules": false
+        "rev": "bcff8046328da388d100b1634718515e1b15415d",
+        "sha256": "XxnX39+0VUbG9TF8+wFEFVxHCm2rzrJsIQryyNsF6zU="
     },
     "melonds": {
         "owner": "libretro",
         "repo": "melonds",
-        "rev": "1ad65728476d7b9594c4ff91a1ba60460a0a30e7",
-        "sha256": "EBV8F2MCmWuxWKMOXipTZKRGHqp8sb/ojK3JpGZe818=",
-        "fetchSubmodules": false
+        "rev": "0053daa700018657bf2e47562b3b4eb86f9b9d03",
+        "sha256": "K6ZYuk7cE+ioq1rLRyAKNQxddCYIOXLU5SXT7sYgGnc="
     },
     "mesen": {
         "owner": "libretro",
         "repo": "mesen",
         "rev": "094d82bf724448426acbaad45e83bc38994e32f6",
-        "sha256": "9+AqZRv8lugNNa+ZZzIPJNO87J1aBUEiOggL8aYno1M=",
-        "fetchSubmodules": false
+        "sha256": "9+AqZRv8lugNNa+ZZzIPJNO87J1aBUEiOggL8aYno1M="
     },
     "mesen-s": {
         "owner": "libretro",
         "repo": "mesen-s",
         "rev": "42eb0e8ad346608dae86feb8a04833d16ad21541",
-        "sha256": "q6zeoNiZtFy8ZYls9/E+O7o9BYTcVcmYjbJA48qiraU=",
-        "fetchSubmodules": false
+        "sha256": "q6zeoNiZtFy8ZYls9/E+O7o9BYTcVcmYjbJA48qiraU="
     },
     "meteor": {
         "owner": "libretro",
         "repo": "meteor-libretro",
         "rev": "e533d300d0561564451bde55a2b73119c768453c",
-        "sha256": "zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ=",
-        "fetchSubmodules": false
+        "sha256": "zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ="
     },
     "mgba": {
         "owner": "libretro",
         "repo": "mgba",
-        "rev": "c33adfa66b4b3f72c939c27ff0668ebeada75086",
-        "sha256": "naZkfIghS4mIT5LT2x1E8W9/bju9pLZb8RfEHOlx7QI=",
-        "fetchSubmodules": false
+        "rev": "43da6e1d54ad0395f474346db88fe59a4c0aa451",
+        "sha256": "JxiWIBQi1fZoBV2lvx2r7iIvlQm0BYuJFz0TsxngUT8="
     },
     "mupen64plus": {
         "owner": "libretro",
         "repo": "mupen64plus-libretro-nx",
-        "rev": "018ee72b4fe247b38ed161033ad12a19bb936f00",
-        "sha256": "vJz9S9lUgJp8O0NgJF6/EYymFqwZefvrT/HJLpMhgEk=",
-        "fetchSubmodules": false
+        "rev": "350f90a73cf0f5d65357ce982ccbaa3b22fc3569",
+        "sha256": "9Hq93+dvO60LBbcXLIHsTq243QThicI0rVJW3tou/5Y="
     },
     "neocd": {
         "owner": "libretro",
         "repo": "neocd_libretro",
         "rev": "83d10f3be10fff2f28aa56fc674c687528cb7f5c",
-        "sha256": "yYZGoMsUfE8cpU9i826UWQGi1l0zPJPcBDb2CINxGeQ=",
-        "fetchSubmodules": false
+        "sha256": "yYZGoMsUfE8cpU9i826UWQGi1l0zPJPcBDb2CINxGeQ="
     },
     "nestopia": {
         "owner": "libretro",
         "repo": "nestopia",
-        "rev": "21e2cec7a13f0a09f493637de289e59386e2fd36",
-        "sha256": "XKEY43wtdE78XN2TnT8AW80irnsbIwPzQ1EkGXOrsG4=",
-        "fetchSubmodules": false
+        "rev": "8af07b7ab49e45495cbc4ba73cd2f879d9908b55",
+        "sha256": "Z447flP1L/7gWEovWhbBearPKzsZNnGE2cz7jH7kEnY="
     },
     "np2kai": {
         "owner": "AZO234",
         "repo": "NP2kai",
-        "rev": "3e8fedc7c1c6f68faa26589187512474a766ee9e",
-        "sha256": "5bfh/aZOqfHz1x2s5AzZo4zq9qA4w10d9vYuuILdKJQ=",
+        "rev": "30d4b6959c48db039207a37e278c868c7737ed69",
+        "sha256": "uIcgbpcEz6yUKrBe0r84Yq2ihWfT0+TdUTIF5kMT5mI=",
         "fetchSubmodules": true
     },
     "o2em": {
         "owner": "libretro",
         "repo": "libretro-o2em",
         "rev": "f1050243e0d5285e7769e94a882b0cf39d2b7370",
-        "sha256": "wD+iJ8cKC8jYFZ6OVvX71uO7sSh5b/LLoc5+g7f3Yyg=",
-        "fetchSubmodules": false
+        "sha256": "wD+iJ8cKC8jYFZ6OVvX71uO7sSh5b/LLoc5+g7f3Yyg="
     },
     "opera": {
         "owner": "libretro",
         "repo": "opera-libretro",
-        "rev": "aa868e656b518567a95b11b2f14c5db8001b11a0",
-        "sha256": "YUzfHtgKCzgxZwslFxwmAN0hg+MIGLAYBAI7RUCIW40=",
-        "fetchSubmodules": false
+        "rev": "3849c969c64b82e622a7655b327fa94bc5a4c7cc",
+        "sha256": "McSrvjrYTemqAAnfHELf9qXC6n6Dg4kNsUDA7e2DvkE="
     },
     "parallel-n64": {
         "owner": "libretro",
         "repo": "parallel-n64",
-        "rev": "0a67445ce63513584d92e5c57ea87efe0da9b3bd",
-        "sha256": "rms+T8JOp/TJ/T5a5uLj8lu1LLz/GAsJZ7UbK42C9yU=",
-        "fetchSubmodules": false
+        "rev": "28c4572c9a09447b3bf5ed5fbd3594a558bc210d",
+        "sha256": "by8NvKjVT9OrgVhNtv5E4Fqmdva42lWV8UQi0SKfBL8="
     },
     "pcsx2": {
         "owner": "libretro",
         "repo": "pcsx2",
-        "rev": "26890da6f34176e70289c2f3004cd5660be0035b",
-        "sha256": "PocOjidZyv30kIjOq++9DZdCNBXbCbyd0vepjMFXflQ=",
-        "fetchSubmodules": false
+        "rev": "3ef2a36b0608e9dcae808c7ef01c7a760d628735",
+        "sha256": "ezqVntonhGfejiGx9cxQEnjsXEHqT++M1fO0Jz1t/Us="
     },
     "pcsx_rearmed": {
         "owner": "libretro",
         "repo": "pcsx_rearmed",
-        "rev": "589bd99ba31de8216624dbf0cbbc016f0663ce3d",
-        "sha256": "6OtsWXTo6ca0M/cofpvWPEd0Tqy3XDa8vaa7OUTxnMU=",
-        "fetchSubmodules": false
+        "rev": "12fc12797064599dfca2d44043d5c02a949711ef",
+        "sha256": "SXmNfHGyk+KChiwkKlA+d/oezzp/7p1DJY+w2bES6kg="
     },
     "picodrive": {
         "owner": "libretro",
         "repo": "picodrive",
-        "rev": "d44605c269e645a6734089ac1f95116a5ce57e0b",
-        "sha256": "Z4d+7Hf55raMAOIA2jrj6M99XhLTZqthHxi89ba+xEo=",
+        "rev": "50b8b47838fea8096535d543caaacdcc56aa7df2",
+        "sha256": "C1Htwel5PHZcjkKmjiiN/QgRofMhqlArxktOSqoTxTc=",
         "fetchSubmodules": true
     },
     "play": {
         "owner": "jpd002",
         "repo": "Play-",
-        "rev": "65492042f0b2146d81decc8f63466362dd6122bc",
-        "sha256": "fpiOT6fXvjGWmnKwncV2NyuYeT2ACE8LLyisKsWqydQ=",
+        "rev": "fd6a5161030215090d48a8036680f57914c71bb0",
+        "sha256": "g6UBRV7biLjPBXdlejjXUSk3v1wrsYWA3quZlpPj23U=",
         "fetchSubmodules": true
     },
     "ppsspp": {
         "owner": "hrydgard",
         "repo": "ppsspp",
-        "rev": "3e5511b6091b8af76d124d101f3d84ccc1021f30",
-        "sha256": "FCaKEdu55c7zxh9Mdi+xAFj8v5/AoT2AzYYEErHd9sQ=",
+        "rev": "54d63cc1daf2a0cdc812e9af85854bb4ae5ef399",
+        "sha256": "iB/8zf4FYdsbiKZVq/YISTEQSoo1kme1uZsyuhbOcoc=",
         "fetchSubmodules": true
     },
     "prboom": {
         "owner": "libretro",
         "repo": "libretro-prboom",
-        "rev": "de19b1124559423244b4d677fd6006444d418c0e",
-        "sha256": "vt43eYYGGUotxYeotUfp/9fvWnKJLJtrvo+GNavH3QY=",
-        "fetchSubmodules": false
+        "rev": "af1b5bf89d01095326ee27e178f9257f9e728873",
+        "sha256": "pvTUv4E+wBOYfjz8Ph11CK4E7rIm1T+u90TWDNXEBIU="
     },
     "prosystem": {
         "owner": "libretro",
         "repo": "prosystem-libretro",
         "rev": "89e6df7b60d151310fedbe118fb472959a9dcd61",
-        "sha256": "uxgKddS53X7ntPClE8MGezBAG+7OAFvMXTnyKpOOau0=",
-        "fetchSubmodules": false
+        "sha256": "uxgKddS53X7ntPClE8MGezBAG+7OAFvMXTnyKpOOau0="
     },
     "quicknes": {
         "owner": "libretro",
         "repo": "QuickNES_Core",
-        "rev": "6444b56659ed887c3492831da188fbc42e3e8ca2",
-        "sha256": "FHV9oM4rmsCm7GsD5TKyVbBCN7uc9GRU5YGQE+2SiRM=",
-        "fetchSubmodules": false
+        "rev": "743e6e06db246c5edab27c738c7a573d83140485",
+        "sha256": "NYmP+HFeZGUeIRaT3bzdpWw9cmEAaBkA3EGnw/zpDXA="
     },
     "sameboy": {
         "owner": "libretro",
         "repo": "sameboy",
-        "rev": "685c6c8b497260f53a984d5c4398ef2b25253104",
-        "sha256": "OosKYG38NvfwrLSEhAe2CrUx8PiSv4OhkmrVUO6l1qc=",
-        "fetchSubmodules": false
+        "rev": "b154b7d3d885a3cf31203f0b8f50d3b37c8b742b",
+        "sha256": "tavGHiNpRiPkibi66orMf93cnCqQCD8XhSl/36nl/9M="
     },
     "scummvm": {
         "owner": "libretro",
         "repo": "scummvm",
-        "rev": "63e57573a9ffe71a1083ff46d9cd210203b87afb",
-        "sha256": "LTFe8HIX9OSJuJj5YfPigrPAE8nrbSpDckh0hj3w52s=",
-        "fetchSubmodules": false
+        "rev": "80cb7269a33b233dcea27d8d01df084b0d35c80a",
+        "sha256": "5kMWM8d5aBbT7TseNyaYxw7VDkrLL0G+KUvJcUboQgA="
     },
     "smsplus-gx": {
         "owner": "libretro",
         "repo": "smsplus-gx",
         "rev": "3f1ffede55bcfe0168caa484a00bf041ab591abf",
-        "sha256": "fD+grzMPk4uXvmzGf+f9Mor0eefBLHIumCydsSHUsck=",
-        "fetchSubmodules": false
+        "sha256": "fD+grzMPk4uXvmzGf+f9Mor0eefBLHIumCydsSHUsck="
     },
     "snes9x": {
         "owner": "snes9xgit",
         "repo": "snes9x",
-        "rev": "cf1a5901fccafdaead225b0a5e55ff74fdcf9678",
-        "sha256": "p6qTCZnZSV5vgpZglI/HMi/wOfu0hG2TuvOQhQHeo2s=",
-        "fetchSubmodules": false
+        "rev": "34b6160805c4995a8edf5f9b3328f5e492ae4c44",
+        "sha256": "YRRqtd5iu2evRk+7SyQpqpxqTaEFOkDZ/XQHEjpSBcM="
     },
     "snes9x2002": {
         "owner": "libretro",
         "repo": "snes9x2002",
         "rev": "e16cb16efa00765b1bc3b8fee195680efb1542c7",
-        "sha256": "0dhLpNy+NUE3mE/ejEwbq3G28/a2HONS5NPslI5LOEc=",
-        "fetchSubmodules": false
+        "sha256": "0dhLpNy+NUE3mE/ejEwbq3G28/a2HONS5NPslI5LOEc="
     },
     "snes9x2005": {
         "owner": "libretro",
         "repo": "snes9x2005",
-        "rev": "88a46f7c085f6e2accc4c777e264b9b5cd41cf0e",
-        "sha256": "5wVKK3xhCXkvonwQRyVtd8Afggb0gv8Sv7PEYkDfKRE=",
-        "fetchSubmodules": false
+        "rev": "77e9cd293c791b47f4397da0a47242b329243cb5",
+        "sha256": "iHGfZIGzE4n3EHrVRxTULuYKsOse5NcJftmasoJFwFo="
     },
     "snes9x2010": {
         "owner": "libretro",
         "repo": "snes9x2010",
         "rev": "714b1c8e08c7580430190119b07e793405773ac2",
-        "sha256": "yKSQEE+lT4V2V1XqemfziHuIt79TcvC0ranU9ounTXo=",
-        "fetchSubmodules": false
+        "sha256": "yKSQEE+lT4V2V1XqemfziHuIt79TcvC0ranU9ounTXo="
     },
     "stella": {
         "owner": "stella-emu",
         "repo": "stella",
-        "rev": "66e2c857c2bd85e778c51ae1cb99fb7669c7af17",
-        "sha256": "RWNEq5qwShbBKIx5bif4NDs/uJES2wf1CVSxZbb6beI=",
-        "fetchSubmodules": false
+        "rev": "1db9de390a331a7d55c35591c93d9e89184cce5f",
+        "sha256": "vICKxx+UBYvMzZ3a3F86yzJRKfdo0jMxa27wsUX0KZw="
     },
     "stella2014": {
         "owner": "libretro",
         "repo": "stella2014-libretro",
         "rev": "934c7a2a44ef038af529b68950ddba4f7ea3478e",
-        "sha256": "s7LQ47sAPTyk4COONk4qnebxCq78zGLIjh3Y2+1fIak=",
-        "fetchSubmodules": false
+        "sha256": "s7LQ47sAPTyk4COONk4qnebxCq78zGLIjh3Y2+1fIak="
     },
     "swanstation": {
         "owner": "libretro",
         "repo": "swanstation",
-        "rev": "8951ed1cea4ea65de5529a35e950f1b185e48b6e",
-        "sha256": "27EH4oiYf154DJwm738qPOMCuWOCKD7wuSng3hz/xh0=",
-        "fetchSubmodules": false
+        "rev": "61c5debe60192b0fecd8c15310b2e4c4473f9438",
+        "sha256": "DZJApJnGDMsUhjO35TBc7tMldCGKDPPtrwxPLe0Ey1s="
     },
     "tgbdual": {
         "owner": "libretro",
         "repo": "tgbdual-libretro",
         "rev": "1e0c4f931d8c5e859e6d3255d67247d7a2987434",
-        "sha256": "0wHv9DpKuzJ/q5vERqCo4GBLre2ggClBIWSjGnMLQq8=",
-        "fetchSubmodules": false
+        "sha256": "0wHv9DpKuzJ/q5vERqCo4GBLre2ggClBIWSjGnMLQq8="
     },
     "thepowdertoy": {
         "owner": "libretro",
         "repo": "ThePowderToy",
         "rev": "ac620c0a89a18774c3ad176a8a1bc596df23ff57",
-        "sha256": "C/X1DbmnucRddemEYml2zN3qr5yoXY3b+nvqfpboS0M=",
-        "fetchSubmodules": false
+        "sha256": "C/X1DbmnucRddemEYml2zN3qr5yoXY3b+nvqfpboS0M="
     },
     "tic80": {
         "owner": "libretro",
         "repo": "tic-80",
-        "rev": "bd03e6a548676745e81fa95e60b233b5a56420c2",
-        "sha256": "SXJvWX6Q3BrdajNnT4HIf6H2z7dXXvnXTJXf/TYRw4I=",
+        "rev": "967eb78c3610385a0e6cba8bb5c60ebc3b886d3e",
+        "sha256": "N0QFNTYFVbhWwt2yx5fLM7Dl6pJZPYrt9o3+6rjnWa8=",
         "fetchSubmodules": true
     },
     "vba-m": {
         "owner": "libretro",
         "repo": "vbam-libretro",
         "rev": "254f6effebe882b7d3d29d9e417c6aeeabc08026",
-        "sha256": "vJWjdqJ913NLGL4G15sRPqO/wp9xPsuhUMLUuAbDRKk=",
-        "fetchSubmodules": false
+        "sha256": "vJWjdqJ913NLGL4G15sRPqO/wp9xPsuhUMLUuAbDRKk="
     },
     "vba-next": {
         "owner": "libretro",
         "repo": "vba-next",
         "rev": "b218f48bb27b5d3885fa4076ff325922b5acd817",
-        "sha256": "idqGMbMA9mZlIh0QAba3BxpPDi/bFJJkUbnxV3xMOCo=",
-        "fetchSubmodules": false
+        "sha256": "idqGMbMA9mZlIh0QAba3BxpPDi/bFJJkUbnxV3xMOCo="
     },
     "vecx": {
         "owner": "libretro",
         "repo": "libretro-vecx",
         "rev": "28d6efc8972313903d0802a736ff8c3bc115e78f",
-        "sha256": "VYa8s+HB8IYF+HS6SA+sO5DzpgCtnMGrh88KTVNGICY=",
-        "fetchSubmodules": false
+        "sha256": "VYa8s+HB8IYF+HS6SA+sO5DzpgCtnMGrh88KTVNGICY="
     },
     "virtualjaguar": {
         "owner": "libretro",
         "repo": "virtualjaguar-libretro",
         "rev": "d1b1b28a6ad2518b746e3f7537ec6d66db96ec57",
-        "sha256": "Io25dt80fqIqIxwzF2DK9J5UFz6YCUQoqThcIuxdEBo=",
-        "fetchSubmodules": false
+        "sha256": "Io25dt80fqIqIxwzF2DK9J5UFz6YCUQoqThcIuxdEBo="
     },
     "yabause": {
         "owner": "libretro",
         "repo": "yabause",
-        "rev": "c940fe68461cb2bc6dd98cc162b46813ba12b081",
-        "sha256": "a4nTgOZ2xEq45sWZ9AxmrjEdMOjnG3Whfm8mrvEMnuY=",
-        "fetchSubmodules": false
+        "rev": "f30153ff9e534b96049c6f1ac3075b572642ceb5",
+        "sha256": "AdqCr5X3Bq8ic2jkIestmYi+CBByZ5Fyf0BUYwBkWnA="
     }
 }

--- a/pkgs/misc/emulators/retroarch/hashes.json
+++ b/pkgs/misc/emulators/retroarch/hashes.json
@@ -110,6 +110,15 @@
         "leaveDotGit": true,
         "deepClone": true
     },
+    "citra-canary": {
+        "owner": "libretro",
+        "repo": "citra",
+        "rev": "5401990a9be46e4497abc92db3d5f2042674303d",
+        "sha256": "JKKJBa840i7ESwMrB5tKamCBmrYvvoEUdibqxkWg5Gc=",
+        "fetchSubmodules": true,
+        "leaveDotGit": true,
+        "deepClone": true
+    },
     "desmume": {
         "owner": "libretro",
         "repo": "desmume",

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -26,7 +26,12 @@ CORES = {
     "bsnes": {"repo": "bsnes-libretro"},
     "bsnes-hd": {"repo": "bsnes-hd", "owner": "DerKoun"},
     "bsnes-mercury": {"repo": "bsnes-mercury"},
-    "citra": {"repo": "citra", "fetch_submodules": True, "deep_clone": True, "leave_dot_git": True},
+    "citra": {
+        "repo": "citra",
+        "fetch_submodules": True,
+        "deep_clone": True,
+        "leave_dot_git": True,
+    },
     "desmume": {"repo": "desmume"},
     "desmume2015": {"repo": "desmume2015"},
     "dolphin": {"repo": "dolphin"},
@@ -116,7 +121,9 @@ def get_repo_hash_fetchFromGitHub(
         capture_output=True,
         text=True,
     )
-    return json.loads(result.stdout)
+    j = json.loads(result.stdout)
+    # Remove False values
+    return {k: v for k, v in j.items() if v}
 
 
 def get_repo_hash(fetcher="fetchFromGitHub", **kwargs):

--- a/pkgs/misc/emulators/retroarch/update.py
+++ b/pkgs/misc/emulators/retroarch/update.py
@@ -32,6 +32,13 @@ CORES = {
         "deep_clone": True,
         "leave_dot_git": True,
     },
+    "citra-canary": {
+        "repo": "citra",
+        "fetch_submodules": True,
+        "deep_clone": True,
+        "leave_dot_git": True,
+        "rev": "canary",
+    },
     "desmume": {"repo": "desmume"},
     "desmume2015": {"repo": "desmume2015"},
     "dolphin": {"repo": "dolphin"},
@@ -107,6 +114,7 @@ def get_repo_hash_fetchFromGitHub(
     deep_clone=False,
     fetch_submodules=False,
     leave_dot_git=False,
+    rev=None,
 ):
     extra_args = []
     if deep_clone:
@@ -115,6 +123,9 @@ def get_repo_hash_fetchFromGitHub(
         extra_args.append("--fetch-submodules")
     if leave_dot_git:
         extra_args.append("--leave-dot-git")
+    if rev:
+        extra_args.append("--rev")
+        extra_args.append(rev)
     result = subprocess.run(
         ["nix-prefetch-github", owner, repo, *extra_args],
         check=True,

--- a/pkgs/misc/emulators/retroarch/wrapper.nix
+++ b/pkgs/misc/emulators/retroarch/wrapper.nix
@@ -28,10 +28,10 @@ stdenv.mkDerivation {
   preferLocalBuild = true;
 
   meta = with retroarch.meta; {
-    inherit license homepage platforms maintainers;
+    inherit changelog license homepage platforms maintainers;
     description = description
-                  + " (with cores: "
-                  + lib.concatStringsSep ", " (map (x: ""+x.name) cores)
-                  + ")";
+      + " (with cores: "
+      + lib.concatStringsSep ", " (map (x: "${x.name}") cores)
+      + ")";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33426,7 +33426,10 @@ with pkgs;
   retroarch = wrapRetroArch { retroarch = retroarchBare; };
 
   retroarchFull = retroarch.override {
-    cores = builtins.filter (c: c ? libretroCore) (builtins.attrValues libretro);
+    cores = builtins.filter
+      # Remove cores not supported on platform
+      (c: c ? libretroCore && (builtins.elem stdenv.hostPlatform.system c.meta.platforms))
+      (builtins.attrValues libretro);
   };
 
   libretro = recurseIntoAttrs (callPackage ../misc/emulators/retroarch/cores.nix {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New release: https://github.com/libretro/RetroArch/releases/tag/v1.10.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
