### PR TITLE
squishyball: port to ncurses-6.3

### DIFF
--- a/pkgs/applications/audio/squishyball/default.nix
+++ b/pkgs/applications/audio/squishyball/default.nix
@@ -1,22 +1,34 @@
-{ lib, stdenv, autoreconfHook, fetchsvn, flac, libao, libvorbis, ncurses
+{ lib, stdenv, autoreconfHook, fetchFromGitLab, fetchpatch, flac, libao, libvorbis, ncurses
 , opusfile, pkg-config
 }:
 
 stdenv.mkDerivation rec {
-  name = "squishyball-${rev}";
-  rev = "19580";
+  pname = "squishyball";
+  version = "unstable-2020-11-23";
 
-  src = fetchsvn {
-    url = "https://svn.xiph.org/trunk/squishyball";
-    rev = rev;
-    sha256 = "013vq52q9z6kpg9iyc2jnb3m2gihcjblvwpg4yj4wy1q2c05pzqp";
+  src = fetchFromGitLab {
+    domain = "gitlab.xiph.org";
+    owner = "xiph";
+    repo = "squishyball";
+    rev = "27590fe6bac545e2dd3eacf048edbd969682263a";
+    sha256 = "07zs8wx1ahf3q505fk9b6cgzlkhnayfsscch46yy9s1wgxgphj7s";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ];
 
   buildInputs = [ flac libao libvorbis ncurses opusfile ];
 
-  patches = [ ./gnu-screen.patch ];
+  patches = [
+    ./gnu-screen.patch
+
+    # Patch pending upstream inclusion for ncurses-6.3 support:
+    #  https://gitlab.xiph.org/xiph/squishyball/-/issues/1
+    (fetchpatch {
+      name = "ncurses-6.3.patch";
+      url = "https://gitlab.xiph.org/xiph/squishyball/uploads/5609ceaf85ebb6dc297c0efe61b9a1b7/0001-mincurses.c-use-ncurses-API-to-enter-raw-mode-ncurse.patch";
+      sha256 = "06llp7cd77f4vvhz8qdld551dnlpjxf98j7rmp3i1x1kng4f0iy3";
+    })
+  ];
 
   postInstall = ''
     # Why doesn’t this happen automagically?
@@ -40,7 +52,7 @@ stdenv.mkDerivation rec {
        comparisons of groups of up to ten samples; this is the default
        mode of operation.
     '';
-    homepage = "https://svn.xiph.org/trunk/squishyball";
+    homepage = "https://gitlab.xiph.org/xiph/squishyball";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ michalrus ];
     platforms = platforms.linux;


### PR DESCRIPTION
Without the change build on `ncurses-6.3` fails as:

    mincurses.c: In function 'setup_term_customize':
    mincurses.c:345:20: error: 'TERMINAL' {aka 'struct term'} has no member named 'Nttyb'
      345 |     term = cur_term->Nttyb;
          |                    ^~

While at it update homepage from svn repository to gitlab one.