### PR TITLE
buku: make bukuserver optional

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3, fetchFromGitHub }:
+{ lib, python3, fetchFromGitHub, withServer ? false }:
 
 let
   python3' = python3.override {
@@ -19,6 +19,21 @@ let
       });
     };
   };
+  serverRequire = with python3'.pkgs; [
+    requests
+    flask
+    flask-admin
+    flask-api
+    flask-bootstrap
+    flask-paginate
+    flask-reverse-proxy-fix
+    flask_wtf
+    arrow
+    werkzeug
+    click
+    vcrpy
+    toml
+  ];
 in
 with python3'.pkgs; buildPythonApplication rec {
   version = "4.6";
@@ -40,27 +55,16 @@ with python3'.pkgs; buildPythonApplication rec {
     flake8
     pyyaml
     mypy-extensions
+    click
   ];
 
   propagatedBuildInputs = [
     cryptography
     beautifulsoup4
-    requests
+    certifi
     urllib3
-    flask
-    flask-admin
-    flask-api
-    flask-bootstrap
-    flask-paginate
-    flask-reverse-proxy-fix
-    flask_wtf
-    arrow
-    werkzeug
-    click
     html5lib
-    vcrpy
-    toml
-  ];
+  ] ++ lib.optionals withServer serverRequire;
 
   postPatch = ''
     # Jailbreak problematic dependencies
@@ -80,6 +84,8 @@ with python3'.pkgs; buildPythonApplication rec {
       --replace "self.assertEqual(url, \"https://www.google.com\")" ""
     substituteInPlace setup.py \
       --replace mypy-extensions==0.4.1 mypy-extensions>=0.4.1
+  '' + lib.optionalString (!withServer) ''
+    rm tests/test_{server,views}.py
   '';
 
   postInstall = ''
@@ -89,6 +95,8 @@ with python3'.pkgs; buildPythonApplication rec {
     cp auto-completion/zsh/* $out/share/zsh/site-functions
     cp auto-completion/bash/* $out/share/bash-completion/completions
     cp auto-completion/fish/* $out/share/fish/vendor_completions.d
+  '' + lib.optionalString (!withServer) ''
+    rm $out/bin/bukuserver
   '';
 
   meta = with lib; {
@@ -99,4 +107,3 @@ with python3'.pkgs; buildPythonApplication rec {
     maintainers = with maintainers; [ matthiasbeyer infinisil ma27 ];
   };
 }
-

--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -47,12 +47,9 @@ with python3'.pkgs; buildPythonApplication rec {
   };
 
   checkInputs = [
-    pytest-cov
     hypothesis
     pytest
     pytest-vcr
-    pylint
-    flake8
     pyyaml
     mypy-extensions
     click
@@ -70,6 +67,9 @@ with python3'.pkgs; buildPythonApplication rec {
     # Jailbreak problematic dependencies
     sed -i \
       -e "s,'PyYAML.*','PyYAML',g" \
+      -e "/'pytest-cov/d" \
+      -e "/'pylint/d" \
+      -e "/'flake8/d" \
       setup.py
   '';
 


### PR DESCRIPTION
###### Motivation for this change

bukuserver (an optional web GUI frontend for buku) depends on a large number of flask packages, which break in nixpkgs very often - I've been forced to remove buku from my system closure at least a couple times a year at this point, even though I have no use for this web interface. It currently does not build, which means buku cannot be used at all.

Once #156188 (or something similar that fixes flask-admin) is landed, it will at least build and can be turned back on by default - though with buku being primarily a command-line tool (plus optional browser extensions that can serve as an interface too), it seems unlikely that a majority of users even use this interface to begin with? We could also maybe consider adding `pkgs.bukuserver` rather than building them both together.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @dermetfan, [do you still use this](https://github.com/NixOS/nixpkgs/pull/74781)? 