### PR TITLE
qt515: Update KDE Qt 5.15 patches

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
+++ b/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
@@ -166,8 +166,8 @@
   },
   "qtwayland": {
     "url": "https://invent.kde.org/qt/qt/qtwayland.git",
-    "rev": "4644d51f4b52e83fc1b4d02b380d80d9d57e76fa",
-    "sha256": "1z5zfx4pfxqkgzg09djlsxyirbj8gq7lwih92zxpi2avn1gzkwfm"
+    "rev": "460a2bb54d8377586dff6d561646f3929c71370d",
+    "sha256": "0h3mx60h5rqk1nj591l4niy9v6ibcbncrszaqwx1dazna5p30s43"
   },
   "qtwebchannel": {
     "url": "https://invent.kde.org/qt/qt/qtwebchannel.git",

--- a/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
+++ b/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
@@ -166,8 +166,8 @@
   },
   "qtwayland": {
     "url": "https://invent.kde.org/qt/qt/qtwayland.git",
-    "rev": "ce2caf493a1343fbd9f8e4c85baf6a61c057f242",
-    "sha256": "18hcgwxrxxn9q7vgfdc534if55ma673r8vb9c55v2inp7yngwvms"
+    "rev": "214f7ab9d3384a4123f14d9f6cd0205cf0aaa794",
+    "sha256": "1qd64w5c16gmpgi936dfjc0pn1a1rbs752k8lfqv2xwysx7qkqwi"
   },
   "qtwebchannel": {
     "url": "https://invent.kde.org/qt/qt/qtwebchannel.git",

--- a/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
+++ b/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
@@ -16,8 +16,8 @@
   },
   "qtbase": {
     "url": "https://invent.kde.org/qt/qt/qtbase.git",
-    "rev": "03933d189a93c760b642c7021dd9bb63802da254",
-    "sha256": "0mwd4m6403qndnv9fya1n8aqs6yw009kkqs0176628bl0cxqc0my"
+    "rev": "d16bf02a11953dcac01dca73e6f3778f293adefe",
+    "sha256": "0rpyd5r60707lzfmfi3y501c7is1gzhh30bframsy8bwglck2hjj"
   },
   "qtcharts": {
     "url": "https://invent.kde.org/qt/qt/qtcharts.git",
@@ -36,8 +36,8 @@
   },
   "qtdeclarative": {
     "url": "https://invent.kde.org/qt/qt/qtdeclarative.git",
-    "rev": "c691908c54ed7815f513f8511005dbf1f13ad40d",
-    "sha256": "1w7mc7ii3m7v858zgj7vzc076qha3asa7nmz43zbhv1vdd7mhn6i"
+    "rev": "1d49a5b678957adde7e2db23a485a3f48157bc8f",
+    "sha256": "1wdpgh23mdn0nny9c837iyg9kszc3m4cdmaanf8glymkzn0rkd8w"
   },
   "qtdoc": {
     "url": "https://invent.kde.org/qt/qt/qtdoc.git",
@@ -166,8 +166,8 @@
   },
   "qtwayland": {
     "url": "https://invent.kde.org/qt/qt/qtwayland.git",
-    "rev": "b6d85c2a75f5618e87267f5b5c361455be257a17",
-    "sha256": "132gvhvqdy0hykj49qsr14gxcbhzrrk4iz1cg2n7kzlmanw7sqg4"
+    "rev": "ce2caf493a1343fbd9f8e4c85baf6a61c057f242",
+    "sha256": "18hcgwxrxxn9q7vgfdc534if55ma673r8vb9c55v2inp7yngwvms"
   },
   "qtwebchannel": {
     "url": "https://invent.kde.org/qt/qt/qtwebchannel.git",

--- a/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
+++ b/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
@@ -16,8 +16,8 @@
   },
   "qtbase": {
     "url": "https://invent.kde.org/qt/qt/qtbase.git",
-    "rev": "366350c2e4a7eccbda0f3936e69c6b9c4fa28f55",
-    "sha256": "08iavd624g3830ghq6iynnl1dr8wnms4zigrp0m0sf6zs7f7cib6"
+    "rev": "03933d189a93c760b642c7021dd9bb63802da254",
+    "sha256": "0mwd4m6403qndnv9fya1n8aqs6yw009kkqs0176628bl0cxqc0my"
   },
   "qtcharts": {
     "url": "https://invent.kde.org/qt/qt/qtcharts.git",
@@ -101,8 +101,8 @@
   },
   "qtquickcontrols2": {
     "url": "https://invent.kde.org/qt/qt/qtquickcontrols2.git",
-    "rev": "b092b19a18d14e70beae6afebc6bde5d83e9eed7",
-    "sha256": "0bkfzkangg5y1d1x0bwb4a13ys0lnr5rhdj7wndax953a4k0l4jc"
+    "rev": "d8d6b14b9907adbc6ce307d52be34aaa761a58fa",
+    "sha256": "15c7nrvvn7qc3l7kdbl5wdpazqwv8zvg1aij2jvcrhbymn0zl3mc"
   },
   "qtquicktimeline": {
     "url": "https://invent.kde.org/qt/qt/qtquicktimeline.git",
@@ -166,8 +166,8 @@
   },
   "qtwayland": {
     "url": "https://invent.kde.org/qt/qt/qtwayland.git",
-    "rev": "460a2bb54d8377586dff6d561646f3929c71370d",
-    "sha256": "0h3mx60h5rqk1nj591l4niy9v6ibcbncrszaqwx1dazna5p30s43"
+    "rev": "b6d85c2a75f5618e87267f5b5c361455be257a17",
+    "sha256": "132gvhvqdy0hykj49qsr14gxcbhzrrk4iz1cg2n7kzlmanw7sqg4"
   },
   "qtwebchannel": {
     "url": "https://invent.kde.org/qt/qt/qtwebchannel.git",

--- a/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
+++ b/pkgs/development/libraries/qt-5/5.15/srcs-generated.json
@@ -1,8 +1,8 @@
 {
   "qt3d": {
     "url": "https://invent.kde.org/qt/qt/qt3d.git",
-    "rev": "7edec6e014de27b9dd03f63875c471aac606a918",
-    "sha256": "0qv4vhciigqd8bnqzrs7y71ls7jx1p9cal2rh78m42qgskk1ci59"
+    "rev": "dba14d48611b9e9d59576172658779ab4a39b416",
+    "sha256": "1w2m1rm6mhj9qbanak36rqvc30x495zvj7mh2syy1yd29by0g5i8"
   },
   "qtactiveqt": {
     "url": "https://invent.kde.org/qt/qt/qtactiveqt.git",
@@ -16,8 +16,8 @@
   },
   "qtbase": {
     "url": "https://invent.kde.org/qt/qt/qtbase.git",
-    "rev": "c9fde86b0a2440133bc08f4811b6ca793be47f0a",
-    "sha256": "1fqhdkv3sp3nbzqi2a5wvxn5d4v0xcrq2bl609bdyj4nx367a8wp"
+    "rev": "366350c2e4a7eccbda0f3936e69c6b9c4fa28f55",
+    "sha256": "08iavd624g3830ghq6iynnl1dr8wnms4zigrp0m0sf6zs7f7cib6"
   },
   "qtcharts": {
     "url": "https://invent.kde.org/qt/qt/qtcharts.git",
@@ -26,8 +26,8 @@
   },
   "qtconnectivity": {
     "url": "https://invent.kde.org/qt/qt/qtconnectivity.git",
-    "rev": "69a87a9b831e36a578594a0a13130c384ad03121",
-    "sha256": "0ph07rdf9qfxnw3z2nqbmh6na65z0p2snmlzdw80amd7s0g255kw"
+    "rev": "5e9ca5d36d65dadb98ef90013a1dcf15fbd7ae26",
+    "sha256": "1lpiq3svlnj8f8apd12if11sng7k0l8y6vhr317srzz4dd77cfry"
   },
   "qtdatavis3d": {
     "url": "https://invent.kde.org/qt/qt/qtdatavis3d.git",
@@ -36,8 +36,8 @@
   },
   "qtdeclarative": {
     "url": "https://invent.kde.org/qt/qt/qtdeclarative.git",
-    "rev": "55324650f9e759a43dce927f823c9858574106c3",
-    "sha256": "0cxz4pqvb8l0wqpc4hr0xmc72csqf7dpbbzdqgil9nyyg21ihkz0"
+    "rev": "c691908c54ed7815f513f8511005dbf1f13ad40d",
+    "sha256": "1w7mc7ii3m7v858zgj7vzc076qha3asa7nmz43zbhv1vdd7mhn6i"
   },
   "qtdoc": {
     "url": "https://invent.kde.org/qt/qt/qtdoc.git",
@@ -101,8 +101,8 @@
   },
   "qtquickcontrols2": {
     "url": "https://invent.kde.org/qt/qt/qtquickcontrols2.git",
-    "rev": "be66bf9a5618c745d2a6ee2262967af6307b3b07",
-    "sha256": "11h3f3rb2kqgsw7njzhjwazw1k03v12i83irjndylafiaqw6c6ks"
+    "rev": "b092b19a18d14e70beae6afebc6bde5d83e9eed7",
+    "sha256": "0bkfzkangg5y1d1x0bwb4a13ys0lnr5rhdj7wndax953a4k0l4jc"
   },
   "qtquicktimeline": {
     "url": "https://invent.kde.org/qt/qt/qtquicktimeline.git",
@@ -146,8 +146,8 @@
   },
   "qtsvg": {
     "url": "https://invent.kde.org/qt/qt/qtsvg.git",
-    "rev": "24128cdf8bef53eddf31a5709bbbc46293006b1c",
-    "sha256": "0vinjcbq4saxhlmvb5i93bzgg30qc3j8r2qfwrzaxc4vmfhfgi56"
+    "rev": "728012f7762ecd5762d493f8796907c6456f31e7",
+    "sha256": "1ldizgybl4fp95xlzf103hqmsqdmr3jbx048jyxcb5gjd3pbwh7p"
   },
   "qttools": {
     "url": "https://invent.kde.org/qt/qt/qttools.git",
@@ -161,18 +161,18 @@
   },
   "qtvirtualkeyboard": {
     "url": "https://invent.kde.org/qt/qt/qtvirtualkeyboard.git",
-    "rev": "353b75b2e34bdae901625bbddf5c5e3f3e6c0de5",
-    "sha256": "12nv773zc05yrbai1z6i481yinih0kxcjzgm9pa0580qz69gd9a5"
+    "rev": "98d1fd864cbb6c7c012c4139118808af110fb8f0",
+    "sha256": "07xjmhca7z5bva03zk73d948qz0a3wnn4kvyy6j4cnp3w5giz5kc"
   },
   "qtwayland": {
     "url": "https://invent.kde.org/qt/qt/qtwayland.git",
-    "rev": "992833ca741efe8f533c61abfaf129a1d8bfcfee",
-    "sha256": "1w8mq38k6s0fncqv113bw1pc7g10ysfmsbyg23hxh9fr5q4ia4q7"
+    "rev": "4644d51f4b52e83fc1b4d02b380d80d9d57e76fa",
+    "sha256": "1z5zfx4pfxqkgzg09djlsxyirbj8gq7lwih92zxpi2avn1gzkwfm"
   },
   "qtwebchannel": {
     "url": "https://invent.kde.org/qt/qt/qtwebchannel.git",
-    "rev": "47be9a51b01d9fd9e7f6dca81e98d4eedcec6d38",
-    "sha256": "167rp43c86xr4grzxs4bl46y6sf1q9xa0641mgp4r94g2ipxyc1d"
+    "rev": "fa8b07105b5e274daaa8adcc129fa4aa0447f9f7",
+    "sha256": "0mggqa8kixknbm1p5i5lkrmkj1na3b2xflj011dkjbj8wb78i42n"
   },
   "qtwebglplugin": {
     "url": "https://invent.kde.org/qt/qt/qtwebglplugin.git",
@@ -181,8 +181,8 @@
   },
   "qtwebsockets": {
     "url": "https://invent.kde.org/qt/qt/qtwebsockets.git",
-    "rev": "e7883bc64440b1ff4666272ac6eb710ee4bc221b",
-    "sha256": "1rj99y1f0wn6g1m2k53xkni5v79zgq25yv8b9wx2bz0n2r9iasca"
+    "rev": "b13b56904b76e96ea52d0efe56395acc94b17d96",
+    "sha256": "047asrq7c44v7cn2d7c5zba47qzpsb6nidba77i2xn7gqlfv6z3b"
   },
   "qtwebview": {
     "url": "https://invent.kde.org/qt/qt/qtwebview.git",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I'm most interested in this change https://invent.kde.org/qt/qt/qtwayland/-/commit/4644d51f4b52e83fc1b4d02b380d80d9d57e76fa which makes performance on nvidia wayland usable, but there are many other changes.

We're expected to keep these up to date as we update plasma5, but that was updated [a few weeks ago](https://github.com/NixOS/nixpkgs/pull/153663) and our patches are from October.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
