### PR TITLE
gnome-2048: init at 3.38.2

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -569,6 +569,7 @@ in
         atomix
         five-or-more
         four-in-a-row
+        pkgs.gnome-2048
         gnome-chess
         gnome-klotski
         gnome-mahjongg

--- a/pkgs/desktops/gnome/games/gnome-2048/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-2048/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchurl
+, wrapGAppsHook
+, meson
+, vala
+, pkg-config
+, ninja
+, itstool
+, clutter-gtk
+, libgee
+, gnome
+, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-twenty-forty-eight";
+  version = "3.38.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gnome-2048/${lib.versions.majorMinor version}/gnome-2048-${version}.tar.xz";
+    sha256 = "0s5fg4z5in1h39fcr69j1qc5ynmg7a8mfprk3mc3c0csq3snfwz2";
+  };
+
+  nativeBuildInputs = [
+    itstool
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    clutter-gtk
+    libgee
+    gnome.libgnome-games-support
+    gtk3
+  ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "gnome-2048";
+    };
+  };
+
+  meta = with lib; {
+    homepage = "https://wiki.gnome.org/Apps/2048";
+    description = "Obtain the 2048 tile";
+    maintainers = teams.gnome.members;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5896,6 +5896,8 @@ with pkgs;
 
   gnirehtet = callPackage ../tools/networking/gnirehtet { };
 
+  gnome-2048 = callPackage ../desktops/gnome/games/gnome-2048 { };
+
   gnome-builder = callPackage ../applications/editors/gnome-builder { };
 
   gnome-feeds = callPackage ../applications/networking/feedreaders/gnome-feeds {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

It's a game. It's part of GNOME.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I looked around and I couldn't find specific guidance on the etiquette around adding packages to existing namespaces like `gnome`. So I tried to replicate the existing patterns I saw. All the GNOME games have the same list of maintainers, so I reused that; I can add myself instead if that's preferable. I also added this package to the list of games installed when `services.gnome.games.enable` is true; I can remove that if desired. Sorry if any of this is wrong!