### PR TITLE
Pantheon updates 2022-01-24

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-code/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-code/default.nix
@@ -48,12 +48,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     appstream
     desktop-file-utils
@@ -94,6 +88,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Code editor designed for elementary OS";

--- a/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
@@ -24,11 +24,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-feedback";
   version = "6.1.0";
 
-  repoName = "feedback";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "feedback";
     rev = version;
     sha256 = "02wydbpa5qaa4xmmh4m7rbj4djbrn2i44zjakj5i6mzwjlj6sv5n";
   };

--- a/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-feedback/default.nix
@@ -42,12 +42,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     gettext
     meson
@@ -73,6 +67,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "GitHub Issue Reporter designed for elementary OS";

--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -26,23 +25,14 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-mail";
-  version = "6.3.1";
+  version = "6.4.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "mail";
     rev = version;
-    sha256 = "sha256-wOu9jvvwG53vzcNa38nk4eREZWW7Cin8el4qApQ8gI8=";
+    sha256 = "sha256-ooqVNMgeAqGlFcfachPPfhSiKTEEcNGv5oWdM7VLWOc=";
   };
-
-  patches = [
-    # Fix build with meson 0.61
-    # https://github.com/elementary/mail/pull/751
-    (fetchpatch {
-      url = "https://github.com/elementary/mail/commit/bbadc56529276d8e0ff98e9df7d9bb1bf8fc5783.patch";
-      sha256 = "sha256-lJEnX5/G6e8PdKy1XGlwFIoCeSy6SR5p68tS4noj+44=";
-    })
-  ];
 
   nativeBuildInputs = [
     appstream

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -58,12 +58,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     desktop-file-utils
     meson
@@ -107,6 +101,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Music player and library designed for elementary OS";

--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -34,11 +34,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-music";
   version = "5.1.1";
 
-  repoName = "music";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "music";
     rev = version;
     sha256 = "1wqsn4ss9acg0scaqpg514ll2dj3bl71wly4mm79qkinhy30yv9n";
   };

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -36,11 +36,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-photos";
   version = "2.7.3";
 
-  repoName = "photos";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "photos";
     rev = version;
     sha256 = "sha256-ja4ElW0FNm9oNyn+00SdI2Cxep6LyWTYM8Blc6bnuiY=";
   };

--- a/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-tasks";
-  version = "6.1.0";
+  version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "tasks";
     rev = version;
-    sha256 = "sha256-Gt9Hp9m28QdAFnKIT1xcbiSM5cn6kW7wEXmi/iFfu8k=";
+    sha256 = "sha256-eHaWXntLkk5G+cR5uFwWsIvbSPsbrvpglYBh91ta/M0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/sideload/default.nix
+++ b/pkgs/desktops/pantheon/apps/sideload/default.nix
@@ -32,12 +32,6 @@ stdenv.mkDerivation rec {
     sha256 = "0abpcawmmv5mgzk2i5n9rlairmjr2v9rg9b8c9g7xa085s496bi9";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     desktop-file-utils
     gettext
@@ -65,6 +59,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://github.com/elementary/sideload";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
@@ -40,12 +40,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -60,6 +54,12 @@ stdenv.mkDerivation rec {
     switchboard
     wingpanel-indicator-a11y
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Universal Access Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -29,11 +29,13 @@ stdenv.mkDerivation rec {
     sha256 = "0c075ac7iqz4hqbp2ph0cwyhiq0jn6c1g1jjfhygjbssv3vvd268";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    # Use NixOS's default wallpaper
+    (substituteAll {
+      src = ./fix-background-path.patch;
+      default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -53,13 +55,11 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  patches = [
-    # Use NixOS's default wallpaper
-    (substituteAll {
-      src = ./fix-background-path.patch;
-      default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
-    })
-  ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard About Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -24,12 +24,6 @@ stdenv.mkDerivation rec {
     sha256 = "18izmzhqp6x5ivha9yl8gyz9adyrsylw7w5p0cwm1bndgqbi7yh5";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -44,6 +38,12 @@ stdenv.mkDerivation rec {
     libgee
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Applications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -35,12 +35,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -56,6 +50,12 @@ stdenv.mkDerivation rec {
     switchboard
     wingpanel-indicator-bluetooth # settings schema
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Bluetooth Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -27,12 +27,6 @@ stdenv.mkDerivation rec {
     sha256 = "10rqhxsqbl1xnz5n84d7m39c3vb71k153989xvyc55djia1wjx96";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
@@ -60,6 +54,12 @@ stdenv.mkDerivation rec {
     libgee
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Date & Time Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -24,12 +24,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3sYZCazGnTjIi3Iry5673TMI13sD0GuY+46AK+NJH70=";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -44,6 +38,12 @@ stdenv.mkDerivation rec {
     libhandy
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Displays Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -40,12 +40,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     libxml2
     meson
@@ -66,6 +60,12 @@ stdenv.mkDerivation rec {
     libxklavier
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Keyboard Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -29,11 +29,12 @@ stdenv.mkDerivation rec {
     sha256 = "0nqgbpk1knvbj5xa078i0ka6lzqmaaa873gwj3mhjr5q2gzkw7y5";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      touchegg = touchegg;
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -54,12 +55,11 @@ stdenv.mkDerivation rec {
     touchegg
   ];
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      touchegg = touchegg;
-    })
-  ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Mouse & Touchpad Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -27,11 +27,12 @@ stdenv.mkDerivation rec {
     sha256 = "0nqihsbrpjw4nx1c50g854bqybniw38adi78vzg8nyl6ikj2r0z4";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit networkmanagerapplet;
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -49,12 +50,11 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit networkmanagerapplet;
-    })
-  ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Networking Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -54,6 +48,12 @@ stdenv.mkDerivation rec {
     libgee
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Notifications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -28,12 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "006h8mrhmdrbd83vhdyahgrfk9wh6j9kjincpp7dz7sl8fsyhmcr";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -52,6 +46,12 @@ stdenv.mkDerivation rec {
     switchboard
     wingpanel-indicator-power # settings schema
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Power Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -54,6 +48,12 @@ stdenv.mkDerivation rec {
     libgee
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Printers Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -33,12 +33,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -52,6 +46,12 @@ stdenv.mkDerivation rec {
     libgee
     switchboard
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Sharing Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
@@ -37,12 +37,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -61,6 +55,12 @@ stdenv.mkDerivation rec {
     xorg.libX11
     xorg.libXi
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Switchboard Wacom Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/default.nix
@@ -28,12 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "02dfsrfmr297cxpyd5m3746ihcgjyfnb3d42ng9m4ljdvh0dxgim";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     gettext
     meson
@@ -72,6 +66,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Extensible System Settings app for Pantheon";

--- a/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-gtk-theme/default.nix
@@ -12,11 +12,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-gtk-theme";
   version = "6.1.1";
 
-  repoName = "stylesheet";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "stylesheet";
     rev = version;
     sha256 = "sha256-gciBn5MQ5Cu+dROL5kCt2GCbNA7W4HOWXyjMBd4OP+8=";
   };

--- a/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-icon-theme/default.nix
@@ -15,11 +15,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-icon-theme";
   version = "6.1.0";
 
-  repoName = "icons";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "icons";
     rev = version;
     sha256 = "sha256-WR4HV0nJKj0WeSFHXLK64O0LhX8myAJE4w0aztyhPn4=";
   };

--- a/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
+++ b/pkgs/desktops/pantheon/artwork/elementary-sound-theme/default.nix
@@ -11,11 +11,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-sound-theme";
   version = "1.1.0";
 
-  repoName = "sound-theme";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "sound-theme";
     rev = version;
     sha256 = "sha256-fR6gtKx9J6o2R1vQZ5yx4kEX3Ak+q8I6hRVMZzyB2E8=";
   };

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -17,11 +17,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-default-settings";
   version = "6.0.2";
 
-  repoName = "default-settings";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "default-settings";
     rev = version;
     sha256 = "sha256-qaPj/Qp7RYzHgElFdM8bHV42oiPUbCMTC9Q+MUj4Q6Y=";
   };

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -40,16 +40,20 @@ stdenv.mkDerivation rec {
     sha256 = "1f606ds56sp1c58q8dblfpaq9pwwkqw9i4gkwksw45m2xkwlbflq";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-
-    xgreeters = linkFarm "pantheon-greeter-xgreeters" [{
-      path = "${elementary-greeter}/share/xgreeters/io.elementary.greeter.desktop";
-      name = "io.elementary.greeter.desktop";
-    }];
-  };
+  patches = [
+    ./sysconfdir-install.patch
+    # Needed until https://github.com/elementary/greeter/issues/360 is fixed
+    (substituteAll {
+      src = ./hardcode-fallback-background.patch;
+      default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
+    })
+    # Fix build with meson 0.61
+    # https://github.com/elementary/greeter/pull/590
+    (fetchpatch {
+      url = "https://github.com/elementary/greeter/commit/a4b25244058fce794a9f13f6b22a8ff7735ebde9.patch";
+      sha256 = "sha256-qPXhdvmYG8YMDU/CjbEkfZ0glgRzxnu0TsOPtvWHxLY=";
+    })
+  ];
 
   nativeBuildInputs = [
     desktop-file-utils
@@ -84,21 +88,6 @@ stdenv.mkDerivation rec {
     "-Dgsd-dir=${gnome-settings-daemon}/libexec/" # trailing slash is needed
   ];
 
-  patches = [
-    ./sysconfdir-install.patch
-    # Needed until https://github.com/elementary/greeter/issues/360 is fixed
-    (substituteAll {
-      src = ./hardcode-fallback-background.patch;
-      default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
-    })
-    # Fix build with meson 0.61
-    # https://github.com/elementary/greeter/pull/590
-    (fetchpatch {
-      url = "https://github.com/elementary/greeter/commit/a4b25244058fce794a9f13f6b22a8ff7735ebde9.patch";
-      sha256 = "sha256-qPXhdvmYG8YMDU/CjbEkfZ0glgRzxnu0TsOPtvWHxLY=";
-    })
-  ];
-
   preFixup = ''
     gappsWrapperArgs+=(
       # dbus-launch needed in path
@@ -124,6 +113,17 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/xgreeters/io.elementary.greeter.desktop \
       --replace "Exec=io.elementary.greeter" "Exec=$out/bin/io.elementary.greeter"
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+
+    xgreeters = linkFarm "pantheon-greeter-xgreeters" [{
+      path = "${elementary-greeter}/share/xgreeters/io.elementary.greeter.desktop";
+      name = "io.elementary.greeter.desktop";
+    }];
+  };
 
   meta = with lib; {
     description = "LightDM Greeter for Pantheon";

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -47,6 +47,18 @@ stdenv.mkDerivation rec {
       src = ./hardcode-fallback-background.patch;
       default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
     })
+    # Revert "UserCard: use accent color for logged_in check (#566)"
+    # https://github.com/elementary/greeter/pull/566
+    # Fixes crash issue reported in:
+    # https://github.com/elementary/greeter/issues/578
+    # https://github.com/NixOS/nixpkgs/issues/151609
+    # Probably also fixes:
+    # https://github.com/elementary/greeter/issues/568
+    # https://github.com/elementary/greeter/issues/583
+    # https://github.com/NixOS/nixpkgs/issues/140513
+    # Revisit this when the greeter is ported to GTK 4:
+    # https://github.com/elementary/greeter/pull/591
+    ./revert-pr566.patch
     # Fix build with meson 0.61
     # https://github.com/elementary/greeter/pull/590
     (fetchpatch {

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/revert-pr566.patch
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/revert-pr566.patch
@@ -1,0 +1,103 @@
+From 572a73cbc84dd9a0f5a7667a60c75ed5580d84a1 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Tue, 25 Jan 2022 10:03:31 +0800
+Subject: [PATCH] Revert "UserCard: use accent color for logged_in check
+ (#566)"
+
+This reverts commit 6f18c79c780582e43039032f6926816efa82e206.
+---
+ data/Check.css             | 11 -----------
+ data/greeter.gresource.xml |  1 -
+ src/Cards/UserCard.vala    | 29 +++--------------------------
+ 3 files changed, 3 insertions(+), 38 deletions(-)
+ delete mode 100644 data/Check.css
+
+diff --git a/data/Check.css b/data/Check.css
+deleted file mode 100644
+index 947db6b..0000000
+--- a/data/Check.css
++++ /dev/null
+@@ -1,11 +0,0 @@
+-check {
+-    background-color: @accent_color;
+-    border-radius: 99px;
+-    color: white;
+-    margin: 2px;
+-    min-height: 20px;
+-    min-width: 20px;
+-    -gtk-icon-shadow: 0 1px 1px shade(@accent_color, 0.7);
+-    -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
+-    -gtk-icon-transform: scale(0.6);
+-}
+diff --git a/data/greeter.gresource.xml b/data/greeter.gresource.xml
+index 604c89a..ce9be29 100644
+--- a/data/greeter.gresource.xml
++++ b/data/greeter.gresource.xml
+@@ -2,7 +2,6 @@
+ <gresources>
+   <gresource prefix="/io/elementary/greeter">
+     <file alias="Card.css" compressed="true">Card.css</file>
+-    <file alias="Check.css" compressed="true">Check.css</file>
+     <file alias="DateTime.css" compressed="true">DateTime.css</file>
+     <file alias="MainWindow.css" compressed="true">MainWindow.css</file>
+   </gresource>
+diff --git a/src/Cards/UserCard.vala b/src/Cards/UserCard.vala
+index 83df22c..02d2b0a 100644
+--- a/src/Cards/UserCard.vala
++++ b/src/Cards/UserCard.vala
+@@ -42,7 +42,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
+     private Gtk.Stack login_stack;
+     private Greeter.PasswordEntry password_entry;
+ 
+-    private unowned Gtk.StyleContext logged_in_context;
+     private weak Gtk.StyleContext main_grid_style_context;
+     private weak Gtk.StyleContext password_entry_context;
+ 
+@@ -214,14 +213,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
+         };
+         avatar_overlay.add (avatar);
+ 
+-        var logged_in = new SelectionCheck () {
+-            halign = Gtk.Align.END,
+-            valign = Gtk.Align.END
+-        };
+-
+-        logged_in_context = logged_in.get_style_context ();
+-
+         if (lightdm_user.logged_in) {
++            var logged_in = new Gtk.Image.from_icon_name ("selection-checked", Gtk.IconSize.LARGE_TOOLBAR);
++            logged_in.halign = logged_in.valign = Gtk.Align.END;
++
+             avatar_overlay.add_overlay (logged_in);
+ 
+             session_button.sensitive = false;
+@@ -304,7 +299,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
+         gtksettings.gtk_theme_name = "io.elementary.stylesheet." + accent_to_string (prefers_accent_color);
+ 
+         var style_provider = Gtk.CssProvider.get_named (gtksettings.gtk_theme_name, null);
+-        logged_in_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+         password_entry_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+     }
+ 
+@@ -451,21 +445,4 @@ public class Greeter.UserCard : Greeter.BaseCard {
+             return GLib.Source.REMOVE;
+         });
+     }
+-
+-    private class SelectionCheck : Gtk.Spinner {
+-        private static Gtk.CssProvider check_provider;
+-
+-        class construct {
+-            set_css_name (Gtk.STYLE_CLASS_CHECK);
+-        }
+-
+-        static construct {
+-            check_provider = new Gtk.CssProvider ();
+-            check_provider.load_from_resource ("/io/elementary/greeter/Check.css");
+-        }
+-
+-        construct {
+-            get_style_context ().add_provider (check_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+-        }
+-    }
+ }

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -35,6 +35,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9voy9eje3VlV4IMM664EyjKWTfSVogX5JoRCqhsUXTE=";
   };
 
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      appcenter = appcenter;
+    })
+    # Provides the directory where the locales are actually installed
+    # https://github.com/elementary/onboarding/pull/147
+    (fetchpatch {
+      url = "https://github.com/elementary/onboarding/commit/af19c3dbefd1c0e0ec18eddacc1f21cb991f5513.patch";
+      sha256 = "sha256-fSFfjSd33W7rXXEUHY8b3rv9B9c31XfCjxjRxBBrqjs=";
+    })
+  ];
+
   nativeBuildInputs = [
     gettext
     meson
@@ -54,19 +67,6 @@ stdenv.mkDerivation rec {
     gtk3
     libgee
     libhandy
-  ];
-
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      appcenter = appcenter;
-    })
-    # Provides the directory where the locales are actually installed
-    # https://github.com/elementary/onboarding/pull/147
-    (fetchpatch {
-      url = "https://github.com/elementary/onboarding/commit/af19c3dbefd1c0e0ec18eddacc1f21cb991f5513.patch";
-      sha256 = "sha256-fSFfjSd33W7rXXEUHY8b3rv9B9c31XfCjxjRxBBrqjs=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-onboarding/default.nix
@@ -26,11 +26,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-onboarding";
   version = "6.1.0";
 
-  repoName = "onboarding";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "onboarding";
     rev = version;
     sha256 = "sha256-9voy9eje3VlV4IMM664EyjKWTfSVogX5JoRCqhsUXTE=";
   };

--- a/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
@@ -22,12 +22,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-l2IUu9Mj22lZ5yajPcsGrJcJDakNu4srCV0Qea5ybPA=";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -36,6 +30,12 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ gtk3 ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Simple shim for printing support via Contractor";

--- a/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-print-shim/default.nix
@@ -13,11 +13,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-print-shim";
   version = "0.1.3";
 
-  repoName = "print";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "print";
     rev = version;
     sha256 = "sha256-l2IUu9Mj22lZ5yajPcsGrJcJDakNu4srCV0Qea5ybPA=";
   };

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -80,7 +80,7 @@ let
     Name=Pantheon
     Comment=This session provides elementary experience
     Exec=@out@/libexec/pantheon
-    TryExec=${wingpanel}/bin/wingpanel
+    TryExec=${wingpanel}/bin/io.elementary.wingpanel
     Icon=
     DesktopNames=Pantheon
     Type=Application

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -92,11 +92,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-session-settings";
   version = "6.0.0";
 
-  repoName = "session-settings";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "session-settings";
     rev = version;
     sha256 = "1faglpa7q3a4335gnd074a3lnsdspyjdnskgy4bfnf6xmwjx7kjx";
   };

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/a11y/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/a11y/default.nix
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -59,6 +53,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Universal Access Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -27,12 +27,6 @@ stdenv.mkDerivation rec {
     sha256 = "12rasf8wy3cqnfjlm9s2qnx4drzx0w0yviagkng3kspdzm3vzsqy";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     glib # for glib-compile-schemas
     libxml2
@@ -56,6 +50,12 @@ stdenv.mkDerivation rec {
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Bluetooth Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -29,11 +29,18 @@ stdenv.mkDerivation rec {
     sha256 = "10zzsil5l6snz47nx887r22sl2n0j6bg4dhxmgk3j3xp3jhgmrgl";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      gkbd_keyboard_display = "${libgnomekbd}/bin/gkbd-keyboard-display";
+    })
+    # Upstream code not respecting our localedir
+    # https://github.com/elementary/wingpanel-indicator-keyboard/pull/110
+    (fetchpatch {
+      url = "https://github.com/elementary/wingpanel-indicator-keyboard/commit/ea5df2f62a99a216ee5ed137268e710490a852a4.patch";
+      sha256 = "0fmdz10xgzsryj0f0dnpjrh9yygjkb91a7pxg0rwddxbprhnr7j0";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -52,18 +59,11 @@ stdenv.mkDerivation rec {
     xorg.xkeyboardconfig
   ];
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      gkbd_keyboard_display = "${libgnomekbd}/bin/gkbd-keyboard-display";
-    })
-    # Upstream code not respecting our localedir
-    # https://github.com/elementary/wingpanel-indicator-keyboard/pull/110
-    (fetchpatch {
-      url = "https://github.com/elementary/wingpanel-indicator-keyboard/commit/ea5df2f62a99a216ee5ed137268e710490a852a4.patch";
-      sha256 = "0fmdz10xgzsryj0f0dnpjrh9yygjkb91a7pxg0rwddxbprhnr7j0";
-    })
-  ];
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Keyboard Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
@@ -34,12 +34,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     libxml2
     meson
@@ -54,6 +48,12 @@ stdenv.mkDerivation rec {
     libgee
     wingpanel
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Night Light Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -30,11 +30,12 @@ stdenv.mkDerivation rec {
     sha256 = "1zlpnl7983jkpy2nik08ih8lwrqvm456h993ixa6armzlazdvnjk";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      gnome_power_manager = gnome.gnome-power-manager;
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -55,17 +56,16 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      gnome_power_manager = gnome.gnome-power-manager;
-    })
-  ];
-
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Power Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -35,12 +35,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -56,6 +50,12 @@ stdenv.mkDerivation rec {
     libhandy
     wingpanel
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Session Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel/default.nix
@@ -31,6 +31,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-WvkQx+9YjKCINpyVg8KjCV0GAb0rJfblSFaO14/4oas=";
   };
 
+  patches = [
+    ./indicators.patch
+  ];
+
   nativeBuildInputs = [
     gettext
     meson
@@ -51,10 +55,6 @@ stdenv.mkDerivation rec {
     libgee
     mutter
     mesa # for libEGL
-  ];
-
-  patches = [
-    ./indicators.patch
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/services/contractor/default.nix
+++ b/pkgs/desktops/pantheon/services/contractor/default.nix
@@ -25,12 +25,6 @@ stdenv.mkDerivation rec {
     sha256 = "1sqww7zlzl086pjww3d21ah1g78lfrc9aagrqhmsnnbji9gwb8ab";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     dbus
     meson
@@ -48,6 +42,12 @@ stdenv.mkDerivation rec {
   ];
 
   PKG_CONFIG_DBUS_1_SESSION_BUS_SERVICES_DIR = "${placeholder "out"}/share/dbus-1/services";
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "A desktop-wide extension service used by elementary OS";

--- a/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-notifications/default.nix
@@ -19,11 +19,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-notifications";
   version = "6.0.0";
 
-  repoName = "notifications";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "notifications";
     rev = version;
     sha256 = "0jfppafbc8jwhhnillylicz4zfds789d8b31ifsx0qijlxa7kji9";
   };

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -23,11 +23,9 @@ stdenv.mkDerivation rec {
   pname = "elementary-settings-daemon";
   version = "1.1.0";
 
-  repoName = "settings-daemon";
-
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "settings-daemon";
     rev = version;
     sha256 = "sha256-1Xp1uJzDFuGZlhJhKj00cYtb4Q1syMAm+82fTOtk0VI=";
   };

--- a/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-geoclue2/default.nix
@@ -25,12 +25,6 @@ stdenv.mkDerivation rec {
     sha256 = "0hx3sky0vd2vshkscy3w5x3s18gd45cfqh510xhbmvc0sa32q9gd";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     desktop-file-utils
     meson
@@ -50,6 +44,12 @@ stdenv.mkDerivation rec {
   postInstall = ''
     ${glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
   '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Pantheon Geoclue2 Agent";

--- a/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
+++ b/pkgs/desktops/pantheon/services/pantheon-agent-polkit/default.nix
@@ -24,12 +24,6 @@ stdenv.mkDerivation rec {
     sha256 = "1acqjjarl225yk0f68wkldsamcrzrj0ibpcxma04wq9w7jlmz60c";
   };
 
-  passthru = {
-    updateScript = nix-update-script {
-      attrPath = "pantheon.${pname}";
-    };
-  };
-
   nativeBuildInputs = [
     meson
     ninja
@@ -44,6 +38,12 @@ stdenv.mkDerivation rec {
     libgee
     polkit
   ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with lib; {
     description = "Polkit Agent for the Pantheon Desktop";


### PR DESCRIPTION
###### Motivation for this change

Pantheon 6.1 follow-ups (previous one at #154414)

fixes #156456 and fixes #151609, likely also fixes #140513.
Easier to review commit by commit.

### To test this

```nix
{ modulesPath, ... }: {

  imports = [
    "${modulesPath}/virtualisation/qemu-vm.nix"
  ];

  environment.enableDebugInfo = true;

  services.xserver = {
    enable = true;
    displayManager = {
      lightdm.enable = true;
      defaultSession = "xfce";
    };

    desktopManager = {
      xfce.enable = true;
      pantheon.enable = true;
    };
  };

  users.mutableUsers = false;

  users.extraUsers.test = {
    isNormalUser = true;
    uid = 1000;
    extraGroups = [ "wheel" "networkmanager" ];
    password = "test";
  };

  nixpkgs.config.allowAliases = false;

  virtualisation = {
    qemu.options = [ "-device intel-hda -device hda-duplex" ];
    memorySize = 4096;
    diskSize = 8192;
  };

}
```

```ShellSession
$ env NIX_PATH=nixpkgs=/path/to/nixpkgs:nixos-config=/path/to/configuration.nix nixos-rebuild build-vm
```

Things to test:

* [x] See if lightdm starts.
* [x] See if Pantheon and Xfce are shown on lightdm.
* [x] Change accent color and do a reboot.
* [x] See if locking works.
* [x] Revert (only) 34d5d14fd0d9e0cab8458342f9e7fb105ceb7db3, reset VM and retest everything.
* [x] Revert (only) 45ec3d3d4abdfa98be7b02afd0f1c5b870b6d775, reset VM and retest everything.
* [ ] Backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
