### PR TITLE
make-initrd: fix reproducibility problems with hard links

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -31,7 +31,7 @@ storePaths=$(perl $pathsFromGraph closure-*)
 
 # Paths in cpio archives *must* be relative, otherwise the kernel
 # won't unpack 'em.
-(cd root && cp -prd --parents $storePaths .)
+(cd root && cp -prP --parents $storePaths .)
 
 
 # Put the closure in a gzipped cpio archive.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The `-d` passed to the `cp` that sets up the initrd files preserves hardlinks and symlinks, which `cpio` then packs into the initrd. This means that whether or not two duplicate files are hardlinks in the inird depends on the history of `nix-store --optimise`s run by the user, as this creates hard links in the store. This fix replaces the `-d` with `-P`, which preserves symlinks but not hardlinks.

Some questions I had and their answers:
Q: Are there cases where a store path in the initrd must have a file which is a hardlink that this breaks?
A: No. Hardlinks are not preserved in NAR files, so if the store path that is to be copied into the initrd comes from a binary cache or otherwise from another machine, any hardlinks in it would already be broken.

Q: Would hardlinking save space in the initrd? Do duplicate files waste space?
A: No. On master, the uncompressed initrd with duplicates hardlinked is 0.15% smaller than the uncompressed initrd with duplicates preserved. The savings are negligible and adding a program to create hardlinks is IMO not worth it.

Q: Are there other cases in nixpkgs where `tar` or `cpio` will pack hardlinks from the store and break reproducibility?
A: Quite possibly. I did a cursory grep and some tests on other image builders and could not find a problem. Nevertheless, store optimization should probably be added to the list of things to check.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
