### PR TITLE
various packages: disable broken parallel builds

### DIFF
--- a/pkgs/applications/editors/deadpixi-sam/default.nix
+++ b/pkgs/applications/editors/deadpixi-sam/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   CFLAGS = "-D_DARWIN_C_SOURCE";
   makeFlags = [ "DESTDIR=$(out)" ];
   buildInputs = [ libX11 libXi libXt libXft ];
+  # build fails when run in parallel
+  enableParallelBuilding = false;
 
   postInstall = ''
     mkdir -p $out/share/applications

--- a/pkgs/applications/science/electronics/alliance/default.nix
+++ b/pkgs/applications/science/electronics/alliance/default.nix
@@ -19,6 +19,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ libtool automake autoconf flex ];
   buildInputs = [ xorgproto motif libX11 libXt libXpm bison ];
 
+  # Disable parallel build, errors:
+  #  ./pat_decl_y.y:736:5: error: expected '=', ...
+  enableParallelBuilding = false;
+
   ALLIANCE_TOP = placeholder "out";
 
   configureFlags = [

--- a/pkgs/desktops/cdesktopenv/default.nix
+++ b/pkgs/desktops/cdesktopenv/default.nix
@@ -46,6 +46,8 @@ in stdenv.mkDerivation rec {
     bison ncompress gawk autoPatchelfHook makeWrapper fakeroot
     rpcsvc-proto
   ];
+  # build fails otherwise
+  enableParallelBuilding = false;
 
   makeFlags = [
     "World"

--- a/pkgs/development/compilers/ats2/default.nix
+++ b/pkgs/development/compilers/ats2/default.nix
@@ -36,6 +36,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gmp ];
 
+  # Disable parallel build, errors:
+  #  *** No rule to make target 'patscc.dats', needed by 'patscc_dats.c'.  Stop.
+  enableParallelBuilding = false;
+
   setupHook = with lib;
     let
       hookFiles =

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals withQt [ libqt5pas qtbase ];
 
+  # Disable parallel build, errors:
+  #  Fatal: (1018) Compilation aborted
+  enableParallelBuilding = false;
+
   nativeBuildInputs = [
     makeWrapper
   ] ++ lib.optional withQt wrapQtAppsHook;

--- a/pkgs/development/compilers/mlton/from-git-source.nix
+++ b/pkgs/development/compilers/mlton/from-git-source.nix
@@ -21,6 +21,9 @@ stdenv.mkDerivation {
 
   buildInputs = [mltonBootstrap gmp];
 
+  # build fails otherwise
+  enableParallelBuilding = false;
+
   preBuild = ''
     find . -type f | grep -v -e '\.tgz''$' | xargs sed -i "s@/usr/bin/env bash@$(type -p bash)@"
     sed -i "s|/tmp|$TMPDIR|" bin/regression

--- a/pkgs/development/ocaml-modules/stdcompat/default.nix
+++ b/pkgs/development/ocaml-modules/stdcompat/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ ocaml findlib ];
+  # build fails otherwise
+  enableParallelBuilding = false;
 
   configureFlags = "--libdir=$(OCAMLFIND_DESTDIR)";
 

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml ];
 
+  # build fails otherwise
+  enableParallelBuilding = false;
+
   preBuild = ''
     mv config/Makefile.unix config/Makefile
     substituteInPlace config/Makefile --replace BINDIR=/usr/local/bin BINDIR=$out

--- a/pkgs/development/tools/ocaml/camlp4/default.nix
+++ b/pkgs/development/tools/ocaml/camlp4/default.nix
@@ -55,6 +55,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ which ocaml ocamlbuild ];
 
+  # build fails otherwise
+  enableParallelBuilding = false;
+
   dontAddPrefix = true;
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/ipvsadm/default.nix
+++ b/pkgs/os-specific/linux/ipvsadm/default.nix
@@ -16,6 +16,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libnl popt ];
 
+  # Disable parallel build, errors:
+  #  *** No rule to make target 'libipvs/libipvs.a', needed by 'ipvsadm'.  Stop.
+  enableParallelBuilding = false;
+
   preBuild = ''
     makeFlagsArray+=(
       INCLUDE=$(pkg-config --cflags libnl-genl-3.0)

--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -87,6 +87,10 @@ stdenv.mkDerivation {
     openldap  # optional
     pam  # optional
   ];
+  # Disable parallel build, errors:
+  #  *** No rule to make target '../util/libfaxutil.so.7.0.4', needed by 'faxmsg'.  Stop.
+  enableParallelBuilding = false;
+
   postPatch = ". ${postPatch}";
   dontAddPrefix = true;
   postInstall = ". ${postInstall}";

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -89,6 +89,10 @@ stdenv.mkDerivation rec {
     sed -i '/ENV{PATH}/d' node/lib/Munin/Node/Service.pm
   '';
 
+  # Disable parallel build, errors:
+  #  Can't locate Munin/Common/Defaults.pm in @INC ...
+  enableParallelBuilding = false;
+
   # DESTDIR shouldn't be needed (and shouldn't have worked), but munin
   # developers have forgotten to use PREFIX everywhere, so we use DESTDIR to
   # ensure that everything is installed in $out.

--- a/pkgs/tools/networking/netboot/default.nix
+++ b/pkgs/tools/networking/netboot/default.nix
@@ -13,6 +13,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  # Disable parallel build, errors:
+  #  link: `parseopt.lo' is not a valid libtool object
+  enableParallelBuilding = false;
+
   meta = with lib; {
     description = "Mini PXE server";
     maintainers = [ maintainers.raskin ];

--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -15,6 +15,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ perl ] ++ extraBuildInputs;
   hardeningDisable = [ "format" ];
 
+  # tests fail when building in parallel
+  enableParallelBuilding = false;
+
   postInstall = ''
     for bin in $out/bin/{splitdiff,rediff,editdiff,dehtmldiff}; do
       wrapProgram "$bin" \


### PR DESCRIPTION
###### Motivation for this change
Part of #142338

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of ~all~ most (only the first iteration) packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review:
```
1 package marked as broken and skipped:
mht2htm

16 packages built:
alliance ats-acc ats2 cqrlog cudatext cudatext-gtk ddrescueview goverlay hylafaxplus ipvsadm lazarus lazarus-qt lazpaint munin netboot transgui
```
