### PR TITLE
JAX ecosystem: `jaxlib` should never be in `propagatedBuildInputs`

### DIFF
--- a/pkgs/development/python-modules/dm-haiku/default.nix
+++ b/pkgs/development/python-modules/dm-haiku/default.nix
@@ -4,6 +4,7 @@
 , dill
 , dm-tree
 , fetchFromGitHub
+, jaxlib
 , jmp
 , lib
 , pytestCheckHook
@@ -31,6 +32,7 @@ buildPythonPackage rec {
     chex
     cloudpickle
     dm-tree
+    jaxlib
     pytestCheckHook
     tensorflow
   ];

--- a/pkgs/development/python-modules/elegy/default.nix
+++ b/pkgs/development/python-modules/elegy/default.nix
@@ -4,6 +4,7 @@
 , deepmerge
 , dm-haiku
 , fetchFromGitHub
+, jaxlib
 , lib
 , poetry
 , pytestCheckHook
@@ -34,6 +35,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry
   ];
+
+  buildInputs = [ jaxlib ];
 
   propagatedBuildInputs = [
     cloudpickle

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchFromGitHub
+, jaxlib
 , keras
 , lib
 , matplotlib
@@ -20,6 +21,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "0zvq0vl88hiwmss49bnm7gdmndr1dfza2bcs1fj88a9r7w9dmlsr";
   };
+
+  buildInputs = [ jaxlib ];
 
   propagatedBuildInputs = [
     matplotlib

--- a/pkgs/development/python-modules/jmp/default.nix
+++ b/pkgs/development/python-modules/jmp/default.nix
@@ -19,10 +19,9 @@ buildPythonPackage rec {
     sha256 = "0hh4cmp93wjyidj48gh07vhx2kjvpwd23xvy79bsjn5qaaf6q4cm";
   };
 
-  # Wheel requires only `numpy`, but the import needs both `jax` and `jaxlib`.
+  # Wheel requires only `numpy`, but the import needs `jax`.
   propagatedBuildInputs = [
     jax
-    jaxlib
   ];
 
   pythonImportsCheck = [
@@ -30,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    jaxlib
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/optax/default.nix
+++ b/pkgs/development/python-modules/optax/default.nix
@@ -22,10 +22,11 @@ buildPythonPackage rec {
     sha256 = "1q8cxc42a5xais2ll1l238cnn3l7w28savhgiz0lg01ilz2ysbli";
   };
 
+  buildInputs = [ jaxlib ];
+
   propagatedBuildInputs = [
     absl-py
     chex
-    jaxlib
     numpy
   ];
 

--- a/pkgs/development/python-modules/treeo/default.nix
+++ b/pkgs/development/python-modules/treeo/default.nix
@@ -22,12 +22,12 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  # These deps are not needed for the wheel, but required during the import.
+  # jax is not declared in the dependencies, but is necessary.
   propagatedBuildInputs = [
     jax
-    jaxlib
   ];
 
+  checkInputs = [ jaxlib ];
   pythonImportsCheck = [
     "treeo"
   ];

--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -5,6 +5,7 @@
 , fetchFromGitHub
 , flax
 , hypothesis
+, jaxlib
 , keras
 , lib
 , poetry-core
@@ -37,6 +38,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     poetry-core
   ];
+
+  buildInputs = [ jaxlib ];
 
   propagatedBuildInputs = [
     einops


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/156767.

There are multiple possible "versions" of the jaxlib package: CPU-only, CUDA-enabled, and TPU-enabled. Currently the jaxlib package defaults to the smallest (and most FOSS) version which is CPU-only. CUDA support can be enabled by end users via the `cudaSupport = true` option. 

This presents an issue when using packages that depend on jax/jaxlib however. If the packages depend directly on jaxlib by adding them to `propagatedBuildInputs` then the end-user is stuck with the CPU-only version of jaxlib, even though the CUDA version may be desired. Using overlays is one possible workaround but unfortunately that requires every end-user to recompile the entire JAX ecosystem locally whenever they want to use a non-CPU jaxlib.

This PR removes jaxlib from any and all `propagatedBuildInputs` and patches packages that require jaxlib as a `setup.py` dependency. AFAIU this is in line with the JAX authors' intention to separate the jax and jaxlib packages. In fact, jax itself does not even have a `setup.py` dependency on jaxlib.

For future debugging purposes, an easy way to test if you have conflicting jaxlib versions is 
```
echo $PYTHONPATH | tr ':' '\n' | grep jaxlib
```
This command should return at most one entry at all times. I've verified that the changes in this PR do in fact resolve this issue based on the shell.nix used in https://github.com/NixOS/nixpkgs/issues/156767.

Assuming we reach consensus that this is the right path forward, I will document this practice on the [wiki page](https://nixos.wiki/wiki/JAX).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
