### PR TITLE
nixos/tests/install: Fix after sandboxed-docs change fc614c3

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -306,6 +306,9 @@ let
           # The test cannot access the network, so any packages we
           # need must be included in the VM.
           system.extraDependencies = with pkgs; [
+            brotli
+            brotli.dev
+            brotli.lib
             desktop-file-utils
             docbook5
             docbook_xsl_ns
@@ -315,6 +318,7 @@ let
             ntp
             perlPackages.ListCompare
             perlPackages.XMLLibXML
+            python3Minimal
             shared-mime-info
             sudo
             texinfo


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix the install tests after fc614c37c653637e5475a0b0a987489b4d1f351d broke them, as noted in https://github.com/NixOS/nixpkgs/pull/149532#issuecomment-1005777871

Before this change:
```
$ nix-build nixos/tests/installer.nix -A simple
...
machine: must succeed: nixos-install < /dev/null >&2
...
machine # these 418 derivations will be built:
...
machine # these 359 paths will be fetched (0.00 MiB download, 1272.37 MiB unpacked):
...
machine # building '/nix/store/f450ks5xaq790h43nc5r78x69cr4721q-Make-build-reproducible.patch.drv'...
machine # building '/nix/store/c99ihlhb2lh875spzsl6rnc4058grxvn-autoconf-2.71.tar.xz.drv'...
machine # building '/nix/store/3yar2pnvz7ll79z3jlzx09qnhrsi7zj5-automake-1.16.5.tar.xz.drv'...
machine # warning: error: unable to download 'https://salsa.debian.org/debian/keyutils/raw/4cecffcb8e2a2aa4ef41777ed40e4e4bcfb2e5bf/debian/patches/Make-build-reproducible.patch': Couldn't resolve host name (6); retrying in 303 ms
...
machine # error: unable to download 'https://salsa.debian.org/debian/keyutils/raw/4cecffcb8e2a2aa4ef41777ed40e4e4bcfb2e5bf/debian/patches/Make-build-reproducible.patch': Couldn't resolve host name (6)
machine # warning: error: unable to download 'https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.xz': Couldn't resolve host name (6); retrying in 326 ms
...
machine # error: builder for '/nix/store/f450ks5xaq790h43nc5r78x69cr4721q-Make-build-reproducible.patch.drv' failed with exit code 1
machine # error: builder for '/nix/store/c99ihlhb2lh875spzsl6rnc4058grxvn-autoconf-2.71.tar.xz.drv' failed with exit code 1
machine # error: 1 dependencies of derivation '/nix/store/c2hvzjl7x004hjiwf3c10r15s6c1gjs3-autoconf-2.71.drv' failed to build
...
machine # error: 1 dependencies of derivation '/nix/store/vhghw81lw7y0bzdjwfhr2lmyrhnsrps3-source.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/vzi1i7flcnrhy8vjp7gqk1b1azk0ky1k-brotli-1.0.9.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/710r40n1k5b4867ynrjzlvklzfnyy121-python3-minimal-3.9.9.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/6rqfgpxig1vpxv8kmx9fijj8h7c3nh7a-options-docbook.xml.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/d47qq562h05ljwid7257hgml41qv1bam-generated-docbook.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/rr13dl32wgbhzdzsf9b4a0zfah48qah0-nixos-manual-combined.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/ifajc0l06201crpfsz5lilvqk3hxksfw-nixos-manpages.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/kk2pbd3dys082cylhfagqr904ljh4bz5-nixos-manual-html.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/72il44y04pib9xk1klcrfr6y57ap8as2-system-path.drv' failed to build
machine # error: 1 dependencies of derivation '/nix/store/dvnz5a6rknrim0mw0ys0653pxbw0663m-nixos-system-nixos-22.05pre-git.drv' failed to build
machine: output:
Test "Perform the installation" failed with error: "command `nixos-install < /dev/null >&2` failed (exit code 1)"
cleanup
kill machine (pid 8)
```

After this change:
```
$ nix-build nixos/tests/installer.nix -A simple
...
machine: must succeed: nixos-install < /dev/null >&2
...
machine # these 230 derivations will be built:
...
machine # these 359 paths will be fetched (0.00 MiB download, 1208.81 MiB unpacked):
...
machine # Installation finished. No error reported.
machine # installation finished!
(finished: must succeed: nixos-install < /dev/null >&2, in 4291.33 seconds)
...
(finished: waiting for the VM to power off, in 1.93 seconds)
(finished: run the VM test script, in 4715.12 seconds)
test script finished in 4715.12s
cleanup
(finished: cleanup, in 0.00 seconds)
kill vlan (pid 7)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
