### PR TITLE
ocamlformat-rpc: init at 0.20.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlformat-rpc/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat-rpc/default.nix
@@ -1,0 +1,16 @@
+{ callPackage }:
+
+
+let mkocamlformat-rpc = callPackage ./generic.nix; in
+
+rec {
+  ocamlformat-rpc_0_20_0 = mkocamlformat-rpc {
+    version = "0.20.0";
+  };
+
+  ocamlformat-rpc_0_20_1 = mkocamlformat-rpc {
+    version = "0.20.1";
+  };
+
+  ocamlformat-rpc = ocamlformat-rpc_0_20_1;
+}

--- a/pkgs/development/tools/ocaml/ocamlformat-rpc/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat-rpc/generic.nix
@@ -1,0 +1,54 @@
+{ lib, fetchurl, fetchzip, ocaml-ng
+, version
+, tarballName ? "ocamlformat-${version}.tbz",
+}:
+
+let src =
+  fetchurl {
+    url = "https://github.com/ocaml-ppx/ocamlformat/releases/download/${version}/${tarballName}";
+    sha256 = {
+      "0.20.0" = "sha256-JtmNCgwjbCyUE4bWqdH5Nc2YSit+rekwS43DcviIfgk=";
+      "0.20.1" = "sha256-fTpRZFQW+ngoc0T6A69reEUAZ6GmHkeQvxspd5zRAjU=";
+    }."${version}";
+  };
+  ocamlPackages = ocaml-ng.ocamlPackages;
+in
+
+with ocamlPackages;
+
+buildDunePackage {
+  pname = "ocamlformat-rpc";
+  inherit src version;
+
+  minimumOCamlVersion = "4.08";
+
+  useDune2 = true;
+
+  buildInputs = [
+    ocamlformat-rpc-lib
+    base
+    cmdliner
+    dune-build-info
+    either
+    fix
+    fpath
+    menhir
+    menhirLib
+    menhirSdk
+    ocaml-version
+    ocp-indent
+    (if version == "0.20.0" then odoc-parser.override { version = "0.9.0"; } else odoc-parser)
+    re
+    stdio
+    uuseg
+    uutf
+  ];
+
+  meta = {
+    homepage = "https://github.com/ocaml-ppx/ocamlformat";
+    description = "Auto-formatter for OCaml code, RPC interface";
+    maintainers = [ lib.maintainers.ulrikstrid ];
+    license = lib.licenses.mit;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12850,6 +12850,10 @@ with pkgs;
     ocamlformat_0_15_1 ocamlformat_0_16_0 ocamlformat_0_17_0 ocamlformat_0_18_0
     ocamlformat_0_19_0 ocamlformat_0_20_0 ocamlformat_0_20_1;
 
+  inherit (callPackage ../development/tools/ocaml/ocamlformat-rpc { })
+    ocamlformat-rpc # latest version
+    ocamlformat-rpc_0_20_0 ocamlformat-rpc_0_20_1;
+
   orc = callPackage ../development/compilers/orc { };
 
   orocos-kdl = callPackage ../development/libraries/orocos-kdl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

ocamlformat-rpc is a new package that is used by ocamlplatform vscode extension.

if @Zimmi48  and @marsam wants to be maintainers for this as well since it is released in tandem with `ocamlformat` feel free to take over.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
