### PR TITLE
goreman: 0.2.1 -> 0.3.9

### DIFF
--- a/pkgs/tools/system/goreman/default.nix
+++ b/pkgs/tools/system/goreman/default.nix
@@ -1,17 +1,26 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
-buildGoPackage rec {
-  pname = "goreman";
-  version = "0.2.1";
+{ lib, buildGoModule, fetchFromGitHub }:
 
-  goPackagePath = "github.com/mattn/goreman";
-  subPackages = ["."];
+buildGoModule rec {
+  pname = "goreman";
+  version = "0.3.9";
+  rev = "df1209e7cdbad10aecc0aa75d332bc32822925f5";
 
   src = fetchFromGitHub {
     owner = "mattn";
     repo = "goreman";
     rev = "v${version}";
-    sha256 = "1h7ip788j7bkygahpp7ylgnrx9jrbhwjzqpjhd1pflmlaxcbflcy";
+    sha256 = "1irjf5i5ybdchyn42bamfq8pj3w00p633h1gg202n0vsr39h0bxw";
   };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.revision=${builtins.substring 0 7 rev}"
+  ];
+
+  vendorSha256 = "sha256-+RFh6Ppxxs7P7DWqOBeEJTvPsBgOfopMjx22hPEI1/U=";
+
+  doCheck = false;
 
   meta = with lib; {
     description = "foreman clone written in go language";
@@ -20,4 +29,3 @@ buildGoPackage rec {
     maintainers = with maintainers; [ zimbatm ];
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release v0.3.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).