### PR TITLE
quartus-prime: usb blaster support

### DIFF
--- a/pkgs/applications/editors/quartus-prime/default.nix
+++ b/pkgs/applications/editors/quartus-prime/default.nix
@@ -25,6 +25,7 @@ in buildFHSUserEnv rec {
     # qsys requirements
     xorg.libXtst
     xorg.libXi
+    libudev0-shim
   ];
   multiPkgs = pkgs: with pkgs; let
     # This seems ugly - can we override `libpng = libpng12` for all `pkgs`?

--- a/pkgs/os-specific/linux/usb-blaster-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/usb-blaster-udev-rules/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenvNoCC }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "usb-blaster-udev-rules";
+
+  udevRules = ./usb-blaster.rules;
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm 644 "${udevRules}" "$out/lib/udev/rules.d/51-usbblaster.rules"
+  '';
+
+  meta = with lib; {
+    description = "udev rules that give NixOS permission to communicate with usb blasters";
+    longDescription = ''
+      udev rules that give NixOS permission to communicate with usb blasters.
+      To use it under NixOS, add
+
+        services.udev.packages = [ pkgs.usb-blaster-udev-rules ];
+
+      to the system configuration.
+    '';
+    license = licenses.free;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/usb-blaster-udev-rules/usb-blaster.rules
+++ b/pkgs/os-specific/linux/usb-blaster-udev-rules/usb-blaster.rules
@@ -1,0 +1,8 @@
+# USB-Blaster
+ATTRS{idVendor}=="09fb", ATTRS{idProduct}=="6001", TAG+="uaccess"
+ATTRS{idVendor}=="09fb", ATTRS{idProduct}=="6002", TAG+="uaccess"
+ATTRS{idVendor}=="09fb", ATTRS{idProduct}=="6003", TAG+="uaccess"
+
+# USB-Blaster II
+ATTRS{idVendor}=="09fb", ATTRS{idProduct}=="6010", TAG+="uaccess"
+ATTRS{idVendor}=="09fb", ATTRS{idProduct}=="6810", TAG+="uaccess"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34424,6 +34424,8 @@ with pkgs;
 
   quartus-prime-lite = callPackage ../applications/editors/quartus-prime {};
 
+  usb-blaster-udev-rules = callPackage ../os-specific/linux/usb-blaster-udev-rules {};
+
   go-license-detector = callPackage ../development/tools/misc/go-license-detector { };
 
   hashdeep = callPackage ../tools/security/hashdeep { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use an intel fpga that is programmed trough a usb-blaster, this requires some udev rules and libudev0 to function trough quartus.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
