### PR TITLE
Fix duplicate Django drv

### DIFF
--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -22,6 +22,9 @@ let
       sha256 = "sha256-Ms55Lum2oMu+w0ASPiKayfdl3/jCpK6SR6FLK6OjZac=";
     };
   });
+  django-extensions' = django-extensions.overrideAttrs (oldAttrs: rec {
+    propagatedBuildInputs = [];
+  });
 in
 
 buildPythonApplication rec {
@@ -37,7 +40,7 @@ buildPythonApplication rec {
     requests
     mypy-extensions
     django_3'
-    django-extensions
+    django-extensions'
     dateparser
     youtube-dl
     python-crontab

--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -22,9 +22,7 @@ let
       sha256 = "sha256-Ms55Lum2oMu+w0ASPiKayfdl3/jCpK6SR6FLK6OjZac=";
     };
   });
-  django-extensions' = django-extensions.overrideAttrs (oldAttrs: rec {
-    propagatedBuildInputs = [];
-  });
+  django-extensions' = django-extensions.override { django = django_3'; };
 in
 
 buildPythonApplication rec {


### PR DESCRIPTION
Related to Issue #154950 that was closed by PR #154153 however archivebox still couldn't build hence this fix.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Allowing Archivebox to build again.

###### Things done

Overriden django-extensions to propagate nothing. This removes the conflicting django dependency.
While not tested specifically on any platform other than x86_64-linux. This change should not interfere with anything other than archivebox, that now works.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
