### PR TITLE
python3Packages.pymdown-extensions: init at 9.1

### DIFF
--- a/pkgs/development/python-modules/pymdown-extensions/default.nix
+++ b/pkgs/development/python-modules/pymdown-extensions/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pytestCheckHook
+, markdown
+, pyyaml
+, pygments
+}:
+
+let
+  extensions = [
+    "arithmatex"
+    "b64"
+    "betterem"
+    "caret"
+    "critic"
+    "details"
+    "emoji"
+    "escapeall"
+    "extra"
+    "highlight"
+    "inlinehilite"
+    "keys"
+    "magiclink"
+    "mark"
+    "pathconverter"
+    "progressbar"
+    "saneheaders"
+    "smartsymbols"
+    "snippets"
+    "striphtml"
+    "superfences"
+    "tabbed"
+    "tasklist"
+    "tilde"
+  ];
+in
+buildPythonPackage rec {
+  pname = "pymdown-extensions";
+  version = "9.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "facelessuser";
+    repo = "pymdown-extensions";
+    rev = version;
+    sha256 = "sha256-II8Po8144h3wPFrzMbOB/qiCm2HseYrcZkyIZFGT+ek=";
+  };
+
+  patches = [
+    # this patch is needed to allow tests to pass for later versions of the
+    # markdown dependency
+    #
+    # it can be removed after the next pymdown-extensions release
+    (fetchpatch {
+      url = "https://github.com/facelessuser/pymdown-extensions/commit/8ee5b5caec8f9373e025f50064585fb9d9b71f86.patch";
+      sha256 = "sha256-jTHNcsV0zL0EkSTSj8zCGXXtpUaLnNPldmL+krZj3Gk=";
+    })
+  ];
+
+  propagatedBuildInputs = [ markdown pygments ];
+
+  checkInputs = [
+    pytestCheckHook
+    pyyaml
+  ];
+
+  pythonImportsCheck = map (ext: "pymdownx.${ext}") extensions;
+
+  meta = with lib; {
+    description = "Extensions for Python Markdown.";
+    homepage = "https://facelessuser.github.io/pymdown-extensions/";
+    license = with licenses; [ mit bsd2 ];
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/pkgs/development/python-modules/pymdown-extensions/default.nix
+++ b/pkgs/development/python-modules/pymdown-extensions/default.nix
@@ -69,7 +69,7 @@ buildPythonPackage rec {
   pythonImportsCheck = map (ext: "pymdownx.${ext}") extensions;
 
   meta = with lib; {
-    description = "Extensions for Python Markdown.";
+    description = "Extensions for Python Markdown";
     homepage = "https://facelessuser.github.io/pymdown-extensions/";
     license = with licenses; [ mit bsd2 ];
     maintainers = with maintainers; [ cpcloud ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7035,6 +7035,8 @@ in {
 
   pymdstat = callPackage ../development/python-modules/pymdstat { };
 
+  pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
+
   pymediainfo = callPackage ../development/python-modules/pymediainfo { };
 
   pymediaroom = callPackage ../development/python-modules/pymediaroom { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add pymdown-extensions to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
