### PR TITLE
artim-dark: init at unstable-2021-12-29

### DIFF
--- a/pkgs/data/themes/artim-dark/default.nix
+++ b/pkgs/data/themes/artim-dark/default.nix
@@ -1,0 +1,35 @@
+{ lib, stdenvNoCC, fetchFromGitHub }:
+
+stdenvNoCC.mkDerivation rec{
+  pname = "artim-dark";
+  version = "unstable-2021-12-29";
+
+  src = fetchFromGitHub {
+    owner="Mrcuve0";
+    repo="Aritim-Dark";
+    rev = "99cd330a1ab4814260e28f15431e3338a1103668";
+    hash = "sha256-xGnw5KpXbVyDdTuAkav1Hec6bitpZdPzZk0xv7WHTdY=";
+  };
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/share/plasma/desktoptheme
+    cp -R KDE/plasmaTheme/Aritim-Dark* $out/share/plasma/desktoptheme
+    mkdir -p $out/share/aurorae/themes
+    cp -R KDE/auroraeTheme $out/share/aurorae/themes/Aritim-Dark
+    mkdir -p $out/share/color-schemes
+    cp -R KDE/colorScheme/*.colors $out/share/color-schemes
+    mkdir -p $out/share/plasma/look-and-feel
+    cp -R KDE/globalTheme $out/share/plasma/look-and-feel/Aritim-Dark
+    mkdir -p $out/share/themes
+    cp -R GTK $out/share/themes/Aritim-Dark
+  '';
+
+  meta = {
+    description = "Dark theme deeply inspired by the Ayu Dark color palette";
+    homepage = "https://github.com/Mrcuve0/Aritim-Dark";
+    license = with lib.licenses; [ gpl3Only ];
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.pasqui23 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4318,6 +4318,8 @@ with pkgs;
     inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
   };
 
+  artim-dark = callPackage ../data/themes/artim-dark {};
+
   bore = callPackage ../tools/networking/bore {
     inherit (darwin) Libsystem;
     inherit (darwin.apple_sdk.frameworks) SystemConfiguration;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
