### PR TITLE
prometheus: Optionally remove service discovery.

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -9,6 +9,12 @@
 , mkYarnPackage
 , nixosTests
 , fetchpatch
+, enableAWS ? true
+, enableAzure ? true
+, enableDigitalOcean ? true
+, enableGCE ? true
+, enableKubernetes ? true
+, enableLinode ? true
 }:
 
 let
@@ -92,6 +98,20 @@ buildGoModule rec {
     # webui-codemirror
     ln -s ${codemirror}/dist web/ui/module/codemirror-promql/dist
     ln -s ${codemirror}/lib web/ui/module/codemirror-promql/lib
+
+    # Disable some service discovery to shrink binaries.
+    ${lib.optionalString (!enableAWS)
+      "sed -i -e '/register aws/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableAzure)
+      "sed -i -e '/register azure/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableDigitalOcean)
+      "sed -i -e '/register digitalocean/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableGCE)
+      "sed -i -e '/register gce/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableKubernetes)
+      "sed -i -e '/register kubernetes/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableLinode)
+      "sed -i -e '/register linode/d' discovery/install/install.go"}
   '';
 
   tags = [ "builtinassets" ];

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -11,10 +11,22 @@
 , fetchpatch
 , enableAWS ? true
 , enableAzure ? true
+, enableConsul ? true
 , enableDigitalOcean ? true
+, enableEureka ? true
 , enableGCE ? true
+, enableHetzner ? true
 , enableKubernetes ? true
 , enableLinode ? true
+, enableMarathon ? true
+, enableMoby ? true
+, enableOpenstack ? true
+, enablePuppetDB ? true
+, enableScaleway ? true
+, enableTriton ? true
+, enableUyuni ? true
+, enableXDS ? true
+, enableZookeeper ? true
 }:
 
 let
@@ -104,14 +116,38 @@ buildGoModule rec {
       "sed -i -e '/register aws/d' discovery/install/install.go"}
     ${lib.optionalString (!enableAzure)
       "sed -i -e '/register azure/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableConsul)
+      "sed -i -e '/register consul/d' discovery/install/install.go"}
     ${lib.optionalString (!enableDigitalOcean)
       "sed -i -e '/register digitalocean/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableEureka)
+      "sed -i -e '/register eureka/d' discovery/install/install.go"}
     ${lib.optionalString (!enableGCE)
       "sed -i -e '/register gce/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableHetzner)
+      "sed -i -e '/register hetzner/d' discovery/install/install.go"}
     ${lib.optionalString (!enableKubernetes)
       "sed -i -e '/register kubernetes/d' discovery/install/install.go"}
     ${lib.optionalString (!enableLinode)
       "sed -i -e '/register linode/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableMarathon)
+      "sed -i -e '/register marathon/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableMoby)
+      "sed -i -e '/register moby/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableOpenstack)
+      "sed -i -e '/register openstack/d' discovery/install/install.go"}
+    ${lib.optionalString (!enablePuppetDB)
+      "sed -i -e '/register puppetdb/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableScaleway)
+      "sed -i -e '/register scaleway/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableTriton)
+      "sed -i -e '/register triton/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableUyuni)
+      "sed -i -e '/register uyuni/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableXDS)
+      "sed -i -e '/register xds/d' discovery/install/install.go"}
+    ${lib.optionalString (!enableZookeeper)
+      "sed -i -e '/register zookeeper/d' discovery/install/install.go"}
   '';
 
   tags = [ "builtinassets" ];


### PR DESCRIPTION
I read this hilarious blog post:

https://wejick.wordpress.com/2022/01/29/can-i-have-a-smaller-prometheus/

We can have a smaller Prometheus too. This patch allows users to remove
service discovery for five public clouds (AWS, Azure, DigitalOcean, GCP,
and Linode) and also Kubernetes, simply by setting the corresponding
enable-flag to `false`. I have tested building with each flag as I added
it to the list. I also tested running with all six flags set to `false`,
and the resulting Prometheus can still handle my orthogonal
service-discovery configuration (files).

To meet Adam Savage's definition of science, I measured the size of the
`prometheus` and `promtool` binaries after adding each flag with
`ls -h`.

flag          | prometheus | promtool
--------------|------------|----------
starting size | 84M        | 74M
AWS           | 72M        | 61M
Azure         | 71M        | 61M
GCE           | 64M        | 53M
k8s           | 40M        | 53M
DO            | 39M        | 52M
Linode        | 38M        | 51M

I did not go as far as the blog post. If folks want, I'll make the rest
of the service discovery optional too.

I did not shrink the build closure, just the output closure; we still
pull all of the various vendored modules into the Nix store during
builds. I don't see how to do this in a neat or easy way.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
