### PR TITLE
nixos/fail2ban: add option to enable sending mail

### DIFF
--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -240,16 +240,41 @@ in
         '';
       };
 
-    };
+      mail = {
+        enable = mkOption {
+          default = false;
+          type = types.bool;
+          description = ''
+            Whether to allow fail2ban send notification emails. Enabling this disables some sandboxing features of the fail2ban systemd service, which may reduce security. You should probably enable <option>services.postfix</option> or some other MTA for this to work. To send whois-lines (e.g., with <literal>action_mwl</literal>), add <literal>pkgs.whois</literal> to <option>fail2ban.extraPackages</option>.
+          '';
+        };
 
+        destemail = mkOption {
+          default = "";
+          type = types.str;
+          description = ''
+            E-mail address to which notification mails are sent.
+          '';
+        };
+
+        sender = mkOption {
+          default = "";
+          type = types.str;
+          description = ''
+            Sender address for notification mails.
+          '';
+        };
+      };
+    };
   };
 
   ###### implementation
 
   config = mkIf cfg.enable {
-
-    warnings = mkIf (config.networking.firewall.enable == false && config.networking.nftables.enable == false) [
+    warnings = optionals (config.networking.firewall.enable == false && config.networking.nftables.enable == false) [
       "fail2ban can not be used without a firewall"
+    ] ++ optionals (cfg.mail.enable && cfg.mail.destemail == "") [
+      "fail2ban.mail is enabled but fail2ban.mail.destemail is not set"
     ];
 
     environment.systemPackages = [ cfg.package ];
@@ -274,7 +299,9 @@ in
 
       restartTriggers = [ fail2banConf jailConf pathsConf ];
 
-      path = [ cfg.package cfg.packageFirewall pkgs.iproute2 ] ++ cfg.extraPackages;
+      path = [ cfg.package cfg.packageFirewall pkgs.iproute2 ]
+        ++ cfg.extraPackages
+        ++ optionals cfg.mail.enable [ pkgs.mailutils ];
 
       unitConfig.Documentation = "man:fail2ban(1)";
 
@@ -288,7 +315,7 @@ in
         # Capabilities
         CapabilityBoundingSet = [ "CAP_AUDIT_READ" "CAP_DAC_READ_SEARCH" "CAP_NET_ADMIN" "CAP_NET_RAW" ];
         # Security
-        NoNewPrivileges = true;
+        NoNewPrivileges = mkIf (!cfg.mail.enable) true;
         # Directory
         RuntimeDirectory = "fail2ban";
         RuntimeDirectoryMode = "0750";
@@ -297,7 +324,7 @@ in
         LogsDirectory = "fail2ban";
         LogsDirectoryMode = "0750";
         # Sandboxing
-        ProtectSystem = "strict";
+        ProtectSystem = mkIf (!cfg.mail.enable) "strict";
         ProtectHome = true;
         PrivateTmp = true;
         PrivateDevices = true;
@@ -327,6 +354,12 @@ in
       # Actions
       banaction   = ${cfg.banaction}
       banaction_allports = ${cfg.banaction-allports}
+      ${optionalString cfg.mail.enable ''
+        # Mail
+        mta = mail
+        ${optionalString (cfg.mail.destemail != "") "destemail = ${cfg.mail.destemail}"}
+        ${optionalString (cfg.mail.sender != "") "sender = ${cfg.mail.sender}"}
+      ''}
     '';
     # Block SSH if there are too many failing connection attempts.
     # Benefits from verbose sshd logging to observe failed login attempts,


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Addresses https://github.com/NixOS/nixpkgs/issues/156480 (cannot send mail because the systemd unit is sandboxed). This PR adds the option `fail2ban.mail.enable`. Setting this prevents adding `NoNewPrivileges` and `ProtectSystem` in the systemd unit configuration. It also adds `mta=mail` to `jail.conf.local`, and adds the package `mailutils`.

This PR also adds options `fail2ban.mail.destemail` and `fail2ban.mail.sender` that add the corresponding entries to `jail.conf.local`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
