### PR TITLE
pinegrow: init at 6.3

### DIFF
--- a/pkgs/applications/editors/pinegrow/default.nix
+++ b/pkgs/applications/editors/pinegrow/default.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, lib
+, fetchurl
+, unzip
+, udev
+, nwjs
+, gcc-unwrapped
+, autoPatchelfHook
+, gsettings-desktop-schemas
+, gtk3
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pinegrow";
+  version = "6.3";
+
+  src = fetchurl {
+    url = "https://download.pinegrow.com/PinegrowLinux64.${version}.zip";
+    sha256 = "0wldj633p67da077nfc67gr9xhq580rkfd0r3904sjq7x01r0kaz";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    autoPatchelfHook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    udev
+    nwjs
+    gcc-unwrapped
+    gsettings-desktop-schemas
+    gtk3
+  ];
+
+  sourceRoot = ".";
+
+  dontUnpack = true;
+
+  # Extract and copy executable in $out/bin
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/applications
+    mkdir -p $out/bin
+    mkdir -p $out/opt/bin
+    # we can't unzip it in $out/lib, because nw.js will start with
+    # an empty screen. Therefore it will be unzipped in a non-typical
+    # folder and symlinked.
+    unzip $src -d $out/opt/pinegrow
+    substituteInPlace $out/opt/pinegrow/Pinegrow.desktop \
+      --replace 'Exec=sh -c "$(dirname %k)/PinegrowLibrary"' 'Exec=sh -c "$out/bin/Pinegrow"'
+    mv $out/opt/pinegrow/Pinegrow.desktop $out/share/applications/Pinegrow.desktop
+    ln -s $out/opt/pinegrow/PinegrowLibrary $out/bin/Pinegrow
+    runHook postInstall
+  '';
+
+  preFixup = ''
+      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+      wrapGApp "$out/opt/pinegrow/PinegrowLibrary" --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+    '';
+
+  meta = with lib; {
+    homepage = "https://pinegrow.com";
+    description = "UI Web Editor";
+    platforms = platforms.linux;
+    license = with licenses; [ unfreeRedistributable ];
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/applications/editors/pinegrow/default.nix
+++ b/pkgs/applications/editors/pinegrow/default.nix
@@ -41,9 +41,8 @@ stdenv.mkDerivation rec {
   # Extract and copy executable in $out/bin
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/share/applications
-    mkdir -p $out/bin
-    mkdir -p $out/opt/bin
+
+    mkdir -p $out/share/applications $out/bin $out/opt/bin
     # we can't unzip it in $out/lib, because nw.js will start with
     # an empty screen. Therefore it will be unzipped in a non-typical
     # folder and symlinked.
@@ -52,13 +51,14 @@ stdenv.mkDerivation rec {
       --replace 'Exec=sh -c "$(dirname %k)/PinegrowLibrary"' 'Exec=sh -c "$out/bin/Pinegrow"'
     mv $out/opt/pinegrow/Pinegrow.desktop $out/share/applications/Pinegrow.desktop
     ln -s $out/opt/pinegrow/PinegrowLibrary $out/bin/Pinegrow
+
     runHook postInstall
   '';
 
   preFixup = ''
-      export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
-      wrapGApp "$out/opt/pinegrow/PinegrowLibrary" --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
-    '';
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+    wrapGApp "$out/opt/pinegrow/PinegrowLibrary" --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+  '';
 
   meta = with lib; {
     homepage = "https://pinegrow.com";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27472,6 +27472,8 @@ with pkgs;
 
   pijuice = with python3Packages; toPythonApplication pijuice;
 
+  pinegrow = callPackage ../applications/editors/pinegrow { };
+
   ping = callPackage ../applications/networking/ping { };
 
   piper = callPackage ../os-specific/linux/piper { };


### PR DESCRIPTION
###### Motivation for this change
Pinegrow is a Mac, Windows and Linux web editor that lets you build modern websites faster with live multi-page editing, CSS & SASS styling, CSS Grid editor and support for Bootstrap, Tailwind CSS and WordPress. [1]

I use Pinegrow editor for web page editing, but it isn't available yet in NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Contacted vendor and asked permission to include the modified binary in cache.nixos.org 
  <details>
   <summary>Email</summary>

  > The legal wording, so that you are covered:
  > 
  > I hereby give permission to include Pinegrow Web Editor and all subsequent releases to the NixOS package manager and  to do the modifications of the software in the binary form, limited to changes that are required to get the software to run on  NixOS.
  > 
  > Have a good day,
  > Matjaz Trontelj
  > CEO, Pinegrow Pte. Ltd.

</details>

[1]: https://pinegrow.com/
