### PR TITLE
fahcontrol,fahviewer: fix variable substitution for shortcuts

### DIFF
--- a/pkgs/applications/science/misc/foldingathome/control.nix
+++ b/pkgs/applications/science/misc/foldingathome/control.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   installPhase = "cp -ar usr $out";
 
   postFixup = ''
-    sed -e 's|/usr/bin|$out/bin|g' -i $out/share/applications/FAHControl.desktop
+    sed -e "s|/usr/bin|$out/bin|g" -i $out/share/applications/FAHControl.desktop
     wrapProgram "$out/bin/FAHControl" \
       --suffix PATH : "${fahviewer.outPath}/bin" \
       --set PYTHONPATH "$out/lib/python2.7/dist-packages"

--- a/pkgs/applications/science/misc/foldingathome/viewer.nix
+++ b/pkgs/applications/science/misc/foldingathome/viewer.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   unpackPhase = ''
     dpkg-deb -x ${src} ./
-    sed -e 's|/usr/bin|$out/bin|g' -i usr/share/applications/FAHViewer.desktop
+    sed -e "s|/usr/bin|$out/bin|g" -i usr/share/applications/FAHViewer.desktop
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Because single quotes are used in the sed command, the application
shortcut had the literal $out instead of the package path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).