### PR TITLE
dcap: Init at 2.47.12

### DIFF
--- a/pkgs/tools/networking/dcap/default.nix
+++ b/pkgs/tools/networking/dcap/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, zlib
+, cunit
+}:
+stdenv.mkDerivation rec {
+  pname = "dcap";
+  version = "2.47.12";
+
+  src = fetchFromGitHub {
+    owner = "dCache";
+    repo = "dcap";
+    rev = version;
+    sha256 = "sha256-pNLEN1YLQGMJNuv8n6bec3qONbwNOYbYDDvkwuP5AR4=";
+  };
+
+  nativeBuildInputs = [ autoconf automake libtool ];
+  buildInputs = [ zlib ];
+
+  preConfigure = ''
+    patchShebangs bootstrap.sh
+    ./bootstrap.sh
+  '';
+
+  doCheck = true;
+
+  checkInputs = [ cunit ];
+
+  outputs = [ "bin" "dev" "out" "man" "doc" ];
+
+  meta = with lib; {
+    description = "dCache access protocol client library";
+    homepage = "https://github.com/dCache/dcap";
+    changelog = "https://github.com/dCache/dcap/blob/master/ChangeLog";
+    license = licenses.lgpl2Only;
+    platforms = platforms.all;
+    mainProgram = "dccp";
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1551,6 +1551,8 @@ with pkgs;
 
   cyclonedx-python = callPackage ../tools/misc/cyclonedx-python { };
 
+  dcap = callPackage ../tools/networking/dcap { };
+
   deltachat-cursed = callPackage ../applications/networking/instant-messengers/deltachat-cursed { };
 
   deltachat-desktop = callPackage ../applications/networking/instant-messengers/deltachat-desktop {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[dcap](https://github.com/dCache/dcap) is a client library of [dCache](https://dcache.org), which is used by some high energy physicists as a sort of remote data accessing infrastructure. It also comes with an executable `dccp` as an example program and a command-line utility.

I'm not using dCache or dccp myself, but the library is in the dependency tree of a package I'm working on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) (`dccp --help` works. Feedback from people who make use of it is welcome.)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
