### PR TITLE
[wip] k3s: 1.22.3+k3s1 -> 1.23.3+k3s1

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -6,6 +6,7 @@
 , iproute2
 , bridge-utils
 , conntrack-tools
+, buildGoModule
 , buildGoPackage
 , runc
 , kmod
@@ -23,34 +24,15 @@
 
 with lib;
 
-# k3s is a kinda weird derivation. One of the main points of k3s is the
-# simplicity of it being one binary that can perform several tasks.
-# However, when you have a good package manager (like nix), that doesn't
-# actually make much of a difference; you don't really care if it's one binary
-# or 10 since with a good package manager, installing and running it is
-# identical.
-# Since upstream k3s packages itself as one large binary with several
-# "personalities" (in the form of subcommands like 'k3s agent' and 'k3s
-# kubectl'), it ends up being easiest to mostly mimic upstream packaging, with
-# some exceptions.
-# K3s also carries patches to some packages (such as containerd and cni
-# plugins), so we intentionally use the k3s versions of those binaries for k3s,
-# even if the upstream version of those binaries exist in nixpkgs already. In
-# the end, that means we have a thick k3s binary that behaves like the upstream
-# one for the most part.
-# However, k3s also bundles several pieces of unpatched software, from the
-# strongswan vpn software, to iptables, to socat, conntrack, busybox, etc.
-# Those pieces of software we entirely ignore upstream's handling of, and just
-# make sure they're in the path if desired.
 let
-  k3sVersion = "1.22.3+k3s1";     # k3s git tag
-  k3sCommit = "61a2aab25eeb97c26fa3f2b177e4355a7654c991"; # k3s git commit at the above version
-  k3sRepoSha256 = "0lz5hr3c86gxm9w5jy3g26n6a26m8k0y559hv6220rsi709j7ma9";
+  k3sVersion = "1.23.3+k3s1";     # k3s git tag
+  k3sCommit = "5fb370e53e0014dc96183b8ecb2c25a61e891e76"; # k3s git commit at the above version
+  k3sRepoSha256 = "0vlsqy4iccjmf4nslmr0a7w5pbb4891j2qk5dr5fsbvgdnq6xm6i";
 
-  traefikChartVersion = "10.3.0"; # taken from ./manifests/traefik.yaml at spec.version
-  traefikChartSha256 = "0y6wr64xp7bgx24kqil0x6myr3pnfrg8rw0d1h5zd2n5a8nfd73f";
+  traefikChartVersion = "10.9.1"; # taken from ./manifests/traefik.yaml at spec.chart
+  traefikChartSha256 = "0r5qs378g1dl7w7kmc8pd39za2vj7ga6qyg02l233mylhwp47kaw";
 
-  k3sRootVersion = "0.9.1";       # taken from ./scripts/download at ROOT_VERSION
+  k3sRootVersion = "0.9.1";       # taken from ./scripts/version.sh at VERSION_ROOT
   k3sRootSha256 = "0r2cj4l50cxkrvszpzxfk36lvbjf9vcmp6d5lvxg8qsah8lki3x8";
 
   k3sCNIVersion = "0.9.1-k3s1";   # taken from ./scripts/version.sh at VERSION_CNIPLUGINS
@@ -64,233 +46,53 @@ let
     platforms = platforms.linux;
   };
 
-  # bundled into the k3s binary
-  traefikChart = fetchurl {
-    url = "https://helm.traefik.io/traefik/traefik-${traefikChartVersion}.tgz";
-    sha256 = traefikChartSha256;
-  };
-  # so, k3s is a complicated thing to package
-  # This derivation attempts to avoid including any random binaries from the
-  # internet. k3s-root is _mostly_ binaries built to be bundled in k3s (which
-  # we don't care about doing, we can add those as build or runtime
-  # dependencies using a real package manager).
-  # In addition to those binaries, it's also configuration though (right now
-  # mostly strongswan configuration), and k3s does use those files.
-  # As such, we download it in order to grab 'etc' and bundle it into the final
-  # k3s binary.
-  k3sRoot = fetchzip {
-    # Note: marked as apache 2.0 license
-    url = "https://github.com/k3s-io/k3s-root/releases/download/v${k3sRootVersion}/k3s-root-amd64.tar";
-    sha256 = k3sRootSha256;
-    stripRoot = false;
-  };
-  k3sPlugins = buildGoPackage rec {
-    name = "k3s-cni-plugins";
-    version = k3sCNIVersion;
-
-    goPackagePath = "github.com/containernetworking/plugins";
-    subPackages = [ "." ];
-
-    src = fetchFromGitHub {
-      owner = "rancher";
-      repo = "plugins";
-      rev = "v${version}";
-      sha256 = k3sCNISha256;
-    };
-
-    meta = baseMeta // {
-      description = "CNI plugins, as patched by rancher for k3s";
-    };
-  };
-  # Grab this separately from a build because it's used by both stages of the
-  # k3s build.
   k3sRepo = fetchgit {
     url = "https://github.com/k3s-io/k3s";
     rev = "v${k3sVersion}";
     sha256 = k3sRepoSha256;
   };
-  # Stage 1 of the k3s build:
-  # Let's talk about how k3s is structured.
-  # One of the ideas of k3s is that there's the single "k3s" binary which can
-  # do everything you need, from running a k3s server, to being a worker node,
-  # to running kubectl.
-  # The way that actually works is that k3s is a single go binary that contains
-  # a bunch of bindata that it unpacks at runtime into directories (either the
-  # user's home directory or /var/lib/rancher if run as root).
-  # This bindata includes both binaries and configuration.
-  # In order to let nixpkgs do all its autostripping/patching/etc, we split this into two derivations.
-  # First, we build all the binaries that get packed into the thick k3s binary
-  # (and output them from one derivation so they'll all be suitably patched up).
-  # Then, we bundle those binaries into our thick k3s binary and use that as
-  # the final single output.
-  # This approach was chosen because it ensures the bundled binaries all are
-  # correctly built to run with nix (we can lean on the existing buildGoPackage
-  # stuff), and we can again lean on that tooling for the final k3s binary too.
-  # Other alternatives would be to manually run the
-  # strip/patchelf/remove-references step ourselves in the installPhase of the
-  # derivation when we've built all the binaries, but haven't bundled them in
-  # with generated bindata yet.
-  k3sBuildStage1 = buildGoPackage rec {
-    name = "k3s-build-1";
-    version = k3sVersion;
-
-    goPackagePath = "github.com/rancher/k3s";
-
-    src = k3sRepo;
-
-    # Patch build scripts so that we can use them.
-    # This makes things more dynamically linked (because nix can deal with
-    # dynamically linked dependencies just fine), removes the upload at the
-    # end, and skips building runc + cni, since we have our own derivations for
-    # those.
-    patches = [ ./patches/0002-Add-nixpkgs-patches.patch ];
-
-    nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ libseccomp ];
-
-    # Versioning info for build script
-    DRONE_TAG = "v${version}";
-    DRONE_COMMIT = k3sCommit;
-
-    buildPhase = ''
-      pushd go/src/${goPackagePath}
-
-      patchShebangs ./scripts/build ./scripts/version.sh
-      mkdir -p bin
-      ./scripts/build
-
-      popd
-    '';
-
-    installPhase = ''
-      pushd go/src/${goPackagePath}
-
-      mkdir -p "$out/bin"
-      install -m 0755 -t "$out/bin" ./bin/*
-
-      popd
-    '';
-
-    meta = baseMeta // {
-      description = "The various binaries that get packaged into the final k3s binary";
-    };
-  };
-  k3sBin = buildGoPackage rec {
-    name = "k3s-bin";
-    version = k3sVersion;
-
-    goPackagePath = "github.com/rancher/k3s";
-
-    src = k3sRepo;
-
-    # See the above comment in k3sBuildStage1
-    patches = [ ./patches/0002-Add-nixpkgs-patches.patch ];
-
-    nativeBuildInputs = [ pkg-config zstd ];
-    # These dependencies are embedded as compressed files in k3s at runtime.
-    # Propagate them to avoid broken runtime references to libraries.
-    propagatedBuildInputs = [ k3sPlugins k3sBuildStage1 runc ];
-
-    # k3s appends a suffix to the final distribution binary for some arches
-    archSuffix =
-      if stdenv.hostPlatform.system == "x86_64-linux" then ""
-      else if stdenv.hostPlatform.system == "aarch64-linux" then "-arm64"
-      else throw "k3s isn't being built for ${stdenv.hostPlatform.system} yet.";
-
-    DRONE_TAG = "v${version}";
-    DRONE_COMMIT = k3sCommit;
-
-    # In order to build the thick k3s binary (which is what
-    # ./scripts/package-cli does), we need to get all the binaries that script
-    # expects in place.
-    buildPhase = ''
-      pushd go/src/${goPackagePath}
-
-      patchShebangs ./scripts/build ./scripts/version.sh ./scripts/package-cli
-
-      mkdir -p bin
-
-      install -m 0755 -t ./bin ${k3sBuildStage1}/bin/*
-      install -m 0755 -T "${k3sPlugins}/bin/plugins" ./bin/cni
-      # Note: use the already-nixpkgs-bundled k3s rather than the one bundled
-      # in k3s because the k3s one is completely unmodified from upstream
-      # (unlike containerd, cni, etc)
-      install -m 0755 -T "${runc}/bin/runc" ./bin/runc
-      cp -R "${k3sRoot}/etc" ./etc
-      mkdir -p "build/static/charts"
-      cp "${traefikChart}" "build/static/charts/traefik-${traefikChartVersion}.tgz"
-
-      ./scripts/package-cli
-
-      popd
-    '';
-
-    installPhase = ''
-      pushd go/src/${goPackagePath}
-
-      mkdir -p "$out/bin"
-      install -m 0755 -T ./dist/artifacts/k3s${archSuffix} "$out/bin/k3s"
-
-      popd
-    '';
-
-    meta = baseMeta // {
-      description = "The k3s go binary which is used by the final wrapped output below";
-    };
-  };
 in
-stdenv.mkDerivation rec {
-  pname = "k3s";
-  version = k3sVersion;
 
-  # `src` here is a workaround for the updateScript bot. It couldn't be empty.
-  src = builtins.filterSource (path: type: false) ./.;
+    buildGoModule rec {
+      name = "k3s";
+      version = k3sVersion;
 
-  # Important utilities used by the kubelet, see
-  # https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
-  # Note the list in that issue is stale and some aren't relevant for k3s.
-  k3sRuntimeDeps = [
-    kmod
-    socat
-    iptables
-    iproute2
-    bridge-utils
-    ethtool
-    util-linux # kubelet wants 'nsenter' from util-linux: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-705994388
-    conntrack-tools
-  ];
+      src = k3sRepo;
 
-  buildInputs = [
-    k3sBin
-  ] ++ k3sRuntimeDeps;
+      vendorSha256 = "sha256-9+2k/ipAOhc8JJU+L2dwaM01Dkw+0xyrF5kt6mL19G0=";
 
-  nativeBuildInputs = [ makeWrapper ];
+      subPackages = [ "." ];
+      # subPackages = [ "cmd/server/" ];
 
-  unpackPhase = "true";
+      ldflags = [
+        "-w -s"
+      ];
+      extldflags = [
+        "-static"
+        "-lm"
+        "-ldl"
+        "-lz"
+        "-lpthread"
+      ];
 
-  # And, one final derivation (you thought the last one was it, right?)
-  # We got the binary we wanted above, but it doesn't have all the runtime
-  # dependencies k8s wants, including mount utilities for kubelet, networking
-  # tools for cni/kubelet stuff, etc
-  # Use a wrapper script to reference all the binaries that k3s tries to
-  # execute, but that we didn't bundle with it.
-  installPhase = ''
-    runHook preInstall
-    mkdir -p "$out/bin"
-    makeWrapper ${k3sBin}/bin/k3s "$out/bin/k3s" \
-      --prefix PATH : ${lib.makeBinPath k3sRuntimeDeps} \
-      --prefix PATH : "$out/bin"
-    runHook postInstall
-  '';
+      # "apparmor seccomp netcgo osusergo providerless"
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/k3s --version | grep v${k3sVersion} > /dev/null
-  '';
+      nativeBuildInputs = [ makeWrapper ];
 
-  passthru.updateScript = ./update.sh;
+      postInstall = ''
+        for appname in agent certificate etcd-snapshot secrets-encrypt server ; do
+          makeWrapper $out/bin/k3s $out/bin/k3s-$appname --argv0 $appname --add-flags $appname
+        done
 
-  passthru.tests = { inherit (nixosTests) k3s-single-node k3s-single-node-docker; };
+        for appname in kubectl crictl ctr ; do
+          makeWrapper $out/bin/k3s $out/bin/$appname --argv0 $appname
+        done
+      '';
 
-  meta = baseMeta;
-}
+      passthru.tests = { inherit (nixosTests) k3s-single-node k3s-single-node-docker; };
+
+      meta = baseMeta // {
+
+        description = "The various binaries that get packaged into the final k3s binary";
+      };
+    }

--- a/pkgs/applications/networking/cluster/k3s/patches/0001-k3s-patch-for-nixpkgs.patch
+++ b/pkgs/applications/networking/cluster/k3s/patches/0001-k3s-patch-for-nixpkgs.patch
@@ -1,27 +1,27 @@
--Subject: [PATCH 2/2] Add nixpkgs patches
--Original patch by: Euan Kemp <euank@euank.com>
--Adapted by: superherointj
--
--This patch allows us to re-use upstream build scripts when building for nix.
-----
-- 2 files changed:
--   scripts/build
--   scripts/package-cli
--
+From 20a4d1c013cdeede5bae65f7a559f959c25aa3a5 Mon Sep 17 00:00:00 2001
+From: superherointj <5861043+superherointj@users.noreply.github.com>
+Date: Wed, 26 Jan 2022 19:50:10 -0300
+Subject: [PATCH] k3s-patch-for-nixpkgs
+
+---
+ scripts/build       | 22 ++++------------------
+ scripts/package-cli | 10 ++++++----
+ 2 files changed, 10 insertions(+), 22 deletions(-)
+
 diff --git a/scripts/build b/scripts/build
-index 2f3d1dc496..4f4e5aa897 100755
+index 139fb68746..1746f38380 100755
 --- a/scripts/build
 +++ b/scripts/build
-@@ -12,7 +12,8 @@ PKG_CONTAINERD="github.com/containerd/containerd"
- PKG_K3S_CONTAINERD="github.com/k3s-io/containerd"
- PKG_CRICTL="github.com/kubernetes-sigs/cri-tools"
+@@ -14,7 +14,8 @@ PKG_CRICTL="github.com/kubernetes-sigs/cri-tools/pkg"
+ PKG_K8S_BASE="k8s.io/component-base"
+ PKG_K8S_CLIENT="k8s.io/client-go/pkg"
  
 -buildDate=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 +# nixpkgs: deterministic build date
 +buildDate="$(date -d "$(git log -1 --format=%ai)" -u "+%Y-%m-%dT%H:%M:%SZ")"
  
- VENDOR_PREFIX="${PKG}/vendor/"
  VERSIONFLAGS="
+     -X ${PKG}/pkg/version.Version=${VERSION}
 @@ -89,17 +90,7 @@ cleanup() {
  }
  
@@ -34,27 +34,27 @@ index 2f3d1dc496..4f4e5aa897 100755
 -    WORKDIR=$TMPDIR/src/github.com/containernetworking/plugins
 -    git clone -b $VERSION_CNIPLUGINS https://github.com/rancher/plugins.git $WORKDIR
 -    cd $WORKDIR
--    GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
+-    GO111MODULE=off GOPATH=$TMPDIR CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
 -)
 -fi
 +# nixpkgs: skip building cni, we build it separately
- # echo Building agent
- # CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s-agent ./cmd/agent/main.go
- echo Building server
-@@ -116,10 +107,7 @@ ln -s containerd ./bin/ctr
- #CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC_SQLITE" -o bin/ctr ./cmd/ctr/main.go
- # echo Building containerd
- # CGO_ENABLED=0 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
--echo Building runc
--rm -f ./build/src/github.com/opencontainers/runc/runc
--make GOPATH=$(pwd)/build EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" -C ./build/src/github.com/opencontainers/runc $RUNC_STATIC
--cp -f ./build/src/github.com/opencontainers/runc/runc ./bin/runc
-+# nixpkgs: we build runc separately
  
- echo Building containerd-shim
- rm -f ./vendor/github.com/containerd/containerd/bin/containerd-shim
+ echo Building k3s
+ CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/k3s ./cmd/server/main.go
+@@ -122,9 +113,4 @@ CGO_ENABLED=1 "${GO}" build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STAT
+ popd
+ cp -vf ./build/src/github.com/containerd/containerd/bin/* ./bin/
+ 
+-echo Building runc
+-pushd ./build/src/github.com/opencontainers/runc
+-rm -f runc
+-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="$RUNC_TAGS" $RUNC_STATIC
+-popd
+-cp -vf ./build/src/github.com/opencontainers/runc/runc ./bin/
++# nixpkgs: we build runc separately
+\ No newline at end of file
 diff --git a/scripts/package-cli b/scripts/package-cli
-index ab4a6dac63..044b5587d0 100755
+index 6c36922c28..a1997177fe 100755
 --- a/scripts/package-cli
 +++ b/scripts/package-cli
 @@ -50,15 +50,17 @@ fi
@@ -79,3 +79,6 @@ index ab4a6dac63..044b5587d0 100755
 -./scripts/build-upload ${CMD_NAME} ${COMMIT}
 +# nixpkgs: skip uploading
 +# ./scripts/build-upload ${CMD_NAME} ${COMMIT}
+-- 
+2.34.1
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26593,7 +26593,9 @@ with pkgs;
 
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };
 
-  k3s = callPackage ../applications/networking/cluster/k3s {};
+  k3s = callPackage ../applications/networking/cluster/k3s {
+    buildGoModule = buildGo117Module;
+  };
 
   kconf = callPackage ../applications/networking/cluster/kconf { };
 


### PR DESCRIPTION
Closes #156615

THIS IS AN EARLY DRAFT

Building K3s is currently broken so I'm attempting to use buildGoModule instead. It is broken still. Trying to sort out things out. And Yes, I have no idea on what I'm doing. And
I wouldn't mind keeping things as they are if updates weren't broken.

I'll try to mimic this (haven't yet):
https://github.com/k3s-io/k3s/blob/master/scripts/build


UPDATE:
K3s builds when using buildGoModule. But tests are failing still.

Code I'm using:

pkgs/applications/networking/cluster/k3s/default.nix
```
let
  k3sVersion = "1.23.3+k3s1";     # k3s git tag
  k3sCommit = "5fb370e53e0014dc96183b8ecb2c25a61e891e76"; # k3s git commit at the above version
  k3sRepoSha256 = "0vlsqy4iccjmf4nslmr0a7w5pbb4891j2qk5dr5fsbvgdnq6xm6i";
in
    buildGo117Module rec {
      name = "k3s";
      version = k3sVersion;

      src = fetchgit {
        url = "https://github.com/k3s-io/k3s";
        rev = "v${k3sVersion}";
        sha256 = k3sRepoSha256;
      };

      vendorSha256 = "sha256-9+2k/ipAOhc8JJU+L2dwaM01Dkw+0xyrF5kt6mL19G0=";

      subPackages = [ "." ];

      passthru.tests = { inherit (nixosTests) k3s-single-node k3s-single-node-docker; };
    }
```

Please *ignore*:
1) Update script
2) Patch
3) Traefik
4) Junk

Tests are breaking as:

nix build .#k3s.passthru.tests.k3s-single-node
```
Error: unknown command "kubectl" for "kubectl"
Exception: command `k3s kubectl cluster-info` failed (exit code 1)
```
Full logs: https://termbin.com/gi7p

I've added a wrapper, and the wrapper when tested in ./result/bin/* seems fine. The applications are executed as expected.

@euank @bryanasdev000