### PR TITLE
strelka: fix build on gcc-12

### DIFF
--- a/pkgs/applications/science/biology/strelka/default.nix
+++ b/pkgs/applications/science/biology/strelka/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchFromGitHub, cmake, zlib, python2}:
+{lib, stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, python2}:
 
 stdenv.mkDerivation rec {
   pname = "strelka";
@@ -10,6 +10,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "1nykbmim1124xh22nrhrsn8xgjb3s2y7akrdapn9sl1gdych4ppf";
   };
+
+  patches = [
+    # Pull pending fix for gcc-12:
+    #   https://github.com/Illumina/strelka/pull/204
+    (fetchpatch {
+      name = "limits.patch";
+      url = "https://github.com/Illumina/strelka/commit/98272cd345c6e4c672e6a5b7721204fcac0502d6.patch";
+      sha256 = "16dx5b4x3xa0dvqggv749l863m114fad9y85z4czr7pnvnw65h56";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ zlib python2 ];


### PR DESCRIPTION
Without the change build fails as:

    src/c++/lib/calibration/IndelErrorModel.hh:100:33: error: 'numeric_limits' is not a member of 'std'
      100 |     double logErrorRate = -std::numeric_limits<double>::infinity();
          |                                 ^~~~~~~~~~~~~~