### PR TITLE
Change maintainer musfay to muscaln

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8799,10 +8799,10 @@
     githubId = 5047140;
     name = "Victor Collod";
   };
-  musfay = {
-    email = "musfay@protonmail.com";
-    github = "musfay";
-    githubId = 33374965;
+  muscaln = {
+    email = "muscaln@protonmail.com";
+    github = "muscaln";
+    githubId = 96225281;
     name = "Mustafa Çalışkan";
   };
   mupdt = {

--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -78,7 +78,7 @@ mkDerivation rec {
     description = "An open source prototyping tool for Arduino-based projects";
     homepage = "https://fritzing.org/";
     license = with licenses; [ gpl3 cc-by-sa-30 ];
-    maintainers = with maintainers; [ robberer musfay ];
+    maintainers = with maintainers; [ robberer muscaln ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/pico-sdk/default.nix
+++ b/pkgs/development/libraries/pico-sdk/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/raspberrypi/picotool";
     description = "SDK provides the headers, libraries and build system necessary to write programs for the RP2040-based devices";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ musfay ];
+    maintainers = with maintainers; [ muscaln ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/picotool/default.nix
+++ b/pkgs/development/tools/picotool/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/raspberrypi/picotool";
     description = "Tool for interacting with a RP2040 device in BOOTSEL mode, or with a RP2040 binary";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ musfay ];
+    maintainers = with maintainers; [ muscaln ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/cd-dvd/bootiso/default.nix
+++ b/pkgs/tools/cd-dvd/bootiso/default.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Script for securely creating a bootable USB device from one image file";
     homepage = "https://github.com/jsamr/bootiso";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ musfay ];
+    maintainers = with maintainers; [ muscaln ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/graphics/adriconf/default.nix
+++ b/pkgs/tools/graphics/adriconf/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.freedesktop.org/mesa/adriconf/";
     description = "A GUI tool used to configure open source graphics drivers";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ musfay ];
+    maintainers = with maintainers; [ muscaln ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/qdl/default.nix
+++ b/pkgs/tools/misc/qdl/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     homepage    = "https://github.com/andersson/qdl";
     description = "Tool for flashing images to Qualcomm devices";
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ musfay ];
+    maintainers = with maintainers; [ muscaln ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I just messed up my 2FA so i can no longer use @musfay. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
