### PR TITLE
openbgpd: 6.8 -> 7.2

### DIFF
--- a/pkgs/servers/openbgpd/default.nix
+++ b/pkgs/servers/openbgpd/default.nix
@@ -1,39 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, m4, bison }:
+{ lib, stdenv, fetchurl, bison }:
 
-let
-  openbsd_version =
-    "OPENBSD_6_8"; # This has to be equal to ${src}/OPENBSD_BRANCH
-  openbsd = fetchFromGitHub {
-    name = "portable";
-    owner = "openbgpd-portable";
-    repo = "openbgpd-openbsd";
-    rev = openbsd_version;
-    sha256 = "sha256-vCVK5k4g6aW2z2fg7Kv0uvkX7f34aRc8K2myb3jjl6w=";
-  };
-in stdenv.mkDerivation rec {
-  pname = "opengpd";
-  version = "6.8p0";
+stdenv.mkDerivation rec {
+  pname = "openbgpd";
+  version = "7.2";
 
-  src = fetchFromGitHub {
-    owner = "openbgpd-portable";
-    repo = "openbgpd-portable";
-    rev = version;
-    sha256 = "sha256-TKs6tt/SCWes6kYAGIrSShZgOLf7xKh26xG3Zk7wCCw=";
+  src = fetchurl {
+    url =
+      "https://cdn.openbsd.org/pub/OpenBSD/OpenBGPD/${pname}-${version}.tar.gz";
+    sha256 = "sha256-5PQGEgZ6DJ7kQMwUOOmEW+j1KaaHLjaQ9QjsQChqBYw=";
   };
 
-  nativeBuildInputs = [ autoconf automake libtool m4 bison ];
+  patches = [ ./openbgpd-paths.patch ];
 
-  preConfigure = ''
-    mkdir ./openbsd
-    cp -r ${openbsd}/* ./openbsd/
-    chmod -R +w ./openbsd
-    openbsd_version=$(cat ./OPENBSD_BRANCH)
-    if [ "$openbsd_version" != "${openbsd_version}" ]; then
-      echo "OPENBSD VERSION does not match"
-      exit 1
-    fi
-    ./autogen.sh
-  '';
+  configureFlags = [ "--with-runstatedir=/run" "--sysconfdir=/etc" ];
+
+  nativeBuildInputs = [ bison ];
 
   meta = with lib; {
     description =

--- a/pkgs/servers/openbgpd/openbgpd-paths.patch
+++ b/pkgs/servers/openbgpd/openbgpd-paths.patch
@@ -1,0 +1,25 @@
+--- openbgpd-7.2/Makefile.in.orig	2022-01-24 19:42:47.610745455 +0530
++++ openbgpd-7.2/Makefile.in	2022-01-24 19:44:43.554761826 +0530
+@@ -822,17 +822,14 @@
+ 
+ 
+ install-data-hook:
+-	@if [ ! -d "$(DESTDIR)$(runstatedir)" ]; then \
+-		$(INSTALL) -m 755 -d "$(DESTDIR)$(runstatedir)"; \
++	@if [ ! -d "$(DESTDIR)$(docdir)" ]; then \
++		$(INSTALL) -m 755 -d "$(DESTDIR)$(docdir)"; \
+ 	fi
+-	@if [ ! -d "$(DESTDIR)$(sysconfdir)" ]; then \
+-		$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)"; \
+-	fi
+-	@if [ ! -f "$(DESTDIR)$(sysconfdir)/bgpd.conf" ]; then \
+-		$(INSTALL) -m 644 "$(srcdir)/bgpd.conf" "$(DESTDIR)$(sysconfdir)/bgpd.conf"; \
++	@if [ ! -f "$(DESTDIR)$(docdir)/bgpd.conf" ]; then \
++		$(INSTALL) -m 644 "$(srcdir)/bgpd.conf" "$(DESTDIR)$(docdir)/bgpd.conf"; \
+ 	else \
+ 		echo; \
+-		echo " $(DESTDIR)$(sysconfdir)/bgpd.conf already exists, install will not overwrite"; \
++		echo " $(DESTDIR)$(docdir)/bgpd.conf already exists, install will not overwrite"; \
+ 	fi
+ 
+ uninstall-local:


### PR DESCRIPTION
- Switch to using distribution tarballs
- Explicitly specify configuration directory, and run state directory,
  otherwise it defaults to prefix based directory
- Remove now unneeded autotools dependencies
- Add a patch to install sample configuration in docdir, and prevent
  creation of unneeded paths

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
