### PR TITLE
nix: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -229,7 +229,7 @@ in rec {
 
   nix = nixStable;
 
-  nixStable = nix_2_5;
+  nixStable = nix_2_6;
 
   nix_2_3 = callPackage common (rec {
     pname = "nix";
@@ -276,6 +276,22 @@ in rec {
     boehmgc = boehmgc_nix;
 
     patches = [ installNlohmannJsonPatch ];
+
+    inherit storeDir stateDir confDir;
+  });
+
+  nix_2_6 = callPackage common (rec {
+    pname = "nix";
+    version = "2.6.0";
+
+    src = fetchFromGitHub {
+      owner = "NixOS";
+      repo = "nix";
+      rev = version;
+      sha256 = "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=";
+    };
+
+    boehmgc = boehmgc_nix;
 
     inherit storeDir stateDir confDir;
   });

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -225,95 +225,72 @@ common =
     sha256 = "sha256-SPnam4xNIjbMgnq6IP1AaM1V62X0yZNo4DEVmI8sHOo=";
   };
 
-in rec {
+  buildNix =
+  { version, suffix ? ""
+  , src ? null, sha256 ? null
+  , boehmgc ? boehmgc_nix, patches ? [ ]
+  }:
+    assert (src == null) -> (sha256 != null);
+    assert (sha256 == null) -> (src != null);
+    callPackage common {
+      pname = "nix";
+      version = "${version}${suffix}";
+      inherit suffix;
 
+      src =
+        if src != null
+        then src
+        else fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          rev = version;
+          inherit sha256;
+        };
+
+      inherit boehmgc patches;
+      inherit storeDir stateDir confDir;
+    };
+
+in rec {
   nix = nixStable;
 
   nixStable = nix_2_6;
 
-  nix_2_3 = callPackage common (rec {
-    pname = "nix";
+  nix_2_3 = buildNix rec {
     version = "2.3.16";
     src = fetchurl {
-      url = "https://nixos.org/releases/nix/${pname}-${version}/${pname}-${version}.tar.xz";
+      url = "https://nixos.org/releases/nix/nix-${version}/nix-${version}.tar.xz";
       sha256 = "sha256-fuaBtp8FtSVJLSAsO+3Nne4ZYLuBj2JpD2xEk7fCqrw=";
     };
-
     boehmgc = boehmgc_nix_2_3;
+  };
 
-    inherit storeDir stateDir confDir;
-  });
-
-  nix_2_4 = callPackage common (rec {
-    pname = "nix";
+  nix_2_4 = buildNix {
     version = "2.4";
-
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "nix";
-      rev = version;
-      sha256 = "sha256-op48CCDgLHK0qV1Batz4Ln5FqBiRjlE6qHTiZgt3b6k=";
-    };
-
-    boehmgc = boehmgc_nix;
-
+    sha256 = "sha256-op48CCDgLHK0qV1Batz4Ln5FqBiRjlE6qHTiZgt3b6k=";
     patches = [ installNlohmannJsonPatch ];
+  };
 
-    inherit storeDir stateDir confDir;
-  });
-
-  nix_2_5 = callPackage common (rec {
-    pname = "nix";
+  nix_2_5 = buildNix {
     version = "2.5.1";
-
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "nix";
-      rev = version;
-      sha256 = "sha256-GOsiqy9EaTwDn2PLZ4eFj1VkXcBUbqrqHehRE9GuGdU=";
-    };
-
-    boehmgc = boehmgc_nix;
-
+    sha256 = "sha256-GOsiqy9EaTwDn2PLZ4eFj1VkXcBUbqrqHehRE9GuGdU=";
     patches = [ installNlohmannJsonPatch ];
+  };
 
-    inherit storeDir stateDir confDir;
-  });
-
-  nix_2_6 = callPackage common (rec {
-    pname = "nix";
+  nix_2_6 = buildNix {
     version = "2.6.0";
+    sha256 = "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=";
+  };
 
-    src = fetchFromGitHub {
-      owner = "NixOS";
-      repo = "nix";
-      rev = version;
-      sha256 = "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=";
-    };
-
-    boehmgc = boehmgc_nix;
-
-    inherit storeDir stateDir confDir;
-  });
-
-  nixUnstable = lib.lowPrio (callPackage common rec {
-    pname = "nix";
-    version = "2.6${suffix}";
+  nixUnstable = lib.lowPrio (buildNix rec {
+    version = "2.6";
     suffix = "pre20211217_${lib.substring 0 7 src.rev}";
-
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
       rev = "6e6e998930f0d7361d64644eb37d9134e74e8501";
       sha256 = "sha256-RZSWOJUPkXIlMNYMC5a+WNrOjpqAHyhzyqD57BGfNY8=";
     };
-
-    boehmgc = boehmgc_nix;
-
     patches = [ installNlohmannJsonPatch ];
-
-    inherit storeDir stateDir confDir;
-
   });
-
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -283,14 +283,13 @@ in rec {
   };
 
   nixUnstable = lib.lowPrio (buildNix rec {
-    version = "2.6";
-    suffix = "pre20211217_${lib.substring 0 7 src.rev}";
+    version = "2.7";
+    suffix = "pre20220124_${lib.substring 0 7 src.rev}";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "6e6e998930f0d7361d64644eb37d9134e74e8501";
-      sha256 = "sha256-RZSWOJUPkXIlMNYMC5a+WNrOjpqAHyhzyqD57BGfNY8=";
+      rev = "0a70b37b5694c769fb855c1afe7642407d1db64f";
+      sha256 = "sha256-aOM9MPNlnWNMobx4CuD4JIXH2poRlG8AKkuxY7FysWg=";
     };
-    patches = [ installNlohmannJsonPatch ];
   });
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33091,6 +33091,7 @@ with pkgs;
     nix_2_3
     nix_2_4
     nix_2_5
+    nix_2_6
     nixUnstable;
 
   nixStatic = pkgsStatic.nix;


### PR DESCRIPTION
- nix: 2.5.1 -> 2.6.0
- nix: introduce buildNix function to avoid so much copy-pasting

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
