### PR TITLE
timescaledb-tune: 0.11.2 -> 0.12.0

### DIFF
--- a/pkgs/development/tools/database/timescaledb-tune/default.nix
+++ b/pkgs/development/tools/database/timescaledb-tune/default.nix
@@ -2,16 +2,19 @@
 
 buildGoModule rec {
   pname = "timescaledb-tune";
-  version = "0.11.2";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-6xMdOqLfD3NQksmcD7rlTW3xoW2Fi6OmwbpjIj9A/tw=";
+    sha256 = "sha256-p1SU0wnB2XftuPMbm47EbJ2aZGV9amlk0y7FI0QOBkk=";
   };
 
   vendorSha256 = "sha256-n2jrg9FiR/gSrbds/QVV8Duf7BTEs36yYi4F3Ve+d0E=";
+
+  # Temporary fix of bug: https://github.com/timescale/timescaledb-tune/issues/95
+  patches = [ ./fixMinMaxConn.diff ];
 
   meta = with lib; {
     description = "A tool for tuning your TimescaleDB for better performance";

--- a/pkgs/development/tools/database/timescaledb-tune/fixMinMaxConn.diff
+++ b/pkgs/development/tools/database/timescaledb-tune/fixMinMaxConn.diff
@@ -1,0 +1,13 @@
+diff --git a/pkg/pgtune/misc.go b/pkg/pgtune/misc.go
+index 1fceb6e..3e76be5 100644
+--- a/pkg/pgtune/misc.go
++++ b/pkg/pgtune/misc.go
+@@ -35,7 +35,7 @@ const (
+ 	// If you want to lower this value, consider that Patroni will not accept anything less than 25 as
+ 	// a valid max_connections and will replace it with 100, per
+ 	// https://github.com/zalando/patroni/blob/00cc62726d6df25d31f9b0baa082c83cd3f7bef9/patroni/postgresql/config.py#L280
+-	minMaxConns = 25
++	minMaxConns = 20
+ )
+ 
+ // MaxConnectionsDefault is the recommended default value for max_connections.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update from version 0.11.2 to 0.12.0. It was introduced a bug, so had to make patch to get tests to run. See issue https://github.com/timescale/timescaledb-tune/issues/95

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
