### PR TITLE
twa: 1.9.1 -> 1.10.0

### DIFF
--- a/pkgs/tools/networking/twa/default.nix
+++ b/pkgs/tools/networking/twa/default.nix
@@ -1,25 +1,25 @@
-{ stdenv
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
 , bash
 , curl
-, fetchFromGitHub
+, dnsutils
 , gawk
-, host
 , jq
-, lib
-, makeWrapper
 , ncurses
 , netcat
 }:
 
 stdenv.mkDerivation rec {
   pname = "twa";
-  version = "1.9.1";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "trailofbits";
     repo = "twa";
-    rev = version;
-    sha256 = "1ab3bcyhfach9y15w8ffvqqan2qk8h62n6z8nqbgygi7n1mf6jzx";
+    rev = "v${version}";
+    hash = "sha256-8c1o03iwStmhjKHmEXIZGyaSOAJRlOuhu0ERjCO5SHg=";
   };
 
   dontBuild = true;
@@ -28,12 +28,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bash
                   curl
+                  dnsutils
                   gawk
-                  host.dnsutils
                   jq
                   netcat ];
 
   installPhase = ''
+    runHook preInstall
+
     install -Dm 0755 twa "$out/bin/twa"
     install -Dm 0755 tscore "$out/bin/tscore"
     install -Dm 0644 twa.1 "$out/share/man/man1/twa.1"
@@ -41,10 +43,13 @@ stdenv.mkDerivation rec {
 
     wrapProgram "$out/bin/twa" \
       --prefix PATH : ${lib.makeBinPath [ curl
-                                                 host.dnsutils
-                                                 jq
-                                                 ncurses
-                                                 netcat ]}
+                                          dnsutils
+                                          gawk
+                                          jq
+                                          ncurses
+                                          netcat ]}
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
