### PR TITLE
sabnzbd: 3.4.2 -> 3.5.0

### DIFF
--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -20,17 +20,18 @@ let
     sabyenc3
     puremagic
     guessit
+    pysocks
   ]);
   path = lib.makeBinPath [ par2cmdline unrar unzip p7zip ];
 in stdenv.mkDerivation rec {
-  version = "3.4.2";
+  version = "3.5.0";
   pname = "sabnzbd";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-Pl2i/k5tilPvMWLRtzZ2imOJQdZYKDAz8bt847ZAXF8=";
+    sha256 = "sha256-Ay+y02kvFuwefT6f/8orClMiBK201AwSEWnPKgoeOFQ=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest release https://github.com/sabnzbd/sabnzbd/releases/tag/3.5.0 ([changes](https://github.com/sabnzbd/sabnzbd/compare/3.4.2...3.5.0)).

Supersedes #157258 which does not add the new dependency to `PySocks`:

From https://github.com/NixOS/nixpkgs/pull/157258/checks?check_run_id=4990588309:
```
machine # [   19.466791] sabnzbd[775]: Not all required Python modules are available, please check requirements.txt
machine # [   19.474676] sabnzbd[775]: Missing module: socks
machine # [   19.476830] sabnzbd[775]: You can read more at: https://sabnzbd.org/wiki/installation/install-off-modules
machine # [   19.484333] sabnzbd[775]: If you still experience problems, remove all .pyc files in this folder and subfolders
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
