### PR TITLE
nixpkgs-basic-release-checks: recurse into package sets

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2367,6 +2367,7 @@ broken-packages:
   - hslua-module-version
   - hsluv-haskell
   - hsmagick
+  - hs-mesos
   - hsmodetweaks
   - Hsmtlib
   - hsmtpclient

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -140,7 +140,7 @@ self: super: builtins.intersectAttrs super {
 
   hs-mesos = overrideCabal (drv: {
     # Pass _only_ mesos; the correct protobuf is propagated.
-    extraLibraries = [ pkgs.mesos ];
+    # extraLibraries = [ pkgs.mesos ]; # mesos is no longer in nixpkgs
     preConfigure = "sed -i -e /extra-lib-dirs/d -e 's|, /usr/include, /usr/local/include/mesos||' hs-mesos.cabal";
   }) super.hs-mesos;
 

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -138,12 +138,6 @@ self: super: builtins.intersectAttrs super {
   # Add necessary reference to gtk3 package
   gi-dbusmenugtk3 = addPkgconfigDepend pkgs.gtk3 super.gi-dbusmenugtk3;
 
-  hs-mesos = overrideCabal (drv: {
-    # Pass _only_ mesos; the correct protobuf is propagated.
-    # extraLibraries = [ pkgs.mesos ]; # mesos is no longer in nixpkgs
-    preConfigure = "sed -i -e /extra-lib-dirs/d -e 's|, /usr/include, /usr/local/include/mesos||' hs-mesos.cabal";
-  }) super.hs-mesos;
-
   # These packages try to access the network.
   amqp = dontCheck super.amqp;
   amqp-conduit = dontCheck super.amqp-conduit;

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -321,13 +321,13 @@ let
     Biostrings = [ pkgs.zlib ];
     bnpmr = [ pkgs.gsl ];
     cairoDevice = [ pkgs.gtk2.dev ];
-    Cairo = with pkgs; [ libtiff libjpeg cairo.dev x11 fontconfig.lib ];
+    Cairo = with pkgs; [ libtiff libjpeg cairo.dev xlibsWrapper fontconfig.lib ];
     Cardinal = [ pkgs.which ];
     chebpol = [ pkgs.fftw ];
     ChemmineOB = with pkgs; [ openbabel pkg-config ];
     curl = [ pkgs.curl.dev ];
     data_table = [ pkgs.zlib.dev ] ++ lib.optional stdenv.isDarwin pkgs.llvmPackages.openmp;
-    devEMF = with pkgs; [ xorg.libXft.dev x11 ];
+    devEMF = with pkgs; [ xorg.libXft.dev xlibsWrapper ];
     diversitree = with pkgs; [ gsl fftw ];
     exactextractr = [ pkgs.geos ];
     EMCluster = [ pkgs.lapack ];
@@ -346,7 +346,7 @@ let
     haven = with pkgs; [ libiconv zlib.dev ];
     h5vc = [ pkgs.zlib.dev ];
     HiCseg = [ pkgs.gsl ];
-    imager = [ pkgs.x11 ];
+    imager = [ pkgs.xlibsWrapper ];
     iBMQ = [ pkgs.gsl ];
     igraph = with pkgs; [ gmp libxml2.dev ];
     JavaGD = [ pkgs.jdk ];
@@ -644,7 +644,7 @@ let
     PING = [ pkgs.gsl ];
     RcppAlgos = [ pkgs.gmp.dev ];
     RcppBigIntAlgos = [ pkgs.gmp.dev ];
-    HilbertVisGUI = [ pkgs.gnome2.gtkmm.dev ];
+    HilbertVisGUI = [ pkgs.gtkmm2.dev ];
     textshaping = with pkgs; [ harfbuzz.dev freetype.dev fribidi libpng ];
     DropletUtils = [ pkgs.zlib.dev ];
     RMariaDB = [ pkgs.libmysqlclient.dev ];
@@ -1114,7 +1114,7 @@ let
         patchShebangs configure
       '';
 
-      R_MAKEVARS_SITE = lib.optionalString (pkgs.system == "aarch64-linux")
+      R_MAKEVARS_SITE = lib.optionalString (pkgs.stdenv.system == "aarch64-linux")
         (pkgs.writeText "Makevars" ''
           CXX14PICFLAGS = -fPIC
         '');


### PR DESCRIPTION
This PR does the following:

- use `pkgs/top-level/packages-config.nix` in `nixpkgs-basic-release-checks` in order to check evaluation of packages in package sets like `haskellPackages`. The point of this (apart from just catching more eval failures) is that `packages-config.nix` is also used in `nixos-search` (https://search.nixos.org) to list packages, and if there are any evaluation errors then the import would fail. This hasn't been a problem since now because we haven't actually needed to evaluate packages, but this will change in the future when we also [index package outputs](https://github.com/NixOS/nixos-search/pull/419) since that requires evaluation. Also see https://github.com/NixOS/nix/pull/5922#issuecomment-1021211734 for more context
- consequently, fix evaluation errors in those package sets. This was easier than I thought and was a matter of removing a few references to aliases in `haskellPackages.hs-mesos` and in `rPackages`
- back in `nixpkgs-basic-release-checks`, fix an issue introduced 2 days ago by https://github.com/NixOS/nixpkgs/pull/156587 where the warnings will not be printed if the first `nix-env` errors. Also do some cleaning up by moving common flags into an array and removing `--system-filter \*` which has been the default [for a while](https://github.com/NixOS/nix/blame/1fe3bfdeaf7c57e9f7044a22edfbdf6fb9629e9d/src/nix-env/nix-env.cc#L1375).

Note that an obvious consequence is that the checks should take a bit longer (and more memory) to run. @edolstra do you remember why the variant with `nix-env --meta --xml` was/is needed (introduced, or rather not removed, in https://github.com/NixOS/nixpkgs/commit/1ba5ef6b6a052dd83d4b1666f424b134810a42e3)? Removing it would save some time.