### PR TITLE
carapace: init at 0.8.5 

### DIFF
--- a/pkgs/shells/carapace/default.nix
+++ b/pkgs/shells/carapace/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildGo117Module, fetchFromGitHub }:
+
+buildGo117Module rec {
+  pname = "carapace";
+  version = "0.8.10";
+
+  src = fetchFromGitHub {
+    owner = "rsteube";
+    repo = "${pname}-bin";
+    rev = "v${version}";
+    sha256 = "0j60fvrmjm4440gj9hib2ar386zxcblw7yifigsnchr7p3i2187n";
+  };
+
+  vendorSha256 = "1s1sws79cyz1rl63wayzf7yhb04x29a4a1mkifqnl4cc2pv806jf";
+
+  subPackages = [ "./cmd/carapace" ];
+
+  tags = [ "release" ];
+
+  preBuild = ''
+    go generate ./...
+  '';
+
+  meta = with lib; {
+    description = "Multi-shell multi-command argument completer";
+    homepage = "https://rsteube.github.io/carapace-bin/";
+    maintainers = with maintainers; [ mredaelli ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11424,6 +11424,8 @@ with pkgs;
 
   undistract-me = callPackage ../shells/bash/undistract-me { };
 
+  carapace = callPackage ../shells/carapace { };
+
   dash = callPackage ../shells/dash { };
 
   dasht = callPackage ../tools/misc/dasht { };


### PR DESCRIPTION
###### Motivation for this change

a cross-shell completion engine

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
