### PR TITLE
treewide: rename name to pname&version

### DIFF
--- a/pkgs/development/tools/haskell/hyper-haskell/server.nix
+++ b/pkgs/development/tools/haskell/hyper-haskell/server.nix
@@ -3,7 +3,8 @@
 let
 hyperHaskellEnv = ghcWithPackages (self: [ self.hyper-haskell-server ] ++ packages self);
 in stdenv.mkDerivation {
-  name = "hyper-haskell-server-with-packages-${hyperHaskellEnv.version}";
+  pname = "hyper-haskell-server-with-packages";
+  version = hyperHaskellEnv.version;
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/tools/misc/direvent/default.nix
+++ b/pkgs/development/tools/misc/direvent/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "direvent-${version}";
+  pname = "direvent";
   version = "5.2";
 
   src = fetchurl {
-    url = "mirror://gnu/direvent/${name}.tar.gz";
+    url = "mirror://gnu/direvent/direvent-${version}.tar.gz";
     sha256 = "0m9vi01b1km0cpknflyzsjnknbava0s1n6393b2bpjwyvb6j5613";
   };
 

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -6,10 +6,10 @@
 }:
 
 let
-  name    = "distcc";
+  pname = "distcc";
   version = "2021-03-11";
   distcc = stdenv.mkDerivation {
-    name = "${name}-${version}";
+    inherit pname version;
     src = fetchFromGitHub {
       owner = "distcc";
       repo = "distcc";

--- a/pkgs/development/tools/misc/kconfig-frontends/default.nix
+++ b/pkgs/development/tools/misc/kconfig-frontends/default.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchurl, pkg-config, bison, flex, gperf, ncurses, python3, bash }:
 
 stdenv.mkDerivation rec {
-  basename = "kconfig-frontends";
+  pname = "kconfig-frontends";
   version = "4.11.0.1";
-  name = "${basename}-${version}";
 
   src = fetchurl {
     sha256 = "1xircdw3k7aaz29snf96q2fby1cs48bidz5l1kkj0a5gbivw31i3";
-    url = "http://ymorin.is-a-geek.org/download/${basename}/${name}.tar.xz";
+    url = "http://ymorin.is-a-geek.org/download/kconfig-frontends/kconfig-frontends-${version}.tar.xz";
   };
 
   nativeBuildInputs = [ bison flex gperf pkg-config ];

--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, autoreconfHook, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "patchelf-${version}";
+  pname = "patchelf";
   version = "2021-11-16";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/misc/premake/3.nix
+++ b/pkgs/development/tools/misc/premake/3.nix
@@ -1,14 +1,11 @@
 {lib, stdenv, fetchurl, unzip}:
 
-let baseName = "premake";
+stdenv.mkDerivation rec {
+  pname = "premake";
   version  = "3.7";
-in
-
-stdenv.mkDerivation {
-  name = "${baseName}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/sourceforge/premake/${baseName}-src-${version}.zip";
+    url = "mirror://sourceforge/sourceforge/premake/premake-src-${version}.zip";
     sha256 = "b59841a519e75d5b6566848a2c5be2f91455bf0cc6ae4d688fcbd4c40db934d5";
   };
 

--- a/pkgs/development/tools/misc/premake/default.nix
+++ b/pkgs/development/tools/misc/premake/default.nix
@@ -1,14 +1,11 @@
 { lib, stdenv, fetchurl, unzip }:
 
-let baseName = "premake";
+stdenv.mkDerivation rec {
+  pname = "premake";
   version  = "4.3";
-in
-
-stdenv.mkDerivation {
-  name = "${baseName}-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${baseName}/${baseName}-${version}-src.zip";
+    url = "mirror://sourceforge/premake/premake-${version}-src.zip";
     sha256 = "1017rd0wsjfyq2jvpjjhpszaa7kmig6q1nimw76qx3cjz2868lrn";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
