### PR TITLE
pythonPackages.brotli: don't use deepClone

### DIFF
--- a/pkgs/development/python-modules/brotli/default.nix
+++ b/pkgs/development/python-modules/brotli/default.nix
@@ -12,9 +12,9 @@ buildPythonPackage rec {
     owner = "google";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1rdp9rx197q467ixp53g4cgc3jbsdaxr62pz0a8ayv2lvm944azh";
+    sha256 = "sha256-tFnXSXv8t3l3HX6GwWLhEtgpqz0c7Yom5U3k47pWM7o=";
     # for some reason, the test data isn't captured in releases, force a git checkout
-    deepClone = true;
+    forceFetchGit = true;
   };
 
   dontConfigure = true;


### PR DESCRIPTION
It's not reproducible: #100498

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

```
hash mismatch in fixed-output derivation '/direct/star+u/veprbl/nix/store/2ghhwz6shb2pvahyqgzm2p6rvklg9sxj-source':
  wanted: sha256:1rdp9rx197q467ixp53g4cgc3jbsdaxr62pz0a8ayv2lvm944azh
  got:    sha256:0idl29gghsbi1gikp86j423hdq30jcwglwi9mzvwg25db4rlwy02
```

```
# diff -r /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source
diff -r /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git/info/refs /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/info/refs
1a2,17
> d811b186c5037b434d56ddb831ceccdf5a954687      refs/tags/v0.1.0
> 7f7a2fb48cec63c0459ec6b6e7260810bfb01819      refs/tags/v0.2.0
> 98ed7a23a83d64133b0a36a884e489bffb0eb864      refs/tags/v0.3.0
> 29d31d5921b0a2b323ac24e7f7d0cdc9a3c0dd08      refs/tags/v0.4.0
> 66c14517cf8afcc1a1649a7833ac789366eb0b51      refs/tags/v0.5.2
> 46c1a881b41bb638c76247558aa04b1591af3aa7      refs/tags/v0.6.0
> c60563591a9a86196f19987c81dde4384a088861      refs/tags/v1.0.0
> 5b4769990dc14a2bd466d2599c946c5652cba4b2      refs/tags/v1.0.1
> 0ad94eed00420bf1154cb16a289aa27efbb30c01      refs/tags/v1.0.2
> 533843e3546cd24c8344eaa899c6b0b681c8d222      refs/tags/v1.0.3
> c6333e1e79fb62ea088443f192293f964409b04e      refs/tags/v1.0.4
> b601fe817bd3217cb144bbb380a43cae8e847388      refs/tags/v1.0.5
> 6eba239a5bb553fd557b7d78f7da8f0059618b9e      refs/tags/v1.0.6
> d6d98957ca8ccb1ef45922e978bb10efca0ea541      refs/tags/v1.0.7
> db361a0bb901d6a71c7cbf1370d97b3703482e3b      refs/tags/v1.0.8
> e61745a6b7add50d380cfd7d3883dd6c62fc2c71      refs/tags/v1.0.9
Only in /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/objects/info: commit-graph
diff -r /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git/objects/info/packs /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/objects/info/packs
1c1
< P pack-6c928cc90e4d56875142dd7ee3f04ba1d9a25c5c.pack
---
> P pack-fd16202a7e51865a14d05403d4684e1aa23a263c.pack
Only in /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git/objects/pack: pack-6c928cc90e4d56875142dd7ee3f04ba1d9a25c5c.idx
Only in /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git/objects/pack: pack-6c928cc90e4d56875142dd7ee3f04ba1d9a25c5c.pack
Only in /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/objects/pack: pack-fd16202a7e51865a14d05403d4684e1aa23a263c.idx
Only in /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/objects/pack: pack-fd16202a7e51865a14d05403d4684e1aa23a263c.pack
diff -r /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git/packed-refs /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/packed-refs
2a3,18
> d811b186c5037b434d56ddb831ceccdf5a954687 refs/tags/v0.1.0
> 7f7a2fb48cec63c0459ec6b6e7260810bfb01819 refs/tags/v0.2.0
> 98ed7a23a83d64133b0a36a884e489bffb0eb864 refs/tags/v0.3.0
> 29d31d5921b0a2b323ac24e7f7d0cdc9a3c0dd08 refs/tags/v0.4.0
> 66c14517cf8afcc1a1649a7833ac789366eb0b51 refs/tags/v0.5.2
> 46c1a881b41bb638c76247558aa04b1591af3aa7 refs/tags/v0.6.0
> c60563591a9a86196f19987c81dde4384a088861 refs/tags/v1.0.0
> 5b4769990dc14a2bd466d2599c946c5652cba4b2 refs/tags/v1.0.1
> 0ad94eed00420bf1154cb16a289aa27efbb30c01 refs/tags/v1.0.2
> 533843e3546cd24c8344eaa899c6b0b681c8d222 refs/tags/v1.0.3
> c6333e1e79fb62ea088443f192293f964409b04e refs/tags/v1.0.4
> b601fe817bd3217cb144bbb380a43cae8e847388 refs/tags/v1.0.5
> 6eba239a5bb553fd557b7d78f7da8f0059618b9e refs/tags/v1.0.6
> d6d98957ca8ccb1ef45922e978bb10efca0ea541 refs/tags/v1.0.7
> db361a0bb901d6a71c7cbf1370d97b3703482e3b refs/tags/v1.0.8
> e61745a6b7add50d380cfd7d3883dd6c62fc2c71 refs/tags/v1.0.9
Only in /nix/store/hzmm1ws2xmhyl8j91whc9vjq03xn5dbw-source/.git/refs: remotes
Only in /nix/store/dh3mb74v22xv2nbfgz90r8j4dcvv7jnb-source/.git: shallow
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
