### PR TITLE
srtrelay: unstable-2021-07-28 -> 1.1.0

### DIFF
--- a/pkgs/applications/video/srtrelay/default.nix
+++ b/pkgs/applications/video/srtrelay/default.nix
@@ -1,17 +1,17 @@
 { lib, buildGoModule, fetchFromGitHub, srt, ffmpeg }:
 
 buildGoModule rec {
-  pname = "srtrelay-unstable";
-  version = "2021-07-28";
+  pname = "srtrelay";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "voc";
     repo = "srtrelay";
-    rev = "c4f02ff2e9637b01a0679b29e5a76f4521eeeef3";
-    sha256 = "06zbl97bjjyv51zp27qk37ffpbh1ylm9bsr0s5qlyd73pyavcj1g";
+    rev = "v${version}";
+    sha256 = "sha256-CA+UuFOWjZjSBDWM62rda3IKO1fwC3X52mP4tg1uoO4=";
   };
 
-  vendorSha256 = "1pdpb0my7gdvjjkka6jhj19b9nx575k6117hg536b106ij2n4zd2";
+  vendorSha256 = "sha256-xTYlfdijSo99ei+ZMX6N9gl+yw0DrPQ2wOhn6SS9S/E=";
 
   buildInputs = [ srt ];
   checkInputs = [ ffmpeg ];


### PR DESCRIPTION
###### Motivation for this change
stable release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
