### PR TITLE
[21.11] mautrix-telegram: 0.10.2 -> 0.11.1

### DIFF
--- a/nixos/modules/services/misc/mautrix-telegram.nix
+++ b/nixos/modules/services/misc/mautrix-telegram.nix
@@ -142,7 +142,7 @@ in {
             --config='${settingsFile}' \
             --registration='${registrationFile}'
         fi
-
+      '' + lib.optionalString (pkgs.mautrix-telegram ? alembic) ''
         # run automatic database init and migration scripts
         ${pkgs.mautrix-telegram.alembic}/bin/alembic -x config='${settingsFile}' upgrade head
       '';

--- a/pkgs/servers/mautrix-telegram/0001-Re-add-entrypoint.patch
+++ b/pkgs/servers/mautrix-telegram/0001-Re-add-entrypoint.patch
@@ -8,22 +8,20 @@ Subject: [PATCH 1/2] Re-add entrypoint
  1 file changed, 6 insertions(+)
 
 diff --git a/setup.py b/setup.py
-index 068c351..95dbf89 100644
+index ea001e5..e1ca536 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -51,6 +51,12 @@ setuptools.setup(
+@@ -54,6 +54,12 @@ setuptools.setup(
      extras_require=extras_require,
-     python_requires="~=3.6",
- 
+     python_requires="~=3.7",
+
 +    entry_points={
 +        'console_scripts': [
 +            'mautrix-telegram=mautrix_telegram.__main__:main'
 +        ]
 +    },
 +
-     setup_requires=["pytest-runner"],
-     tests_require=["pytest", "pytest-asyncio", "pytest-mock"],
- 
--- 
-2.28.0
+     classifiers=[
+         "Development Status :: 4 - Beta",
+         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
 

--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -5,20 +5,20 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.3.24";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519";
-        };
-      });
-
       tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
-        version = "1.24.0a2";
+        version = "1.25.0a3";
         pname = "tulir-telethon";
         src = oldAttrs.src.override {
           inherit pname version;
-          sha256 = "sha256-Qbx164FwC8nhesoY2fkaKvErN8g0Ph8vGcx+Cc1AqRg=";
+          sha256 = "sha256-/kau9Q2+7giVx52tmjvYIbcDcY1/om31X9BlRvZipuk=";
+        };
+      });
+      mautrix = super.mautrix.overridePythonAttrs (oldAttrs: rec {
+        version = "0.14.5";
+        pname = "mautrix";
+        src = oldAttrs.src.override {
+          inherit pname version;
+          sha256 = "sha256-dh3uQUBEMqtlrOpnO5Aa7GC5gajwQ12rWyVPwX6xIsQ=";
         };
       });
     };
@@ -33,19 +33,18 @@ let
 
 in python.pkgs.buildPythonPackage rec {
   pname = "mautrix-telegram";
-  version = "0.10.2";
+  version = "0.11.1";
   disabled = python.pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "mautrix";
     repo = "telegram";
     rev = "v${version}";
-    sha256 = "sha256-BYsGLyxhdjBVmnZXLC5ZjwDlWcHdUGp+DsNIOXA1/Tc=";
+    sha256 = "sha256-Df+v1Q+5Iaa9GKcwIabMKjJwmVd5Qub8M54jEEiAPFc=";
   };
 
-  patches = [ ./0001-Re-add-entrypoint.patch ./0002-Don-t-depend-on-pytest-runner.patch ];
+  patches = [ ./0001-Re-add-entrypoint.patch ];
   postPatch = ''
-    sed -i -e '/alembic>/d' requirements.txt
     substituteInPlace requirements.txt \
       --replace "telethon>=1.22,<1.23" "telethon"
   '';
@@ -71,18 +70,6 @@ in python.pkgs.buildPythonPackage rec {
     pycryptodome
     unpaddedbase64
   ]) ++ dbDrivers;
-
-  # `alembic` (a database migration tool) is only needed for the initial setup,
-  # and not needed during the actual runtime. However `alembic` requires `mautrix-telegram`
-  # in its environment to create a database schema from all models.
-  #
-  # Hence we need to patch away `alembic` from `mautrix-telegram` and create an `alembic`
-  # which has `mautrix-telegram` in its environment.
-  passthru.alembic = python.pkgs.alembic.overrideAttrs (old: {
-    propagatedBuildInputs = old.propagatedBuildInputs ++ dbDrivers ++ [
-      mautrix-telegram
-    ];
-  });
 
   # Tests are broken and throw the following for every test:
   #   TypeError: 'Mock' object is not subscriptable


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See #156099.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
