### PR TITLE
nixos/thelounge: add ensureUsers option

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -720,6 +720,13 @@
       </listitem>
       <listitem>
         <para>
+          The option <literal>services.thelounge.ensureUsers</literal>
+          has been added to allow ensuring that users exist for The
+          Lounge.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>firmwareLinuxNonfree</literal> package has been
           renamed to <literal>linux-firmware</literal>.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -241,6 +241,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The option `services.thelounge.plugins` has been added to allow installing plugins for The Lounge. Plugins can be found in `pkgs.theLoungePlugins.plugins` and `pkgs.theLoungePlugins.themes`.
 
+- The option `services.thelounge.ensureUsers` has been added to allow ensuring that users exist for The Lounge.
+
 - The `firmwareLinuxNonfree` package has been renamed to `linux-firmware`.
 
 - The `services.mbpfan` module was converted to a [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) configuration.

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -18,6 +18,33 @@ let
     ln -s ${pkg}/lib/node_modules/${getName pkg} $out/node_modules/${getName pkg}
     '') cfg.plugins}
   '';
+  userOptions = {
+    options =
+      let
+        passwordDesc = ''
+          This can be generated with <literal>mkpasswd -m bcrypt -R 11</literal>.
+        '';
+      in
+      {
+        hashedPassword = mkOption {
+          type = types.nullOr types.nonEmptyStr;
+          default = null;
+          description = ''
+            The hashed password for this user. ${passwordDesc}
+          '';
+        };
+
+        hashedPasswordFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            The path to a file containing the hashed password for this user. ${passwordDesc}
+          '';
+        };
+
+        enableLogging = (mkEnableOption "message logging for this user") // { default = true; };
+      };
+  };
 in
 {
   imports = [ (mkRemovedOptionModule [ "services" "thelounge" "private" ] "The option was renamed to `services.thelounge.public` to follow upstream changes.") ];
@@ -74,9 +101,32 @@ in
         <literal>pkgs.theLoungePlugins.plugins</literal> and <literal>pkgs.theLoungePlugins.themes</literal>.
       '';
     };
+
+    ensureUsers = mkOption {
+      default = { };
+      type = types.attrsOf (types.submodule userOptions);
+      example = literalExpression ''
+        john = {
+          password = "$2b$05$fK.qf8vOxvOeSA4D3W0znOhkASuXTceypm6uwqPkrAHh7bWaji7U2";
+        };
+      '';
+      description = ''
+        Ensures that the specified users exist. If one does not, a user with the specified options will be created.
+        This option will not delete or update existing users.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
+    assertions = mapAttrsToList
+      (name: user:
+        {
+          assertion = (user.hashedPassword != null && user.hashedPasswordFile == null) || (user.hashedPasswordFile != null && user.hashedPassword == null);
+          message = "Exactly one of services.thelounge.ensureUsers.${name}.hashedPassword or services.thelounge.ensureUsers.${name}.hashedPasswordFile must be set.";
+        }
+      )
+      cfg.ensureUsers;
+
     users.users.thelounge = {
       description = "The Lounge service user";
       group = "thelounge";
@@ -88,7 +138,33 @@ in
     systemd.services.thelounge = {
       description = "The Lounge web IRC client";
       wantedBy = [ "multi-user.target" ];
-      preStart = "ln -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js";
+      preStart = ''
+        set -o errexit -o pipefail -o nounset -o errtrace
+        shopt -s inherit_errexit
+
+        ln -sf ${pkgs.writeText "config.js" configJsData} ${dataDir}/config.js
+
+        mkdir ${dataDir}/users
+
+        ${concatStrings (mapAttrsToList (user: options:
+          let
+            path = "${dataDir}/users/${user}.json";
+          in
+          ''
+            if [ ! -e ${path} ]; then
+              ${if options.hashedPassword != null then ''
+                PASSWORD=${escapeShellArg options.hashedPassword}
+              '' else ''
+                PASSWORD="$(<${escapeShellArg options.hashedPasswordFile})"
+              ''}
+
+              export PASSWORD
+
+              ${pkgs.jq}/bin/jq --null-input \
+                '{password: $ENV.PASSWORD, log: ${if options.enableLogging then "true" else "false"}}' > ${path}
+            fi
+          '') cfg.ensureUsers)}
+      '';
       environment.THELOUNGE_PACKAGES = mkIf (cfg.plugins != [ ]) "${plugins}";
       serviceConfig = {
         User = "thelounge";

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -176,7 +176,18 @@ in
       };
     };
 
-    environment.systemPackages = [ pkgs.thelounge ];
+    environment.systemPackages =
+      let
+        thelounge =
+          if cfg.plugins != [ ] then
+            pkgs.runCommand "thelounge-wrapper"
+              {
+                buildInputs = [ pkgs.makeWrapper ];
+              }
+              "makeWrapper ${pkgs.thelounge}/bin/thelounge $out/bin/thelounge --prefix THELOUNGE_PACKAGES : ${plugins}"
+          else pkgs.thelounge;
+      in
+      [ thelounge ];
   };
 
   meta = {

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -13,9 +13,9 @@ let
   };
   plugins = pkgs.runCommandLocal "thelounge-plugins" { } ''
     mkdir -p $out/node_modules
-    echo ${escapeShellArg (builtins.toJSON pluginManifest)} >> $out/package.json
+    echo ${escapeShellArg (builtins.toJSON pluginManifest)} > $out/package.json
     ${concatMapStringsSep "\n" (pkg: ''
-    ln -s ${pkg}/lib/node_modules/${getName pkg} $out/node_modules/${getName pkg}
+      ln -s ${pkg}/lib/node_modules/${getName pkg} $out/node_modules/${getName pkg}
     '') cfg.plugins}
   '';
   userOptions = {
@@ -73,14 +73,16 @@ in
     extraConfig = mkOption {
       default = { };
       type = types.attrs;
-      example = literalExpression ''{
-        reverseProxy = true;
-        defaults = {
-          name = "Your Network";
-          host = "localhost";
-          port = 6697;
-        };
-      }'';
+      example = literalExpression ''
+        {
+          reverseProxy = true;
+          defaults = {
+            name = "Your Network";
+            host = "localhost";
+            port = 6697;
+          };
+        }
+      '';
       description = ''
         The Lounge's <filename>config.js</filename> contents as attribute set (will be
         converted to JSON to generate the configuration file).
@@ -168,7 +170,7 @@ in
       environment.THELOUNGE_PACKAGES = mkIf (cfg.plugins != [ ]) "${plugins}";
       serviceConfig = {
         User = "thelounge";
-        StateDirectory = baseNameOf dataDir;
+        StateDirectory = builtins.baseNameOf dataDir;
         ExecStart = "${pkgs.thelounge}/bin/thelounge start";
       };
     };

--- a/nixos/modules/services/networking/thelounge.nix
+++ b/nixos/modules/services/networking/thelounge.nix
@@ -170,6 +170,7 @@ in
       environment.THELOUNGE_PACKAGES = mkIf (cfg.plugins != [ ]) "${plugins}";
       serviceConfig = {
         User = "thelounge";
+        Group = "thelounge";
         StateDirectory = builtins.baseNameOf dataDir;
         ExecStart = "${pkgs.thelounge}/bin/thelounge start";
       };

--- a/nixos/tests/thelounge.nix
+++ b/nixos/tests/thelounge.nix
@@ -1,4 +1,6 @@
 import ./make-test-python.nix {
+  name = "thelounge";
+
   nodes =
     let
       mkTestRunner =

--- a/nixos/tests/thelounge.nix
+++ b/nixos/tests/thelounge.nix
@@ -54,10 +54,14 @@ import ./make-test-python.nix {
                                               assert any([theme["name"] == "thelounge-theme-solarized" for theme in payload["themes"]])
                                             ''}
 
-                                            break
+                                            await ws.send_str("42" + json.dumps(["changelog"]))
                                         elif event == "auth:start":
                                             payload = ["auth:perform", {"user": user, "password": password}]
                                             await ws.send_str("42" + json.dumps(payload))
+                                        elif event == "changelog":
+                                            assert payload["packages"] is False
+
+                                            break
 
 
             asyncio.run(main())
@@ -116,5 +120,8 @@ import ./make-test-python.nix {
     public.succeed("PYTHONUNBUFFERED=1 test-runner")
     private.succeed("PYTHONUNBUFFERED=1 test-runner john password123")
     private.succeed("PYTHONUNBUFFERED=1 test-runner jane password123")
+
+    for command in ["install foo", "uninstall foo", "outdated", "upgrade"]:
+        private.succeed(f"sudo -u thelounge thelounge {command} |& grep NixOS")
   '';
 }

--- a/nixos/tests/thelounge.nix
+++ b/nixos/tests/thelounge.nix
@@ -1,19 +1,108 @@
 import ./make-test-python.nix {
-  nodes = {
-    private = { config, pkgs, ... }: {
-      services.thelounge = {
-        enable = true;
-        plugins = [ pkgs.theLoungePlugins.themes.solarized ];
-      };
-    };
+  nodes =
+    let
+      mkTestRunner =
+        cfg: pkgs: pkgs.writers.writePython3Bin "test-runner"
+          {
+            libraries = [ pkgs.python3Packages.aiohttp ];
+            flakeIgnore = [ "E271" "E303" "E501" "W293" ];
+          }
+          ''
+            import aiohttp
+            import asyncio
+            import json
+            import sys
 
-    public = { config, pkgs, ... }: {
-      services.thelounge = {
-        enable = true;
-        public = true;
+
+            async def main():
+                user = None
+                password = None
+
+                if len(sys.argv) > 2:
+                    user = sys.argv[1]
+                    password = sys.argv[2]
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.ws_connect("http://localhost:9000/socket.io/?EIO=4&transport=websocket") as ws:
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                typ = msg.data[0]
+                                data = msg.data[1:]
+
+                                if typ == "2":
+                                    await ws.send_str("3")
+                                elif typ == "0":
+                                    await ws.send_str("40")
+                                elif typ == "4":
+                                    typ = data[0]
+                                    data = data[1:]
+
+                                    if typ == "2":
+                                        data = json.loads(data)
+                                        event = data[0]
+                                        payload = None
+
+                                        if len(data) > 1:
+                                            payload = data[1]
+
+                                        if event == "configuration":
+                                            assert ${pkgs.lib.optionalString (!cfg.public) "not"} payload["public"]
+
+                                            ${pkgs.lib.optionalString ((builtins.length cfg.plugins) > 0) ''
+                                              assert any([theme["name"] == "thelounge-theme-solarized" for theme in payload["themes"]])
+                                            ''}
+
+                                            break
+                                        elif event == "auth:start":
+                                            payload = ["auth:perform", {"user": user, "password": password}]
+                                            await ws.send_str("42" + json.dumps(payload))
+
+
+            asyncio.run(main())
+          '';
+    in
+    {
+      private = { config, pkgs, ... }: {
+        services.thelounge = {
+          enable = true;
+          plugins = [ pkgs.theLoungePlugins.themes.solarized ];
+          ensureUsers = {
+            john = {
+              hashedPassword = "$2b$11$SqnMvKNEERan67wC9pQZX.MnCX2yXsTjh/EM0RLwhuZWq.Y/rGFLu"; # password123
+            };
+            jane =
+              let
+                file = pkgs.writeTextFile {
+                  name = "jane-password";
+                  text = config.services.thelounge.ensureUsers.john.hashedPassword;
+                };
+              in
+              {
+                hashedPasswordFile = "${file}";
+              };
+          };
+        };
+
+        environment.systemPackages =
+          let
+            testRunner = mkTestRunner config.services.thelounge pkgs;
+          in
+          [ testRunner ];
+      };
+
+      public = { config, pkgs, ... }: {
+        services.thelounge = {
+          enable = true;
+          public = true;
+        };
+
+        environment.systemPackages =
+          let
+            testRunner = mkTestRunner config.services.thelounge pkgs;
+          in
+          [ testRunner ];
       };
     };
-  };
 
   testScript = ''
     start_all()
@@ -22,8 +111,8 @@ import ./make-test-python.nix {
       machine.wait_for_unit("thelounge.service")
       machine.wait_for_open_port(9000)
 
-    private.wait_until_succeeds("journalctl -u thelounge.service | grep thelounge-theme-solarized")
-    private.wait_until_succeeds("journalctl -u thelounge.service | grep 'in private mode'")
-    public.wait_until_succeeds("journalctl -u thelounge.service | grep 'in public mode'")
+    public.succeed("PYTHONUNBUFFERED=1 test-runner")
+    private.succeed("PYTHONUNBUFFERED=1 test-runner john password123")
+    private.succeed("PYTHONUNBUFFERED=1 test-runner jane password123")
   '';
 }

--- a/pkgs/development/node-packages/thelounge-packages-path.patch
+++ b/pkgs/development/node-packages/thelounge-packages-path.patch
@@ -1,15 +1,122 @@
+diff --git a/src/command-line/install.js b/src/command-line/install.js
+index bc30a851..e35664b5 100644
+--- a/src/command-line/install.js
++++ b/src/command-line/install.js
+@@ -17,6 +17,11 @@ program
+ 		const path = require("path");
+ 		const packageJson = require("package-json");
+ 
++		if (Helper.isUsingNixOSPackages()) {
++			log.error("This command is disabled because packages are being managed via the NixOS module.");
++			return;
++		}
++
+ 		if (!fs.existsSync(Helper.getConfigPath())) {
+ 			log.error(`${Helper.getConfigPath()} does not exist.`);
+ 			return;
+diff --git a/src/command-line/outdated.js b/src/command-line/outdated.js
+index 72c561d4..19455b0e 100644
+--- a/src/command-line/outdated.js
++++ b/src/command-line/outdated.js
+@@ -10,6 +10,11 @@ program
+ 	.description("Check for any outdated packages")
+ 	.on("--help", Utils.extraHelp)
+ 	.action(async () => {
++		if (process.env.THELOUNGE_PACKAGES !== undefined) {
++			log.error("This command is disabled because packages are being managed via the NixOS module.");
++			return;
++		}
++
+ 		log.info("Checking for outdated packages");
+ 
+ 		await packageManager
+diff --git a/src/command-line/uninstall.js b/src/command-line/uninstall.js
+index 8686e668..d4fbbb97 100644
+--- a/src/command-line/uninstall.js
++++ b/src/command-line/uninstall.js
+@@ -14,6 +14,11 @@ program
+ 		const fs = require("fs");
+ 		const path = require("path");
+ 
++		if (Helper.isUsingNixOSPackages()) {
++			log.error("This command is disabled because packages are being managed via the NixOS module.");
++			return;
++		}
++
+ 		const packagesConfig = path.join(Helper.getPackagesPath(), "package.json");
+ 		const packages = JSON.parse(fs.readFileSync(packagesConfig, "utf-8"));
+ 
+diff --git a/src/command-line/upgrade.js b/src/command-line/upgrade.js
+index 6911ad72..b22a8374 100644
+--- a/src/command-line/upgrade.js
++++ b/src/command-line/upgrade.js
+@@ -14,6 +14,11 @@ program
+ 		const fs = require("fs");
+ 		const path = require("path");
+ 
++		if (Helper.isUsingNixOSPackages()) {
++			log.error("This command is disabled because packages are being managed via the NixOS module.");
++			return;
++		}
++
+ 		// Get paths to the location of packages directory
+ 		const packagesConfig = path.join(Helper.getPackagesPath(), "package.json");
+ 		const packagesList = JSON.parse(fs.readFileSync(packagesConfig, "utf-8")).dependencies;
 diff --git a/src/helper.js b/src/helper.js
-index 27352b53..7078e4c5 100644
+index 27352b53..c50fa092 100644
 --- a/src/helper.js
 +++ b/src/helper.js
-@@ -110,6 +110,10 @@ function setHome(newPath) {
+@@ -19,6 +19,7 @@ let packagesPath;
+ let fileUploadPath;
+ let userLogsPath;
+ let clientCertificatesPath;
++let usingNixOSPackages;
+ 
+ const Helper = {
+ 	config: null,
+@@ -44,6 +45,7 @@ const Helper = {
+ 	parseHostmask,
+ 	compareHostmask,
+ 	compareWithWildcard,
++	isUsingNixOSPackages,
+ 
+ 	password: {
+ 		hash: passwordHash,
+@@ -109,6 +111,11 @@ function setHome(newPath) {
+ 	packagesPath = path.join(homePath, "packages");
  	userLogsPath = path.join(homePath, "logs");
  	clientCertificatesPath = path.join(homePath, "certificates");
- 
-+	if (process.env.THELOUNGE_PACKAGES !== undefined) {
++	usingNixOSPackages = process.env.THELOUNGE_PACKAGES !== undefined;
++
++	if (usingNixOSPackages) {
 +		packagesPath = process.env.THELOUNGE_PACKAGES;
 +	}
-+
+ 
  	// Reload config from new home location
  	if (fs.existsSync(configPath)) {
- 		const userConfig = require(configPath);
+@@ -200,6 +207,10 @@ function getPackageModulePath(packageName) {
+ 	return path.join(Helper.getPackagesPath(), "node_modules", packageName);
+ }
+ 
++function isUsingNixOSPackages() {
++	return usingNixOSPackages;
++}
++
+ function ip2hex(address) {
+ 	// no ipv6 support
+ 	if (!net.isIPv4(address)) {
+diff --git a/src/plugins/packages/index.js b/src/plugins/packages/index.js
+index 6db96280..c8863f2b 100644
+--- a/src/plugins/packages/index.js
++++ b/src/plugins/packages/index.js
+@@ -186,6 +186,10 @@ function watchPackages(packageJson) {
+ }
+ 
+ async function outdated(cacheTimeout = TIME_TO_LIVE) {
++	if (Helper.isUsingNixOSPackages()) {
++		return false;
++	}
++
+ 	if (cache.outdated !== undefined) {
+ 		return cache.outdated;
+ 	}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This allows ensuring that users exist in The Lounge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
