### PR TITLE
Make `lib` more unified and overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
 
         nixosSystem = args:
           import ./nixos/lib/eval-config.nix (
-            args // {
+            { lib = final; } // args // {
               modules = args.modules ++ [{
                 system.nixos.versionSuffix =
                   ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -107,7 +107,10 @@ rec {
   # Same as `makeExtensible` but the name of the extending attribute is
   # customized.
   makeExtensibleWithCustomName = extenderName: rattrs:
-    fix' rattrs // {
-      ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
-   };
+    let
+      self = rattrs self // {
+        ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
+        __unfix__ = rattrs; # TODO: remove this?
+      };
+    in self;
 }

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -94,11 +94,11 @@ let
             };
       in
       import ../../.. ({
-        inherit (cfg) config overlays;
+        inherit (cfg) lib config overlays;
       } // systemArgs)
     else
       import ../../.. {
-        inherit (cfg) config overlays localSystem crossSystem;
+        inherit (cfg) lib config overlays localSystem crossSystem;
       };
 
   finalPkgs = if opt.pkgs.isDefined then cfg.pkgs.appendOverlays cfg.overlays else defaultPkgs;
@@ -117,7 +117,7 @@ in
     pkgs = mkOption {
       defaultText = literalExpression ''
         import "''${nixos}/.." {
-          inherit (cfg) config overlays localSystem crossSystem;
+          inherit (cfg) lib config overlays localSystem crossSystem;
         }
       '';
       type = pkgsType;
@@ -152,6 +152,26 @@ in
 
         Note that using a distinct version of Nixpkgs with NixOS may
         be an unexpected source of problems. Use this option with care.
+      '';
+    };
+
+    lib = mkOption {
+      default = lib;
+      defaultText = literalMD "the `lib` argument passed to modules";
+      example = literalExpression ''
+        lib.extend (final: prev: {
+          # Make lib.foo available in package expressions
+          foo = "bar";
+        })
+      '';
+      type = types.unique
+        { message = "`lib` is not suitable for plain attrset merging, as it does not interact well with the `extend` function. Any fixes to `lib` should be applied by invoking `extend` on some original `lib` value."; }
+        (types.lazyAttrsOf types.raw);
+      description = lib.mdDoc ''
+        The library used in nixpkgs. You shouldn't need to set this
+        unless you know what you're doing.
+
+        Ignored when `nixpkgs.pkgs` is set.
       '';
     };
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -146,7 +146,7 @@ rec {
         '' + mkExtraBuildCommands cc;
       });
 
-      thisStdenv = import ../generic {
+      thisStdenv = import ../generic lib {
         name = "${name}-stdenv-darwin";
 
         inherit config shell extraBuildInputs;
@@ -665,7 +665,7 @@ rec {
         inherit binutils binutils-unwrapped;
       };
     in
-    import ../generic rec {
+    import ../generic lib rec {
       name = "stdenv-darwin";
 
       inherit config;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -200,7 +200,7 @@ in
       curl = bootstrapTools;
     };
 
-    stdenv = import ../generic {
+    stdenv = import ../generic lib {
       name = "stdenv-freebsd-boot-1";
       buildPlatform = localSystem;
       hostPlatform = localSystem;
@@ -220,7 +220,7 @@ in
 
     inherit (prevStage) bootstrapTools;
 
-    stdenv = import ../generic {
+    stdenv = import ../generic lib {
       name = "stdenv-freebsd-boot-0";
       inherit config;
       initialPath = [ prevStage.bootstrapTools ];
@@ -234,7 +234,7 @@ in
 
   (prevStage: {
     inherit config overlays;
-    stdenv = import ../generic rec {
+    stdenv = import ../generic lib rec {
       name = "stdenv-freebsd-boot-3";
       inherit config;
 

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,4 +1,6 @@
-let lib = import ../../../lib; stdenv-overridable = lib.makeOverridable (
+lib:
+
+let stdenv-overridable = lib.makeOverridable (
 
 argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -86,7 +86,7 @@ let
 
     let
 
-      thisStdenv = import ../generic {
+      thisStdenv = import ../generic lib {
         name = "${name}-stdenv-linux";
         buildPlatform = localSystem;
         hostPlatform = localSystem;
@@ -390,7 +390,7 @@ in
   # binutils built.
   (prevStage: {
     inherit config overlays;
-    stdenv = import ../generic rec {
+    stdenv = import ../generic lib rec {
       name = "stdenv-linux";
 
       buildPlatform = localSystem;

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -80,7 +80,7 @@ let
   makeStdenv =
     { cc, fetchurl, extraPath ? [], overrides ? (self: super: { }), extraNativeBuildInputs ? [] }:
 
-    import ../generic {
+    import ../generic lib {
       buildPlatform = localSystem;
       hostPlatform = localSystem;
       targetPlatform = localSystem;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -10,7 +10,7 @@ bootStages ++ [
   (prevStage: {
     inherit config overlays;
 
-    stdenv = import ../generic rec {
+    stdenv = import ../generic lib rec {
       inherit config;
 
       inherit (prevStage.stdenv) buildPlatform hostPlatform targetPlatform;

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -16,7 +16,10 @@
    evaluation is taking place, and the configuration from environment variables
    or dot-files. */
 
-{ # The system packages will be built on. See the manual for the
+{ # The library to be used across pkgs.
+  lib ? import ../../lib
+
+, # The system packages will be built on. See the manual for the
   # subtle division of labor between these two `*System`s and the three
   # `*Platform`s.
   localSystem
@@ -47,8 +50,6 @@ let # Rename the function arguments
   crossSystem0 = crossSystem;
 
 in let
-  lib = import ../../lib;
-
   inherit (lib) throwIfNot;
 
   checked =


### PR DESCRIPTION
A broad attempt at fixing #156312-like issues. With this, the following flake works as expected:

```nix
{
  outputs = { nixpkgs, ... }: let
    lib = nixpkgs.lib.extend (final: prev: {
      licenses = prev.licenses // {
        sspl = prev.licenses.sspl // {
          shortName = "sspl";
        };
      };
    });
  in {
    nixosConfigurations.foo = lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        ./configuration.nix
        ({ lib, ... }: {
          nixpkgs.config.blocklistedLicenses = [ lib.licenses.sspl ];
        })
      ];
    };
  };
}
```

See each commit's description for details.

This will probably need release notes.

The type `lazyAttrsOf unspecified` for `nixpkgs.lib` is the most precise I could make it. With `attrsOf` we get warnings from trying to evaluate deprecated attributes, and with `anything` instead of `unspecified` there's a weird infinite recursion.