### PR TITLE
plocate: 1.1.7 -> 1.1.14

### DIFF
--- a/pkgs/tools/misc/plocate/default.nix
+++ b/pkgs/tools/misc/plocate/default.nix
@@ -11,17 +11,16 @@
 
 stdenv.mkDerivation rec {
   pname = "plocate";
-  version = "1.1.7";
+  version = "1.1.14";
 
   src = fetchgit {
     url = "https://git.sesse.net/plocate";
     rev = version;
-    sha256 = "sha256-5Ie4qgiKUoI9Kma6YvjXirvBbpbKVuaMSSAZa36zN3M=";
+    sha256 = "sha256-SgvCy03H5aKolbkI1dg/0G5VwT3TdSGenn2h9H4gfTY=";
   };
 
   postPatch = ''
     sed -i meson.build \
-      -e "s@unitdir =.*@unitdir = '$out/lib/systemd/system'@" \
       -e '/mkdir\.sh/d'
   '';
 
@@ -30,8 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ systemd liburing zstd ];
 
   mesonFlags = [
-    # I don't know why we can't do this but instead have to resort to patching meson.build
-    #   "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
+    "-Dsystemunitdir=${placeholder "out"}/etc/systemd/system"
     "-Dsharedstatedir=/var/lib"
   ];
 


### PR DESCRIPTION
###### Motivation for this change

Update to latest released plocate

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
