### PR TITLE
cfripper: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/cfn-flip/default.nix
+++ b/pkgs/development/python-modules/cfn-flip/default.nix
@@ -1,25 +1,25 @@
-{ buildPythonPackage
-, fetchFromGitHub
-, lib
-
-# pythonPackages
+{ lib
+, buildPythonPackage
 , click
-, pytest
-, pytest-cov
-, pytest-runner
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
 , pyyaml
 , six
 }:
 
 buildPythonPackage rec {
   pname = "cfn-flip";
-  version = "1.2.2";
+  version = "1.3.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-cfn-template-flip";
     rev = version;
-    sha256 = "05fk725a1i3zl3idik2hxl3w6k1ln0j33j3jdq1gvy1sfyc79ifm";
+    hash = "sha256-1cV0mHc6+P0CbnLIMSSwNEzDB+1QzNjioH/EoIo40xU=";
   };
 
   propagatedBuildInputs = [
@@ -29,27 +29,27 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest
-    pytest-cov
-    pytest-runner
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    py.test \
-      --cov=cfn_clean \
-      --cov=cfn_flip \
-      --cov=cfn_tools \
-      --cov-report term-missing \
-      --cov-report html
+  postPatch = ''
+    sed -i "/--cov/d" tox.ini
   '';
+
+  disabledTests = [
+    # TypeError: load() missing 1 required positional argument: 'Loader'
+    "test_flip_to_yaml_with_longhand_functions"
+    "test_yaml_no_ordered_dict"
+  ];
+
+  pythonImportsCheck = [
+    "cfn_flip"
+  ];
 
   meta = with lib; {
     description = "Tool for converting AWS CloudFormation templates between JSON and YAML formats";
     homepage = "https://github.com/awslabs/aws-cfn-template-flip";
     license = licenses.asl20;
-    maintainers = with maintainers; [
-      kamadorueda
-      psyanticy
-    ];
+    maintainers = with maintainers; [ kamadorueda psyanticy ];
   };
 }

--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, httpx
+, pydantic
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pycfmodel";
+  version = "0.13.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Skyscanner";
+    repo = pname;
+    rev = version;
+    hash = "sha256-BlnLf0C/wxPXhoAH0SRB22eGWbbZ05L20rNy6qfOI+A=";
+  };
+
+  propagatedBuildInputs = [
+    pydantic
+  ];
+
+  checkInputs = [
+    httpx
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Test require network access
+    "test_cloudformation_actions"
+  ];
+
+  pythonImportsCheck = [
+    "pycfmodel"
+  ];
+
+  meta = with lib; {
+    description = "Model for Cloud Formation scripts";
+    homepage = "https://github.com/Skyscanner/pycfmodel";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pydash/default.nix
+++ b/pkgs/development/python-modules/pydash/default.nix
@@ -1,23 +1,46 @@
-{ lib, buildPythonPackage, fetchFromGitHub, mock, pytestCheckHook, invoke }:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, invoke
+, mock
+, pytestCheckHook
+, pythonOlder
+, sphinx_rtd_theme
+}:
 
 buildPythonPackage rec {
   pname = "pydash";
-  version = "4.9.3";
+  version = "5.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "dgilland";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-BAyiSnILvujUOFOAkiXSgyozs2Q809pYihHwa+6BHcQ=";
+    hash = "sha256-BAyiSnILvujUOFOAkiXSgyozs2Q809pYihHwa+6BHcQ=";
   };
 
-  patches = [ ./0001-Only-build-unit-tests.patch ];
+  checkInputs = [
+    invoke
+    mock
+    sphinx_rtd_theme
+    pytestCheckHook
+  ];
 
-  checkInputs = [ mock pytestCheckHook invoke ];
+  postPatch = ''
+    sed -i "/--cov/d" setup.cfg
+    sed -i "/--no-cov/d" setup.cfg
+  '';
+
+  pythonImportsCheck = [
+    "pydash"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/dgilland/pydash";
-    description = "The kitchen sink of Python utility libraries for doing \"stuff\" in a functional way. Based on the Lo-Dash Javascript library.";
+    description = "Python utility libraries for doing stuff in a functional way";
+    homepage = "https://pydash.readthedocs.io";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };

--- a/pkgs/tools/security/cfripper/default.nix
+++ b/pkgs/tools/security/cfripper/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "cfripper";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Skyscanner";
+    repo = pname;
+    rev = version;
+    hash = "sha256-BWdXSHIicMa3PgGoF4GGAOh2LAJWt+7svMLFGhWIkn0=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    boto3
+    cfn-flip
+    click
+    pluggy
+    pycfmodel
+    pydash
+    pyyaml
+    setuptools
+  ];
+
+  checkInputs = with python3.pkgs; [
+    moto
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "click~=7.1.1" "click" \
+      --replace "pluggy~=0.13.1" "pluggy" \
+      --replace "pydash~=4.7.6" "pydash"
+  '';
+
+  disabledTestPaths = [
+    # Tests are failing
+    "tests/test_boto3_client.py"
+    "tests/config/test_pluggy.py"
+  ];
+
+  pythonImportsCheck = [
+    "cfripper"
+  ];
+
+  meta = with lib; {
+    description = "Tool for analysing CloudFormation templates";
+    homepage = "https://github.com/Skyscanner/cfripper";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14379,6 +14379,8 @@ with pkgs;
 
   cfr = callPackage ../development/tools/java/cfr { };
 
+  cfripper = callPackage ../tools/security/cfripper { };
+
   checkra1n = callPackage ../development/mobile/checkra1n { };
 
   checkstyle = callPackage ../development/tools/analysis/checkstyle { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6550,6 +6550,8 @@ in {
     inherit (pkgs) graphviz;
   };
 
+  pycfmodel = callPackage ../development/python-modules/pycfmodel { };
+
   pychannels = callPackage ../development/python-modules/pychannels { };
 
   pychart = callPackage ../development/python-modules/pychart { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool for analysing CloudFormation templates

https://github.com/Skyscanner/cfripper

- Related to #81418
- Fix build (https://hydra.nixos.org/build/163438905)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
