### PR TITLE
python3Packages.objax: fix tensorboard dependency

### DIFF
--- a/pkgs/development/python-modules/objax/default.nix
+++ b/pkgs/development/python-modules/objax/default.nix
@@ -7,7 +7,7 @@
 , parameterized
 , pillow
 , scipy
-, tensorflow-tensorboard_2 ? null
+, tensorflow-tensorboard
 }:
 
 buildPythonPackage rec {
@@ -21,14 +21,19 @@ buildPythonPackage rec {
     sha256 = "09gm61ghn5mi92q5mhx22mcv6aa6z78jsrnfar1hd3nwwyn9dq42";
   };
 
+  # Avoid propagating the dependency on `jaxlib`, see
+  # https://github.com/NixOS/nixpkgs/issues/156767
+  buildInputs = [
+    jaxlib
+  ];
+
   propagatedBuildInputs = [
     jax
-    jaxlib
     numpy
     parameterized
     pillow
     scipy
-    tensorflow-tensorboard_2
+    tensorflow-tensorboard
   ];
 
   pythonImportsCheck = [
@@ -40,7 +45,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/google/objax";
     license = licenses.asl20;
     maintainers = with maintainers; [ ndl ];
-    # Darwin doesn't have `tensorflow-tensorboard_2` which is required by wheel deps.
-    platforms = [ "aarch64-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
`tensorflow-tensorboard_2` was renamed to `tensorflow-tensorboard` but the breakage of `objax` likely wasn't noticed because this package was marked as optional in `objax` dependencies due to `tensorflow-tensorboard_2` not being available on Darwin.

ATM looks like `tensorflow-tensorboard` _is_ available on Darwin, so the workaround with the optional dependency is no longer necessary and I removed it.

I've also moved `jaxlib` to `buildInputs` to avoid injecting it into dependent packages (see https://github.com/NixOS/nixpkgs/issues/156767) to avoid conflicts with upcoming https://github.com/NixOS/nixpkgs/pull/156808 - `objax` conversion now can just be dropped from that PR.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
