### PR TITLE
podman: make work on darwin

### DIFF
--- a/pkgs/applications/virtualization/podman/0001-Look-for-gvproxy-in-PATH.patch
+++ b/pkgs/applications/virtualization/podman/0001-Look-for-gvproxy-in-PATH.patch
@@ -1,0 +1,25 @@
+From f2883a5bfb099f7690518ac612f82aa7f7d30709 Mon Sep 17 00:00:00 2001
+From: Jason Felice <jason.m.felice@gmail.com>
+Date: Thu, 27 Jan 2022 13:55:05 -0500
+Subject: [PATCH] Look for gvproxy in PATH
+
+---
+ pkg/machine/qemu/machine.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/machine/qemu/machine.go b/pkg/machine/qemu/machine.go
+index ab1b6c7df..866b3d6a5 100644
+--- a/pkg/machine/qemu/machine.go
++++ b/pkg/machine/qemu/machine.go
+@@ -652,7 +652,7 @@ func (v *MachineVM) startHostNetworking() error {
+ 	if err != nil {
+ 		return err
+ 	}
+-	binary, err := cfg.FindHelperBinary(machine.ForwarderBinaryName, false)
++	binary, err := cfg.FindHelperBinary(machine.ForwarderBinaryName, true)
+ 	if err != nil {
+ 		return err
+ 	}
+-- 
+2.34.1
+

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -44,6 +44,14 @@ buildGoModule rec {
     systemd
   ];
 
+  patches = [
+    # Temporary fix for darwin.  This works because the wrapper correctly sets the
+    # path.  When 4.0.0 is released, this goes away and the wrapper should set
+    # $CONTAINERS_HELPER_BINARY_DIR instead:
+    # https://github.com/containers/podman/blob/main/vendor/github.com/containers/common/pkg/config/config.go#L1171
+    ./0001-Look-for-gvproxy-in-PATH.patch
+  ];
+
   buildPhase = ''
     runHook preBuild
     patchShebangs .

--- a/pkgs/applications/virtualization/podman/wrapper.nix
+++ b/pkgs/applications/virtualization/podman/wrapper.nix
@@ -2,6 +2,7 @@
 , runCommand
 , makeWrapper
 , lib
+, stdenv
 , extraPackages ? []
 , podman # Docker compat
 , runc # Default container runtime
@@ -13,12 +14,15 @@
 , cni-plugins # not added to path
 , iptables
 , iproute2
+, gvproxy
+, qemu
+, xz
 }:
 
 let
   podman = podman-unwrapped;
 
-  binPath = lib.makeBinPath ([
+  binPath = lib.makeBinPath ([ ] ++ lib.optionals stdenv.isLinux [
     runc
     crun
     conmon
@@ -27,6 +31,10 @@ let
     util-linux
     iptables
     iproute2
+  ] ++ lib.optionals stdenv.isDarwin [
+    gvproxy
+    qemu
+    xz
   ] ++ extraPackages);
 
 in runCommand podman.name {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8847,10 +8847,7 @@ with pkgs;
 
   podiff = callPackage ../tools/text/podiff { };
 
-  podman = if stdenv.isDarwin then
-    callPackage ../applications/virtualization/podman { }
-  else
-    callPackage ../applications/virtualization/podman/wrapper.nix { };
+  podman = callPackage ../applications/virtualization/podman/wrapper.nix { };
   podman-unwrapped = callPackage ../applications/virtualization/podman { };
 
   podman-compose = python3Packages.callPackage ../applications/virtualization/podman-compose {};


### PR DESCRIPTION
- podman: Use path to find gvproxy on Darwin
- Revert "podman: remove darwin wrapper"

###### Motivation for this change

Make podman work on Mac.

This is a temporary solution to #141041, with notes on how to work with upstream's change once 4.0.0 is released.

This restores the wrapper for darwin.  @zowoq mentions that this wrapper somehow wrote to the store, but I don't
see how that could be unless there is a problem with one of packages passed to lib.makeBinPath (in which case
removing the wrapper isn't the right fix).

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@marsam @zowoq

