### PR TITLE
trse: init at 0.13.337

### DIFF
--- a/pkgs/applications/editors/trse/default.nix
+++ b/pkgs/applications/editors/trse/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, libGL
+, lua
+, qmake
+, qtbase
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation {
+  pname = "trse";
+  version = "0.13.337";
+
+  src = fetchFromGitHub {
+    owner = "leuat";
+    repo = "TRSE";
+    rev = "a06ab438db51e31eedf1c9329316672783e7b9e8";
+    sha256 = "1hmihjrcvlwvr39737rbvl6nyib1mxzxbbjxfqxpmhw6n14qgi4p";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libGL
+    lua
+    qtbase
+  ];
+
+  qmakeFlags = [
+    "TRSE.pro"
+  ];
+
+  postInstall = ''
+    cp -r Publish/project_templates $out
+    cp -r Publish/source/themes $out
+    cp -r Publish/tutorials $out
+    cp -r units $out
+  '';
+
+  meta = with lib; {
+    description = "Turbo Rascal Syntax Error";
+    longDescription = ''
+      TRSE (or its full original name "Turbo Rascal Syntax error, ";" expected
+      but "BEGIN") is a complete suite (IDE, compiler, programming language and
+      resource editor) intended for developing games/demos for 8/16-bit lines
+      of computers.
+    '';
+    homepage = "https://lemonspawn.com/turbo-rascal-syntax-error-expected-but-begin/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ evenbrenden ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15317,6 +15317,8 @@ with pkgs;
 
   qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit {} ;
 
+  trse = libsForQt5.callPackage ../applications/editors/trse { };
+
   r10k = callPackage ../tools/system/r10k { };
 
   radare2 = callPackage ../development/tools/analysis/radare2 ({

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -218,6 +218,8 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   telepathy = callPackage ../development/libraries/telepathy/qt { };
 
+  trse = callPackage ../applications/editors/trse {};
+
   qtwebkit-plugins = callPackage ../development/libraries/qtwebkit-plugins { };
 
   # Not a library, but we do want it to be built for every qt version there


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add TRSE editor. There isn't really a release cycle for this package, so I'm starting out with the latest nightly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
