### PR TITLE
sox: 14.4.2 -> unstable-2021-05-09

### DIFF
--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -1,7 +1,9 @@
 { config
 , lib
 , stdenv
-, fetchurl
+, fetchzip
+, autoreconfHook
+, autoconf-archive
 , pkg-config
 , CoreAudio
 , enableAlsa ? true
@@ -35,15 +37,16 @@
 
 stdenv.mkDerivation rec {
   pname = "sox";
-  version = "14.4.2";
+  version = "unstable-2021-05-09";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/sox/sox-${version}.tar.gz";
-    sha256 = "0v2znlxkxxcd3f48hf3dx9pq7i6fdhb62kgj7wv8xggz8f35jpxl";
+  src = fetchzip {
+    url = "https://sourceforge.net/code-snapshots/git/s/so/sox/code.git/sox-code-42b3557e13e0fe01a83465b672d89faddbe65f49.zip";
+    sha256 = "15rp55vr0h2954zl1rllsnriv64qab8fzsp0aprnpx1s5b14xjpm";
   };
 
-  # configure.ac uses pkg-config only to locate libopusfile
-  nativeBuildInputs = lib.optional enableOpusfile pkg-config;
+  nativeBuildInputs = [ autoreconfHook autoconf-archive ]
+    # configure.ac uses pkg-config only to locate libopusfile
+    ++ lib.optional enableOpusfile pkg-config;
 
   patches = [ ./0001-musl-rewind-pipe-workaround.patch ];
 


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-8357
https://nvd.nist.gov/vuln/detail/CVE-2019-8356
https://nvd.nist.gov/vuln/detail/CVE-2019-8355
https://nvd.nist.gov/vuln/detail/CVE-2019-8354
https://nvd.nist.gov/vuln/detail/CVE-2019-13590
https://nvd.nist.gov/vuln/detail/CVE-2019-1010004
https://nvd.nist.gov/vuln/detail/CVE-2017-18189
https://nvd.nist.gov/vuln/detail/CVE-2017-15642
https://nvd.nist.gov/vuln/detail/CVE-2017-15372
https://nvd.nist.gov/vuln/detail/CVE-2017-15371
https://nvd.nist.gov/vuln/detail/CVE-2017-15370
https://nvd.nist.gov/vuln/detail/CVE-2017-11359
https://nvd.nist.gov/vuln/detail/CVE-2017-11358
https://nvd.nist.gov/vuln/detail/CVE-2017-11332

`sox` hasn't seen a release in many years but there is some barebones maintenance going on in the sourceforge git repo, enough to fix CVEs that get brought up. Judging by the state of the project I'd wager money there's more lurking there and I wouldn't recommend use of `sox` for anything non-trivial.

Rather than just applying numerous patches to fix the above issues as debian is doing (https://sources.debian.org/patches/sox/14.4.2+git20190427-2/) I thought for `master` it would be better to just switch to an "unstable" version which contains all these patches and a few more worrying issues that didn't get CVEs assigned to them.

For stable perhaps the patch route is better as I can't really vouch for any potential behaviour changes from 14.4.2 to this version?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https:// github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
