### PR TITLE
mepo: 0.2 -> 0.3

### DIFF
--- a/pkgs/applications/misc/mepo/default.nix
+++ b/pkgs/applications/misc/mepo/default.nix
@@ -5,32 +5,28 @@
 , zig
 , curl
 , SDL2
+, SDL2_gfx
 , SDL2_image
 , SDL2_ttf
 }:
 
 stdenv.mkDerivation rec {
   pname = "mepo";
-  version = "0.2";
+  version = "0.3";
 
   src = fetchFromSourcehut {
     owner = "~mil";
     repo = pname;
     rev = version;
-    hash = "sha256-ECq748GpjOjvchzAWlGA7H7HBvKNxY9d43+PTOWopiM=";
+    hash = "sha256-B7BOAFhiOTILUdzh49hTMrNNHZpCNRDLW2uekXyptqQ=";
   };
 
   nativeBuildInputs = [ pkg-config zig ];
 
-  buildInputs = [ curl SDL2 SDL2_image SDL2_ttf ];
+  buildInputs = [ curl SDL2 SDL2_gfx SDL2_image SDL2_ttf ];
 
-  buildPhase = ''
-    runHook preBuild
-
+  preBuild = ''
     export HOME=$TMPDIR
-    zig build -Drelease-safe=true -Dcpu=baseline
-
-    runHook postBuild
   '';
 
   doCheck = true;
@@ -45,8 +41,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 zig-out/bin/mepo -t $out/bin
-    install -Dm755 scripts/mepo_* $out/bin
+    zig build -Drelease-safe=true -Dcpu=baseline --prefix $out install
 
     runHook postInstall
   '';


### PR DESCRIPTION
###### Motivation for this change

Not exactly motivation, but scripts installation has been added to zig build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
