### PR TITLE
system76-oled: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13777,4 +13777,10 @@
       fingerprint = "3586 3350 BFEA C101 DB1A 4AF0 1F81 112D 62A9 ADCE";
     }];
   };
+  zarthross = {
+    name = "Darren Gibson";
+    email = "zarthross@gmail.com";
+    github = "zarthross";
+    githubId = 1111592;
+  };
 }

--- a/pkgs/os-specific/linux/system76-oled/default.nix
+++ b/pkgs/os-specific/linux/system76-oled/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, dbus
+, libX11
+, libXrandr
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "system76-oled";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:0xy6fpr9k5wnq074flsxm1k27svvk4pvqyryhdsw1jpch46lzm1f";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus libX11 libXrandr ];
+
+  cargoSha256 = "sha256:13nhs17gzya1by5b301hl8q0pm9m9k1pnzmmgx1v1qam0zd7qj91";
+
+  postInstall = ''
+    install -D -m -0644 data/system76-oled.desktop $out/etc/xdg/autostart/system76-oled.desktop
+  '';
+
+  meta = with lib; {
+    description = "Brightness control for System76 laptops with OLED displays";
+    homepage = "https://github.com/pop-os/system76-oled";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ zarthross ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "system76-oled";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22683,6 +22683,7 @@ with pkgs;
   nvmet-cli = callPackage ../os-specific/linux/nvmet-cli { };
 
   system76-firmware = callPackage ../os-specific/linux/firmware/system76-firmware { };
+  system76-oled = callPackage ../os-specific/linux/system76-oled {};
 
   ocf-resource-agents = callPackage ../os-specific/linux/ocf-resource-agents { };
 


### PR DESCRIPTION
###### Motivation for this change

System76 Adder WS line of laptops use an OLED display. The standard brightness controls do not work with these OLED screens.

This package provides the System76-oled application that System76 uses with PopOS to provide brightness controls on these notebooks.  

This was tested on a System76 Adder WS 1 (addw1) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
