### PR TITLE
xpra: 4.2 -> 4.3.1

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchurl
-, fetchpatch
 , substituteAll, python3, pkg-config, runCommand, writeText
 , xorg, gtk3, glib, pango, cairo, gdk-pixbuf, atk, pandoc
 , wrapGAppsHook, xorgserver, getopt, xauth, util-linux, which
@@ -44,11 +43,11 @@ let
   '';
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "4.2";
+  version = "4.3.1";
 
   src = fetchurl {
-    url = "https://xpra.org/src/${pname}-${version}.tar.gz";
-    hash = "sha256-KkQw4FJeH4G5jZ4GdP3aXZ3zxu4GALbiOI6POKJW6fk=";
+    url = "https://xpra.org/src/${pname}-${version}.tar.xz";
+    hash = "sha256-v0Abn0oYcl1I4H9GLN1pV9hk9tTE+Wlv2gPTtEE6t6k=";
   };
 
   patches = [
@@ -57,21 +56,14 @@ in buildPythonApplication rec {
       inherit libfakeXinerama;
     })
     ./fix-41106.patch  # https://github.com/NixOS/nixpkgs/issues/41106
-    # Xorg won't start without. Remove on next version!
-    (fetchpatch {
-      url = "https://github.com/Xpra-org/xpra/commit/f9f242abad69363dfa558e1f6f7956ae99164b67.patch";
-      sha256 = "sha256-TOP9RuXPuqxyKY/7LSSrCWnAmJstEE+D5EwjMiVmchM=";
-    })
   ];
 
-  postPatch = ''
-    substituteInPlace setup.py --replace '/usr/include/security' '${pam}/include/security'
-  '';
+  INCLUDE_DIRS = "${pam}/include";
 
   nativeBuildInputs = [ pkg-config wrapGAppsHook pandoc ]
     ++ lib.optional withNvenc cudatoolkit;
   buildInputs = with xorg; [
-    libX11 xorgproto libXrender libXi
+    libX11 xorgproto libXrender libXi libXres
     libXtst libXfixes libXcomposite libXdamage
     libXrandr libxkbfile
     ] ++ [

--- a/pkgs/tools/X11/xpra/fix-41106.patch
+++ b/pkgs/tools/X11/xpra/fix-41106.patch
@@ -1,15 +1,15 @@
 diff --git a/xpra/server/server_util.py b/xpra/server/server_util.py
-index dd7c7c1..066b9ff 100644
+index f46998ee9f..60068f21b6 100644
 --- a/xpra/server/server_util.py
 +++ b/xpra/server/server_util.py
-@@ -37,6 +37,10 @@ def sh_quotemeta(s):
-     return b"'" + s.replace(b"'", b"'\\''") + b"'"
+@@ -157,6 +157,10 @@ def xpra_env_shell_script(socket_dir, env):
+     return b"\n".join(script)
  
- def xpra_runner_shell_script(xpra_file, starting_dir, socket_dir):
+ def xpra_runner_shell_script(xpra_file, starting_dir):
 +    # Nixpkgs contortion:
 +    # xpra_file points to a shell wrapper, not to the python script.
 +    dirname, basename = os.path.split(xpra_file)
 +    xpra_file = os.path.join(dirname, "."+basename+"-wrapped")
      script = []
-     script.append(b"#!/bin/sh\n")
-     for var, value in os.environb.items():
+     # We ignore failures in cd'ing, b/c it's entirely possible that we were
+     # started from some temporary directory and all paths are absolute.

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -1,23 +1,28 @@
 diff --git a/setup.py b/setup.py
-index f962330..b02b6dd 100755
+index fc67abb50a..c29db3a6d2 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -2224,11 +2224,7 @@ if v4l2_ENABLED:
-     videodev2_h = "/usr/include/linux/videodev2.h"
+@@ -2348,17 +2348,7 @@ if v4l2_ENABLED:
+             break
      constants_pxi = "xpra/codecs/v4l2/constants.pxi"
      if not os.path.exists(videodev2_h) or should_rebuild(videodev2_h, constants_pxi):
 -        ENABLE_DEVICE_CAPS = 0
 -        if os.path.exists(videodev2_h):
--            with open(videodev2_h) as f:
--                hdata = f.read()
--            ENABLE_DEVICE_CAPS = int(hdata.find("device_caps")>=0)
+-            try:
+-                with subprocess.Popen("cpp -fpreprocessed %s | grep -q device_caps" % videodev2_h,
+-                                     shell=True) as proc:
+-                    ENABLE_DEVICE_CAPS = proc.wait()==0
+-            except OSError:
+-                with open(videodev2_h) as f:
+-                    hdata = f.read()
+-                ENABLE_DEVICE_CAPS = int(hdata.find("device_caps")>=0)
+-                print("failed to detect device caps, assuming off")
 +        ENABLE_DEVICE_CAPS = 1
          with open(constants_pxi, "wb") as f:
              f.write(b"DEF ENABLE_DEVICE_CAPS=%i" % ENABLE_DEVICE_CAPS)
-     cython_add(Extension("xpra.codecs.v4l2.pusher",
-     
+     add_cython_ext("xpra.codecs.v4l2.pusher",
 diff --git a/xpra/x11/fakeXinerama.py b/xpra/x11/fakeXinerama.py
-index c867258..617af7c 100755
+index d5c1c8bb10..88c77e8142 100755
 --- a/xpra/x11/fakeXinerama.py
 +++ b/xpra/x11/fakeXinerama.py
 @@ -22,31 +22,7 @@ fakeXinerama_config_files = [
@@ -48,8 +53,8 @@ index c867258..617af7c 100755
 -            log("find_libfakeXinerama()", exc_info=True)
 -            log.error("Error: cannot launch ldconfig -p to locate libfakeXinerama:")
 -            log.error(" %s", e)
--    return find_lib(libname)
-+    return "@libfakeXinerama@/lib/libfakeXinerama.so.1.0"
+-    return find_lib("libfakeXinerama.so.1")
++    return "@libfakeXinerama@/lib/libfakeXinerama.so.1"
  
  current_xinerama_config = None
  


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
