### PR TITLE
pitch-black: init at unstable-2019-07-23

### DIFF
--- a/pkgs/data/themes/pitch-black/default.nix
+++ b/pkgs/data/themes/pitch-black/default.nix
@@ -1,0 +1,30 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec{
+  pname = "pitch-black";
+  version = "unstable-2019-07-23";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "freefreeno";
+    rev = "d8039341419aef1157c030bf3d9237bd926e0b95";
+    hash = "sha256-Rn3ZMBD6srIkYFNN3HT5JFP46Akodmeqz5tbV2/2ZDA=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    rm LICENSE README.md
+    mkdir -p $out/share
+    mv GTK $out/share/themes
+    mv * $out/share
+  '';
+
+  meta = with lib; {
+    description = "Pitch-Black theme is a dark plasma theme built with usability in mind and it looks great.";
+    homepage = "https://github.com/freefreeno/Pitch-Black";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.pasqui23 ];
+  };
+}

--- a/pkgs/data/themes/pitch-black/default.nix
+++ b/pkgs/data/themes/pitch-black/default.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation rec{
   '';
 
   meta = with lib; {
-    description = "Pitch-Black theme is a dark plasma theme built with usability in mind and it looks great.";
+    description = "A dark plasma theme built with usability in mind";
     homepage = "https://github.com/freefreeno/Pitch-Black";
     license = licenses.gpl3Only;
     platforms = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23874,6 +23874,8 @@ with pkgs;
 
   penna = callPackage ../data/fonts/penna { };
 
+  pitch-black = callPackage ../data/themes/pitch-black {};
+
   plano-theme = callPackage ../data/themes/plano { };
 
   plata-theme = callPackage ../data/themes/plata {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
