### PR TITLE
tuptime: pass through nixosTests.tuptime

### DIFF
--- a/pkgs/tools/system/tuptime/default.nix
+++ b/pkgs/tools/system/tuptime/default.nix
@@ -1,6 +1,8 @@
 { lib, stdenv, fetchFromGitHub
 , makeWrapper, installShellFiles
-, python3, sqlite }:
+, python3, sqlite
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
   pname = "tuptime";
@@ -33,6 +35,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/share/tuptime/db-tuptime-migrate-4.0-to-5.0.sh \
       --prefix PATH : "${lib.makeBinPath [ sqlite ]}"
   '';
+
+  passthru.tests = nixosTests.tuptime;
 
   meta = with lib; {
     description = "Total uptime & downtime statistics utility";


### PR DESCRIPTION
###### Motivation for this change
i noticed in #156134 that the NixOS test for the module isn't passed through in the package

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
