### PR TITLE
xtruss: 20181001 -> 20211025

### DIFF
--- a/pkgs/tools/X11/xtruss/default.nix
+++ b/pkgs/tools/X11/xtruss/default.nix
@@ -1,13 +1,15 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, cmake, halibut }:
 
 stdenv.mkDerivation rec {
   pname = "xtruss";
-  version = "20181001.82973f5";
+  version = "20211025.c25bf48";
 
   src = fetchurl {
     url = "https://www.chiark.greenend.org.uk/~sgtatham/xtruss/${pname}-${version}.tar.gz";
-    sha256 = "1mm8k92zc318jk71wlf2r4rb723nd9lalhjl0pf48raiajb5ifgd";
+    sha256 = "sha256-ikuKHtXEn2UVLE62l7qD9qc9ZUk6jiAqj5ru36vgdHk=";
   };
+
+  nativeBuildInputs = [ cmake halibut ];
 
   meta = with lib; {
     description = "easy-to-use X protocol tracing program";


### PR DESCRIPTION
https://git.tartarus.org/?p=simon/xtruss.git;a=shortlog;h=c25bf48c14c977d1c76f122b73c37f15df6ae6d5

(back to 2018-09-30 commit 82973f5)

* now uses cmake to build
* halibut for manpage generation


###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).