### PR TITLE
mysql57: 5.7.27 -> 5.7.37

### DIFF
--- a/nixos/tests/mysql/common.nix
+++ b/nixos/tests/mysql/common.nix
@@ -3,7 +3,7 @@
     inherit (pkgs.darwin) cctools;
     inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
   });
-  mysqlPackage = {
+  mysqlPackages = {
     inherit (pkgs) mysql57 mysql80;
   };
   mkTestName = pkg: "mariadb_${builtins.replaceStrings ["."] [""] (lib.versions.majorMinor pkg.version)}";

--- a/nixos/tests/mysql/mysql.nix
+++ b/nixos/tests/mysql/mysql.nix
@@ -142,7 +142,7 @@ let
 in
   lib.mapAttrs (_: package: makeMySQLTest {
     inherit package;
-    hasRocksDB = false; hasMroonga = false;
+    hasRocksDB = false; hasMroonga = false; useSocketAuth = false;
   }) mysqlPackages
   // (lib.mapAttrs (_: package: makeMySQLTest {
     inherit package;

--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, cmake, bison, pkg-config
 , boost, libedit, libevent, lz4, ncurses, openssl, protobuf, readline, zlib, perl
 , cctools, CoreServices, developer_cmds
-, libtirpc, rpcsvc-proto
+, libtirpc, rpcsvc-proto, nixosTests
 }:
 
 # Note: zlib is not required; MySQL can use an internal zlib.
@@ -9,11 +9,11 @@
 let
 self = stdenv.mkDerivation rec {
   pname = "mysql";
-  version = "5.7.27";
+  version = "5.7.37";
 
   src = fetchurl {
     url = "mirror://mysql/MySQL-5.7/${pname}-${version}.tar.gz";
-    sha256 = "1fhv16zr46pxm1j8vb8x8mh3nwzglg01arz8gnazbmjqldr5idpq";
+    sha256 = "sha256-qZqaqGNdJWbat2Sy3la+0XMDZdNg4guyf1Y5LOVOGL0=";
   };
 
   preConfigure = lib.optionalString stdenv.isDarwin ''
@@ -75,6 +75,7 @@ self = stdenv.mkDerivation rec {
     connector-c = self;
     server = self;
     mysqlVersion = "5.7";
+    tests = nixosTests.mysql.mysql57;
   };
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changes:
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-37.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-36.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-35.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-34.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-33.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-32.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-31.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-30.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-29.html
https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-28.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>amarok</li>
    <li>cqrlog</li>
    <li>mysql57</li>
    <li>powerdns</li>
  </ul>
</details>