### PR TITLE
breitbandmessung: init at 3.1.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -55,6 +55,7 @@ in
   borgbackup = handleTest ./borgbackup.nix {};
   botamusique = handleTest ./botamusique.nix {};
   bpf = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bpf.nix {};
+  breitbandmessung = handleTest ./breitbandmessung.nix {};
   brscan5 = handleTest ./brscan5.nix {};
   btrbk = handleTest ./btrbk.nix {};
   buildbot = handleTest ./buildbot.nix {};

--- a/nixos/tests/breitbandmessung.nix
+++ b/nixos/tests/breitbandmessung.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "breitbandmessung";
+  meta.maintainers = with lib.maintainers; [ b4dm4n ];
+
+  machine = { pkgs, ... }: {
+    imports = [
+      ./common/user-account.nix
+      ./common/x11.nix
+    ];
+
+    test-support.displayManager.auto.user = "alice";
+
+    environment.systemPackages = with pkgs; [ breitbandmessung ];
+    environment.variables.XAUTHORITY = "/home/alice/.Xauthority";
+
+    # breitbandmessung is unfree
+    nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "breitbandmessung" ];
+  };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.wait_for_x()
+    # increase screen size to make the whole program visible
+    machine.succeed("xrandr --output Virtual-1 --mode 1280x1024")
+    machine.execute("su - alice -c breitbandmessung >&2  &")
+    machine.wait_for_window("Breitbandmessung")
+    machine.wait_for_text("Breitbandmessung")
+    machine.wait_for_text("Datenschutz")
+    machine.screenshot("breitbandmessung")
+  '';
+})

--- a/nixos/tests/breitbandmessung.nix
+++ b/nixos/tests/breitbandmessung.nix
@@ -8,6 +8,9 @@ import ./make-test-python.nix ({ lib, ... }: {
       ./common/x11.nix
     ];
 
+    # increase screen size to make the whole program visible
+    virtualisation.resolution = { x = 1280; y = 1024; };
+
     test-support.displayManager.auto.user = "alice";
 
     environment.systemPackages = with pkgs; [ breitbandmessung ];
@@ -21,8 +24,6 @@ import ./make-test-python.nix ({ lib, ... }: {
 
   testScript = ''
     machine.wait_for_x()
-    # increase screen size to make the whole program visible
-    machine.succeed("xrandr --output Virtual-1 --mode 1280x1024")
     machine.execute("su - alice -c breitbandmessung >&2  &")
     machine.wait_for_window("Breitbandmessung")
     machine.wait_for_text("Breitbandmessung")

--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -1,0 +1,153 @@
+{ lib
+, stdenv
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, autoPatchelfHook
+, cairo
+, cups
+, dbus
+, dpkg
+, expat
+, fetchurl
+, gdk-pixbuf
+, glib
+, gtk3
+, libdrm
+, libxkbcommon
+, makeWrapper
+, mesa
+, nixosTests
+, nspr
+, nss
+, pango
+, pciutils
+, systemd
+, undmg
+, writeShellScriptBin
+, xorg
+}:
+
+let
+  inherit (stdenv.hostPlatform) system;
+
+  version = "3.1.0";
+
+  # At first start, the program checks for supported operating systems by calling `lsb_release -a`
+  # and only runs when it finds Debian/Ubuntu. So we present us as Debian an make it happy.
+  fake-lsb-release = writeShellScriptBin "lsb_release" ''
+    echo "Distributor ID: Debian"
+    echo "Description:    Debian GNU/Linux 10 (buster)"
+    echo "Release:        10"
+    echo "Codename:       buster"
+  '';
+
+  binPath = lib.makeBinPath [
+    fake-lsb-release
+  ];
+
+  systemArgs = rec {
+    x86_64-linux = rec {
+      src = fetchurl {
+        url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-linux.deb";
+        sha256 = "sha256-jSP+H9ej9Wd+swBZSy9uMi2ExSTZ191FGZhqaocTl7w=";
+      };
+
+      dontUnpack = true;
+
+      nativeBuildInputs = [
+        autoPatchelfHook
+        dpkg
+        makeWrapper
+      ];
+
+      buildInputs = runtimeDependencies;
+
+      runtimeDependencies = [
+        alsa-lib
+        at-spi2-atk
+        at-spi2-core
+        atk
+        cairo
+        cups
+        dbus
+        expat
+        gdk-pixbuf
+        glib
+        gtk3
+        libdrm
+        libxkbcommon
+        mesa
+        nspr
+        nss
+        pango
+        pciutils
+        systemd
+        xorg.libX11
+        xorg.libXcomposite
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXfixes
+        xorg.libXrandr
+        xorg.libxcb
+        xorg.libxshmfence
+      ];
+
+      installPhase = ''
+        dpkg-deb -x $src $out
+        mkdir -p $out/bin
+
+        chmod -R g-w $out
+
+        addAutoPatchelfSearchPath --no-recurse $out/opt/Breitbandmessung
+        autoPatchelfFile $out/opt/Breitbandmessung/breitbandmessung
+
+        makeWrapper $out/opt/Breitbandmessung/breitbandmessung $out/bin/breitbandmessung \
+          --prefix PATH : ${binPath}
+
+        mv $out/usr/share $out/share
+        rmdir $out/usr
+
+        # Fix the desktop link
+        substituteInPlace $out/share/applications/breitbandmessung.desktop \
+          --replace /opt/Breitbandmessung $out/bin
+      '';
+
+      dontAutoPatchelf = true;
+      dontPatchELF = true;
+    };
+
+    x86_64-darwin = {
+      src = fetchurl {
+        url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-mac.dmg";
+        sha256 = "sha256-2c8mDKJuHDSw7p52EKnJO5vr2kNTLU6r9pmGPANjE20=";
+      };
+
+      nativeBuildInputs = [ undmg ];
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/Applications/Breitbandmessung.app
+        cp -R . $out/Applications/Breitbandmessung.app
+        runHook postInstall
+      '';
+    };
+
+    aarch64-darwin = x86_64-darwin;
+  }.${system} or (throw "Unsupported system: ${system}");
+in
+stdenv.mkDerivation ({
+  pname = "breitbandmessung";
+  inherit version;
+
+  passthru.tests = { inherit (nixosTests) breitbandmessung; };
+
+  meta = with lib; {
+    description = "Broadband internet speed test app from the german Bundesnetzagentur";
+    homepage = "https://www.breitbandmessung.de";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ b4dm4n ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+} // systemArgs)

--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -135,7 +135,7 @@ let
     };
 
     aarch64-darwin = x86_64-darwin;
-  }.${system} or (throw "Unsupported system: ${system}");
+  }.${system} or { src = throw "Unsupported system: ${system}"; };
 in
 stdenv.mkDerivation ({
   pname = "breitbandmessung";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1083,6 +1083,8 @@ with pkgs;
 
   archi = callPackage ../tools/misc/archi { };
 
+  breitbandmessung = callPackage ../applications/networking/breitbandmessung { };
+
   contour = libsForQt5.callPackage ../applications/terminal-emulators/contour { };
 
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };


### PR DESCRIPTION
###### Motivation for this change

Add a new package for the German Breitbandmessung app. Sadly it is only available as a binary download.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
