### PR TITLE
hdrmerge: init at unstable-2020-11-12

### DIFF
--- a/pkgs/applications/graphics/hdrmerge/default.nix
+++ b/pkgs/applications/graphics/hdrmerge/default.nix
@@ -63,9 +63,9 @@ mkDerivation rec {
   ];
 
   postInstallPhase = ''
-      # Make a desktop item
-      mkdir -p $out/share/icons/ $out/share/applications/
-      cp ../data/images/logo.png $out/share/icons/hdrmerge.png
+    # Make a desktop item
+    mkdir -p $out/share/icons/ $out/share/applications/
+    cp ../data/images/logo.png $out/share/icons/hdrmerge.png
   '';
 
   meta = with lib; {

--- a/pkgs/applications/graphics/hdrmerge/default.nix
+++ b/pkgs/applications/graphics/hdrmerge/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, mkDerivation
+, fetchpatch
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, qtbase
+, wrapQtAppsHook
+, libraw
+, exiv2
+, zlib
+, alglib
+, pkg-config
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+mkDerivation rec {
+  pname = "hdrmerge";
+  version = "unstable-2020-11-12";
+  src = fetchFromGitHub {
+    owner = "jcelaya";
+    repo = "hdrmerge";
+    rev = "f5a2538cffe3e27bd9bea5d6a199fa211d05e6da";
+    sha256 = "1bzf9wawbdvdbv57hnrmh0gpjfi5hamgf2nwh2yzd4sh1ssfa8jz";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [ qtbase libraw exiv2 zlib alglib ];
+
+  cmakeFlags = [
+    "-DALGLIB_DIR:PATH=${alglib}"
+  ];
+
+  patches = [
+    (fetchpatch {
+      # patch FindAlglib.cmake to respect ALGLIB_DIR
+      # see https://github.com/jcelaya/hdrmerge/pull/213
+      name = "patch-hdrmerge-CMake.patch";
+      url = "https://github.com/mkroehnert/hdrmerge/commit/472b2dfe7d54856158aea3d5412a02d0bab1da4c.patch";
+      sha256 = "0jc713ajr4w08pfbi6bva442prj878nxp1fpl9112i3xj34x9sdi";
+    })
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "HDRMerge";
+      genericName = "HDR raw image merge";
+      desktopName = "HDRMerge";
+      comment = meta.description;
+      icon = "hdrmerge";
+      exec = "@out@/bin/hdrmerge -F";
+      categories = [ "Graphics" ];
+      mimeTypes = [ "image/x-dcraw" "image/x-adobe-dng" ];
+      terminal = false;
+    })
+  ];
+
+  postInstallPhase = ''
+      # Make a desktop item
+      mkdir -p $out/share/icons/ $out/share/applications/
+      cp ../data/images/logo.png $out/share/icons/hdrmerge.png
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jcelaya/hdrmerge";
+    description = "Combines two or more raw images into an HDR";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.paperdigits ];
+  };
+}

--- a/pkgs/development/libraries/alglib/default.nix
+++ b/pkgs/development/libraries/alglib/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, cmake, clang }:
+
+stdenv.mkDerivation rec {
+  pname = "alglib3";
+  version = "3.18.0";
+
+  src = fetchurl {
+    url = "https://www.alglib.net/translator/re/alglib-${version}.cpp.gpl.tgz";
+    sha256 = "0ag8dvcxzzp9riqvk4lhcbwhvh0lq54lbdnsbyr107rjfi2p1vlq";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    clang
+  ];
+
+  patches = [
+    ./patch-alglib-CMakeLists.patch
+  ];
+
+  meta = with lib; {
+    description = "Numerical analysis and data processing library";
+    homepage = "https://www.alglib.net/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ maintainers.paperdigits ];
+    longDescription = ''
+      ALGLIB is a cross-platform numerical analysis and data processing library. It supports several programming languages (C++, C#, Delphi) and several operating systems (Windows and POSIX, including Linux). ALGLIB features include:
+
+      * Data analysis (classification/regression, statistics)
+      * Optimization and nonlinear solvers
+      * Interpolation and linear/nonlinear least-squares fitting
+      * Linear algebra (direct algorithms, EVD/SVD), direct and iterative linear solvers
+      * Fast Fourier Transform and many other algorithms
+    '';
+  };
+}

--- a/pkgs/development/libraries/alglib/patch-alglib-CMakeLists.patch
+++ b/pkgs/development/libraries/alglib/patch-alglib-CMakeLists.patch
@@ -1,0 +1,23 @@
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,20 @@
++cmake_minimum_required(VERSION 2.8)
++
++project(alglib3 CXX)
++
++file(GLOB_RECURSE sources src/*.cpp)
++file(GLOB_RECURSE headers src/*.h)
++
++add_library(${PROJECT_NAME} STATIC ${sources} ${headers})
++
++install(
++  TARGETS ${PROJECT_NAME}
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
++
++install(
++  FILES ${headers}
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/alglib
++)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1277,6 +1277,8 @@ with pkgs;
 
   aldo = callPackage ../applications/radio/aldo { };
 
+  alglib = callPackage ../development/libraries/alglib { };
+
   almanah = callPackage ../applications/misc/almanah { };
 
   alpine-make-vm-image = callPackage ../tools/virtualization/alpine-make-vm-image { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25411,6 +25411,8 @@ with pkgs;
 
   haruna = libsForQt5.callPackage ../applications/video/haruna { };
 
+  hdrmerge = libsForQt5.callPackage ../applications/graphics/hdrmerge { };
+
   helix = callPackage ../applications/editors/helix { };
 
   icesl = callPackage ../applications/misc/icesl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To package this application.

Based on the flake package by @mkroehnert at https://codeberg.org/mkroehnert/nix-flakes/src/branch/hdrmerge-latest

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
