### PR TITLE
libcef: update + update script

### DIFF
--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -60,27 +60,27 @@ let
     "aarch64-linux" = {
       platformStr = "linuxarm64";
       projectArch = "arm64";
-      sha256 = "01ny1k10dklsqrrqmxqd9433413wmpk4ddsmkjp9dzv52dvpcl08";
     };
     "i686-linux" = {
       platformStr = "linux32";
       projectArch = "x86";
-      sha256 = "000j6pc336c43xczl1rs5zf8nsf17y76f1kpy14gqgpwyzl8my0w";
     };
     "x86_64-linux" = {
       platformStr = "linux64";
       projectArch = "x86_64";
-      sha256 = "1ydjckld89dkpy5zrvk7jjpz70mnlmbm8yinkfpzgcwbkcakk6k7";
     };
   };
+  platforms."aarch64-linux".sha256 = "0m12adzcs6xsmgnqsdc5g0xs6xmjbj560x4d9rnv9fpf1p7jv2fa";
+  platforms."i686-linux".sha256 = "00cy5kxx8hpifkwhn9qbfch7ng3crx0zb6ypllzip6qms956mama";
+  platforms."x86_64-linux".sha256 = "1f1hxx4xl0wljyrgj0m3zq47yz2cyqd52qigrkpcvavr1d2sx6m3";
 
   platformInfo = builtins.getAttr stdenv.targetPlatform.system platforms;
 in
 stdenv.mkDerivation rec {
   pname = "cef-binary";
-  version = "96.0.18";
-  gitRevision = "fe551e4";
-  chromiumVersion = "96.0.4664.110";
+  version = "98.1.21";
+  gitRevision = "9782362";
+  chromiumVersion = "98.0.4758.102";
 
   src = fetchurl {
     url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_${platformInfo.platformStr}_minimal.tar.bz2";

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -26,6 +26,7 @@
 , at-spi2-core
 , cups
 , libxshmfence
+, obs-studio
 }:
 
 let
@@ -102,6 +103,9 @@ stdenv.mkDerivation rec {
     cp -r ../include $out/
   '';
 
+  passthru.tests = {
+    inherit obs-studio; # frequently breaks on CEF updates
+  };
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {

--- a/pkgs/development/libraries/libcef/default.nix
+++ b/pkgs/development/libraries/libcef/default.nix
@@ -102,6 +102,8 @@ stdenv.mkDerivation rec {
     cp -r ../include $out/
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     description = "Simple framework for embedding Chromium-based browsers in other applications";
     homepage = "https://cef-builds.spotifycdn.com/index.html";

--- a/pkgs/development/libraries/libcef/update.sh
+++ b/pkgs/development/libraries/libcef/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused jq
+
+set -x -eu -o pipefail
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+VERSION_JSON=$(curl --silent https://cef-builds.spotifycdn.com/index.json | jq '[.linux64.versions[] | select (.channel == "stable")][0]')
+
+CEF_VERSION=$(echo ${VERSION_JSON} | jq -r '.cef_version' | cut -d'+' -f1)
+GIT_REVISION=$(echo ${VERSION_JSON} | jq -r '.cef_version' | cut -d'+' -f2 | cut -c 2-)
+CHROMIUM_VERSION=$(echo ${VERSION_JSON} | jq -r '.chromium_version')
+
+SHA256_LINUX64=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linux64_minimal.tar.bz2)
+SHA256_LINUX32=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linux32_minimal.tar.bz2)
+SHA256_LINUXARM64=$(nix-prefetch-url --quiet https://cef-builds.spotifycdn.com/cef_binary_${CEF_VERSION}+g${GIT_REVISION}+chromium-${CHROMIUM_VERSION}_linuxarm64_minimal.tar.bz2)
+
+setKV () {
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
+}
+
+setKV version ${CEF_VERSION}
+setKV gitRevision ${GIT_REVISION}
+setKV chromiumVersion ${CHROMIUM_VERSION}
+setKV 'platforms."aarch64-linux".sha256' ${SHA256_LINUXARM64}
+setKV 'platforms."i686-linux".sha256' ${SHA256_LINUX32}
+setKV 'platforms."x86_64-linux".sha256' ${SHA256_LINUX64}


### PR DESCRIPTION
###### Motivation for this change
Fix #126510.

###### Things done
Tested that the update script works + basic functionality of OBS.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] i686-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review:
```
1 package failed to build:
obs-studio-plugins.obs-ndi

9 packages built:
libcef obs-studio obs-studio-plugins.looking-glass-obs obs-studio-plugins.obs-gstreamer obs-studio-plugins.obs-move-transition obs-studio-plugins.obs-multi-rtmp obs-studio-plugins.obs-nvfbc obs-studio-plugins.obs-websocket obs-studio-plugins.wlrobs
```
(obs-ndi requires a manual download)