### PR TITLE
python3Packages.ftputil: 5.0.2 -> 5.0.3

### DIFF
--- a/pkgs/development/python-modules/ftputil/default.nix
+++ b/pkgs/development/python-modules/ftputil/default.nix
@@ -1,32 +1,45 @@
-{ stdenv, lib, buildPythonPackage, fetchPypi, pythonOlder, pytest, freezegun }:
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, freezegun
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
-  version = "5.0.2";
   pname = "ftputil";
+  version = "5.0.3";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "afa2ba402235e8c6583c1d2630269628344134c9246b961ff14f182047f3e633";
+    hash = "sha256-m4buZ8GYDOHYmxN1K8SLlJP+4GNJy0doKFlOduCPhIg=";
   };
 
-  checkInputs = [ pytest freezegun ];
+  checkInputs = [
+    freezegun
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    touch Makefile
-    # Disable tests that require network access or access /home or assume execution before year 2020
-    py.test test \
-      -k "not test_public_servers and not test_real_ftp \
-          and not test_set_parser and not test_repr \
-          and not test_conditional_upload and not test_conditional_download_with_older_target \
-  ''
-  # need until https://ftputil.sschwarzer.net/trac/ticket/140#ticket is fixed
-  + lib.optionalString stdenv.isDarwin "and not test_error_message_reuse"
-  + ''"'';
+  disabledTests = [
+    # Tests require network access
+    "test_public_servers"
+    "test_real_ftp"
+    "test_set_parser"
+    "test_upload"
+  ];
+
+  pythonImportsCheck = [
+    "ftputil"
+  ];
 
   meta = with lib; {
     description = "High-level FTP client library (virtual file system and more)";
     homepage = "http://ftputil.sschwarzer.net/";
-    license = licenses.bsd2; # "Modified BSD license, says pypi"
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
- Switch to pytestCheckHook
- Add pythonImportsCheck
- Adjust disabled tests

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Switch to pytestCheckHook
- Add pythonImportsCheck
- Adjust disabled tests

Success of #156945

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
