### PR TITLE
meek: init at 0.37.0

### DIFF
--- a/pkgs/applications/networking/onionshare/default.nix
+++ b/pkgs/applications/networking/onionshare/default.nix
@@ -20,6 +20,7 @@
 , requests
 , unidecode
 , tor
+, meek
 , obfs4
 , snowflake
 }:
@@ -56,9 +57,6 @@ let
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ lourkeur ];
   };
-
-  # TODO: package meek https://support.torproject.org/glossary/meek/
-  meek = "/meek-not-available";
 
 in
 rec {

--- a/pkgs/tools/networking/meek/default.nix
+++ b/pkgs/tools/networking/meek/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildGoModule, fetchgit }:
+
+buildGoModule rec {
+  pname = "meek";
+  version = "0.37.0";
+  src = fetchgit {
+    url = "https://git.torproject.org/pluggable-transports/meek.git";
+    rev = "v${version}";
+    hash = "sha256-bH7zrrHaVD7WplpEte1KfjzX0FMwp8MsHaOXe4Xlz3Q=";
+  };
+
+  vendorSha256 = "uFHqiYOKNVUXeNjVnVjjDQm2sLBh81Q2yWgQjusb9Ys=";
+
+  meta = with lib; {
+    maintainers = with maintainers; [ lourkeur ];
+    license = licenses.cc0;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1124,6 +1124,8 @@ with pkgs;
 
   lxterminal = callPackage ../applications/terminal-emulators/lxterminal { };
 
+  meek = callPackage ../tools/networking/meek { };
+
   microcom = callPackage ../applications/terminal-emulators/microcom { };
 
   mlterm = callPackage ../applications/terminal-emulators/mlterm {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Useful for Tor users

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
