### PR TITLE
openssl: trim propagatedBuildOutputs to reduce closure size

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -152,6 +152,8 @@ let
       rmdir $out/etc/ssl/{certs,private}
     '';
 
+    propagatedBuildOutputs = [ "out" ];
+
     postFixup = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
       # Check to make sure the main output doesn't depend on perl
       if grep -r '${buildPackages.perl}' $out; then


### PR DESCRIPTION

###### Motivation for this change

I'd like to reduce the closure size of `openssl.dev` by removing the `propagatedBuildOutputs` dependency on `openssl.bin`. This benefits dependencies that don't require `openssl.bin`, such as `nodejs-slim`. 

This was previously discussed in https://github.com/NixOS/nixpkgs/pull/125240, which is where I learned about this patch.

With this change, the closure of `openssl.dev` shrinks by 56MB:

## Before:

```
> nix path-info -Shr ./result-dev
/nix/store/3rd24wjad31avvylb8z4kph632gjbrnq-libidn2-2.3.2          1.8M
/nix/store/4i8j2n8lmmc9pqar468fsx3dw3d7hv1b-openssl-1.1.1m        35.6M
/nix/store/6jd4pwngw10mbqzfxcwgjp6a2a658w5j-attr-2.5.1            31.7M
/nix/store/f2whkwjdawwcyxs2c6ldxr5axadihpk8-perl-5.34.0           86.6M
/nix/store/jy5vn8pmbbsgg2651dqp832f8n79sjia-openssl-1.1.1m-bin    91.4M
/nix/store/pcqj12x7hwc2kciyc0yj6qw04ndx4rfp-libunistring-0.9.10    1.6M
/nix/store/pm7hm97hs8fifq04csfg2cy3wi71biwf-openssl-1.1.1m-dev    92.7M
/nix/store/s99ykmdxh7cn5vx76vyh9y9k08rl79na-acl-2.3.1             31.8M
/nix/store/saw6nkqqqfx5xm1h5cpk7gxnxmw9wk47-glibc-2.33-62         31.6M
/nix/store/vizjhz04x6xl57x2vrpqa52j8q6rkjfh-coreutils-9.0         33.6M
```

## After:

```
nix path-info -Shr ./result-dev
/nix/store/3rd24wjad31avvylb8z4kph632gjbrnq-libidn2-2.3.2          1.8M
/nix/store/cqw026vs0kpbbvfqhnfhda3pkmia0ll0-openssl-1.1.1m        35.6M
/nix/store/idjqsdxzw5yv0y3i999vk2wdsm3vzyq8-openssl-1.1.1m-dev    36.9M
/nix/store/pcqj12x7hwc2kciyc0yj6qw04ndx4rfp-libunistring-0.9.10    1.6M
/nix/store/saw6nkqqqfx5xm1h5cpk7gxnxmw9wk47-glibc-2.33-62         31.6M
```

The closure size of `nodejs-slim` goes down from 180.4MB --> 126.6MB.

I have no idea what this might break. But I think it makes sense for these two outputs to be separate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
