### PR TITLE
shogun: use python3

### DIFF
--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -6,7 +6,7 @@
   # build
 , cmake
 , ctags
-, python2Packages
+, python3
 , swig
   # math
 , eigen
@@ -36,7 +36,7 @@
 , withSvmLight ? false
 }:
 
-assert pythonSupport -> python2Packages != null;
+assert pythonSupport -> python3 != null;
 assert opencvSupport -> opencv != null;
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (!withSvmLight) ./svmlight-scrubber.patch;
 
   nativeBuildInputs = [ cmake swig ctags ]
-    ++ (with python2Packages; [ python jinja2 ply ]);
+    ++ (with python3.pkgs; [ python jinja2 ply ]);
 
   buildInputs = [
     eigen
@@ -121,7 +121,7 @@ stdenv.mkDerivation rec {
     nlopt
     lp_solve
     colpack
-  ] ++ lib.optionals pythonSupport (with python2Packages; [ python numpy ])
+  ] ++ lib.optionals pythonSupport (with python3.pkgs; [ python numpy ])
     ++ lib.optional opencvSupport opencv;
 
   cmakeFlags = let


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#148779

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
