### PR TITLE
fetchpatch: improve error message when sha256 isnt set

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -5,23 +5,28 @@
 # stripLen acts as the -p parameter when applying a patch.
 
 { lib, fetchurl, buildPackages }:
+
+{ stripLen ? 0
+, extraPrefix ? null
+, excludes ? []
+, includes ? []
+, revert ? false
+, postFetch ? ""
+, ... } @ args:
+
 let
   # 0.3.4 would change hashes: https://github.com/NixOS/nixpkgs/issues/25154
   patchutils = buildPackages.patchutils_0_3_3;
 in
-{ stripLen ? 0, extraPrefix ? null, excludes ? [], includes ? [], revert ? false, ... }@args:
-
-let
-  # Make base-64 encoded SRI hash filename-safe using RFC 4648 §5
-  tmpname = lib.replaceStrings [ "+" "/" "=" ] [ "-" "_" "" ] args.sha256;
-in
 fetchurl ({
   postFetch = ''
-    tmpfile="$TMPDIR/${tmpname}"
+    tmpfile="patch"
+
     if [ ! -s "$out" ]; then
       echo "error: Fetched patch file '$out' is empty!" 1>&2
       exit 1
     fi
+
     "${patchutils}/bin/lsdiff" "$out" \
       | sort -u | sed -e 's/[*?]/\\&/g' \
       | xargs -I{} \
@@ -33,6 +38,7 @@ fetchurl ({
            --addnewprefix=b/${extraPrefix} \
         ''} \
         --clean "$out" > "$tmpfile"
+
     if [ ! -s "$tmpfile" ]; then
       echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
       echo "Did you maybe fetch a HTML representation of a patch instead of a raw patch?" 1>&2
@@ -40,6 +46,7 @@ fetchurl ({
       cat "$out" 1>&2
       exit 1
     fi
+
     ${patchutils}/bin/filterdiff \
       -p1 \
       ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
@@ -56,6 +63,7 @@ fetchurl ({
   '' + lib.optionalString revert ''
     ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
     mv "$tmpfile" "$out"
-  '' + (args.postFetch or "");
+  '' + postFetch;
+
   meta.broken = excludes != [] && includes != [];
 } // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"])


### PR DESCRIPTION
Previously, when sha256 either wasn't defined or set to an empty string `fetchpatch` would error out as follows:

```
warning: found empty hash, assuming 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
...
/nix/store/agwlk2bcfvz2ggrsbvwd7696qj55frbi-stdenv-linux/setup: line 96: /build/: Is a directory
sed: couldn't flush stdout: Broken pipe
```

This patch makes it show `fetchurl`'s error message instead, which is a lot more helpful:

```
warning: found empty hash, assuming 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
...
error: hash mismatch in fixed-output derivation:
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-NWGWoyEgT/ztCwbhNgGPvG+nqX4bxtFnD+wds6fklbs=
```

###### Motivation
I would expect this kind of output, seeing how it tells you it assumes an empty hash. This is useful when adding patches you don't yet know the hash of.

###### Things done
Tested this with `sha256` unset, set to an empty variable, and correctly set.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
