### PR TITLE
gurk: init at 0.2.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gurk/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gurk/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv
+, fetchFromGitHub
+, rustPlatform
+, protobuf
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gurk";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "boxdot";
+    repo = "${pname}-rs";
+    rev = "v${version}";
+    sha256 = "1bhiqhwzrvc0bw4l1mhfq78aq7y4288yy9scp5s8w19wsfwkjjij";
+  };
+
+  cargoSha256 = "07ccd61crx2fnh4bh78z6cqmsh2hbgz36scyhwipz7hg2aqbis8b";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  preBuild = ''
+  export PROTOC=${protobuf}/bin/protoc
+  export PROTOC_INCLUDE="${protobuf}/include";
+  '';
+
+  buildInputs = [ protobuf ];
+
+  meta = with lib; {
+    description = "Signal Messenger client for terminal";
+    homepage = "https://github.com/boxdot/gurk-rs";
+    license = with licenses; [ agpl3 ];
+    maintainers = with maintainers; [ mredaelli ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32965,6 +32965,8 @@ with pkgs;
 
   gummi = callPackage ../applications/misc/gummi { };
 
+  gurk = callPackage ../applications/networking/instant-messengers/gurk { };
+
   gxemul = callPackage ../misc/emulators/gxemul { };
 
   hatari = callPackage ../misc/emulators/hatari { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

a nice slim cli signal client

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
