### PR TITLE
isabelle: Enable and use naproche from nixpkgs

### DIFF
--- a/pkgs/applications/science/logic/isabelle/default.nix
+++ b/pkgs/applications/science/logic/isabelle/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, coreutils, nettools, java, scala, polyml, z3, veriT, vampire, eprover-ho, rlwrap, perl, makeDesktopItem }:
+{ lib, stdenv, fetchurl, coreutils, nettools, java, scala, polyml, z3, veriT, vampire, eprover-ho, naproche, rlwrap, perl, makeDesktopItem }:
 # nettools needed for hostname
 
 stdenv.mkDerivation rec {
@@ -66,7 +66,8 @@ stdenv.mkDerivation rec {
       ISABELLE_JDK_HOME=${java}
     EOF
 
-    sed -i -e 's/naproche_server : bool = true/naproche_server : bool = false/' contrib/naproche-*/etc/options
+    rm contrib/naproche-*/x86*/Naproche-SAD
+    ln -s ${naproche}/bin/Naproche-SAD contrib/naproche-*/x86*/
 
     echo ISABELLE_LINE_EDITOR=${rlwrap}/bin/rlwrap >>etc/settings
 

--- a/pkgs/applications/science/logic/naproche/default.nix
+++ b/pkgs/applications/science/logic/naproche/default.nix
@@ -1,0 +1,38 @@
+{ lib, fetchFromGitHub, haskellPackages, makeWrapper, eprover }:
+
+with haskellPackages; mkDerivation {
+  pname = "Naproche-SAD";
+  version = "0.1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "naproche";
+    repo = "naproche";
+    rev = "d39cea85ace04d5b3775fde9972a33886799bfe6";
+    sha256 = "1zqrldmxkzbyg9bssrbwb00zic29904igcipaz1m9al0456yjnkf";
+  };
+
+  isExecutable = true;
+
+  buildTools = [ hpack makeWrapper ];
+  executableHaskellDepends = [
+    base array bytestring containers ghc-prim megaparsec mtl network process
+    split temporary text threads time transformers uuid
+  ];
+
+  prePatch = "hpack";
+
+  checkPhase = ''
+    export NAPROCHE_EPROVER=${eprover}/bin/eprover
+    dist/build/Naproche-SAD/Naproche-SAD examples/cantor.ftl.tex -t 60 --tex=on
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/Naproche-SAD \
+      --set-default NAPROCHE_EPROVER ${eprover}/bin/eprover
+  '';
+
+  homepage = "https://github.com/naproche/naproche#readme";
+  description = "Write formal proofs in natural language and LaTeX";
+  maintainers = with lib.maintainers; [ jvanbruegge ];
+  license = lib.licenses.gpl3Only;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3543,6 +3543,8 @@ with pkgs;
 
   mrkd = with python3Packages; toPythonApplication mrkd;
 
+  naproche = callPackage ../applications/science/logic/naproche { };
+
   nautilus-open-any-terminal = callPackage ../tools/misc/nautilus-open-any-terminal { };
 
   n2n = callPackage ../tools/networking/n2n { };


### PR DESCRIPTION
###### Motivation for this change

naproche was broken before, and had to be disabled in the options. This PR packages naproche and uses it for Isabelle.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
