### PR TITLE
snarkos: init at 2021-01-21

### DIFF
--- a/pkgs/applications/blockchains/snarkos/default.nix
+++ b/pkgs/applications/blockchains/snarkos/default.nix
@@ -1,0 +1,61 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, rustPlatform
+, Security
+, curl
+, pkg-config
+, openssl
+, llvmPackages
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "snarkos";
+  version = "unstable-2021-01-21";
+
+  src = fetchFromGitHub {
+    owner = "AleoHQ";
+    repo = "snarkOS";
+    rev = "7068dc0394139c887f5187288ca2af54bc729614";
+    sha256 = "sha256-fgdIJX/Ep3amPAjo00BtNGSXhaItw41S1XliDXk6b7k=";
+  };
+
+  cargoSha256 = "sha256-bax7cnqVY49rdcWs73+KqW+dzPebKLlsbPvOM1d25zA=";
+
+  # buildAndTestSubdir = "cli";
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config llvmPackages.clang ];
+
+  # Needed to get openssl-sys to use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
+  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_DIR="${lib.getDev openssl}";
+
+  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+
+  # TODO check why rust compilation fails by including the rocksdb from nixpkgs
+  # Used by build.rs in the rocksdb-sys crate. If we don't set these, it would
+  # try to build RocksDB from source.
+  # ROCKSDB_INCLUDE_DIR="${rocksdb}/include";
+  # ROCKSDB_LIB_DIR="${rocksdb}/lib";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security curl ];
+
+  # some tests are flaky and some need network access
+  # TODO finish filtering the tests to enable them
+  doCheck = !stdenv.isLinux;
+  # checkFlags = [
+  #   # tries to make a network access
+  #   "--skip=rpc::rpc::tests::test_send_transaction_large"
+  #   # flaky test
+  #   "--skip=helpers::block_requests::tests::test_block_requests_case_2ca"
+  # ];
+
+
+  meta = with lib; {
+    description = "A Decentralized Operating System for Zero-Knowledge Applications";
+    homepage = "https://snarkos.org";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30180,6 +30180,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) IOKit Security AppKit;
   };
 
+  snarkos = callPackage ../applications/blockchains/snarkos {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   tessera = callPackage ../applications/blockchains/tessera { };
 
   vertcoin  = libsForQt514.callPackage ../applications/blockchains/vertcoin {


### PR DESCRIPTION
###### Motivation for this change

There was an issue with snarkos on a previous version (not compiling with cargo vendor) that was just fixed in one of the latest commits, that is why it's on unstable

Tested on both linux and darwin. Waiting the weekend to see if anyone is interested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
