### PR TITLE
Add Lisp-Packages `lisp-binary`, `quasiquote-2.0` and `float-features`

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/float-features.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/float-features.nix
@@ -1,0 +1,30 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "float-features";
+  version = "20210228-git";
+
+  description = "A portability library for IEEE float features not covered by the CL standard.";
+
+  deps = [ args."documentation-utils" args."trivial-indent" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/float-features/2021-02-28/float-features-20210228-git.tgz";
+    sha256 = "1giy9qm9bgdfp1mm4d36fcj544kfq68qckmijlrhwbvkpk18hgrd";
+  };
+
+  packageName = "float-features";
+
+  asdFilesToKeep = ["float-features.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM float-features DESCRIPTION
+    A portability library for IEEE float features not covered by the CL standard.
+    SHA256 1giy9qm9bgdfp1mm4d36fcj544kfq68qckmijlrhwbvkpk18hgrd URL
+    http://beta.quicklisp.org/archive/float-features/2021-02-28/float-features-20210228-git.tgz
+    MD5 77223b9c85dca49d0f599e51ba95953a NAME float-features FILENAME
+    float-features DEPS
+    ((NAME documentation-utils FILENAME documentation-utils)
+     (NAME trivial-indent FILENAME trivial-indent))
+    DEPENDENCIES (documentation-utils trivial-indent) VERSION 20210228-git
+    SIBLINGS (float-features-tests) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-binary.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lisp-binary.nix
@@ -1,0 +1,37 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "lisp-binary";
+  version = "20210411-git";
+
+  description = "Declare binary formats as structs and then read and write them.";
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."closer-mop" args."flexi-streams" args."iterate" args."moptilities" args."quasiquote-2_dot_0" args."trivial-features" args."trivial-gray-streams" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/lisp-binary/2021-04-11/lisp-binary-20210411-git.tgz";
+    sha256 = "1sbapl8qla4xb8wcix9yxpijkbk1bpybhay7ncb3z2im7r2kzsnb";
+  };
+
+  packageName = "lisp-binary";
+
+  asdFilesToKeep = ["lisp-binary.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM lisp-binary DESCRIPTION
+    Declare binary formats as structs and then read and write them. SHA256
+    1sbapl8qla4xb8wcix9yxpijkbk1bpybhay7ncb3z2im7r2kzsnb URL
+    http://beta.quicklisp.org/archive/lisp-binary/2021-04-11/lisp-binary-20210411-git.tgz
+    MD5 29d85f01a1cb17742164bacae940d29c NAME lisp-binary FILENAME lisp-binary
+    DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi) (NAME closer-mop FILENAME closer-mop)
+     (NAME flexi-streams FILENAME flexi-streams)
+     (NAME iterate FILENAME iterate) (NAME moptilities FILENAME moptilities)
+     (NAME quasiquote-2.0 FILENAME quasiquote-2_dot_0)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-gray-streams FILENAME trivial-gray-streams))
+    DEPENDENCIES
+    (alexandria babel cffi closer-mop flexi-streams iterate moptilities
+     quasiquote-2.0 trivial-features trivial-gray-streams)
+    VERSION 20210411-git SIBLINGS (lisp-binary-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/quasiquote-2_dot_0.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/quasiquote-2_dot_0.nix
@@ -1,0 +1,31 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "quasiquote-2_dot_0";
+  version = "20150505-git";
+
+  parasites = [ "quasiquote-2.0-tests" ];
+
+  description = "Writing macros that write macros. Effortless.";
+
+  deps = [ args."fiveam" args."iterate" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/quasiquote-2.0/2015-05-05/quasiquote-2.0-20150505-git.tgz";
+    sha256 = "0bgcqk7wp7qblw7avsawkg24zjiq9vgsbfa0yhk64avhxwjw6974";
+  };
+
+  packageName = "quasiquote-2.0";
+
+  asdFilesToKeep = ["quasiquote-2.0.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM quasiquote-2.0 DESCRIPTION
+    Writing macros that write macros. Effortless. SHA256
+    0bgcqk7wp7qblw7avsawkg24zjiq9vgsbfa0yhk64avhxwjw6974 URL
+    http://beta.quicklisp.org/archive/quasiquote-2.0/2015-05-05/quasiquote-2.0-20150505-git.tgz
+    MD5 7c557e0c10cf7608afa5a20e4a83c778 NAME quasiquote-2.0 FILENAME
+    quasiquote-2_dot_0 DEPS
+    ((NAME fiveam FILENAME fiveam) (NAME iterate FILENAME iterate))
+    DEPENDENCIES (fiveam iterate) VERSION 20150505-git SIBLINGS NIL PARASITES
+    (quasiquote-2.0-tests)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -137,6 +137,7 @@ fast-io
 file-attributes
 fiveam
 flexi-streams
+float-features
 form-fiddle
 fset
 generic-cl

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -163,6 +163,7 @@ lfarm-client
 lfarm-server
 lfarm-ssl
 lift
+lisp-binary
 lisp-namespace
 lla
 local-time

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -3257,6 +3257,16 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "float-features" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."float-features" or (x: {}))
+       (import ./quicklisp-to-nix-output/float-features.nix {
+         inherit fetchurl;
+           "documentation-utils" = quicklisp-to-nix-packages."documentation-utils";
+           "trivial-indent" = quicklisp-to-nix-packages."trivial-indent";
+       }));
+
+
   "flexi-streams" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."flexi-streams" or (x: {}))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -345,6 +345,16 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "quasiquote-2_dot_0" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."quasiquote-2_dot_0" or (x: {}))
+       (import ./quicklisp-to-nix-output/quasiquote-2_dot_0.nix {
+         inherit fetchurl;
+           "fiveam" = quicklisp-to-nix-packages."fiveam";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+       }));
+
+
   "lfarm-common" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."lfarm-common" or (x: {}))
@@ -2833,6 +2843,24 @@ let quicklisp-to-nix-packages = rec {
        (import ./quicklisp-to-nix-output/lisp-namespace.nix {
          inherit fetchurl;
            "alexandria" = quicklisp-to-nix-packages."alexandria";
+       }));
+
+
+  "lisp-binary" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."lisp-binary" or (x: {}))
+       (import ./quicklisp-to-nix-output/lisp-binary.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "iterate" = quicklisp-to-nix-packages."iterate";
+           "moptilities" = quicklisp-to-nix-packages."moptilities";
+           "quasiquote-2_dot_0" = quicklisp-to-nix-packages."quasiquote-2_dot_0";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-gray-streams" = quicklisp-to-nix-packages."trivial-gray-streams";
        }));
 
 


### PR DESCRIPTION
###### Motivation for this change
I just edited the txt file and ran the update script.

@7c6f434c Can you review this please?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
