### PR TITLE
jetbrains.jdk: Fix darwin build

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/darwin.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/darwin.nix
@@ -1,0 +1,30 @@
+{ lib, stdenv, fetchurl, openjdk11, jetbrains }:
+let
+  version = import ./version.nix;
+  dist = {
+    x86_64-darwin = {
+      arch = "osx-x64";
+      sha256 = "e+nI4gK7COE+Wp7mmBJYFPvv3nBWkzf49pBdaGNOdeM=";
+    };
+    aarch64-darwin = {
+      arch = "osx-aarch64";
+      sha256 = "4DpSwHNEES74WJhqJOny9ZP8ZYL44ufCKMxCJFrH7Yg=";
+    };
+  }."${stdenv.hostPlatform.system}";
+in
+stdenv.mkDerivation {
+  pname = "jetbrains-jdk";
+  version = version.full;
+  src = fetchurl {
+    # JBR with JCEF (bundled by default with editors)
+    url =
+      "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-${version.major}-${dist.arch}-${version.minor}.tar.gz";
+    inherit (dist) sha256;
+  };
+  installPhase = ''
+    mkdir -p $out
+    mv * $out
+  '';
+  meta = import ./meta.nix { inherit openjdk11 lib; };
+  passthru = { home = "${jetbrains.jdk}/Contents/Home"; };
+}

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -2,32 +2,15 @@
 
 openjdk11.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk";
-  version = "11_0_13-b1751.25";
-
+  version = (import ./version.nix).full;
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    sha256 = "sha256-TPNYZUkAoiZfp7Ci3fslKnRNGY1lnyIhXYUt6J31lwI=";
+    sha256 = "4tRV6Owl8wY0kJlXDzhyv3fsGIQWREqLXS57Qgs+A2k=";
   };
   patches = [];
-  meta = with lib; {
-    description = "An OpenJDK fork to better support Jetbrains's products.";
-    longDescription = ''
-     JetBrains Runtime is a runtime environment for running IntelliJ Platform
-     based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
-     based on OpenJDK project with some modifications. These modifications
-     include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
-     support, ligatures, some fixes for native crashes not presented in
-     official build, and other small enhancements.
-
-     JetBrains Runtime is not a certified build of OpenJDK. Please, use at
-     your own risk.
-    '';
-    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (openjdk11.meta) license platforms mainProgram;
-    maintainers = with maintainers; [ edwtjo ];
-  };
+  meta = import ./meta.nix { inherit openjdk11 lib; };
   passthru = oldAttrs.passthru // {
     home = "${jetbrains.jdk}/lib/openjdk";
   };

--- a/pkgs/development/compilers/jetbrains-jdk/meta.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/meta.nix
@@ -1,0 +1,18 @@
+{ openjdk11, lib }:
+with lib; {
+  description = "An OpenJDK fork to better support Jetbrains's products.";
+  longDescription = ''
+    JetBrains Runtime is a runtime environment for running IntelliJ Platform
+    based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+    based on OpenJDK project with some modifications. These modifications
+    include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+    support, ligatures, some fixes for native crashes not presented in
+    official build, and other small enhancements.
+
+    JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+    your own risk.
+  '';
+  homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+  inherit (openjdk11.meta) license platforms mainProgram;
+  maintainers = with maintainers; [ edwtjo ];
+}

--- a/pkgs/development/compilers/jetbrains-jdk/version.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/version.nix
@@ -1,0 +1,7 @@
+rec {
+  # https://github.com/JetBrains/JetBrainsRuntime/tree/jbr11
+  # lists which version should be bundled with which version of the IDE
+  major = "11_0_15";
+  minor = "b2043.56";
+  full = "${major}-${minor}";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27448,7 +27448,10 @@ with pkgs;
     vmopts = config.jetbrains.vmopts or null;
     jdk = jetbrains.jdk;
   }) // {
-    jdk = callPackage ../development/compilers/jetbrains-jdk {  };
+    jdk = if stdenv.isDarwin then
+      callPackage ../development/compilers/jetbrains-jdk/darwin.nix {  }
+    else
+      callPackage ../development/compilers/jetbrains-jdk {  };
   });
 
   jmusicbot = callPackage ../applications/audio/jmusicbot { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Similarly to how OpenJDK is a source build on Linux but using binaries from Azul the source build of JetbrainsRuntime (OpenJDK fork) is currently broken on Darwin.

I think it makes sense to use binaries for Darwin here as well.

I also updated from 11_0_13-b1751.25 to 11_0_14_1-b2043.45 as we currently have IDE version 2021.3 for which https://github.com/JetBrains/JetBrainsRuntime/blob/master/README.md recommends this version.

I tested using `jetbrains.idea-community` which seems to work.

I am not sure yet how the directory structure of the resulting package should be.

Currently it looks like this 

```
result/
└── Contents
    ├── CodeResources
    ├── Frameworks
    │   ├── Chromium\ Embedded\ Framework.framework
    │   ├── JavaNativeFoundation.framework
    │   ├── jcef\ Helper\ (GPU).app
    │   ├── jcef\ Helper\ (Plugin).app
    │   ├── jcef\ Helper\ (Renderer).app
    │   └── jcef\ Helper.app
    ├── Home
    │   ├── bin
    │   ├── conf
    │   ├── include
    │   ├── legal
    │   ├── lib
    │   └── release
    ├── Info.plist
    ├── MacOS
    │   └── libjli.dylib
    └── _CodeSignature
        └── CodeResources
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
