### PR TITLE
Shogun: use Python 3 and fix CMake targets

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -6,7 +6,7 @@
   # build
 , cmake
 , ctags
-, python2Packages
+, python3Packages
 , swig
   # math
 , eigen
@@ -30,13 +30,13 @@
 , lp_solve
 , colpack
   # extra support
-, pythonSupport ? true
+, pythonSupport ? false
 , opencvSupport ? false
 , opencv ? null
 , withSvmLight ? false
 }:
 
-assert pythonSupport -> python2Packages != null;
+assert pythonSupport -> python3Packages != null;
 assert opencvSupport -> opencv != null;
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!withSvmLight) ./svmlight-scrubber.patch;
 
   nativeBuildInputs = [ cmake swig ctags ]
-    ++ (with python2Packages; [ python jinja2 ply ]);
+    ++ (with python3Packages; [ python jinja2 ply ]);
 
   buildInputs = [
     eigen
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
     nlopt
     lp_solve
     colpack
-  ] ++ lib.optionals pythonSupport (with python2Packages; [ python numpy ])
+  ] ++ lib.optionals pythonSupport (with python3Packages; [ python numpy ])
     ++ lib.optional opencvSupport opencv;
 
   cmakeFlags = let
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
     "-DENABLE_TESTING=${enableIf doCheck}"
     "-DDISABLE_META_INTEGRATION_TESTS=ON"
     "-DTRAVIS_DISABLE_META_CPP=ON"
-    "-DPythonModular=${enableIf pythonSupport}"
+    "-DINTERFACE_PYTHON=${enableIf pythonSupport}"
     "-DOpenCV=${enableIf opencvSupport}"
     "-DUSE_SVMLIGHT=${enableIf withSvmLight}"
   ];

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -177,6 +177,12 @@ stdenv.mkDerivation rec {
     rm -r $out/share
   '';
 
+  postFixup = ''
+    # CMake incorrectly calculates library path from dev prefix
+    substituteInPlace $dev/lib/cmake/shogun/ShogunTargets-release.cmake \
+      --replace "\''${_IMPORT_PREFIX}/lib/" "$out/lib/"
+  '';
+
   meta = with lib; {
     description = "A toolbox which offers a wide range of efficient and unified machine learning methods";
     homepage = "http://shogun-toolbox.org/";


### PR DESCRIPTION
###### Motivation for this change

Use Python 3 (#148779) and fix #156098.

###### Things done

- Use Python 3 as build dependency.
  
  The Python interface has been disabled for a while now because the wrong CMake flag was used, but now disable it explicitly because the generation of the Python interface is broken with Python 3.

  This should fix the Darwin build, that it looks it's gone from Hydra (https://hydra.nixos.org/job/nixpkgs/trunk/shogun.x86_64-darwin), and it didn't work for me on macOS with Python 2 neither.

- Fix the path to the shared library in the installed CMake targets file.
 
<!-- -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
