### PR TITLE
diffoscope: fix nixpkgs patch to be black-compliant

### DIFF
--- a/pkgs/tools/misc/diffoscope/ignore_links.patch
+++ b/pkgs/tools/misc/diffoscope/ignore_links.patch
@@ -6,7 +6,7 @@ index 5f34d62..36999a3 100644
          FILE_RE = re.compile(r"^\s*File:.*$")
          DEVICE_RE = re.compile(r"Device: [0-9a-f]+h/[0-9]+d\s+")
          INODE_RE = re.compile(r"Inode: [0-9]+\s+")
-+        LINKS_RE = re.compile(r'Links: [0-9]+\s+')
++        LINKS_RE = re.compile(r"Links: [0-9]+\s+")
          ACCESS_TIME_RE = re.compile(r"^Access: [0-9]{4}-[0-9]{2}-[0-9]{2}.*$")
          CHANGE_TIME_RE = re.compile(r"^Change: [0-9]{4}-[0-9]{2}-[0-9]{2}.*$")
          BIRTH_TIME_RE = re.compile(r"^\s*Birth:.*$")


### PR DESCRIPTION
Otherwise diffocsope's tests fail as:

    diffoscope> -        LINKS_RE = re.compile(r'Links: [0-9]+\s+')
    diffoscope> +        LINKS_RE = re.compile(r"Links: [0-9]+\s+")
    diffoscope> FAILED tests/test_source.py::test_code_is_black_clean