### PR TITLE
firecracker: 0.24.5 -> 0.25.2

### DIFF
--- a/pkgs/applications/virtualization/firecracker/default.nix
+++ b/pkgs/applications/virtualization/firecracker/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv }:
 
 let
-  version = "0.24.5";
+  version = "0.25.2";
 
   suffix = {
     x86_64-linux = "x86_64";
@@ -22,15 +22,15 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
   src = dlbin {
-    x86_64-linux = "sha256-drcm2kz2csuJqr8Oqs0r1BrxgPHOyuwC2S+99MhbMjA=";
-    aarch64-linux = "sha256-x8RoBmgY3HRUOLw8YzEwQfQuT83zGfBHHWu88b4i05o=";
+    x86_64-linux = "sha256-ZzlPq+Q9XfWQJr+7nKS0e6bfKwYNfpMHSiBIKeOr/s4=";
+    aarch64-linux = "sha256-75UC+HeVUfUk1HRvTJsOHbHHkgr6me1OtxDF7lahf68=";
   };
 
   dontConfigure = true;
 
   buildPhase = ''
-    mv release-v${version}/firecracker-v${version}-${suffix} firecracker
-    mv release-v${version}/jailer-v${version}-${suffix} jailer
+    mv release-v${version}-${suffix}/firecracker-v${version}-${suffix} firecracker
+    mv release-v${version}-${suffix}/jailer-v${version}-${suffix} jailer
     chmod +x firecracker jailer
   '';
 


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
