### PR TITLE
mpvacious: remove hack for multi-file script loading

### DIFF
--- a/pkgs/applications/video/mpv/scripts/mpvacious.nix
+++ b/pkgs/applications/video/mpv/scripts/mpvacious.nix
@@ -18,10 +18,7 @@ stdenvNoCC.mkDerivation rec {
   };
 
   postPatch = ''
-    # 'require' replaced with 'dofile' to work around
-    # https://github.com/mpv-player/mpv/issues/7399 until fixed in mpvacious
     substituteInPlace subs2srs.lua \
-      --replace "require('osd_styler')" "dofile('"$out/share/mpv/scripts/mpvacious/osd_styler.lua"')" \
       --replace "'curl'" "'${curl}/bin/curl'" \
       --replace "'wl-copy'" "'${wl-clipboard}/bin/wl-copy'" \
       --replace "xclip" "${xclip}/bin/xclip"
@@ -36,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.scriptName = "mpvacious/subs2srs.lua";
+  passthru.scriptName = "mpvacious";
 
   meta = with lib; {
     description = "Adds mpv keybindings to create Anki cards from movies and TV shows";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/139795 introduced a hack for loading a library script file, but I discovered that the `--script` argument added by the wrapper supports loading a directory. The next release of mpvacious adds more files so it's good to remove this hack first.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
