### PR TITLE
[21.11] Pantheon 6.1 backports 2022-01-25

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calendar/default.nix
@@ -28,15 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-calendar";
-  version = "6.0.3";
-
-  repoName = "calendar";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
-    repo = repoName;
+    repo = "calendar";
     rev = version;
-    sha256 = "sha256-+RQUiJLuCIbmcbtsOCfF9HYFrxtldZMbg2vg/a/IOaY=";
+    sha256 = "sha256-LaVJ7QLc0UdSLgLIuHP4Anc7kPUelZW9PnIWuqKGtEQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-files/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-files/default.nix
@@ -32,7 +32,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-files";
-  version = "6.1.1";
+  version = "6.1.2";
 
   outputs = [ "out" "dev" ];
 
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = "files";
     rev = version;
-    sha256 = "sha256-5TSzV8MQG81aCCR8yiCPhKJaLrp/fwf4mjP32KkcbbY=";
+    sha256 = "sha256-g9g4wJXjjudk4Qt96XGUiV/X86Ae2lqhM+psh9h+XFE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-mail";
-  version = "6.3.1";
+  version = "6.4.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "mail";
     rev = version;
-    sha256 = "sha256-wOu9jvvwG53vzcNa38nk4eREZWW7Cin8el4qApQ8gI8=";
+    sha256 = "sha256-ooqVNMgeAqGlFcfachPPfhSiKTEEcNGv5oWdM7VLWOc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-tasks/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-tasks";
-  version = "6.1.0";
+  version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "tasks";
     rev = version;
-    sha256 = "sha256-Gt9Hp9m28QdAFnKIT1xcbiSM5cn6kW7wEXmi/iFfu8k=";
+    sha256 = "sha256-eHaWXntLkk5G+cR5uFwWsIvbSPsbrvpglYBh91ta/M0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-network";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0nqihsbrpjw4nx1c50g854bqybniw38adi78vzg8nyl6ikj2r0z4";
+    sha256 = "sha256-CdSX4p98HQNC0VF5Ae/ZnDqm000+9KJ6JhQWhSHC4CI=";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -94,6 +94,18 @@ stdenv.mkDerivation rec {
       src = ./hardcode-fallback-background.patch;
       default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
     })
+    # Revert "UserCard: use accent color for logged_in check (#566)"
+    # https://github.com/elementary/greeter/pull/566
+    # Fixes crash issue reported in:
+    # https://github.com/elementary/greeter/issues/578
+    # https://github.com/NixOS/nixpkgs/issues/151609
+    # Probably also fixes:
+    # https://github.com/elementary/greeter/issues/568
+    # https://github.com/elementary/greeter/issues/583
+    # https://github.com/NixOS/nixpkgs/issues/140513
+    # Revisit this when the greeter is ported to GTK 4:
+    # https://github.com/elementary/greeter/pull/591
+    ./revert-pr566.patch
   ];
 
   preFixup = ''

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/revert-pr566.patch
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/revert-pr566.patch
@@ -1,0 +1,103 @@
+From 572a73cbc84dd9a0f5a7667a60c75ed5580d84a1 Mon Sep 17 00:00:00 2001
+From: Bobby Rong <rjl931189261@126.com>
+Date: Tue, 25 Jan 2022 10:03:31 +0800
+Subject: [PATCH] Revert "UserCard: use accent color for logged_in check
+ (#566)"
+
+This reverts commit 6f18c79c780582e43039032f6926816efa82e206.
+---
+ data/Check.css             | 11 -----------
+ data/greeter.gresource.xml |  1 -
+ src/Cards/UserCard.vala    | 29 +++--------------------------
+ 3 files changed, 3 insertions(+), 38 deletions(-)
+ delete mode 100644 data/Check.css
+
+diff --git a/data/Check.css b/data/Check.css
+deleted file mode 100644
+index 947db6b..0000000
+--- a/data/Check.css
++++ /dev/null
+@@ -1,11 +0,0 @@
+-check {
+-    background-color: @accent_color;
+-    border-radius: 99px;
+-    color: white;
+-    margin: 2px;
+-    min-height: 20px;
+-    min-width: 20px;
+-    -gtk-icon-shadow: 0 1px 1px shade(@accent_color, 0.7);
+-    -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
+-    -gtk-icon-transform: scale(0.6);
+-}
+diff --git a/data/greeter.gresource.xml b/data/greeter.gresource.xml
+index 604c89a..ce9be29 100644
+--- a/data/greeter.gresource.xml
++++ b/data/greeter.gresource.xml
+@@ -2,7 +2,6 @@
+ <gresources>
+   <gresource prefix="/io/elementary/greeter">
+     <file alias="Card.css" compressed="true">Card.css</file>
+-    <file alias="Check.css" compressed="true">Check.css</file>
+     <file alias="DateTime.css" compressed="true">DateTime.css</file>
+     <file alias="MainWindow.css" compressed="true">MainWindow.css</file>
+   </gresource>
+diff --git a/src/Cards/UserCard.vala b/src/Cards/UserCard.vala
+index 83df22c..02d2b0a 100644
+--- a/src/Cards/UserCard.vala
++++ b/src/Cards/UserCard.vala
+@@ -42,7 +42,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
+     private Gtk.Stack login_stack;
+     private Greeter.PasswordEntry password_entry;
+ 
+-    private unowned Gtk.StyleContext logged_in_context;
+     private weak Gtk.StyleContext main_grid_style_context;
+     private weak Gtk.StyleContext password_entry_context;
+ 
+@@ -214,14 +213,10 @@ public class Greeter.UserCard : Greeter.BaseCard {
+         };
+         avatar_overlay.add (avatar);
+ 
+-        var logged_in = new SelectionCheck () {
+-            halign = Gtk.Align.END,
+-            valign = Gtk.Align.END
+-        };
+-
+-        logged_in_context = logged_in.get_style_context ();
+-
+         if (lightdm_user.logged_in) {
++            var logged_in = new Gtk.Image.from_icon_name ("selection-checked", Gtk.IconSize.LARGE_TOOLBAR);
++            logged_in.halign = logged_in.valign = Gtk.Align.END;
++
+             avatar_overlay.add_overlay (logged_in);
+ 
+             session_button.sensitive = false;
+@@ -304,7 +299,6 @@ public class Greeter.UserCard : Greeter.BaseCard {
+         gtksettings.gtk_theme_name = "io.elementary.stylesheet." + accent_to_string (prefers_accent_color);
+ 
+         var style_provider = Gtk.CssProvider.get_named (gtksettings.gtk_theme_name, null);
+-        logged_in_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+         password_entry_context.add_provider (style_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+     }
+ 
+@@ -451,21 +445,4 @@ public class Greeter.UserCard : Greeter.BaseCard {
+             return GLib.Source.REMOVE;
+         });
+     }
+-
+-    private class SelectionCheck : Gtk.Spinner {
+-        private static Gtk.CssProvider check_provider;
+-
+-        class construct {
+-            set_css_name (Gtk.STYLE_CLASS_CHECK);
+-        }
+-
+-        static construct {
+-            check_provider = new Gtk.CssProvider ();
+-            check_provider.load_from_resource ("/io/elementary/greeter/Check.css");
+-        }
+-
+-        construct {
+-            get_style_context ().add_provider (check_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+-        }
+-    }
+ }

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -80,7 +80,7 @@ let
     Name=Pantheon
     Comment=This session provides elementary experience
     Exec=@out@/libexec/pantheon
-    TryExec=${wingpanel}/bin/wingpanel
+    TryExec=${wingpanel}/bin/io.elementary.wingpanel
     Icon=
     DesktopNames=Pantheon
     Type=Application

--- a/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-capnet-assist/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-capnet-assist";
-  version = "2.4.0";
+  version = "2.4.1";
 
   repoName = "capnet-assist";
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = repoName;
     rev = version;
-    sha256 = "sha256-UdkS+w61c8z2TCJyG7YsDb0n0b2LOpFyaHzMbdCJsZI=";
+    sha256 = "sha256-8hhp37EBzZxEVvPaRw9PohjaPWKQZ/AfqqvwLxQCBKk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-pantheon/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-pantheon";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "portals";
     rev = version;
-    sha256 = "sha256-8gBMjCMEzrFmKHhkXsgcIESC93EOT0ADkRUIJMmerjw=";
+    sha256 = "sha256-YICNOeNrpO2tJFyULjQEhZQCrrMyQau59EC7c5K9q40=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Monthly Pantheon update backport for 21.11.

- Backports #156115
- Backports #156646
- Backports #156801
- Backports #156936
- Fixes #151609


###### Previous stable channel backport pull request

- #150634
- #154475

###### How to test on NixOS

> For flakes enabled system, you can also try [bobby285271/test-pantheon](https://github.com/bobby285271/test-pantheon).

1. Clone the `NixOS/nixpkgs` repository and checkout to this PR, you can use the GitHub CLI tool `gh`.
```
$ gh repo clone NixOS/nixpkgs
$ cd nixpkgs
$ gh pr checkout 156723
```

2. Save the following NixOS configuration file as `configuration.nix`, you can save the file to any directory.

```nix
{ modulesPath, pkgs, config, ... }: {
  imports = [
    "${modulesPath}/virtualisation/qemu-vm.nix"
  ];

  environment.enableDebugInfo = true;
  services.xserver = {
    enable = true;
    layout = "us";
    desktopManager.pantheon.enable = true;
    desktopManager.pantheon.debug = true;
  };

  users.mutableUsers = false;

  users.extraUsers.test = {
    isNormalUser = true;
    uid = 1000;
    extraGroups = [ "wheel" "networkmanager" ];
    password = "test";
  };
  nixpkgs.config.allowAliases = false;

  virtualisation.qemu.options = [ "-device intel-hda -device hda-duplex" ];
  virtualisation.memorySize = 2048;
  virtualisation.diskSize = 8192;
}
```

3. Run the following command to build the packages and create a virtual machine with the above configuration. Do not forget to adjust the path to the `nixpkgs` checkout (`/path/to/nixpkgs`) and the configuration (`/path/to/configuration.nix`). It will take some time to build the packages, so grab some coffee while waiting.

```
$ env NIX_PATH=nixpkgs=/path/to/nixpkgs:nixos-config=/path/to/configuration.nix nixos-rebuild build-vm
```

4. You should see a message like this, run the command provided by the output:
```
Done. The virtual machine can be started by running /nix/store/...-nixos-vm/bin/run-nixos-vm
```

5. A QEMU virtual machine will be launched, wait for LightDM to start and login with the password `test`.

6. Test the upgrade and if you find anything wrong, please also try reproduce the issue on `master` then comment here with your findings so we can handle that properly (i.e. we will drop the commit here that introduces major regressions).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
