### PR TITLE
ocamlPackages.ppx_import: 1.8.0 -> 1.9.1

### DIFF
--- a/pkgs/development/coq-modules/serapi/default.nix
+++ b/pkgs/development/coq-modules/serapi/default.nix
@@ -1,19 +1,6 @@
 { lib, fetchzip, mkCoqDerivation, coq, version ? null }:
 
 let
-  ocamlPackages =
-    coq.ocamlPackages.overrideScope'
-      (self: super: {
-        ppxlib = super.ppxlib.override { version = "0.15.0"; };
-        # the following does not work
-        ppx_sexp_conv = super.ppx_sexp_conv.overrideAttrs (_: {
-          src = fetchzip {
-            url = "https://github.com/janestreet/ppx_sexp_conv/archive/v0.14.1.tar.gz";
-            sha256 = "04bx5id99clrgvkg122nx03zig1m7igg75piphhyx04w33shgkz2";
-          };
-        });
-      });
-
   release = {
     "8.14.0+0.14.0".sha256 = "sha256:1kh80yb791yl771qbqkvwhbhydfii23a7lql0jgifvllm2k8hd8d";
     "8.14+rc1+0.14.0".sha256 = "1w7d7anvcfx8vz51mnrf1jkw6rlpzjkjlr06avf58wlhymww7pja";
@@ -29,8 +16,6 @@ in
   inherit version release;
 
   defaultVersion =  with versions;
-    if isGe "4.12" coq.ocamlPackages.ocaml.version then null
-    else
     switch coq.version [
       { case = isEq "8.14"; out = "8.14.0+0.14.0"; }
       { case = isEq "8.13"; out = "8.13.0+0.13.0"; }
@@ -42,7 +27,7 @@ in
   useDune2 = true;
 
   propagatedBuildInputs =
-    with ocamlPackages; [
+    with coq.ocamlPackages; [
       cmdliner
       findlib # run time dependency of SerAPI
       ppx_deriving

--- a/pkgs/development/ocaml-modules/ppx_import/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_import/default.nix
@@ -1,27 +1,42 @@
-{ lib, fetchurl, buildDunePackage
-, ppx_tools_versioned
-, ocaml-migrate-parsetree
+{ lib
+, fetchurl
+, buildDunePackage
+, ounit
+, ppx_deriving
+, ppx_sexp_conv
+, ppxlib
 }:
+
+lib.throwIfNot (lib.versionAtLeast ppxlib.version "0.24.0")
+  "ppx_import is not available with ppxlib-${ppxlib.version}"
 
 buildDunePackage rec {
   pname = "ppx_import";
-  version = "1.8.0";
+  version = "1.9.1";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.05";
 
   src = fetchurl {
-    url = "https://github.com/ocaml-ppx/ppx_import/releases/download/v${version}/ppx_import-${version}.tbz";
-    sha256 = "0zqcj70yyp4ik4jc6jz3qs2xhb94vxc6yq9ij0d5cyak28klc3gv";
+    url = "https://github.com/ocaml-ppx/ppx_import/releases/download/${version}/ppx_import-${version}.tbz";
+    sha256 = "1li1f9b1i0yhjy655k74hgzhd05palz726zjbhwcy3iqxvi9id6i";
   };
 
   propagatedBuildInputs = [
-    ppx_tools_versioned ocaml-migrate-parsetree
+    ppxlib
   ];
 
+  checkInputs = [
+    ounit
+    ppx_deriving
+    ppx_sexp_conv
+  ];
+
+  doCheck = true;
+
   meta = {
-    description = "A syntax extension that allows to pull in types or signatures from other compiled interface files";
+    description = "A syntax extension for importing declarations from interface files";
     license = lib.licenses.mit;
     homepage = "https://github.com/ocaml-ppx/ppx_import";
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to version [1.9.1](https://github.com/ocaml-ppx/ppx_import/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
