### PR TITLE
linthesia: init at 0.8.0

### DIFF
--- a/pkgs/development/libraries/SDL2_ttf/2.0.15.nix
+++ b/pkgs/development/libraries/SDL2_ttf/2.0.15.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, pkg-config, darwin, fetchurl, SDL2, freetype, libGL }:
+
+stdenv.mkDerivation rec {
+  pname = "SDL2_ttf";
+  version = "2.0.15";
+
+  src = fetchurl {
+    url = "https://www.libsdl.org/projects/SDL_ttf/release/${pname}-${version}.tar.gz";
+    sha256 = "0cyd48dipc0m399qy8s03lci8b0bpiy8xlkvrm2ia7wcv0dfpv59";
+  };
+
+  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ SDL2 freetype libGL ]
+    ++ lib.optional stdenv.isDarwin darwin.libobjc;
+
+  meta = with lib; {
+    description = "SDL TrueType library";
+    platforms = platforms.unix;
+    license = licenses.zlib;
+    homepage = "https://www.libsdl.org/projects/SDL_ttf/";
+  };
+}

--- a/pkgs/games/linthesia/default.nix
+++ b/pkgs/games/linthesia/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, python3, libGL, libGLU
+, alsa-lib, glibmm, sqlite, SDL2, SDL2_ttf_2_0_15, SDL2_image, gtk3, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "linthesia";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "linthesia";
+    repo = "linthesia";
+    rev = version;
+    sha256 = "sha256-bdW0RlV14ttnK8NizfNfXmZ7zlJOqZCpVvt8vT2Pjys=";
+  };
+
+  postPatch = ''
+    patchShebangs meson_post_install.py
+  '';
+
+  nativeBuildInputs = [ meson ninja pkg-config python3 wrapGAppsHook ];
+  buildInputs = [
+    libGL
+    libGLU
+    alsa-lib
+    glibmm
+    sqlite
+    SDL2
+    SDL2_ttf_2_0_15
+    SDL2_image
+    gtk3.out # icon cache
+  ];
+
+  meta = with lib; {
+    description = "A game of playing music using a MIDI keyboard following a MIDI file";
+    inherit (src.meta) homepage;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22640,6 +22640,8 @@ with pkgs;
 
   linuxConsoleTools = callPackage ../os-specific/linux/consoletools { };
 
+  linthesia = callPackage ../games/linthesia/default.nix { };
+
   libreelec-dvb-firmware = callPackage ../os-specific/linux/firmware/libreelec-dvb-firmware { };
 
   openiscsi = callPackage ../os-specific/linux/open-iscsi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19966,6 +19966,8 @@ with pkgs;
 
   SDL2_ttf = callPackage ../development/libraries/SDL2_ttf { };
 
+  SDL2_ttf_2_0_15 = callPackage ../development/libraries/SDL2_ttf/2.0.15.nix { };
+
   sdnotify-wrapper = skawarePackages.sdnotify-wrapper;
 
   sdrplay = callPackage ../applications/radio/sdrplay {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Playing piano better!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
