### PR TITLE
btdu: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1077,6 +1077,12 @@
     githubId = 55833;
     name = "Troels Henriksen";
   };
+  atila = {
+    name = "Átila Saraiva";
+    email = "atilasaraiva@gmail.com";
+    github = "AtilaSaraiva";
+    githubId = 29521461;
+  };
   atkinschang = {
     email = "atkinschang+nixpkgs@gmail.com";
     github = "AtkinsChang";

--- a/pkgs/tools/misc/btdu/default.nix
+++ b/pkgs/tools/misc/btdu/default.nix
@@ -1,0 +1,83 @@
+{stdenv, lib, fetchurl, dub, ncurses, ldc, zlib, removeReferencesTo }:
+
+let
+    _d_ae_ver              = "0.0.3100";
+    _d_btrfs_ver           = "0.0.12";
+    _d_ncurses_ver         = "0.0.149";
+    _d_emsi_containers_ver = "0.9.0";
+in
+stdenv.mkDerivation rec {
+    pname = "btdu";
+    version = "0.3.1";
+
+    srcs = [
+      (fetchurl {
+        url = "https://github.com/CyberShadow/${pname}/archive/v${version}.tar.gz";
+        sha256 = "760b2f0d28920a78b7967dd34c429125135688a3aefc57ab3a92d07bc3ef10cb";
+      })
+      (fetchurl {
+        url = "https://github.com/CyberShadow/ae/archive/v${_d_ae_ver}.tar.gz";
+        sha256 = "86fa09ef6c1be4cbe8ad1c85729054e5d691b41ff57c7980d99937ec0f45b950";
+      })
+      (fetchurl {
+        url = "https://github.com/CyberShadow/d-btrfs/archive/v${_d_btrfs_ver}.tar.gz";
+        sha256 = "cf2b1fa3e94a0aa239d465adbac239514838835283521d632f571948aa517f92";
+      })
+      (fetchurl {
+        url = "https://github.com/D-Programming-Deimos/ncurses/archive/v${_d_ncurses_ver}.tar.gz";
+        sha256 = "2c8497f5dd93f9d3a05ca7ed57c4fcaee1e988fd25a24de106917ddf72f34646";
+      })
+      (fetchurl {
+        url = "https://github.com/dlang-community/containers/archive/v${_d_emsi_containers_ver}.tar.gz";
+        sha256 = "5e256b84bbdbd2bd625cba0472ea27a1fde6d673d37a85fe971a20d52874acaa";
+      })
+    ];
+
+    sourceRoot = ".";
+
+    postUnpack = ''
+      mv ae-${_d_ae_ver} "ae"
+    '';
+
+
+    nativeBuildInputs = [ dub ldc ];
+    buildInputs = [ ncurses zlib ];
+
+    configurePhase = ''
+      runHook preConfigure
+      mkdir home
+      HOME="home" dub add-local ae ${_d_ae_ver}
+      HOME="home" dub add-local d-btrfs-${_d_btrfs_ver} ${_d_btrfs_ver}
+      HOME="home" dub add-local ncurses-${_d_ncurses_ver} ${_d_ncurses_ver}
+      HOME="home" dub add-local containers-${_d_emsi_containers_ver} ${_d_emsi_containers_ver}
+      runHook postConfigure
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      cd ${pname}-${version}
+      HOME="../home" dub --skip-registry=all build -b release
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp btdu $out/bin/
+      runHook postInstall
+    '';
+
+    postInstall = ''
+      ${removeReferencesTo}/bin/remove-references-to -t ${ldc} $out/bin/btdu
+    '';
+
+    passthru.updateScript = ./update.py;
+
+    meta = with lib; {
+      description = "Sampling disk usage profiler for btrfs";
+      homepage = "https://github.com/CyberShadow/btdu";
+      license = licenses.gpl2Only;
+      platforms = platforms.linux;
+      maintainers = with maintainers; [ atila ];
+    };
+}

--- a/pkgs/tools/misc/btdu/update.py
+++ b/pkgs/tools/misc/btdu/update.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p python39Packages.requests
+
+import requests
+import subprocess
+
+pkgbuild = requests.get('https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=btdu').text
+
+def grabDepVersions(depDict, pkgbuild=pkgbuild):
+    for line in pkgbuild.split('\n'):
+        if depDict["string"] in line:
+            start = len(depDict["string"]) + 1
+            depDict["version"] = line[start:]
+            break
+
+def grabDepHashes(key,pkgbuild=pkgbuild):
+    start = pkgbuild.find(key) + len(key)
+    end = start+64
+    hashes = []
+    for i in range(5):
+        hashes.append(pkgbuild[start:end])
+        start     = pkgbuild.find("'",end+1) + 1
+        end       = start+64
+    return hashes
+
+def findLine(key,derivation):
+    count = 0
+    lines = []
+    for line in derivation:
+        if key in line:
+            lines.append(count)
+        count += 1
+    return lines
+
+def updateVersions(btdu,ae,btrfs,ncurses,containers,derivation):
+    key = "let"
+    line = findLine(key,derivation)[0] + 1
+    derivation[line+0] = f'    _d_ae_ver              = "{ae["version"]}";\n'
+    derivation[line+1] = f'    _d_btrfs_ver           = "{btrfs["version"]}";\n'
+    derivation[line+2] = f'    _d_ncurses_ver         = "{ncurses["version"]}";\n'
+    derivation[line+3] = f'    _d_emsi_containers_ver = "{containers["version"]}";\n'
+
+    key = "version = "
+    line = findLine(key,derivation)[0]
+    derivation[line] = f'    version = "{btdu["version"]}";\n'
+
+    return derivation
+
+def updateHashes(btdu,ae,btrfs,ncurses,containers,derivation):
+    key = "sha256 = "
+    hashLines = findLine(key,derivation)
+    for i in range(len(hashes)):
+        derivation[hashLines[i]] = f'        sha256 = "{hashes[i]}";\n'
+
+    return derivation
+
+if __name__ == "__main__":
+
+    btdu       = {"string": "pkgver"}
+    ae         = {"string": "_d_ae_ver"}
+    btrfs      = {"string": "_d_btrfs_ver"}
+    ncurses    = {"string": "_d_ncurses_ver"}
+    containers = {"string": "_d_emsi_containers_ver"}
+
+    grabDepVersions(btdu)
+    grabDepVersions(ae)
+    grabDepVersions(btrfs)
+    grabDepVersions(ncurses)
+    grabDepVersions(containers)
+
+    hashes = grabDepHashes("sha256sums=('")
+
+    nixpkgs = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip('\n')
+    btduFolder = "/pkgs/tools/misc/btdu/"
+    with open(nixpkgs + btduFolder + "default.nix", 'r') as arq:
+        derivation = arq.readlines()
+
+    derivation = updateVersions(btdu,ae,btrfs,ncurses,containers,derivation)
+    derivation = updateHashes(btdu,ae,btrfs,ncurses,containers,derivation)
+
+    with open(nixpkgs + btduFolder + "default.nix", 'w') as arq:
+        arq.writelines(derivation)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -255,6 +255,8 @@ with pkgs;
 
   cen64 = callPackage ../misc/emulators/cen64 { };
 
+  btdu = callPackage ../tools/misc/btdu { };
+
   uxn = callPackage ../misc/emulators/uxn { };
 
   cereal = callPackage ../development/libraries/cereal { };


### PR DESCRIPTION
###### Motivation for this change
I use the BTRFS filesystem and felt the need to have the tool [btdu](https://github.com/CyberShadow/btdu) installed, so I wrote this derivation. It is a very simple application that is very similar to [ncdu](https://dev.yorhel.nl/ncdu), but tailored for the BTRFS filesystem.
I hope it can be added to the repo to help more people.

###### Things done

Added the package btdu to the repository.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
