### PR TITLE
remake: 4.3+dbg-1.5 -> 4.3+dbg-1.6

### DIFF
--- a/pkgs/development/tools/build-managers/remake/default.nix
+++ b/pkgs/development/tools/build-managers/remake/default.nix
@@ -10,12 +10,12 @@
 stdenv.mkDerivation rec {
   pname = "remake";
   remakeVersion = "4.3";
-  dbgVersion = "1.5";
+  dbgVersion = "1.6";
   version = "${remakeVersion}+dbg-${dbgVersion}";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/bashdb/remake/${version}/remake-${remakeVersion}+dbg-${dbgVersion}.tar.gz";
-    sha256 = "0xlx2485y0israv2pfghmv74lxcv9i5y65agy69mif76yc4vfvif";
+    sha256 = "11vvch8bi0yhjfz7gn92b3xmmm0cgi3qfiyhbnnj89frkhbwd87n";
   };
 
   patches = [


### PR DESCRIPTION
Among other things this upstream fixes build on fno-common toolchains.