### PR TITLE
[21.11] bundler: 2.2.24 -> 2.2.33

### DIFF
--- a/pkgs/development/ruby-modules/bundler/default.nix
+++ b/pkgs/development/ruby-modules/bundler/default.nix
@@ -4,8 +4,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "bundler";
-  version = "2.2.24";
-  source.sha256 = "1x3czmqhlyb593ap7mxkk47idi2jnbnrpwj8xlsjdpi7iair9y62";
+  version = "2.2.33";
+  source.sha256 = "0m06ywj0lq3ba2i7sdk7wsx8dfi94w3dkw8m7l2k54ix1pdx8vqa";
   dontPatchShebangs = true;
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Fix #150677

###### Things done
- Built on platform(s)
  - [x] x86_64-linux: bundler, anystyle-cli, metasploit, vagrant
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
