### PR TITLE
sky: init at 2.1.7801

### DIFF
--- a/pkgs/applications/networking/instant-messengers/sky/default.nix
+++ b/pkgs/applications/networking/instant-messengers/sky/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, mkDerivation
+, fetchurl
+, autoPatchelfHook
+, zstd
+, curl
+, ffmpeg
+, libjpeg_turbo
+, libpam-wrapper
+, libv4l
+, pulseaudio
+, zlib
+, xorg
+}:
+
+mkDerivation rec {
+  pname = "sky";
+  version = "2.1.7801";
+
+  src = fetchurl {
+    url = "https://tel.red/repos/archlinux/sky-archlinux-${version}-1-x86_64.pkg.tar.zst";
+    sha256 = "sha256-3xiq2b3CwNjRd09q0z8olrmLGhgkJGAVkZoJSIHom+k=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook zstd ];
+
+  buildInputs = [
+    curl
+    ffmpeg
+    libjpeg_turbo
+    libpam-wrapper
+    libv4l
+    pulseaudio
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXinerama
+    xorg.libXmu
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libXv
+    xorg.libxkbfile
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv * $out/
+    ln --force --symbolic $out/lib/sky/sky{,_sender} $out/bin
+    substituteInPlace $out/share/applications/sky.desktop \
+      --replace /usr/ $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lync & Skype for Business on Linux";
+    homepage = "https://tel.red/";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.wucke13 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28688,6 +28688,10 @@ with pkgs;
 
   sish = callPackage ../tools/networking/sish { };
 
+  sky = libsForQt5.callPackage ../applications/networking/instant-messengers/sky {
+    libjpeg_turbo = libjpeg_turbo.override { enableJpeg8 = true; };
+  };
+
   skypeforlinux = callPackage ../applications/networking/instant-messengers/skypeforlinux { };
 
   SkypeExport = callPackage ../applications/networking/instant-messengers/SkypeExport { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I want to push the use of NixOS in the corporate. This seems like a valuable tool to interact in the corporate.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
