### PR TITLE
aardvark-dns, netavark: init

### DIFF
--- a/pkgs/tools/networking/aardvark-dns/default.nix
+++ b/pkgs/tools/networking/aardvark-dns/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "aardvark-dns";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-RFA/C0Q4u1WMQ0bsFKbkyzar0vDRfQ6YPpu/Np3xXWA=";
+  };
+
+  cargoVendorDir = "vendor";
+
+  preBuild = ''
+    rm build.rs
+
+    export \
+      VERGEN_BUILD_SEMVER="${version}" \
+      VERGEN_BUILD_TIMESTAMP="$SOURCE_DATE_EPOCH" \
+      VERGEN_GIT_SHA="${src.rev}" \
+      VERGEN_RUSTC_HOST_TRIPLE=""
+  '';
+
+  meta = with lib; {
+    description = "Authoritative dns server for A/AAAA container records";
+    homepage = "https://github.com/containers/aardvark-dns";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ] ++ teams.podman.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/netavark/default.nix
+++ b/pkgs/tools/networking/netavark/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, mandown
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "netavark";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-E3Mdrc8/IwuOOwwVf4LaLrNFzuO95MEvy8BbStQRgoE=";
+  };
+
+  cargoVendorDir = "vendor";
+
+  preBuild = ''
+    substituteInPlace Cargo.toml \
+      --replace 'build = "build.rs"' ""
+
+    rm build.rs
+
+    export \
+      VERGEN_BUILD_SEMVER="${version}" \
+      VERGEN_BUILD_TIMESTAMP="$SOURCE_DATE_EPOCH" \
+      VERGEN_GIT_SHA="${src.rev}" \
+      VERGEN_RUSTC_HOST_TRIPLE=""
+  '';
+
+  nativeBuildInputs = [ installShellFiles mandown ];
+
+  postBuild = ''
+    make -C docs
+    installManPage docs/*.1
+  '';
+
+  meta = with lib; {
+    description = "Rust based network stack for containers";
+    homepage = "https://github.com/containers/netavark";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ] ++ teams.podman.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -879,6 +879,8 @@ with pkgs;
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };
 
+  aardvark-dns = callPackage ../tools/networking/aardvark-dns { };
+
   a2ps = callPackage ../tools/text/a2ps { };
 
   abcm2ps = callPackage ../tools/audio/abcm2ps { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8071,6 +8071,8 @@ with pkgs;
 
   netatalk = callPackage ../tools/filesystems/netatalk { };
 
+  netavark = callPackage ../tools/networking/netavark { };
+
   netcdf = callPackage ../development/libraries/netcdf {
     hdf5 = hdf5.override { usev110Api = true; };
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
