### PR TITLE
fwupd: fix aarch64 build

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -214,7 +214,7 @@ let
       "-Dc_link_args=-Wl,-rpath,${placeholder "out"}/lib"
     ] ++ lib.optionals (!haveDell) [
       "-Dplugin_dell=false"
-      "-Dplugin_synaptics=false"
+      "-Dplugin_synaptics_mst=false"
     ] ++ lib.optionals (!haveRedfish) [
       "-Dplugin_redfish=false"
     ] ++ lib.optionals haveFlashrom [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/154708#issuecomment-1019218085
https://hydra.nixos.org/job/nixpkgs/staging-next/fwupd.aarch64-linux

The following changes are introduced in 1.5.6 and the plugin_synaptics option no longer exist:

https://github.com/fwupd/fwupd/pull/2753/files

With meson 0.60 the build will fail.

###### Things done

Use `meson_0_60` and build it on x86_64-linux with `-Dplugin_dell=false -Dplugin_synaptics_mst=false -Dplugin_synaptics_rmi=false -Dplugin_redfish=false -Dplugin_flashrom=true -Dplugin_msr=false`

(Feel free to change the merge base to master)