### PR TITLE
python3Packages.pydrive2: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/pydrive2/default.nix
+++ b/pkgs/development/python-modules/pydrive2/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, google-api-python-client
+, oauth2client
+, pyopenssl
+, pyyaml
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pydrive2";
+  version = "1.10.0";
+
+  src = fetchPypi {
+    pname = "PyDrive2";
+    inherit version;
+    sha256 = "sha256-970ZtP8e9sC5IvtqxVwNlHJKtTc4euSh3nl3hNd0Y6s=";
+  };
+
+  propagatedBuildInputs = [
+    google-api-python-client
+    oauth2client
+    pyopenssl
+    pyyaml
+    six
+  ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "pydrive2" ];
+
+  meta = {
+    description = "Google Drive API Python wrapper library. Maintained fork of PyDrive.";
+    homepage = "https://github.com/iterative/PyDrive2";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6671,6 +6671,8 @@ in {
 
   pydrive = callPackage ../development/python-modules/pydrive { };
 
+  pydrive2 = callPackage ../development/python-modules/pydrive2 { };
+
   pydroid-ipcam = callPackage ../development/python-modules/pydroid-ipcam  { };
 
   pydsdl = callPackage ../development/python-modules/pydsdl { };


### PR DESCRIPTION
###### Motivation for this change

Add [PyDrive2](https://github.com/iterative/PyDrive2), a fork of PyDrive, which is actively maintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
