### PR TITLE
nixos/polkit: Disable pkexec by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -230,6 +230,14 @@
       </listitem>
       <listitem>
         <para>
+          The polkit module now disables the <literal>pkexec</literal>
+          setuid wrapper by default because it introduces an additional
+          attack surface. It can be re-enabled using
+          <literal>security.polkit.enablePkexec</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>mailpile</literal> email webclient
           (<literal>services.mailpile</literal>) has been removed due to
           its reliance on python2.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -78,6 +78,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `services.kubernetes.addons.dashboard` was removed due to it being an outdated version.
 
+- The polkit module now disables the `pkexec` setuid wrapper by default because it introduces an additional attack surface. It can be re-enabled using `security.polkit.enablePkexec`.
+
 - The `mailpile` email webclient (`services.mailpile`) has been removed due to its reliance on python2.
 
 - The MoinMoin wiki engine (`services.moinmoin`) has been removed, because Python 2 is being retired from nixpkgs.

--- a/nixos/modules/programs/gamemode.nix
+++ b/nixos/modules/programs/gamemode.nix
@@ -53,7 +53,10 @@ in
     };
 
     security = {
-      polkit.enable = true;
+      polkit = {
+        enable = true;
+        enablePkexec = true;
+      };
       wrappers = mkIf cfg.enableRenice {
         gamemoded = {
           owner = "root";

--- a/nixos/modules/security/polkit.nix
+++ b/nixos/modules/security/polkit.nix
@@ -18,6 +18,8 @@ in
       description = "Whether to enable PolKit.";
     };
 
+    security.polkit.enablePkexec = lib.mkEnableOption "the pkexec setuid binary";
+
     security.polkit.extraConfig = mkOption {
       type = types.lines;
       default = "";
@@ -83,7 +85,7 @@ in
     security.pam.services.polkit-1 = {};
 
     security.wrappers = {
-      pkexec =
+      pkexec = lib.mkIf cfg.enablePkexec
         { setuid = true;
           owner = "root";
           group = "root";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Reduce attack surface.
This is not really tested yet which is why it's a draft.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
