### PR TITLE
[staging] spice: properly test for existance of python modules

### DIFF
--- a/pkgs/development/libraries/spice/default.nix
+++ b/pkgs/development/libraries/spice/default.nix
@@ -46,6 +46,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     install ${doxygen_sh} doxygen.sh
     patchShebangs build-aux
+
+    # https://gitlab.freedesktop.org/spice/spice-common/-/issues/5
+    substituteInPlace subprojects/spice-common/meson.build \
+      --replace \
+      "cmd = run_command(python, '-m', module)" \
+      "cmd = run_command(python, '-c', 'import @0@'.format(module))"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
spice-common| Program python3 found: YES (/nix/store/hxgsg4nn1w47lrbzb20l0b2kzhgi6fmy-python3-3.9.10/bin/python3.9)
spice-common| Message: Checking for python module six
spice-common| Message: Checking for python module pyparsing

subprojects/spice-common/meson.build:137:8: ERROR: Problem encountered: Python module pyparsing not found

A full log can be found at /build/spice-0.15.0/build/meson-logs/meson-log.txt
```

```
❯ python3 -m pyparsing
/nix/store/civfhqs0ldmyplxhwhm0rja4is242q0p-python3-3.9.10-env/bin/python3.9: No module named pyparsing.__main__; 'pyparsing' is a package and cannot be directly executed
❯ python3 -c 'import pyparsing'; echo $?
0
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
