### PR TITLE
roc-toolkit: bump scons

### DIFF
--- a/pkgs/development/libraries/audio/roc-toolkit/0001-Remove-deprecated-scons-call.patch
+++ b/pkgs/development/libraries/audio/roc-toolkit/0001-Remove-deprecated-scons-call.patch
@@ -1,0 +1,24 @@
+From abdfbb94df98fe88be4dd92ca587500126558411 Mon Sep 17 00:00:00 2001
+From: Victor Gaydov <victor@enise.org>
+Date: Sun, 26 Jul 2020 11:54:52 +0300
+Subject: [PATCH] Remove deprecated scons call
+
+---
+ SConstruct | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/SConstruct b/SConstruct
+index 407025d8..04afa91f 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -49,7 +49,6 @@ env = Environment(ENV=os.environ, tools=[
+ # performance tuning
+ env.Decider('MD5-timestamp')
+ env.SetOption('implicit_cache', 1)
+-env.SourceCode('.', None)
+ 
+ # provide absolute path to force single sconsign file
+ # per-directory sconsign files seems to be buggy with generated sources
+-- 
+2.34.1
+

--- a/pkgs/development/libraries/audio/roc-toolkit/0002-Fix-compatibility-with-new-SCons.patch
+++ b/pkgs/development/libraries/audio/roc-toolkit/0002-Fix-compatibility-with-new-SCons.patch
@@ -1,0 +1,31 @@
+From 15b37bb12a362c7889ac431eca4a47d6b2bdb97c Mon Sep 17 00:00:00 2001
+From: Victor Gaydov <victor@enise.org>
+Date: Sat, 5 Dec 2020 18:38:36 +0300
+Subject: [PATCH] Fix compatibility with new SCons
+
+---
+ site_scons/site_tools/roc/config.py | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/site_scons/site_tools/roc/config.py b/site_scons/site_tools/roc/config.py
+index b42b3adb..03b76be7 100644
+--- a/site_scons/site_tools/roc/config.py
++++ b/site_scons/site_tools/roc/config.py
+@@ -13,7 +13,13 @@ def _run_prog(context, src, suffix):
+     # RunProg may incorrectly use cached results from a previous run saved for
+     # different file contents but the same invocation number. To prevent this, we
+     # monkey patch its global counter with a hashsum of the file contents.
+-    SCons.SConf._ac_build_counter = int(hashlib.md5(src.encode()).hexdigest(), 16)
++    # The workaround is needed only for older versions of SCons, where
++    # _ac_build_counter was an integer.
++    try:
++        if type(SCons.SConf._ac_build_counter) is int:
++            SCons.SConf._ac_build_counter = int(hashlib.md5(src.encode()).hexdigest(), 16)
++    except:
++        pass
+     return context.RunProg(src, suffix)
+ 
+ def CheckLibWithHeaderExt(context, libs, headers, language, expr='1', run=True):
+-- 
+2.34.1
+

--- a/pkgs/development/libraries/audio/roc-toolkit/default.nix
+++ b/pkgs/development/libraries/audio/roc-toolkit/default.nix
@@ -1,7 +1,7 @@
 { stdenv,
   lib,
   fetchFromGitHub,
-  sconsPackages,
+  scons,
   ragel,
   gengetopt,
   pkg-config,
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    sconsPackages.scons_3_0_1
+    scons
     ragel
     gengetopt
     pkg-config
@@ -44,6 +44,7 @@ stdenv.mkDerivation rec {
       "--host=${stdenv.hostPlatform.config}"
       "--prefix=${placeholder "out"}"
       "--disable-sox"
+      "--disable-doc"
       "--disable-tests" ] ++
     lib.optional (!libunwindSupport) "--disable-libunwind" ++
     lib.optional (!pulseaudioSupport) "--disable-pulseaudio" ++
@@ -54,6 +55,12 @@ stdenv.mkDerivation rec {
 
   prePatch = lib.optionalString stdenv.isAarch64
     "sed -i 's/c++98/c++11/g' SConstruct";
+
+  # TODO: Remove these patches in the next version.
+  patches = [
+    ./0001-Remove-deprecated-scons-call.patch
+    ./0002-Fix-compatibility-with-new-SCons.patch
+  ];
 
   meta = with lib; {
     description = "Roc is a toolkit for real-time audio streaming over the network";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Scons 3 uses python2 by default on nix, bumping scons removes the python2 dependency.
#148779

###### Things done

Updated the scons version and added two patches from upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
