### PR TITLE
skjold: init at 0.4.1

### DIFF
--- a/pkgs/development/tools/skjold/default.nix
+++ b/pkgs/development/tools/skjold/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "skjold";
+  version = "0.4.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "twu";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-xz6N7/LS3wOymh9tet8OLgsSaretzuMU4hQd+LeUPJ4=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    packaging
+    pyyaml
+    toml
+  ];
+
+  checkInputs = with python3.pkgs; [
+    pytest-mock
+    pytest-watch
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to poetry-core, https://github.com/twu/skjold/pull/91
+    (fetchpatch {
+      name = "switch-poetry-core.patch";
+      url = "https://github.com/twu/skjold/commit/b341748c9b11798b6a5182d659a651b0f200c6f5.patch";
+      sha256 = "sha256-FTZTbIudO6lYO9tLD4Lh1h5zsTeKYtflR2tbbHZ5auM=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'packaging = "^21.0"' 'packaging = "*"' \
+      --replace 'pyyaml = "^5.3"' 'pyyaml = "*"'
+  '';
+
+  disabledTestPaths = [
+    # Too sensitive to pass
+    "tests/test_cli.py"
+  ];
+
+  disabledTests = [
+    # Requires network access
+    "pyup-werkzeug"
+    "test_ensure_accessing_advisories_triggers_update"
+    "test_ensure_accessing_advisories_triggers_update"
+    "test_ensure_gemnasium_update"
+    "test_ensure_missing_github_token_raises_usage_error"
+    "test_ensure_pypi_advisory_db_update"
+    "test_ensure_source_is_affected_single"
+    "test_osv_advisory_with_vulnerable_package_via_osv_api"
+    "urllib3"
+  ];
+
+  pythonImportsCheck = [
+    "skjold"
+  ];
+
+  meta = with lib; {
+    description = "Tool to Python dependencies against security advisory databases";
+    homepage = "https://github.com/twu/skjold";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19765,6 +19765,8 @@ with pkgs;
 
   skaffold = callPackage ../development/tools/skaffold { };
 
+  skjold = callPackage ../development/tools/skjold { };
+
   skalibs = skawarePackages.skalibs;
   skalibs_2_10 = skawarePackages.skalibs_2_10;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Tool to check Python dependencies against security advisory databases

https://github.com/twu/skjold

Related to #81418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
