### PR TITLE
adguardhome: 0.107.0 - 0.107.3

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,19 +1,19 @@
 { fetchurl, fetchzip }:
 {
 "x86_64-darwin" = fetchzip {
-  sha256 = "sha256-vRfKVjFFy4cO/TrA+wEFYp6jcJSB/QDU3if0FDdYu+M=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.0/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-hB3TL1FocAtLpBe+Rv2Pyon4f1ld+Fqapz6TUQ0O1jU=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.3/AdGuardHome_darwin_amd64.zip";
 };
 "i686-linux" = fetchurl {
-  sha256 = "sha256-gWylZgCk+bGf1h2lTX2gRnW39P7C2ks0LH7anJW6JKw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.0/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-ZPHmFxKLJ1oxT18P6FDv74/leCzlESTrhNYuC8T6u+I=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.3/AdGuardHome_linux_386.tar.gz";
 };
 "x86_64-linux" = fetchurl {
-  sha256 = "sha256-g2DIeXwaqTTfshYyyDNHbOU57YUbuxXDKJHFqKFrqzw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.0/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-yOvkEimDp646BCCFV2fnmVGe6R8geFlxtWLfPMVQ9Uk=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.3/AdGuardHome_linux_amd64.tar.gz";
 };
 "aarch64-linux" = fetchurl {
-  sha256 = "sha256-PovduGRcfSUbhqX1cxRgMknN8mWJekjjpB0b1TE1//g=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.0/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-ayNv2O0Ge3dT6YAN4SW/gsyoErCB3BJYsx/daMbGHjs=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.3/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.0";
+  version = "0.107.3";
 
   src = (import ./bins.nix { inherit fetchurl fetchzip; }).${stdenv.hostPlatform.system};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
