### PR TITLE
stork: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , openssl
 , pkg-config
+, stdenv
+, darwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -20,12 +22,16 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
   meta = with lib; {
     description = "Impossibly fast web search, made for static sites";
     homepage = "https://github.com/jameslittle230/stork";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ chuahou ];
+    # TODO: Remove once nixpkgs uses macOS SDK 10.14+ for x86_64-darwin
+    # Undefined symbols for architecture x86_64: "_SecTrustEvaluateWithError"
+    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }

--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "stork";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jameslittle230";
     repo = "stork";
     rev = "v${version}";
-    sha256 = "sha256-or8PDEj97ChZq6r3WlwETYbU6EvoEuh8HfTyBIbbO8M=";
+    sha256 = "sha256-9fylJcUuModemkBRnXeFfB1b+CD9IvTxW+CnlqaUb60=";
   };
 
-  cargoSha256 = "sha256-UpIPbY2beO1H0YR9kV1SkG6C3qcO4x2acfgqI3x5jiM=";
+  cargoSha256 = "sha256-j7OXl66xuTuP6hWJs+xHrwtaBGAYt02OESCN6FH3KX0=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release [v1.4.0](https://github.com/jameslittle230/stork/releases/tag/v1.4.0).

Tested:
- `stork build`
- `stork search`
- Running on static site with `stork.js` + `stork.wasm`

<details><summary>Run results</summary>

```
$ ../nixpkgs/result/bin/stork build --input stork/config.toml --output stork/index.st
Success: Index built successfully, wrote 485,403 bytes.
Index stats:
  - 50 entries
  - 9,792 search terms
  - 9,708 bytes per entry
  - 49 bytes per search term

$ ../nixpkgs/result/bin/stork search --index stork/index.st --query beta | head
{
  "results": [
    {
      "entry": {
        "url": "https://chuahou.dev/miso/uni/lc/notes/theories.html",
        "title": "LC, Equational Theories",
        "fields": {}
      },
      "excerpts": [
        {
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
