### PR TITLE
rubyPackages.addressable: 2.4.0 -> 2.8.0

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -121,14 +121,15 @@
     version = "7.0.1";
   };
   addressable = {
+    dependencies = ["idn-ruby"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0mpn7sbjl477h56gmxsjqb89r5s3w7vx5af994ssgc3iamvgzgvs";
+      sha256 = "sha256-920p0tH1S2xqSa7Fj5WDsI2X4IjCJ6P8upL2xlMdWQg=";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "2.8.0";
   };
   ansi = {
     groups = ["default"];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes CVE-2021-32740
https://github.com/sporkmonger/addressable/blob/addressable-2.8.0/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>27 packages built:</summary>
  <ul>
    <li>rubyPackages.addressable</li>
    <li>rubyPackages.data_objects</li>
    <li>rubyPackages.do_sqlite3</li>
    <li>rubyPackages.github-pages</li>
    <li>rubyPackages.github-pages-health-check</li>
    <li>rubyPackages.jekyll-gist</li>
    <li>rubyPackages.jekyll-github-metadata</li>
    <li>rubyPackages.octokit</li>
    <li>rubyPackages.sawyer</li>
    <li>rubyPackages_3_0.addressable</li>
    <li>rubyPackages_3_0.data_objects</li>
    <li>rubyPackages_3_0.do_sqlite3</li>
    <li>rubyPackages_3_0.github-pages</li>
    <li>rubyPackages_3_0.github-pages-health-check</li>
    <li>rubyPackages_3_0.jekyll-gist</li>
    <li>rubyPackages_3_0.jekyll-github-metadata</li>
    <li>rubyPackages_3_0.octokit</li>
    <li>rubyPackages_3_0.sawyer</li>
    <li>rubyPackages_3_1.addressable</li>
    <li>rubyPackages_3_1.data_objects</li>
    <li>rubyPackages_3_1.do_sqlite3</li>
    <li>rubyPackages_3_1.github-pages</li>
    <li>rubyPackages_3_1.github-pages-health-check</li>
    <li>rubyPackages_3_1.jekyll-gist</li>
    <li>rubyPackages_3_1.jekyll-github-metadata</li>
    <li>rubyPackages_3_1.octokit</li>
    <li>rubyPackages_3_1.sawyer</li>
  </ul>
</details>