### PR TITLE
opentelemetry-collector: 0.40.0 -> 0.43.1, opentelemetry-collector-contrib: init at 0.43.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -430,6 +430,20 @@
       </listitem>
       <listitem>
         <para>
+          The existing <literal>pkgs.opentelemetry-collector</literal>
+          has been moved to
+          <literal>pkgs.opentelemetry-collector-contrib</literal> to
+          match the actual source being the <quote>contrib</quote>
+          edition. <literal>pkgs.opentelemetry-collector</literal> is
+          now the actual core release of opentelemetry-collector. If you
+          use the community contributions you should change the package
+          you refer to. If you don’t need them update your commands from
+          <literal>otelcontribcol</literal> to
+          <literal>otelcorecol</literal> and enjoy a 7x smaller binary.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.noto-fonts-cjk</literal> is now deprecated in
           favor of <literal>pkgs.noto-fonts-cjk-sans</literal> and
           <literal>pkgs.noto-fonts-cjk-serif</literal> because they each

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -130,10 +130,19 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - MultiMC has been replaced with the fork PolyMC due to upstream developers being hostile to 3rd party package maintainers. PolyMC removes all MultiMC branding and is aimed at providing proper 3rd party packages like the one contained in Nixpkgs. This change affects the data folder where game instances and other save and configuration files are stored. Users with existing installations should rename `~/.local/share/multimc` to `~/.local/share/polymc`. The main config file's path has also moved from `~/.local/share/multimc/multimc.cfg` to `~/.local/share/polymc/polymc.cfg`.
 
+
 - The terraform 0.12 compatibility has been removed and the `terraform.withPlugins` and `terraform-providers.mkProvider` implementations simplified. Providers now need to be stored under
 `$out/libexec/terraform-providers/<registry>/<owner>/<name>/<version>/<os>_<arch>/terraform-provider-<name>_v<version>` (which mkProvider does).
 
   This breaks back-compat so it's not possible to mix-and-match with previous versions of nixpkgs. In exchange, it now becomes possible to use the providers from [nixpkgs-terraform-providers-bin](https://github.com/numtide/nixpkgs-terraform-providers-bin) directly.
+
+- The existing `pkgs.opentelemetry-collector` has been moved to
+  `pkgs.opentelemetry-collector-contrib` to match the actual source being the
+  "contrib" edition. `pkgs.opentelemetry-collector` is now the actual core
+  release of opentelemetry-collector. If you use the community contributions
+  you should change the package you refer to. If you don't need them update your
+  commands from `otelcontribcol` to `otelcorecol` and enjoy a 7x smaller binary.
+
 
 - `pkgs.noto-fonts-cjk` is now deprecated in favor of `pkgs.noto-fonts-cjk-sans`
   and `pkgs.noto-fonts-cjk-serif` because they each have different release

--- a/pkgs/tools/misc/opentelemetry-collector/contrib.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/contrib.nix
@@ -1,0 +1,45 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "opentelemetry-collector-contrib";
+  version = "0.43.0";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-collector-contrib";
+    rev = "v${version}";
+    sha256 = "sha256-ktzP+ugG2sa0v8B1Zp47o8Bmpxv98zQyFyWf9QfQRoQ=";
+  };
+  # proxy vendor to avoid hash missmatches between linux and macOS
+  proxyVendor = true;
+  vendorSha256 = "sha256-0E52YSWlq1ebHA3kR9Qo/6ufug9R+z1cSD9AfbN/Mi0=";
+
+  subPackages = [ "cmd/otelcontribcol" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/open-telemetry/opentelemetry-collector-contrib/internal/version.Version=v${version}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/open-telemetry/opentelemetry-collector-contrib";
+    changelog = "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v${version}/CHANGELOG.md";
+    description = "OpenTelemetry Collector superset with additional community collectors";
+    longDescription = ''
+      The OpenTelemetry Collector offers a vendor-agnostic implementation on how
+      to receive, process and export telemetry data. In addition, it removes the
+      need to run, operate and maintain multiple agents/collectors in order to
+      support open-source telemetry data formats (e.g. Jaeger, Prometheus, etc.)
+      sending to multiple open-source or commercial back-ends. The Contrib
+      edition provides aditional vendor specific receivers/exporters and/or
+      components that are only useful to a relatively small number of users and
+      is multiple times larger as a result.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ uri-canva jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8474,7 +8474,9 @@ with pkgs;
 
   opae = callPackage ../development/libraries/opae { };
 
-  opentelemetry-collector = callPackage ../tools/misc/opentelemetry-collector { };
+  opentelemetry-collector = callPackage ../tools/misc/opentelemetry-collector {
+      buildGoModule = buildGo117Module;
+  };
 
   opentracing-cpp = callPackage ../development/libraries/opentracing-cpp { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8477,6 +8477,9 @@ with pkgs;
   opentelemetry-collector = callPackage ../tools/misc/opentelemetry-collector {
       buildGoModule = buildGo117Module;
   };
+  opentelemetry-collector-contrib = callPackage ../tools/misc/opentelemetry-collector/contrib.nix {
+      buildGoModule = buildGo117Module;
+  };
 
   opentracing-cpp = callPackage ../development/libraries/opentracing-cpp { };
 


### PR DESCRIPTION
- opentelemetry-collector: 0.40.0 -> 0.43.1
- opentelemetry-collector-contrib: init at 0.43.0

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* separately package `opentelemetry-collector` and `opentelemetry-collector-contrib`
* update each to their lates releases: `0.43.1` and `0.43.0` respectively
* dropped vendor proxy since it seems to build fine
* added ldflags for a smaller build (trims 3MB off the contrib build)
* dropped `CGO_ENABLED = 0;` since it builds fine without
  * we can add this back in if it's important these packages are statically linked or people can build it themselves adding `CGO_ENABLED = 0;` via an overlay
* added myself as a maintainer

the core build is 7 times smaller than the contrib build

otelcontribcol:

```bash
λ ls -al ./result/bin/otelcontribcol
.r-xr-xr-x root root 118 MB Thu Jan  1 01:00:01 1970  ./result/bin/otelcontribcol

λ du -h ./result/bin/otelcontribcol
119M	./result/bin/otelcontribcol

# the Makefile builds with the vX.X.X prefix
λ ./result/bin/otelcontribcol -v
otelcontribcol version v0.43.0
```

otelcorecol:

```bash
λ ls -al ./result/bin/otelcorecol
.r-xr-xr-x root root 17 MB Thu Jan  1 01:00:01 1970  ./result/bin/otelcorecol

λ du -h ./result/bin/otelcorecol
17M	./result/bin/otelcorecol

# the cmd/otelcorecol/main.go file does not have a vX.X.X prefix
λ ./result/bin/otelcorecol -v
otelcorecol version 0.43.1
```

I've added release notes to cover the breaking change and added a script incase people try to call `otelcontribcol` using the the non contrib package:

```bash
λ ./result/bin/otelcontribcol
ERROR: otelcontribcol is now in `pkgs.opentelemetry-collector-contrib`, call the collector with `otelcorecol` or move to `pkgs.opentelemetry-collector-contrib`
```

cc: @uri-canva what are your thoughts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
