### PR TITLE
zutty: init at 0.11

### DIFF
--- a/pkgs/applications/terminal-emulators/zutty/default.nix
+++ b/pkgs/applications/terminal-emulators/zutty/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, wafHook
+, python3
+, pkg-config
+, freetype
+, libglvnd
+, libXmu
+, fontmiscmisc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zutty";
+  version = "0.11";
+
+  src = fetchFromGitHub {
+    owner = "tomszilagyi";
+    repo = pname;
+    rev = version;
+    hash = "sha256-OUBGNLasFo1EmlpDE31CVu7u7B+cWcCB7ASqfU56i4k=";
+  };
+
+  nativeBuildInputs = [
+    wafHook
+    python3
+    pkg-config
+  ];
+
+  buildInputs = [
+    freetype
+    libglvnd
+    libXmu
+  ];
+
+  postPatch = ''
+    substituteInPlace src/options.h \
+      --replace '/usr/share/fonts' '${fontmiscmisc}/lib/X11/fonts/misc'
+  '';
+
+  postInstall = ''
+    install -Dm644 -t $out/share/doc/${pname} doc/*
+  '';
+
+  meta = with lib; {
+    homepage = "https://tomscii.sig7.se/zutty/";
+    description = "A high-end terminal for low-end systems";
+    longDescription = ''
+      Zutty is a terminal emulator for the X Window System, functionally
+      similar to several other X terminal emulators such as xterm, rxvt and
+      countless others. It is also similar to other, much more modern,
+      GPU-accelerated terminal emulators such as Alacritty and Kitty. What
+      really sets Zutty apart is its radically simple, yet extremely efficient
+      rendering implementation, coupled with a sufficiently complete feature
+      set to make it useful for a wide range of users. Zutty offers high
+      throughput with low latency, and strives to conform to relevant
+      (published or de-facto) standards.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ gravndal ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1213,6 +1213,8 @@ with pkgs;
 
   yaft = callPackage ../applications/terminal-emulators/yaft { };
 
+  zutty = callPackage ../applications/terminal-emulators/zutty { fontmiscmisc = xorg.fontmiscmisc; };
+
   aldo = callPackage ../applications/radio/aldo { };
 
   almanah = callPackage ../applications/misc/almanah { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
