### PR TITLE
mandoc: fix executableCross condition

### DIFF
--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -1,16 +1,6 @@
 { lib, stdenv, fetchurl, zlib, perl, nixosTests }:
 
 let
-  # check if we can execute binaries for the host platform on the build platform
-  # even though the platforms aren't the same. mandoc can't be cross compiled
-  # (easily) because of its configurePhase, but we want to allow “native” cross
-  # such as pkgsLLVM and pkgsStatic.
-  # For a lack of a better predicate at the moment, we compare the platforms'
-  # system tuples. See also:
-  # * https://github.com/NixOS/nixpkgs/pull/140271
-  # * https://github.com/NixOS/nixpkgs/issues/61414
-  executableCross = stdenv.buildPlatform.system == stdenv.hostPlatform.system;
-
   # Name of an UTF-8 locale _always_ present at runtime, used for UTF-8 support
   # (locale set by the user may differ). This would usually be C.UTF-8, but
   # darwin has no such locale.
@@ -19,9 +9,6 @@ let
     then "en_US.UTF-8"
     else "C.UTF-8";
 in
-
-assert executableCross ||
-  throw "mandoc relies on executing compiled programs in configurePhase, can't cross compile";
 
 stdenv.mkDerivation rec {
   pname = "mandoc";
@@ -61,7 +48,7 @@ stdenv.mkDerivation rec {
     printf '%s' "$configureLocal" > configure.local
   '';
 
-  doCheck = executableCross;
+  doCheck = true;
   checkTarget = "regress";
   checkInputs = [ perl ];
   preCheck = "patchShebangs --build regress/regress.pl";
@@ -71,6 +58,19 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
+    # check if we can execute binaries for the host platform on the build platform
+    # even though the platforms aren't the same. mandoc can't be cross compiled
+    # (easily) because of its configurePhase which executes compiled programs
+    # for gathering information about the host system. Consequently, we can only
+    # allow “native” cross such as pkgsLLVM and pkgsStatic.
+    # For a lack of a better predicate at the moment, we compare the platforms'
+    # system tuples. See also:
+    # * https://github.com/NixOS/nixpkgs/pull/140271
+    # * https://github.com/NixOS/nixpkgs/issues/61414
+    # We need to use broken instead of, say a top level assert, to keep splicing
+    # working.
+    broken = stdenv.buildPlatform.system != stdenv.hostPlatform.system;
+
     homepage = "https://mandoc.bsd.lv/";
     description = "suite of tools compiling mdoc and man";
     downloadPage = "http://mandoc.bsd.lv/snapshots/";

--- a/pkgs/tools/misc/mandoc/default.nix
+++ b/pkgs/tools/misc/mandoc/default.nix
@@ -5,7 +5,11 @@ let
   # even though the platforms aren't the same. mandoc can't be cross compiled
   # (easily) because of its configurePhase, but we want to allow “native” cross
   # such as pkgsLLVM and pkgsStatic.
-  executableCross = stdenv.hostPlatform.isCompatible stdenv.buildPlatform;
+  # For a lack of a better predicate at the moment, we compare the platforms'
+  # system tuples. See also:
+  # * https://github.com/NixOS/nixpkgs/pull/140271
+  # * https://github.com/NixOS/nixpkgs/issues/61414
+  executableCross = stdenv.buildPlatform.system == stdenv.hostPlatform.system;
 
   # Name of an UTF-8 locale _always_ present at runtime, used for UTF-8 support
   # (locale set by the user may differ). This would usually be C.UTF-8, but


### PR DESCRIPTION
isCompatible concerns itself with architecture compatibility which does
not constitute executability by itself, since there are other key
factors like the Kernel/syscall interface targeted. As mode switching is
considered compatible (e.g. ppc64le and ppc64), we can't even use
isCompatible to establish the architecture subset of executability.
For the lack of a better alternative, we'll just compare the system
tuples for now which will loose us support for x86_64-linux ->
i686-linux, but this is probably a bearable consequence.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
