### PR TITLE
[staging-next] libredirect: fix build for aarch64-darwin

### DIFF
--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -44,7 +44,7 @@ else stdenv.mkDerivation rec {
       -isystem ${llvmPackages_13.clang.libc}/include \
       -isystem ${llvmPackages_13.libclang.lib}/lib/clang/*/include \
       -L${llvmPackages_13.clang.libc}/lib \
-      -Wl,-install_name,$out/lib/$libName \
+      -Wl,-install_name,$libName \
       -Wall -std=c99 -O3 -fPIC libredirect.c \
       -ldl -shared -o "$libName"
     '' else if stdenv.isDarwin then ''
@@ -72,7 +72,12 @@ else stdenv.mkDerivation rec {
     runHook preInstall
 
     install -vD "$libName" "$out/lib/$libName"
-
+  '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
+    # dylib will be rejected unless dylib rpath gets explictly set
+    install_name_tool \
+      -change $libName $out/lib/$libName \
+      $out/lib/$libName
+  '' + ''
     # Provide a setup hook that injects our library into every process.
     mkdir -p "$hook/nix-support"
     cat <<SETUP_HOOK > "$hook/nix-support/setup-hook"

--- a/pkgs/build-support/libredirect/default.nix
+++ b/pkgs/build-support/libredirect/default.nix
@@ -72,6 +72,7 @@ else stdenv.mkDerivation rec {
     runHook preInstall
 
     install -vD "$libName" "$out/lib/$libName"
+
   '' + lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) ''
     # dylib will be rejected unless dylib rpath gets explictly set
     install_name_tool \


### PR DESCRIPTION
###### Motivation for this change
Fix failing build for m1 mac

related: #154708
closes: #152667

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
