### PR TITLE
netflix: init

### DIFF
--- a/pkgs/applications/video/netflix/default.nix
+++ b/pkgs/applications/video/netflix/default.nix
@@ -1,0 +1,56 @@
+{ fetchurl
+, google-chrome
+, lib
+, makeDesktopItem
+, runtimeShell
+, symlinkJoin
+, writeScriptBin
+}:
+
+let
+  name = "netflix-via-google-chrome";
+
+  meta = {
+    description = "Open Netflix in Google Chrome app mode";
+    longDescription = ''
+      Netflix is a video streaming service providing films, TV series and exclusive content. See https://www.netflix.com.
+
+      This package installs an application launcher item that opens Netflix in a dedicated Google Chrome window. If your preferred browser doesn't support Netflix's DRM, this package provides a quick and easy way to launch Netflix on a supported browser, without polluting your application list with a redundant, single-purpose browser.
+    '';
+    homepage = google-chrome.meta.homepage or null;
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.roberth ];
+    platforms = google-chrome.meta.platforms or lib.platforms.all;
+  };
+
+  desktopItem = makeDesktopItem {
+    inherit name;
+    # Executing by name as opposed to store path is conventional and prevents
+    # copies of the desktop file from bitrotting too much.
+    # (e.g. a copy in ~/.config/autostart, you lazy lazy bastard ;) )
+    exec = name;
+    icon = fetchurl {
+      name = "netflix-icon-2016.png";
+      url = "https://assets.nflxext.com/us/ffe/siteui/common/icons/nficon2016.png";
+      sha256 = "sha256-c0H3uLCuPA2krqVZ78MfC1PZ253SkWZP3PfWGP2V7Yo=";
+      meta.license = lib.licenses.unfree;
+    };
+    desktopName = "Netflix via Google Chrome";
+    genericName = "A video streaming service providing films and exclusive TV series";
+    categories = [ "TV" "AudioVideo" "Network" ];
+    startupNotify = true;
+  };
+
+  script = writeScriptBin name ''
+    #!${runtimeShell}
+    exec ${google-chrome}/bin/${google-chrome.meta.mainProgram} \
+      --app=https://netflix.com \
+      --no-first-run --no-default-browser-check --no-crash-upload
+  '';
+
+in
+
+symlinkJoin {
+  inherit name meta;
+  paths = [ script desktopItem ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21672,6 +21672,8 @@ with pkgs;
 
   nemo-qml-plugin-dbus = libsForQt5.callPackage ../development/libraries/nemo-qml-plugin-dbus { };
 
+  netflix = callPackage ../applications/video/netflix { };
+
   nifticlib = callPackage ../development/libraries/science/biology/nifticlib { };
 
   notify-sharp = callPackage ../development/libraries/notify-sharp { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

If your preferred browser doesn't support Netflix's DRM, this package provides a quick and easy way to launch Netflix on a supported browser, without polluting your application list with a redundant, single-purpose browser.

Manually tested with XFCE (and GNOME only in an earlier iteration).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
