### PR TITLE
rxvt-unicode-emoji: variant of rxvt-unicode with emoji support

### DIFF
--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, makeDesktopItem
+{ lib, stdenv, fetchurl, fetchpatch, makeDesktopItem
 , libX11, libXt, libXft, libXrender
 , ncurses, fontconfig, freetype
 , pkg-config, gdk-pixbuf, perl
@@ -6,6 +6,7 @@
 , perlSupport      ? true
 , gdkPixbufSupport ? true
 , unicode3Support  ? true
+, emojiSupport     ? false
 }:
 
 let
@@ -22,6 +23,13 @@ let
     genericName = pname;
     categories = "System;TerminalEmulator;";
   };
+
+  fetchPatchFromAUR = { package, name, rev, sha256 }:
+    fetchpatch rec {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/${name}?h=${package}&id=${rev}";
+      extraPrefix = "";
+      inherit name sha256;
+    };
 in
 
 with lib;
@@ -44,18 +52,33 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "terminfo" ];
 
-  patches = [
+  patches = (if emojiSupport then [
+    # the required patches to libXft are in nixpkgs by default, see
+    # ../../../servers/x11/xorg/overrides.nix
+    (fetchPatchFromAUR {
+      name = "enable-wide-glyphs.patch";
+      package = "rxvt-unicode-truecolor-wide-glyphs";
+      rev = "69701a09c2c206233952b84bc966407f6774f1dc";
+      sha256 = "0jfcj0ahky4dxdfrhqvh1v83mblhf5nak56dk1vq3bhyifdg7ffq";
+    })
+    (fetchPatchFromAUR {
+      name = "improve-font-rendering.patch";
+      package = "rxvt-unicode-truecolor-wide-glyphs";
+      rev = "69701a09c2c206233952b84bc966407f6774f1dc";
+      sha256 = "1jj5ai2182nq912279adihi4zph1w4dvbdqa1pwacy4na6y0fz9y";
+    })
+  ] else [
     ./patches/9.06-font-width.patch
+  ]) ++ [
     ./patches/256-color-resources.patch
-  ] ++ optional stdenv.isDarwin ./patches/makefile-phony.patch;
-
+  ]++ optional stdenv.isDarwin ./patches/makefile-phony.patch;
 
   configureFlags = [
     "--with-terminfo=${placeholder "terminfo"}/share/terminfo"
     "--enable-256-color"
     (enableFeature perlSupport "perl")
     (enableFeature unicode3Support "unicode3")
-  ];
+  ] ++ optional emojiSupport "--enable-wide-glyphs";
 
   LDFLAGS = [ "-lfontconfig" "-lXrender" "-lpthread" ];
   CFLAGS = [ "-I${freetype.dev}/include/freetype2" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1160,9 +1160,17 @@ with pkgs;
 
   rxvt-unicode = callPackage ../applications/terminal-emulators/rxvt-unicode/wrapper.nix { };
 
+  rxvt-unicode-emoji = rxvt-unicode.override {
+    rxvt-unicode-unwrapped = rxvt-unicode-unwrapped-emoji;
+  };
+
   rxvt-unicode-plugins = import ../applications/terminal-emulators/rxvt-unicode-plugins { inherit callPackage; };
 
   rxvt-unicode-unwrapped = callPackage ../applications/terminal-emulators/rxvt-unicode { };
+
+  rxvt-unicode-unwrapped-emoji = rxvt-unicode-unwrapped.override {
+    emojiSupport = true;
+  };
 
   sakura = callPackage ../applications/terminal-emulators/sakura { };
 


### PR DESCRIPTION
###### Motivation for this change

Add `rxvt-unicode-emoji` variant of `rxvt-unicode`, which has emoji support :tada:

The relevant patches for wide glyph support [date back to 2014](https://github.com/blueyed/PKGBUILD-rxvt-unicode-wide/commit/a7241b714da18259621a8d404817ac60f8849ee8) where they had been rejected by upstream. They have since been maintained by various packagers. 

**Note:** While this package works for me without any apparent issues, I do not have deep enough knowledge of the rxvt-unicode codebase or xft font rendering to really attest to their quality or security. That said, I do believe emoji support is a valuable feature, and the patches have been in fairly widespread use for a long time. I think a variant is a good compromise for users who care about the feature.

###### Things done

I adapted the patches from [rxvt-unicode-truecolor-wide-glyphs](https://aur.archlinux.org/packages/rxvt-unicode-truecolor-wide-glyphs/) AUR package for rxvt-unicode 9.30, and packaged them into a variant of rxvt-unicode. I took care to do this in such a way that the original derivation is unchanged when emojiSupport isn't set to true.

Tested locally as such:

```
result/bin/urxvt -fn 'xft:BitstreamVeraSansMono Nerd Font Mono:pixelsize=18,xft:Noto Color Emoji:size=12' -e sh -c 'echo works as expected 👍; sleep 3'
```

Where the first font is used for text rendering (replace with any you like), then [noto](https://github.com/googlefonts/noto-emoji) is used as a fallback for emoji glyphs.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
