### PR TITLE
obsidian: add uri scheme support to obsidian.desktop file

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -14,8 +14,9 @@ let
     desktopName = "Obsidian";
     comment = "Knowledge base";
     icon = "obsidian";
-    exec = "obsidian";
+    exec = "obsidian %u";
     categories = "Office";
+    mimeType = "text/html;x-scheme-handler/obsidian;";
   };
 
   updateScript = writeScript "obsidian-updater" ''


### PR DESCRIPTION
###### Motivation for this change
obsidian.desktop does not declare the `obsidian://` uri scheme


see https://help.obsidian.md/Advanced+topics/Using+obsidian+URI
and https://forum.obsidian.md/t/obsidian-uri-set-up-for-linux-obsidian-desktop/7494/4
for details

after this change
```
xdg-mime query default x-scheme-handler/obsidian
```
correctly identifies `obsidian.desktop`


###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
