### PR TITLE
systemd: v249.7 -> v250.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -17,6 +17,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   Migrations may take a while, see the [changelog](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6-3-extended-support-release)
   and [important upgrade notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
 
+- Systemd has been upgraded to the version 250.
+
 ## New Services {#sec-release-22.05-new-services}
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).
@@ -58,6 +60,21 @@ In addition to numerous new and upgraded packages, this release has the followin
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
+
+- Since systemd version 250 wireguard tunnels that are managed using networkd
+  will install routes for each of the `AllowedIPs` entries. This is in contrast
+  to the previous behaviour where routes had to be added manually.
+  To disable the new behaviour you must set the `RoutingTable=off` option in
+  the `WireGuard` section within each of your netdev definitions.
+  For example like this:
+  ```nix
+  {
+    systemd.network.netdev.my-wireguard-interface = {
+      wireguardConfig.RouteTable = "off";
+    };
+  }
+  ```
+-
 
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.
   This *only* makes a difference if you are cross-compiling and will

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -60,15 +60,27 @@ with lib;
     };
     users.groups.systemd-timesync.gid = config.ids.gids.systemd-timesync;
 
-    system.activationScripts.systemd-timesyncd-migration = mkIf (versionOlder config.system.stateVersion "19.09") ''
+    system.activationScripts.systemd-timesyncd-migration =
       # workaround an issue of systemd-timesyncd not starting due to upstream systemd reverting their dynamic users changes
       #  - https://github.com/NixOS/nixpkgs/pull/61321#issuecomment-492423742
       #  - https://github.com/systemd/systemd/issues/12131
-      if [ -L /var/lib/systemd/timesync ]; then
-        rm /var/lib/systemd/timesync
-        mv /var/lib/private/systemd/timesync /var/lib/systemd/timesync
+      mkIf (versionOlder config.system.stateVersion "19.09") ''
+        if [ -L /var/lib/systemd/timesync ]; then
+          rm /var/lib/systemd/timesync
+          mv /var/lib/private/systemd/timesync /var/lib/systemd/timesync
+        fi
+      '';
+    system.activationScripts.systemd-timesyncd-init-clock =
+      # Ensure that we have some stored time to prevent systemd-timesyncd to
+      # resort back to the fallback time.
+      # If the file doesn't exist we assume that our current system clock is
+      # good enough to provide an initial value.
+      ''
+      if ! [ -f /var/lib/systemd/timesync/clock ]; then
+        test -d /var/lib/systemd/timesync || mkdir -p /var/lib/systemd/timesync
+        touch /var/lib/systemd/timesync/clock
       fi
-    '';
+      '';
   };
 
 }

--- a/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,4 +1,4 @@
-From 93b2d29de784c68d1b4d70d7f214b19432aec6a8 Mon Sep 17 00:00:00 2001
+From 8622539fe2ce67934ed2e60626a2303ef8191e40 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Tue, 8 Jan 2013 15:46:30 +0100
 Subject: [PATCH 01/19] Start device units for uninitialised encrypted devices
@@ -16,17 +16,6 @@ diff --git a/rules.d/99-systemd.rules.in b/rules.d/99-systemd.rules.in
 index 25b8a590a6..d18999ea87 100644
 --- a/rules.d/99-systemd.rules.in
 +++ b/rules.d/99-systemd.rules.in
-@@ -17,10 +17,6 @@ SUBSYSTEM=="ubi", TAG+="systemd"
- SUBSYSTEM=="block", TAG+="systemd"
- SUBSYSTEM=="block", ACTION=="add", ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}="0"
- 
--# Ignore encrypted devices with no identified superblock on it, since
--# we are probably still calling mke2fs or mkswap on it.
--SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}=="", ENV{SYSTEMD_READY}="0"
--
- # add symlink to GPT root disk
- SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}!="crypto_LUKS", SYMLINK+="gpt-auto-root"
- SUBSYSTEM=="block", ENV{ID_PART_GPT_AUTO_ROOT}=="1", ENV{ID_FS_TYPE}=="crypto_LUKS", SYMLINK+="gpt-auto-root-luks"
 -- 
-2.33.1
+2.34.0
 

--- a/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
+++ b/pkgs/os-specific/linux/systemd/0002-Don-t-try-to-unmount-nix-or-nix-store.patch
@@ -1,4 +1,4 @@
-From 41edb381df0326e216b3c569d2cd5764591267d9 Mon Sep 17 00:00:00 2001
+From a845786195182c376b72a85433e278c35243676d Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 12 Apr 2013 13:16:57 +0200
 Subject: [PATCH 02/19] Don't try to unmount /nix or /nix/store
@@ -11,24 +11,11 @@ https://github.com/NixOS/nixos/issues/126
  src/shutdown/umount.c   | 2 ++
  2 files changed, 4 insertions(+)
 
-diff --git a/src/shared/fstab-util.c b/src/shared/fstab-util.c
-index f683f05981..5a04c2c2a6 100644
---- a/src/shared/fstab-util.c
-+++ b/src/shared/fstab-util.c
-@@ -40,6 +40,8 @@ bool fstab_is_extrinsic(const char *mount, const char *opts) {
-         /* Don't bother with the OS data itself */
-         if (PATH_IN_SET(mount,
-                         "/",
-+                        "/nix",
-+                        "/nix/store",
-                         "/usr",
-                         "/etc"))
-                 return true;
 diff --git a/src/shutdown/umount.c b/src/shutdown/umount.c
-index 1f945b7875..6df9d383ba 100644
+index f5a2cb20c1..51608d24c0 100644
 --- a/src/shutdown/umount.c
 +++ b/src/shutdown/umount.c
-@@ -508,6 +508,8 @@ static int delete_md(MountPoint *m) {
+@@ -502,6 +502,8 @@ static int delete_md(MountPoint *m) {
  
  static bool nonunmountable_path(const char *path) {
          return path_equal(path, "/")
@@ -38,5 +25,4 @@ index 1f945b7875..6df9d383ba 100644
                  || path_equal(path, "/usr")
  #endif
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -1,4 +1,4 @@
-From 43620479f6bfbbc4c3eed28947e0676c817acb7c Mon Sep 17 00:00:00 2001
+From d33f3461fa2202ef9b0d6cdf2137c510c59fb052 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Wed, 16 Apr 2014 10:59:28 +0200
 Subject: [PATCH 03/19] Fix NixOS containers
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 575b9da447..438ca294db 100644
+index 8f17ab8810..197e5aa252 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -5590,6 +5590,7 @@ static int run(int argc, char *argv[]) {
+@@ -5625,6 +5625,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 575b9da447..438ca294db 100644
                          const char *p, *q;
  
                          if (arg_pivot_root_new)
-@@ -5604,6 +5605,7 @@ static int run(int argc, char *argv[]) {
+@@ -5639,6 +5640,7 @@ static int run(int argc, char *argv[]) {
                                  r = -EINVAL;
                                  goto finish;
                          }
@@ -30,5 +30,4 @@ index 575b9da447..438ca294db 100644
  
          } else {
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
+++ b/pkgs/os-specific/linux/systemd/0004-Look-for-fsck-in-the-right-place.patch
@@ -1,4 +1,4 @@
-From a08ed6697974d7f7dabe60d42bbc9e31a10f7e23 Mon Sep 17 00:00:00 2001
+From 8fd5968163f3a1cb5f196d934756ba08ccaa5b1e Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Thu, 1 May 2014 14:10:10 +0200
 Subject: [PATCH 04/19] Look for fsck in the right place
@@ -8,7 +8,7 @@ Subject: [PATCH 04/19] Look for fsck in the right place
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/fsck/fsck.c b/src/fsck/fsck.c
-index cd7adfaeb9..68cebdd158 100644
+index 745d01ff50..dd4eef45c3 100644
 --- a/src/fsck/fsck.c
 +++ b/src/fsck/fsck.c
 @@ -368,7 +368,7 @@ static int run(int argc, char *argv[]) {
@@ -21,5 +21,4 @@ index cd7adfaeb9..68cebdd158 100644
                  cmdline[i++] = "-T";
  
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Add-some-NixOS-specific-unit-directories.patch
@@ -1,4 +1,4 @@
-From ddcfae6de8c460903c5db8c536ffeb5771e976f8 Mon Sep 17 00:00:00 2001
+From 90d1a90d3147e9c8db5caec8befabda270e755d4 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Fri, 19 Dec 2014 14:46:17 +0100
 Subject: [PATCH 05/19] Add some NixOS-specific unit directories
@@ -14,10 +14,10 @@ Also, remove /usr and /lib as these don't exist on NixOS.
  2 files changed, 6 insertions(+), 19 deletions(-)
 
 diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
-index 05eb17d66c..1cd141d012 100644
+index 6fb8c40e7a..142ecdecec 100644
 --- a/src/basic/path-lookup.c
 +++ b/src/basic/path-lookup.c
-@@ -91,11 +91,7 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
+@@ -92,11 +92,7 @@ int xdg_user_data_dir(char **ret, const char *suffix) {
  }
  
  static const char* const user_data_unit_paths[] = {
@@ -29,7 +29,7 @@ index 05eb17d66c..1cd141d012 100644
          NULL
  };
  
-@@ -613,15 +609,13 @@ int lookup_paths_init(
+@@ -614,15 +610,13 @@ int lookup_paths_init(
                                          persistent_config,
                                          SYSTEM_CONFIG_UNIT_DIR,
                                          "/etc/systemd/system",
@@ -46,7 +46,7 @@ index 05eb17d66c..1cd141d012 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -637,14 +631,11 @@ int lookup_paths_init(
+@@ -638,14 +632,11 @@ int lookup_paths_init(
                                          persistent_config,
                                          USER_CONFIG_UNIT_DIR,
                                          "/etc/systemd/user",
@@ -62,7 +62,7 @@ index 05eb17d66c..1cd141d012 100644
                                          STRV_IFNOTNULL(generator_late));
                          break;
  
-@@ -794,7 +785,6 @@ char **generator_binary_paths(UnitFileScope scope) {
+@@ -795,7 +786,6 @@ char **generator_binary_paths(UnitFileScope scope) {
                  case UNIT_FILE_SYSTEM:
                          add = strv_new("/run/systemd/system-generators",
                                         "/etc/systemd/system-generators",
@@ -70,7 +70,7 @@ index 05eb17d66c..1cd141d012 100644
                                         SYSTEM_GENERATOR_DIR);
                          break;
  
-@@ -802,7 +792,6 @@ char **generator_binary_paths(UnitFileScope scope) {
+@@ -803,7 +793,6 @@ char **generator_binary_paths(UnitFileScope scope) {
                  case UNIT_FILE_USER:
                          add = strv_new("/run/systemd/user-generators",
                                         "/etc/systemd/user-generators",
@@ -78,7 +78,7 @@ index 05eb17d66c..1cd141d012 100644
                                         USER_GENERATOR_DIR);
                          break;
  
-@@ -841,12 +830,10 @@ char **env_generator_binary_paths(bool is_system) {
+@@ -842,12 +831,10 @@ char **env_generator_binary_paths(bool is_system) {
                  if (is_system)
                          add = strv_new("/run/systemd/system-environment-generators",
                                          "/etc/systemd/system-environment-generators",
@@ -122,5 +122,4 @@ index fc0f8c34fa..162432e77f 100644
  
  systemd_sleep_dir=${root_prefix}/lib/systemd/system-sleep
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0006-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -1,4 +1,4 @@
-From b39b8871bcaa07280d6b0cf2226b1a3be31232b8 Mon Sep 17 00:00:00 2001
+From 213279752124dc4a57a4189df9b5b2e96feaa0b3 Mon Sep 17 00:00:00 2001
 From: Eelco Dolstra <eelco.dolstra@logicblox.com>
 Date: Mon, 11 May 2015 15:39:38 +0200
 Subject: [PATCH 06/19] Get rid of a useless message in user sessions
@@ -13,10 +13,10 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 34891a8754..b9b4789720 100644
+index 9368a1dfa1..5b0bdb1bc7 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -1375,7 +1375,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
+@@ -1408,7 +1408,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {
                  if (!unit_is_bound_by_inactive(u, &culprit))
                          continue;
  
@@ -27,5 +27,4 @@ index 34891a8754..b9b4789720 100644
                  /* If stopping a unit fails continuously we might enter a stop loop here, hence stop acting on the
                   * service being unnecessary after a while. */
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
+++ b/pkgs/os-specific/linux/systemd/0007-hostnamed-localed-timedated-disable-methods-that-cha.patch
@@ -1,4 +1,4 @@
-From 566208aea81057789218b959f4d0e898eec54fc9 Mon Sep 17 00:00:00 2001
+From 14474d5e116609ce4fac60d779b08fa3eab840c3 Mon Sep 17 00:00:00 2001
 From: Gabriel Ebner <gebner@gebner.org>
 Date: Sun, 6 Dec 2015 14:26:36 +0100
 Subject: [PATCH 07/19] hostnamed, localed, timedated: disable methods that
@@ -11,10 +11,10 @@ Subject: [PATCH 07/19] hostnamed, localed, timedated: disable methods that
  3 files changed, 25 insertions(+)
 
 diff --git a/src/hostname/hostnamed.c b/src/hostname/hostnamed.c
-index 36702f2fb0..669257ea2f 100644
+index b20a93ad81..6292fca4fc 100644
 --- a/src/hostname/hostnamed.c
 +++ b/src/hostname/hostnamed.c
-@@ -797,6 +797,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
+@@ -813,6 +813,9 @@ static int method_set_static_hostname(sd_bus_message *m, void *userdata, sd_bus_
          if (r < 0)
                  return r;
  
@@ -24,7 +24,7 @@ index 36702f2fb0..669257ea2f 100644
          name = empty_to_null(name);
  
          context_read_etc_hostname(c);
-@@ -860,6 +863,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
+@@ -876,6 +879,9 @@ static int set_machine_info(Context *c, sd_bus_message *m, int prop, sd_bus_mess
          if (r < 0)
                  return r;
  
@@ -104,5 +104,4 @@ index 66b454269d..0a8fe25d0f 100644
          if (r < 0)
                  return r;
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0008-Fix-hwdb-paths.patch
@@ -1,4 +1,4 @@
-From 3b9983969de2a86929768f6362ed41c20dd13bd3 Mon Sep 17 00:00:00 2001
+From d668df39728c992ec0c691ef6e76664e7121f5bd Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 7 Jul 2016 02:47:13 +0300
 Subject: [PATCH 08/19] Fix hwdb paths
@@ -24,5 +24,4 @@ index 5ddc2211e6..ee621eec46 100644
 +        "/etc/udev/hwdb.bin\0"
 +
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0009-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -1,4 +1,4 @@
-From b5966b6abb9696798618367cab33d1fed317734f Mon Sep 17 00:00:00 2001
+From dd59ce5f1bbdafb0b92f8aeacc68b000ec347a61 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Tue, 11 Oct 2016 13:12:08 +0300
 Subject: [PATCH 09/19] Change /usr/share/zoneinfo to /etc/zoneinfo
@@ -35,10 +35,10 @@ index e486474c44..5f373d0723 100644
      <literal>Etc/UTC</literal>. The resulting link should lead to the
      corresponding binary
 diff --git a/src/basic/time-util.c b/src/basic/time-util.c
-index 5d162e8ffe..1bec83e555 100644
+index b659d6905d..660b1c6fed 100644
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1269,7 +1269,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
+@@ -1267,7 +1267,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
  
          assert(ret);
  
@@ -47,7 +47,7 @@ index 5d162e8ffe..1bec83e555 100644
          if (!f)
                  return -errno;
  
-@@ -1308,7 +1308,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
+@@ -1306,7 +1306,7 @@ static int get_timezones_from_tzdata_zi(char ***ret) {
          _cleanup_strv_free_ char **zones = NULL;
          int r;
  
@@ -56,7 +56,7 @@ index 5d162e8ffe..1bec83e555 100644
          if (!f)
                  return -errno;
  
-@@ -1421,7 +1421,7 @@ int verify_timezone(const char *name, int log_level) {
+@@ -1419,7 +1419,7 @@ int verify_timezone(const char *name, int log_level) {
          if (p - name >= PATH_MAX)
                  return -ENAMETOOLONG;
  
@@ -65,7 +65,7 @@ index 5d162e8ffe..1bec83e555 100644
  
          fd = open(t, O_RDONLY|O_CLOEXEC);
          if (fd < 0)
-@@ -1512,7 +1512,7 @@ int get_timezone(char **ret) {
+@@ -1510,7 +1510,7 @@ int get_timezone(char **ret) {
          if (r < 0)
                  return r; /* returns EINVAL if not a symlink */
  
@@ -75,10 +75,10 @@ index 5d162e8ffe..1bec83e555 100644
                  return -EINVAL;
  
 diff --git a/src/firstboot/firstboot.c b/src/firstboot/firstboot.c
-index 2cb4f80d5d..ebeaeac52f 100644
+index d28a416e5d..c7c215731d 100644
 --- a/src/firstboot/firstboot.c
 +++ b/src/firstboot/firstboot.c
-@@ -491,7 +491,7 @@ static int process_timezone(void) {
+@@ -494,7 +494,7 @@ static int process_timezone(void) {
          if (isempty(arg_timezone))
                  return 0;
  
@@ -88,10 +88,10 @@ index 2cb4f80d5d..ebeaeac52f 100644
          (void) mkdir_parents(etc_localtime, 0755);
          if (symlink(e, etc_localtime) < 0)
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 438ca294db..98bd110d92 100644
+index 197e5aa252..c674fa61d5 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1887,8 +1887,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
+@@ -1899,8 +1899,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -137,5 +137,4 @@ index 0a8fe25d0f..2f02b9a520 100644
                          return -ENOMEM;
  
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
+++ b/pkgs/os-specific/linux/systemd/0010-localectl-use-etc-X11-xkb-for-list-x11.patch
@@ -1,4 +1,4 @@
-From f4e9304560ad42eeb8d42be583cc55eb2e5b4bb1 Mon Sep 17 00:00:00 2001
+From a93da270bed88972f4d60a1fa08f24e00712d7fb Mon Sep 17 00:00:00 2001
 From: Imuli <i@imu.li>
 Date: Wed, 19 Oct 2016 08:46:47 -0400
 Subject: [PATCH 10/19] localectl: use /etc/X11/xkb for list-x11-*
@@ -10,10 +10,10 @@ NixOS has an option to link the xkb data files to /etc/X11, but not to
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/locale/localectl.c b/src/locale/localectl.c
-index 548ac8eb2c..5e372f1566 100644
+index b5624209dc..4ab7adfdb6 100644
 --- a/src/locale/localectl.c
 +++ b/src/locale/localectl.c
-@@ -280,7 +280,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
+@@ -279,7 +279,7 @@ static int list_x11_keymaps(int argc, char **argv, void *userdata) {
          } state = NONE, look_for;
          int r;
  
@@ -23,5 +23,4 @@ index 548ac8eb2c..5e372f1566 100644
                  return log_error_errno(errno, "Failed to open keyboard mapping list. %m");
  
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
+++ b/pkgs/os-specific/linux/systemd/0011-build-don-t-create-statedir-and-don-t-touch-prefixdi.patch
@@ -1,4 +1,4 @@
-From 43a363f30b6012d600cfb62a3851c4ac7af4d1d5 Mon Sep 17 00:00:00 2001
+From 3bc3462165cd72de93a1c71f03e6c4150726b159 Mon Sep 17 00:00:00 2001
 From: Franz Pletz <fpletz@fnordicwalking.de>
 Date: Sun, 11 Feb 2018 04:37:44 +0100
 Subject: [PATCH 11/19] build: don't create statedir and don't touch prefixdir
@@ -8,12 +8,12 @@ Subject: [PATCH 11/19] build: don't create statedir and don't touch prefixdir
  1 file changed, 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 5bdfd9753d..5bf6afc7b7 100644
+index c0cbadecb1..8266bf57de 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -3539,9 +3539,6 @@ install_data('LICENSE.GPL2',
-              'docs/GVARIANT-SERIALIZATION.md',
-              install_dir : docdir)
+@@ -3729,9 +3729,6 @@ install_data('LICENSE.GPL2',
+ install_subdir('LICENSES',
+                install_dir : docdir)
  
 -meson.add_install_script('sh', '-c', mkdir_p.format(systemdstatedir))
 -meson.add_install_script('sh', '-c', 'touch $DESTDIR@0@'.format(prefixdir))
@@ -22,5 +22,4 @@ index 5bdfd9753d..5bf6afc7b7 100644
  
  # Ensure that changes to the docs/ directory do not break the
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0012-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0012-inherit-systemd-environment-when-calling-generators.patch
@@ -1,4 +1,4 @@
-From 7ea935a5ac4f31106ce9347227d4eb59b77b02cd Mon Sep 17 00:00:00 2001
+From 85f0ad0cb7b4f0cfd482c9611f9cbc2dacbba33a Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Fri, 2 Nov 2018 21:15:42 +0100
 Subject: [PATCH 12/19] inherit systemd environment when calling generators.
@@ -16,10 +16,10 @@ executables that are being called from managers.
  1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index b9b4789720..79239afe4a 100644
+index 5b0bdb1bc7..1538a5200a 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
-@@ -4149,10 +4149,15 @@ static int manager_run_generators(Manager *m) {
+@@ -3653,10 +3653,15 @@ static int manager_run_generators(Manager *m) {
          argv[4] = NULL;
  
          RUN_WITH_UMASK(0022)
@@ -40,5 +40,4 @@ index b9b4789720..79239afe4a 100644
  
  finish:
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0013-add-rootprefix-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0013-add-rootprefix-to-lookup-dir-paths.patch
@@ -1,4 +1,4 @@
-From eb93778af78a127e8e20d6ed7fd9f91fd22dc7c9 Mon Sep 17 00:00:00 2001
+From b30d2273d3ce1480b0c4c27c25211f84e04172e9 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
 Subject: [PATCH 13/19] add rootprefix to lookup dir paths
@@ -12,7 +12,7 @@ files that I might have missed.
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/def.h b/src/basic/def.h
-index 2e60abb4f1..732ec51d36 100644
+index eccee3d3fa..e94a2c8bd0 100644
 --- a/src/basic/def.h
 +++ b/src/basic/def.h
 @@ -39,13 +39,15 @@
@@ -34,5 +34,4 @@ index 2e60abb4f1..732ec51d36 100644
  #define CONF_PATHS(n)                           \
          CONF_PATHS_USR(n)                       \
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0014-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
+++ b/pkgs/os-specific/linux/systemd/0014-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
@@ -1,4 +1,4 @@
-From 1d623def80a3532ac1445499c9d4673e21ae8195 Mon Sep 17 00:00:00 2001
+From 76da27ff77e5db07e502d4d8d26286d69c3f0319 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:45:55 +0300
 Subject: [PATCH 14/19] systemd-shutdown: execute scripts in
@@ -10,12 +10,12 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shutdown/shutdown.c b/src/shutdown/shutdown.c
-index a98cfc4d8a..b0b34edda7 100644
+index 7ad9930677..fdb03a2e1a 100644
 --- a/src/shutdown/shutdown.c
 +++ b/src/shutdown/shutdown.c
-@@ -312,7 +312,7 @@ int main(int argc, char *argv[]) {
+@@ -335,7 +335,7 @@ int main(int argc, char *argv[]) {
          _cleanup_free_ char *cgroup = NULL;
-         char *arguments[3], *watchdog_device;
+         char *arguments[3];
          int cmd, r, umount_log_level = LOG_INFO;
 -        static const char* const dirs[] = {SYSTEM_SHUTDOWN_PATH, NULL};
 +        static const char* const dirs[] = {SYSTEM_SHUTDOWN_PATH, "/etc/systemd/system-shutdown", NULL};
@@ -23,5 +23,4 @@ index a98cfc4d8a..b0b34edda7 100644
          /* The log target defaults to console, but the original systemd process will pass its log target in through a
           * command line argument, which will override this default. Also, ensure we'll never log to the journal or
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0015-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
+++ b/pkgs/os-specific/linux/systemd/0015-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
@@ -1,4 +1,4 @@
-From 5a96c4a98be971d84a12ae04e42bc3cb889d5191 Mon Sep 17 00:00:00 2001
+From 47c651f97acae814d4ff679ae04d78d4532cbca6 Mon Sep 17 00:00:00 2001
 From: Nikolay Amiantov <ab@fmap.me>
 Date: Thu, 25 Jul 2019 20:46:58 +0300
 Subject: [PATCH 15/19] systemd-sleep: execute scripts in
@@ -10,7 +10,7 @@ This is needed for NixOS to use such scripts as systemd directory is immutable.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
-index a3aeb24633..0ed6a34d79 100644
+index 7064f3a905..b60ced9d9b 100644
 --- a/src/sleep/sleep.c
 +++ b/src/sleep/sleep.c
 @@ -182,6 +182,7 @@ static int execute(
@@ -22,5 +22,4 @@ index a3aeb24633..0ed6a34d79 100644
          };
  
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
+++ b/pkgs/os-specific/linux/systemd/0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
@@ -1,4 +1,4 @@
-From 775a2a8940c07f4af33a2a11bfa17e0257b427cb Mon Sep 17 00:00:00 2001
+From df0fec7ac2f33bcca60ba9a2396af33397ba42cc Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sat, 7 Mar 2020 22:40:27 +0100
 Subject: [PATCH 16/19] kmod-static-nodes.service: Update ConditionFileNotEmpty
@@ -28,5 +28,4 @@ index 777e82d16b..9a5e05a1cc 100644
  [Service]
  Type=oneshot
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0017-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
+++ b/pkgs/os-specific/linux/systemd/0017-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -1,4 +1,4 @@
-From 6ddb2011b379f3232374327517af874b68c434b5 Mon Sep 17 00:00:00 2001
+From f21722ac0f51b0b59a5c030af3db5fe4e6397f7c Mon Sep 17 00:00:00 2001
 From: Florian Klink <flokli@flokli.de>
 Date: Sun, 8 Mar 2020 01:05:54 +0100
 Subject: [PATCH 17/19] path-util.h: add placeholder for DEFAULT_PATH_NORMAL
@@ -10,7 +10,7 @@ systemd itself uses extensively.
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/basic/path-util.h b/src/basic/path-util.h
-index 26e7362d1f..a8f8a863ec 100644
+index 518f3340bf..18e826ea0b 100644
 --- a/src/basic/path-util.h
 +++ b/src/basic/path-util.h
 @@ -24,11 +24,11 @@
@@ -29,5 +29,4 @@ index 26e7362d1f..a8f8a863ec 100644
  #if HAVE_SPLIT_USR
  #  define DEFAULT_PATH DEFAULT_PATH_SPLIT_USR
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0018-pkg-config-derive-prefix-from-prefix.patch
+++ b/pkgs/os-specific/linux/systemd/0018-pkg-config-derive-prefix-from-prefix.patch
@@ -1,4 +1,4 @@
-From 50f2ada6cbfafa75b628410e8834f29581854e6f Mon Sep 17 00:00:00 2001
+From 968bd0c7bc058a4b05b6457f9ff20d02b70c9852 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
 Date: Sun, 6 Dec 2020 08:34:19 +0100
 Subject: [PATCH 18/19] pkg-config: derive prefix from --prefix
@@ -29,5 +29,4 @@ index 162432e77f..2fc20daf03 100644
  rootprefix=${root_prefix}
  sysconf_dir={{SYSCONF_DIR}}
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/0019-core-handle-lookup-paths-being-symlinks.patch
+++ b/pkgs/os-specific/linux/systemd/0019-core-handle-lookup-paths-being-symlinks.patch
@@ -1,4 +1,4 @@
-From 2ab388cf0be320879e668a6206cb15d002b55f98 Mon Sep 17 00:00:00 2001
+From 169fc6f270ff3e3903a7a31550c964152f9751ec Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Wed, 18 Aug 2021 19:10:08 +0200
 Subject: [PATCH 19/19] core: handle lookup paths being symlinks
@@ -15,10 +15,10 @@ directory itself is already a symlink.
  1 file changed, 31 insertions(+), 2 deletions(-)
 
 diff --git a/src/basic/unit-file.c b/src/basic/unit-file.c
-index 0d58b1c4fe..7314f1245f 100644
+index 30c632dfce..6179100126 100644
 --- a/src/basic/unit-file.c
 +++ b/src/basic/unit-file.c
-@@ -254,6 +254,7 @@ int unit_file_build_name_map(
+@@ -255,6 +255,7 @@ int unit_file_build_name_map(
  
          _cleanup_hashmap_free_ Hashmap *ids = NULL, *names = NULL;
          _cleanup_set_free_free_ Set *paths = NULL;
@@ -26,7 +26,7 @@ index 0d58b1c4fe..7314f1245f 100644
          uint64_t timestamp_hash;
          char **dir;
          int r;
-@@ -273,6 +274,34 @@ int unit_file_build_name_map(
+@@ -274,6 +275,34 @@ int unit_file_build_name_map(
                          return log_oom();
          }
  
@@ -59,9 +59,9 @@ index 0d58b1c4fe..7314f1245f 100644
 +        }
 +
          STRV_FOREACH(dir, (char**) lp->search_path) {
-                 struct dirent *de;
                  _cleanup_closedir_ DIR *d = NULL;
-@@ -351,11 +380,11 @@ int unit_file_build_name_map(
+ 
+@@ -386,11 +415,11 @@ int unit_file_build_name_map(
                                          continue;
                                  }
  
@@ -76,5 +76,4 @@ index 0d58b1c4fe..7314f1245f 100644
                                          log_debug("%s: linked unit file: %s → %s",
                                                    __func__, filename, simplified);
 -- 
-2.33.1
-
+2.34.0

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -29,7 +29,6 @@
   # Optional dependencies
 , pam
 , cryptsetup
-, lvm2
 , audit
 , acl
 , lz4

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -168,40 +168,43 @@ stdenv.mkDerivation {
     # need (AFAICT).
     # See https://github.com/systemd/systemd/pull/20479 for upsteam discussion.
     ./0019-core-handle-lookup-paths-being-symlinks.patch
-  ] ++ lib.optional stdenv.hostPlatform.isMusl (let
-    oe-core = fetchzip {
-      url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-14c6e5a4b72d0e4665279158a0740dd1dc21f72f.tar.bz2";
-      sha256 = "1jixya4czkr5p5rdcw3d6ips8zzr82dvnanvzvgjh67730scflya";
-    };
-    musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
-  in [
-    (musl-patches + "/0002-don-t-use-glibc-specific-qsort_r.patch")
-    (musl-patches + "/0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch")
-    (musl-patches + "/0004-add-fallback-parse_printf_format-implementation.patch")
-    (musl-patches + "/0005-src-basic-missing.h-check-for-missing-strndupa.patch")
-    (musl-patches + "/0006-Include-netinet-if_ether.h.patch")
-    (musl-patches + "/0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
-    (musl-patches + "/0008-add-missing-FTW_-macros-for-musl.patch")
-    (musl-patches + "/0009-fix-missing-of-__register_atfork-for-non-glibc-build.patch")
-    (musl-patches + "/0010-Use-uintmax_t-for-handling-rlim_t.patch")
-    (musl-patches + "/0011-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch")
-    (musl-patches + "/0012-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
-    (musl-patches + "/0013-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
-    (musl-patches + "/0014-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
-    (musl-patches + "/0015-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
-    (musl-patches + "/0016-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch")
-    (musl-patches + "/0017-missing_type.h-add-__compar_d_fn_t-definition.patch")
-    (musl-patches + "/0018-avoid-redefinition-of-prctl_mm_map-structure.patch")
-    (musl-patches + "/0019-Handle-missing-LOCK_EX.patch")
-    (musl-patches + "/0021-test-json.c-define-M_PIl.patch")
-    (musl-patches + "/0022-do-not-disable-buffer-in-writing-files.patch")
-    (musl-patches + "/0025-Handle-__cpu_mask-usage.patch")
-    (musl-patches + "/0026-Handle-missing-gshadow.patch")
-    (musl-patches + "/0028-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
+  ] ++ lib.optional stdenv.hostPlatform.isMusl (
+    let
+      oe-core = fetchzip {
+        url = "https://git.openembedded.org/openembedded-core/snapshot/openembedded-core-14c6e5a4b72d0e4665279158a0740dd1dc21f72f.tar.bz2";
+        sha256 = "1jixya4czkr5p5rdcw3d6ips8zzr82dvnanvzvgjh67730scflya";
+      };
+      musl-patches = oe-core + "/meta/recipes-core/systemd/systemd";
+    in
+    [
+      (musl-patches + "/0002-don-t-use-glibc-specific-qsort_r.patch")
+      (musl-patches + "/0003-missing_type.h-add-__compare_fn_t-and-comparison_fn_.patch")
+      (musl-patches + "/0004-add-fallback-parse_printf_format-implementation.patch")
+      (musl-patches + "/0005-src-basic-missing.h-check-for-missing-strndupa.patch")
+      (musl-patches + "/0006-Include-netinet-if_ether.h.patch")
+      (musl-patches + "/0007-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch")
+      (musl-patches + "/0008-add-missing-FTW_-macros-for-musl.patch")
+      (musl-patches + "/0009-fix-missing-of-__register_atfork-for-non-glibc-build.patch")
+      (musl-patches + "/0010-Use-uintmax_t-for-handling-rlim_t.patch")
+      (musl-patches + "/0011-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch")
+      (musl-patches + "/0012-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch")
+      (musl-patches + "/0013-Define-glibc-compatible-basename-for-non-glibc-syste.patch")
+      (musl-patches + "/0014-Do-not-disable-buffering-when-writing-to-oom_score_a.patch")
+      (musl-patches + "/0015-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch")
+      (musl-patches + "/0016-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch")
+      (musl-patches + "/0017-missing_type.h-add-__compar_d_fn_t-definition.patch")
+      (musl-patches + "/0018-avoid-redefinition-of-prctl_mm_map-structure.patch")
+      (musl-patches + "/0019-Handle-missing-LOCK_EX.patch")
+      (musl-patches + "/0021-test-json.c-define-M_PIl.patch")
+      (musl-patches + "/0022-do-not-disable-buffer-in-writing-files.patch")
+      (musl-patches + "/0025-Handle-__cpu_mask-usage.patch")
+      (musl-patches + "/0026-Handle-missing-gshadow.patch")
+      (musl-patches + "/0028-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch")
 
-    # Being discussed upstream: https://lists.openembedded.org/g/openembedded-core/topic/86411771#157056
-    ./musl.diff
-  ]);
+      # Being discussed upstream: https://lists.openembedded.org/g/openembedded-core/topic/86411771#157056
+      ./musl.diff
+    ]
+  );
 
   postPatch = ''
     substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -123,7 +123,7 @@ assert withHomed -> withCryptsetup;
 assert withCryptsetup -> (cryptsetup != null);
 let
   wantCurl = withRemote || withImportd;
-  version = "249.7";
+  version = "250.3";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -134,12 +134,12 @@ stdenv.mkDerivation {
     owner = "systemd";
     repo = "systemd-stable";
     rev = "v${version}";
-    sha256 = "sha256-y33/BvvI+JyhsvuT1Cbm6J2Z72j71oXgLw6X9NwCMPE=";
+    sha256 = "sha256-O1XE0BhIuDAlFVX7WIy02M9YTIxLX0Q8atJAYsUgQDQ=";
   };
 
-  # If these need to be regenerated, `git am path/to/00*.patch` them into a
-  # systemd worktree, rebase to the more recent systemd version, and export the
-  # patches again via `git -c format.signoff=false format-patch v${version}`.
+  # On major changes, or when otherwise required, you *must* reformat the patches,
+  # `git am path/to/00*.patch` them into a systemd worktree, rebase to the more recent
+  # systemd version, and export the patches again via `git -c format.signoff=false format-patch v${version}`.
   # Use `find . -name "*.patch" | sort` to get an up-to-date listing of all patches
   patches = [
     ./0001-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -160,7 +160,6 @@ stdenv.mkDerivation {
     ./0016-kmod-static-nodes.service-Update-ConditionFileNotEmp.patch
     ./0017-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
     ./0018-pkg-config-derive-prefix-from-prefix.patch
-
     # In v248 or v249 we started to get in trouble due to our
     # /etc/systemd/system being a symlink and thus being treated differently by
     # systemd. With the below patch we mitigate that effect by special casing
@@ -279,6 +278,10 @@ stdenv.mkDerivation {
           { name = "libtss2-mu.so.0"; pkg = opt withTpm2Tss tpm2-tss; }
           { name = "libtss2-tcti-"; pkg = opt withTpm2Tss tpm2-tss; }
           { name = "libfido2.so.1"; pkg = opt withFido2 libfido2; }
+
+          # inspect-elf support
+          { name = "libelf.so.1"; pkg = opt withCoredump elfutils; }
+          { name = "libdw.so.1"; pkg = opt withCoredump elfutils; }
         ];
 
       patchDlOpen = dl:
@@ -438,7 +441,12 @@ stdenv.mkDerivation {
     "-Dsmack=true"
     "-Db_pie=true"
     "-Dinstall-sysconfdir=false"
-    "-Defi-ld=${stdenv.cc.bintools.targetPrefix}ld"
+    "-Defi-ld=gold"
+    "-Dsbat-distro=nixos"
+    "-Dsbat-distro-summary=NixOS"
+    "-Dsbat-distro-url=https://nixos.org/"
+    "-Dsbat-distro-pkgname=${pname}"
+    "-Dsbat-distro-version=${version}"
     /*
       As of now, systemd doesn't allow runtime configuration of these values. So
       the settings in /etc/login.defs have no effect on it. Many people think this
@@ -490,57 +498,105 @@ stdenv.mkDerivation {
     "-Dutmp=false"
     "-Didn=false"
   ];
+  preConfigure =
+    let
+      # A list of all the runtime binaries that the systemd exectuables, tests and libraries are referencing in their source code, scripts and unit files.
+      # As soon as a dependency isn't required anymore we should remove it from the list. The `where` attribute for each of the replacement patterns must be exhaustive. If another (unhandled) case is found in the source code the build fails with an error message.
+      binaryReplacements = [
+        { search = "/usr/bin/getent"; replacement = "${getent}/bin/getent"; where = [ "src/nspawn/nspawn-setuid.c" ]; }
 
-  preConfigure = ''
-    mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")
-    export LC_ALL="en_US.UTF-8";
-    # FIXME: patch this in systemd properly (and send upstream).
-    # already fixed in f00929ad622c978f8ad83590a15a765b4beecac9: (u)mount
-    for i in \
-      src/core/mount.c \
-      src/core/swap.c \
-      src/cryptsetup/cryptsetup-generator.c \
-      src/journal/cat.c \
-      src/nspawn/nspawn.c \
-      src/remount-fs/remount-fs.c \
-      src/shared/generator.c \
-      src/shutdown/shutdown.c \
-      units/emergency.service.in \
-      units/modprobe@.service \
-      units/rescue.service.in \
-      units/systemd-logind.service.in \
-      units/systemd-nspawn@.service.in; \
-    do
-      test -e $i
-      substituteInPlace $i \
-        --replace /usr/bin/getent ${getent}/bin/getent \
-        --replace /sbin/mkswap ${lib.getBin util-linux}/sbin/mkswap \
-        --replace /sbin/swapon ${lib.getBin util-linux}/sbin/swapon \
-        --replace /sbin/swapoff ${lib.getBin util-linux}/sbin/swapoff \
-        --replace /bin/echo ${coreutils}/bin/echo \
-        --replace /bin/cat ${coreutils}/bin/cat \
-        --replace /sbin/sulogin ${lib.getBin util-linux}/sbin/sulogin \
-        --replace /sbin/modprobe ${lib.getBin kmod}/sbin/modprobe \
-        --replace /usr/lib/systemd/systemd-fsck $out/lib/systemd/systemd-fsck \
-        --replace /bin/plymouth /run/current-system/sw/bin/plymouth # To avoid dependency
-    done
+        {
+          search = "/sbin/mkswap";
+          replacement = "${lib.getBin util-linux}/sbin/mkswap";
+          where = [
+            "man/systemd-makefs@.service.xml"
+          ];
+        }
+        { search = "/sbin/swapon"; replacement = "${lib.getBin util-linux}/sbin/swapon"; where = [ "src/core/swap.c" "src/basic/unit-def.h" ]; }
+        { search = "/sbin/swapoff"; replacement = "${lib.getBin util-linux}/sbin/swapoff"; where = [ "src/core/swap.c" ]; }
+        {
+          search = "/bin/echo";
+          replacement = "${coreutils}/bin/echo";
+          where = [
+            "man/systemd-analyze.xml"
+            "man/systemd.service.xml"
+            "src/analyze/test-verify.c"
+            "src/test/test-env-file.c"
+            "src/test/test-fileio.c"
+            "test/test-execute/exec-systemcallfilter-failing2.service"
+            "test/test-execute/exec-systemcallfilter-failing3.service"
+            "test/test-execute/exec-systemcallfilter-failing.service"
+            "test/testsuite-06.units/hola.service"
+            "test/udev-test.pl"
+            "test/units/hello.service"
+            "test/units/testsuite-07.sh"
+            "test/units/testsuite-15.sh"
+            "test/units/testsuite-17.05.sh"
+            "test/units/testsuite-40.sh"
+            "test/units/unstoppable.service"
+          ];
+        }
+        {
+          search = "/bin/cat";
+          replacement = "${coreutils}/bin/cat";
+          where = [ "test/create-busybox-container" "test/test-execute/exec-noexecpaths-simple.service" "src/journal/cat.c" ];
+        }
+        { search = "/sbin/modprobe"; replacement = "${lib.getBin kmod}/sbin/modprobe"; where = [ "units/modprobe@.service" ]; }
+        {
+          search = "/usr/lib/systemd/systemd-fsck";
+          replacement = "$out/lib/systemd/systemd-fsck";
+          where = [ "man/systemd-fsck@.service.xml" ];
+        }
+      ] ++ lib.optionals withImportd [
+        {
+          search = "\"gpg\"";
+          replacement = "\\\"${gnupg}/bin/gpg\\\"";
+          where = [ "src/import/pull-common.c" ];
+        }
+        {
+          search = "\"tar\"";
+          replacement = "\\\"${gnutar}/bin/tar\\\"";
+          where = [
+            "src/import/export-tar.c"
+            "src/import/export.c"
+            "src/import/import-common.c"
+            "src/import/import-tar.c"
+            "src/import/import.c"
+            "src/import/importd.c"
+            "src/import/pull-tar.c"
+            "src/import/pull.c"
+          ];
+        }
+      ];
 
-    for dir in tools src/resolve test src/test src/shared; do
-      patchShebangs $dir
-    done
+      # { replacement, search, where } -> List[str]
+      mkSubstitute = { replacement, search, where }:
+        map (path: "substituteInPlace ${path} --replace '${search}' \"${replacement}\"") where;
+      mkEnsureSubstituted = { replacement, search, where }:
+        ''
+          if [[ $(grep -r '${search}' | grep -v "${replacement}" | grep -Ev 'NEWS|^test/' | wc -l) -gt 0 ]]; then
+            echo "Not all references to '${search}' have been replace. Found the following matches:"
+            grep '${search}' -r | grep -v "${replacement}" | grep -Ev 'NEWS|^test/'
+            exit 1
+          fi
+        '';
 
-    # absolute paths to gpg & tar
-    substituteInPlace src/import/pull-common.c \
-      --replace '"gpg"' '"${gnupg}/bin/gpg"'
-    for file in src/import/{{export,import,pull}-tar,import-common}.c; do
-      substituteInPlace $file \
-        --replace '"tar"' '"${gnutar}/bin/tar"'
-    done
+    in
+    ''
+      mesonFlagsArray+=(-Dntp-servers="0.nixos.pool.ntp.org 1.nixos.pool.ntp.org 2.nixos.pool.ntp.org 3.nixos.pool.ntp.org")
+      export LC_ALL="en_US.UTF-8";
+
+      ${lib.concatStringsSep "\n" (lib.flatten (map mkSubstitute binaryReplacements))}
+      ${lib.concatMapStringsSep "\n" mkEnsureSubstituted binaryReplacements}
 
 
-    substituteInPlace src/libsystemd/sd-journal/catalog.c \
-      --replace /usr/lib/systemd/catalog/ $out/lib/systemd/catalog/
-  '';
+      for dir in tools src/resolve test src/test src/shared; do
+        patchShebangs $dir
+      done
+
+      substituteInPlace src/libsystemd/sd-journal/catalog.c \
+        --replace /usr/lib/systemd/catalog/ $out/lib/systemd/catalog/
+    '';
 
   # These defines are overridden by CFLAGS and would trigger annoying
   # warning messages
@@ -548,7 +604,7 @@ stdenv.mkDerivation {
     substituteInPlace config.h \
       --replace "POLKIT_AGENT_BINARY_PATH" "_POLKIT_AGENT_BINARY_PATH" \
       --replace "SYSTEMD_BINARY_PATH" "_SYSTEMD_BINARY_PATH" \
-      --replace "SYSTEMD_CGROUP_AGENT_PATH" "_SYSTEMD_CGROUP_AGENT_PATH"
+      --replace "SYSTEMD_CGROUP_AGENTS_PATH" "_SYSTEMD_CGROUP_AGENT_PATH"
   '';
 
   NIX_CFLAGS_COMPILE = toString ([
@@ -560,8 +616,8 @@ stdenv.mkDerivation {
     # Set the release_agent on /sys/fs/cgroup/systemd to the
     # currently running systemd (/run/current-system/systemd) so
     # that we don't use an obsolete/garbage-collected release agent.
-    "-USYSTEMD_CGROUP_AGENT_PATH"
-    "-DSYSTEMD_CGROUP_AGENT_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
+    "-USYSTEMD_CGROUP_AGENTS_PATH"
+    "-DSYSTEMD_CGROUP_AGENTS_PATH=\"/run/current-system/systemd/lib/systemd/systemd-cgroups-agent\""
 
     "-USYSTEMD_BINARY_PATH"
     "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
@@ -596,6 +652,13 @@ stdenv.mkDerivation {
   '' + lib.optionalString (!withDocumentation) ''
     rm -rf $out/share/doc
   '';
+
+  disallowedReferences =
+    [
+
+    ]
+    ++ lib.optional withTests [ glib ]
+  ;
 
   # The interface version prevents NixOS from switching to an
   # incompatible systemd at runtime.  (Switching across reboots is

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -15,6 +15,8 @@
 , gperf
 , getent
 , glibcLocales
+
+  # glib is only used during tests (test-bus-gvariant, test-bus-marshal)
 , glib
 , substituteAll
 , gettext
@@ -98,6 +100,8 @@
 , withTimesyncd ? true
 , withTpm2Tss ? !stdenv.hostPlatform.isMusl
 , withUserDb ? !stdenv.hostPlatform.isMusl
+  # tests assume too much system access for them to be feasible for us right now
+, withTests ? false
 
   # name argument
 , pname ? "systemd"
@@ -362,7 +366,6 @@ stdenv.mkDerivation {
     [
       acl
       audit
-      glib
       kmod
       libcap
       libidn2
@@ -372,6 +375,7 @@ stdenv.mkDerivation {
     ]
 
     ++ lib.optional wantGcrypt libgcrypt
+    ++ lib.optional withTests glib
     ++ lib.optional withApparmor libapparmor
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz zstd ]
@@ -406,7 +410,7 @@ stdenv.mkDerivation {
     "-Dsetfont-path=${kbd}/bin/setfont"
     "-Dtty-gid=3" # tty in NixOS has gid 3
     "-Ddebug-shell=${bashInteractive}/bin/bash"
-    "-Dglib=${lib.boolToString (glib != null)}"
+    "-Dglib=${lib.boolToString withTests}"
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
     "-Danalyze=${lib.boolToString withAnalyze}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -61,6 +61,8 @@
 , kexec-tools
 , bashInteractive
 , libmicrohttpd
+, libfido2
+, p11-kit
 
   # the (optional) BPF feature requires bpftool, libbpf, clang and llmv-strip to be avilable during build time.
   # Only libbpf should be a runtime dependency.
@@ -97,8 +99,6 @@
 , withTimesyncd ? true
 , withTpm2Tss ? !stdenv.hostPlatform.isMusl
 , withUserDb ? !stdenv.hostPlatform.isMusl
-, libfido2
-, p11-kit
 
   # name argument
 , pname ? "systemd"
@@ -123,6 +123,7 @@ assert withHomed -> withCryptsetup;
 assert withCryptsetup -> (cryptsetup != null);
 let
   wantCurl = withRemote || withImportd;
+  wantGcrypt = withResolved || withImportd;
   version = "250.3";
 in
 stdenv.mkDerivation {
@@ -365,13 +366,13 @@ stdenv.mkDerivation {
       glib
       kmod
       libcap
-      libgcrypt
       libidn2
       libuuid
       linuxHeaders
       pam
     ]
 
+    ++ lib.optional wantGcrypt libgcrypt
     ++ lib.optional withApparmor libapparmor
     ++ lib.optional wantCurl (lib.getDev curl)
     ++ lib.optionals withCompression [ bzip2 lz4 xz zstd ]
@@ -410,7 +411,7 @@ stdenv.mkDerivation {
     # while we do not run tests we should also not build them. Removes about 600 targets
     "-Dtests=false"
     "-Danalyze=${lib.boolToString withAnalyze}"
-    "-Dgcrypt=${lib.boolToString (libgcrypt != null)}"
+    "-Dgcrypt=${lib.boolToString wantGcrypt}"
     "-Dimportd=${lib.boolToString withImportd}"
     "-Dlz4=${lib.boolToString withCompression}"
     "-Dhomed=${lib.boolToString withHomed}"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -128,6 +128,12 @@ let
   wantCurl = withRemote || withImportd;
   wantGcrypt = withResolved || withImportd;
   version = "250.3";
+
+  # Bump this variable on every (major) version change. See below (in the meson options list) for why.
+  # command:
+  #  $ curl -s https://api.github.com/repos/systemd/systemd/releases/latest | \
+  #     jq '.created_at|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
+  releaseTimestamp = "1640290180";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -399,6 +405,14 @@ stdenv.mkDerivation {
 
   mesonFlags = [
     "-Dversion-tag=${version}"
+    # We bump this variable on every (major) version change to ensure
+    # that we have known-good value for a timestamp that is in the (not so distant) past.
+    # This serves as a lower bound for valid system timestamps during startup. Systemd will
+    # reset the system timestamp if this date is +- 15 years from the system time.
+    # See the systemd v250 release notes for further details:
+    # https://github.com/systemd/systemd/blob/60e930fc3e6eb8a36fbc184773119eb8d2f30364/NEWS#L258-L266
+    "-Dtime-epoch=${releaseTimestamp}"
+
     "-Ddbuspolicydir=${placeholder "out"}/share/dbus-1/system.d"
     "-Ddbussessionservicedir=${placeholder "out"}/share/dbus-1/services"
     "-Ddbussystemservicedir=${placeholder "out"}/share/dbus-1/system-services"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23028,10 +23028,8 @@ with pkgs;
     withTpm2Tss = false;
     withUserDb = false;
     glib = null;
-    libgcrypt = null;
+
     lvm2 = null;
-    libfido2 = null;
-    p11-kit = null;
   };
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23027,7 +23027,6 @@ with pkgs;
     withTimesyncd = false;
     withTpm2Tss = false;
     withUserDb = false;
-    glib = null;
   };
 
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23028,8 +23028,6 @@ with pkgs;
     withTpm2Tss = false;
     withUserDb = false;
     glib = null;
-
-    lvm2 = null;
   };
 
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
