### PR TITLE
vgmstream: r1050-3448-g77cc431b -> r1702-5534-ab6139c11

### DIFF
--- a/pkgs/applications/audio/vgmstream/default.nix
+++ b/pkgs/applications/audio/vgmstream/default.nix
@@ -1,26 +1,33 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config
-, mpg123, ffmpeg, libvorbis, libao, jansson
+, mpg123, ffmpeg, libvorbis, libao, jansson, speex
 }:
+let
+  vgmstreamVersion = "r1702-5596-00bdb165b";
+in
 stdenv.mkDerivation rec {
-  pname   = "vgmstream";
-  version = "r1050-3448-g77cc431b";
+  pname = "vgmstream";
+  version = "unstable-2022-02-21";
 
   src = fetchFromGitHub {
-    owner  = "vgmstream";
-    repo   = "vgmstream";
-    rev    = version;
-    sha256 = "030q02c9li14by7vm00gn6v3m4dxxmfwiy9iyz3xsgzq1i7pqc1d";
+    owner = "vgmstream";
+    repo = "vgmstream";
+    rev = "00bdb165ba6b55420bbd5b21f54c4f7a825d15a0";
+    sha256 = "18g1yqlnf48hi2xn2z2wajnjljpdbfdqmcmi7y8hi1r964ypmfcr";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ mpg123 ffmpeg libvorbis libao jansson ];
+  buildInputs = [ mpg123 ffmpeg libvorbis libao jansson speex ];
 
-  # There's no nice way to build the audacious plugin without a circular dependency
-  cmakeFlags = [ "-DBUILD_AUDACIOUS=OFF" ];
+  cmakeFlags = [
+    # There's no nice way to build the audacious plugin without a circular dependency
+    "-DBUILD_AUDACIOUS=OFF"
+    # It always tries to download it, no option to use the system one
+    "-DUSE_CELT=OFF"
+  ];
 
-  preConfigure = ''
-    echo "#define VERSION \"${version}\"" > cli/version.h
+  postConfigure = ''
+    echo "#define VGMSTREAM_VERSION \"${vgmstreamVersion}\"" > ../version.h
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/vgmstream/default.nix
+++ b/pkgs/applications/audio/vgmstream/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "18g1yqlnf48hi2xn2z2wajnjljpdbfdqmcmi7y8hi1r964ypmfcr";
   };
 
+  passthru.updateScript = ./update.sh;
+
   nativeBuildInputs = [ cmake pkg-config ];
 
   buildInputs = [ mpg123 ffmpeg libvorbis libao jansson speex ];

--- a/pkgs/applications/audio/vgmstream/update.sh
+++ b/pkgs/applications/audio/vgmstream/update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash --pure --keep GITHUB_TOKEN -p gnused jq nix-prefetch-git curl cacert
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+if [[ ! "$(basename $ROOT)" == "vgmstream" || ! -f "$ROOT/default.nix" ]]; then
+    echo "ERROR: Not in the vgmstream folder"
+    exit 1
+fi
+
+if [[ ! -v GITHUB_TOKEN ]]; then
+    echo "ERROR: \$GITHUB_TOKEN not set"
+    exit 1
+fi
+
+
+payload=$(jq -cn --rawfile query /dev/stdin '{"query": $query}' <<EOF | curl -s -H "Authorization: bearer $GITHUB_TOKEN" -d '@-' https://api.github.com/graphql
+{
+  repository(owner: "vgmstream", name: "vgmstream") {
+    branch: ref(qualifiedName: "refs/heads/master") {
+      target {
+        oid
+        ... on Commit {
+          committedDate
+          history {
+            totalCount
+          }
+        }
+      }
+    }
+
+    tag: refs(refPrefix: "refs/tags/", first: 1, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
+      nodes {
+        name
+      }
+    }
+  }
+}
+EOF
+)
+
+committed_full_date=$(jq -r .data.repository.branch.target.committedDate <<< "$payload")
+committed_date=$(sed -nE 's/^([0-9]{4}-[0-9]{2}-[0-9]{2}).+$/\1/p' <<< $committed_full_date)
+commit_unix=$(date --utc --date="$committed_date" +%s)
+last_updated_unix=$(date --utc --date=$(sed -nE 's/^\s*version\s*=\s*\"unstable-([0-9]{4}-[0-9]{2}-[0-9]{2})\";$/\1/p' default.nix) +%s)
+
+commit_sha=$(jq -r .data.repository.branch.target.oid <<< "$payload")
+major_ver=$(jq -r .data.repository.tag.nodes[0].name <<< "$payload" | sed 's/^v//g')
+commit_count=$(jq -r .data.repository.branch.target.history.totalCount <<< "$payload")
+final_ver="$major_ver-$commit_count-${commit_sha::9}"
+
+
+echo "INFO: Latest commit is $commit_sha"
+echo "INFO: Latest commit date is $committed_full_date"
+echo "INFO: Latest version is $final_ver"
+
+##
+# VGMStream has no stable releases, so only update if there's been at
+# least a week between commits to reduce maintainer pressure.
+##
+time_diff=$(( $commit_unix - $last_updated_unix ))
+if [[ $time_diff -lt 604800 ]]; then
+  echo "INFO: Not updating, less than a week between commits."
+  echo "INFO: $time_diff < 604800"
+  exit 0
+fi
+
+nix_sha256=$(nix-prefetch-git --quiet https://github.com/vgmstream/vgmstream.git "$commit_sha" | jq -r .sha256)
+echo "INFO: SHA256 is $nix_sha256"
+
+sed -i -E \
+    -e "s/vgmstreamVersion\s*=\s*\"[a-z0-9-]+\";$/vgmstreamVersion = \"${final_ver}\";/g" \
+    -e "s/version\s*=\s*\"[a-z0-9-]+\";$/version = \"unstable-${committed_date}\";/g" \
+    -e "s/rev\s*=\s*\"[a-z0-9]+\";$/rev = \"${commit_sha}\";/g" \
+    -e "s/sha256\s*=\s*\"[a-z0-9]+\";$/sha256 = \"${nix_sha256}\";/g" \
+    "$ROOT/default.nix"


### PR DESCRIPTION
###### Motivation for this change
Updating.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
