### PR TITLE
ocamlPackages.ocaml_libvirt: fix build by bringing pre/post phases in

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -17,11 +17,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml ];
 
-  createFindlibDestdir = true;
-
-  buildPhase = "make all opt CPPFLAGS=-Wno-error";
-
-  installPhase = "make install-opt";
+  buildFlags = [ "all" "opt" "CPPFLAGS=-Wno-error" ];
+  installTargets = "install-opt";
+  preInstall = ''
+    # Fix 'dllmllibvirt.so' install failure into non-existent directory.
+    mkdir -p $OCAMLFIND_DESTDIR/stublibs
+  '';
 
   meta = with lib; {
     description = "OCaml bindings for libvirt";


### PR DESCRIPTION
9a778368f2a617 "move destdir creation to installPhase" moved directory
creation to preInstallHooks and exposed a bug in ocaml_libvirt:

```
ocaml-libvirt> ocamlfind install  -ldconf ignore libvirt \
ocaml-libvirt>   ../META *.so *.a *.cma *.cmx *.cmxa *.cmi *.mli
ocaml-libvirt> ocamlfind: Bad configuration: Cannot mkdir
  /nix/store/...aml-libvirt-0.6.1.5/lib/ocaml/4.12.0/site-lib/libvirt
    because a path component does not exist or is not a directory
ocaml-libvirt> make[1]: *** [Makefile:134: install-opt] Error 2
```

The change restore pre/post phases by overriding build targets instead
of overriding full phases.