### PR TITLE
nixos/pulseaudio: remove broken support for 32bit on 64bit systems

### DIFF
--- a/nixos/modules/config/pulseaudio.nix
+++ b/nixos/modules/config/pulseaudio.nix
@@ -101,6 +101,14 @@ in {
         '';
       };
 
+      support32Bit = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          This option is no longer supported, and will eventually be removed.
+        '';
+      };
+
       configFile = mkOption {
         type = types.nullOr types.path;
         description = ''
@@ -210,6 +218,11 @@ in {
     }
 
     (mkIf cfg.enable {
+      assertions = [{
+        assertion = !cfg.support32Bit;
+        message = "`hardware.pulseaudio.support32Bit` is no longer supported.";
+      }];
+
       environment.systemPackages = [ overriddenPackage ];
 
       sound.enable = true;

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -39,9 +39,6 @@ in {
       driSupport32Bit = true;
     };
 
-    # optionally enable 32bit pulseaudio support if pulseaudio is enabled
-    hardware.pulseaudio.support32Bit = config.hardware.pulseaudio.enable;
-
     hardware.steam-hardware.enable = true;
 
     environment.systemPackages = [ steam steam.run ];

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -8,8 +8,6 @@ let
   pcmPlugin = cfg.jackd.enable && cfg.alsa.enable;
   loopback = cfg.jackd.enable && cfg.loopback.enable;
 
-  enable32BitAlsaPlugins = cfg.alsa.support32Bit && pkgs.stdenv.isx86_64 && pkgs.pkgsi686Linux.alsa-lib != null;
-
   umaskNeeded = versionOlder cfg.jackd.package.version "1.9.12";
   bridgeNeeded = versionAtLeast cfg.jackd.package.version "1.9.12";
 in {
@@ -60,14 +58,6 @@ in {
           default = true;
           description = ''
             Route audio to/from generic ALSA-using applications using ALSA JACK PCM plugin.
-          '';
-        };
-
-        support32Bit = mkOption {
-          type = types.bool;
-          default = false;
-          description = ''
-            Whether to support sound for 32-bit ALSA applications on 64-bit system.
           '';
         };
       };
@@ -129,9 +119,7 @@ in {
     (mkIf pcmPlugin {
       sound.extraConfig = ''
         pcm_type.jack {
-          libs.native = ${pkgs.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_jack.so ;
-          ${lib.optionalString enable32BitAlsaPlugins
-          "libs.32Bit = ${pkgs.pkgsi686Linux.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_jack.so ;"}
+          lib ${pkgs.alsa-plugins}/lib/alsa-lib/libasound_module_pcm_jack.so ;
         }
         pcm.!default {
           @func getenv

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -60,6 +60,14 @@ in {
             Route audio to/from generic ALSA-using applications using ALSA JACK PCM plugin.
           '';
         };
+
+        support32Bit = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            This option is no longer supported, and will eventually be removed.
+          '';
+        };
       };
 
       loopback = {
@@ -204,6 +212,10 @@ in {
         {
           assertion = !(cfg.alsa.enable && cfg.loopback.enable);
           message = "For JACK both alsa and loopback options shouldn't be used at the same time.";
+        }
+        {
+          assertion = !cfg.alsa.support32Bit;
+          message = "`services.jack.alsa.support32Bit` is no longer supported.";
         }
       ];
 

--- a/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire-media-session.nix
@@ -6,9 +6,6 @@ with lib;
 let
   json = pkgs.formats.json {};
   cfg = config.services.pipewire.media-session;
-  enable32BitAlsaPlugins = cfg.alsa.support32Bit
-                           && pkgs.stdenv.isx86_64
-                           && pkgs.pkgsi686Linux.pipewire != null;
 
   # Use upstream config files passed through spa-json-dump as the base
   # Patched here as necessary for them to work with this module

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -6,9 +6,6 @@ with lib;
 let
   json = pkgs.formats.json {};
   cfg = config.services.pipewire;
-  enable32BitAlsaPlugins = cfg.alsa.support32Bit
-                           && pkgs.stdenv.isx86_64
-                           && pkgs.pkgsi686Linux.pipewire != null;
 
   # The package doesn't output to $out/lib/pipewire directly so that the
   # overlays can use the outputs to replace the originals in FHS environments.
@@ -115,7 +112,6 @@ in {
 
       alsa = {
         enable = mkEnableOption "ALSA support";
-        support32Bit = mkEnableOption "32-bit ALSA support on 64-bit systems";
       };
 
       jack = {
@@ -186,14 +182,10 @@ in {
     environment.etc."alsa/conf.d/49-pipewire-modules.conf" = mkIf cfg.alsa.enable {
       text = ''
         pcm_type.pipewire {
-          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
-          ${optionalString enable32BitAlsaPlugins
-            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;"}
+          lib ${cfg.package.lib}/lib/alsa-lib/libasound_module_pcm_pipewire.so ;
         }
         ctl_type.pipewire {
-          libs.native = ${cfg.package.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;
-          ${optionalString enable32BitAlsaPlugins
-            "libs.32Bit = ${pkgs.pkgsi686Linux.pipewire.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;"}
+          lib ${cfg.package.lib}/lib/alsa-lib/libasound_module_ctl_pipewire.so ;
         }
       '';
     };

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -112,6 +112,7 @@ in {
 
       alsa = {
         enable = mkEnableOption "ALSA support";
+        support32Bit = mkEnableOption "This option is no longer supported, and will eventually be removed";
       };
 
       jack = {
@@ -151,6 +152,10 @@ in {
       {
         assertion = cfg.jack.enable -> !config.services.jack.jackd.enable;
         message = "PipeWire based JACK emulation doesn't use the JACK service. This option requires `services.jack.jackd.enable` to be set to false";
+      }
+      {
+        assertion = !cfg.alsa.support32Bit;
+        message = "`services.pipewire.alsa.support32Bit` is no longer supported.";
       }
     ];
 

--- a/nixos/tests/installed-tests/pipewire.nix
+++ b/nixos/tests/installed-tests/pipewire.nix
@@ -9,7 +9,6 @@ makeInstalledTest {
       pulse.enable = true;
       jack.enable = true;
       alsa.enable = true;
-      alsa.support32Bit = true;
     };
   };
 }

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -33,7 +33,6 @@ let
             imports = [ ./common/wayland-cage.nix ];
             hardware.pulseaudio = {
               enable = true;
-              support32Bit = true;
               inherit systemWide;
             };
 

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -299,7 +299,6 @@ in buildFHSUserEnv rec {
     and then run \`sudo nixos-rebuild switch\`:
     {
       hardware.opengl.driSupport32Bit = true;
-      hardware.pulseaudio.support32Bit = true;
     }
     **
     EOF


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

In #154276, alsa-lib was updated and old patches removed. One of those patches, from 2014, allowed alsa-lib to recognize a `libs` field in /etc/asound.conf, and the pulseaudio module leveraged this to optionally add support for running both 32bit and 64bit apps on 64bit platforms.

With the patch removed, alsa-lib is unable to parse the /etc/asound.conf generated by the pulseaudio module (regardless whether the user has opted into 32bit support), and alsa utils such as `alsactl`, `alsamixer`, `speaker-test`, are broken. E.g.
```
$ alsactl monitor default
alsa-lib control.c:1464:(snd_ctl_open_conf) Unknown field libs
Cannot open ctl default
```

Once the issue was identified, it was reasoned that the 32bit support is too niche a use-case to justify patching a system as complex as alsa, especially given the availability of pipewire.

I removed the `support32Bit` option from pulseaudio and changed the generated config to use syntax recognized by alsa-lib. I then removed several references to this option from other modules (steam, jack, pipewire).

***Note***: I rebuilt my system against this branch and confirmed that alsa works as expected for my use-cases. I have not tested steam, jack, or pipewire.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
