### PR TITLE
deadd-notification-center: 2022-04-20 -> 2022-11-07 and build from source

### DIFF
--- a/pkgs/applications/misc/deadd-notification-center/default.nix
+++ b/pkgs/applications/misc/deadd-notification-center/default.nix
@@ -1,62 +1,57 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, autoPatchelfHook
-, wrapGAppsHook
-, hicolor-icon-theme
-, gtk3
-, gobject-introspection
-, libxml2
-, fetchpatch
-}:
-stdenv.mkDerivation rec {
+{ mkDerivation, haskellPackages, fetchFromGitHub, lib, writeText }:
+
+let
+  # deadd-notification-center.service
+  systemd-service = ''
+    [Unit]
+    Description=Deadd Notification Center
+    PartOf=graphical-session.target
+
+    [Service]
+    Type=dbus
+    BusName=org.freedesktop.Notifications
+    ExecStart=$out/bin/deadd-notification-center
+
+    [Install]
+    WantedBy=graphical-session.target
+  '';
+in mkDerivation rec {
   pname = "deadd-notification-center";
-  version = "2022-04-20";
+  version = "unstable-2022-11-07";
 
   src = fetchFromGitHub {
     owner = "phuhl";
     repo = "linux_notification_center";
-    rev = "d31867472c35a09562c832b0a589479930c52b86";
-    sha256 = "sha256-Arl4niscJPYCFWd4mw42IgNs+JsHsVpaTx86zEj3KFM=";
+    rev = "f4b8e2b724d86def9e7b0e12ea624f95760352d5";
+    hash = "sha256-ClJfWqStULvmj5YRAUDAmn2WOSA2sVtyZsa+qSY51Gk=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/phuhl/linux_notification_center/commit/5244e1498574983322be97925e1ff7ebe456d974.patch";
-      sha256 = "sha256-hbqbgBmuewOhtx0na2tmFa5W128ZrBvDcyPme/mRzlI=";
-    })
+  isLibrary = false;
+
+  isExecutable = true;
+
+  libraryHaskellDepends = with haskellPackages; [
+    base bytestring ConfigFile containers dbus directory env-locale
+    filepath gi-cairo gi-gdk gi-gdkpixbuf gi-gio gi-glib gi-gobject
+    gi-gtk gi-pango haskell-gettext haskell-gi haskell-gi-base
+    hdaemonize here lens mtl process regex-tdfa setlocale split stm
+    tagsoup text time transformers tuple unix
   ];
 
-  nativeBuildInputs = [
-    autoPatchelfHook
-    wrapGAppsHook
-  ];
+  executableHaskellDepends = with haskellPackages; [ base ];
 
-  buildInputs = [
-    gtk3
-    gobject-introspection
-    libxml2
-    hicolor-icon-theme
-  ];
+  # Test suite does nothing.
+  doCheck = false;
 
-  buildFlags = [
-    # Exclude stack from `make all` to use the prebuilt binary from .out/
-    "service"
-  ];
+  # Add systemd user unit.
+  postInstall = ''
+    mkdir -p $out/lib/systemd/user
+    echo "${systemd-service}" > $out/lib/systemd/user/deadd-notification-center.service
+  '';
 
-  makeFlags = [
-    "PREFIX=${placeholder "out"}"
-    "SERVICEDIR_SYSTEMD=${placeholder "out"}/etc/systemd/user"
-    "SERVICEDIR_DBUS=${placeholder "out"}/share/dbus-1/services"
-    # Override systemd auto-detection.
-    "SYSTEMD=1"
-  ];
-
-  meta = with lib; {
-    description = "A haskell-written notification center for users that like a desktop with style";
-    homepage = "https://github.com/phuhl/linux_notification_center";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.pacman99 ];
-    platforms = platforms.linux;
-  };
+  description = "A haskell-written notification center for users that like a desktop with style";
+  homepage = "https://github.com/phuhl/linux_notification_center";
+  license = lib.licenses.bsd3;
+  maintainers = with lib.maintainers; [ melkor333 sna ];
+  platforms = lib.platforms.linux;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30349,7 +30349,7 @@ with pkgs;
 
   linvstmanager = qt5.callPackage ../applications/audio/linvstmanager { };
 
-  deadd-notification-center = callPackage ../applications/misc/deadd-notification-center { };
+  deadd-notification-center = haskell.lib.compose.justStaticExecutables (haskellPackages.callPackage ../applications/misc/deadd-notification-center { });
 
   lollypop = callPackage ../applications/audio/lollypop { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update and switch to building from source. 

cc @Pacman99 @teto for extra testing if possible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
