### PR TITLE
python3Packages.watchdog: use older version on x86_64-darwin to fix build

### DIFF
--- a/pkgs/development/python-modules/watchdog/1.0.2.nix
+++ b/pkgs/development/python-modules/watchdog/1.0.2.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, argh
+, pathtools
+, pyyaml
+, flaky
+, pytestCheckHook
+, CoreServices
+}:
+
+buildPythonPackage rec {
+  pname = "watchdog";
+  version = "1.0.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-N2y8KjXAOSsP5/8W+8GzA/2Z1N2ZEatVge6daa3IiYI=";
+  };
+
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
+
+  propagatedBuildInputs = [
+    argh
+    pathtools
+    pyyaml
+  ];
+
+  checkInputs = [
+    flaky
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov=watchdog" "" \
+      --replace "--cov-report=term-missing" ""
+  '';
+
+  disabledTestPaths = [
+    # Tests are flaky
+    "tests/test_inotify_buffer.py"
+  ];
+
+  pytestFlagsArray = lib.optional stdenv.isDarwin [
+    # fail in darwin sandbox
+    "--deselect=tests/test_fsevents.py::test_unschedule_removed_folder"
+    "--deselect=tests/test_fsevents.py::test_watchdog_recursive"
+  ];
+
+  pythonImportsCheck = [
+    "watchdog"
+  ];
+
+  meta = with lib; {
+    description = "Python API and shell utilities to monitor file system events";
+    homepage = "https://github.com/gorakhargosh/watchdog";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10307,9 +10307,16 @@ in {
   wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
   inherit (self.wasmerPackages) wasmer wasmer-compiler-cranelift wasmer-compiler-llvm wasmer-compiler-singlepass;
 
-  watchdog = callPackage ../development/python-modules/watchdog {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
-  };
+  watchdog =
+    if stdenv.isDarwin && stdenv.isx86_64 then
+      # last version to not require the 10.13 SDK
+      callPackage ../development/python-modules/watchdog/1.0.2.nix {
+        inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
+      }
+    else
+      callPackage ../development/python-modules/watchdog {
+        inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
+      };
 
   watchgod = callPackage ../development/python-modules/watchgod { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

A working version is better than nothing

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
