### PR TITLE
garble: Update to v0.5.1 and go1.17

### DIFF
--- a/pkgs/build-support/go/garble.nix
+++ b/pkgs/build-support/go/garble.nix
@@ -2,25 +2,25 @@
 , buildGoModule
 , fetchFromGitHub
 , lib
+, git
 }:
 buildGoModule rec {
   pname = "garble";
-  version = "20200107";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "burrowers";
     repo = pname;
-    rev = "835f4aadf321521acf06aac4d5068473dc4b2ac1";
-    sha256 = "sha256-NodsVHRll2YZoxrhmniJvelQOStG82u3kJyc0t8OXD8=";
+    rev = "v${version}";
+    sha256 = "sha256-F8O/33o//yGnum9sZo1dzcvf3ifRalva6SDC36iPbDA==";
   };
 
-  vendorSha256 = "sha256-x2fk2QmZDK2yjyfYdK7x+sQjvt7tuggmm8ieVjsNKek=";
+  vendorSha256 = "sha256-iNH/iBEOTkIhVlDGfI66ZYyVjyH6WrLbUSMyONPjUc4=";
 
-  preBuild = ''
-    # https://github.com/burrowers/garble/issues/184
-    substituteInPlace testdata/scripts/tiny.txt \
-      --replace "{6,8}" "{4,8}"
-  '' + lib.optionalString (!stdenv.isx86_64) ''
+  # Used for some of the tests.
+  checkInputs = [git];
+
+  preBuild = lib.optionalString (!stdenv.isx86_64) ''
     # The test assumex amd64 assembly
     rm testdata/scripts/asm.txt
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16567,8 +16567,7 @@ with pkgs;
   ganv = callPackage ../development/libraries/ganv { };
 
   garble = callPackage ../build-support/go/garble.nix {
-    # https://github.com/burrowers/garble/issues/124
-    buildGoModule = buildGo115Module;
+    buildGoModule = buildGo117Module;
   };
 
   gcab = callPackage ../development/libraries/gcab { };


### PR DESCRIPTION
This was pretty straightforward, note that go1.17 is explicitly required
by v0.5.1, and one of the tests requires git, so I added it to the
nativeBuildInputs.

Also the tests now pass and don't need the mangle, so I removed the
patch. I left the darwin/aarch64 patch in.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
