### PR TITLE
Improve check that evaluation does not depend on the Nixpkgs path

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/functions.nix
+++ b/pkgs/development/ruby-modules/bundled-common/functions.nix
@@ -76,7 +76,7 @@ in rec {
           bundledByPath = true;
           name = gemName;
           version = version;
-          outPath = path;
+          outPath = "${path}";
           outputs = [ "out" ];
           out = res;
           outputName = "out";

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -19,15 +19,8 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
         exit 1
     fi
 
-    # Make sure that derivation paths do not depend on the Nixpkgs path.
-    mkdir $TMPDIR/foo
-    ln -s $(readlink -f $src) $TMPDIR/foo/bar
-    p1=$(nix-instantiate $src --dry-run -A firefox --show-trace)
-    p2=$(nix-instantiate $TMPDIR/foo/bar --dry-run -A firefox --show-trace)
-    if [ "$p1" != "$p2" ]; then
-        echo "Nixpkgs evaluation depends on Nixpkgs path ($p1 vs $p2)!"
-        exit 1
-    fi
+    src2=$TMPDIR/foo
+    cp -rd $src $src2
 
     # Check that all-packages.nix evaluates on a number of platforms without any warnings.
     for platform in ${pkgs.lib.concatStringsSep " " supportedSystems}; do
@@ -42,7 +35,25 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
             --arg config '{ allowAliases = false; }' \
             --option experimental-features 'no-url-literals' \
             -qa --drv-path --system-filter \* --system \
-            "''${opts[@]}" 2>&1 >/dev/null | tee eval-warnings.log
+            "''${opts[@]}" 2> eval-warnings.log > packages1
+
+        s1=$(sha1sum packages1 | cut -c1-40)
+        echo $s1
+
+        nix-env -f $src2 \
+            --show-trace --argstr system "$platform" \
+            --arg config '{ allowAliases = false; }' \
+            --option experimental-features 'no-url-literals' \
+            -qa --drv-path --system-filter \* --system \
+            "''${opts[@]}" > packages2
+
+        s2=$(sha1sum packages2 | cut -c1-40)
+
+        if [[ $s1 != $s2 ]]; then
+            echo "Nixpkgs evaluation depends on Nixpkgs path"
+            diff packages1 packages2
+            exit 1
+        fi
 
         # Catch any trace calls not caught by NIX_ABORT_ON_WARN (lib.warn)
         if [ -s eval-warnings.log ]; then


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While adding a evaluation regression test to Nix, I found that the `docbookrx` package in revision b1f2623e3cfbf5d944c63b16820333165f302c3b depends on the location of Nixpkgs. The function `pathDerivation` in `pkgs/development/ruby-modules/bundled-common/functions.nix` encodes the source path of the Gem (e.g. `/home/eelco/Dev/nixpkgs/pkgs/tools/typesetting/docbookrx`) into the derivation, which is impure and doesn't work in a sandboxed environment. The fix is to ensure that the input is copied to the store. I also improved the test in `pkgs/top-level/nixpkgs-basic-release-checks.nix` to make sure that this is caught.

Note that `docbookrx` has been removed in master, but we should ensure that this doesn't reoccur.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
