### PR TITLE
nixos/powerdns: replace extraConfig with settings option

### DIFF
--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -4,15 +4,24 @@ with lib;
 
 let
   cfg = config.services.powerdns;
-  configDir = pkgs.writeTextDir "pdns.conf" "${cfg.extraConfig}";
-in {
+  configDir = pkgs.writeTextDir "pdns.conf" (concatStringsSep "\n" (mapAttrsToList (key: value: "${key}=${toStr value}") cfg.settings));
+  toStr = value:
+    if value == true then "yes"
+    else if value == false then "no"
+    else builtins.toString value
+  ;
+in
+{
+  imports = [
+    (mkRemovedOptionModule [ "services" "powerdns" "extraConfig" ] "Use services.powerdns.settings instead.")
+  ];
+
   options = {
     services.powerdns = {
       enable = mkEnableOption "PowerDNS domain name server";
 
-      extraConfig = mkOption {
-        type = types.lines;
-        default = "launch=bind";
+      settings = mkOption {
+        type = with types; attrsOf (oneOf [ bool int str ]);
         description = ''
           PowerDNS configuration. Refer to
           <link xlink:href="https://doc.powerdns.com/authoritative/settings.html"/>
@@ -23,6 +32,10 @@ in {
   };
 
   config = mkIf cfg.enable {
+
+    services.powerdns.settings = {
+      launch = mkDefault "bind";
+    };
 
     systemd.packages = [ pkgs.powerdns ];
 

--- a/nixos/tests/powerdns.nix
+++ b/nixos/tests/powerdns.nix
@@ -7,10 +7,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
   nodes.server = { ... }: {
     services.powerdns.enable = true;
-    services.powerdns.extraConfig = ''
-      launch=gmysql
-      gmysql-user=pdns
-    '';
+    services.powerdns.settings = {
+      launch = "gmysql";
+      gmysql-user = "pdns";
+    };
 
     services.mysql = {
       enable = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#144575

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
