### PR TITLE
tortoisehg: added smoke test for thg

### DIFF
--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -1,54 +1,59 @@
-{ lib, fetchurl, python3Packages
-, mercurial, qt5
+{ lib
+, fetchurl
+, python3Packages
+, mercurial
+, qt5
 }:
 
 python3Packages.buildPythonApplication rec {
-    pname = "tortoisehg";
-    version = "5.9";
+  pname = "tortoisehg";
+  version = "5.9";
 
-    src = fetchurl {
-      url = "https://www.mercurial-scm.org/release/tortoisehg/targz/tortoisehg-${version}.tar.gz";
-      sha256 = "1y8nb2b9j9qx11k1wrb9hydc94dgbsqx4yf2bv8y878hqmk1z57a";
-    };
+  src = fetchurl {
+    url = "https://www.mercurial-scm.org/release/tortoisehg/targz/tortoisehg-${version}.tar.gz";
+    sha256 = "1y8nb2b9j9qx11k1wrb9hydc94dgbsqx4yf2bv8y878hqmk1z57a";
+  };
 
-    # Extension point for when thg's mercurial is lagging behind mainline.
-    tortoiseMercurial = mercurial;
+  # Extension point for when thg's mercurial is lagging behind mainline.
+  tortoiseMercurial = mercurial;
 
-    propagatedBuildInputs = with python3Packages; [
-      tortoiseMercurial qscintilla-qt5 iniparse
-    ];
-    nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  propagatedBuildInputs = with python3Packages; [
+    tortoiseMercurial
+    qscintilla-qt5
+    iniparse
+  ];
+  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
-    doCheck = true;
-    postInstall = ''
-      mkdir -p $out/share/doc/tortoisehg
-      cp COPYING.txt $out/share/doc/tortoisehg/Copying.txt
-      # convenient alias
-      ln -s $out/bin/thg $out/bin/tortoisehg
-      wrapQtApp $out/bin/thg
-    '';
+  doCheck = true;
+  postInstall = ''
+    mkdir -p $out/share/doc/tortoisehg
+    cp COPYING.txt $out/share/doc/tortoisehg/Copying.txt
+    # convenient alias
+    ln -s $out/bin/thg $out/bin/tortoisehg
+    wrapQtApp $out/bin/thg
+  '';
 
-    checkPhase = ''
-      export QT_QPA_PLATFORM=offscreen
-      echo "test: thg smoke test"
-      $out/bin/thg -h > help.txt &
-      sleep 1s
-      if grep "list of commands" help.txt; then
-        echo "thg help output was captured. Seems like package in a working state."
-        exit 0
-      else
-        echo "thg help output was not captured. Seems like package is broken."
-        exit 1
-      fi
-    '';
+  checkPhase = ''
+    export QT_QPA_PLATFORM=offscreen
+    echo "test: thg smoke test"
+    $out/bin/thg -h > help.txt &
+    sleep 1s
+    if grep "list of commands" help.txt; then
+      echo "thg help output was captured. Seems like package in a working state."
+      exit 0
+    else
+      echo "thg help output was not captured. Seems like package is broken."
+      exit 1
+    fi
+  '';
 
-    passthru.mercurial = tortoiseMercurial;
+  passthru.mercurial = tortoiseMercurial;
 
-    meta = {
-      description = "Qt based graphical tool for working with Mercurial";
-      homepage = "https://tortoisehg.bitbucket.io/";
-      license = lib.licenses.gpl2Only;
-      platforms = lib.platforms.linux;
-      maintainers = with lib.maintainers; [ danbst ];
-    };
+  meta = {
+    description = "Qt based graphical tool for working with Mercurial";
+    homepage = "https://tortoisehg.bitbucket.io/";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ danbst ];
+  };
 }

--- a/pkgs/applications/version-management/tortoisehg/default.nix
+++ b/pkgs/applications/version-management/tortoisehg/default.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
     ];
     nativeBuildInputs = [ qt5.wrapQtAppsHook ];
 
-    doCheck = false; # tests fail with "thg: cannot connect to X server"
+    doCheck = true;
     postInstall = ''
       mkdir -p $out/share/doc/tortoisehg
       cp COPYING.txt $out/share/doc/tortoisehg/Copying.txt
@@ -29,8 +29,17 @@ python3Packages.buildPythonApplication rec {
     '';
 
     checkPhase = ''
-      echo "test: thg version"
-      $out/bin/thg version
+      export QT_QPA_PLATFORM=offscreen
+      echo "test: thg smoke test"
+      $out/bin/thg -h > help.txt &
+      sleep 1s
+      if grep "list of commands" help.txt; then
+        echo "thg help output was captured. Seems like package in a working state."
+        exit 0
+      else
+        echo "thg help output was not captured. Seems like package is broken."
+        exit 1
+      fi
     '';
 
     passthru.mercurial = tortoiseMercurial;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/155636#issuecomment-1017015028
cc @pacien 

###### Things done

Added smoke test for thg, based on an output of thg -h command. Main purpose of this test is to detect breakage of thg in case of out-of-sync mercurial update. In that case any thg subcommand just opens up an gui dialog with a description of version mismatch.
Also in order for thg to work in a checkPhase environment I have to add QT_QPA_PLATFORM=offscreen, otherwise the infamous xcb plugin error does show up. 
Also I've run nixpkgs-fmt on file.

Right now the test should fail because of version mismatch, so https://github.com/NixOS/nixpkgs/pull/155636 should be merged first in order for a test to pass.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).