### PR TITLE
Add 'jsierles' as a maintainer for the flyctl package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5984,6 +5984,13 @@
     githubId = 107689;
     name = "Josh Holland";
   };
+  jsierles = {
+    email = "joshua@hey.com";
+    matrix = "@jsierles:matrix.org";
+    name = "Joshua Sierles";
+    github = "jsierles";
+    githubId = 82;
+  };
   jtcoolen = {
     email = "jtcoolen@pm.me";
     name = "Julien Coolen";

--- a/pkgs/development/web/flyctl/default.nix
+++ b/pkgs/development/web/flyctl/default.nix
@@ -27,6 +27,6 @@ buildGoModule rec {
     description = "Command line tools for fly.io services";
     homepage = "https://fly.io/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ aaronjanse ];
+    maintainers = with maintainers; [ aaronjanse jsierles ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I'm one of the contributors to `flyctl` at [Fly.io](https://fly.io). I'd like to make sure this package stays up to date as we publish new versions regularly.

###### Things done

Just added myself as a maintainer of the flyctl package definition on the advice of those in the Matrix community. My goal is to submit, review and merge updates to this package on a regular basis.