### PR TITLE
teams: Adds Darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -16,6 +16,7 @@
 , nodePackages
 , xar
 , cpio
+, makeWrapper
 , enableRectOverlay ? false }:
 
 let 
@@ -132,10 +133,10 @@ let
 
       src = fetchurl {
         url = "https://statics.teams.cdn.office.net/production-osx/${version}/Teams_osx.pkg";
-        sha256 = "TlQEYNvIkQ7drkS2SInTe26iYRdf3u3kptRcgQMEVqk=";
+        sha256 = "1mg6a3b3954w4xy5rlcrwxczymygl61dv2rxqp45sjcsh3hp39q0";
       };
 
-      buildInputs = [ xar cpio ];
+      buildInputs = [ xar cpio makeWrapper ];
 
       unpackPhase = ''
         xar -xf $src
@@ -151,7 +152,7 @@ let
         runHook preInstallPhase
         mkdir -p $out/{Applications/${appName},bin}
         cp -R . $out/Applications/${appName}
-        ln -s $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
+        makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
         runHook postInstallPhase
       '';
     };

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -14,109 +14,147 @@
 , xdg-utils
 , systemd
 , nodePackages
+, xar
+, cpio
 , enableRectOverlay ? false }:
 
-stdenv.mkDerivation rec {
+let 
   pname = "teams";
   version = "1.4.00.26453";
-
-  src = fetchurl {
-    url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
-    sha256 = "0ndqk893l17m42hf5fiiv6mka0v7v8r54kblvb67jsxajdvva5gf";
-  };
-
-  nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook nodePackages.asar ];
-
-  unpackCmd = "dpkg -x $curSrc .";
-
-  buildInputs = atomEnv.packages ++ [
-    libuuid
-    at-spi2-atk
-  ];
-
-  runtimeDependencies = [
-    (lib.getLib systemd)
-    pulseaudio
-    libappindicator-gtk3
-  ];
-
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin")
-    gappsWrapperArgs+=(--add-flags --disable-namespace-sandbox)
-    gappsWrapperArgs+=(--add-flags --disable-setuid-sandbox)
-  '';
-
-
-  buildPhase = ''
-    runHook preBuild
-
-    asar extract share/teams/resources/app.asar "$TMP/work"
-    substituteInPlace $TMP/work/main.bundle.js \
-        --replace "/usr/share/pixmaps/" "$out/share/pixmaps" \
-        --replace "/usr/bin/xdg-mime" "${xdg-utils}/bin/xdg-mime" \
-        --replace "Exec=/usr/bin/" "Exec=" # Remove usage of absolute path in autostart.
-    asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" share/teams/resources/app.asar
-
-    runHook postBuild
-  '';
-
-  preferLocalBuild = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/{opt,bin}
-
-    mv share/teams $out/opt/
-    mv share $out/share
-
-    substituteInPlace $out/share/applications/teams.desktop \
-      --replace /usr/bin/ ""
-
-    ln -s $out/opt/teams/teams $out/bin/
-
-    ${lib.optionalString (!enableRectOverlay) ''
-    # Work-around screen sharing bug
-    # https://docs.microsoft.com/en-us/answers/questions/42095/sharing-screen-not-working-anymore-bug.html
-    rm $out/opt/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
-    ''}
-
-    runHook postInstall
-  '';
-
-  dontAutoPatchelf = true;
-
-  # Includes runtimeDependencies in the RPATH of the included Node modules
-  # so that dynamic loading works. We cannot use directly runtimeDependencies
-  # here, since the libraries from runtimeDependencies are not propagated
-  # to the dynamically loadable node modules because of a condition in
-  # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
-  # instead of EXEC or INTERP it expects.
-  # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
-  postFixup = ''
-    autoPatchelf "$out"
-
-    runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
-
-    for mod in $(find "$out/opt/teams" -name '*.node'); do
-      mod_rpath="$(patchelf --print-rpath "$mod")"
-
-      echo "Adding runtime dependencies to RPATH of Node module $mod"
-      patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
-    done;
-
-    # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
-    # while we create the wrapper ourselves, gappsWrapperArgs leads to the same issue
-    # another option would be to introduce gappsWrapperAppendedArgs, to allow control of positioning
-    substituteInPlace "$out/bin/teams" --replace '.teams-wrapped"  --disable-namespace-sandbox --disable-setuid-sandbox "$@"' '.teams-wrapped" "$@" --disable-namespace-sandbox --disable-setuid-sandbox'
-  '';
-
   meta = with lib; {
     description = "Microsoft Teams";
     homepage = "https://teams.microsoft.com";
     downloadPage = "https://teams.microsoft.com/downloads";
     license = licenses.unfree;
     maintainers = [ maintainers.liff ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
-}
+  
+  linux = stdenv.mkDerivation rec {
+      inherit pname version meta;
+
+      src = fetchurl {
+        url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
+        sha256 = "0ndqk893l17m42hf5fiiv6mka0v7v8r54kblvb67jsxajdvva5gf";
+      };
+
+      nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook nodePackages.asar ];
+
+      unpackCmd = "dpkg -x $curSrc .";
+
+      buildInputs = atomEnv.packages ++ [
+        libuuid
+        at-spi2-atk
+      ];
+
+      runtimeDependencies = [
+        (lib.getLib systemd)
+        pulseaudio
+        libappindicator-gtk3
+      ];
+
+      preFixup = ''
+        gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin")
+        gappsWrapperArgs+=(--add-flags --disable-namespace-sandbox)
+        gappsWrapperArgs+=(--add-flags --disable-setuid-sandbox)
+      '';
+
+
+      buildPhase = ''
+        runHook preBuild
+
+        asar extract share/teams/resources/app.asar "$TMP/work"
+        substituteInPlace $TMP/work/main.bundle.js \
+            --replace "/usr/share/pixmaps/" "$out/share/pixmaps" \
+            --replace "/usr/bin/xdg-mime" "${xdg-utils}/bin/xdg-mime" \
+            --replace "Exec=/usr/bin/" "Exec=" # Remove usage of absolute path in autostart.
+        asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" share/teams/resources/app.asar
+
+        runHook postBuild
+      '';
+
+      preferLocalBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/{opt,bin}
+
+        mv share/teams $out/opt/
+        mv share $out/share
+
+        substituteInPlace $out/share/applications/teams.desktop \
+          --replace /usr/bin/ ""
+
+        ln -s $out/opt/teams/teams $out/bin/
+
+        ${lib.optionalString (!enableRectOverlay) ''
+        # Work-around screen sharing bug
+        # https://docs.microsoft.com/en-us/answers/questions/42095/sharing-screen-not-working-anymore-bug.html
+        rm $out/opt/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
+        ''}
+
+        runHook postInstall
+      '';
+
+      dontAutoPatchelf = true;
+
+      # Includes runtimeDependencies in the RPATH of the included Node modules
+      # so that dynamic loading works. We cannot use directly runtimeDependencies
+      # here, since the libraries from runtimeDependencies are not propagated
+      # to the dynamically loadable node modules because of a condition in
+      # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
+      # instead of EXEC or INTERP it expects.
+      # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
+      postFixup = ''
+        autoPatchelf "$out"
+
+        runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
+
+        for mod in $(find "$out/opt/teams" -name '*.node'); do
+          mod_rpath="$(patchelf --print-rpath "$mod")"
+
+          echo "Adding runtime dependencies to RPATH of Node module $mod"
+          patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
+        done;
+
+        # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
+        # while we create the wrapper ourselves, gappsWrapperArgs leads to the same issue
+        # another option would be to introduce gappsWrapperAppendedArgs, to allow control of positioning
+        substituteInPlace "$out/bin/teams" --replace '.teams-wrapped"  --disable-namespace-sandbox --disable-setuid-sandbox "$@"' '.teams-wrapped" "$@" --disable-namespace-sandbox --disable-setuid-sandbox'
+      '';
+    };
+
+    appName = "Teams.app";
+
+    darwin = stdenv.mkDerivation {
+      inherit pname version meta;
+
+      src = fetchurl {
+        url = "https://statics.teams.cdn.office.net/production-osx/${version}/Teams_osx.pkg";
+        sha256 = "TlQEYNvIkQ7drkS2SInTe26iYRdf3u3kptRcgQMEVqk=";
+      };
+
+      buildInputs = [ xar cpio ];
+
+      unpackPhase = ''
+        xar -xf $src
+        zcat < Teams_osx_app.pkg/Payload | cpio -i
+      '';
+
+      sourceRoot = "Microsoft\ Teams.app";
+      dontPatch = true;
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstallPhase
+        mkdir -p $out/{Applications/${appName},bin}
+        cp -R . $out/Applications/${appName}
+        ln -s $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
+        runHook postInstallPhase
+      '';
+    };
+in if stdenv.isDarwin
+   then darwin
+   else linux

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -17,9 +17,10 @@
 , xar
 , cpio
 , makeWrapper
-, enableRectOverlay ? false }:
+, enableRectOverlay ? false
+}:
 
-let 
+let
   pname = "teams";
   version = "1.4.00.26453";
   meta = with lib; {
@@ -30,132 +31,133 @@ let
     maintainers = [ maintainers.liff ];
     platforms = platforms.linux ++ platforms.darwin;
   };
-  
+
   linux = stdenv.mkDerivation rec {
-      inherit pname version meta;
+    inherit pname version meta;
 
-      src = fetchurl {
-        url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
-        sha256 = "0ndqk893l17m42hf5fiiv6mka0v7v8r54kblvb67jsxajdvva5gf";
-      };
-
-      nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook nodePackages.asar ];
-
-      unpackCmd = "dpkg -x $curSrc .";
-
-      buildInputs = atomEnv.packages ++ [
-        libuuid
-        at-spi2-atk
-      ];
-
-      runtimeDependencies = [
-        (lib.getLib systemd)
-        pulseaudio
-        libappindicator-gtk3
-      ];
-
-      preFixup = ''
-        gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin")
-        gappsWrapperArgs+=(--add-flags --disable-namespace-sandbox)
-        gappsWrapperArgs+=(--add-flags --disable-setuid-sandbox)
-      '';
-
-
-      buildPhase = ''
-        runHook preBuild
-
-        asar extract share/teams/resources/app.asar "$TMP/work"
-        substituteInPlace $TMP/work/main.bundle.js \
-            --replace "/usr/share/pixmaps/" "$out/share/pixmaps" \
-            --replace "/usr/bin/xdg-mime" "${xdg-utils}/bin/xdg-mime" \
-            --replace "Exec=/usr/bin/" "Exec=" # Remove usage of absolute path in autostart.
-        asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" share/teams/resources/app.asar
-
-        runHook postBuild
-      '';
-
-      preferLocalBuild = true;
-
-      installPhase = ''
-        runHook preInstall
-
-        mkdir -p $out/{opt,bin}
-
-        mv share/teams $out/opt/
-        mv share $out/share
-
-        substituteInPlace $out/share/applications/teams.desktop \
-          --replace /usr/bin/ ""
-
-        ln -s $out/opt/teams/teams $out/bin/
-
-        ${lib.optionalString (!enableRectOverlay) ''
-        # Work-around screen sharing bug
-        # https://docs.microsoft.com/en-us/answers/questions/42095/sharing-screen-not-working-anymore-bug.html
-        rm $out/opt/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
-        ''}
-
-        runHook postInstall
-      '';
-
-      dontAutoPatchelf = true;
-
-      # Includes runtimeDependencies in the RPATH of the included Node modules
-      # so that dynamic loading works. We cannot use directly runtimeDependencies
-      # here, since the libraries from runtimeDependencies are not propagated
-      # to the dynamically loadable node modules because of a condition in
-      # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
-      # instead of EXEC or INTERP it expects.
-      # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
-      postFixup = ''
-        autoPatchelf "$out"
-
-        runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
-
-        for mod in $(find "$out/opt/teams" -name '*.node'); do
-          mod_rpath="$(patchelf --print-rpath "$mod")"
-
-          echo "Adding runtime dependencies to RPATH of Node module $mod"
-          patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
-        done;
-
-        # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
-        # while we create the wrapper ourselves, gappsWrapperArgs leads to the same issue
-        # another option would be to introduce gappsWrapperAppendedArgs, to allow control of positioning
-        substituteInPlace "$out/bin/teams" --replace '.teams-wrapped"  --disable-namespace-sandbox --disable-setuid-sandbox "$@"' '.teams-wrapped" "$@" --disable-namespace-sandbox --disable-setuid-sandbox'
-      '';
+    src = fetchurl {
+      url = "https://packages.microsoft.com/repos/ms-teams/pool/main/t/teams/teams_${version}_amd64.deb";
+      sha256 = "0ndqk893l17m42hf5fiiv6mka0v7v8r54kblvb67jsxajdvva5gf";
     };
 
-    appName = "Teams.app";
+    nativeBuildInputs = [ dpkg autoPatchelfHook wrapGAppsHook nodePackages.asar ];
 
-    darwin = stdenv.mkDerivation {
-      inherit pname version meta;
+    unpackCmd = "dpkg -x $curSrc .";
 
-      src = fetchurl {
-        url = "https://statics.teams.cdn.office.net/production-osx/${version}/Teams_osx.pkg";
-        sha256 = "1mg6a3b3954w4xy5rlcrwxczymygl61dv2rxqp45sjcsh3hp39q0";
-      };
+    buildInputs = atomEnv.packages ++ [
+      libuuid
+      at-spi2-atk
+    ];
 
-      buildInputs = [ xar cpio makeWrapper ];
+    runtimeDependencies = [
+      (lib.getLib systemd)
+      pulseaudio
+      libappindicator-gtk3
+    ];
 
-      unpackPhase = ''
-        xar -xf $src
-        zcat < Teams_osx_app.pkg/Payload | cpio -i
-      '';
+    preFixup = ''
+      gappsWrapperArgs+=(--prefix PATH : "${coreutils}/bin:${gawk}/bin")
+      gappsWrapperArgs+=(--add-flags --disable-namespace-sandbox)
+      gappsWrapperArgs+=(--add-flags --disable-setuid-sandbox)
+    '';
 
-      sourceRoot = "Microsoft\ Teams.app";
-      dontPatch = true;
-      dontConfigure = true;
-      dontBuild = true;
 
-      installPhase = ''
-        runHook preInstallPhase
-        mkdir -p $out/{Applications/${appName},bin}
-        cp -R . $out/Applications/${appName}
-        makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
-        runHook postInstallPhase
-      '';
+    buildPhase = ''
+      runHook preBuild
+
+      asar extract share/teams/resources/app.asar "$TMP/work"
+      substituteInPlace $TMP/work/main.bundle.js \
+          --replace "/usr/share/pixmaps/" "$out/share/pixmaps" \
+          --replace "/usr/bin/xdg-mime" "${xdg-utils}/bin/xdg-mime" \
+          --replace "Exec=/usr/bin/" "Exec=" # Remove usage of absolute path in autostart.
+      asar pack --unpack='{*.node,*.ftz,rect-overlay}' "$TMP/work" share/teams/resources/app.asar
+
+      runHook postBuild
+    '';
+
+    preferLocalBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{opt,bin}
+
+      mv share/teams $out/opt/
+      mv share $out/share
+
+      substituteInPlace $out/share/applications/teams.desktop \
+        --replace /usr/bin/ ""
+
+      ln -s $out/opt/teams/teams $out/bin/
+
+      ${lib.optionalString (!enableRectOverlay) ''
+      # Work-around screen sharing bug
+      # https://docs.microsoft.com/en-us/answers/questions/42095/sharing-screen-not-working-anymore-bug.html
+      rm $out/opt/teams/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
+      ''}
+
+      runHook postInstall
+    '';
+
+    dontAutoPatchelf = true;
+
+    # Includes runtimeDependencies in the RPATH of the included Node modules
+    # so that dynamic loading works. We cannot use directly runtimeDependencies
+    # here, since the libraries from runtimeDependencies are not propagated
+    # to the dynamically loadable node modules because of a condition in
+    # autoPatchElfHook since *.node modules have Type: DYN (Shared object file)
+    # instead of EXEC or INTERP it expects.
+    # Fixes: https://github.com/NixOS/nixpkgs/issues/85449
+    postFixup = ''
+      autoPatchelf "$out"
+
+      runtime_rpath="${lib.makeLibraryPath runtimeDependencies}"
+
+      for mod in $(find "$out/opt/teams" -name '*.node'); do
+        mod_rpath="$(patchelf --print-rpath "$mod")"
+
+        echo "Adding runtime dependencies to RPATH of Node module $mod"
+        patchelf --set-rpath "$runtime_rpath:$mod_rpath" "$mod"
+      done;
+
+      # fix for https://docs.microsoft.com/en-us/answers/questions/298724/open-teams-meeting-link-on-linux-doens39t-work.html?childToView=309406#comment-309406
+      # while we create the wrapper ourselves, gappsWrapperArgs leads to the same issue
+      # another option would be to introduce gappsWrapperAppendedArgs, to allow control of positioning
+      substituteInPlace "$out/bin/teams" --replace '.teams-wrapped"  --disable-namespace-sandbox --disable-setuid-sandbox "$@"' '.teams-wrapped" "$@" --disable-namespace-sandbox --disable-setuid-sandbox'
+    '';
+  };
+
+  appName = "Teams.app";
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://statics.teams.cdn.office.net/production-osx/${version}/Teams_osx.pkg";
+      sha256 = "1mg6a3b3954w4xy5rlcrwxczymygl61dv2rxqp45sjcsh3hp39q0";
     };
-in if stdenv.isDarwin
-   then darwin
-   else linux
+
+    buildInputs = [ xar cpio makeWrapper ];
+
+    unpackPhase = ''
+      xar -xf $src
+      zcat < Teams_osx_app.pkg/Payload | cpio -i
+    '';
+
+    sourceRoot = "Microsoft\ Teams.app";
+    dontPatch = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstallPhase
+      mkdir -p $out/{Applications/${appName},bin}
+      cp -R . $out/Applications/${appName}
+      makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
+      runHook postInstallPhase
+    '';
+  };
+in
+if stdenv.isDarwin
+then darwin
+else linux

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -29,7 +29,7 @@ let
     downloadPage = "https://teams.microsoft.com/downloads";
     license = licenses.unfree;
     maintainers = [ maintainers.liff ];
-    platforms = platforms.linux ++ platforms.darwin;
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 
   linux = stdenv.mkDerivation rec {

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -154,7 +154,7 @@ let
       mkdir -p $out/{Applications/${appName},bin}
       cp -R . $out/Applications/${appName}
       makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams
-      runHook postInstallPhase
+      runHook postInstall
     '';
   };
 in

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -150,7 +150,7 @@ let
     dontBuild = true;
 
     installPhase = ''
-      runHook preInstallPhase
+      runHook preInstall
       mkdir -p $out/{Applications/${appName},bin}
       cp -R . $out/Applications/${appName}
       makeWrapper $out/Applications/${appName}/Contents/MacOS/Teams $out/bin/teams

--- a/pkgs/applications/networking/instant-messengers/teams/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams/default.nix
@@ -28,7 +28,7 @@ let
     homepage = "https://teams.microsoft.com";
     downloadPage = "https://teams.microsoft.com/downloads";
     license = licenses.unfree;
-    maintainers = [ maintainers.liff ];
+    maintainers = with maintainers; [ liff tricktron ];
     platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Closes #146242.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
