### PR TITLE
go-swag: enable automatic updating by r-ryantm

### DIFF
--- a/pkgs/development/tools/go-swag/default.nix
+++ b/pkgs/development/tools/go-swag/default.nix
@@ -7,7 +7,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "swaggo";
     repo = "swag";
-    rev = "df209afeed2334a97c83aff34ea7abcad85c31f6";
+    rev = "v${version}";
     sha256 = "17pmcfkcmgjvs4drs0fyhp2m39gw83s0ck3rdzdkgdhrbhva9ksx";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
r-ryantm bot is failing to open a PR to bump the version because it is not properly parameterized:

```
2022-01-24T11:40:07 Diff after rewrites:
diff --git a/pkgs/development/tools/go-swag/default.nix b/pkgs/development/tools/go-swag/default.nix
index 0a0eb41d613..810f90e8e21 100644
--- a/pkgs/development/tools/go-swag/default.nix
+++ b/pkgs/development/tools/go-swag/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "go-swag";
-  version = "1.6.7";
+  version = "1.7.8";
 
   src = fetchFromGitHub {
     owner = "swaggo";
     repo = "swag";
     rev = "df209afeed2334a97c83aff34ea7abcad85c31f6";
-    sha256 = "17pmcfkcmgjvs4drs0fyhp2m39gw83s0ck3rdzdkgdhrbhva9ksx";
+    sha256 = "sha256-Xc+kNlwZtjfbb3lMBvRA/KVRxYXeAZ0b0Vu+yqZj9Z4=";
   };
 
-  vendorSha256 = "1i2n2sz2hc89nf2fqfq3swldz0xwrnms4j9q0lrss5gm3bk49q7f";
+  vendorSha256 = "sha256-7uBE5hr1Fa0zBThJoqvNvIPfKNcDO+yEswkxKL4WVsQ=";
 
   subPackages = [ "cmd/swag" ];
```
(https://r.ryantm.com/log/github/go-swag/2022-01-24.log)


###### Things done
Properly parametrizes `rev` in `fetchFromGitHub` in order to wire up `version` to work with r-ryantm bot. 

---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
