### PR TITLE
osmtogeojson: init at 3.0.0-beta.4

### DIFF
--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -216,6 +216,7 @@
 , {"npm2nix": "git://github.com/NixOS/npm2nix.git#5.12.0"}
 , "nrm"
 , "ocaml-language-server"
+, "osmtogeojson"
 , "parcel-bundler"
 , "parsoid"
 , "patch-package"


### PR DESCRIPTION
###### Motivation for this change

`osmtogeojson` was not packaged.

3 packages do not build, but they were broken before this patch.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>hyperspace-cli</li>
    <li>timedoctor</li>
  </ul>
</details>
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>theLoungePlugins.plugins.closepms</li>
    <li>theLoungePlugins.themes.flat-blue</li>
    <li>theLoungePlugins.themes.flat-dark</li>
  </ul>
</details>
<details>
  <summary>43 packages built:</summary>
  <ul>
    <li>antennas</li>
    <li>antora</li>
    <li>balanceofsatoshis</li>
    <li>castnow</li>
    <li>commitlint</li>
    <li>create-cycle-app</li>
    <li>deltachat-desktop</li>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>epgstation</li>
    <li>fast-cli</li>
    <li>flexoptix-app</li>
    <li>gtop</li>
    <li>joplin</li>
    <li>lessc</li>
    <li>lumo</li>
    <li>mastodon-bot</li>
    <li>pm2</li>
    <li>postcss-cli</li>
    <li>pyright</li>
    <li>redoc-cli</li>
    <li>reveal-md</li>
    <li>shepherd</li>
    <li>slack</li>
    <li>styx</li>
    <li>teams</li>
    <li>thelounge</li>
    <li>vimPlugins.coc-explorer</li>
    <li>vimPlugins.coc-metals</li>
    <li>vimPlugins.coc-prettier</li>
    <li>vimPlugins.coc-pyright</li>
    <li>vimPlugins.coc-stylelint</li>
    <li>vimPlugins.coc-vetur</li>
    <li>vscode</li>
    <li>vscode-extensions.matklad.rust-analyzer</li>
    <li>vscode-extensions.ms-python.vscode-pylance</li>
    <li>vscode-extensions.vadimcn.vscode-lldb</li>
    <li>vscode-fhs</li>
    <li>vscode-with-extensions</li>
    <li>vscodium</li>
    <li>vscodium-fhs</li>
    <li>whalebird</li>
    <li>zerobin</li>
  </ul>
</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
