### PR TITLE
Groestlcoin: init at 22.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4571,6 +4571,12 @@
     githubId = 343415;
     name = "Greg Roodt";
   };
+  gruve-p = {
+    email = "groestlcoin@gmail.com";
+    github = "gruve-p";
+    githubId = 11212268;
+    name = "gruve-p";
+  };
   gschwartz = {
     email = "gsch@pennmedicine.upenn.edu";
     github = "GregorySchwartz";

--- a/pkgs/applications/blockchains/groestlcoin/default.nix
+++ b/pkgs/applications/blockchains/groestlcoin/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, util-linux
+, hexdump
+, autoSignDarwinBinariesHook
+, wrapQtAppsHook ? null
+, boost
+, libevent
+, miniupnpc_2
+, zeromq
+, zlib
+, db53
+, sqlite
+, qrencode
+, qtbase ? null
+, qttools ? null
+, python3
+, withGui ? false
+, withWallet ? true
+}:
+
+let
+  version = "22.0";
+  desktop = fetchurl {
+    url = "https://raw.githubusercontent.com/Groestlcoin/packaging/${version}/debian/groestlcoin-qt.desktop";
+    sha256 = "0mxwq4jvcip44a796iwz7n1ljkhl3a4p47z7qlsxcfxw3zmm0k0k";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = if withGui then "groestlcoin" else "groestlcoind";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Groestlcoin";
+    repo = "groestlcoin";
+    rev = "v${version}";
+    sha256 = "104zzcigpk976iqyinjn6mw3l36zb1if7249iz44ds1zaxv3g1v1";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ]
+    ++ lib.optionals stdenv.isLinux [ util-linux ]
+    ++ lib.optionals stdenv.isDarwin [ hexdump ]
+    ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ autoSignDarwinBinariesHook ]
+    ++ lib.optionals withGui [ wrapQtAppsHook ];
+
+  buildInputs = [ boost libevent miniupnpc_2 zeromq zlib ]
+    ++ lib.optionals withWallet [ db53 sqlite ]
+    ++ lib.optionals withGui [ qrencode qtbase qttools ];
+
+  postInstall = lib.optionalString withGui ''
+    install -Dm644 ${desktop} $out/share/applications/groestlcoin-qt.desktop
+    substituteInPlace $out/share/applications/groestlcoin-qt.desktop --replace "Icon=groestlcoin128" "Icon=groestlcoin"
+    install -Dm644 share/pixmaps/groestlcoin256.png $out/share/pixmaps/groestlcoin.png
+  '';
+
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--disable-bench"
+  ] ++ lib.optionals (!withWallet) [
+    "--disable-wallet"
+  ] ++ lib.optionals withGui [
+    "--with-gui=qt5"
+    "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+  ];
+
+  checkInputs = [ python3 ];
+
+  checkFlags = [ "LC_ALL=en_US.UTF-8" ]
+    # QT_PLUGIN_PATH needs to be set when executing QT, which is needed when testing Groestlcoin's GUI.
+    # See also https://github.com/NixOS/nixpkgs/issues/24256
+    ++ lib.optional withGui "QT_PLUGIN_PATH=${qtbase}/${qtbase.qtPluginPrefix}";
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "Peer-to-peer electronic cash system";
+    longDescription = ''
+      Groestlcoin is a free open source peer-to-peer electronic cash system that is
+      completely decentralized, without the need for a central server or trusted
+      parties. Users hold the crypto keys to their own money and transact directly
+      with each other, with the help of a P2P network to check for double-spending.
+    '';
+    homepage = "https://groestlcoin.org/";
+    downloadPage = "https://github.com/Groestlcoin/groestlcoin/releases/tag/v{version}/";
+    maintainers = with maintainers; [ gruve-p ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30174,6 +30174,17 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit;
   };
 
+  groestlcoin  = libsForQt5.callPackage ../applications/blockchains/groestlcoin {
+    boost = boost17x;
+    withGui = true;
+    inherit (darwin) autoSignDarwinBinariesHook;
+  };
+
+  groestlcoind = callPackage ../applications/blockchains/groestlcoin {
+    boost = boost17x;
+    inherit (darwin) autoSignDarwinBinariesHook;
+  };
+
   ledger_agent = with python3Packages; toPythonApplication ledger_agent;
 
   ledger-live-desktop = callPackage ../applications/blockchains/ledger-live-desktop { };


### PR DESCRIPTION
###### Motivation for this change
Groestlcoin: init at 22.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
