### PR TITLE
colima: backport from unstable

### DIFF
--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, lima
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "colima";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "abiosoft";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-vWNkYsT2XF+oMOQ3pb1+/a207js8B+EmVanRQrYE/2A=";
+  };
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  vendorSha256 = "sha256-F1ym88JrJWzsBg89Y1ufH4oefIRBwTGOw72BrjtpvBw=";
+
+  postInstall = ''
+    wrapProgram $out/bin/colima \
+      --prefix PATH : ${lib.makeBinPath [ lima ]}
+
+    installShellCompletion --cmd colima \
+      --bash <($out/bin/colima completion bash) \
+      --fish <($out/bin/colima completion fish) \
+      --zsh <($out/bin/colima completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Container runtimes on MacOS with minimal setup";
+    homepage = "https://github.com/abiosoft/colima";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ aaschmid ];
+  };
+}

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  vendorSha256 = "sha256-F1ym88JrJWzsBg89Y1ufH4oefIRBwTGOw72BrjtpvBw=";
+  vendorSha256 = "sha256-VGSwu1WBYfcWjA6BczfMY1s+r9s9aGjlQJjPXgss56s=";
 
   postInstall = ''
     wrapProgram $out/bin/colima \

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -8,13 +8,13 @@
 
 buildGoModule rec {
   pname = "colima";
-  version = "0.3.1";
+  version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "abiosoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+P4kxiib1xkS4iGC2HrYAt0YMyXyEYPqoo1BkDs7jp8=";
+    sha256 = "sha256-hZ5BqNHQAMzL69ptpbTT+fN4NdV4AFhboCL2t1sF5AQ=";
   };
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];

--- a/pkgs/applications/virtualization/colima/default.nix
+++ b/pkgs/applications/virtualization/colima/default.nix
@@ -8,18 +8,18 @@
 
 buildGoModule rec {
   pname = "colima";
-  version = "0.2.2";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "abiosoft";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-vWNkYsT2XF+oMOQ3pb1+/a207js8B+EmVanRQrYE/2A=";
+    sha256 = "sha256-+P4kxiib1xkS4iGC2HrYAt0YMyXyEYPqoo1BkDs7jp8=";
   };
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
-  vendorSha256 = "sha256-VGSwu1WBYfcWjA6BczfMY1s+r9s9aGjlQJjPXgss56s=";
+  vendorSha256 = "sha256-Z4+qwoX04VnLsUIYRfOowFLgcaA9w8oGRl77jzFigIc=";
 
   postInstall = ''
     wrapProgram $out/bin/colima \
@@ -35,7 +35,6 @@ buildGoModule rec {
     description = "Container runtimes on MacOS with minimal setup";
     homepage = "https://github.com/abiosoft/colima";
     license = licenses.mit;
-    platforms = platforms.darwin;
     maintainers = with maintainers; [ aaschmid ];
   };
 }

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "lima";
-  version = "0.7.4";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-pn8GtFAZMQyFjOpn6blNBoDgQL7X1gaYjGsQHwvMzaQ=";
+    sha256 = "sha256-bO7o3z9E7mGiUtlqI+mhhh+D6CG9j3BZ7IB8o/LDUPM=";
   };
 
-  vendorSha256 = "sha256-egZFJSGnFYfOcBMNNEsPV6ngf3ddoYCSntnuloYfpxo=";
+  vendorSha256 = "sha256-MDmRkGa1m3YuUbffCwoChG0Fg74jyuQQ6ljfDlLatjI=";
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 

--- a/pkgs/applications/virtualization/lima/default.nix
+++ b/pkgs/applications/virtualization/lima/default.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "lima";
-  version = "0.7.3";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "lima-vm";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-HVWZ0XF1oBUHhkOQHELlZ/pxXUsUo2cVo6EhZl6S0W4=";
+    sha256 = "sha256-pn8GtFAZMQyFjOpn6blNBoDgQL7X1gaYjGsQHwvMzaQ=";
   };
 
-  vendorSha256 = "sha256-LhmZRa7vDylA4DRTfKFRs3lQMnwNfzF1H6ki1/zdpUg=";
+  vendorSha256 = "sha256-egZFJSGnFYfOcBMNNEsPV6ngf3ddoYCSntnuloYfpxo=";
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32357,6 +32357,8 @@ with pkgs;
 
   idsk = callPackage ../tools/filesystems/idsk { };
 
+  colima = callPackage ../applications/virtualization/colima {};
+
   lima = callPackage ../applications/virtualization/lima {};
 
   logtop = callPackage ../tools/misc/logtop { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32357,7 +32357,9 @@ with pkgs;
 
   idsk = callPackage ../tools/filesystems/idsk { };
 
-  colima = callPackage ../applications/virtualization/colima {};
+  colima = callPackage ../applications/virtualization/colima {
+    buildGoModule = buildGo117Module;
+  };
 
   lima = callPackage ../applications/virtualization/lima {};
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backport Colima to release 21.11.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @zowoq @aaschmid