### PR TITLE
weechat: 3.3 -> 3.4.1

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -28,14 +28,14 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "3.3";
+      version = "3.4";
       pname = "weechat";
 
       hardeningEnable = [ "pie" ];
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "sha256-GnSi7uMxiyWSQau75q07NlX1ikaBeWOdrzOf9f0jnBM=";
+        sha256 = "sha256-+JhIVcGA2wcvTr4O5eTn5vNszHpCuEt6D90a743PfQU=";
       };
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -42,7 +42,7 @@ let
 
       cmakeFlags = with lib; [
         "-DENABLE_MAN=ON"
-        "-DENABLE_DOC=ON"
+        "-DENABLE_DOC=OFF"         # TODO: Documentation fails to build, was deactivated to push through security update
         "-DENABLE_JAVASCRIPT=OFF"  # Requires v8 <= 3.24.3, https://github.com/weechat/weechat/issues/360
         "-DENABLE_PHP=OFF"
       ]

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -28,14 +28,14 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "3.4";
+      version = "3.4.1";
       pname = "weechat";
 
       hardeningEnable = [ "pie" ];
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "sha256-+JhIVcGA2wcvTr4O5eTn5vNszHpCuEt6D90a743PfQU=";
+        sha256 = "sha256-TJ4JI97WiobkBxgnkUGh/XQAIlDV+PDgIxCzTqefiMw=";
       };
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

WeeChat version 3.4 was released on 13-12-2021

###### Things done

The WeeChat version has been bumped to 3.4 (from 3.3)

###### Things to do

After this change, WeeChat fails to build; this needs to be fixed

(I built with `nix build`, version 2.7.0pre20220124_0a70b37)

<details>

<summary> (Click to expand) It fails with the following errors: </summary>

(`[…]` = omitted)
```
No such file or directory - /nix/store/7vl7rzs7vz0pi039nrn3r2hcnjp7r6q2-ruby2.7.5-pygments.rb-2.2.0/lib/ruby/gems/2.7.0/gems/pygments.rb-2.2.0/lib/pygments/mentos.py
  Use --trace for backtrace
[…]
make[2]: *** [doc/de/CMakeFiles/doc-scripting-de.dir/build.make:74: doc/de/weechat_scripting.de.html] Error 1
make[1]: *** [CMakeFiles/Makefile2:2400: doc/de/CMakeFiles/doc-scripting-de.dir/all] Error 2

```

```
No such file or directory - /nix/store/7vl7rzs7vz0pi039nrn3r2hcnjp7r6q2-ruby2.7.5-pygments.rb-2.2.0/lib/ruby/gems/2.7.0/gems/pygments.rb-2.2.0/lib/pygments/mentos.py
  Use --trace for backtrace
make[2]: *** [doc/de/CMakeFiles/doc-user-de.dir/build.make:79: doc/de/weechat_user.de.html] Error 1
make[1]: *** [CMakeFiles/Makefile2:2374: doc/de/CMakeFiles/doc-user-de.dir/all] Error 2
```

</details>

Note also that these logs don’t match the logs I got the first time I built this; there’s likely concurrent jobs running, so I did my best to associate the error messages together into groups

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

###### Checkboxes

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
