### PR TITLE
qMasterPassword: 1.2.2 -> git master

### DIFF
--- a/pkgs/applications/misc/qMasterPassword/default.nix
+++ b/pkgs/applications/misc/qMasterPassword/default.nix
@@ -1,18 +1,18 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub, qtbase, qmake, libX11, libXtst, openssl, libscrypt }:
+{ lib, stdenv, mkDerivation, fetchFromGitHub, qtbase, qmake, qttools, libX11, libXtst, openssl, libscrypt }:
 
 mkDerivation rec {
-  name = "qMasterPassword";
-  version = "1.2.2";
+  pname = "qMasterPassword-unstable";
+  version = "2022-01-28";
 
   src = fetchFromGitHub {
     owner = "bkueng";
-    repo = name;
-    rev = "v${version}";
-    sha256 = "0l0jarvfdc69rcjl2wa0ixq8gp3fmjsy9n84m38sxf3n9j2bh13c";
+    repo = "qMasterPassword";
+    rev = "7ade33952531731c266c2597f4212c93aca68c59";
+    sha256 = "sha256-MdV6AkRh072++sKoeuwvhgqLEfUkTF34xt6OH9n59Q0=";
   };
 
   buildInputs = [ qtbase libX11 libXtst openssl libscrypt ];
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake qttools ];
 
   # Upstream install is mostly defunct. It hardcodes target.path and doesn't
   # install anything but the binary.
@@ -22,12 +22,16 @@ mkDerivation rec {
     ln -s ../Applications/qMasterPassword.app/Contents/MacOS/qMasterPassword "$out"/bin/qMasterPassword
   '' else ''
     mkdir -p $out/bin
-    mkdir -p $out/share/{applications,doc/qMasterPassword,icons/qmasterpassword,icons/hicolor/512x512/apps}
+    mkdir -p $out/share/{applications,doc/qMasterPassword,icons/qmasterpassword,icons/hicolor/512x512/apps,qMasterPassword/translations}
     mv qMasterPassword $out/bin
     mv data/qMasterPassword.desktop $out/share/applications
     mv LICENSE README.md $out/share/doc/qMasterPassword
     mv data/icons/app_icon.png $out/share/icons/hicolor/512x512/apps/qmasterpassword.png
     mv data/icons/* $out/share/icons/qmasterpassword
+    lrelease ./data/translations/translation_de.ts
+    lrelease ./data/translations/translation_pl.ts
+    mv ./data/translations/translation_de.qm $out/share/qMasterPassword/translations/translation_de.qm
+    mv ./data/translations/translation_pl.qm $out/share/qMasterPassword/translations/translation_pl.qm
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
There have been [fixes and translation additions on the master branch](https://github.com/bkueng/qMasterPassword/compare/v1.2.2...master), but no release since 2016. Let's pin to the latest commit on the master branch to benefit from all recent changes. 
Regarding translations on Darwin, I couldn't find where to put the translation `*.qm` files so that they'll be read at runtime. Feedback welcome to fix this.

###### Things done
Tested in all three translated languages and confirmed working:
```
LANG=de_DE ./result/bin/qMasterPassword
LANG=pl_PL ./result/bin/qMasterPassword
LANG=en_US ./result/bin/qMasterPassword
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
