### PR TITLE
lib.modules: Let module declare options directly in bare submodule

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -527,7 +527,7 @@ rec {
               #  d. magically combine (a) and (c).
               # All of the above are merely syntax sugar though.
               then
-                let opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToOption decls));
+                let opt = mergeOptionDecls loc (map optionTreeToOption decls);
                 in {
                   matchedOptions = evalOptionValue loc opt defns';
                   unmatchedDefns = [];

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -496,6 +496,9 @@ rec {
             options = mkOption {
               type = types.submoduleWith {
                 modules = [ { options = decl.options; } ];
+                # `null` is not intended for use by modules. It is an internal
+                # value that means "whatever the user has declared elsewhere".
+                # This might become obsolete with https://github.com/NixOS/nixpkgs/issues/162398
                 shorthandOnlyDefinesConfig = null;
               };
             };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -496,6 +496,7 @@ rec {
             options = mkOption {
               type = types.submoduleWith {
                 modules = [ { options = decl.options; } ];
+                shorthandOnlyDefinesConfig = null;
               };
             };
           };

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -505,7 +505,7 @@ rec {
               firstOption = findFirst (m: isOption m.options) "" decls;
               firstNonOption = findFirst (m: !isOption m.options) "" decls;
             in
-              if firstOption.options.type?isSubmodule && firstOption.options.type.isSubmodule
+              if firstOption.options.type.name == "submodule"
               then
                 let opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToOption decls));
                 in {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -527,7 +527,7 @@ rec {
               #  d. magically combine (a) and (c).
               # All of the above are merely syntax sugar though.
               then
-                let opt = mergeOptionDecls loc (map optionTreeToOption decls);
+                let opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToOption decls));
                 in {
                   matchedOptions = evalOptionValue loc opt defns';
                   unmatchedDefns = [];

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -501,6 +501,15 @@ rec {
             }
           else if optionDecls != [] then
               if (lib.head optionDecls).options.type.name == "submodule"
+              # Raw options can only be merged into submodules. Merging into
+              # attrsets might be nice, but ambiguous. Suppose we have
+              # attrset as a `attrsOf submodule`. User declares option
+              # attrset.foo.bar, this could mean:
+              #  a. option `bar` is only available in `attrset.foo`
+              #  b. option `foo.bar` is available in all `attrset.*`
+              #  c. reject and require "<name>" as a reminder that it behaves like (b).
+              #  d. magically combine (a) and (c).
+              # All options are merely syntax sugar though.
               then
                 let opt = fixupOptionType loc (mergeOptionDecls loc (map optionTreeToOption decls));
                 in {

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -799,13 +799,14 @@ rec {
       compare = a: b: (a.priority or 1000) < (b.priority or 1000);
     in sort compare defs';
 
-  /* Hack for backward compatibility: convert options of type
-     optionSet to options of type submodule.  FIXME: remove
-     eventually. */
   fixupOptionType = loc: opt:
     let
       options = opt.options or
         (throw "Option `${showOption loc}' has type optionSet but has no option attribute, in ${showFiles opt.declarations}.");
+
+      # Hack for backward compatibility: convert options of type
+      # optionSet to options of type submodule.  FIXME: remove
+      # eventually.
       f = tp:
         let optionSetIn = type: (tp.name == type) && (tp.functor.wrapped.name == "optionSet");
         in

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -62,6 +62,11 @@ checkConfigError() {
 checkConfigOutput '^false$' config.enable ./declare-enable.nix
 checkConfigError 'The option .* does not exist. Definition values:\n\s*- In .*: true' config.enable ./define-enable.nix
 
+checkConfigOutput '^1$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix
+checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix
+checkConfigOutput '^42$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
+checkConfigOutput '^420$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
+
 # Check integer types.
 # unsigned
 checkConfigOutput '^42$' config.value ./declare-int-unsigned-value.nix ./define-value-int-positive.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -67,6 +67,7 @@ checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix 
 checkConfigOutput '^42$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
 checkConfigOutput '^420$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
 checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix ./define-shorthandOnlyDefinesConfig-true.nix
+checkConfigError 'The option .bare-submodule.deep. in .*/declare-bare-submodule-deep-option.nix. is already declared in .*/declare-bare-submodule-deep-option-duplicate.nix' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix  ./declare-bare-submodule-deep-option-duplicate.nix
 
 # Check integer types.
 # unsigned

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -309,6 +309,12 @@ checkConfigOutput "10" config.processedToplevel ./raw.nix
 checkConfigError "The option .multiple. is defined multiple times" config.multiple ./raw.nix
 checkConfigOutput "bar" config.priorities ./raw.nix
 
+## Option collision
+checkConfigError \
+  'The option .set. in module .*/declare-set.nix. would be a parent of the following options, but its type .attribute set of signed integers. does not support nested options.\n\s*- option[(]s[)] with prefix .set.enable. in module .*/declare-enable-nested.nix.' \
+  config.set \
+  ./declare-set.nix ./declare-enable-nested.nix
+
 # Test that types.optionType merges types correctly
 checkConfigOutput '^10$' config.theOption.int ./optionTypeMerging.nix
 checkConfigOutput '^"hello"$' config.theOption.str ./optionTypeMerging.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -66,6 +66,7 @@ checkConfigOutput '^1$' config.bare-submodule.nested ./declare-bare-submodule.ni
 checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix
 checkConfigOutput '^42$' config.bare-submodule.nested ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
 checkConfigOutput '^420$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-nested-option.nix ./declare-bare-submodule-deep-option.nix ./define-bare-submodule-values.nix
+checkConfigOutput '^2$' config.bare-submodule.deep ./declare-bare-submodule.nix ./declare-bare-submodule-deep-option.nix ./define-shorthandOnlyDefinesConfig-true.nix
 
 # Check integer types.
 # unsigned

--- a/lib/tests/modules/declare-bare-submodule-deep-option-duplicate.nix
+++ b/lib/tests/modules/declare-bare-submodule-deep-option-duplicate.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.bare-submodule.deep = mkOption {
+    type = types.int;
+    default = 2;
+  };
+}

--- a/lib/tests/modules/declare-bare-submodule-deep-option.nix
+++ b/lib/tests/modules/declare-bare-submodule-deep-option.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.bare-submodule.deep = mkOption {
+    type = types.int;
+    default = 2;
+  };
+}

--- a/lib/tests/modules/declare-bare-submodule-nested-option.nix
+++ b/lib/tests/modules/declare-bare-submodule-nested-option.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.bare-submodule = mkOption {
+    type = types.submoduleWith {
+      modules = [
+        {
+          options.nested = mkOption {
+            type = types.int;
+            default = 1;
+          };
+        }
+      ];
+    };
+  };
+}

--- a/lib/tests/modules/declare-bare-submodule-nested-option.nix
+++ b/lib/tests/modules/declare-bare-submodule-nested-option.nix
@@ -1,10 +1,11 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   inherit (lib) mkOption types;
 in
 {
   options.bare-submodule = mkOption {
     type = types.submoduleWith {
+      shorthandOnlyDefinesConfig = config.shorthandOnlyDefinesConfig;
       modules = [
         {
           options.nested = mkOption {

--- a/lib/tests/modules/declare-bare-submodule.nix
+++ b/lib/tests/modules/declare-bare-submodule.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   inherit (lib) mkOption types;
 in
@@ -6,7 +6,13 @@ in
   options.bare-submodule = mkOption {
     type = types.submoduleWith {
       modules = [ ];
+      shorthandOnlyDefinesConfig = config.shorthandOnlyDefinesConfig;
     };
     default = {};
+  };
+
+  # config-dependent options: won't recommend, but useful for making this test parameterized
+  options.shorthandOnlyDefinesConfig = mkOption {
+    default = false;
   };
 }

--- a/lib/tests/modules/declare-bare-submodule.nix
+++ b/lib/tests/modules/declare-bare-submodule.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options.bare-submodule = mkOption {
+    type = types.submoduleWith {
+      modules = [ ];
+    };
+    default = {};
+  };
+}

--- a/lib/tests/modules/declare-set.nix
+++ b/lib/tests/modules/declare-set.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+{
+  options.set = lib.mkOption {
+    default = { };
+    example = { a = 1; };
+    type = lib.types.attrsOf lib.types.int;
+    description = ''
+      Some descriptive text
+    '';
+  };
+}

--- a/lib/tests/modules/define-bare-submodule-values.nix
+++ b/lib/tests/modules/define-bare-submodule-values.nix
@@ -1,0 +1,4 @@
+{
+  bare-submodule.nested = 42;
+  bare-submodule.deep = 420;
+}

--- a/lib/tests/modules/define-shorthandOnlyDefinesConfig-true.nix
+++ b/lib/tests/modules/define-shorthandOnlyDefinesConfig-true.nix
@@ -1,0 +1,1 @@
+{ shorthandOnlyDefinesConfig = true; }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -637,7 +637,11 @@ rec {
               then lhs.specialArgs // rhs.specialArgs
               else throw "A submoduleWith option is declared multiple times with the same specialArgs \"${toString (attrNames intersecting)}\"";
             shorthandOnlyDefinesConfig =
-              if lhs.shorthandOnlyDefinesConfig == rhs.shorthandOnlyDefinesConfig
+              if lhs.shorthandOnlyDefinesConfig == null
+              then rhs.shorthandOnlyDefinesConfig
+              else if rhs.shorthandOnlyDefinesConfig == null
+              then lhs.shorthandOnlyDefinesConfig
+              else if lhs.shorthandOnlyDefinesConfig == rhs.shorthandOnlyDefinesConfig
               then lhs.shorthandOnlyDefinesConfig
               else throw "A submoduleWith option is declared multiple times with conflicting shorthandOnlyDefinesConfig values";
           };

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -562,9 +562,13 @@ rec {
       let
         inherit (lib.modules) evalModules;
 
+        shorthandToModule = if shorthandOnlyDefinesConfig == false
+          then value: value
+          else value: { config = value; };
+
         coerce = unify: value: if isFunction value
           then setFunctionArgs (args: unify (value args)) (functionArgs value)
-          else unify (if shorthandOnlyDefinesConfig then { config = value; } else value);
+          else unify (shorthandToModule value);
 
         allModules = defs: imap1 (n: { value, file }:
           if isAttrs value || isFunction value then

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -642,11 +642,6 @@ rec {
               else throw "A submoduleWith option is declared multiple times with conflicting shorthandOnlyDefinesConfig values";
           };
         };
-      } // {
-        # Submodule-typed options get special treatment in order to facilitate
-        # certain migrations, such as the addition of freeformTypes onto
-        # existing option trees.
-        isSubmodule = true;
       };
 
     # A value from a set of allowed ones.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -642,6 +642,11 @@ rec {
               else throw "A submoduleWith option is declared multiple times with conflicting shorthandOnlyDefinesConfig values";
           };
         };
+      } // {
+        # Submodule-typed options get special treatment in order to facilitate
+        # certain migrations, such as the addition of freeformTypes onto
+        # existing option trees.
+        isSubmodule = true;
       };
 
     # A value from a set of allowed ones.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -566,14 +566,14 @@ rec {
           then value: value
           else value: { config = value; };
 
-        coerce = unify: value: if isFunction value
-          then setFunctionArgs (args: unify (value args)) (functionArgs value)
-          else unify (shorthandToModule value);
-
         allModules = defs: imap1 (n: { value, file }:
-          if isAttrs value || isFunction value then
-            # Annotate the value with the location of its definition for better error messages
-            coerce (lib.modules.unifyModuleSyntax file "${toString file}-${toString n}") value
+          if isFunction value
+          then setFunctionArgs
+                (args: lib.modules.unifyModuleSyntax file "${toString file}-${toString n}" (value args))
+                (functionArgs value)
+          else if isAttrs value
+          then
+            lib.modules.unifyModuleSyntax file "${toString file}-${toString n}" (shorthandToModule value)
           else value
         ) defs;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Let module declare options directly in bare submodule, where a bare submodule is an option that has a type like `submoduleWith x`, as opposed to `attrsOf (submoduleWith x)`.

This makes migration unnecessary when introducing a freeform type in an existing option tree and it removes some unwieldy syntax. Refs https://github.com/NixOS/nixpkgs/pull/156503/files#r790768951

Mainly, it allows the introduction of a freeformType at any place in an existing options tree without breaking compatibility with existing option declarations inside the new freeformType.

Another use case is for modules that should be imported in multiple locations in the options tree, such as `systemd` and `systemd.user`.

Closes #146882

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
