### PR TITLE
nixos-containers: add option for user-specified container dependencies

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -669,6 +669,17 @@ in
               '';
             };
 
+            startAfter = mkOption {
+              type = types.listOf types.str;
+              default = [];
+              example = [ "container@mariadb.service" "nginx.service" ];
+              description = ''
+                List of systemd units to wait for before starting the container.
+                This option can be used to specify dependencies on another
+                container, target or service.
+              '';
+            };
+
             extraFlags = mkOption {
               type = types.listOf types.str;
               default = [];
@@ -789,7 +800,7 @@ in
             {
               wantedBy = [ "machines.target" ];
               wants = [ "network.target" ];
-              after = [ "network.target" ];
+              after = [ "network.target" ] ++ cfg.startAfter;
               restartTriggers = [
                 containerConfig.path
                 config.environment.etc."containers/${name}.conf".source

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -80,6 +80,7 @@ in
   cockroachdb = handleTestOn ["x86_64-linux"] ./cockroachdb.nix {};
   collectd = handleTest ./collectd.nix {};
   consul = handleTest ./consul.nix {};
+  containers-after = handleTest ./containers-after.nix {};
   containers-bridge = handleTest ./containers-bridge.nix {};
   containers-custom-pkgs.nix = handleTest ./containers-custom-pkgs.nix {};
   containers-ephemeral = handleTest ./containers-ephemeral.nix {};

--- a/nixos/tests/containers-after.nix
+++ b/nixos/tests/containers-after.nix
@@ -1,0 +1,79 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "containers-after";
+  meta = {
+    maintainers = with lib.maintainers; [ thesola10 ];
+  };
+
+  machine =
+    { lib, ... }:
+    {
+      virtualisation.vlans = [];
+
+      systemd.tmpfiles.rules = [
+        "d /run/dest 1777 root root -"
+      ];
+
+      networking.bridges.br0.interfaces = [];
+      networking.interfaces.br0.ipv4.addresses = [
+        { address = "10.10.0.254"; prefixLength = 24; }
+      ];
+
+      containers.before = {
+        autoStart = true;
+        privateNetwork = true;
+        localAddress = "10.10.0.1/24";
+        hostBridge = "br0";
+
+        config = { lib, ... }:
+        {
+          networking.firewall.extraCommands = ''
+            iptables -A INPUT -s 10.10.0.0/24 -j ACCEPT
+          '';
+          services.darkhttpd = {
+            enable = true;
+            address = "10.10.0.1";
+            rootDir = ./common/webroot;
+          };
+        };
+      };
+
+      containers.after = {
+        autoStart = true;
+        privateNetwork = true;
+        startAfter = [ "container@before.service" ];
+        localAddress = "10.10.0.2/24";
+        hostBridge = "br0";
+        bindMounts."/dest" = {
+          hostPath = "/run/dest";
+          isReadOnly = false;
+        };
+
+        config = { lib, ... }:
+        {
+          networking.firewall.extraCommands = ''
+            iptables -A INPUT -s 10.10.0.0/24 -j ACCEPT
+          '';
+          systemd.services."fetchBefore" =
+            { path = with pkgs; [ wget ];
+              wantedBy = [ "default.target" ];
+              enable = true;
+              serviceConfig =
+              { ExecStart = pkgs.writeShellScript "run.sh" ''
+                  wget http://10.10.0.1/news-rss.xml -O /dest/news-rss.xml
+                '';
+                Restart = "no";
+                Type = "oneshot";
+              };
+            };
+        };
+      };
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("default.target")
+
+    with subtest("Check if containers were started in the correct order"):
+        machine.succeed("diff ${./common/webroot/news-rss.xml} /run/dest/news-rss.xml")
+  '';
+})


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There is currently no way to tell a NixOS container to wait for another container or dependency before starting, which can cause a race condition.

Concrete example I encountered: My Gitea container starts _before_ my MariaDB container, causing Gitea to error out and remain in that state until it is restarted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
