### PR TITLE
nixos/wrappers: require argc to be at least one

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -170,6 +170,7 @@ int readlink_malloc(const char *p, char **ret) {
 }
 
 int main(int argc, char **argv) {
+    ASSERT(argc >= 1);
     char *self_path = NULL;
     int self_path_size = readlink_malloc("/proc/self/exe", &self_path);
     if (self_path_size < 0) {

--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -2,12 +2,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <stdnoreturn.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/xattr.h>
 #include <fcntl.h>
 #include <dirent.h>
-#include <assert.h>
 #include <errno.h>
 #include <linux/capability.h>
 #include <sys/prctl.h>
@@ -16,10 +16,7 @@
 #include <syscall.h>
 #include <byteswap.h>
 
-// Make sure assertions are not compiled out, we use them to codify
-// invariants about this program and we want it to fail fast and
-// loudly if they are violated.
-#undef NDEBUG
+#define ASSERT(expr) ((expr) ? (void) 0 : assert_failure(#expr))
 
 extern char **environ;
 
@@ -37,6 +34,12 @@ static char *wrapper_debug = "WRAPPER_DEBUG";
 #else
 #define LE32_TO_H(x) (x)
 #endif
+
+static noreturn void assert_failure(const char *assertion) {
+    fprintf(stderr, "Assertion `%s` in NixOS's wrapper.c failed.\n", assertion);
+    fflush(stderr);
+    abort();
+}
 
 int get_last_cap(unsigned *last_cap) {
     FILE* file = fopen("/proc/sys/kernel/cap_last_cap", "r");
@@ -181,36 +184,36 @@ int main(int argc, char **argv) {
     int len = strlen(wrapper_dir);
     if (len > 0 && '/' == wrapper_dir[len - 1])
       --len;
-    assert(!strncmp(self_path, wrapper_dir, len));
-    assert('/' == wrapper_dir[0]);
-    assert('/' == self_path[len]);
+    ASSERT(!strncmp(self_path, wrapper_dir, len));
+    ASSERT('/' == wrapper_dir[0]);
+    ASSERT('/' == self_path[len]);
 
     // Make *really* *really* sure that we were executed as
     // `self_path', and not, say, as some other setuid program. That
     // is, our effective uid/gid should match the uid/gid of
     // `self_path'.
     struct stat st;
-    assert(lstat(self_path, &st) != -1);
+    ASSERT(lstat(self_path, &st) != -1);
 
-    assert(!(st.st_mode & S_ISUID) || (st.st_uid == geteuid()));
-    assert(!(st.st_mode & S_ISGID) || (st.st_gid == getegid()));
+    ASSERT(!(st.st_mode & S_ISUID) || (st.st_uid == geteuid()));
+    ASSERT(!(st.st_mode & S_ISGID) || (st.st_gid == getegid()));
 
     // And, of course, we shouldn't be writable.
-    assert(!(st.st_mode & (S_IWGRP | S_IWOTH)));
+    ASSERT(!(st.st_mode & (S_IWGRP | S_IWOTH)));
 
     // Read the path of the real (wrapped) program from <self>.real.
     char real_fn[PATH_MAX + 10];
     int real_fn_size = snprintf(real_fn, sizeof(real_fn), "%s.real", self_path);
-    assert(real_fn_size < sizeof(real_fn));
+    ASSERT(real_fn_size < sizeof(real_fn));
 
     int fd_self = open(real_fn, O_RDONLY);
-    assert(fd_self != -1);
+    ASSERT(fd_self != -1);
 
     char source_prog[PATH_MAX];
     len = read(fd_self, source_prog, PATH_MAX);
-    assert(len != -1);
-    assert(len < sizeof(source_prog));
-    assert(len > 0);
+    ASSERT(len != -1);
+    ASSERT(len < sizeof(source_prog));
+    ASSERT(len > 0);
     source_prog[len] = 0;
 
     close(fd_self);


### PR DESCRIPTION
setuid applications were exploited in the past with an empty argc, such as pkexec using CVE-2021-4034. In order to avoid the risk of such vulnerabilities in the future, wrapper was updated to prevent calling setuid like this.

See #156750.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
