### PR TITLE
[staging-next] Fix meson builds

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -515,6 +515,8 @@
   };
   algorith = {
     email = "dries_van_daele@telenet.be";
+    github = "DriesVanDaele";
+    githubId = 1141488;
     name = "Dries Van Daele";
   };
   alibabzo = {

--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     description = "A minimalist command line interface to MPD";
     homepage = "https://www.musicpd.org/clients/mpc/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ algorith ];
+    maintainers = with maintainers; [ algorith ncfavier ];
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/audio/mpc/default.nix
+++ b/pkgs/applications/audio/mpc/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -19,6 +20,14 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-2FjYBfak0IjibuU+CNQ0y9Ei8hTZhynS/BK2DNerhVw=";
   };
+
+  patches = [
+    # fix the build with meson 0.60 (https://github.com/MusicPlayerDaemon/mpc/pull/76)
+    (fetchpatch {
+      url = "https://github.com/MusicPlayerDaemon/mpc/commit/b656ca4b6c2a0d5b6cebd7f7daa679352f664e0e.patch";
+      sha256 = "sha256-fjjSlCKxgkz7Em08CaK7+JAzl8YTzLcpGGMz2HJlsVw=";
+    })
+  ];
 
   buildInputs = [ libmpdclient ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -40,8 +40,6 @@ stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
-  mesonFlags = [ "-Dlibreoffice=false" ];
-
   postPatch = ''
     chmod +x data/meson_post_install.py
     patchShebangs data/meson_post_install.py

--- a/pkgs/applications/audio/zrythm/default.nix
+++ b/pkgs/applications/audio/zrythm/default.nix
@@ -13,7 +13,6 @@
 , curl
 , dconf
 , libepoxy
-, ffmpeg
 , fftw
 , fftwFloat
 , flex
@@ -95,7 +94,6 @@ stdenv.mkDerivation rec {
     curl
     dconf
     libepoxy
-    ffmpeg
     fftw
     fftwFloat
     flex
@@ -133,10 +131,9 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Denable_ffmpeg=true"
-    "-Denable_rtmidi=true"
-    "-Denable_rtaudio=true"
-    "-Denable_sdl=true"
+    "-Drtmidi=enabled"
+    "-Drtaudio=enabled"
+    "-Dsdl=enabled"
     "-Dcarla=enabled"
     "-Dmanpage=true"
     # "-Duser_manual=true" # needs sphinx-intl

--- a/pkgs/applications/misc/iptsd/default.nix
+++ b/pkgs/applications/misc/iptsd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       --replace "install_dir: rulesdir" "install_dir: datadir" \
   '';
   mesonFlags = [
-    "-Dsystemd=true"
+    "-Dservice_manager=systemd"
     "-Dsample_config=false"
     "-Ddebug_tool=false"
   ];

--- a/pkgs/applications/networking/irc/hexchat/default.nix
+++ b/pkgs/applications/networking/irc/hexchat/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  mesonFlags = [ "-Dwith-lua=lua" "-Dwith-text=true" ];
+  mesonFlags = [ "-Dwith-lua=lua" "-Dtext-frontend=true" ];
 
   postInstall = ''
     wrapProgram $out/bin/hexchat --prefix PYTHONPATH : "$PYTHONPATH"

--- a/pkgs/applications/office/gtg/default.nix
+++ b/pkgs/applications/office/gtg/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , meson
 , python3Packages
 , ninja
@@ -25,6 +26,13 @@ python3Packages.buildPythonApplication rec {
     sha256 = "0b2slm7kjq6q8c7v4m7aqc8m1ynjxn3bl7445srpv1xc0dilq403";
   };
 
+  patches = [
+    # fix build with meson 0.60 (https://github.com/getting-things-gnome/gtg/pull/729)
+    (fetchpatch {
+      url = "https://github.com/getting-things-gnome/gtg/commit/1809d10663ae3d8f69c04138b66f9b4e66ee14f6.patch";
+      sha256 = "sha256-bYr5PAsuvcSqTf0vaJj2APtuBrwHdhXJxtXoAb7CfGk=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/desktops/arcan/xarcan/default.nix
+++ b/pkgs/desktops/arcan/xarcan/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , arcan
 , audit
 , dbus
@@ -45,6 +46,14 @@ stdenv.mkDerivation rec {
     rev = "98d28a5f2c6860bb191fbc1c9e577c18e4c9a9b7";
     hash = "sha256-UTIVDKnYD/q0K6G7NJUKh1tHcqnsuiJ/cQxWuPMJ2G4=";
   };
+
+  patches = [
+    # fix build with meson 0.60
+    (fetchpatch {
+      url = "https://github.com/letoram/xarcan/commit/b67e514dbb59bffc23b75d47ca7f24e96c4aeb05.patch";
+      sha256 = "sha256-tSQmNy1Id6nDIN+03dc1+rEEF8fMq0yJBiscNM60xic=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/development/libraries/libfprint-tod/default.nix
+++ b/pkgs/development/libraries/libfprint-tod/default.nix
@@ -19,7 +19,9 @@ in  {
     sha256 = "0cj7iy5799pchyzqqncpkhibkq012g3bdpn18pfb19nm43svhn4j";
   };
 
-  mesonFlags = mesonFlags ++ [
+  mesonFlags = [
+    # Include virtual drivers for fprintd tests
+    "-Ddrivers=all"
     "-Dudev_hwdb_dir=${placeholder "out"}/lib/udev/hwdb.d"
   ];
 

--- a/pkgs/development/libraries/libhttpseverywhere/default.nix
+++ b/pkgs/development/libraries/libhttpseverywhere/default.nix
@@ -15,11 +15,16 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ vala gobject-introspection meson ninja pkg-config ];
   buildInputs = [ glib libgee json-glib libsoup libarchive ];
 
-  # Fixes build with vala >=0.42
   patches = [
+    # Fixes build with vala >=0.42
     (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/libhttpseverywhere/commit/6da08ef1ade9ea267cecf14dd5cb2c3e6e5e50cb.patch";
       sha256 = "1nwjlh8iqgjayccwdh0fbpq2g1h8bg1k1g9i324f2bhhvyhmpq8f";
+    })
+    # fix build with meson 0.60
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/libhttpseverywhere/-/commit/4c38b2ca25802c464f3204a62815201d8cf549fd.patch";
+      sha256 = "sha256-1+fmR0bpvJ9ISN2Hr+BTIQz+Bf6VfY1RdVZ/OohUlWU=";
     })
   ];
 

--- a/pkgs/development/libraries/retro-gtk/default.nix
+++ b/pkgs/development/libraries/retro-gtk/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , cmake
 , meson
 , ninja
@@ -27,6 +28,11 @@ stdenv.mkDerivation rec {
   patches = [
     # https://gitlab.gnome.org/GNOME/retro-gtk/-/merge_requests/150
     ./gio-unix.patch
+    # fix build with meson 0.60 (https://gitlab.gnome.org/GNOME/retro-gtk/-/merge_requests/167)
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/retro-gtk/-/commit/8016c10e7216394bc66281f2d9be740140b6fad6.patch";
+      sha256 = "sha256-HcQnqadK5sJM5mMqi4KERkJM3H+MUl8AJAorpFDsJ68=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/misc/intel-gpu-tools/default.nix
+++ b/pkgs/development/tools/misc/intel-gpu-tools/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , pkg-config
 , libdrm
 , libpciaccess
@@ -44,6 +45,14 @@ stdenv.mkDerivation rec {
     url = "https://xorg.freedesktop.org/archive/individual/app/igt-gpu-tools-${version}.tar.xz";
     sha256 = "1dwvxh1yplsh1a7h3gpp40g91v12cfxy6yy99s1v9yr2kwxikm1n";
   };
+
+  patches = [
+    # fix build with meson 0.60
+    (fetchpatch {
+      url = "https://github.com/freedesktop/xorg-intel-gpu-tools/commit/963917a3565466832a3b2fc22e9285d34a0bf944.patch";
+      sha256 = "sha256-goO2N7aK2dJYMhFGS1DlvjEYMSijN6stV6Q5z/RP8Ko=";
+    })
+  ];
 
   nativeBuildInputs = [ pkg-config utilmacros meson ninja flex bison gtk-doc docutils docbook_xsl ];
   buildInputs = [

--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation rec {
     echo -n > server/meson.build
   '';
 
-  mesonFlags = [ "-Doverride_server_path=${prebuilt_server}" ];
   postInstall = ''
     mkdir -p "$out/share/scrcpy"
     ln -s "${prebuilt_server}" "$out/share/scrcpy/scrcpy-server"

--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -105,11 +105,7 @@ in multiStdenv.mkDerivation rec {
     "-Dwith-bitbridge=true"
 
     # Requires CMake and is unnecessary
-    "-Dtomlplusplus:GENERATE_CMAKE_CONFIG=disabled"
-
-    # tomlplusplus examples and tests don't build with winegcc
-    "-Dtomlplusplus:BUILD_EXAMPLES=disabled"
-    "-Dtomlplusplus:BUILD_TESTS=disabled"
+    "-Dtomlplusplus:generate_cmake_config=false"
   ];
 
   installPhase = ''


### PR DESCRIPTION
The update to meson 0.60 made some warnings become errors. This fixes all the meson build errors I could find in https://hydra.nixos.org/eval/1739607?filter=x86_64-linux&compare=1739453&full=#tabs-now-fail (except `urbit` which is nontrivial and needs an update anyway).