### PR TITLE
python3Packages.fakeredis: add patch to support redis<=4.1.0

### DIFF
--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -61,7 +61,8 @@ buildPythonPackage rec {
   postPatch = ''
     sed -i setup.py -e "/pip>=/c\'pip',"
     substituteInPlace setup.py \
-      --replace 'typing==3.6.4' 'typing'
+      --replace "typing==3.6.4" "typing" \
+      --replace "attrs>=19.3.0,<21.3.0" "attrs"
   '';
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/fakeredis/default.nix
+++ b/pkgs/development/python-modules/fakeredis/default.nix
@@ -2,7 +2,8 @@
 , aioredis
 , async_generator
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, fetchpatch
 , hypothesis
 , lupa
 , pytest-asyncio
@@ -19,11 +20,13 @@ buildPythonPackage rec {
   version = "1.7.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-yb0S5DAzbL0+GJ+uDpHrmZl7k+dtv91u1n+jUtxoTHE=";
+  src = fetchFromGitHub {
+    owner = "jamesls";
+    repo = pname;
+    rev = version;
+    hash = "sha256-P6PUg9SY0Qshlvj+iV1xdrzVLJ9JXUV4cGHUynKO3m0=";
   };
 
   propagatedBuildInputs = [
@@ -40,6 +43,15 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-mock
     pytestCheckHook
+  ];
+
+  patches = [
+    # Support for redis >= 4.1.0, https://github.com/jamesls/fakeredis/pull/324
+    (fetchpatch {
+      name = "support-redis-4.1.0.patch";
+      url = "https://github.com/jamesls/fakeredis/commit/8ef8dc6dacc9baf571d66a25ffbf0fadd7c70f78.patch";
+      sha256 = "sha256-4DrF/5WEWQWlJZtAi4qobMDyRAAcO/weHIaK9waN00k=";
+    })
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/fakeredis/default.nix
+++ b/pkgs/development/python-modules/fakeredis/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   ];
 
   patches = [
-    # Support for redis >= 4.1.0, https://github.com/jamesls/fakeredis/pull/324
+    # Support for redis <= 4.1.0, https://github.com/jamesls/fakeredis/pull/324
     (fetchpatch {
       name = "support-redis-4.1.0.patch";
       url = "https://github.com/jamesls/fakeredis/commit/8ef8dc6dacc9baf571d66a25ffbf0fadd7c70f78.patch";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #156815

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
