### PR TITLE
gauge: 1.1.6 -> 1.4.3

### DIFF
--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   meta = with lib; {
     description = "Light weight cross-platform test automation";
     homepage = "https://gauge.org";
-    license = licenses.gpl3;
+    license = licenses.asl20;
     maintainers = [ maintainers.vdemeester ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -1,24 +1,25 @@
-{ lib, buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "gauge";
-  version = "1.1.6";
+  version = "1.4.3";
 
-  goPackagePath = "github.com/getgauge/gauge";
   excludedPackages = ''\(build\|man\)'';
 
   src = fetchFromGitHub {
     owner = "getgauge";
     repo = "gauge";
     rev = "v${version}";
-    sha256 = "02yrk4d5mm4j2grlhqkf4grxawx91kd2vhdn7k5wd2dl6wsnlgcl";
+    sha256 = "sha256-TszZAREk6Hs2jULjftQAhHRIVKaZ8fw0NLJkBdr0FPw=";
   };
 
+  vendorSha256 = "1wp19m5n85c7lsv8rvcbfz1bv4zhhb7dj1frkdh14cqx70s33q8r";
+
   meta = with lib; {
-   description = "Light weight cross-platform test automation";
-   homepage    = "https://gauge.org";
-   license     = licenses.gpl3;
-   maintainers = [ maintainers.vdemeester ];
-   platforms   = platforms.unix;
+    description = "Light weight cross-platform test automation";
+    homepage = "https://gauge.org";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.vdemeester ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION


###### Motivation for this change

And switching to buildGoModule.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
