### PR TITLE
id3tool: init at 1.2a

### DIFF
--- a/pkgs/applications/audio/id3tool/default.nix
+++ b/pkgs/applications/audio/id3tool/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "id3tool-1.2a";
+  src = fetchurl {
+    url = "http://nekohako.xware.cx/id3tool/id3tool-1.2a.tar.gz";
+    sha256 = "eQjWbFqr4qU66AGegjT0IxSF2Avksv5yydBAE8/xyuw=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv id3tool $out/bin
+  '';
+
+  meta = with lib; {
+    description = "ID3 editing tool";
+    homepage = "http://nekohako.xware.cx/id3tool/";
+    license = licenses.bsd3;
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/applications/audio/id3tool/default.nix
+++ b/pkgs/applications/audio/id3tool/default.nix
@@ -1,21 +1,27 @@
-{ stdenv, lib, fetchurl }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation {
-  name = "id3tool-1.2a";
+  pname = "id3tool";
+  version = "1.2a";
+
   src = fetchurl {
     url = "http://nekohako.xware.cx/id3tool/id3tool-1.2a.tar.gz";
     sha256 = "eQjWbFqr4qU66AGegjT0IxSF2Avksv5yydBAE8/xyuw=";
   };
 
   installPhase = ''
-    mkdir -p $out/bin
-    mv id3tool $out/bin
+    runHook preInstall
+
+    install -D id3tool "$out/bin/id3tool"
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "ID3 editing tool";
     homepage = "http://nekohako.xware.cx/id3tool/";
     license = licenses.bsd3;
+    maintainers = with maintainers; [  ];
     platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Add derivation for https://github.com/NixOS/nixpkgs/issues/157008

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Closes: #157008