### PR TITLE
libf2c: explicitly disable parallel builds

### DIFF
--- a/pkgs/development/libraries/libf2c/default.nix
+++ b/pkgs/development/libraries/libf2c/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
+  # Makefile is missing depepdencies on generated headers:
+  #   main.c:4:10: fatal error: signal1.h: No such file or directory
+  enableParallelBuilding = false;
+
   meta = {
     description = "F2c converts Fortran 77 source code to C";
     homepage = "http://www.netlib.org/f2c/";


### PR DESCRIPTION
Attempt to enable build parallelism exposes missing dependency:

    libf2c> main.c:4:10: fatal error: signal1.h: No such file or directory
    libf2c>     4 | #include "signal1.h"
    libf2c>       |          ^~~~~~~~~~~