### PR TITLE
youki: init

### DIFF
--- a/pkgs/applications/virtualization/youki/default.nix
+++ b/pkgs/applications/virtualization/youki/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, dbus
+, libseccomp
+, systemd
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "youki";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-iO7vX0xJRZB4c3Tvvx9IWs+oEJQ90mQarJ43EttFYzY=";
+  };
+
+  cargoSha256 = "sha256-oygT0DMDKaJEVeVkEY12T99qgvc0G/z0ZSNWabqOu50=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ dbus libseccomp systemd ];
+
+  preBuild = ''
+    rm .cargo/config
+
+    substituteInPlace crates/youki/Cargo.toml \
+      --replace 'build = "build.rs"' ""
+
+    rm crates/youki/build.rs
+
+    export \
+      VERGEN_BUILD_SEMVER="${version}" \
+      VERGEN_BUILD_TIMESTAMP="$SOURCE_DATE_EPOCH" \
+      VERGEN_GIT_SHA_SHORT="${src.rev}" \
+      VERGEN_GIT_SHA="${src.rev}" \
+      VERGEN_RUSTC_HOST_TRIPLE=""
+  '';
+
+  doCheck = false; # timeout
+
+  meta = with lib; {
+    description = "Container runtime written in Rust";
+    homepage = "https://github.com/containers/youki";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29626,6 +29626,8 @@ with pkgs;
 
   yeahwm = callPackage ../applications/window-managers/yeahwm { };
 
+  youki = callPackage ../applications/virtualization/youki { };
+
   vym = qt5.callPackage ../applications/misc/vym { };
 
   wad = callPackage ../tools/security/wad { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
