### PR TITLE
briar-desktop: init at 0.2.1-beta

### DIFF
--- a/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/briar-desktop/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+, fetchzip
+, openjdk
+, makeWrapper
+, tor
+, p7zip
+, bash
+, writeScript
+}:
+let
+
+  briar-tor = writeScript "briar-tor" ''
+    #! ${bash}/bin/bash
+    exec ${tor}/bin/tor "$@"
+  '';
+
+in
+stdenv.mkDerivation rec {
+  pname = "briar-desktop";
+  version = "0.2.1-beta";
+
+  src = fetchzip {
+    url = "https://code.briarproject.org/briar/briar-desktop/-/jobs/18424/artifacts/download?file_type=archive";
+    sha256 = "sha256-ivMbgo0+iZE4/Iffq9HUBErGIQMVLrRZUQ6R3V3X8II=";
+    extension = "zip";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    p7zip
+  ];
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    cp ${src}/briar-desktop.jar $out/lib/
+    makeWrapper ${openjdk}/bin/java $out/bin/briar-desktop \
+      --add-flags "-jar $out/lib/briar-desktop.jar"
+  '';
+
+  fixupPhase = ''
+    # Replace the embedded Tor binary (which is in a Tar archive)
+    # with one from Nixpkgs.
+    cp ${briar-tor} ./tor
+    for arch in {aarch64,armhf,x86_64}; do
+      7z a tor_linux-$arch.zip tor
+      7z a $out/lib/briar-desktop.jar tor_linux-$arch.zip
+    done
+  '';
+
+  meta = with lib; {
+    description = "Decentalized and secure messnger";
+    homepage = "https://code.briarproject.org/briar/briar-desktop";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ onny ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "armv7l-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ with pkgs;
 
   boofuzz= callPackage ../tools/security/boofuzz { };
 
+  briar-desktop = callPackage ../applications/networking/instant-messengers/briar-desktop { };
+
   bsdbuild = callPackage ../development/tools/misc/bsdbuild { };
 
   bsdiff = callPackage ../tools/compression/bsdiff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Packaging [briar](https://briarproject.org/), a decentralized p2p messenger

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
