### PR TITLE
[21.11] python3Packages.ipython: add patch for CVE-2022-21699

### DIFF
--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pythonOlder
 # Build dependencies
 , glibcLocales
@@ -18,6 +19,7 @@
 , pexpect
 , appnope
 , backcall
+, pytest
 }:
 
 buildPythonPackage rec {
@@ -30,13 +32,21 @@ buildPythonPackage rec {
     sha256 = "2097be5c814d1b974aea57673176a924c4c8c9583890e7a5f082f547b9975b11";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2022-21699.patch";
+      url = "https://github.com/ipython/ipython/commit/67ca2b3aa9039438e6f80e3fccca556f26100b4d.patch";
+      excludes = [ "docs/source/whatsnew/version7.rst" ];
+      sha256 = "1ybpgfqppkzaz4q15qgacvhicdxfsdacl89sgj2fd9llc5mvfl26";
+    })
+  ];
+
   prePatch = lib.optionalString stdenv.isDarwin ''
     substituteInPlace setup.py --replace "'gnureadline'" " "
   '';
 
   buildInputs = [ glibcLocales ];
 
-  checkInputs = [ nose pygments ];
 
   propagatedBuildInputs = [
     jedi
@@ -52,10 +62,12 @@ buildPythonPackage rec {
 
   LC_ALL="en_US.UTF-8";
 
-  doCheck = false; # Circular dependency with ipykernel
-
+  # full tests normally disabled due to a circular dependency with
+  # ipykernel, but we want to test the CVE-2022-21699 fix in this
+  # branch
+  checkInputs = [ pytest ];
   checkPhase = ''
-    nosetests
+    pytest IPython/tests/cve.py
   '';
 
   pythonImportsCheck = [


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-21699

Add a hacky `checkPhase` just covering this fix, seeing as the full tests are normally disabled due to some circular dependency problem and our stable branch is unlikely to ever change this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
