### PR TITLE
nixos/polkit: don't enable by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -721,6 +721,14 @@
           <literal>tmux</literal>.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The polkit service, available at
+          <literal>security.polkit.enable</literal>, is now disabled by
+          default. It will automatically be enabled through services and
+          desktop environments as needed.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -245,4 +245,6 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `programs.tmux` has a new option `plugins` that accepts a list of packages from the `tmuxPlugins` group. The specified packages are added to the system and loaded by `tmux`.
 
+- The polkit service, available at `security.polkit.enable`, is now disabled by default. It will automatically be enabled through services and desktop environments as needed.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -134,6 +134,7 @@ in {
         '';
       };
     };
+    security.polkit.enable = true;
     security.pam.services.swaylock = {};
     hardware.opengl.enable = mkDefault true;
     fonts.enableDefaultFonts = mkDefault true;

--- a/nixos/modules/security/polkit.nix
+++ b/nixos/modules/security/polkit.nix
@@ -12,11 +12,7 @@ in
 
   options = {
 
-    security.polkit.enable = mkOption {
-      type = types.bool;
-      default = true;
-      description = "Whether to enable PolKit.";
-    };
+    security.polkit.enable = mkEnableOption "polkit";
 
     security.polkit.extraConfig = mkOption {
       type = types.lines;

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -30,6 +30,8 @@ in {
 
     environment.systemPackages = [ pkgs.flatpak ];
 
+    security.polkit.enable = true;
+
     services.dbus.packages = [ pkgs.flatpak ];
 
     systemd.packages = [ pkgs.flatpak ];

--- a/nixos/modules/services/hardware/udisks2.nix
+++ b/nixos/modules/services/hardware/udisks2.nix
@@ -32,6 +32,8 @@ with lib;
 
     environment.systemPackages = [ pkgs.udisks2 ];
 
+    security.polkit.enable = true;
+
     services.dbus.packages = [ pkgs.udisks2 ];
 
     systemd.tmpfiles.rules = [ "d /var/lib/udisks2 0755 root root -" ];

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -539,6 +539,7 @@ in {
 
     boot.kernelModules = [ "ctr" ];
 
+    security.polkit.enable = true;
     security.polkit.extraConfig = polkitConf;
 
     services.dbus.packages = cfg.packages

--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -81,6 +81,8 @@ in {
       };
     };
 
+    security.polkit.enable = true;
+
     security.pam.services.cage.text = ''
       auth    required pam_unix.so nullok
       account required pam_unix.so

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -267,6 +267,8 @@ in
     # Enable the accounts daemon to find lightdm's dbus interface
     environment.systemPackages = [ lightdm ];
 
+    security.polkit.enable = true;
+
     security.pam.services.lightdm.text = ''
         auth      substack      login
         account   include       login

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -620,9 +620,6 @@ in
       in optional (driver != null) ({ inherit name; modules = []; driverName = name; display = true; } // driver));
 
     assertions = [
-      { assertion = config.security.polkit.enable;
-        message = "X11 requires Polkit to be enabled (‘security.polkit.enable = true’).";
-      }
       (let primaryHeads = filter (x: x.primary) cfg.xrandrHeads; in {
         assertion = length primaryHeads < 2;
         message = "Only one head is allowed to be primary in "

--- a/nixos/tests/tinywl.nix
+++ b/nixos/tests/tinywl.nix
@@ -10,6 +10,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       # Automatically login on tty1 as a normal user:
       imports = [ ./common/user-account.nix ];
       services.getty.autologinUser = "alice";
+      security.polkit.enable = true;
 
       environment = {
         systemPackages = with pkgs; [ tinywl foot wayland-utils ];


### PR DESCRIPTION
###### Motivation for this change
SUID wrappers really shouldn't be enabled by default, unless a consumer
relies on them. So in my opinion this falls upon the desktop
environments if needed or a user to explicltly enable this if wanted.

Most desktop environments and services like CUPS already enable polkit
by default, that should really be sufficient.


###### Things done

Successfully ran the following tests:

- [x] gnome
- [x] gnome-xorg
- [x] pantheon
- [x] plasma5
- [x] sway (enabled polkit in module)
- [x] tinywl
- [x] vscodium 
- [x] xfce

Working after dropping the polkit assertion in x11server.nix

- [x] domination
- [x] ft2-clone
- [x] herbstluftwm
- [x] i3wm
- [x] keepassxc
- [x] keymap
- [x] libinput
- [x] lightdm
- [x] musescore
- [x] plasma5-systemd-start
- [x] pt2-clone
- [x] shattered-pixel-dungeon
- [x] sddm
- [x] signal-desktop
- [x] soapui
- [x] systemd
- [x] tigervnc
- [x] tuxguitar
- [x] vengi-tools
- [x] wmderland
- [x] xautolock
- [x] xmonad
- [x] xrdp
- [x] xss-lock
- [x] xterm

Unrelated failures

- enlightenment (https://hydra.nixos.org/build/165253196)
- fcitx (https://hydra.nixos.org/build/165247989)
- libresprite (https://hydra.nixos.org/build/165251332)
- teeworlds (https://hydra.nixos.org/build/165252382 timeout)
- virtualbox (package fails to build)
