### PR TITLE
python3Packages.sentry-sdk: disable web test

### DIFF
--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -109,6 +109,8 @@ buildPythonPackage rec {
     "test_circular_references"
     # Failing wsgi test
     "test_session_mode_defaults_to_request_mode_in_wsgi_handler"
+    # Network requests to public web
+    "test_crumb_capture"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
###### Motivation for this change
Keep seeing this package create false negatives

example: https://github.com/NixOS/nixpkgs/pull/156946

```
______________________________ test_crumb_capture ______________________________
/nix/store/ivcvpckmabmn7p7sg1n1q85iipn2x8cq-python3.9-urllib3-1.26.7/lib/python3.9/site-packages/urllib3/connection.py:174: in _new_conn
    conn = connection.create_connection(
/nix/store/ivcvpckmabmn7p7sg1n1q85iipn2x8cq-python3.9-urllib3-1.26.7/lib/python3.9/site-packages/urllib3/util/connection.py:73: in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
/nix/store/i6vabb4div9iy6lsl642d86k1q8riasn-python3-3.9.9/lib/python3.9/socket.py:954: in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
E   socket.gaierror: [Errno -2] Name or service not known
...
/nix/store/23x8xw10z0slsdvy9jjnblvf0hyl78yh-python3.9-requests-2.26.0/lib/python3.9/site-packages/requests/adapters.py:516: in send
    raise ConnectionError(e, request=request)
E   requests.exceptions.ConnectionError: HTTPSConnectionPool(host='httpbin.org', port=443): Max retries exceeded with url: /status/418 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fffc9d30fa0>: Failed to establish a new
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
