### PR TITLE
rng-tools: fix missing opensc reference

### DIFF
--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     ${optionalString withPkcs11 ''
+      substituteInPlace configure.ac \
+        --replace '/usr/lib/opensc-pkcs11.so' '${opensc}/lib/opensc-pkcs11.so' \
+        --replace '/usr/lib64/opensc-pkcs11.so' '${opensc}/lib/opensc-pkcs11.so'
+
       substituteInPlace rngd.c \
         --replace /usr/lib64/opensc-pkcs11.so ${opensc}/lib/opensc-pkcs11.so
     ''}


### PR DESCRIPTION
###### Motivation for this change
Without this, rngd prints the error message "PKCS11 Engine /usr/lib64/opensc-pkcs11.so Error: No such file or directory".
I didn't test if this actually works, since I don't have a compatible smartcard. But running rngd does not print the error message anymore.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).