### PR TITLE
Improvements to qgis and grass packaging, introduce qgis-ltr derivation (revised)

### DIFF
--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,24 +1,25 @@
 { lib, stdenv, fetchFromGitHub, flex, bison, pkg-config, zlib, libtiff, libpng, fftw
-, cairo, readline, ffmpeg_3, makeWrapper, wxGTK30, netcdf, blas
-, proj, gdal, geos, sqlite, postgresql, libmysqlclient, python2Packages, libLAS, proj-datumgrid
+, cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
+, proj, gdal, geos, sqlite, postgresql, libmysqlclient, python3Packages, libLAS, proj-datumgrid
+, zstd
 }:
 
 stdenv.mkDerivation rec {
   name = "grass";
-  version = "7.6.1";
+  version = "7.8.6";
 
   src = with lib; fetchFromGitHub {
     owner = "OSGeo";
     repo = "grass";
-    rev = "${name}_${replaceStrings ["."] ["_"] version}";
-    sha256 = "1amjk9rz7vw5ha7nyl5j2bfwj5if9w62nlwx5qbp1x7spldimlll";
+    rev = version;
+    sha256 = "sha256-zvZqFWuxNyA+hu+NMiRbQVdzzrQPsZrdGdfVB17+SbM=";
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo proj
-  readline ffmpeg_3 makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
-  libLAS proj-datumgrid ]
-    ++ (with python2Packages; [ python python-dateutil wxPython30 numpy ]);
+  buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo
+  readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
+  libLAS proj-datumgrid zstd ]
+    ++ (with python3Packages; [ python python-dateutil wxPython_4_1 numpy ]);
 
   # On Darwin the installer tries to symlink the help files into a system
   # directory
@@ -62,6 +63,7 @@ stdenv.mkDerivation rec {
       scripts/g.extension.all/g.extension.all.py \
       scripts/r.drain/r.drain.py \
       scripts/r.pack/r.pack.py \
+      scripts/r.import/r.import.py \
       scripts/r.tileset/r.tileset.py \
       scripts/r.unpack/r.unpack.py \
       scripts/v.clip/v.clip.py \
@@ -79,18 +81,17 @@ stdenv.mkDerivation rec {
       temporal/t.rast.algebra/t.rast.algebra.py \
       temporal/t.rast3d.algebra/t.rast3d.algebra.py \
       temporal/t.vect.algebra/t.vect.algebra.py \
+      temporal/t.downgrade/t.downgrade.py \
       temporal/t.select/t.select.py
     for d in gui lib scripts temporal tools; do
       patchShebangs $d
     done
   '';
 
-  NIX_CFLAGS_COMPILE = "-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1";
-
   postInstall = ''
-    wrapProgram $out/bin/grass76 \
+    wrapProgram $out/bin/grass78 \
     --set PYTHONPATH $PYTHONPATH \
-    --set GRASS_PYTHON ${python2Packages.python}/bin/${python2Packages.python.executable} \
+    --set GRASS_PYTHON ${python3Packages.python}/bin/${python3Packages.python.executable} \
     --suffix LD_LIBRARY_PATH ':' '${gdal}/lib'
     ln -s $out/grass*/lib $out/lib
     ln -s $out/grass*/include $out/include

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, flex, bison, pkg-config, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
 , proj, gdal, geos, sqlite, postgresql, libmysqlclient, python3Packages, libLAS, proj-datumgrid
-, zstd, pdal
+, zstd, pdal, wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo
   readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
-  libLAS proj-datumgrid zstd pdal ]
+  libLAS proj-datumgrid zstd pdal wrapGAppsHook ]
     ++ (with python3Packages; [ python python-dateutil wxPython_4_1 numpy ]);
 
   # On Darwin the installer tries to symlink the help files into a system

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, flex, bison, pkg-config, zlib, libtiff, libpng, fftw
 , cairo, readline, ffmpeg, makeWrapper, wxGTK30, netcdf, blas
 , proj, gdal, geos, sqlite, postgresql, libmysqlclient, python3Packages, libLAS, proj-datumgrid
-, zstd
+, zstd, pdal
 }:
 
 stdenv.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ flex bison zlib proj gdal libtiff libpng fftw sqlite cairo
   readline ffmpeg makeWrapper wxGTK30 netcdf geos postgresql libmysqlclient blas
-  libLAS proj-datumgrid zstd ]
+  libLAS proj-datumgrid zstd pdal ]
     ++ (with python3Packages; [ python python-dateutil wxPython_4_1 numpy ]);
 
   # On Darwin the installer tries to symlink the help files into a system
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     "--with-readline"
     "--with-wxwidgets"
     "--with-netcdf"
+    "--with-pdal"
     "--with-geos"
     "--with-postgres"
     "--with-postgres-libs=${postgresql.lib}/lib/"
@@ -47,6 +48,9 @@ stdenv.mkDerivation rec {
     "--with-mysql-libs=${libmysqlclient}/lib/mysql"
     "--with-blas"
     "--with-liblas=${libLAS}/bin/liblas-config"
+    "--with-zstd"
+    "--with-fftw"
+    "--with-pthread"
   ];
 
   # Otherwise a very confusing "Can't load GDAL library" error

--- a/pkgs/applications/gis/grass/default.nix
+++ b/pkgs/applications/gis/grass/default.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/grass78 \
     --set PYTHONPATH $PYTHONPATH \
-    --set GRASS_PYTHON ${python3Packages.python}/bin/${python3Packages.python.executable} \
+    --set GRASS_PYTHON ${python3Packages.python.interpreter} \
     --suffix LD_LIBRARY_PATH ':' '${gdal}/lib'
     ln -s $out/grass*/lib $out/lib
     ln -s $out/grass*/include $out/include

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,5 +1,5 @@
 { lib, makeWrapper, symlinkJoin
-, qgis-unwrapped, extraPythonPackages ? (ps: [ ])
+, qgis-unwrapped, grass, extraPythonPackages ? (ps: [ ])
 }:
 with lib;
 symlinkJoin rec {
@@ -8,7 +8,7 @@ symlinkJoin rec {
 
   paths = [ qgis-unwrapped ];
 
-  nativeBuildInputs = [ makeWrapper qgis-unwrapped.python3Packages.wrapPython ];
+  nativeBuildInputs = [ grass makeWrapper qgis-unwrapped.python3Packages.wrapPython ];
 
   # extend to add to the python environment of QGIS without rebuilding QGIS application.
   pythonInputs = qgis-unwrapped.pythonBuildInputs ++ (extraPythonPackages qgis-unwrapped.python3Packages);
@@ -20,6 +20,7 @@ symlinkJoin rec {
 
     wrapProgram $out/bin/qgis \
       --prefix PATH : $program_PATH \
+      --prefix PATH : ${lib.makeBinPath [grass]} \
       --set PYTHONPATH $program_PYTHONPATH
   '';
 

--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,8 +1,12 @@
 { lib, makeWrapper, symlinkJoin
-, qgis-unwrapped, extraPythonPackages ? (ps: [ ])
+, extraPythonPackages ? (ps: [ ])
+, libsForQt5
 }:
 with lib;
-symlinkJoin rec {
+let
+  qgis-unwrapped = libsForQt5.callPackage ./unwrapped.nix {  };
+in symlinkJoin rec {
+
   inherit (qgis-unwrapped) version;
   name = "qgis-${version}";
 
@@ -22,6 +26,8 @@ symlinkJoin rec {
       --prefix PATH : $program_PATH \
       --set PYTHONPATH $program_PYTHONPATH
   '';
+
+  passthru.unwrapped = qgis-unwrapped;
 
   meta = qgis-unwrapped.meta;
 }

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -1,8 +1,12 @@
 { lib, makeWrapper, symlinkJoin
-, qgis-ltr-unwrapped, extraPythonPackages ? (ps: [ ])
+, extraPythonPackages ? (ps: [ ])
+, libsForQt5
 }:
 with lib;
-symlinkJoin rec {
+let
+  qgis-ltr-unwrapped = libsForQt5.callPackage ./unwrapped-ltr.nix {  };
+in symlinkJoin rec {
+
   inherit (qgis-ltr-unwrapped) version;
   name = "qgis-${version}";
 
@@ -21,6 +25,8 @@ symlinkJoin rec {
       --prefix PATH : $program_PATH \
       --set PYTHONPATH $program_PYTHONPATH
   '';
+
+  passthru.unwrapped = qgis-ltr-unwrapped;
 
   inherit (qgis-ltr-unwrapped) meta;
 }

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -1,20 +1,19 @@
 { lib, makeWrapper, symlinkJoin
-, qgis-unwrapped, extraPythonPackages ? (ps: [ ])
+, qgis-ltr-unwrapped, extraPythonPackages ? (ps: [ ])
 }:
 with lib;
 symlinkJoin rec {
-  inherit (qgis-unwrapped) version;
+  inherit (qgis-ltr-unwrapped) version;
   name = "qgis-${version}";
 
-  paths = [ qgis-unwrapped ];
+  paths = [ qgis-ltr-unwrapped ];
 
-  nativeBuildInputs = [ makeWrapper qgis-unwrapped.py.pkgs.wrapPython ];
+  nativeBuildInputs = [ makeWrapper qgis-ltr-unwrapped.py.pkgs.wrapPython ];
 
   # extend to add to the python environment of QGIS without rebuilding QGIS application.
-  pythonInputs = qgis-unwrapped.pythonBuildInputs ++ (extraPythonPackages qgis-unwrapped.py.pkgs);
+  pythonInputs = qgis-ltr-unwrapped.pythonBuildInputs ++ (extraPythonPackages qgis-ltr-unwrapped.py.pkgs);
 
   postBuild = ''
-    # unpackPhase
 
     buildPythonPath "$pythonInputs"
 
@@ -23,5 +22,5 @@ symlinkJoin rec {
       --set PYTHONPATH $program_PYTHONPATH
   '';
 
-  meta = qgis-unwrapped.meta;
+  inherit (qgis-ltr-unwrapped) meta;
 }

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -67,14 +67,14 @@ let
     six
   ];
 in mkDerivation rec {
-  version = "3.16.14";
+  version = "3.16.16";
   pname = "qgis-ltr-unwrapped";
 
   src = fetchFromGitHub {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "sha256-3FUGSBdlhJhhpTPtYuzKOznsC7PJV3kRL9Il2Yryi1Q=";
+    sha256 = "85RlV1Ik1BeN9B7UE51ktTWMiGkMga2E/fnhyiVwjIs=";
   };
 
   passthru = {

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -35,8 +35,6 @@
 , grass
 , withWebKit ? true
 , qtwebkit
-, pdal
-, zstd
 , makeWrapper
 }:
 
@@ -69,14 +67,14 @@ let
     six
   ];
 in mkDerivation rec {
-  version = "3.22.1";
-  pname = "qgis-unwrapped";
+  version = "3.16.14";
+  pname = "qgis-ltr-unwrapped";
 
   src = fetchFromGitHub {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "0hpbbv84lh1m7vrxv8d8x5kxgxcf0dydsvr3r2brgv3b40lpavd4";
+    sha256 = "sha256-3FUGSBdlhJhhpTPtYuzKOznsC7PJV3kRL9Il2Yryi1Q=";
   };
 
   passthru = {
@@ -110,8 +108,6 @@ in mkDerivation rec {
     qtserialport
     qtxmlpatterns
     qt3d
-    pdal
-    zstd
   ] ++ lib.optional withGrass grass
     ++ lib.optional withWebKit qtwebkit
     ++ pythonBuildInputs;
@@ -130,7 +126,6 @@ in mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DWITH_3D=True"
-    "-DWITH_PDAL=TRUE"
     "-DPYQT5_SIP_DIR=${py.pkgs.pyqt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
     "-DQSCI_SIP_DIR=${py.pkgs.qscintilla-qt5}/${py.pkgs.python.sitePackages}/PyQt5/bindings"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
@@ -143,11 +138,11 @@ in mkDerivation rec {
       --prefix PATH : ${lib.makeBinPath [ grass ]}
   '';
 
-  meta = {
+  meta = with lib; {
     description = "A Free and Open Source Geographic Information System";
     homepage = "https://www.qgis.org";
-    license = lib.licenses.gpl2Plus;
-    platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [ lsix sikmir erictapen ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lsix sikmir erictapen ];
   };
 }

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -27,6 +27,7 @@
 , qtsensors
 , qca-qt5
 , qtkeychain
+, qt3d
 , qscintilla
 , qtserialport
 , qtxmlpatterns
@@ -96,6 +97,7 @@ in mkDerivation rec {
     qscintilla
     qtserialport
     qtxmlpatterns
+    qt3d
   ] ++ lib.optional withGrass grass
     ++ lib.optional withWebKit qtwebkit
     ++ pythonBuildInputs;
@@ -113,10 +115,11 @@ in mkDerivation rec {
 
   cmakeFlags = [
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+    "-DWITH_3D=True"
     "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/${python3Packages.python.sitePackages}/PyQt5/bindings"
     "-DQSCI_SIP_DIR=${python3Packages.qscintilla-qt5}/${python3Packages.python.sitePackages}/PyQt5/bindings"
   ] ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
-    ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
+    ++ lib.optional withGrass "-DGRASS_PREFIX7=${grass}/grass78";
 
   meta = {
     description = "A Free and Open Source Geographic Information System";

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -69,14 +69,14 @@ let
     six
   ];
 in mkDerivation rec {
-  version = "3.22.1";
+  version = "3.22.3";
   pname = "qgis-unwrapped";
 
   src = fetchFromGitHub {
     owner = "qgis";
     repo = "QGIS";
     rev = "final-${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "0hpbbv84lh1m7vrxv8d8x5kxgxcf0dydsvr3r2brgv3b40lpavd4";
+    sha256 = "TLXhXHU0dp0MnKHFw/+1rQnJbebnwje21Oasy0qWctk=";
   };
 
   passthru = {

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -13,6 +13,7 @@
 , withMultimedia ? false
 , withWebKit ? false
 , withWebSockets ? false
+, withLocation ? false
 }:
 
 let
@@ -59,6 +60,7 @@ in buildPythonPackage rec {
     ++ lib.optional withMultimedia qtmultimedia
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
+    ++ lib.optional withLocation qtlocation
   ;
 
   buildInputs = with libsForQt5; [
@@ -71,6 +73,7 @@ in buildPythonPackage rec {
     ++ lib.optional withConnectivity qtconnectivity
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets
+    ++ lib.optional withLocation qtlocation
   ;
 
   propagatedBuildInputs = [
@@ -107,6 +110,7 @@ in buildPythonPackage rec {
     ++ lib.optional withWebKit "PyQt5.QtWebKit"
     ++ lib.optional withMultimedia "PyQt5.QtMultimedia"
     ++ lib.optional withConnectivity "PyQt5.QtConnectivity"
+    ++ lib.optional withLocation "PyQt5.QtPositioning"
   ;
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28229,11 +28229,7 @@ with pkgs;
 
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };
 
-  qgis-ltr-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped-ltr.nix { };
-
   qgis-ltr = callPackage ../applications/gis/qgis/ltr.nix { };
-
-  qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix { };
 
   qgis = callPackage ../applications/gis/qgis { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28230,7 +28230,7 @@ with pkgs;
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };
 
   qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix {
-    withGrass = false;
+    withGrass = true;
   };
 
   qgis = callPackage ../applications/gis/qgis { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28229,9 +28229,11 @@ with pkgs;
 
   wrapQemuBinfmtP = callPackage ../applications/virtualization/qemu/binfmt-p-wrapper.nix { };
 
-  qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix {
-    withGrass = true;
-  };
+  qgis-ltr-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped-ltr.nix { };
+
+  qgis-ltr = callPackage ../applications/gis/qgis/ltr.nix { };
+
+  qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix { };
 
   qgis = callPackage ../applications/gis/qgis { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Picking up on @mpickering's #150286

- Rebased #150286 to latest master to address merge conflicts
- Adopts the suggestions from the latest set of review from @SuperSandro2000 in #150286 (amending @mpickering's previous commits for the qtlocation changes, with one final additional commit for the smaller stylistic stuff)
- Also updates qgis and qgis-ltr to latest point releases

I've built it on an x86_linux machine but don't actually have a working X environment on it that I can access so I can only confirm that it builds rather than test functionality. 

@sikmir @erictapen @lsix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
