### PR TITLE
linkerd_edge: 21.10.3 -> 22.1.4

### DIFF
--- a/pkgs/applications/networking/cluster/linkerd/edge.nix
+++ b/pkgs/applications/networking/cluster/linkerd/edge.nix
@@ -2,7 +2,7 @@
 
 (callPackage ./generic.nix { }) {
   channel = "edge";
-  version = "21.10.3";
-  sha256 = "09k4c0dgn9vvgp6xb20x0vylk6bbd03srk3sra8vnpywwi591mcv";
-  vendorSha256 = "sha256-J/+YFXHC6UTyhln2ZDEq/EyqMEP9XcNC4GRuJjGEY3g=";
+  version = "22.1.4";
+  sha256 = "00r58k26qnxjsqjdcqz04p21c1vvw5ls485gad0pcny370wrp65n";
+  vendorSha256 = "sha256-5vYf9/BCSHJ0iydKhz+9yDg0rRXpLd+j8uD8kcKhByc=";
 }

--- a/pkgs/applications/networking/cluster/linkerd/generic.nix
+++ b/pkgs/applications/networking/cluster/linkerd/generic.nix
@@ -1,8 +1,9 @@
-{ lib, fetchFromGitHub, buildGoModule, installShellFiles }:
+{ lib, fetchFromGitHub, buildGo117Module, installShellFiles }:
 
 { channel, version, sha256, vendorSha256 }:
 
-buildGoModule rec {
+# Fix-Me: Unlock buildGoModule version when #154059 is merged.
+buildGo117Module rec {
   pname = "linkerd-${channel}";
   inherit version vendorSha256;
 


### PR DESCRIPTION
linkerd_edge: 21.10.3 -> 22.1.4

* Note: There is a *temporary* locking of `buildGoModule = buildGo117Module` this is to be removed once PR #154059 is merged.