### PR TITLE
rnote: init at 0.3.4

### DIFF
--- a/pkgs/applications/graphics/rnote/default.nix
+++ b/pkgs/applications/graphics/rnote/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, desktop-file-utils
+, gio-sharp
+, glib
+, gstreamer
+, gtk4
+, libadwaita
+, libxml2
+, meson
+, ninja
+, pkg-config
+, poppler
+, python3
+, rustPlatform
+, shared-mime-info
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rnote";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "flxzt";
+    repo = "rnote";
+    rev = "v${version}";
+    sha256 = "5g5SQJc5aopYxtHNP5T85TtcazovrveUCnMhJ90p2t4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-vnLesWXdqNzlWNQsUVy03kfmcDNazQ1BbizQDoG1kgM=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils # For update-desktop-database
+    meson
+    ninja
+    pkg-config
+    python3 # For the postinstall script
+    rustPlatform.cargoSetupHook
+    rustPlatform.rust.cargo
+    rustPlatform.rust.rustc
+    shared-mime-info # For update-mime-database
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gio-sharp
+    glib
+    gstreamer
+    gtk4
+    libadwaita
+    libxml2
+    poppler
+  ];
+
+  postPatch = ''
+    pushd build-aux
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+    substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+    popd
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/flxzt/rnote";
+    description = "Simple drawing application to create handwritten notes";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ dotlambda yrd ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9440,6 +9440,10 @@ with pkgs;
 
   rnnoise-plugin = callPackage ../development/libraries/rnnoise-plugin {};
 
+  rnote = callPackage ../applications/graphics/rnote {
+    inherit (gst_all_1) gstreamer;
+  };
+
   rnp = callPackage ../tools/security/rnp { };
 
   rnv = callPackage ../tools/text/xml/rnv { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds a package for [rnote](https://github.com/flxzt/rnote), a desktop drawing application similar to Xournal++.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
