### PR TITLE
7zz: compile optimized assembly code for x86_64

### DIFF
--- a/pkgs/development/compilers/uasm/default.nix
+++ b/pkgs/development/compilers/uasm/default.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch }:
+
+stdenv.mkDerivation rec {
+  pname = "uasm";
+  version = "2.53";
+
+  src = fetchFromGitHub {
+    owner = "Terraspace";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Aohwrcb/KTKUFFpfmqVDPNjJh1dMYSNnBJ2eFaP20pM=";
+  };
+
+  # https://github.com/Terraspace/UASM/pull/154
+  patches = [
+    # fix `invalid operands to binary - (have 'char *' and 'uint_8 *' {aka 'unsigned char *'})`
+    (fetchpatch {
+      name = "fix_pointers_compare.patch";
+      url = "https://github.com/clouds56/UASM/commit/9cd3a400990e230571e06d4c758bd3bd35f90ab6.patch";
+      sha256 = "sha256-8mY36dn+g2QNJ1JbWt/y4p0Ha9RSABnOE3vlWANuhsA=";
+    })
+    # fix `dbgcv.c:*:*: fatal error: direct.h: No such file or directory`
+    (fetchpatch {
+      name = "fix_build_dbgcv_c_on_unix.patch";
+      url = "https://github.com/clouds56/UASM/commit/806d54cf778246c96dcbe61a4649bf0aebcb0eba.patch";
+      sha256 = "sha256-uc1LaizdYEh1Ry55Cq+6wrCa1OeBPFo74H5iBpmteAE=";
+    })
+  ];
+
+  enableParallelBuilding = true;
+
+  makefile = "gccLinux64.mak";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt "$out/bin" -m0755 GccUnixR/uasm
+    install -Dt "$out/share/doc/${pname}" -m0644 {Readme,History}.txt Doc/*
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "http://www.terraspace.co.uk/uasm.html";
+    description = "A free MASM-compatible assembler based on JWasm";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ thiagokokada ];
+    license = licenses.watcom;
+  };
+}

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, lib, fetchurl, p7zip }:
+{ stdenv, lib, fetchurl, p7zip, uasm, useUasm ? stdenv.isx86_64 }:
 
+let
+  inherit (stdenv.hostPlatform) system;
+  platformSuffix =
+    if useUasm then
+      {
+        x86_64-linux = "_x64";
+      }.${system} or (throw "`useUasm` is not supported for system ${system}")
+    else "";
+in
 stdenv.mkDerivation rec {
   pname = "7zz";
   version = "21.07";
@@ -11,19 +20,18 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "CPP/7zip/Bundles/Alone2";
 
-  # we need https://github.com/nidud/asmc/tree/master/source/asmc/linux in order
-  # to build with the optimized assembler but that doesn't support building with
-  # GCC: https://github.com/nidud/asmc/issues/8
-  makefile = "../../cmpl_gcc.mak"; # "../../cmpl_gcc_x64.mak";
+  makeFlags = lib.optionals useUasm [ "MY_ASM=uasm" ];
 
-  nativeBuildInputs = [ p7zip ];
+  makefile = "../../cmpl_gcc${platformSuffix}.mak";
+
+  nativeBuildInputs = [ p7zip ] ++ lib.optionals useUasm [ uasm ];
 
   enableParallelBuilding = true;
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin b/g/7zz
+    install -Dm555 -t $out/bin b/g${platformSuffix}/7zz
     install -Dm444 -t $out/share/doc/${pname} ../../../../DOC/*.txt
 
     runHook postInstall
@@ -37,7 +45,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Command line archiver utility";
-    homepage = "https://7zip.org";
+    homepage = "https://7-zip.org";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ anna328p peterhoeg ];
     platforms = platforms.linux;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13283,6 +13283,8 @@ with pkgs;
 
   bupc = callPackage ../development/compilers/bupc { };
 
+  uasm = callPackage ../development/compilers/uasm { };
+
   urn = callPackage ../development/compilers/urn { };
 
   urweb = callPackage ../development/compilers/urweb {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR compiles `7zz` with optimized assembly code for faster operations. To do this, this PR also introduces the `uasm` compiler at version `2.53`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
