### PR TITLE
wluma: 4.0.0 -> 4.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5715,13 +5715,11 @@
     githubId = 6634716;
     name = "João Figueira";
     keys = [
-
       # GitHub signing key
       {
         longkeyid = "rsa4096/0xDC7AE56AE98E02D7";
         fingerprint = "EC08 7AA3 DEAD A972 F015  6371 DC7A E56A E98E 02D7";
       }
-
       # Email encryption
       {
         longkeyid = "ed25519/0x197F9A632D139E30";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5709,6 +5709,26 @@
     githubId = 8900;
     name = "Johan Magnus Jonsson";
   };
+  jmc-figueira = {
+    email = "business+nixos@jmc-figueira.dev";
+    github = "jmc-figueira";
+    githubId = 6634716;
+    name = "João Figueira";
+    keys = [
+
+      # GitHub signing key
+      {
+        longkeyid = "rsa4096/0xDC7AE56AE98E02D7";
+        fingerprint = "EC08 7AA3 DEAD A972 F015  6371 DC7A E56A E98E 02D7";
+      }
+
+      # Email encryption
+      {
+        longkeyid = "ed25519/0x197F9A632D139E30";
+        fingerprint = "816D 23F5 E672 EC58 7674  4A73 197F 9A63 2D13 9E30";
+      }
+    ];
+  };
   jmettes = {
     email = "jonathan@jmettes.com";
     github = "jmettes";

--- a/pkgs/tools/wayland/wluma/default.nix
+++ b/pkgs/tools/wayland/wluma/default.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wluma";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "maximbaz";
     repo = "wluma";
     rev = version;
-    sha256 = "sha256-lh0GX2M3AFXjlu+jTQGiNKQXM7DiBc7RYMH9PYMLmV4=";
+    sha256 = "sha256-kUYh4RmD4zRI3ZNZWl2oWcO0Ze5czLBXUgPMl/cLW/I=";
   };
 
   nativeBuildInputs = [
@@ -48,13 +48,13 @@ rustPlatform.buildRustPackage rec {
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ vulkan-loader ]}"
   '';
 
-  cargoSha256 = "sha256-ArT4xDi+qRpukuIX1RgTgC/At9kkuG3Lf1X56Q2j/2Q=";
+  cargoSha256 = "sha256-oOIL18gij7DdvgNOuaHtuyFemNBUB85Ouh/sdhKas+s=";
 
   meta = with lib; {
     description = "Automatic brightness adjustment based on screen contents and ALS";
     homepage = "https://github.com/maximbaz/wluma";
     license = licenses.isc;
-    maintainers = with maintainers; [ yevhenshymotiuk ];
+    maintainers = with maintainers; [ yevhenshymotiuk jmc-figueira ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated the package version from 4.0.0 to 4.1.0.

This version added documentation (in the form of manpages) to `wluma`. However, [building this documentation](https://github.com/maximbaz/wluma/blob/a94209094256df23b581a01bc9295370e9fbaebe/Makefile#L36) depends on `marked-man`, an utility which, as far as I could find, is not packaged in nixpkgs. If this is a requirement for packaging, I may attempt to package `marked-man` as well; however, having no experience with packaging node.js packages, it may take a bit more time.

I also added myself as maintainer for this package, as it seems like a rather simple package to maintain as a new maintainer, coupled with the fact that it is written in Rust, a language I am familiar with.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
