### PR TITLE
mullvad: init at 2022.1

### DIFF
--- a/pkgs/applications/networking/mullvad/default.nix
+++ b/pkgs/applications/networking/mullvad/default.nix
@@ -4,4 +4,5 @@
 lib.makeScope newScope (self: {
   libwg = self.callPackage ./libwg.nix { };
   mullvad = self.callPackage ./mullvad.nix { };
+  openvpn-mullvad = self.callPackage ./openvpn.nix { };
 })

--- a/pkgs/applications/networking/mullvad/default.nix
+++ b/pkgs/applications/networking/mullvad/default.nix
@@ -1,0 +1,7 @@
+{ lib
+, newScope
+}:
+lib.makeScope newScope (self: {
+  libwg = self.callPackage ./libwg.nix { };
+  mullvad = self.callPackage ./mullvad.nix { };
+})

--- a/pkgs/applications/networking/mullvad/libwg.nix
+++ b/pkgs/applications/networking/mullvad/libwg.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, mullvad
+}:
+buildGoModule {
+  pname = "libwg";
+
+  inherit (mullvad)
+    version
+    src
+    ;
+
+  sourceRoot = "source/wireguard/libwg";
+
+  vendorSha256 = "qvymWCdJ+GY90W/Fpdp+r1+mTq6O4LyN2Yw/PjKdFm0=";
+
+  # XXX: hack to make the ar archive go to the correct place
+  # This is necessary because passing `-o ...` to `ldflags` does not work
+  # (this doesn't get communicated everywhere in the chain, apparently, so
+  # `go` complains that it can't find an `a.out` file).
+  GOBIN = "${placeholder "out"}/lib";
+  ldflags = [ "-s" "-w" "-buildmode=c-archive" ];
+
+  postInstall = ''
+    mv $out/lib/libwg{,.a}
+  '';
+
+  meta = with lib; {
+    description = "A tiny wrapper around wireguard-go";
+    homepage = "https://github.com/mullvad/mullvadvpn-app/tree/master/wireguard/libwg";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ cole-h ];
+  };
+}

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -10,6 +10,7 @@
 , libnftnl
 , libmnl
 , libwg
+, openvpn-mullvad
 }:
 let
   # result of running address_cache as of 02 Mar 2022
@@ -87,6 +88,8 @@ rustPlatform.buildRustPackage rec {
       wrapProgram $out/bin/mullvad-daemon \
         --set-default MULLVAD_RESOURCE_DIR "$out/share/mullvad"
     '';
+
+  passthru = { inherit openvpn-mullvad; };
 
   meta = with lib; {
     description = "Mullvad VPN command-line client tools";

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, writeText
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, protobuf
+, makeWrapper
+, dbus
+, libnftnl
+, libmnl
+, libwg
+}:
+let
+  # result of running address_cache as of 02 Mar 2022
+  bootstrap-address-cache = writeText "api-ip-address.txt" ''
+    193.138.218.78:443
+    193.138.218.71:444
+    185.65.134.66:444
+    185.65.135.117:444
+    217.138.254.130:444
+    91.90.44.10:444
+  '';
+in
+rustPlatform.buildRustPackage rec {
+  pname = "mullvad";
+  version = "2022.1";
+
+  src = fetchFromGitHub {
+    owner = "mullvad";
+    repo = "mullvadvpn-app";
+    rev = version;
+    hash = "sha256-bLwuM3Qy2iStbXIvDEWp31vuiihSQThOej297XKo5Xc=";
+  };
+
+  cargoHash = "sha256-CBbm8cJHTjyvvzCFQfKmsE5d9N7azEm8nI6KeWLVaa8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+    makeWrapper
+  ];
+
+  buildInputs = [
+    dbus.dev
+    libnftnl
+    libmnl
+  ];
+
+  # talpid-core wants libwg.a in build/lib/{triple}
+  preBuild = ''
+    dest=build/lib/${stdenv.targetPlatform.config}
+    mkdir -p $dest
+    ln -s ${libwg}/lib/libwg.a $dest
+  '';
+
+  postFixup =
+    # Place all binaries in the 'mullvad-' namespace, even though these
+    # specific binaries aren't used in the lifetime of the program.
+    # `address_cache` is used to generate the `api-ip-address.txt` file, which
+    # contains list of Mullvad API servers -- though we provide a "backup" of
+    # the output of this command, it could change at any time, so we want
+    # users to be able to regenerate the list at any time. (The daemon will
+    # refuse to start without this file.)
+    ''
+      for bin in address_cache relay_list translations-converter; do
+        mv "$out/bin/$bin" "$out/bin/mullvad-$bin"
+      done
+    '' +
+    # Put distributed assets in-place -- specifically, the
+    # bootstrap-address-cache is necessary; otherwise, the user will have to run
+    # the `address_cache` binary and move the contents into place at
+    # `/var/cache/mullvad-vpn/api-ip-address.txt` manually. `ca.crt` is
+    # necessary for OpenVPN tunnels to work.
+    # XXX: Use of OpenVPN requires their fork of OpenVPN, which can be found at
+    # https://github.com/mullvad/openvpn/tree/mullvad-patches/
+    ''
+      mkdir -p $out/share
+      ln -s ${bootstrap-address-cache} $out/share/api-ip-address.txt
+      cp dist-assets/ca.crt $out/share
+    '' +
+    # Set the directory where Mullvad will look for its resources by default to
+    # `$out/share`, so that we can avoid putting the files in `$out/bin` --
+    # Mullvad defaults to looking inside the directory its binary is located in
+    # for its resources.
+    ''
+      wrapProgram $out/bin/mullvad-daemon \
+        --set-default MULLVAD_RESOURCE_DIR "$out/share/mullvad"
+    '';
+
+  meta = with lib; {
+    description = "Mullvad VPN command-line client tools";
+    homepage = "https://github.com/mullvad/mullvadvpn-app";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ cole-h ];
+  };
+}

--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -1,0 +1,87 @@
+{ lib
+, openvpn
+, fetchpatch
+, fetchurl
+, iproute2
+, autoconf
+, automake
+}:
+
+openvpn.overrideAttrs (oldAttrs:
+  let
+    fetchMullvadPatch = { commit, sha256 }: fetchpatch {
+      url = "https://github.com/mullvad/openvpn/commit/${commit}.patch";
+      inherit sha256;
+    };
+  in
+  rec {
+    pname = "openvpn-mullvad";
+    version = "2.5.3";
+
+    src = fetchurl {
+      url = "https://swupdate.openvpn.net/community/releases/openvpn-${version}.tar.gz";
+      sha256 = "sha256-dfAETfRJQwVVynuZWit3qyTylG/cNmgwG47cI5hqX34=";
+    };
+
+    buildInputs = oldAttrs.buildInputs or [ ] ++ [
+      iproute2
+    ];
+
+    configureFlags = oldAttrs.configureFlags  or [ ] ++ [
+      "--enable-iproute2"
+      "IPROUTE=${iproute2}/sbin/ip"
+    ];
+
+    nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [
+      autoconf
+      automake
+    ];
+
+    patches = oldAttrs.patches or [ ] ++ [
+      # look at compare to find the relevant commits
+      # https://github.com/OpenVPN/openvpn/compare/release/2.5...mullvad:mullvad-patches
+      # used openvpn version is the latest tag ending with -mullvad
+      # https://github.com/mullvad/openvpn/tags
+      (fetchMullvadPatch {
+        # "Reduce PUSH_REQUEST_INTERVAL to one second"
+        commit = "41e44158fc71bb6cc8cc6edb6ada3307765a12e8";
+        sha256 = "sha256-UoH0V6gTPdEuybFkWxdaB4zomt7rZeEUyXs9hVPbLb4=";
+      })
+      (fetchMullvadPatch {
+        # "Allow auth plugins to set a failure reason"
+        commit = "f51781c601e8c72ae107deaf25bf66f7c193e9cd";
+        sha256 = "sha256-+kwG0YElL16T0e+avHlI8gNQdAxneRS6fylv7QXvC1s=";
+      })
+      (fetchMullvadPatch {
+        # "Send an event to any plugins when authentication fails"
+        commit = "c2f810f966f2ffd68564d940b5b8946ea6007d5a";
+        sha256 = "sha256-PsKIxYwpLD66YaIpntXJM8OGcObyWBSAJsQ60ojvj30=";
+      })
+      (fetchMullvadPatch {
+        # "Shutdown when STDIN is closed"
+        commit = "879d6a3c0288b5443bbe1b94261655c329fc2e0e";
+        sha256 = "sha256-pRFY4r+b91/xAKXx6u5GLzouQySXuO5gH0kMGm77a3c=";
+      })
+      (fetchMullvadPatch {
+        # "Update TAP hardware ID"
+        commit = "7f71b37a3b25bec0b33a0e29780c222aef869e9d";
+        sha256 = "sha256-RF/GvD/ZvhLdt34wDdUT/yxa+IVWx0eY6WRdNWXxXeQ=";
+      })
+      (fetchMullvadPatch {
+        # "Undo dependency on Python docutils"
+        commit = "abd3c6214529d9f4143cc92dd874d8743abea17c";
+        sha256 = "sha256-SC2RlpWHUDMAEKap1t60dC4hmalk3vok6xY+/xhC2U0=";
+      })
+      (fetchMullvadPatch {
+        # "Prevent signal when stdin is closed from being cleared (#10)"
+        commit = "b45b090c81e7b4f2dc938642af7a1e12f699f5c5";
+        sha256 = "sha256-KPTFmbuJhMI+AvaRuu30CPPLQAXiE/VApxlUCqbZFls=";
+      })
+    ];
+
+    meta = oldAttrs.meta or { } // {
+      description = "OpenVPN with Mullvad-specific patches applied";
+      homepage = "https://github.com/mullvad/openvpn";
+      maintainers = with lib; [ maintainers.cole-h ];
+    };
+  })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21636,6 +21636,9 @@ with pkgs;
 
   morty = callPackage ../servers/web-apps/morty { };
 
+  inherit (callPackage ../applications/networking/mullvad { })
+    mullvad;
+
   mullvad-vpn = callPackage ../applications/networking/mullvad-vpn { };
 
   mycorrhiza = callPackage ../servers/mycorrhiza {


### PR DESCRIPTION
This package includes the CLI binaries for mullvad, but does not attempt
to build the GUI. This allows it to be (more) cross-platform than the
mullvad-vpn package, which depends on a tool that is unavailable for
e.g. ARM platforms.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I tried to set up Mullvad on an aarch64 machine, but was relegated to a `wg-quick` config file generated on their website. Their reasoning for not providing an ARM build is that a dependency for the GUI part of their software does not support ARM (see https://github.com/mullvad/mullvadvpn-app/issues/952 for more information). I'd much rather use their CLI tools than have to keep copies of the config files lying around.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

~~This is still WIP because I haven't tested if it actually works (everything is properly executable, but I haven't deployed it to my aarch64 machine yet).~~ I'm also not entirely happy with the separation between the `libwg` and `mullvad` packages, but I wasn't going to put the `libwg` derivation inside the `mullvad` package -- that would be much worse, IMO.