### PR TITLE
Add a link to cntr docs in breakpointHook

### DIFF
--- a/pkgs/build-support/setup-hooks/breakpoint-hook.sh
+++ b/pkgs/build-support/setup-hooks/breakpoint-hook.sh
@@ -4,7 +4,7 @@ breakpointHook() {
 
     echo -e "${red}build failed in ${curPhase} with exit code ${exitCode}${no_color}"
     printf "To attach install cntr and run the following command as root:\n\n"
-    echo '   cntr attach -t command cntr-${out}'
+    echo "   cntr attach -t command cntr-${out}"
     echo 'See more info on cntr at https://github.com/Mic92/cntr#usage'
     sh -c "while true; do sleep 99999999; done"
 }

--- a/pkgs/build-support/setup-hooks/breakpoint-hook.sh
+++ b/pkgs/build-support/setup-hooks/breakpoint-hook.sh
@@ -4,6 +4,8 @@ breakpointHook() {
 
     echo -e "${red}build failed in ${curPhase} with exit code ${exitCode}${no_color}"
     printf "To attach install cntr and run the following command as root:\n\n"
-    sh -c "echo '   cntr attach -t command cntr-${out}'; while true; do sleep 99999999; done"
+    echo '   cntr attach -t command cntr-${out}'
+    echo 'See more info on cntr at https://github.com/Mic92/cntr#usage'
+    sh -c "while true; do sleep 99999999; done"
 }
 failureHooks+=(breakpointHook)


### PR DESCRIPTION
For explanation of `cntr attach` vs `cntr exec` and the `/var/lib/cntr` prefix and host vs container filesystems

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
