### PR TITLE
kupfer: Pass `-s` to python instead of setting `PYTHONNOUSERSITE`

### DIFF
--- a/pkgs/applications/misc/kupfer/default.nix
+++ b/pkgs/applications/misc/kupfer/default.nix
@@ -41,10 +41,16 @@ buildPythonApplication rec {
   # see https://github.com/NixOS/nixpkgs/issues/56943 for details
   strictDeps = false;
 
+  # pass -s to python executable so the user site directory is not added to
+  # sys.path similar to setting PYTHONNOUSERSITE=1 but without passing it down
+  # to child processes
+  preBuild = ''
+    substituteInPlace bin/kupfer.in --replace "\''${PYTHON}"  "\''${PYTHON} -s"
+  '';
+
   postInstall = ''
     gappsWrapperArgs+=(
       "--prefix" "PYTHONPATH" : "${makePythonPath propagatedBuildInputs}"
-      "--set" "PYTHONNOUSERSITE" "1"
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change

When launching a program from kupfer (like a terminal),  the newly created process has the `PYTHONNOUSERSITE` variable inherited in its environment.

This breaks any locally installed python programs (ie. using `pip install --user ...`).

For example:
```console
❯ env | grep PYTH
PYTHONNOUSERSITE=1
PYTHONPATH=/nix/store/abiagjx0ckg2adfd0m8ksnlx4ijf9cmy-python3-3.6.13/lib/python3.6/site-packages:/nix/store/0qcy7v4b4hv08h6953mcyy082dddxdxz-python3.6-pygobject-3.40.1/lib/python3.6/site-packages:/nix/store/1a25ysg00dlq8ds3r9211q5q60jw4shd-python3.6-pyxdg-0.27/lib/python3.6/site-packages:/nix/store/fhvm25nqw58qlqmqgm2dmpdbc6ma8rrx-python3.6-dbus-python-1.2.16/lib/python3.6/site-packages:/nix/store/40q0rwmdhbrr0p1sgqwa09s8mzk7ybwh-python3.6-pycairo-1.20.0/lib/python3.6/site-packages:/nix/store/k0z9n599k02hab8qjjp3ljw065iwjcvg-python3-3.9.6/lib/python3.9/site-packages:/nix/store/w678bii9vh6l0dfif1cpl06l7jlg76c0-python3.9-pygobject-3.42.0/lib/python3.9/site-packages:/nix/store/vjq32vmg36h6j786gpzsl1qyxjf2wrdr-python3.9-pyxdg-0.27/lib/python3.9/site-packages:/nix/store/2zgdfzjys937x24cd3yq6xd2a3pdw6sx-python3.9-dbus-python-1.2.18/lib/python3.9/site-packages:/nix/store/mk3k4hrpxi2j1s8pca0rpsijlza31l4f-python3.9-pycairo-1.20.1/lib/python3.9/site-packages
❯ yamllint
Traceback (most recent call last):
  File "/home/claudio/.local/bin/yamllint", line 5, in <module>
    from yamllint.cli import run
ModuleNotFoundError: No module named 'yamllint'
```

Unsetting the `PYTHONNOUSERSITE` variable makes this work again:
```console
❯ unset PYTHONNOUSERSITE
❯ yamllint
usage: yamllint [-h] [-] [-c CONFIG_FILE | -d CONFIG_DATA]
                [-f {parsable,standard,colored,github,auto}] [-s]
                [--no-warnings] [-v]
                [FILE_OR_DIR [FILE_OR_DIR ...]]
yamllint: error: one of the arguments FILE_OR_DIR - is required
```

This PR passes the `-s` flag directly to the python interpreter instead of setting the variable, so it does no longer trickle down the process tree.

Previously: https://github.com/NixOS/nixpkgs/issues/32915

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
