### PR TITLE
redux: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7903,6 +7903,12 @@
       fingerprint = "FEF0 AE2D 5449 3482 5F06  40AA 186A 1EDA C5C6 3F83";
     }];
   };
+  mihnea-s = {
+    email = "mihn.stn@gmail.com";
+    github = "mihnea-s";
+    githubId = 43088426;
+    name = "Mihnea Stoian";
+  };
   mikefaille = {
     email = "michael@faille.io";
     github = "mikefaille";

--- a/pkgs/applications/audio/redux/default.nix
+++ b/pkgs/applications/audio/redux/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, libX11
+, alsa-lib
+, autoPatchelfHook
+, releasePath ? null
+}:
+
+# To use the full release version (same as renoise):
+# 1) Sign into https://backstage.renoise.com and download the release version to some stable location.
+# 2) Override the releasePath attribute to point to the location of the newly downloaded bundle.
+# Note: Renoise creates an individual build for each license which screws somewhat with the
+# use of functions like requireFile as the hash will be different for every user.
+
+stdenv.mkDerivation rec {
+  pname = "redux";
+  version = "1.2.2";
+
+  src = if releasePath != null then releasePath
+    else fetchurl {
+      url = "https://files.renoise.com/demo/Renoise_Redux_${lib.replaceStrings ["."] ["_"] version}_Demo_Linux.tar.gz";
+      sha256 = "0zbwsg7nh9x3q29jv2kpqb3vwi0ksdwybhb4m2qr95rxrpx1kxhm";
+    };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [ libX11 alsa-lib stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    OUTDIR=$out/lib/vst2/RenoiseRedux.vst2
+    mkdir -p $OUTDIR
+    cp -r ./renoise_redux_x86_64/* $OUTDIR
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Sample-based instrument, with a powerful phrase sequencer";
+    homepage = "https://www.renoise.com/products/redux";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ mihnea-s ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28380,6 +28380,8 @@ with pkgs;
 
   renoise = callPackage ../applications/audio/renoise {};
 
+  redux = callPackage ../applications/audio/redux { };
+
   roomeqwizard = callPackage ../applications/audio/roomeqwizard { };
 
   radiotray-ng = callPackage ../applications/audio/radiotray-ng {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I messed up the previous PR, sorry!

@IvarWithoutBones I implemented your suggestions, except for `requireFile`, unfortunately I cannot use it since builds are different for each individual, I added a note to reflect this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
