### PR TITLE
 python3Packages.molecule{,-docker}: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5479,6 +5479,12 @@
     githubId = 3948275;
     name = "Harikrishnan R";
   };
+  ilpianista = {
+    email = "andrea@scarpino.dev";
+    github = "ilpianista";
+    githubId = 529436;
+    name = "Andrea Scarpino";
+  };
   ilya-fedin = {
     email = "fedin-ilja2010@ya.ru";
     github = "ilya-fedin";

--- a/pkgs/development/python-modules/molecule-docker/default.nix
+++ b/pkgs/development/python-modules/molecule-docker/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, docker
+, requests
+, molecule
+}:
+
+buildPythonPackage rec {
+  pname = "molecule-docker";
+  version = "1.1.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1gsjc9wi6l48k1v33wjqf7y4fxzl8mqswnhjfl7zdnqhbwwk6lg1";
+  };
+
+  propagatedBuildInputs = [
+    docker
+    molecule
+    requests
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "molecule_docker" ];
+
+  meta = {
+    description = "Molecule Docker Driver allows molecule users to test Ansible code using docker containers";
+    homepage = "https://github.com/ansible-community/molecule-docker";
+    maintainers = with lib.maintainers; [ ilpianista ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/molecule/default.nix
+++ b/pkgs/development/python-modules/molecule/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools-scm
+, ansible-lint
+, ansible-compat
+, cerberus
+, click
+, click-help-colors
+, click-completion
+, cookiecutter
+, pluggy
+, pyyaml
+, selinux-python
+, subprocess-tee
+}:
+
+buildPythonPackage rec {
+  pname = "molecule";
+  version = "3.5.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1jp0djj69w0vw2697yr471zdkvd4smggcfvan5z8v6f0wncz0an8";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace 'PyYAML >= 5.1, < 6' 'PyYAML' \
+      --replace 'cerberus >= 1.3.1, !=1.3.3, !=1.3.4' 'cerberus'
+  '';
+
+  propagatedBuildInputs = [
+    ansible-lint
+    ansible-compat
+    cerberus
+    click
+    click-completion
+    click-help-colors
+    cookiecutter
+    pluggy
+    pyyaml
+    selinux-python
+    subprocess-tee
+  ];
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  pythonImportsCheck = [ "molecule" ];
+
+  meta = with lib; {
+    description = "Molecule aids in the development and testing of Ansible roles";
+    homepage = "https://github.com/ansible-community/molecule";
+    maintainers = with maintainers; [ ilpianista ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/molecule/default.nix
+++ b/pkgs/development/python-modules/molecule/default.nix
@@ -11,6 +11,7 @@
 , cookiecutter
 , pluggy
 , pyyaml
+, pytestCheckHook
 , selinux-python
 , subprocess-tee
 }:
@@ -18,6 +19,7 @@
 buildPythonPackage rec {
   pname = "molecule";
   version = "3.5.2";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -47,6 +49,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools-scm
   ];
+
+  checkInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "molecule" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5488,6 +5488,8 @@ in {
 
   moku = callPackage ../development/python-modules/moku { };
 
+  molecule = callPackage ../development/python-modules/molecule { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5490,6 +5490,8 @@ in {
 
   molecule = callPackage ../development/python-modules/molecule { };
 
+  molecule-docker = callPackage ../development/python-modules/molecule-docker { };
+
   monero = callPackage ../development/python-modules/monero { };
 
   mongomock = callPackage ../development/python-modules/mongomock { };


### PR DESCRIPTION
###### Motivation for this change

Add `molecule`. Follow up of #138849.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
