### PR TITLE
talosctl: init at 0.14.1

### DIFF
--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,0 +1,44 @@
+{ lib, buildGo117Module, fetchFromGitHub }:
+
+buildGo117Module rec {
+  pname = "talosctl";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "talos-systems";
+    repo = "talos";
+    rev = "v${version}";
+    sha256 = "sha256-JeZ+Q6LTDJtoxfu4mJNc3wv3Y6OPcIUvgnozj9mWwLw=";
+  };
+
+  vendorSha256 = "sha256-ujbEWvcNJJOUegVgAGEPwYF02TiqD1lZELvqc/Gmb4A=";
+
+  # look for GO_LDFLAGS getting set in the Makefile
+  ldflags =
+    let
+      versionPkg = "github.com/talos-systems/talos/pkg/version"; # VERSION_PKG
+      imagesPkgs = "github.com/talos-systems/talos/pkg/images"; # IMAGES_PKGS
+      mgmtHelpersPkg = "github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"; #MGMT_HELPERS_PKG
+    in
+    [
+      "-X ${versionPkg}.Name=Talos"
+      "-X ${versionPkg}.SHA=${src.rev}" # should be the hash, but as we build from tags, this needs to do
+      "-X ${versionPkg}.Tag=${src.rev}"
+      "-X ${versionPkg}.PkgsVersion=v0.9.0-2-g447ce75" # PKGS
+      "-X ${versionPkg}.ExtrasVersion=v0.7.0-1-gd6b73a7" # EXTRAS
+      "-X ${imagesPkgs}.Username=talos-systems" # USERNAME
+      "-X ${imagesPkgs}.Registry=ghcr.io" # REGISTRY
+      "-X ${mgmtHelpersPkg}.ArtifactsPath=_out" # ARTIFACTS
+    ];
+
+  subPackages = [ "cmd/talosctl" ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A CLI for out-of-band management of Kubernetes nodes created by Talos";
+    homepage = "https://github.com/talos-systems/talos";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28925,6 +28925,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  talosctl = callPackage ../applications/networking/cluster/talosctl { };
+
   talentedhack = callPackage ../applications/audio/talentedhack { };
 
   tambura = callPackage ../applications/audio/tambura { };


### PR DESCRIPTION
```
❯ result/bin/talosctl cluster create --wait
validating CIDR and reserving IPs
generating PKI and tokens
downloading ghcr.io/talos-systems/talos:v0.14.1
creating network talos-default
creating master nodes
creating worker nodes
renamed talosconfig context "talos-default" -> "talos-default-1"
waiting for API
bootstrapping cluster
waiting for etcd to be healthy: OK
waiting for apid to be ready: OK
waiting for kubelet to be healthy: OK
waiting for all nodes to finish boot sequence: OK
waiting for all k8s nodes to report: OK
waiting for all k8s nodes to report ready: OK
waiting for all control plane components to be ready: OK
waiting for kube-proxy to report ready: OK
waiting for coredns to report ready: OK
waiting for all k8s nodes to report schedulable: OK

merging kubeconfig into "/home/flokli/.kube/config"
PROVISIONER       docker
NAME              talos-default
NETWORK NAME      talos-default
NETWORK CIDR      10.5.0.0/24
NETWORK GATEWAY   10.5.0.1
NETWORK MTU       1500

NODES:

NAME                      TYPE           IP         CPU    RAM      DISK
/talos-default-master-1   controlplane   10.5.0.2   2.00   2.1 GB   -
/talos-default-worker-1   worker         10.5.0.3   2.00   2.1 GB   -
```

`--provisioner qemu` was also tested. Note you need to have
`_out/{initramfs-$arch.xz,vmlinuz-$arch}` available, as documented in
their [docs](https://www.talos.dev/docs/v0.14/local-platforms/qemu/#install-talos-kernel-and-initramfs)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
