### PR TITLE
 openssl: better check that withPerl=false prevents perl reference

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -206,6 +206,17 @@ let
         echo "Found an erroneous dependency on perl ^^^" >&2
         exit 1
       fi
+    '' + lib.optionalString (!withPerl) ''
+      # If withPerl is disabled, clear out any references to perl that remain in the bin output
+      # (after the postInstall hook above and fixup phase have run)
+      substituteInPlace $bin/bin/c_rehash --replace ${buildPackages.perl}/bin/perl "/usr/bin/env perl"
+      substituteInPlace $bin/bin/c_rehash --replace ${perl}/bin/perl "/usr/bin/env perl"
+
+      # Check to make sure the bin output doesn't depend on perl
+      if grep -r '${buildPackages.perl}' $bin; then
+        echo "Found an erroneous dependency on perl in bin output ^^^" >&2
+        exit 1
+      fi
     '';
 
     passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;


### PR DESCRIPTION

###### Motivation for this change

This is a PR to fix #19965, making it possible to remove a large 50MB `perl` dependency from the closure of `openssl.bin` when using `withPerl=false`. The checks in `openssl/default.nix` weren't quite right before, and there was an unnecessarily restrictive assert preventing you from setting `withPerl` to `false` when not cross-compiling.

I wanted to do this so I could deploy `nodejs-slim` in a Docker container, without bringing in `perl`. I'll open a separate PR for that.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
