### PR TITLE
bash-supergenpass: use resholvePackage

### DIFF
--- a/pkgs/tools/security/bash-supergenpass/default.nix
+++ b/pkgs/tools/security/bash-supergenpass/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenv
+{ lib
+, resholve
 , fetchFromGitHub
 , unstableGitUpdater
-, makeWrapper
+, bash
 , openssl
 , coreutils
-, gnugrep }:
+, gnugrep
+}:
 
-stdenv.mkDerivation {
+resholve.mkDerivation {
   pname = "bash-supergenpass";
   version = "unstable-2020-02-03";
-
-  nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
     owner = "lanzz";
@@ -21,8 +21,19 @@ stdenv.mkDerivation {
 
   installPhase = ''
     install -m755 -D supergenpass.sh "$out/bin/supergenpass"
-    wrapProgram "$out/bin/supergenpass" --prefix PATH : "${lib.makeBinPath [ openssl coreutils gnugrep ]}"
   '';
+
+  solutions = {
+    default = {
+      scripts = [ "bin/supergenpass" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        coreutils
+        openssl
+        gnugrep
+      ];
+    };
+  };
 
   passthru.updateScript = unstableGitUpdater {
     url = "https://github.com/lanzz/bash-supergenpass.git";


### PR DESCRIPTION
@fgaz opening this as a draft to start a conversation. 

This PR repackages bash-supergenpass with resholve, a tool I develop to improve Shell packaging in Nixpkgs. resholve identifies unspecified dependencies, and rewrites external invocations to absolute paths so that end-users of Shell projects don't need to manually add dependencies to their system/user packages. 

I'm hoping to get to a simple yes/no on whether you're okay with the change (and confirmation that it isn't breaking any of your own uses, if you have some?), so I'm happy to field any questions you have to help you decide. 

(If we move forward, I'm happy to pick at any style/format/organization complaints you have :)

<details>
<summary>For a little additional context, here's the resulting built script:</summary>

```bash
#!/nix/store/z6rd8wq02azalrlm2m5k08iy53klg624-bash-5.1-p12/bin/bash

################################################################################

default_password_length="10"	### Default is 10. It can be overwritten on an individual basis by adding the custom length as a second argument after the domain when invoking the command.
default_hashing_algorithm="md5"		### Default is "md5". Alternate value is "sha512". It can be overwritten with the third argument.

################################################################################

domain=$(echo $1 | /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/tr A-Z a-z)
length=${2:-$default_password_length}
hashing_algorithm=${3:-$default_hashing_algorithm}

read -srp 'Password: ' master_password

hash=$master_password:$domain

i=0
while true
do
	hash=$(echo -n "$hash" | /nix/store/wih7p8yp6mi1d96ffrbbvsw6jdzigmm6-openssl-1.1.1m-bin/bin/openssl "$hashing_algorithm" -binary | /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/base64 | /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/tr -d '\n' | /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/tr +/= 98A)
	i=$(($i + 1))
	if [ $i -lt 10 ]
	then
		continue
	fi
	valid=$(echo "${hash:0:$length}" | /nix/store/pkw9ckmar4dw7sgsszg8zgydfq4xc11k-gnugrep-3.7/bin/egrep '^[[:lower:]]' | /nix/store/pkw9ckmar4dw7sgsszg8zgydfq4xc11k-gnugrep-3.7/bin/egrep '.[[:upper:]]' | /nix/store/pkw9ckmar4dw7sgsszg8zgydfq4xc11k-gnugrep-3.7/bin/egrep '.[[:digit:]]')
	if [ "$valid" != "" ]
	then
		break
	fi
done
echo ${hash:0:$length}

### resholve directives (auto-generated) ## format_version: 2
# resholve: keep /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/base64
# resholve: keep /nix/store/2hfc8dk1g3bsms4l4xf620x7ynslvq3k-coreutils-9.0/bin/tr
# resholve: keep /nix/store/pkw9ckmar4dw7sgsszg8zgydfq4xc11k-gnugrep-3.7/bin/egrep
# resholve: keep /nix/store/wih7p8yp6mi1d96ffrbbvsw6jdzigmm6-openssl-1.1.1m-bin/bin/openssl
```
</details>

---

###### Motivation for this change

Convert bash-supergenpass to use `resholvePackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
