### PR TITLE
commitizen: 2.20.3 -> 2.20.4

### DIFF
--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -12,6 +12,11 @@
 , argcomplete
 , typing-extensions
 , packaging
+, pytestCheckHook
+, pytest-freezegun
+, pytest-mock
+, pytest-regressions
+, git
 }:
 
 buildPythonApplication rec {
@@ -23,6 +28,7 @@ buildPythonApplication rec {
     repo = pname;
     rev = "v${version}";
     sha256 = "sha256-2DhWiUAkAkyNxYB1CGzUB2nGZeCWvFqSztrxasUPSXw=";
+    deepClone = true;
   };
 
   format = "pyproject";
@@ -40,6 +46,58 @@ buildPythonApplication rec {
     argcomplete
     typing-extensions
     packaging
+  ];
+
+  doCheck = true;
+  checkInputs = [
+    pytestCheckHook
+    pytest-freezegun
+    pytest-mock
+    pytest-regressions
+    argcomplete
+    git
+  ];
+
+  # NB: These require full git history
+  disabledTests = [
+    "test_breaking_change_content_v1"
+    "test_breaking_change_content_v1_beta"
+    "test_breaking_change_content_v1_multiline"
+    "test_bump_command_prelease"
+    "test_bump_dry_run"
+    "test_bump_files_only"
+    "test_bump_local_version"
+    "test_bump_major_increment"
+    "test_bump_minor_increment"
+    "test_bump_on_git_with_hooks_no_verify_disabled"
+    "test_bump_on_git_with_hooks_no_verify_enabled"
+    "test_bump_patch_increment"
+    "test_bump_tag_exists_raises_exception"
+    "test_bump_when_bumpping_is_not_support"
+    "test_bump_when_version_inconsistent_in_version_files"
+    "test_bump_with_changelog_arg"
+    "test_bump_with_changelog_config"
+    "test_bump_with_changelog_to_stdout_arg"
+    "test_changelog_config_flag_increment"
+    "test_changelog_config_start_rev_option"
+    "test_changelog_from_start"
+    "test_changelog_from_version_zero_point_two"
+    "test_changelog_hook"
+    "test_changelog_incremental_angular_sample"
+    "test_changelog_incremental_keep_a_changelog_sample"
+    "test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag"
+    "test_changelog_incremental_with_release_candidate_version"
+    "test_changelog_is_persisted_using_incremental"
+    "test_changelog_multiple_incremental_do_not_add_new_lines"
+    "test_changelog_replacing_unreleased_using_incremental"
+    "test_changelog_with_different_cz"
+    "test_get_commits"
+    "test_get_commits_author_and_email"
+    "test_get_commits_with_signature"
+    "test_get_latest_tag_name"
+    "test_is_staging_clean_when_updating_file"
+    "test_none_increment_should_not_call_git_tag_and_error_code_is_not_zero"
+    "test_prevent_prerelease_when_no_increment_detected"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -11,17 +11,18 @@
 , pyyaml
 , argcomplete
 , typing-extensions
+, packaging
 }:
 
 buildPythonApplication rec {
   pname = "commitizen";
-  version = "2.20.3";
+  version = "2.20.4";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-rAm2GTRxZIHQmn/FM0IwwH/2h+oOvzGmeVr5xkvD/zA=";
+    sha256 = "sha256-2DhWiUAkAkyNxYB1CGzUB2nGZeCWvFqSztrxasUPSXw=";
   };
 
   format = "pyproject";
@@ -38,6 +39,7 @@ buildPythonApplication rec {
     pyyaml
     argcomplete
     typing-extensions
+    packaging
   ];
 
   meta = with lib; {


### PR DESCRIPTION
- commitizen: 2.20.3 -> 2.20.4
- commitizen: enable some tests

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
