### PR TITLE
rxvt-unicode: 9.26 -> 9.30

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -2,6 +2,7 @@
 , libX11, libXt, libXft, libXrender
 , ncurses, fontconfig, freetype
 , pkg-config, gdk-pixbuf, perl
+, libptytty
 , perlSupport      ? true
 , gdkPixbufSupport ? true
 , unicode3Support  ? true
@@ -9,7 +10,7 @@
 
 let
   pname = "rxvt-unicode";
-  version = "9.26";
+  version = "9.30";
   description = "A clone of the well-known terminal emulator rxvt";
 
   desktopItem = makeDesktopItem {
@@ -31,12 +32,13 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${version}.tar.bz2";
-    sha256 = "12y9p32q0v7n7rhjla0j2g9d5rj2dmwk20c9yhlssaaxlawiccb4";
+    sha256 = "0badnkjsn3zps24r5iggj8k5v4f00npc77wqg92pcn1q5z8r677y";
   };
 
   buildInputs =
     [ libX11 libXt libXft ncurses  # required to build the terminfo file
       fontconfig freetype pkg-config libXrender
+      libptytty
     ] ++ optional perlSupport perl
       ++ optional gdkPixbufSupport gdk-pixbuf;
 

--- a/pkgs/development/libraries/libptytty/default.nix
+++ b/pkgs/development/libraries/libptytty/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, lib
+, fetchurl
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libptytty";
+  version = "2.0";
+
+  src = fetchurl {
+    url = "http://dist.schmorp.de/libptytty/${pname}-${version}.tar.gz";
+    sha256 = "1xrikmrsdkxhdy9ggc0ci6kg5b1hn3bz44ag1mk5k1zjmlxfscw0";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "OS independent and secure pty/tty and utmp/wtmp/lastlog";
+    homepage = "http://dist.schmorp.de/libptytty";
+    maintainers = with maintainers; [ rnhmjoj ];
+    platforms = platforms.unix;
+    license = licenses.gpl2;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18310,6 +18310,8 @@ with pkgs;
 
   libpst = callPackage ../development/libraries/libpst { };
 
+  libptytty = callPackage ../development/libraries/libptytty { };
+
   libpwquality = callPackage ../development/libraries/libpwquality { };
 
   libqalculate = callPackage ../development/libraries/libqalculate {


### PR DESCRIPTION
###### Motivation for this change

Version bump

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change
- [x] Tested basic functionality of all binary files
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).