### PR TITLE
[21.11] backport go 1.16.13 to stable to fix CVE-2021-44716

### DIFF
--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -51,11 +51,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.16.11";
+  version = "1.16.12";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-WAQe3NgUY7TPG8KLhtwMF/TZVo1jxa/IU2fdj6577+c=";
+    sha256 = "sha256-Kv2Dnct20rsILFAsAaClzb/An9YwdXg1NjxP3o4vv+g=";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -51,11 +51,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.16.9";
+  version = "1.16.10";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-ChzH/XvSBEj3Hr7WTYRhOIUNUJmxjPXMEKT8RRYNjD0=";
+    sha256 = "sha256-qQVHIBFYXkA9ANKkHefO0puIhDCdc0gqMH9on9DzILU=";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -51,11 +51,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.16.10";
+  version = "1.16.11";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-qQVHIBFYXkA9ANKkHefO0puIhDCdc0gqMH9on9DzILU=";
+    sha256 = "sha256-WAQe3NgUY7TPG8KLhtwMF/TZVo1jxa/IU2fdj6577+c=";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.16.nix
+++ b/pkgs/development/compilers/go/1.16.nix
@@ -51,11 +51,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "go";
-  version = "1.16.12";
+  version = "1.16.13";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "sha256-Kv2Dnct20rsILFAsAaClzb/An9YwdXg1NjxP3o4vv+g=";
+    sha256 = "sha256-sJJmVOrrAe9DgWY49C17FoHy0/QblVnwdzVSK3r61Bo=";
   };
 
   # perl is used for testing go vet


### PR DESCRIPTION
Fixed CVE-2021-44716 and other non-api breaking fixes.

(cherry picked from commit d50b6bff8956e674ff4091f2ff27e965c078b215)

<!--
I hope i did this right :)
-->

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Go 1.16.12 fixed https://nvd.nist.gov/vuln/detail/CVE-2021-44716
Go 1.16.13 fixed other internal issues including: 
* x/net/http2: http.Server.WriteTimeout does not fire if the http2 stream's window is out of space. [1.16 backport]
* cmd/link: does not set section type of .init_array correctly [1.16 backport] (was breaking lld support)

###### Things done
Bumps the golang 1.16 version to the latest stable release (1.16.13).

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
