### PR TITLE
lib: add mkPackageOption to default.nix

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -126,7 +126,7 @@ let
       getValues getFiles
       optionAttrSetToDocList optionAttrSetToDocList'
       scrubOptionValue literalExpression literalExample literalDocBook
-      showOption showFiles unknownModule mkOption;
+      showOption showFiles unknownModule mkOption mkPackageOption;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
     inherit (self.asserts)


### PR DESCRIPTION
this was forgotten in #155669. tested by running `lib.mkPackageOption pkgs "hello" {}` in repl.