### PR TITLE
terraform-providers: update scripts

### DIFF
--- a/.github/workflows/update-terraform-providers.yml
+++ b/.github/workflows/update-terraform-providers.yml
@@ -21,7 +21,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           pushd pkgs/applications/networking/cluster/terraform-providers
-          ./update-all-providers
+          ./update-all-providers --no-build
           git commit -m "${{ steps.setup.outputs.title }}" providers.json
           popd
       - name: create PR

--- a/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
@@ -18,5 +18,5 @@ echo "${providers}"
 
 for provider in ${providers}; do
   echo "Updating ${provider}"
-  ./update-provider "${provider}"
+  ./update-provider "$@" "${provider}"
 done

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -11,7 +11,7 @@ shopt -s inherit_errexit
 
 show_usage() {
   cat <<DOC
-Usage: ./update-provider [--force] [--vendor] [<owner>/]<provider>
+Usage: ./update-provider [--force] [--no-build] [<owner>/]<provider>
 
 Update a single provider in the providers.json inventory file.
 
@@ -27,14 +27,14 @@ to add the provider to the list:
 Options:
 
   * --force: Force the update even if the version matches.
-  * --vendor: Switch from go package to go modules with vendor.
+  * --no-build: Don't build provider
   * --vendor-sha256 <sha256>: Override the SHA256 or "null".
 DOC
 }
 
 force=
 provider=
-vendor=
+build=1
 vendorSha256=
 
 while [[ $# -gt 0 ]]; do
@@ -47,9 +47,8 @@ while [[ $# -gt 0 ]]; do
     force=1
     shift
     ;;
-  --vendor)
-    force=1
-    vendor=1
+  --no-build)
+    build=0
     shift
     ;;
   --vendor-sha256)
@@ -142,12 +141,10 @@ update_attr rev "${rev}"
 sha256=$(prefetch_github "${org}" "${repo}" "${rev}")
 update_attr sha256 "${sha256}"
 
-repo_root=$(git rev-parse --show-toplevel)
-
 if [[ -z ${vendorSha256} ]]; then
   if [[ ${old_vendor_sha256} == null ]]; then
     vendorSha256=null
-  elif [[ -n ${old_vendor_sha256} || ${vendor} == 1 ]]; then
+  elif [[ -n ${old_vendor_sha256} ]]; then
     echo "=== Calculating vendorSha256 ==="
     vendorSha256=$(nix-prefetch -I nixpkgs=../../../../.. "{ sha256 }: (import ../../../../.. {}).terraform-providers.${provider_name}.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
     # Deal with nix unstable
@@ -162,5 +159,7 @@ if [[ -n ${vendorSha256} ]]; then
 fi
 
 # Check that the provider builds
-echo "=== Building terraform-providers.${provider_name} ==="
-nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider_name}"
+if [[ ${build} == 1 ]]; then
+  echo "=== Building terraform-providers.${provider_name} ==="
+  nix-build --no-out-link ../../../../.. -A "terraform-providers.${provider_name}"
+fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Easier to use `ofborg` to test that they build and then we don't need to bother handling build failures in the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @zimbatm