### PR TITLE
roc-toolkit: add sox support

### DIFF
--- a/pkgs/development/libraries/audio/roc-toolkit/default.nix
+++ b/pkgs/development/libraries/audio/roc-toolkit/default.nix
@@ -11,7 +11,9 @@
   libunwindSupport ? true,
   libunwind,
   pulseaudioSupport ? true,
-  libpulseaudio
+  libpulseaudio,
+  soxSupport ? true,
+  sox
 }:
 
 stdenv.mkDerivation rec {
@@ -36,15 +38,16 @@ stdenv.mkDerivation rec {
     libuv
   ] ++ lib.optional openfecSupport openfec
     ++ lib.optional libunwindSupport libunwind
-    ++ lib.optional pulseaudioSupport libpulseaudio;
+    ++ lib.optional pulseaudioSupport libpulseaudio
+    ++ lib.optional soxSupport sox;
 
   sconsFlags =
     [ "--build=${stdenv.buildPlatform.config}"
       "--host=${stdenv.hostPlatform.config}"
       "--prefix=${placeholder "out"}"
-      "--disable-sox"
       "--disable-doc"
       "--disable-tests" ] ++
+    lib.optional (!soxSupport) "--disable-sox" ++
     lib.optional (!libunwindSupport) "--disable-libunwind" ++
     lib.optional (!pulseaudioSupport) "--disable-pulseaudio" ++
     (if (!openfecSupport)

--- a/pkgs/development/libraries/audio/roc-toolkit/default.nix
+++ b/pkgs/development/libraries/audio/roc-toolkit/default.nix
@@ -34,10 +34,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libuv
-    libunwind
-    openfec
-    libpulseaudio
-  ];
+  ] ++ lib.optional openfecSupport openfec
+    ++ lib.optional libunwindSupport libunwind
+    ++ lib.optional pulseaudioSupport libpulseaudio;
 
   sconsFlags =
     [ "--build=${stdenv.buildPlatform.config}"


### PR DESCRIPTION
###### Motivation for this change
adds support to roc-send to send from file sources other than 

###### Things done

replaced --disable-sox with a option to enable sox

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
