### PR TITLE
online-judge-template-generator: init at 4.8.1

### DIFF
--- a/pkgs/tools/misc/online-judge-template-generator/default.nix
+++ b/pkgs/tools/misc/online-judge-template-generator/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonApplication
+, appdirs
+, beautifulsoup4
+, colorlog
+, fetchFromGitHub
+, Mako
+, online-judge-api-client
+, online-judge-tools
+, ply
+, pyyaml
+, requests
+, setuptools
+, toml
+}:
+
+buildPythonApplication rec {
+  pname = "online-judge-template-generator";
+  version = "4.8.1";
+
+  src = fetchFromGitHub {
+    owner = "online-judge-tools";
+    repo = "template-generator";
+    rev = "v${version}";
+    sha256 = "sha256-cS1ED1a92fEFqy6ht8UFjxocWIm35IA/VuaPSLsdlqg=";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    beautifulsoup4
+    colorlog
+    Mako
+    online-judge-api-client
+    online-judge-tools
+    ply
+    pyyaml
+    requests
+    setuptools
+    toml
+  ];
+
+  # Needs internet to run tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Analyze problems of competitive programming and automatically generate boilerplate";
+    homepage = "https://github.com/online-judge-tools/template-generator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sei40kr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3629,6 +3629,8 @@ with pkgs;
 
   orjail = callPackage ../tools/security/orjail { };
 
+  online-judge-template-generator = python3Packages.callPackage ../tools/misc/online-judge-template-generator { };
+
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
   xkbd = callPackage ../applications/misc/xkbd { };


### PR DESCRIPTION
###### Motivation for this change

Add [online-judge-template-generator](https://github.com/online-judge-tools/template-generator).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
