### PR TITLE
Package python3Packages.pygeos

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8564,6 +8564,12 @@
     githubId = 7845120;
     name = "Alex Martens";
   };
+  nialov = {
+    email = "nikolasovaskainen@gmail.com";
+    github = "nialov";
+    githubId = 47318483;
+    name = "Nikolas Ovaskainen";
+  };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikitavoloboev";

--- a/pkgs/development/python-modules/pygeos/default.nix
+++ b/pkgs/development/python-modules/pygeos/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python
+, geos
+, pytestCheckHook
+, cython
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "pygeos";
+  version = "0.12.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-PEFULvZ8ZgFfRDrj5uaDUDqKIh+cJPsjgPauQq7RYAo=";
+  };
+
+  nativeBuildInputs = [
+    geos # for geos-config
+    cython
+  ];
+
+  propagatedBuildInputs = [ numpy ];
+
+  # The cythonized extensions are required to exist in the pygeos/ directory
+  # for the package to function. Therefore override of buildPhase was
+  # necessary.
+  buildPhase = ''
+    ${python.interpreter} setup.py build_ext --inplace
+    ${python.interpreter} setup.py bdist_wheel
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pygeos" ];
+
+  meta = with lib; {
+    description = "Wraps GEOS geometry functions in numpy ufuncs.";
+    homepage = "https://github.com/pygeos/pygeos";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nialov ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6803,6 +6803,8 @@ in {
 
   pygeoip = callPackage ../development/python-modules/pygeoip { };
 
+  pygeos = callPackage ../development/python-modules/pygeos { };
+
   pygetwindow = callPackage ../development/python-modules/pygetwindow { };
 
   pygit2 = callPackage ../development/python-modules/pygit2 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`pygeos` is a Python package that vectorizes spatial operations between geometries such as points and lines. It is a vectorized version of `shapely` i.e. faster and is used by e.g. `geopandas` to speed up operations.

Both `shapely` and `geopandas` are already packaged so `pygeos` is a natural addition. 

However I would note that there is currently an ongoing effort to merge `pygeos` to `shapely` completely: https://github.com/shapely/shapely/issues/962

However such a merge is a long process and having `pygeos` in `nixpkgs` might help people (such as me) to use it in Python projects without waiting for the merge.

Tested on x86_64-linux. If checking the `shapely` recipe on `nixpkgs` is an indicator (https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/shapely/default.nix) darwin might require some additional config.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
