### PR TITLE
fcitx-engines.libpinyin: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/fcitx-engines/fcitx-libpinyin/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fcitx-libpinyin";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchurl {
     url = "http://download.fcitx-im.org/fcitx-libpinyin/${pname}-${version}.tar.xz";
-    sha256 = "196c229ckib3xvafkk4n3n3jk9rpksfcjsbbwka6a9k2f34qrjj6";
+    sha256 = "1wvsc21imbgq3chlxfw4aycmkb2vi1bkjj9frvhga2m5b5pq82k5";
   };
 
   nativeBuildInputs = [ cmake pkg-config  ];


### PR DESCRIPTION
###### Motivation for this change
Fix #157354

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).