### PR TITLE
viper4linux-gui: init at unstable-2022-04-23

### DIFF
--- a/pkgs/applications/audio/viper4linux-gui/default.nix
+++ b/pkgs/applications/audio/viper4linux-gui/default.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, copyDesktopItems
+, pkg-config
+, qtbase
+, qtsvg
+, qtmultimedia
+, qmake
+, gst_all_1
+, libpulseaudio
+, makeDesktopItem
+, viper4linux
+, wrapQtAppsHook
+}:
+let
+  gstPluginPath = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with gst_all_1; [ gstreamer gst-plugins-viperfx gst-plugins-base gst-plugins-good ]);
+in
+stdenv.mkDerivation rec {
+  pname = "viper4linux-gui";
+  version = "unstable-2022-04-23";
+
+  src = fetchFromGitHub {
+    owner = "Audio4Linux";
+    repo = "Viper4Linux-GUI";
+    rev = "2d0c84d7dda76c59e31c850e38120002eb779b7a";
+    sha256 = "sha256-5YlLCF598i/sldczPEgCB+1KJDA7jqM964QDSNjgTKM=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = "viper-gui";
+      icon = "viper";
+      desktopName = "viper4linux";
+      genericName = "Equalizer";
+      comment = meta.description;
+      categories = [ "AudioVideo" "Audio" ];
+      startupNotify = false;
+    })
+  ];
+
+  nativeBuildInputs = [
+    qmake
+    pkg-config
+    wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qtbase
+    qtmultimedia
+    qtsvg
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-viperfx
+    libpulseaudio
+    viper4linux
+  ];
+
+  qmakeFlags = [ "V4L_Frontend.pro" ];
+
+  qtWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ viper4linux gst_all_1.gstreamer ]}"
+    "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${gstPluginPath}"
+  ];
+
+  installPhase = ''
+    runHook preInstalli
+    install -D V4L_Frontend $out/bin/viper-gui
+    install -D icons/viper.png $out/share/icons/viper.png
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Official UI for Viper4Linux2";
+    homepage = "https://github.com/Audio4Linux/Viper4Linux-GUI";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/applications/audio/viper4linux/default.nix
+++ b/pkgs/applications/audio/viper4linux/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, gst_all_1
+, libviperfx
+, makeWrapper
+}:
+let
+  gstPluginPath = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" (with gst_all_1; [ gstreamer gst-plugins-viperfx gst-plugins-base gst-plugins-good ]);
+in
+stdenv.mkDerivation rec {
+  pname = "viper4linux";
+  version = "unstable-2022-03-13";
+
+  src = fetchFromGitHub {
+    owner = "Audio4Linux";
+    repo = "Viper4Linux";
+    rev = "5da25644824f88cf0db24378d2c84770ba4f6816";
+    sha256 = "sha256-CJNVr/1ehJzX45mxunXcRAypBBGEBdswOzAVG2H+ayg=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-viperfx
+    libviperfx
+  ];
+
+  dontBuild = true;
+
+  postPatch = ''
+    substituteInPlace viper --replace "/etc/viper4linux" "$out/etc/viper4linux"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D viper -t $out/bin
+    mkdir -p $out/etc/viper4linux
+    cp -r viper4linux/* $out/etc/viper4linux
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/viper" \
+      --prefix PATH : $out/bin:${lib.makeBinPath [ gst_all_1.gstreamer ]} \
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : ${gstPluginPath} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libviperfx ]}
+  '';
+
+  meta = with lib; {
+    description = "An Adaptive Digital Sound Processor";
+    homepage = "https://github.com/Audio4Linux/Viper4Linux";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/development/libraries/gstreamer/default.nix
+++ b/pkgs/development/libraries/gstreamer/default.nix
@@ -13,6 +13,8 @@
 
   gst-plugins-ugly = callPackage ./ugly { inherit CoreFoundation DiskArbitration IOKit; };
 
+  gst-plugins-viperfx = callPackage ./viperfx { };
+
   gst-rtsp-server = callPackage ./rtsp-server { };
 
   gst-libav = callPackage ./libav { };

--- a/pkgs/development/libraries/gstreamer/viperfx/default.nix
+++ b/pkgs/development/libraries/gstreamer/viperfx/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook
+, gst_all_1
+, cmake
+}:
+stdenv.mkDerivation rec {
+  pname = "gst-plugins-viperfx";
+  version = "unstable-2020-9-20";
+
+  src = fetchFromGitHub {
+    owner = "Audio4Linux";
+    repo = "gst-plugin-viperfx";
+    rev = "a5c1b03dfe1ab0822b717a5f9392e9f1237fdba0";
+    sha256 = "sha256-0so4jV56nl3tZHuZpvtyMrpOZ4tNJ59Pyj6zbV5bJ5Y=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config wrapGAppsHook ];
+
+  propagatedBuildInputs = [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D libgstviperfx.so $out/lib/gstreamer-1.0/libgstviperfx.so
+    install -D $src/COPYING $out/share/licenses/gst-plugins-viperfx/LICENSE
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "ViPER FX core wrapper plug-in for GStreamer1";
+    homepage = "https://github.com/Audio4Linux/gst-plugin-viperfx";
+    license = licenses.unfreeRedistributable;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ rewine ];
+  };
+}

--- a/pkgs/development/libraries/libviperfx/default.nix
+++ b/pkgs/development/libraries/libviperfx/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "libviperfx";
+  version = "unstable-2018-01-15";
+
+  src = fetchFromGitHub {
+    owner = "vipersaudio";
+    repo = "viperfx_core_binary";
+    rev = "6f7d0da725affe854f083baf5d90c70e172e4488";
+    sha256 = "sha256-hfX46Kk91eQgiO3uhew91I6eEHxazhdGwSkhfNZ+HvQ=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -D libviperfx_x64_linux.so $out/lib/libviperfx.so
+    install -D README.md $out/share/licenses/libviperfx/LICENSE
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/vipersaudio/viperfx_core_binary";
+    description = "The ViPER FX core";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ rewine ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19266,6 +19266,8 @@ with pkgs;
 
   libviper = callPackage ../development/libraries/libviper { };
 
+  libviperfx = callPackage ../development/libraries/libviperfx { };
+
   libvpx = callPackage ../development/libraries/libvpx { };
   libvpx_1_8 = callPackage ../development/libraries/libvpx/1_8.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30221,6 +30221,7 @@ with pkgs;
   uvcdynctrl = callPackage ../os-specific/linux/uvcdynctrl { };
 
   viper4linux = callPackage ../applications/audio/viper4linux { };
+  viper4linux-gui = libsForQt5.callPackage ../applications/audio/viper4linux-gui { };
 
   vkeybd = callPackage ../applications/audio/vkeybd {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30220,6 +30220,8 @@ with pkgs;
 
   uvcdynctrl = callPackage ../os-specific/linux/uvcdynctrl { };
 
+  viper4linux = callPackage ../applications/audio/viper4linux { };
+
   vkeybd = callPackage ../applications/audio/vkeybd {};
 
   vlc = libsForQt5.callPackage ../applications/video/vlc {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
