### PR TITLE
nixos/swaync: init module and package at 0.3

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -611,6 +611,16 @@
       </listitem>
       <listitem>
         <para>
+          A new module was added for
+          <link xlink:href="https://github.com/ErikReider/SwayNotificationCenter">SwayNotificationCenter</link>,
+          a notification daemon with a GTK gui for Wayland compositors,
+          providing the options
+          <literal>programs.swaync.enable</literal> and
+          <literal>programs.swaync.package</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>services.mattermost.plugins</literal> has been added
           to allow the declarative installation of Mattermost plugins.
           Plugins are automatically repackaged using autoPatchelf.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -210,6 +210,10 @@ In addition to numerous new and upgraded packages, this release has the followin
 - A new module was added for the [Starship](https://starship.rs/) shell prompt,
   providing the options `programs.starship.enable` and `programs.starship.settings`.
 
+- A new module was added for [SwayNotificationCenter](https://github.com/ErikReider/SwayNotificationCenter),
+  a notification daemon with a GTK gui for Wayland compositors,
+  providing the options `programs.swaync.enable` and `programs.swaync.package`.
+
 - `services.mattermost.plugins` has been added to allow the declarative installation of Mattermost plugins.
   Plugins are automatically repackaged using autoPatchelf.
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -201,6 +201,7 @@
   ./programs/starship.nix
   ./programs/steam.nix
   ./programs/sway.nix
+  ./programs/swaync.nix
   ./programs/system-config-printer.nix
   ./programs/thefuck.nix
   ./programs/tilp2.nix

--- a/nixos/modules/programs/swaync.nix
+++ b/nixos/modules/programs/swaync.nix
@@ -1,0 +1,38 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let cfg = config.programs.swaync;
+
+in
+{
+
+  options = {
+
+    programs.swaync = {
+
+      enable = mkEnableOption "Sway Notification Center";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.swaync;
+        defaultText = literalExpression "pkgs.swaync";
+        description = "SwayNotificationCenter derivation to use.";
+      };
+
+    };
+
+  };
+
+
+  config = mkIf config.programs.evince.enable {
+
+    environment.systemPackages = [ cfg.package ];
+
+    services.dbus.packages = [ cfg.package ];
+
+    systemd.packages = [ cfg.package ];
+
+  };
+
+}

--- a/pkgs/tools/wayland/swaync/default.nix
+++ b/pkgs/tools/wayland/swaync/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, gtk-layer-shell
+, gtk3
+, json-glib
+, libgee
+, libhandy
+, vala
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "swaync";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "ErikReider";
+    repo = "SwayNotificationCenter";
+    rev = "v${version}";
+    hash = "sha256-gXo/V2FHkHZBRmaimqJCzi0BqS4tP9IniIlubBmK5u0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk-layer-shell
+    gtk3
+    json-glib
+    libgee
+    libhandy
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"
+    )
+  '';
+
+  meta = with lib; {
+    description = "A simple notification daemon with a GTK gui for notifications and the control center";
+    homepage = "https://github.com/ErikReider/SwayNotificationCenter";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ mvnetbiz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2593,6 +2593,8 @@ with pkgs;
 
   swaycwd = callPackage ../tools/wayland/swaycwd { };
 
+  swaync = callPackage ../tools/wayland/swaync { };
+
   swayr = callPackage ../tools/wayland/swayr { };
 
   wayland-utils = callPackage ../tools/wayland/wayland-utils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
gtk based notification daemon / tray for wayland window managers.

###### Things done
- Packaged SwayNotificationCenter
- Added NixOS module
- Tested with notify-send, opening panel

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
