### PR TITLE
gocyclo: 2015-02-08 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -1,26 +1,23 @@
-{ buildGoPackage
+{ buildGoModule
 , lib
 , fetchFromGitHub
 }:
-
-buildGoPackage rec {
-  pname = "gocyclo-unstable";
-  version = "2015-02-08";
-  rev = "aa8f8b160214d8dfccfe3e17e578dd0fcc6fede7";
-
-  goPackagePath = "github.com/alecthomas/gocyclo";
+buildGoModule rec {
+  pname = "gocyclo";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
-    inherit rev;
-
-    owner = "alecthomas";
+    owner = "fzipp";
     repo = "gocyclo";
-    sha256 = "094rj97q38j53lmn2scshrg8kws8c542yq5apih1ahm9wdkv8pxr";
+    rev = "v${version}";
+    sha256 = "1s9m5m5p76wcxi5n4diz891kd5db4ll21fsh9fnvvf9w7yrmgdw2";
   };
+
+  vendorSha256 = "0sjjj9z1dhilhpc8pq4154czrb79z9cm044jvn75kxcjv6v5l2m5";
 
   meta = with lib; {
     description = "Calculate cyclomatic complexities of functions in Go source code";
-    homepage = "https://github.com/alecthomas/gocyclo";
+    homepage = "https://github.com/fzipp/gocyclo";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/tools/gocyclo/default.nix
+++ b/pkgs/development/tools/gocyclo/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 }:
+
 buildGoModule rec {
   pname = "gocyclo";
   version = "0.4.0";
@@ -20,6 +21,5 @@ buildGoModule rec {
     homepage = "https://github.com/fzipp/gocyclo";
     license = licenses.bsd3;
     maintainers = with maintainers; [ kalbasit ];
-    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Updating.

We're pulling from a random fork, so switch to the actual upstream.

Also change to use buildGoModule instead of buildGoPackage.

Should supersede https://github.com/NixOS/nixpkgs/pull/145102.

@stackshadow I can add `Co-Authored-By:` if you'd like.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
