### PR TITLE
phosh: 0.14.1 -> 0.15.0, phoc: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -43,7 +43,7 @@ let
   });
 in stdenv.mkDerivation rec {
   pname = "phoc";
-  version = "0.11.0";
+  version = "0.12.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     owner = "Phosh";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-oUZtJzclVRSbLG3flF3ryLuvp1kPUtYNsmCG0csSC2A=";
+    sha256 = "sha256-kfMM/YjgAktpOKHNcxxl1FPVbgATPDNRhEJ/sVT1LYs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -30,7 +30,7 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     repo = pname;
     rev = "v${version}";
     fetchSubmodules = true; # including gvc and libcall-ui which are designated as subprojects
-    sha256 = "sha256-FILSNVBYpWSPXeDb1Vc4jZ7zJMg0Gj6EY5yoc81gUr0=";
+    sha256 = "sha256-ZEfYjgSaj4vVdfgdIcg0PWwlFX90PIm5wvdn9P/8tvo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

See upstream changelogs for [Phosh](https://gitlab.gnome.org/World/Phosh/phosh/-/tags/v0.15.0) and [Phoc](https://gitlab.gnome.org/World/Phosh/phoc/-/tags/v0.12.0). Most notably, the lock screen now has a button to summon the on-screen keyboard so that arbitrary passwords can be entered.

Also note the required/recommended patches on other packages ([Phosh](https://gitlab.gnome.org/World/Phosh/phosh/-/tags/v0.15.0#required-patchesversions-off-other-projects), [Phoc](https://gitlab.gnome.org/World/Phosh/phoc/-/tags/v0.12.0)). A [new patch](https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/1074) for g-s-c has been added to the list for the "Add VPN" dialog (not included).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
