### PR TITLE
mbedtls: 2.26.0 -> 2.28.0

### DIFF
--- a/pkgs/development/libraries/mbedtls/default.nix
+++ b/pkgs/development/libraries/mbedtls/default.nix
@@ -15,13 +15,13 @@ stdenv.mkDerivation rec {
   # versions. See
   #  * https://github.com/NixOS/nixpkgs/pull/119838#issuecomment-822100428
   #  * https://github.com/NixOS/nixpkgs/commit/0ee02a9d42b5fe1825b0f7cee7a9986bb4ba975d
-  version = "2.26.0"; # nixpkgs-update: no auto update
+  version = "2.28.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "ARMmbed";
     repo = "mbedtls";
     rev = "${pname}-${version}";
-    sha256 = "0scwpmrgvg6q7rvqkc352d2fqlsx0aylcbyibcp1f1rsn8iiif2m";
+    sha256 = "sha256-VDoIUBaK2e0E5nkwU1u3Wvxc+s6OzBSdIeHsJKJuZ2g=";
   };
 
   nativeBuildInputs = [ cmake ninja perl python3 ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changes:
https://github.com/ARMmbed/mbedtls/releases/tag/v2.27.0
https://github.com/ARMmbed/mbedtls/releases/tag/v2.28.0

Security advisories:
https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-07-1
https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-07-2
https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2021-12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>lutris</li>
    <li>obs-studio-plugins.obs-ndi</li>
  </ul>
</details>
<details>
  <summary>43 packages built:</summary>
  <ul>
    <li>bctoolbox</li>
    <li>belcard</li>
    <li>belle-sip</li>
    <li>belr</li>
    <li>bzrtp</li>
    <li>dislocker</li>
    <li>dolphin-emu</li>
    <li>dolphin-emu-beta</li>
    <li>dolphin-emu-primehack</li>
    <li>gauche</li>
    <li>gaucheBootstrap</li>
    <li>haxe</li>
    <li>haxePackages.hxcpp</li>
    <li>haxePackages.hxcs</li>
    <li>haxePackages.hxjava</li>
    <li>haxePackages.hxnodejs_4</li>
    <li>haxe_3_2</li>
    <li>haxe_3_4</li>
    <li>haxe_4_0</li>
    <li>haxe_4_1</li>
    <li>hiawatha</li>
    <li>liblinphone</li>
    <li>lime</li>
    <li>linphone</li>
    <li>lutris-free</li>
    <li>mbedtls</li>
    <li>mediastreamer</li>
    <li>mediastreamer-openh264</li>
    <li>msilbc</li>
    <li>neko</li>
    <li>obs-studio</li>
    <li>obs-studio-plugins.looking-glass-obs</li>
    <li>obs-studio-plugins.obs-gstreamer</li>
    <li>obs-studio-plugins.obs-move-transition</li>
    <li>obs-studio-plugins.obs-multi-rtmp</li>
    <li>obs-studio-plugins.obs-nvfbc</li>
    <li>obs-studio-plugins.obs-websocket</li>
    <li>obs-studio-plugins.wlrobs</li>
    <li>openrgb</li>
    <li>ortp</li>
    <li>shadowsocks-libev</li>
    <li>trx</li>
    <li>yojimbo</li>
  </ul>
</details>