### PR TITLE
lib/modules: Add mkPostMerge

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -115,7 +115,7 @@ let
       applyIfFunction mergeModules
       mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
       pushDownProperties dischargeProperties filterOverrides
-      sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride
+      sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride mkPostMerge
       mkOptionDefault mkDefault mkImageMediaOverride mkForce mkVMOverride
       mkFixStrictness mkOrder mkBefore mkAfter mkAliasDefinitions
       mkAliasAndWrapDefinitions fixMergeModules mkRemovedOptionModule

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -621,30 +621,34 @@ rec {
   mergeDefinitions = loc: type: defs: rec {
     defsFinal' =
       let
+        # Extract the final map functions and unwrap their contents
+        defs' = extractPostMergeDefs defs;
+
         # Process mkMerge and mkIf properties.
-        defs' = concatMap (m:
+        defs'' = concatMap (m:
           map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
-        ) defs;
+        ) defs'.values;
 
         # Process mkOverride properties.
-        defs'' = filterOverrides' defs';
+        defs''' = filterOverrides' defs'';
 
         # Sort mkOrder properties.
-        defs''' =
+        defs'''' =
           # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defs''.values
-          then sortProperties defs''.values
-          else defs''.values;
+          if any (def: def.value._type or "" == "order") defs'''.values
+          then sortProperties defs'''.values
+          else defs'''.values;
       in {
-        values = defs''';
-        inherit (defs'') highestPrio;
+        postMergeFns = defs'.functions;
+        values = defs'''';
+        inherit (defs''') highestPrio;
       };
     defsFinal = defsFinal'.values;
 
     # Type-check the remaining definitions, and merge them. Or throw if no definitions.
     mergedValue =
       if isDefined then
-        if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
+        if all (def: type.check def.value) defsFinal then applyAll defsFinal'.postMergeFns (type.merge loc defsFinal)
         else let allInvalid = filter (def: ! type.check def.value) defsFinal;
         in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
       else
@@ -681,6 +685,8 @@ rec {
       map (mapAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
     else if cfg._type or "" == "override" then
       map (mapAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
+    else if cfg._type or "" == "postmerge" then
+      map (mapAttrs (n: v: mkPostMerge cfg.f v)) (pushDownProperties cfg.content)
     else # FIXME: handle mkOrder?
       [ cfg ];
 
@@ -707,6 +713,19 @@ rec {
         throw "‘mkIf’ called with a non-Boolean condition"
     else
       [ def ];
+
+  # Apply a list of functions starting from the left.
+  applyAll = functions: x:
+    foldl' (acc: f: f acc) x functions;
+
+  /* Given a list of config values, extract the map functions for later use
+     and unwrap the contents so they can be processed the same as the others.
+  */
+  extractPostMergeDefs = defs:
+    {
+      functions = map (def: def.value.f) (filter (def: def.value._type or "" == "postmerge") defs);
+      values = map (def: if def.value._type or ""  == "postmerge" then def // { value = def.value.content; } else def) defs;
+    };
 
   /* Given a list of config values, process the mkOverride properties,
      that is, return the values that have the highest (that is,
@@ -794,6 +813,11 @@ rec {
   mkOverride = priority: content:
     { _type = "override";
       inherit priority content;
+    };
+
+  mkPostMerge = f: content:
+    { _type = "postmerge";
+      inherit f content;
     };
 
   mkOptionDefault = mkOverride 1500; # priority of option defaults


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
NixOS provides the ability to forcibly set the value of an option and add to the value value of option but what is missing is a way to remove from an option's value. Currently the only way to achieve the same thing is with mkOverride but that is impractical if the module that is being overriden is non trivial. This change adds a new property that allows you to to provide an arbitrary function that gets applied to the merged value.
From my config the use of it looks like this:
```
qemu.options = lib.mkPostMerge (lib.remove "-device virtio-keyboard")
  [
    "-nographic"
    "-cpu host"
    "-device vfio-pci,host=0000:28:00.0"
    "-device vfio-pci,host=0000:28:00.1"
    "-device vfio-pci,host=0000:28:00.2"
    "-device vfio-pci,host=0000:28:00.3"
  ];
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
