### PR TITLE
proxychains-ng: 4.15 -> 4.16

### DIFF
--- a/pkgs/tools/networking/proxychains-ng/default.nix
+++ b/pkgs/tools/networking/proxychains-ng/default.nix
@@ -1,28 +1,18 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
   pname = "proxychains-ng";
-  version = "4.15";
+  version = "4.16";
 
   src = fetchFromGitHub {
     owner = "rofl0r";
     repo = pname;
     rev = "v${version}";
-    sha256 = "128d502y8pn7q2ls6glx9bvibwzfh321sah5r5li6b6iywh2zqlc";
+    sha256 = "sha256-uu/zN6W0ue526/3a9QeYg6J4HLaovZJVOYXksjouYok=";
   };
-
-  patches = [
-    # Fix build on aarch64-darwin, should be removed in v4.16
-    # https://github.com/rofl0r/proxychains-ng/issues/400
-    (fetchpatch {
-      url = "https://github.com/rofl0r/proxychains-ng/commit/7de7dd0de1ff387a627620ac3482b4cd9b3fba95.patch?full_index=1";
-      sha256 = "sha256-m3a4Jal8L7w+xA0OJTPU68ILTaKgiITgsM1WVxuMce0=";
-    })
-  ];
 
   meta = with lib; {
     description = "A preloader which hooks calls to sockets in dynamically linked programs and redirects it through one or more socks/http proxies";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
