### PR TITLE
flask-{wtf,admin} fixes

### DIFF
--- a/pkgs/development/python-modules/flask-admin/default.nix
+++ b/pkgs/development/python-modules/flask-admin/default.nix
@@ -26,13 +26,13 @@
 
 buildPythonPackage rec {
   pname = "flask-admin";
-  version = "1.5.8";
+  version = "1.6.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "Flask-Admin";
     inherit version;
-    sha256 = "sha256-6wah8xuYiB3uU6VcZPrr0ZkNaqw4gmNksoDfCyZ5/3Q=";
+    sha256 = "1209qhm51d4z66mbw55cmkzqvr465shnws2m2l2zzpxhnxwzqks2";
   };
 
   propagatedBuildInputs = [
@@ -69,6 +69,7 @@ buildPythonPackage rec {
     "flask_admin/tests/pymongo/test_basic.py"
     "flask_admin/tests/sqla/test_basic.py"
     "flask_admin/tests/sqla/test_form_rules.py"
+    "flask_admin/tests/sqla/test_inlineform.py"
     "flask_admin/tests/sqla/test_postgres.py"
     "flask_admin/tests/sqla/test_translation.py"
   ];

--- a/pkgs/development/python-modules/flask-appbuilder/default.nix
+++ b/pkgs/development/python-modules/flask-appbuilder/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , apispec
 , colorama
 , click
@@ -36,7 +37,20 @@ buildPythonPackage rec {
   # See here: https://github.com/dpgaspar/Flask-AppBuilder/commit/7097a7b133f27c78d2b54d2a46e4a4c24478a066.patch
   #           https://github.com/dpgaspar/Flask-AppBuilder/pull/1610
   # The patch from the PR doesn't apply cleanly so I edited it manually.
-  patches = [ ./upgrade-to-flask_jwt_extended-4.patch ];
+  patches = [
+    ./upgrade-to-flask_jwt_extended-4.patch
+    (fetchpatch {
+      # https://github.com/dpgaspar/Flask-AppBuilder/pull/1734
+      name = "flask-appbuilder-wtf3.patch";
+      url = "https://github.com/dpgaspar/Flask-AppBuilder/commit/bccb3d719cd3ceb872fe74a9ab304d74664fbf43.patch";
+      sha256 = "1rsci0ynb7y6k53j164faggjr2g6l5v78w7953qbxcy8f55sb2fv";
+      excludes = [
+        "requirements.txt"
+        "setup.py"
+        "examples/employees/app/views.py"
+      ];
+    })
+  ];
 
   propagatedBuildInputs = [
     apispec
@@ -68,6 +82,7 @@ buildPythonPackage rec {
       --replace "Flask-Login>=0.3, <0.5" "Flask-Login >=0.3, <0.6" \
       --replace "Flask-Babel>=1, <2" "Flask-Babel >=1, <3" \
       --replace "Flask-WTF>=0.14.2, <0.15.0" "Flask-WTF" \
+      --replace "WTForms<3.0.0" "WTForms" \
       --replace "marshmallow-sqlalchemy>=0.22.0, <0.24.0" "marshmallow-sqlalchemy" \
       --replace "Flask-JWT-Extended>=3.18, <4" "Flask-JWT-Extended>=4.1.0" \
       --replace "PyJWT>=1.7.1, <2.0.0" "PyJWT>=2.0.1" \

--- a/pkgs/development/python-modules/wtf-peewee/default.nix
+++ b/pkgs/development/python-modules/wtf-peewee/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , peewee
 , wtforms
 , python
@@ -14,6 +15,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "faa953fe3f705d4f2b48f3c1a81c5c5a6a38f9ed1378c9a830e6efc1b0fccb15";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-wtforms3.patch";
+      url = "https://github.com/coleifer/wtf-peewee/commit/b1764f4474c73a9a2b34ae6b7db61274f5252a7f.patch";
+      sha256 = "0maz3fm9bi8p80nk9sdb34xq55xq8ihm51y7k0m8ck9aaypvwbig";
+    })
+  ];
 
   propagatedBuildInputs = [
     peewee


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/155221#issuecomment-1013973738 broke a number of packages, most of which haven't been updated or released with support for wtforms 3.0 yet. This selectively overrides the dependency for the affected packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @gador @SuperSandro2000 