### PR TITLE
onefetch: 2.10.2 -> 2.11.0

### DIFF
--- a/pkgs/tools/misc/onefetch/default.nix
+++ b/pkgs/tools/misc/onefetch/default.nix
@@ -3,6 +3,8 @@
 , lib
 , stdenv
 , fetchpatch
+, pkg-config
+, zstd
 , CoreFoundation
 , libiconv
 , libresolv
@@ -11,18 +13,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.10.2";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lrRp01ZeK9bGn7L7SqAxJAU9qugpHnC06CWChhVPGGQ=";
+    sha256 = "sha256-16oiZAyj6haBk6mgUT25pPDUrCMd7pGo2kAQ0gTe2kM=";
   };
 
-  cargoSha256 = "sha256-vNa1OF1x/MCTo9B4DTDZNWyHTsOl7Za3EgjnpsL/gWg=";
+  # enable pkg-config feature of zstd
+  cargoPatches = [ ./zstd-pkg-config.patch ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [ CoreFoundation libiconv libresolv Security ];
+  cargoSha256 = "sha256-6wnfn33mfye5o/vY1JQX1Lc4+jzHiKKgGsSLxeJWyFc=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ zstd ]
+    ++ lib.optionals stdenv.isDarwin [ CoreFoundation libiconv libresolv Security ];
 
   meta = with lib; {
     description = "Git repository summary on your terminal";

--- a/pkgs/tools/misc/onefetch/zstd-pkg-config.patch
+++ b/pkgs/tools/misc/onefetch/zstd-pkg-config.patch
@@ -1,0 +1,31 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 202cda0..bc864cc 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -872,6 +872,7 @@ dependencies = [
+  "tokei",
+  "toml",
+  "yaml-rust",
++ "zstd-sys",
+ ]
+ 
+ [[package]]
+@@ -1678,4 +1679,5 @@ checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
+ dependencies = [
+  "cc",
+  "libc",
++ "pkg-config",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index 8e0b5ff..48959b4 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -57,6 +57,8 @@ libc = "0.2.112"
+ [dev-dependencies]
+ more-asserts = "0.2"
+ paste = "1.0.6"
++# Specify that the indirect dependency ztsd-sys should pick up the system zstd C library
++zstd-sys = { version = "1", features = [ "pkg-config" ] }
+ 
+ [features]
+ fail-on-deprecated = []


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
