### PR TITLE
plik,plikd: 1.3.1 -> 1.3.4

### DIFF
--- a/pkgs/servers/plik/default.nix
+++ b/pkgs/servers/plik/default.nix
@@ -1,16 +1,17 @@
 { lib, fetchurl, makeWrapper, runCommand, callPackage }:
 
 let
-  version = "1.3.1";
+  version = "1.3.4";
 
-  programs = callPackage ./programs.nix {};
+  programs = callPackage ./programs.nix { };
 
   webapp = fetchurl {
     url = "https://github.com/root-gg/plik/releases/download/${version}/plik-${version}-linux-amd64.tar.gz";
-    sha256 = "KN6cp29KKdGamYnfL3jYltx0EDx6syDPfV0jShOk7Zw=";
+    sha256 = "1qp96va5l0m7jp4g007bhgcpf4ydg3cpg2x9wa9rkpp9k1svdhjy";
   };
 
-in {
+in
+{
 
   inherit (programs) plik plikd-unwrapped;
 

--- a/pkgs/servers/plik/programs.nix
+++ b/pkgs/servers/plik/programs.nix
@@ -1,16 +1,16 @@
 { lib, buildGoModule, fetchFromGitHub, fetchurl, makeWrapper, runCommand }:
 
 let
-  version = "1.3.1";
+  version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "root-gg";
     repo = "plik";
     rev = version;
-    sha256 = "C/1Uwjsqd9n3WSXlnlq9K3EJHkLOSavS9cPqF2UqmGo=";
+    sha256 = "0kmcidnjw26vnxx9h3swcg72i507awg89s4nfxw6rwbyw36iiiqf";
   };
 
-  vendorSha256 = "klmWXC3tkoOcQHhiQZjR2C5jqaRJqMQOLtVxZ0cFq/Y=";
+  vendorSha256 = null;
 
   meta = with lib; {
     homepage = "https://plik.root.gg/";
@@ -18,7 +18,8 @@ let
     maintainers = with maintainers; [ freezeboy ];
     license = licenses.mit;
   };
-in {
+in
+{
 
   plik = buildGoModule {
     pname = "plik";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
