### PR TITLE
wraith: 1.4.7 -> 1.4.10

### DIFF
--- a/pkgs/applications/networking/irc/wraith/configure.patch
+++ b/pkgs/applications/networking/irc/wraith/configure.patch
@@ -1,8 +1,8 @@
 --- a/configure
 +++ b/configure
-@@ -6029,53 +6029,8 @@
+@@ -6143,53 +6143,8 @@ rm -f confcache
+ #AC_CHECK_HEADERS(openssl/ssl.h openssl/crypto.h)
  #AC_CHECK_HEADERS(zlib.h)
- #EGG_CHECK_ZLIB
  
 -{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for path to OpenSSL" >&5
 -$as_echo_n "checking for path to OpenSSL... " >&6; }

--- a/pkgs/applications/networking/irc/wraith/default.nix
+++ b/pkgs/applications/networking/irc/wraith/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "wraith";
-  version = "1.4.7";
+  version = "1.4.10";
   src = fetchurl {
     url = "mirror://sourceforge/wraithbotpack/wraith-v${version}.tar.gz";
-    sha256 = "0h6liac5y7im0jfm2sj18mibvib7d1l727fjs82irsjj1v9kif3j";
+    sha256 = "1h8159g6wh1hi69cnhqkgwwwa95fa6z1zrzjl219mynbf6vjjzkw";
   };
   hardeningDisable = [ "format" ];
   buildInputs = [ openssl ];

--- a/pkgs/applications/networking/irc/wraith/dlopen.patch
+++ b/pkgs/applications/networking/irc/wraith/dlopen.patch
@@ -1,15 +1,15 @@
 diff --git a/src/libcrypto.cc b/src/libcrypto.cc
-index 0339258..68746c8 100644
+index 5139f66..517103f 100644
 --- a/src/libcrypto.cc
 +++ b/src/libcrypto.cc
-@@ -95,17 +95,9 @@ int load_libcrypto() {
+@@ -100,17 +100,9 @@ int load_libcrypto() {
    }
  
    sdprintf("Loading libcrypto");
 +  dlerror(); // Clear Errors
 +  libcrypto_handle = dlopen("@openssl@/lib/libcrypto.so", RTLD_LAZY|RTLD_GLOBAL);
  
--  bd::Array<bd::String> libs_list(bd::String("libcrypto.so." SHLIB_VERSION_NUMBER " libcrypto.so libcrypto.so.0.9.8 libcrypto.so.7 libcrypto.so.6").split(' '));
+-  bd::Array<bd::String> libs_list(bd::String("libcrypto.so." SHLIB_VERSION_NUMBER " libcrypto.so libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.so.0.9.8 libcrypto.so.10 libcrypto.so.9 libcrypto.so.8 libcrypto.so.7 libcrypto.so.6").split(' '));
 -
 -  for (size_t i = 0; i < libs_list.length(); ++i) {
 -    dlerror(); // Clear Errors
@@ -23,17 +23,17 @@ index 0339258..68746c8 100644
      fprintf(stderr, STR("Unable to find libcrypto\n"));
      return(1);
 diff --git a/src/libssl.cc b/src/libssl.cc
-index b432c7b..8940998 100644
+index 6010abc..86e29fc 100644
 --- a/src/libssl.cc
 +++ b/src/libssl.cc
-@@ -68,17 +68,9 @@ int load_libssl() {
+@@ -78,17 +78,9 @@ int load_libssl() {
    }
  
    sdprintf("Loading libssl");
 +  dlerror(); // Clear Errors
 +  libssl_handle = dlopen("@openssl@/lib/libssl.so", RTLD_LAZY);
  
--  bd::Array<bd::String> libs_list(bd::String("libssl.so." SHLIB_VERSION_NUMBER " libssl.so libssl.so.0.9.8 libssl.so.7 libssl.so.6").split(' '));
+-  bd::Array<bd::String> libs_list(bd::String("libssl.so." SHLIB_VERSION_NUMBER " libssl.so libssl.so.1.1 libssl.so.1.0.0 libssl.so.0.9.8 libssl.so.10 libssl.so.9 libssl.so.8 libssl.so.7 libssl.so.6").split(' '));
 -
 -  for (size_t i = 0; i < libs_list.length(); ++i) {
 -    dlerror(); // Clear Errors

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33898,9 +33898,7 @@ with pkgs;
 
   wprecon = callPackage ../tools/security/wprecon { };
 
-  wraith = callPackage ../applications/networking/irc/wraith {
-    openssl = openssl_1_0_2;
-  };
+  wraith = callPackage ../applications/networking/irc/wraith { };
 
   wxmupen64plus = callPackage ../misc/emulators/wxmupen64plus { };
 


### PR DESCRIPTION
###### Motivation for this change
Splitting out parts of #150880

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
