### PR TITLE
nixos/dhcpcd: don't assert for hardened malloc, use scudo instead

### DIFF
--- a/nixos/modules/config/malloc-providers.nix
+++ b/nixos/modules/config/malloc-providers.nix
@@ -1,0 +1,44 @@
+{ pkgs }:
+
+{
+  graphene-hardened = {
+    libPath = "${pkgs.graphene-hardened-malloc}/lib/libhardened_malloc.so";
+    description = ''
+      An allocator designed to mitigate memory corruption attacks, such as
+      those caused by use-after-free bugs.
+    '';
+  };
+
+  jemalloc = {
+    libPath = "${pkgs.jemalloc}/lib/libjemalloc.so";
+    description = ''
+      A general purpose allocator that emphasizes fragmentation avoidance
+      and scalable concurrency support.
+    '';
+  };
+
+  scudo = let
+    platformMap = {
+      aarch64-linux = "aarch64";
+      x86_64-linux  = "x86_64";
+    };
+
+    systemPlatform = platformMap.${pkgs.stdenv.hostPlatform.system} or (throw "scudo not supported on ${pkgs.stdenv.hostPlatform.system}");
+  in {
+    libPath = "${pkgs.llvmPackages_latest.compiler-rt}/lib/linux/libclang_rt.scudo-${systemPlatform}.so";
+    description = ''
+      A user-mode allocator based on LLVM Sanitizer’s CombinedAllocator,
+      which aims at providing additional mitigations against heap based
+      vulnerabilities, while maintaining good performance.
+    '';
+  };
+
+  mimalloc = {
+    libPath = "${pkgs.mimalloc}/lib/libmimalloc.so";
+    description = ''
+      A compact and fast general purpose allocator, which may
+      optionally be built with mitigations against various heap
+      vulnerabilities.
+    '';
+  };
+}

--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -5,48 +5,7 @@ let
   cfg = config.environment.memoryAllocator;
 
   # The set of alternative malloc(3) providers.
-  providers = {
-    graphene-hardened = {
-      libPath = "${pkgs.graphene-hardened-malloc}/lib/libhardened_malloc.so";
-      description = ''
-        An allocator designed to mitigate memory corruption attacks, such as
-        those caused by use-after-free bugs.
-      '';
-    };
-
-    jemalloc = {
-      libPath = "${pkgs.jemalloc}/lib/libjemalloc.so";
-      description = ''
-        A general purpose allocator that emphasizes fragmentation avoidance
-        and scalable concurrency support.
-      '';
-    };
-
-    scudo = let
-      platformMap = {
-        aarch64-linux = "aarch64";
-        x86_64-linux  = "x86_64";
-      };
-
-      systemPlatform = platformMap.${pkgs.stdenv.hostPlatform.system} or (throw "scudo not supported on ${pkgs.stdenv.hostPlatform.system}");
-    in {
-      libPath = "${pkgs.llvmPackages_latest.compiler-rt}/lib/linux/libclang_rt.scudo-${systemPlatform}.so";
-      description = ''
-        A user-mode allocator based on LLVM Sanitizer’s CombinedAllocator,
-        which aims at providing additional mitigations against heap based
-        vulnerabilities, while maintaining good performance.
-      '';
-    };
-
-    mimalloc = {
-      libPath = "${pkgs.mimalloc}/lib/libmimalloc.so";
-      description = ''
-        A compact and fast general purpose allocator, which may
-        optionally be built with mitigations against various heap
-        vulnerabilities.
-      '';
-    };
-  };
+  providers = import ./malloc-providers.nix { inherit pkgs; };
 
   providerConf = providers.${cfg.provider};
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/151795 broke the hardened test (see https://github.com/NixOS/nixpkgs/issues/151696#issuecomment-1025183261). not sure this is a good solution, but it is *a* solution. the hardened test still fails with this applied, but apparently not due to dhcpcd:
```
machine: must succeed: su -l alice -c 'nix ping-store'
machine # [   22.382193] su[973]: Successful su for alice by root
machine # [   22.391510] su[973]: pam_unix(su:session): session opened for user alice(uid=1000) by (uid=0)
machine # warning: 'ping-store' is a deprecated alias for 'store ping'
machine # error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
machine # [   22.521474] su[973]: pam_unix(su:session): session closed for user alice
machine: output: 
Test "nix-daemon cannot be used by all users" failed with error: "command `su -l alice -c 'nix ping-store'` failed (exit code 1)"
cleanup
kill machine (pid 8)
machine # qemu-system-x86_64: terminating on signal 15 from pid 6 (/nix/store/i6vabb4div9iy6lsl642d86k1q8riasn-python3-3.9.9/bin/python3.9)
(finished: cleanup, in 0.10 seconds)
kill vlan (pid 7)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
