### PR TITLE
yabridge, yabridgectl: 3.7.0 → 3.8.0

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -34,28 +34,28 @@ let
   tomlplusplus = fetchFromGitHub {
     owner = "marzer";
     repo = "tomlplusplus";
-    rev = "47216c8a73d77e7431ec536fb3e251aed06cc420";
-    sha256 = "sha256-cwAzWu5j3ch/56a6JmEoKCsxVNTk6tiZswNdNT6qzX0=";
+    rev = "8e669aa6990e0ed219c169d491472d749f54c393";
+    sha256 = "sha256-l8ckbCqjz3GUfwStcl3H2C+un5dZfT2uLtayvdu93D4=";
   };
 
   # Derived from vst3.wrap
   vst3 = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = "vst3sdk";
-    rev = "v3.7.3_build_20-patched";
+    rev = "v3.7.4_build_25-patched";
     fetchSubmodules = true;
-    sha256 = "sha256-m2y7No7BNbIjLNgdAqIAEr6UuAZZ/wwM2+iPWKK17gQ=";
+    sha256 = "sha256-oHRJZItw+he5M+beVZkUrhJir6rgFZ80ORzA73mJT2A=";
   };
 in multiStdenv.mkDerivation rec {
   pname = "yabridge";
-  version = "3.7.0";
+  version = "3.8.0";
 
   # NOTE: Also update yabridgectl's cargoHash when this is updated
   src = fetchFromGitHub {
     owner = "robbert-vdh";
     repo = pname;
     rev = version;
-    sha256 = "sha256-dz7kScNrVUsjokJntzUCJzDIboqi3vQI+RpXl0UFmUQ=";
+    sha256 = "sha256-XacJjHxsp60/l36pFPGonUyOsyFF2lmqplAaisHXZDY=";
   };
 
   # Unpack subproject sources

--- a/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
+++ b/pkgs/tools/audio/yabridge/hardcode-dependencies.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 8eae0442..ec0649da 100644
+index 95ecb728..cb30f3af 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -196,6 +196,7 @@ if with_32bit_libraries or with_bitbridge
+@@ -201,6 +201,7 @@ if with_32bit_libraries or with_bitbridge
        'boost_filesystem',
        static : with_static_boost,
        dirs : [
@@ -10,7 +10,7 @@ index 8eae0442..ec0649da 100644
          # Used by Arch based distros
          '/usr/local/lib32',
          '/usr/lib32',
-@@ -219,7 +220,7 @@ if is_64bit_system
+@@ -224,7 +225,7 @@ if is_64bit_system
    xcb_64bit_dep = dependency('xcb')
  endif
  if with_32bit_libraries or with_bitbridge
@@ -20,7 +20,7 @@ index 8eae0442..ec0649da 100644
  
  # These are all headers-only libraries, and thus won't require separate 32-bit
 diff --git a/src/plugin/utils.cpp b/src/plugin/utils.cpp
-index 6e32b4c9..f6eb09eb 100644
+index 1a457f03..20ca1e63 100644
 --- a/src/plugin/utils.cpp
 +++ b/src/plugin/utils.cpp
 @@ -107,7 +107,7 @@ std::string PluginInfo::wine_version() const {

--- a/pkgs/tools/audio/yabridgectl/default.nix
+++ b/pkgs/tools/audio/yabridgectl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   src = yabridge.src;
   sourceRoot = "source/tools/yabridgectl";
-  cargoSha256 = "sha256-/VREh/f4bAt2DXCqK0noEjn+4hcK5VZUn+gdbYbeAmk=";
+  cargoSha256 = "sha256-pwy2Q2HUCihr7W81hGvDm9EiZHk9G8knSy0yxPy6hl8=";
 
   patches = [
     # By default, yabridgectl locates libyabridge.so by using

--- a/pkgs/tools/audio/yabridgectl/libyabridge-from-nix-profiles.patch
+++ b/pkgs/tools/audio/yabridgectl/libyabridge-from-nix-profiles.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/yabridgectl/src/config.rs b/tools/yabridgectl/src/config.rs
-index bc5ccfc4..c6d119bc 100644
+index bc5f6a81..0fcd38d3 100644
 --- a/tools/yabridgectl/src/config.rs
 +++ b/tools/yabridgectl/src/config.rs
 @@ -23,6 +23,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -10,7 +10,7 @@ index bc5ccfc4..c6d119bc 100644
  use std::path::{Path, PathBuf};
  use which::which;
  use xdg::BaseDirectories;
-@@ -233,34 +234,24 @@ impl Config {
+@@ -235,34 +236,27 @@ impl Config {
                  }
              }
              None => {
@@ -20,6 +20,8 @@ index bc5ccfc4..c6d119bc 100644
 -                // in the error message when `libyabridge-vst2.so` can't be found.
 -                let system_path = Path::new("/usr/lib");
 +                // Search through NIX_PROFILES & data home directory if no path was set explicitly.
++                // NIX_PROFILES is iterated in reverse from the most specific (the user profile) to
++                // the least specific (the system profile).
 +                let nix_profiles = env::var("NIX_PROFILES");
                  let user_path = xdg_dirs.get_data_home();
 -                let lib_directories = [
@@ -35,6 +37,7 @@ index bc5ccfc4..c6d119bc 100644
 -                ];
 +                let lib_directories = nix_profiles.iter()
 +                    .flat_map(|profiles| profiles.split(' ')
++                              .rev()
 +                              .map(|profile| Path::new(profile).join("lib")))
 +                    .chain(iter::once(user_path.clone()));
 +
@@ -56,12 +59,12 @@ index bc5ccfc4..c6d119bc 100644
                          ));
                      }
 diff --git a/tools/yabridgectl/src/main.rs b/tools/yabridgectl/src/main.rs
-index 8c273f92..432619ec 100644
+index 48cce4fa..209e40e4 100644
 --- a/tools/yabridgectl/src/main.rs
 +++ b/tools/yabridgectl/src/main.rs
-@@ -148,7 +148,7 @@ fn main() -> Result<()> {
-                         .about("Path to the directory containing 'libyabridge-{vst2,vst3}.so'")
-                         .long_about(
+@@ -151,7 +151,7 @@ fn main() -> Result<()> {
+                         .help("Path to the directory containing 'libyabridge-{vst2,vst3}.so'")
+                         .long_help(
                              "Path to the directory containing 'libyabridge-{vst2,vst3}.so'. If this \
 -                             is not set, then yabridgectl will look in both '/usr/lib' and \
 +                             is not set, then yabridgectl will look through 'NIX_PROFILES' and \


### PR DESCRIPTION
###### Motivation for this change
Update to the latest version: https://github.com/robbert-vdh/yabridge/releases/tag/3.8.0

This also fixes `libyabridge-from-nix-profiles.patch` to iterate `NIX_PROFILES` in reverse. It ensures that the `libyabridge` in your user profile takes priority over the one in your system profile.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Tested 64bit VST2 & VST3 versions of [Upright Piano](https://99sounds.sellfy.store/p/8vh6xs) in REAPER.

  Requires configuring an unlimited memlock limit (See https://github.com/robbert-vdh/yabridge/tree/3.7.0#troubleshooting-common-issues)

  For example:
  ```nix
  {
    users.groups.audio = {};

    security.pam.loginLimits = [
      {
        domain = "@audio";
        type = "-";
        item = "memlock";
        value = "unlimited";
      }
    ];

    users.users.kira = {
      isNormalUser = true;
      description = "Kira Bruneau";
      extraGroups = [ "wheel" "audio" ];
    };
  }
  ```
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).