### PR TITLE
opentracker: add overridable build flags

### DIFF
--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation {
     bittorrent-integration = nixosTests.bittorrent;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://erdgeist.org/arts/software/opentracker/";
     license = licenses.beerware;

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -1,4 +1,46 @@
-{ lib, stdenv, fetchgit, libowfat, zlib, nixosTests }:
+{ lib
+, stdenv
+, fetchgit
+, libowfat
+, zlib
+, nixosTests
+, ipv6 ? false
+, blacklist ? false
+, whitelist ? false
+, syncLive ? false
+, ipFromQueryString ? false
+, restrictStats ? true
+, ipFromProxy ? false
+, fullLogNetwork ? false
+, logNumWant ? false
+, modestFullScrape ? fullscrape
+, spotWoodpecker ? false
+, fullscrape ? false
+}:
+
+assert !blacklist || !whitelist;
+
+let
+  features = {
+    V6 = ipv6;
+    ACCESSLIST_BLACK = blacklist;
+    ACCESSLIST_WHITE = whitelist;
+    SYNC_LIVE = syncLive;
+    IP_FROM_QUERY_STRING = ipFromQueryString;
+    COMPRESSION_GZIP = true;
+    COMPRESSION_GZIP_ALWAYS = false;
+    LOG_NETWORKS = false;
+    RESTRICT_STATS = restrictStats;
+    IP_FROM_PROXY = ipFromProxy;
+    FULLLOG_NETWORKS = fullLogNetwork;
+    LOG_NUMWANT = logNumWant;
+    MODEST_FULLSCRAPES = modestFullScrape;
+    SPOT_WOODPECKER = spotWoodpecker;
+    SYSLOGS = false;
+    DEV_RANDOM = false;
+    FULLSCRAPE = fullscrape;
+  };
+in
 
 stdenv.mkDerivation {
   pname = "opentracker";
@@ -11,6 +53,18 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ libowfat zlib ];
+
+  /* FEATURES flag contains spaces so we have to add it this way
+     see https://nixos.org/manual/nixpkgs/stable/#var-stdenv-makeFlagsArray
+  */
+  preBuild = ''
+    makeFlagsArray+=('FEATURES=${
+      lib.concatMapStringsSep
+        " "
+        (name: "-DWANT_${name}")
+        (lib.attrNames (lib.filterAttrs (_: use: use) features))
+    }')
+  '';
 
   makeFlags = [
     "LIBOWFAT_HEADERS=${libowfat}/include/libowfat"

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "opentracker";
-  version = "unstable-2018-05-26";
+  version = "unstable-2021-08-23";
 
   src = fetchgit {
     url = "https://erdgeist.org/gitweb/opentracker";
-    rev = "6411f1567f64248b0d145493c2e61004d2822623";
-    sha256 = "110nfb6n4clykwdzpk54iccsfjawq0krjfqhg114i1z0ri5dyl8j";
+    rev = "110868ec4ebe60521d5a4ced63feca6a1cf0aa2a";
+    sha256 = "1cphy0r4yabwmm7bzpk7jk4fzdxxf9587ciqjmlf7k1vd5z2bqaa";
   };
 
   buildInputs = [ libowfat zlib ];

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation {
   makeFlags = [
     "LIBOWFAT_HEADERS=${libowfat}/include/libowfat"
     "LIBOWFAT_LIBRARY=${libowfat}/lib"
+    "opentracker"
   ];
 
   installPhase = ''

--- a/pkgs/applications/networking/p2p/opentracker/update.sh
+++ b/pkgs/applications/networking/p2p/opentracker/update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts git jq nix nix-prefetch-git
+git_url='https://erdgeist.org/gitweb/opentracker'
+git_branch='master'
+git_dir='/var/tmp/opentracker.git'
+nix_file="$(dirname "${BASH_SOURCE[0]}")/default.nix"
+pkg='opentracker'
+
+set -euo pipefail
+
+info() {
+    if [ -t 2 ]; then
+        set -- '\033[32m%s\033[39m\n' "$@"
+    else
+        set -- '%s\n' "$@"
+    fi
+    printf "$@" >&2
+}
+
+old_rev=$(nix-instantiate --eval --strict --json -A "$pkg.src.rev" | jq -r)
+
+info "fetching $git_url..."
+if [ ! -d "$git_dir" ]; then
+    git init --initial-branch="$git_branch" "$git_dir"
+    git -C "$git_dir" remote add origin "$git_url"
+fi
+git -C "$git_dir" fetch origin "$git_branch"
+
+new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' "origin/$git_branch")
+info "latest commit: $new_rev"
+if [ "$new_rev" = "$old_rev" ]; then
+    info "$pkg is up-to-date."
+    exit
+fi
+
+new_version=$(
+    TZ=UTC0 git -C "$git_dir" \
+        log -n 1 \
+        --format='format:unstable-%cd' \
+        --date='format-local:%Y-%m-%d' \
+        "$new_rev"
+)
+new_sha256=$(nix-prefetch-git --rev "$new_rev" "$git_dir" | jq -r .sha256)
+update-source-version "$pkg" \
+    "$new_version" \
+    "$new_sha256" \
+    --rev="$new_rev"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Because things like IPv6 support have to be enabled during build, introduce derivation arguments to enable those features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
