### PR TITLE
tlp: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/tools/misc/tlp/default.nix
+++ b/pkgs/tools/misc/tlp/default.nix
@@ -24,19 +24,19 @@
 , networkmanager
 }: stdenv.mkDerivation rec {
   pname = "tlp";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "linrunner";
     repo = "TLP";
     rev = version;
-    sha256 = "sha256-Blwj4cqrrYXohnGyJYe+1NYifxqfS4DoVUHmxFf62i4=";
+    sha256 = "sha256-hHel3BVMzTYfE59kxxADnm8tqtUFntqS3RzmJSZlWjM=";
   };
 
   # XXX: See patch files for relevant explanations.
   patches = [
     ./patches/0001-makefile-correctly-sed-paths.patch
-    ./patches/0002-tlp-sleep.service-reintroduce.patch
+    ./patches/0002-reintroduce-tlp-sleep-service.patch
   ];
 
   buildInputs = [ perl ];
@@ -50,12 +50,11 @@
   # [1]: https://github.com/NixOS/nixpkgs/issues/65718
   # [2]: https://github.com/linrunner/TLP/blob/ab788abf4936dfb44fbb408afc34af834230a64d/Makefile#L4-L46
   makeFlags = [
-    "DESTDIR=${placeholder "out"}"
-
     "TLP_NO_INIT=1"
     "TLP_WITH_ELOGIND=0"
     "TLP_WITH_SYSTEMD=1"
 
+    "DESTDIR=${placeholder "out"}"
     "TLP_BATD=/share/tlp/bat.d"
     "TLP_BIN=/bin"
     "TLP_CONFDEF=/share/tlp/defaults.conf"

--- a/pkgs/tools/misc/tlp/patches/0002-reintroduce-tlp-sleep-service.patch
+++ b/pkgs/tools/misc/tlp/patches/0002-reintroduce-tlp-sleep-service.patch
@@ -57,23 +57,6 @@ index ab05720..075b42f 100644
  	rm -f $(_ELOD)/49-tlp-sleep
  	rm -f $(_SHCPL)/tlp-stat
  	rm -f $(_SHCPL)/bluetooth
-diff --git a/tlp-sleep b/tlp-sleep
-deleted file mode 100644
-index e548d55..0000000
---- a/tlp-sleep
-+++ /dev/null
-@@ -1,11 +0,0 @@
--#!/bin/sh
--
--# tlp - systemd suspend/resume hook
--#
--# Copyright (c) 2021 Thomas Koch <linrunner at gmx.net> and others.
--# This software is licensed under the GPL v2 or later.
--
--case $1 in
--    pre)  tlp suspend ;;
--    post) tlp resume  ;;
--esac
 diff --git a/tlp-sleep.service.in b/tlp-sleep.service.in
 new file mode 100644
 index 0000000..79c202c


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
