### PR TITLE
pipewire: 0.3.43 -> 0.3.45

### DIFF
--- a/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
+++ b/pkgs/development/libraries/pipewire/0050-pipewire-pulse-path.patch
@@ -1,19 +1,19 @@
 diff --git a/meson_options.txt b/meson_options.txt
-index 71c2e35e9..a0f380c04 100644
+index 961ae2a76..692b84dfd 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -176,6 +176,9 @@ option('udev',
+@@ -179,6 +179,9 @@ option('udev',
  option('udevrulesdir',
         type : 'string',
         description : 'Directory for udev rules (defaults to /lib/udev/rules.d)')
 +option('pipewire_pulse_prefix',
 +       type : 'string',
 +       description: 'Install directory for the pipewire-pulse daemon')
- option('systemd-user-unit-dir',
+ option('systemd-system-unit-dir',
         type : 'string',
-        description : 'Directory for user systemd units (defaults to /usr/lib/systemd/user)')
+        description : 'Directory for system systemd units (defaults to /usr/lib/systemd/system)')
 diff --git a/src/daemon/systemd/user/meson.build b/src/daemon/systemd/user/meson.build
-index 5bd134537..5a3ca9ed5 100644
+index d17f3794f..34afe4f1a 100644
 --- a/src/daemon/systemd/user/meson.build
 +++ b/src/daemon/systemd/user/meson.build
 @@ -9,7 +9,7 @@ install_data(

--- a/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
+++ b/pkgs/development/libraries/pipewire/0090-pipewire-config-template-paths.patch
@@ -1,8 +1,8 @@
-diff --git a/src/daemon/pipewire.conf.in b/src/daemon/pipewire.conf.in
-index 648e13069..50f767f0c 100644
---- a/src/daemon/pipewire.conf.in
-+++ b/src/daemon/pipewire.conf.in
-@@ -131,7 +131,7 @@ context.modules = [
+diff --git a/src/daemon/minimal.conf.in b/src/daemon/minimal.conf.in
+index 6464839a0..05546201f 100644
+--- a/src/daemon/minimal.conf.in
++++ b/src/daemon/minimal.conf.in
+@@ -110,7 +110,7 @@ context.modules = [
              # access.allowed to list an array of paths of allowed
              # apps.
              #access.allowed = [
@@ -11,7 +11,27 @@ index 648e13069..50f767f0c 100644
              #]
  
              # An array of rejected paths.
-@@ -235,12 +235,12 @@ context.exec = [
+@@ -298,5 +298,5 @@ context.exec = [
+     # It can be interesting to start another daemon here that listens
+     # on another address with the -a option (eg. -a tcp:4713).
+     #
+-    #@pulse_comment@{ path = "@pipewire_path@" args = "-c pipewire-pulse.conf" }
++    #@pulse_comment@{ path = "<pipewire_path>" args = "-c pipewire-pulse.conf" }
+ ]
+diff --git a/src/daemon/pipewire.conf.in b/src/daemon/pipewire.conf.in
+index a948a1b9b..4ece43c6f 100644
+--- a/src/daemon/pipewire.conf.in
++++ b/src/daemon/pipewire.conf.in
+@@ -132,7 +132,7 @@ context.modules = [
+             # access.allowed to list an array of paths of allowed
+             # apps.
+             #access.allowed = [
+-            #    @session_manager_path@
++            #    <session_manager_path>
+             #]
+ 
+             # An array of rejected paths.
+@@ -246,12 +246,12 @@ context.exec = [
      # but it is better to start it as a systemd service.
      # Run the session manager with -h for options.
      #

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -69,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.44";
+    version = "0.3.45";
 
     outputs = [
       "out"
@@ -87,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-nSupM8A3iPUFXe08k0bzZ2wQJ4QOHg8J7pLPSxbClVY=";
+      sha256 = "sha256-OnQd98qfOekAsVXLbciZLNPrM84KBX6fOx/f8y2BYI0=";
     };
 
     patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -27,7 +27,6 @@
 , ncurses
 , readline81 # meson can't find <7 as those versions don't have a .pc file
 , lilv
-, openssl
 , makeFontsConf
 , callPackage
 , nixosTests
@@ -55,8 +54,13 @@
 , libpulseaudio
 , zeroconfSupport ? true
 , avahi
+, raopSupport ? true
+, openssl
 , rocSupport ? true
 , roc-toolkit
+, x11Support ? true
+, libcanberra
+, xorg
 }:
 
 let
@@ -65,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.43";
+    version = "0.3.44";
 
     outputs = [
       "out"
@@ -83,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-vjMA9dQvZe7dPbF9BNtCYf1V240RUBdtxeyqFjWA4j4=";
+      sha256 = "sha256-nSupM8A3iPUFXe08k0bzZ2wQJ4QOHg8J7pLPSxbClVY=";
     };
 
     patches = [
@@ -120,7 +124,6 @@ let
       libsndfile
       lilv
       ncurses
-      openssl
       readline81
       udev
       vulkan-headers
@@ -134,7 +137,9 @@ let
     ++ lib.optionals bluezSupport [ bluez libfreeaptx ldacbt sbc fdk_aac ]
     ++ lib.optional pulseTunnelSupport libpulseaudio
     ++ lib.optional zeroconfSupport avahi
-    ++ lib.optional rocSupport roc-toolkit;
+    ++ lib.optional raopSupport openssl
+    ++ lib.optional rocSupport roc-toolkit
+    ++ lib.optionals x11Support [ libcanberra xorg.libxcb ];
 
     # Valgrind binary is required for running one optional test.
     checkInputs = lib.optional withValgrind valgrind;
@@ -160,8 +165,10 @@ let
       "-Dbluez5-backend-hsphfpd=${mesonEnableFeature hsphfpdSupport}"
       "-Dsysconfdir=/etc"
       "-Dpipewire_confdata_dir=${placeholder "lib"}/share/pipewire"
+      "-Draop=${mesonEnableFeature raopSupport}"
       "-Dsession-managers="
       "-Dvulkan=enabled"
+      "-Dx11=${mesonEnableFeature x11Support}"
     ];
 
     # Fontconfig error: Cannot load default config file
@@ -191,6 +198,8 @@ let
       moveToOutput "share/systemd/user/pipewire-pulse.*" "$pulse"
       moveToOutput "lib/systemd/user/pipewire-pulse.*" "$pulse"
       moveToOutput "bin/pipewire-pulse" "$pulse"
+
+      moveToOutput "bin/pw-jack" "$jack"
     '';
 
     passthru = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.44
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.45

It is now possible to use pipewire without a session manager (to some extent).
Audible bell from X11 terminals should work with the new X11 module. (seems to be commented out in the default config though)

Lots of bluetooth and pulse-server fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
