### PR TITLE
nixos/mediatomb: wait for network-online.target + fix test

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -362,7 +362,9 @@ in {
     in mkIf cfg.enable {
     systemd.services.mediatomb = {
       description = "${cfg.serverName} media Server";
-      after = [ "network.target" ];
+      # Gerbera might fail if the network interface is not available on startup
+      # https://github.com/gerbera/gerbera/issues/1324
+      after = [ "network.target" "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig.ExecStart = "${binaryCommand} --port ${toString cfg.port} ${interfaceFlag} ${configFlag} --home ${cfg.dataDir}";
       serviceConfig.User = cfg.user;

--- a/nixos/tests/mediatomb.nix
+++ b/nixos/tests/mediatomb.nix
@@ -1,81 +1,44 @@
-import ./make-test-python.nix ({ pkgs, ... }:
-
-{
+import ./make-test-python.nix {
   name = "mediatomb";
 
   nodes = {
-    serverGerbera =
-      { ... }:
-      let port = 49152;
-      in {
-        imports = [ ../modules/profiles/minimal.nix ];
-        services.mediatomb = {
-          enable = true;
-          serverName = "Gerbera";
-          package = pkgs.gerbera;
-          interface = "eth1";  # accessible from test
-          openFirewall = true;
-          mediaDirectories = [
-            { path = "/var/lib/gerbera/pictures"; recursive = false; hidden-files = false; }
-            { path = "/var/lib/gerbera/audio"; recursive = true; hidden-files = false; }
-          ];
-        };
+    server = {
+      services.mediatomb = {
+        enable = true;
+        serverName = "Gerbera";
+        interface = "eth1";
+        openFirewall = true;
+        mediaDirectories = [
+          {
+            path = "/var/lib/gerbera/pictures";
+            recursive = false;
+            hidden-files = false;
+          }
+          {
+            path = "/var/lib/gerbera/audio";
+            recursive = true;
+            hidden-files = false;
+          }
+        ];
       };
+      systemd.tmpfiles.rules = [
+        "d /var/lib/gerbera/pictures 0770 mediatomb mediatomb"
+        "d /var/lib/gerbera/audio 0770 mediatomb mediatomb"
+      ];
+    };
 
-    serverMediatomb =
-      { ... }:
-      let port = 49151;
-      in {
-        imports = [ ../modules/profiles/minimal.nix ];
-        services.mediatomb = {
-          enable = true;
-          serverName = "Mediatomb";
-          package = pkgs.mediatomb;
-          interface = "eth1";
-          inherit port;
-          mediaDirectories = [
-            { path = "/var/lib/mediatomb/pictures"; recursive = false; hidden-files = false; }
-            { path = "/var/lib/mediatomb/audio"; recursive = true; hidden-files = false; }
-          ];
-        };
-        networking.firewall.interfaces.eth1 = {
-          allowedUDPPorts = [ 1900 port ];
-          allowedTCPPorts = [ port ];
-        };
-      };
-
-      client = { ... }: { };
+    client = {};
   };
 
-  testScript =
-  ''
+  testScript = ''
     start_all()
 
-    port = 49151
-    serverMediatomb.succeed("mkdir -p /var/lib/mediatomb/{pictures,audio}")
-    serverMediatomb.succeed("chown -R mediatomb:mediatomb /var/lib/mediatomb")
-    serverMediatomb.wait_for_unit("mediatomb")
-    serverMediatomb.wait_for_open_port(port)
-    serverMediatomb.succeed(f"curl --fail http://serverMediatomb:{port}/")
-    page = client.succeed(f"curl --fail http://serverMediatomb:{port}/")
-    assert "MediaTomb" in page and "Gerbera" not in page
-    serverMediatomb.shutdown()
+    server.wait_for_unit("mediatomb")
+    server.wait_until_succeeds("nc -z 192.168.1.2 49152")
+    server.succeed("curl -v --fail http://server:49152/")
 
-    port = 49152
-    serverGerbera.succeed("mkdir -p /var/lib/mediatomb/{pictures,audio}")
-    serverGerbera.succeed("chown -R mediatomb:mediatomb /var/lib/mediatomb")
-    # service running gerbera fails the first time claiming something is already bound
-    # gerbera[715]: 2020-07-18 23:52:14   info: Please check if another instance of Gerbera or
-    # gerbera[715]: 2020-07-18 23:52:14   info: another application is running on port TCP 49152 or UDP 1900.
-    # I did not find anything so here I work around this
-    serverGerbera.succeed("sleep 2")
-    serverGerbera.wait_until_succeeds("systemctl restart mediatomb")
-    serverGerbera.wait_for_unit("mediatomb")
-    serverGerbera.succeed(f"curl --fail http://serverGerbera:{port}/")
-    page = client.succeed(f"curl --fail http://serverGerbera:{port}/")
+    client.wait_for_unit("multi-user.target")
+    page = client.succeed("curl -v --fail http://server:49152/")
     assert "Gerbera" in page and "MediaTomb" not in page
-
-    serverGerbera.shutdown()
-    client.shutdown()
   '';
-})
+}


### PR DESCRIPTION
###### Motivation for this change

Gerbera might fail if the network interface is not available on startup, so wait for `network-online.target`.

This also fixes the test for Mediatomb/Gerbera and splits the two test cases into two separate tests for more clarity.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
