### PR TITLE
tree-sitter: 0.20.2 -> 0.20.4 and updater script fixes

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -29,9 +29,9 @@ let
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) OPTIONAL: Set GITHUB_TOKEN env variable to avoid api rate limit
   # 4) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.20.2";
-  sha256 = "sha256-XCTS58q1XCl7XH6SLTZDZv22nUPBK8d4oqk063ZObkg=";
-  cargoSha256 = "sha256-fKS9Q3BFGzyMnbNH6ItYnPj4dybeX7ucQfzYiOxVvhA=";
+  version = "0.20.3";
+  sha256 = "sha256-I0jHuW9bcaJrp49gHqbWQCPiTtxgMK6hFVlVj3x/zBA=";
+  cargoSha256 = "sha256-9qbCQYdpGxPrZMiNmG5ZrqyuYbhSeADaYOgnn+zHDog=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -29,9 +29,9 @@ let
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) OPTIONAL: Set GITHUB_TOKEN env variable to avoid api rate limit
   # 4) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.20.3";
-  sha256 = "sha256-I0jHuW9bcaJrp49gHqbWQCPiTtxgMK6hFVlVj3x/zBA=";
-  cargoSha256 = "sha256-9qbCQYdpGxPrZMiNmG5ZrqyuYbhSeADaYOgnn+zHDog=";
+  version = "0.20.4";
+  sha256 = "sha256-H/7j4HnaccmaH5m/FMTbi01uA3JtKVHiJLTQ4VZ7jfo=";
+  cargoSha256 = "sha256-Pf/gVBQFssOomzq0IZp5H7MYwvFBRjMYfifLKCB7DCs=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -1,5 +1,4 @@
 { lib }:
-
 {
   tree-sitter-agda = lib.importJSON ./tree-sitter-agda.json;
   tree-sitter-bash = lib.importJSON ./tree-sitter-bash.json;
@@ -55,8 +54,8 @@
   tree-sitter-nix = lib.importJSON ./tree-sitter-nix.json;
   tree-sitter-norg = lib.importJSON ./tree-sitter-norg.json;
   tree-sitter-ocaml = lib.importJSON ./tree-sitter-ocaml.json;
-  tree-sitter-perl = lib.importJSON ./tree-sitter-perl.json;
   tree-sitter-org = lib.importJSON ./tree-sitter-org.json;
+  tree-sitter-perl = lib.importJSON ./tree-sitter-perl.json;
   tree-sitter-php = lib.importJSON ./tree-sitter-php.json;
   tree-sitter-pioasm = lib.importJSON ./tree-sitter-pioasm.json;
   tree-sitter-prisma = lib.importJSON ./tree-sitter-prisma.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-c-sharp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-c-sharp",
-  "rev": "3104df21065af0f3d51e05a96cd0e2ff16a6f982",
-  "date": "2021-12-09T21:13:54+00:00",
-  "path": "/nix/store/1xgrz7rm6mc6j2svaidj4x0zyda0ahz4-tree-sitter-c-sharp",
-  "sha256": "14g8x5q4xc87s2wpycws6r6ci083j7pk1jdw6sr8qp96zyzs17pp",
+  "rev": "352a4630c81a7a5cbd3bc67327743bd8d38f2dd2",
+  "date": "2022-01-03T12:31:17+00:00",
+  "path": "/nix/store/c7k10h98vzqag0rsywm0p71jaz57880x-tree-sitter-c-sharp",
+  "sha256": "198n5i9bvks0mmbqgzjgrhv6hy1afnx806jnap10241iyd817jbf",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-comment.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-comment",
-  "rev": "5dd3c62f1bbe378b220fe16b317b85247898639e",
-  "date": "2021-10-01T17:13:56-05:00",
-  "path": "/nix/store/isrc5wlyxvcawfj35yi4nmblshy69b1j-tree-sitter-comment",
-  "sha256": "1wk6lxzndaikbrn72pa54y59qs0xnfaffc8mxmm6c5v5x16l8vb3",
+  "rev": "6975eb268f42df2afc313f96c0693e284685dba7",
+  "date": "2022-01-22T20:58:19-05:00",
+  "path": "/nix/store/nl4whdipy7a4g3ds2yv3c0qr7z4pifwn-tree-sitter-comment",
+  "sha256": "009krarzs9qykd8fas67gychjzcbgj8j0jm9h0963dlxs4hyay73",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "e8dcc9d2b404c542fd236ea5f7208f90be8a6e89",
-  "date": "2021-10-28T08:16:36-05:00",
-  "path": "/nix/store/d08ymiv4qjs9hnc8b0yw700da47879wb-tree-sitter-cpp",
-  "sha256": "1h0q4prr8yf714abz16i2ym41sskmilmga521sxv9d75kqhyb3wl",
+  "rev": "656d7ea44b2b0daece78791e30281e283f30001e",
+  "date": "2022-01-17T09:06:11-06:00",
+  "path": "/nix/store/w4qqya24zf0cd7rqw1440szrrad8nf23-tree-sitter-cpp",
+  "sha256": "0vfgv9rw8pw4d41p5rndy7cjw8w0k0vnn54cwpxkm3r2vblnjn58",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "bc20ed7a36031437a69a88ef368af4b9f1ecec70",
-  "date": "2021-12-10T00:43:38+01:00",
-  "path": "/nix/store/zagrgq7zfh6n90z4qpp8cy002g588dhj-tree-sitter-cuda",
-  "sha256": "04gnfjq5rd1vcby8737wxhzmg4vmn2ggjz6n94bbna8b96qc1xxj",
+  "rev": "14cd86e18ba45e327017de5b3e0f8d8f7f8e98ec",
+  "date": "2022-01-24T00:39:28+01:00",
+  "path": "/nix/store/3lskjrhqd16ymvsbrwzcsdd80cyr7ljj-tree-sitter-cuda",
+  "sha256": "09qpl5mfv39788smz87zbzp04i3rdhsckjjqngvr0w24dsw30nyx",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "1b3ecf7765979a5602bbb8988b8fc0d9f4c887d6",
-  "date": "2021-12-15T23:29:48+01:00",
-  "path": "/nix/store/ahdmwdlw7g63wf681cvclxh92mp8waba-tree-sitter-elixir",
-  "sha256": "09kmi989hp2fp7w1xsambnlnp49fnnivdh45pwz9y3dab8iyngsn",
+  "rev": "de20391afe5cb03ef1e8a8e43167e7b58cc52869",
+  "date": "2022-01-10T10:35:12-06:00",
+  "path": "/nix/store/099pwd7iv86g1j4fplgq33a4jpwbvv60-tree-sitter-elixir",
+  "sha256": "0zrkrwhw3g1vazsxcwrfd1fk4wvs9hdwmwp6073mfh370bz4140h",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elm-tooling/tree-sitter-elm",
-  "rev": "8dd06afd9ca60a420374c6b65831e58a1d1237ad",
-  "date": "2021-07-26T03:59:46+02:00",
-  "path": "/nix/store/pz5nbdx19mdq6dp238l1qc3n81l2i88f-tree-sitter-elm",
-  "sha256": "1mncr0nvb616zn2172pqcjd2jrqzyfad0y1pz2mwh8pqwfr0c3nf",
+  "rev": "bd50ccf66b42c55252ac8efc1086af4ac6bab8cd",
+  "date": "2021-12-27T23:25:02+01:00",
+  "path": "/nix/store/l5b9nhvrnq4a105rpmfi59dpg2xqs5nr-tree-sitter-elm",
+  "sha256": "1ls9l81nkcyym92n6h983m3jjjxdlr27nxa21p9l6czwf34564ky",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-embedded-template.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-embedded-template",
-  "rev": "1c03594a44df1fc2020b989d503cb084abd5fd01",
-  "date": "2021-03-04T10:06:18-08:00",
-  "path": "/nix/store/09b9drfnywcy1i8wlw6slnn76ch40kqk-tree-sitter-embedded-template",
-  "sha256": "0c9l4i6kwb29zp05h616y3vk2hhcfc8bhdf9m436bk47pfy2zabg",
+  "rev": "d21df11b0ecc6fd211dbe11278e92ef67bd17e97",
+  "date": "2021-12-23T08:53:16-08:00",
+  "path": "/nix/store/zy74brmd1x2q68bpvi5v4z52bhmkcmy8-tree-sitter-embedded-template",
+  "sha256": "0h3nj6fz512riyx2b65pg9pjprkpkasnglwljlzi6s1in9fdig3x",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-glsl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-glsl",
-  "rev": "26ba31a3f5a85ebed5d71e49eef11a003bed782b",
-  "date": "2021-11-22T08:02:47+01:00",
-  "path": "/nix/store/khlrphky7p7qdivnn34r8hxlpzgav3xm-tree-sitter-glsl",
-  "sha256": "0qvn45whhd6q4wwqaihfd90197xr8lcynwjj418hxl83m9zy8xcz",
+  "rev": "ffb93961426926554a0ba4a389ea6e9d6fafdea9",
+  "date": "2022-01-24T11:15:06+01:00",
+  "path": "/nix/store/x508b69xq0y2ly4hspkgyq5g0v29xvjz-tree-sitter-glsl",
+  "sha256": "1b91wamhdzqq76l9k3vkmrdb1j98w5slzw8d4piqlgp70j396813",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "1203c11e422c73350e672445c5c32b8c0f79266d",
-  "date": "2021-12-03T14:22:11-08:00",
-  "path": "/nix/store/5h584m7qgvlh0s5k10503zj3idggandz-tree-sitter-go",
-  "sha256": "03i63mh5g21y424pf9whl42p7shqp9xlrx90xpyrd12dlc9zhh2j",
+  "rev": "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75",
+  "date": "2022-01-06T10:54:10+01:00",
+  "path": "/nix/store/bw2hilbj37ys9lig2fzz58cvjy7nhn3l-tree-sitter-go",
+  "sha256": "0kgy4yyd0z8pydldnfwsfw2iwbhn4f43qxfhy94wvpwiwi74kfmg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "d72f2e42c0d5ccf8e8b1c39e3642428317e8fe02",
-  "date": "2021-11-14T23:21:37+01:00",
-  "path": "/nix/store/n36iwva3hk2045wx87mahbsfrqhx6mbw-tree-sitter-haskell",
-  "sha256": "0clqyd1mnfz8xcpsr90nzh6j37pdgbgrr4jqf9ifn6m851k4f09g",
+  "rev": "d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb",
+  "date": "2022-01-07T03:13:04+01:00",
+  "path": "/nix/store/biyjfajma7nr175xviaw65jksqfak893-tree-sitter-haskell",
+  "sha256": "0zfxi3adqhy7d1w2dvnywkms8a4vfxkjswdhar7p5sxyps8a5wry",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-heex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/connorlay/tree-sitter-heex",
-  "rev": "625a721ac38d9dd23d4f2b08eceb6700a2e670d5",
-  "date": "2021-10-19T12:18:28-07:00",
-  "path": "/nix/store/pr36q25xgnpmywm53w6rg58ygs9l93wj-tree-sitter-heex",
-  "sha256": "1r7wrb1h2l35wp0hlswb3xpwcf55dr56r865sriq3ngv89y64yha",
+  "rev": "d8b5b9f016cd3c7b0ee916cf031d9a2188c0fc44",
+  "date": "2022-01-23T20:01:08-08:00",
+  "path": "/nix/store/iv3vxp8cdnfhpr75gvqvm8hmvfw8hw51-tree-sitter-heex",
+  "sha256": "0dx6l9k6l5ibvrdb7x13lqnpj5nmjz8f5lc8j8wh4cq2jdabfw0k",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "ed3a87f750b1d1d533f15ab93fef3e1f5a46e234",
-  "date": "2021-10-17T09:05:07+02:00",
-  "path": "/nix/store/crd0zzw31hx5jw7m95dvpssr3pi60k5l-tree-sitter-java",
-  "sha256": "14qwmpm7dzqwby59vy1nhyddfz2lpf69ajr65s7qaqh0jcs6rs19",
+  "rev": "a24ae7d16de3517bff243a87d087d0b4877a65c5",
+  "date": "2022-01-12T08:57:59-08:00",
+  "path": "/nix/store/dipis7syj55xrmc72gvx2f9q672mn6dg-tree-sitter-java",
+  "sha256": "0p01xkxzdjwx32hd6k4kqidlhkgj8q9b9lp4g4fra5gx9w159iqm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "2c0d03a36ee979bc697f6a9dd119174cf0ef15e0",
-  "date": "2021-07-19T17:50:34+02:00",
-  "path": "/nix/store/vrpfbjfps3bd9vrx8760l0vx7m7ijhja-tree-sitter-latex",
-  "sha256": "0dfpdv5sibvajf2grlc0mqhyggjf6ip9j01jikk58n1yc9va88ib",
+  "rev": "6f796b700c69a8af28132e84ed6d0c8f0c17a5e2",
+  "date": "2022-01-11T19:20:05+01:00",
+  "path": "/nix/store/48rdm71qngr9szsfhr85708srwn6b4ra-tree-sitter-latex",
+  "sha256": "0rbaql6jh3kwa4fap3b438l1733h2pbiazdbjzv38bbigkirad0n",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-llvm.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/benwilliamgraham/tree-sitter-llvm",
-  "rev": "d4f61bed8ecb632addcd5e088c4f4cb9c1bf1c5b",
-  "date": "2021-10-03T12:19:51-04:00",
-  "path": "/nix/store/k9vpa9lvrvf1im6wx0c0xyjf2yzgbn0x-tree-sitter-llvm",
-  "sha256": "0iiigra7knvwsb6v76qs7vxpkmfnggakd27gl6sz9dm6gimp1adp",
+  "rev": "3b213925b9c4f42c1acfe2e10bfbb438d9c6834d",
+  "date": "2021-12-27T14:02:51-05:00",
+  "path": "/nix/store/hjg9z82l3iqyjw0s9lf1kkm31p5wlv3d-tree-sitter-llvm",
+  "sha256": "0ymrdcajji11852c158w67mgcsycphwj9mh777q3n4jn8pp37y8j",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "665736e400cfd52ae92ead244ca9f5d44db98151",
-  "date": "2021-12-14T15:04:57+01:00",
-  "path": "/nix/store/crbl24rj54f8c9pjq8igadz3wqcw6qrw-tree-sitter-norg",
-  "sha256": "0hxar07a7n3ghqagr0qjxbz4sgzcpyxwgd4dbj1vvy4xnk07i0br",
+  "rev": "c4be6addec0a8ada234684ced6c928189fd399af",
+  "date": "2022-01-22T17:12:52+01:00",
+  "path": "/nix/store/x73fgsrav1fg0vzydcy4ayrawn0cw7w2-tree-sitter-norg",
+  "sha256": "14wf53p6lkf4xknzb4bngh9fsas6hnr8iv73xnalyf8mqq1977pc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-org.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/milisims/tree-sitter-org",
-  "rev": "39a377f5072ee9f79884e227dc49d42c2eba67d8",
-  "date": "2021-11-01T23:43:23-04:00",
-  "path": "/nix/store/cgsn53p4gp1ahq2zl38jz51xal60dckf-tree-sitter-org",
-  "sha256": "0vfnph4xxvkalzk3rgvzi6ckqkjg31ddzgh4mwbk7qwsacbq9rss",
+  "rev": "f110024d539e676f25b72b7c80b0fd43c34264ef",
+  "date": "2021-11-28T23:04:31-05:00",
+  "path": "/nix/store/8vc7ddhd2wzrin3cj14zrw5mmi58f8sl-tree-sitter-org",
+  "sha256": "1gvqvdapqfac1ny1a0l590h1w617wczwv234fsnal6amfdyganxc",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ganezdragon/tree-sitter-perl",
-  "rev": "0ac2c6da562c7a2c26ed7e8691d4a590f7e8b90a",
-  "date": "2021-11-01T14:40:51-04:00",
-  "path": "/nix/store/1yzkap7jvps3xdj19pygyv1bn6c33qak-tree-sitter-perl",
-  "sha256": "184zaicrl9i4cywhyc2cxpghw7daz9pi0fhwkkgpv7j6kvp1ig2w",
+  "rev": "ab2b39439f2fc82fd5ea0b7e08509760d4cbacd5",
+  "date": "2022-01-23T13:55:11-05:00",
+  "path": "/nix/store/s55aybm3r5n7l7nx916mhjyry96xcvin-tree-sitter-perl",
+  "sha256": "16ap0yq9gmh0kbyka7zcpjw3dl368n23sxp3v82z4ccwzmgfmaw4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-query.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-treesitter/tree-sitter-query",
-  "rev": "9a2ccff9f672f1f3d320cf925b8e5acc89b27055",
-  "date": "2021-07-13T08:51:40-05:00",
-  "path": "/nix/store/k843gr9rlkd5jaf9arvlwcs31wsznn81-tree-sitter-query",
-  "sha256": "0x5ssq8pb767s1l68123jaa5p4570xmz74ii94kckd46wmqbk4v9",
+  "rev": "5217c6805c09f8fc00ed13d17d5fcb791437aee6",
+  "date": "2021-12-23T16:48:02-05:00",
+  "path": "/nix/store/b8n553bwlyzi05p8vn08qv6vbzg9875q-tree-sitter-query",
+  "sha256": "00q6cpw5rkb20cypx820glqhfs4vsgqdymj5y0sknd874lq6crfg",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-r.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/r-lib/tree-sitter-r",
-  "rev": "91f587e5685f46e26f9f6e55f2e06d503f8f0fc0",
-  "date": "2021-12-03T10:44:27-05:00",
-  "path": "/nix/store/z89yfih6g05fkrzz6s7snkyqp8wj8pi5-tree-sitter-r",
-  "sha256": "0dds34vgrvgxi1918a2w6xcw5l8n9ch3qi43vql769p8zxf8qijp",
+  "rev": "d9868735e401e4870a3d4422790b585fea3faec8",
+  "date": "2022-01-10T10:12:40-05:00",
+  "path": "/nix/store/b2dp06sk8s3ksm382gndshhd1mxmd6n6-tree-sitter-r",
+  "sha256": "1pl38gksb4cwdgrb92rbmkanxn65m99i6c8w8xldhs0q97d1v5k0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-regex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-regex",
-  "rev": "7b97502cfc3ffa7110f6b68bb39fb259c9a0500c",
-  "date": "2021-08-17T11:21:39-07:00",
-  "path": "/nix/store/3lpj820c141i26p20kin465xlr5jpyjs-tree-sitter-regex",
-  "sha256": "0n9lmwwgij00078v3fr19vfn1g3wh3agm8jqp80v1cnrcsmpn97p",
+  "rev": "e1cfca3c79896ff79842f057ea13e529b66af636",
+  "date": "2022-01-03T09:37:11-08:00",
+  "path": "/nix/store/24lr7jzznsd3z7cld007aww25kbwcf51-tree-sitter-regex",
+  "sha256": "0j6j0h8ciyhgmcq9iy3843anyfvd7s0biqzgbsqgwbgbqbg2nfwl",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rst.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/stsewd/tree-sitter-rst",
-  "rev": "a5514617ae3644effa80d4696be428e4a371c01a",
-  "date": "2021-11-05T20:58:51-05:00",
-  "path": "/nix/store/is0j0cpd3i7q7liqlcrfdflabmm9rnlg-tree-sitter-rst",
-  "sha256": "1bw0yry968qz4arzckxpyz5zkw6ajyirrxyf78m9lr1zmz1vnivy",
+  "rev": "b74770c0166f28c1a0ab293513a78712ca1c338b",
+  "date": "2022-01-22T20:59:44-05:00",
+  "path": "/nix/store/ymhzq6hwq43gf918zyxk7can4qfkz7n1-tree-sitter-rst",
+  "sha256": "0q50vwk72lrgnrdjjn5aj1fjksrwkd0gfmdnrjy59a6cw8m1gmf0",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-ruby.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-ruby",
-  "rev": "888e2e563ed3b43c417f17e57f7e29c39ce9aeea",
-  "date": "2021-12-03T16:33:06+01:00",
-  "path": "/nix/store/6g101r5pwy6iqicch9srlhwfz9xdrvzd-tree-sitter-ruby",
-  "sha256": "0xfcqafslxlpkw7agw4a179w3c6k6ivi3fzlf32pqfd5bjrlx9d7",
+  "rev": "fe6a2d634da0e16b11b5aa255cc3df568a4572fd",
+  "date": "2021-03-03T16:54:30-08:00",
+  "path": "/nix/store/ragrvqj7hm98r74v5b3fljvc47gd3nhj-tree-sitter-ruby",
+  "sha256": "0m3h4928rbs300wcb6776h9r88hi32rybbhcaf6rdympl5nzi83v",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "d045b04b66d51c0ba8671e7ce1ee23a9f286b7d7",
-  "date": "2021-12-12T10:08:54-08:00",
-  "path": "/nix/store/2h6vkl05jxqgp4738a0dxccmg40yhqvj-tree-sitter-rust",
-  "sha256": "0ckyaw1ll3yazyg18wd40kc09h6f0zmwqmahsm07bwgfyc2nvf3h",
+  "rev": "eeb0702ebdac504b97196577b1dac43c80913d7b",
+  "date": "2022-01-10T13:05:56-08:00",
+  "path": "/nix/store/sh170d6b589l16rhlygz6hvn1dmfhlb1-tree-sitter-rust",
+  "sha256": "1npx8kc4qdjj1fszqx6ks1d0x0pklmzm3gkxracs7y28lh2whrvq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-supercollider.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/madskjeldgaard/tree-sitter-supercollider",
-  "rev": "ac83e9d5ef3a62d2160d0f1e0a64a949ecda1d8b",
-  "date": "2021-12-21T18:04:07+01:00",
-  "path": "/nix/store/zk5zwg98pljk2dwqax81pib3l68wgl8x-tree-sitter-supercollider",
-  "sha256": "0qpjy40wigcf6r23j2i3yqr061n6zdz60mlm9i5mkii2y65ff8cf",
+  "rev": "a7201b61779be59ac0fc0d118746c886dbc3edbd",
+  "date": "2022-01-14T01:11:12+01:00",
+  "path": "/nix/store/rgy05854am625shbs13gjx0yggbb6awh-tree-sitter-supercollider",
+  "sha256": "118mbv8d5n2lb4w5cbjy657g9z9z910gvjjj41a2rkx971vgb6w3",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-swift.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-swift.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-swift",
-  "rev": "a22fa5e19bae50098e2252ea96cba3aba43f4c58",
-  "date": "2019-10-24T19:04:02-06:00",
-  "path": "/nix/store/pk5xk8yp6vanbar75bhfrs104w0k1ph0-tree-sitter-swift",
-  "sha256": "14b40lmwrnyvdz2wiv684kfh4fvqfhbj1dgrx81ppmy7hsz7jcq7",
+  "rev": "db675450dcc1478ee128c96ecc61c13272431aab",
+  "date": "2022-01-13T10:47:55-08:00",
+  "path": "/nix/store/l3535ndrmi24v5nidxppi1rqccj4s17v-tree-sitter-swift",
+  "sha256": "06mq1an55p75ajwn6pvcy9vlcmzrj8qmbri3mn4bxq53icnj4fya",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-tlaplus.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus",
-  "rev": "26bbaf5d07356cacbf21defa9316988bc732c8b3",
-  "date": "2021-10-12T19:50:03-04:00",
-  "path": "/nix/store/52rs1n8y6krfkb9z2h7jsl4s3j15dp08-tree-sitter-tlaplus",
-  "sha256": "1yj2hjc48sjjpysjgyji7nx2l0rpc5dnsm68i8amff5wcag5lyhw",
+  "rev": "ffa98bbbd80e425f07e92bf511e64c8b0dffc1c7",
+  "date": "2022-01-23T09:32:54-05:00",
+  "path": "/nix/store/rbxa4biim19pwiz6gmh0ag5cz68rws3k-tree-sitter-tlaplus",
+  "sha256": "0j8bwxdvdhfhvpiahbf0hr9hfkbg75p7qpxx2i1rgvidavflbpiv",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-typescript.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-typescript",
-  "rev": "111b07762e86efab9a918b7c721f720c37e76b0a",
-  "date": "2021-11-09T11:34:06-08:00",
-  "path": "/nix/store/kndz7jkpl2adcaac64j7y9sb6zd7mp5h-tree-sitter-typescript",
-  "sha256": "1364bm3wbqqzvp03cvpx1w89bbqynb1v62i46gy7f6rhib9bf63a",
+  "rev": "e8e8e8dc2745840b036421b4e43286750443cb13",
+  "date": "2022-01-10T13:42:45-08:00",
+  "path": "/nix/store/zl36qsk7pd9pcawfsy368axax97d83wz-tree-sitter-typescript",
+  "sha256": "1z1v7fjgp418qsp0xkycfpvc8vm4a2ai5kx10xif1dvjpfgcj1qq",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "1d23679256edb241ebed8da1247e340bf9e0c0ad",
-  "date": "2021-10-18T11:21:06+02:00",
-  "path": "/nix/store/5a4kihij5jcdpn73i3m7av82k4pvvzpy-tree-sitter-viml",
-  "sha256": "1660y9n1s76xcv0z27kzbbsr9bdv4c4xakzglzhl7z7qcylxg2rr",
+  "rev": "274b004d226a6686546ef83231f0f836b91700ae",
+  "date": "2022-01-21T14:12:20+01:00",
+  "path": "/nix/store/lpl3kbb5kwawr71m6qhqrwj1adkll540-tree-sitter-viml",
+  "sha256": "01bmn3l3fsi1r36ak72ly0v8fr62wchida965c60244bfg2s4r2c",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "cf93353d5682c3e9d8112d448ff24d4de7b2304e",
-  "date": "2021-11-25T20:46:40+09:00",
-  "path": "/nix/store/jwrs3fdgdqymjkrni6mlz1j0f0ai6h9y-tree-sitter-zig",
-  "sha256": "04ja9w28zprw575s4734d02ibi498whh3z7cxm3m1fdydhjsdlrj",
+  "rev": "93331b8bd8b4ebee2b575490b2758f16ad4e9f30",
+  "date": "2022-01-10T15:22:15+09:00",
+  "path": "/nix/store/g54w7vid7nf9shzfipch646dk4d88ah7-tree-sitter-zig",
+  "sha256": "0irckd6bh3i1vr5bi2lwsbvibbpih3jv3xqdq0dbsiy447dfiv50",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -398,7 +398,11 @@ let
     res=$(${curl}/bin/curl "''${args[@]}")
 
     if [[ "$(printf "%s" "$res" | ${jq}/bin/jq '.message?')" =~ "rate limit" ]]; then
-      echo "rate limited" >&2   #
+      echo "rate limited" >&2
+      exit 1
+    elif [[ "$(printf "%s" "$res" | ${jq}/bin/jq '.message?')" =~ "Bad credentials" ]]; then
+      echo "bad credentials" >&2
+      exit 1
     fi
 
     printf "%s" "$res" | ${jq}/bin/jq 'map(.name)' \

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -366,7 +366,7 @@ let
     set -euo pipefail
 
     args=( '--silent' )
-    if [ -n "$GITHUB_TOKEN" ]; then
+    if [ -n "''${GITHUB_TOKEN:-}" ]; then
       args+=( "-H" "Authorization: token ''${GITHUB_TOKEN}" )
     fi
     args+=( "https://api.github.com/repos/${urlEscape orga}/${urlEscape repo}/releases/latest" )
@@ -390,7 +390,7 @@ let
     set -euo pipefail
 
     args=( '--silent' )
-    if [ -n "$GITHUB_TOKEN" ]; then
+    if [ -n "''${GITHUB_TOKEN:-}" ]; then
       args+=( "-H" "Authorization: token ''${GITHUB_TOKEN}" )
     fi
     args+=( 'https://api.github.com/orgs/${urlEscape orga}/repos?per_page=100' )

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -436,7 +436,8 @@ let
     mkdir -p "$outputDir"
     ${foreachSh allGrammars
       ({name, orga, repo}: ''${updateGrammar { inherit orga repo; }} > $outputDir/${name}.json'')}
-    ( echo "{"
+    ( echo "{ lib }:"
+      echo "{"
       ${foreachSh allGrammars
         ({name, ...}: ''
            # indentation hack


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upstream update and update script errors.

Closes #156292 (commit included)

- Fix update script bug introduced in https://github.com/NixOS/nixpkgs/pull/154753 (due to script options used, unbound variable error is thrown when token env variable is not set)
- Handle "bad credentials" error
- Output `{ lib }:` at the top of the generated nix file
- Grammar updates

This fixed https://github.com/nvim-treesitter/nvim-treesitter/issues/2295 in my neovim setup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
