### PR TITLE
python3Packages.ipwhl: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/ipwhl/default.nix
+++ b/pkgs/development/python-modules/ipwhl/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, pythonOlder, fetchFromSourcehut
+, ipfs, packaging, tomli }:
+
+buildPythonPackage rec {
+  pname = "ipwhl";
+  version = "1.0.0";
+  format = "flit";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromSourcehut {
+    owner = "~cnx";
+    repo = "ipwhl-utils";
+    rev = version;
+    sha256 = "sha256-KstwdmHpn4ypBNpX56NeStqdzy5RElMTW1oR2hCtJ7c=";
+  };
+
+  buildInputs = [ ipfs ];
+  propagatedBuildInputs = [ packaging tomli ];
+  doCheck = false; # there's no test
+  pythonImportsCheck = [ "ipwhl" ];
+
+  meta = with lib; {
+    description = "Utilities for the InterPlanetary Wheels";
+    homepage = "https://git.sr.ht/~cnx/ipwhl-utils";
+    license = licenses.agpl3Plus;
+    maintainers = [ maintainers.McSinyx ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4001,6 +4001,8 @@ in {
 
   iptools = callPackage ../development/python-modules/iptools { };
 
+  ipwhl = callPackage ../development/python-modules/ipwhl { };
+
   ipy = callPackage ../development/python-modules/IPy { };
 
   ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };


### PR DESCRIPTION
###### Motivation for this change

These are utilities for working with [IPWHL, a Python downstream distribution](https://man.sr.ht/~cnx/ipwhl).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
