### PR TITLE
razerCommander: init at 1.2.1.2

### DIFF
--- a/pkgs/os-specific/linux/razercommander/default.nix
+++ b/pkgs/os-specific/linux/razercommander/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, meson
+, ninja
+, pkg-config
+, fetchFromGitLab
+, python3
+, wrapGAppsHook
+, gtk3
+, glib
+, desktop-file-utils
+, gobject-introspection
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "razerCommander";
+  version = "1.2.1.2";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    owner = "gabmus";
+    repo = "razerCommander";
+    rev = version;
+    sha256 = "NiLKui1GfEqb5MfsWZ9SYuwLQLCf67sn8tMKy9yk3mw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    glib # for glib-compile-schemas
+    pkg-config
+    wrapGAppsHook
+    desktop-file-utils
+    gobject-introspection.setupHook
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+  ];
+
+  pythonPath = with python3.pkgs; [
+    pygobject3
+    openrazer
+  ];
+
+  # Work around setup hook issues https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  postPatch = ''
+    substituteInPlace razercommander/__main__.py \
+      --replace plugdev openrazer
+  '';
+
+  meta = with lib; {
+    description = "GTK contol center for managing razer peripherals on Linux";
+    homepage = "https://gitlab.com/gabmus/razerCommander";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27625,6 +27625,8 @@ with pkgs;
 
   qemacs = callPackage ../applications/editors/qemacs { };
 
+  razerCommander = callPackage ../os-specific/linux/razercommander { };
+
   rqbit = callPackage ../applications/networking/p2p/rqbit {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
###### Motivation for this change

GTK contol center for managing razer peripherals on Linux

https://gitlab.com/gabmus/razerCommander

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
