### PR TITLE
yquake2: migrate from cmake to gnumake

### DIFF
--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -15,13 +15,13 @@ let
 
   yquake2 = stdenv.mkDerivation rec {
     pname = "yquake2";
-    version = "8.00";
+    version = "8.01";
 
     src = fetchFromGitHub {
       owner = "yquake2";
       repo = "yquake2";
       rev = "QUAKE2_${builtins.replaceStrings ["."] ["_"] version}";
-      sha256 = "0xnpmh0pl1095dykhc76rp242x587yh9zh6wayqzaam6cn3xlz3w";
+      sha256 = "1dll5lx4bnls5w5f2zwjhwpcpxa97rjn6ymb2v3vrjm19jbd16yd";
     };
 
     postPatch = ''

--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -1,15 +1,13 @@
-{ stdenv, lib, fetchFromGitHub, buildEnv, cmake, makeWrapper
+{ stdenv, lib, fetchFromGitHub, buildEnv, makeWrapper
 , SDL2, libGL, curl
-, oggSupport ? true, libogg, libvorbis
 , openalSupport ? true, openal
-, zipSupport ? true, zlib
 , Cocoa, OpenAL
 }:
 
 let
-  mkFlag = b: if b then "ON" else "OFF";
+  mkFlag = b: if b then "yes" else "no";
 
-  games = import ./games.nix { inherit stdenv lib fetchFromGitHub cmake; };
+  games = import ./games.nix { inherit stdenv lib fetchFromGitHub; };
 
   wrapper = import ./wrapper.nix { inherit stdenv lib buildEnv makeWrapper yquake2; };
 
@@ -25,39 +23,33 @@ let
     };
 
     postPatch = ''
-      substituteInPlace src/common/filesystem.c \
-        --replace /usr/share/games/quake2 $out/share/games/quake2
+      substituteInPlace src/client/curl/qcurl.c \
+        --replace "\"libcurl.so.3\", \"libcurl.so.4\"" "\"${curl.out}/lib/libcurl.so\", \"libcurl.so.3\", \"libcurl.so.4\""
+    '' + lib.optionalString (openalSupport && !stdenv.isDarwin) ''
+      substituteInPlace Makefile \
+        --replace "\"libopenal.so.1\"" "\"${openal}/lib/libopenal.so.1\""
     '';
-
-    nativeBuildInputs = [ cmake ];
 
     buildInputs = [ SDL2 libGL curl ]
       ++ lib.optionals stdenv.isDarwin [ Cocoa OpenAL ]
-      ++ lib.optionals oggSupport [ libogg libvorbis ]
-      ++ lib.optional openalSupport openal
-      ++ lib.optional zipSupport zlib;
+      ++ lib.optional openalSupport openal;
 
-    cmakeFlags = [
-      "-DCMAKE_BUILD_TYPE=Release"
-      "-DOGG_SUPPORT=${mkFlag oggSupport}"
-      "-DOPENAL_SUPPORT=${mkFlag openalSupport}"
-      "-DZIP_SUPPORT=${mkFlag zipSupport}"
-      "-DSYSTEMWIDE_SUPPORT=ON"
+    makeFlags = [
+      "WITH_OPENAL=${mkFlag openalSupport}"
+      "WITH_SYSTEMWIDE=yes"
+      "WITH_SYSTEMDIR=$\{out}/share/games/quake2"
     ];
 
-    preConfigure = ''
-      # Since we can't expand $out in `cmakeFlags`
-      cmakeFlags="$cmakeFlags -DSYSTEMDIR=$out/share/games/quake2"
-    '';
+    enableParallelBuilding = true;
 
     installPhase = ''
       # Yamagi Quake II expects all binaries (executables and libs) to be in the
       # same directory.
-      mkdir -p $out/bin $out/lib/yquake2 $out/share/games/quake2
+      mkdir -p $out/bin $out/lib/yquake2 $out/share/games/quake2/baseq2
       cp -r release/* $out/lib/yquake2
       ln -s $out/lib/yquake2/quake2 $out/bin/yquake2
       ln -s $out/lib/yquake2/q2ded $out/bin/yq2ded
-      cp $src/stuff/yq2.cfg $out/share/games/quake2
+      cp $src/stuff/yq2.cfg $out/share/games/quake2/baseq2
     '';
 
     meta = with lib; {

--- a/pkgs/games/quake2/yquake2/games.nix
+++ b/pkgs/games/quake2/yquake2/games.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake }:
+{ stdenv, lib, fetchFromGitHub }:
 
 let
   games = {
@@ -37,11 +37,9 @@ let
       rev = "${lib.toUpper id}_${builtins.replaceStrings ["."] ["_"] version}";
     };
 
-    nativeBuildInputs = [ cmake ];
-
     installPhase = ''
       mkdir -p $out/lib/yquake2/${id}
-      cp Release/* $out/lib/yquake2/${id}
+      cp release/* $out/lib/yquake2/${id}
     '';
 
     meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
See: https://github.com/yquake2/yquake2/commit/fb1a2b0ce7b249cd50990225cc484dc2a9f965de

Fixes finding libcurl.so. Moves yq2.cfg into baseq2/ so that it can be found.

Also includes the update to 8.01 just like #156280.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


closes #156895