### PR TITLE
Update and fix Linphone

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12503,6 +12503,12 @@
     githubId = 844343;
     name = "Thiago K. Okada";
   };
+  thibaultlemaire = {
+    email = "thibault.lemaire@protonmail.com";
+    github = "ThibaultLemaire";
+    githubId = 21345269;
+    name = "Thibault Lemaire";
+  };
   thibautmarty = {
     email = "github@thibautmarty.fr";
     matrix = "@thibaut:thibautmarty.fr";

--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -49,9 +49,25 @@
 , zlib
 }:
 
+# How to update Linphone? (The Qt desktop app)
+#
+# Belledonne Communications (BC), the company making Linphone, has split the
+# project into several sub-projects that they maintain, plus some third-party
+# dependencies that they also extend with commits of their own, specific to
+# Linphone and not (yet?) upstreamed.
+#
+# All of this is organised in a Software Development Kit (SDK) meta-repository
+# with git submodules to pin all those repositories into a coherent whole.
+#
+# The Linphone Qt desktop app uses this SDK as submodule as well.
+#
+# So, in order to update the desktop app to a new release, one has to follow
+# the submodule chain and update the corresponding derivations here, in nixpkgs,
+# with the corresponding version number (or commit hash)
+
 mkDerivation rec {
   pname = "linphone-desktop";
-  version = "4.2.5";
+  version = "4.4.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -59,12 +75,13 @@ mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1gq4l9p21rbrcksa7fbkzn9fzbbynqmn6ni6lhnvzk359sb1xvbz";
+    sha256 = "sha256-BBOTyKMZikkxMJSmzAuChVHpVeCvbAimn1K3REGbqEg=";
   };
 
   patches = [
     ./do-not-build-linphone-sdk.patch
     ./remove-bc_compute_full_version-usage.patch
+    ./no-store-path-in-autostart.patch
   ];
 
   # See: https://gitlab.linphone.org/BC/public/linphone-desktop/issues/21
@@ -78,12 +95,21 @@ mkDerivation rec {
   # there might be some build inputs here that aren't needed for
   # linphone-desktop.
   buildInputs = [
+    # Made by BC
     bcg729
     bctoolbox
     belcard
     belle-sip
     belr
     bzrtp
+    liblinphone
+    mediastreamer
+    mediastreamer-openh264
+    ortp
+
+    # Vendored by BC but we use upstream, might cause problems
+    libmatroska
+
     cairo
     cyrus_sasl
     ffmpeg
@@ -92,19 +118,14 @@ mkDerivation rec {
     gtk2
     libX11
     libexosip
-    liblinphone
-    libmatroska
     libnotify
     libosip
     libsoup
     libupnp
     libxml2
     mbedtls
-    mediastreamer
-    mediastreamer-openh264
     minizip2
     openldap
-    ortp
     pango
     qtbase
     qtgraphicaleffects
@@ -118,7 +139,9 @@ mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    # Made by BC
     bcunit
+
     cmake
     gnused
     graphviz
@@ -128,7 +151,6 @@ mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
     "-DMINIZIP_INCLUDE_DIRS=${minizip2}/include"
     "-DMINIZIP_LIBRARIES=minizip"
   ];
@@ -162,18 +184,25 @@ mkDerivation rec {
   # Linphone will randomly crash when it tries to access those files. Then,
   # those just need to be copied manually below.
   installPhase = ''
-    mkdir -p $out/bin
+    mkdir -p $out/bin $out/lib
     cp linphone-app/linphone $out/bin/
+    cp linphone-app/libapp-plugin.so $out/lib/
+    mkdir -p $out/lib/mediastreamer/plugins
+    ln -s ${mediastreamer-openh264}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
+    ln -s ${mediastreamer}/lib/mediastreamer/plugins/* $out/lib/mediastreamer/plugins/
     wrapProgram $out/bin/linphone \
       --set MEDIASTREAMER_PLUGINS_DIR \
-            ${mediastreamer-openh264}/lib/mediastreamer/plugins
+            $out/lib/mediastreamer/plugins
     mkdir -p $out/share/applications
     cp linphone-app/linphone.desktop $out/share/applications/
-    cp -r ../linphone-app/assets/icons $out/share/
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp ../linphone-app/assets/images/linphone_logo.svg $out/share/icons/hicolor/scalable/apps/linphone.svg
     mkdir -p $out/share/belr/grammars
     ln -s ${liblinphone}/share/belr/grammars/* $out/share/belr/grammars/
+    ln -s ${belle-sip}/share/belr/grammars/* $out/share/belr/grammars/
     mkdir -p $out/share/linphone
     ln -s ${liblinphone}/share/linphone/* $out/share/linphone/
+    ln -s ${liblinphone}/share/sounds $out/share/sounds
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/linphone/do-not-build-linphone-sdk.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/do-not-build-linphone-sdk.patch
@@ -1,30 +1,31 @@
-From 08b8b1811a1ad079fa713d19a8cc6bf2dc782bb7 Mon Sep 17 00:00:00 2001
-From: David P <megver83@parabola.nu>
-Date: Thu, 26 Nov 2020 15:56:30 -0300
-Subject: [PATCH 1/2] do not build linphone-sdk
+From e6a9992461f368d08d1ad63ffe454714ec0c59ce Mon Sep 17 00:00:00 2001
+From: Lorenz Brun <lorenz@brun.one>
+Date: Fri, 28 Jan 2022 02:36:01 +0100
+Subject: [PATCH] Remove Linphone SDK build
 
-Signed-off-by: David P <megver83@parabola.nu>
 ---
- CMakeLists.txt                                | 61 +------------------
- .../cmake_builder/additional_steps.cmake      |  9 ---
- 2 files changed, 3 insertions(+), 67 deletions(-)
+ CMakeLists.txt                                | 86 ++-----------------
+ .../cmake_builder/additional_steps.cmake      |  9 --
+ 2 files changed, 5 insertions(+), 90 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f7eb05f2..5921ee5b 100644
+index 2002b925..6d92a8e5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -118,7 +118,6 @@ list(APPEND APP_OPTIONS "-DENABLE_RELATIVE_PREFIX=${ENABLE_RELATIVE_PREFIX}")
- 
+@@ -152,7 +152,6 @@ list(APPEND APP_OPTIONS "-DENABLE_RELATIVE_PREFIX=${ENABLE_RELATIVE_PREFIX}")
  list(APPEND APP_OPTIONS "-DLINPHONE_OUTPUT_DIR=${LINPHONE_OUTPUT_DIR}")
+ list(APPEND APP_OPTIONS "-DENABLE_QT_GL=${ENABLE_VIDEO}")#Activate on video
  
 -include(ExternalProject)
  set(PROJECT_BUILD_COMMAND "")
  if(CMAKE_BUILD_PARALLEL_LEVEL)
  	list(APPEND APP_OPTIONS "-DCMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL}")
-@@ -136,29 +135,8 @@ if(UNIX AND NOT APPLE)
- 	set(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/lib64:$ORIGIN/../lib64:$ORIGIN/lib:$ORIGIN/../lib:${LINPHONE_OUTPUT_DIR}/${CMAKE_INSTALL_LIBDIR}")
- 	list(APPEND APP_OPTIONS "-DCMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH}")
+@@ -190,30 +189,8 @@ if(ENABLE_BUILD_APP_PLUGINS)
+ 	endif()
  endif()
+ 
+-
+-if(NOT LINPHONE_QT_ONLY)
 -ExternalProject_Add(sdk PREFIX "${CMAKE_BINARY_DIR}/sdk"
 -    SOURCE_DIR "${CMAKE_SOURCE_DIR}/linphone-sdk"
 -    INSTALL_DIR "${LINPHONE_OUTPUT_DIR}"
@@ -35,7 +36,7 @@ index f7eb05f2..5921ee5b 100644
 -    INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
 -    LIST_SEPARATOR | # Use the alternate list separator
 -    CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
--    #BUILD_ALWAYS NO #${DO_BUILD}
+-    BUILD_ALWAYS NO #${DO_BUILD}
 -)
 -ExternalProject_Add_Step(sdk force_build
 -	COMMENT "Forcing build for 'desktop'"
@@ -43,17 +44,16 @@ index f7eb05f2..5921ee5b 100644
 -	DEPENDERS build
 -	ALWAYS 1
 -)
+-endif()
  include(FindPkgConfig)
  
 -set(APP_DEPENDS sdk)
--
--
- find_package(Qt5 5.12 COMPONENTS Core REQUIRED)
+ find_package(Qt5 5.10 COMPONENTS Core REQUIRED)
  
  if ( NOT Qt5_FOUND )
-@@ -173,39 +151,6 @@ find_package(Mediastreamer2 CONFIG QUIET)
+@@ -227,62 +204,9 @@ find_package(belcard CONFIG QUIET)
+ find_package(Mediastreamer2 CONFIG QUIET)
  find_package(ortp CONFIG QUIET)
- 
  
 -if(NOT (LinphoneCxx_FOUND) OR NOT (Linphone_FOUND) OR NOT (bctoolbox_FOUND) OR NOT (belcard_FOUND) OR NOT (Mediastreamer2_FOUND) OR NOT (ortp_FOUND) OR FORCE_APP_EXTERNAL_PROJECTS)
 -	message("Projects are set as External projects. You can start building them by using for example : cmake --build . --target install")
@@ -63,23 +63,51 @@ index f7eb05f2..5921ee5b 100644
 -		BINARY_DIR "${CMAKE_BINARY_DIR}/linphone-app"
 -		DEPENDS ${APP_DEPENDS}
 -		BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
--		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step will not be done by external project"
+-		INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
 -		LIST_SEPARATOR | # Use the alternate list separator
 -		CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
 -	# ${APP_OPTIONS}
 -		BUILD_ALWAYS ON
 -	)
+-	if( ENABLE_BUILD_APP_PLUGINS)
+-		ExternalProject_Add(app-plugins PREFIX "${CMAKE_BINARY_DIR}/plugins-app"
+-			SOURCE_DIR "${CMAKE_SOURCE_DIR}/plugins"
+-			INSTALL_DIR "${APPLICATION_OUTPUT_DIR}"
+-			BINARY_DIR "${CMAKE_BINARY_DIR}/plugins-app"
+-			DEPENDS linphone-qt
+-			BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> ${PROJECT_BUILD_COMMAND}
+-			INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Install step is already done at build time."
+-			LIST_SEPARATOR | # Use the alternate list separator
+-			CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
+-		)
+-	endif()
 -	install(CODE "message(STATUS Running install)")
 -	set(AUTO_REGENERATION auto_regeneration)
--	add_custom_target(${AUTO_REGENERATION} ALL
--		COMMAND ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}
--		DEPENDS linphone-qt)
+-	if(	ENABLE_BUILD_APP_PLUGINS)
+-		add_custom_target(${AUTO_REGENERATION} ALL
+-			COMMAND ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}
+-			DEPENDS app-plugins)
+-	else()
+-		add_custom_target(${AUTO_REGENERATION} ALL
+-			COMMAND ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}
+-			DEPENDS linphone-qt)
+-	endif()
 -else()
 -	message("Adding Linphone Desktop in an IDE-friendly state")
 -	set(CMAKE_INSTALL_PREFIX "${APPLICATION_OUTPUT_DIR}")
 -	add_subdirectory(${CMAKE_SOURCE_DIR}/linphone-app)
--	add_dependencies(app-library ${APP_DEPENDS})
--endif()
+-	if(NOT LINPHONE_QT_ONLY)
+-		add_dependencies(app-library ${APP_DEPENDS})
+-	endif()
+-	if( ENABLE_BUILD_APP_PLUGINS)
+-		add_subdirectory(${CMAKE_SOURCE_DIR}/plugins "plugins-app")
+-	endif()
++message("Adding Linphone Desktop in an IDE-friendly state")
++set(CMAKE_INSTALL_PREFIX "${APPLICATION_OUTPUT_DIR}")
++add_subdirectory(${CMAKE_SOURCE_DIR}/linphone-app)
++if( ENABLE_BUILD_APP_PLUGINS)
++	add_subdirectory(${CMAKE_SOURCE_DIR}/plugins "plugins-app")
+ endif()
 -ExternalProject_Add(linphone-qt-only PREFIX "${CMAKE_BINARY_DIR}/linphone-app"
 -    SOURCE_DIR "${CMAKE_SOURCE_DIR}/linphone-app"
 -    INSTALL_DIR "${APPLICATION_OUTPUT_DIR}"
@@ -89,11 +117,8 @@ index f7eb05f2..5921ee5b 100644
 -    LIST_SEPARATOR | # Use the alternate list separator
 -    CMAKE_ARGS ${APP_OPTIONS} ${USER_ARGS} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_PREFIX_PATH=${PREFIX_PATH}
 -    EXCLUDE_FROM_ALL ON
--    BUILD_ALWAYS ON
+-    #BUILD_ALWAYS ON
 -)
-+message("Adding Linphone Desktop in an IDE-friendly state")
-+set(CMAKE_INSTALL_PREFIX "${APPLICATION_OUTPUT_DIR}")
-+add_subdirectory(${CMAKE_SOURCE_DIR}/linphone-app)
 diff --git a/linphone-app/cmake_builder/additional_steps.cmake b/linphone-app/cmake_builder/additional_steps.cmake
 index 7f7fd573..a69a04e8 100644
 --- a/linphone-app/cmake_builder/additional_steps.cmake
@@ -114,5 +139,5 @@ index 7f7fd573..a69a04e8 100644
    endif ()
  endif ()
 -- 
-2.29.2
+2.25.1
 

--- a/pkgs/applications/networking/instant-messengers/linphone/no-store-path-in-autostart.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/no-store-path-in-autostart.patch
@@ -1,0 +1,27 @@
+From 6a26922e5e4363de36057d635a1bf889160b2533 Mon Sep 17 00:00:00 2001
+From: Lorenz Brun <lorenz@brun.one>
+Date: Fri, 28 Jan 2022 18:44:43 +0100
+Subject: [PATCH] Do not use store path for autostart on Nix
+
+---
+ linphone-app/src/app/App.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/linphone-app/src/app/App.cpp b/linphone-app/src/app/App.cpp
+index 868f8f44..2c61c648 100644
+--- a/linphone-app/src/app/App.cpp
++++ b/linphone-app/src/app/App.cpp
+@@ -858,6 +858,10 @@ void App::setAutoStart (bool enabled) {
+ 		exec = QProcessEnvironment::systemEnvironment().value(QStringLiteral("APPIMAGE"));
+ 		qDebug() << "exec path autostart set appimage=" << exec;
+ 	}
++	else if (binPath.startsWith("/nix/store")) { // Nix/NixOS
++		exec = QStringLiteral("linphone");
++		qDebug() << "exec path autostart set nix=" << exec;
++	}
+ 	else { //classic package
+ 		exec = binPath;
+ 		qDebug() << "exec path autostart set classic package=" << exec;
+-- 
+2.25.1
+

--- a/pkgs/applications/networking/instant-messengers/linphone/remove-bc_compute_full_version-usage.patch
+++ b/pkgs/applications/networking/instant-messengers/linphone/remove-bc_compute_full_version-usage.patch
@@ -1,7 +1,7 @@
-From 6fc23da651d54979e73776fcda38614e290d65dc Mon Sep 17 00:00:00 2001
+From 4849d5633b98e6d3514355436eab5ba537cbfd99 Mon Sep 17 00:00:00 2001
 From: David P <megver83@parabola.nu>
 Date: Fri, 23 Oct 2020 16:44:17 -0300
-Subject: [PATCH 2/2] remove bc_compute_full_version usage
+Subject: [PATCH] remove bc_compute_full_version usage
 
 ---
  linphone-app/CMakeLists.txt                           | 11 +----------
@@ -10,7 +10,7 @@ Subject: [PATCH 2/2] remove bc_compute_full_version usage
  3 files changed, 2 insertions(+), 24 deletions(-)
 
 diff --git a/linphone-app/CMakeLists.txt b/linphone-app/CMakeLists.txt
-index 3bc9420a..27b418ee 100644
+index de7f917f..ee14ff78 100644
 --- a/linphone-app/CMakeLists.txt
 +++ b/linphone-app/CMakeLists.txt
 @@ -21,17 +21,8 @@
@@ -30,8 +30,8 @@ index 3bc9420a..27b418ee 100644
 -
 -project(linphoneqt VERSION "${version_major}.${version_minor}.${version_patch}")
  
+ 
  if(ENABLE_BUILD_VERBOSE)
- 	#message("CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH}")
 diff --git a/linphone-app/build/CMakeLists.txt b/linphone-app/build/CMakeLists.txt
 index 8ef03faa..97d94bd6 100644
 --- a/linphone-app/build/CMakeLists.txt
@@ -49,7 +49,7 @@ index 8ef03faa..97d94bd6 100644
  
  set(CPACK_SOURCE_PACKAGE_FILE_NAME ${CPACK_PACKAGE_FILE_NAME})
 diff --git a/linphone-app/cmake_builder/linphone_package/CMakeLists.txt b/linphone-app/cmake_builder/linphone_package/CMakeLists.txt
-index baea03cf..08ffc1b5 100644
+index ac85c68a..e6af5a66 100644
 --- a/linphone-app/cmake_builder/linphone_package/CMakeLists.txt
 +++ b/linphone-app/cmake_builder/linphone_package/CMakeLists.txt
 @@ -38,15 +38,7 @@ set(LINPHONE_QML_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../ui")
@@ -70,5 +70,5 @@ index baea03cf..08ffc1b5 100644
  endif ()
  string(REGEX REPLACE "([0-9.]+)-?.*" "\\1" LINPHONE_VERSION "${APP_PROJECT_VERSION}")
 -- 
-2.29.2
+2.25.1
 

--- a/pkgs/development/libraries/bc-decaf/default.nix
+++ b/pkgs/development/libraries/bc-decaf/default.nix
@@ -1,0 +1,36 @@
+{ cmake
+, fetchFromGitLab
+, lib
+, python3
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bc-decaf";
+  version = "linphone-4.4.1";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    python3
+  ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    group = "BC";
+    owner = "public/external";
+    repo = "decaf";
+    rev = "6e78a9beb24d1e3d7050dd52a65e4f88b101a1fc";
+    sha256 = "sha256-D2SzkinloL0Ya9p25YUsc+7lKvoTMUsdkKrkv/5AEeY=";
+  };
+
+  # Do not build static libraries and do not enable -Werror
+  cmakeFlags = [ "-DENABLE_STATIC=NO" "-DENABLE_STRICT=NO" ];
+
+  meta = with lib; {
+    description = "Elliptic curve library supporting Ed448-Goldilocks and Curve25519. Belledonne Communications' fork for Linphone.";
+    homepage = "https://gitlab.linphone.org/BC/public/bctoolbox";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thibaultlemaire ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/bctoolbox/default.nix
+++ b/pkgs/development/libraries/bctoolbox/default.nix
@@ -1,16 +1,28 @@
 { bcunit
 , cmake
+, bc-decaf
 , fetchFromGitLab
 , mbedtls
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "bctoolbox";
   version = "5.1.17";
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ mbedtls bcunit ];
+  nativeBuildInputs = [
+    cmake
+  ];
+  buildInputs = [
+    # Made by BC
+    bcunit
+
+    # Vendored by BC
+    bc-decaf
+
+    mbedtls
+  ];
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -22,9 +34,7 @@ stdenv.mkDerivation rec {
   };
 
   # Do not build static libraries
-  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
-
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=stringop-truncation" ];
+  cmakeFlags = [ "-DENABLE_STATIC=NO" "-DENABLE_STRICT=NO" ];
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/belcard/default.nix
+++ b/pkgs/development/libraries/belcard/default.nix
@@ -2,12 +2,13 @@
 , belr
 , cmake
 , fetchFromGitLab
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "belcard";
-  version = "5.1.10";
+  version = "5.1.12";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -25,7 +26,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   meta = with lib; {
-    description = "C++ library to manipulate VCard standard format";
+    description = "C++ library to manipulate VCard standard format. Part of the Linphone project.";
     homepage = "https://gitlab.linphone.org/BC/public/belcard";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/libraries/belle-sip/default.nix
+++ b/pkgs/development/libraries/belle-sip/default.nix
@@ -1,5 +1,5 @@
-{ antlr3_4
-, bctoolbox
+{ bctoolbox
+, belr
 , cmake
 , fetchFromGitLab
 , lib
@@ -11,18 +11,18 @@
 
 stdenv.mkDerivation rec {
   pname = "belle-sip";
-  version = "4.5.14";
+  version = "linphone-4.4.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-L6dhgBJrzYgBuMNd2eMZJCqB/GIZjKipfn1SffxBFWw=";
+    rev = "44d5977570280763ee1fecdb920736715bad58a3";
+    sha256 = "sha256-w++v3YlDZfpCHAbUQA/RftjRNGkz9J/zYoxZqRgtvnA=";
   };
 
-  nativeBuildInputs = [ antlr3_4 cmake ];
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [ zlib ];
 
@@ -36,11 +36,11 @@ stdenv.mkDerivation rec {
     "-Wno-error=stringop-overflow"
   ];
 
-  propagatedBuildInputs = [ libantlr3c mbedtls bctoolbox ];
+  propagatedBuildInputs = [ libantlr3c mbedtls bctoolbox belr ];
 
   meta = with lib; {
     homepage = "https://linphone.org/technical-corner/belle-sip";
-    description = "Modern library implementing SIP (RFC 3261) transport, transaction and dialog layers";
+    description = "Modern library implementing SIP (RFC 3261) transport, transaction and dialog layers. Part of the Linphone project.";
     license = licenses.gpl3Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ jluttine ];

--- a/pkgs/development/libraries/belr/default.nix
+++ b/pkgs/development/libraries/belr/default.nix
@@ -1,12 +1,13 @@
 { bctoolbox
 , cmake
 , fetchFromGitLab
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "belr";
-  version = "5.1.3";
+  version = "5.1.12";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   meta = with lib; {
-    description = "Belledonne Communications' language recognition library";
+    description = "Belledonne Communications' language recognition library. Part of the Linphone project.";
     homepage = "https://gitlab.linphone.org/BC/public/belr";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/libraries/bzrtp/default.nix
+++ b/pkgs/development/libraries/bzrtp/default.nix
@@ -2,12 +2,13 @@
 , cmake
 , fetchFromGitLab
 , sqlite
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "bzrtp";
-  version = "5.1.0";
+  version = "5.1.12";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -22,12 +23,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   # Do not build static libraries
-  cmakeFlags = [ "-DENABLE_STATIC=NO" ];
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=cast-function-type";
+  cmakeFlags = [ "-DENABLE_STATIC=NO" "-DCMAKE_C_FLAGS=-Wno-error=cast-function-type" ];
 
   meta = with lib; {
-    description = "An opensource implementation of ZRTP keys exchange protocol";
+    description = "An opensource implementation of ZRTP keys exchange protocol. Part of the Linphone project.";
     homepage = "https://gitlab.linphone.org/BC/public/bzrtp";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/libraries/liblinphone/default.nix
+++ b/pkgs/development/libraries/liblinphone/default.nix
@@ -16,6 +16,7 @@
 , graphviz
 , gtk2
 , intltool
+, jsoncpp
 , libexosip
 , libmatroska
 , libnotify
@@ -34,11 +35,12 @@
 , pkg-config
 , python3
 , readline
-, soci
+, bc-soci
 , boost
 , speex
 , sqlite
-, lib, stdenv
+, lib
+, stdenv
 , udev
 , xercesc
 , xsd
@@ -47,7 +49,7 @@
 
 stdenv.mkDerivation rec {
   pname = "liblinphone";
-  version = "4.5.17";
+  version = "5.1.22";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -55,8 +57,10 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ryyT4bG3lnE72ydvCAoiT3IeHY4mZwX9nCqaTRC1wyc=";
+    sha256 = "sha256-hTyp/fUA1+7J1MtqX33kH8Vn1XNjx51Wy5REvrpdJTY=";
   };
+
+  patches = [ ./use-normal-jsoncpp.patch ];
 
   # Do not build static libraries
   cmakeFlags = [ "-DENABLE_STATIC=NO" ];
@@ -66,12 +70,24 @@ stdenv.mkDerivation rec {
   # of them might not be needed for liblinphone alone.
   buildInputs = [
     (python3.withPackages (ps: [ ps.pystache ps.six ]))
+
+    # Made by BC
     bcg729
     bctoolbox
     belcard
     belle-sip
     belr
     bzrtp
+    lime
+    mediastreamer
+    ortp
+
+    # Vendored by BC
+    bc-soci
+
+    # Vendored by BC but we use upstream, might cause problems
+    libmatroska
+
     cairo
     cyrus_sasl
     ffmpeg
@@ -80,20 +96,15 @@ stdenv.mkDerivation rec {
     gtk2
     libX11
     libexosip
-    libmatroska
     libnotify
     libosip
     libsoup
     libupnp
     libxml2
-    lime
     mbedtls
-    mediastreamer
     openldap
-    ortp
     pango
     readline
-    soci
     boost
     speex
     sqlite
@@ -101,10 +112,13 @@ stdenv.mkDerivation rec {
     xercesc
     xsd
     zlib
+    jsoncpp
   ];
 
   nativeBuildInputs = [
+    # Made by BC
     bcunit
+
     cmake
     doxygen
     graphviz

--- a/pkgs/development/libraries/liblinphone/use-normal-jsoncpp.patch
+++ b/pkgs/development/libraries/liblinphone/use-normal-jsoncpp.patch
@@ -1,0 +1,57 @@
+From ea6901c9ed0f804bd2d6d09e514610518c2f4f09 Mon Sep 17 00:00:00 2001
+From: Lorenz Brun <lorenz@brun.one>
+Date: Fri, 18 Mar 2022 17:36:22 +0100
+Subject: [PATCH] Use normal jsoncpp
+
+---
+ src/CMakeLists.txt    | 6 +++---
+ tester/CMakeLists.txt | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 5cd87fe9a..822b2151e 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -34,7 +34,7 @@ if (ENABLE_FLEXIAPI)
+ 	if (XCODE)
+ 		list(APPEND LINK_LIBS jsoncpp_static)
+ 	else()
+-		list(APPEND LINK_LIBS jsoncpp_object)
++		list(APPEND LINK_LIBS jsoncpp)
+ 	endif()
+ endif()
+ 
+@@ -592,7 +592,7 @@ if(ENABLE_STATIC)
+ 		if (XCODE)
+ 			target_link_libraries(linphone PRIVATE jsoncpp_static)
+ 		else()
+-			target_link_libraries(linphone PRIVATE jsoncpp_object)
++			target_link_libraries(linphone PRIVATE jsoncpp)
+ 		endif()
+ 	endif()
+ 
+@@ -646,7 +646,7 @@ if(ENABLE_SHARED)
+ 		if (XCODE)
+ 			target_link_libraries(linphone PRIVATE jsoncpp_static)
+ 		else()
+-			target_link_libraries(linphone PRIVATE jsoncpp_object)
++			target_link_libraries(linphone PRIVATE jsoncpp)
+ 		endif()
+ 	endif()
+ 
+diff --git a/tester/CMakeLists.txt b/tester/CMakeLists.txt
+index b97042678..b4c5a5794 100644
+--- a/tester/CMakeLists.txt
++++ b/tester/CMakeLists.txt
+@@ -34,7 +34,7 @@ if (ENABLE_FLEXIAPI)
+ 	if (XCODE)
+ 		list(APPEND OTHER_LIBS_FOR_TESTER jsoncpp_static)
+ 	else()
+-		list(APPEND OTHER_LIBS_FOR_TESTER jsoncpp_object)
++		list(APPEND OTHER_LIBS_FOR_TESTER jsoncpp)
+ 	endif()
+ endif()
+ 
+-- 
+2.25.1
+

--- a/pkgs/development/libraries/lime/default.nix
+++ b/pkgs/development/libraries/lime/default.nix
@@ -3,7 +3,7 @@
 , cmake
 , fetchFromGitLab
 , lib
-, soci
+, bc-soci
 , sqlite
 , boost
 , stdenv
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation rec {
   pname = "lime";
-  version = "5.0.53";
+  version = "5.1.12";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -19,17 +19,27 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "sha256-M+KdauIVsN3c+cEPw4CaMzXnQZwAPNXeJCriuk9NCWM=";
+    sha256 = "sha256-vgaxb8sfgtAhqG8kg3C4+UrTOHyTVR9QVO9iuKFgSBk=";
   };
 
-  buildInputs = [ bctoolbox soci belle-sip sqlite boost ];
+  buildInputs = [
+    # Made by BC
+    bctoolbox
+    belle-sip
+
+    # Vendored by BC
+    bc-soci
+
+    sqlite
+    boost
+  ];
   nativeBuildInputs = [ cmake ];
 
   # Do not build static libraries
   cmakeFlags = [ "-DENABLE_STATIC=NO" ];
 
   meta = with lib; {
-    description = "End-to-end encryption library for instant messaging";
+    description = "End-to-end encryption library for instant messaging. Part of the Linphone project.";
     homepage = "http://www.linphone.org/technical-corner/lime";
     license = licenses.gpl3Only;
     platforms = platforms.all;

--- a/pkgs/development/libraries/mediastreamer/msopenh264.nix
+++ b/pkgs/development/libraries/mediastreamer/msopenh264.nix
@@ -5,22 +5,21 @@
 , mediastreamer
 , openh264
 , pkg-config
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "msopenh264";
-  # Using master branch for linphone-desktop caused a chain reaction that many
-  # of its dependencies needed to use master branch too.
-  version = "unstable-2020-03-03";
+  version = "linphone-4.4.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
     owner = "public";
     group = "BC";
     repo = pname;
-    rev = "2c3abf52824ad23a4caae7565ef158ef91767704";
-    sha256 = "140hs5lzpshzswvl39klcypankq3v2qck41696j22my7s4wsa0hr";
+    rev = "5603a432be2ed10f5d5a5ce068ef83ab2a996d6b";
+    sha256 = "sha256-AqZ7tsNZw2Djgyo1JBJbT/c3eQVyEn6r3CT6DQLD/B8=";
   };
 
   nativeBuildInputs = [ autoreconfHook cmake pkg-config ];
@@ -40,7 +39,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "H.264 encoder/decoder plugin for mediastreamer2";
+    description = "H.264 encoder/decoder plugin for mediastreamer2. Part of the Linphone project.";
     homepage = "https://www.linphone.org/technical-corner/mediastreamer2";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/ortp/default.nix
+++ b/pkgs/development/libraries/ortp/default.nix
@@ -1,12 +1,13 @@
 { bctoolbox
 , cmake
 , fetchFromGitLab
-, lib, stdenv
+, lib
+, stdenv
 }:
 
 stdenv.mkDerivation rec {
   pname = "ortp";
-  version = "4.5.1";
+  version = "5.1.12";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     group = "BC";
     repo = pname;
     rev = version;
-    sha256 = "1lc1j7wvkyp5lhcflq3h5y7n8aiwgwj84ffm81ggbsmavamgwkk7";
+    sha256 = "sha256-CD9xn1m6zpUEC+shmNeWfGAJxNto87UbznD+TLdeuEg=";
   };
 
   # Do not build static libraries
@@ -26,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {
-    description = "A Real-Time Transport Protocol (RFC3550) stack";
+    description = "A Real-Time Transport Protocol (RFC3550) stack. Part of the Linphone project.";
     homepage = "https://linphone.org/technical-corner/ortp";
     license = licenses.gpl3Plus;
     platforms = platforms.all;

--- a/pkgs/development/libraries/soci/bc-soci.nix
+++ b/pkgs/development/libraries/soci/bc-soci.nix
@@ -1,0 +1,53 @@
+{ cmake
+, fetchFromGitLab
+, fetchpatch
+, sqlite
+, boost
+, lib
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bc-soci";
+  version = "linphone-4.4.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.linphone.org";
+    group = "BC";
+    owner = "public/external";
+    repo = "soci";
+    rev = "bc8ce0c5628dd48eca6ef5ce0a0a2f52547d88b6";
+    sha256 = "sha256-qo26aYp/G2C6UkGA1qkHQwTKD5go7TQ9JWxb9xtbe6M=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-backend-search-path.patch";
+      url = "https://github.com/SOCI/soci/commit/56c93afc467bdba8ffbe68739eea76059ea62f7a.patch";
+      sha256 = "sha256-nC/39pn3Cv5e65GgIfF3l64/AbCsfZHPUPIWETZFZAY=";
+    })
+  ];
+
+  cmakeFlags = [
+    # Do not build static libraries
+    "-DSOCI_SHARED=YES"
+    "-DSOCI_STATIC=OFF"
+
+    "-DSOCI_TESTS=NO"
+    "-DWITH_SQLITE3=YES"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [
+    sqlite
+    boost
+  ];
+
+  meta = with lib; {
+    description = "Database access library for C++. Belledonne Communications' fork for Linphone.";
+    homepage = "https://gitlab.linphone.org/BC/public/external/soci";
+    license = licenses.boost;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ thibaultlemaire ];
+  };
+}

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -5,9 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "bcunit";
-  # Latest release 3.0.2 is missing some functions needed by bctoolbox. See:
-  # https://gitlab.linphone.org/BC/public/bcunit/issues/1
-  version = "unstable-2019-11-19";
+  version = "linphone-4.4.1";
 
   nativeBuildInputs = [ cmake ];
   src = fetchFromGitLab {
@@ -15,12 +13,12 @@ stdenv.mkDerivation rec {
     owner = "public";
     group = "BC";
     repo = pname;
-    rev = "3c720fbf67dd3c02b0c7011ed4036982b2c93532";
-    sha256 = "1237hpmkls2igp60gdfkbknxpgwvxn1vmv2m41vyl25xw1d3g35w";
+    rev = "c5eebcc7f794e9567d3c72d15d3f28bffe6bfd0f";
+    sha256 = "sha256-8DSfqHerx/V00SJjTSQaG9Rjqx330iG6sGivBDUvQfA=";
   };
 
   meta = with lib; {
-    description = "A fork of CUnit test framework";
+    description = "Belledonne Communications' fork of CUnit test framework. Part of the Linphone project.";
     homepage = "https://gitlab.linphone.org/BC/public/bcunit";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ raskin jluttine ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6964,6 +6964,8 @@ with pkgs;
 
   darkice = callPackage ../tools/audio/darkice { };
 
+  bc-decaf = callPackage ../development/libraries/bc-decaf { };
+
   deco = callPackage ../applications/misc/deco { };
 
   icoutils = callPackage ../tools/graphics/icoutils { };
@@ -16540,6 +16542,8 @@ with pkgs;
 
   bctoolbox = callPackage ../development/libraries/bctoolbox { };
 
+  bc-soci = callPackage ../development/libraries/soci/bc-soci.nix { };
+
   bearssl = callPackage ../development/libraries/bearssl { };
 
   beecrypt = callPackage ../development/libraries/beecrypt { };
@@ -19455,7 +19459,7 @@ with pkgs;
 
   mdds = callPackage ../development/libraries/mdds { };
 
-  mediastreamer = callPackage ../development/libraries/mediastreamer { };
+  mediastreamer = libsForQt5.callPackage ../development/libraries/mediastreamer { };
 
   mediastreamer-openh264 = callPackage ../development/libraries/mediastreamer/msopenh264.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
Linphone in Nix is currently quite broken, it doesn't even launch without fixes since at least a few months. See #144577.
Additionally lots of features were broken, including the desktop icon, ringtones and video calling.

###### Things done
This change bumps Linphone to 4.4.1 and fixes a bunch of broken things. I've successfully tested ICE-enabled encrypted video calls and all starter-related things now look fine (including the autostarter). This contains lots of library updates, but most of them are just libraries by the authors of Linphone itself.

Thanks to @ThibaultLemaire who co-authored this and fixed issues with Linphone's own account system. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
