### PR TITLE
azpainter: 2.1.6 -> 3.0.4

### DIFF
--- a/pkgs/applications/graphics/azpainter/default.nix
+++ b/pkgs/applications/graphics/azpainter/default.nix
@@ -1,4 +1,6 @@
 { lib, stdenv, fetchFromGitLab
+, desktop-file-utils, shared-mime-info
+, libiconv
 , libX11, libXcursor, libXext, libXi
 , freetype, fontconfig
 , libjpeg, libpng, libtiff, libwebp
@@ -13,19 +15,26 @@ stdenv.mkDerivation rec {
     owner = "azelpg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2gTTF1ti9bO24d75mhwyvJISSgMKdmp+oJVmgzEQHdY=";
+    hash = "sha256-2gTTF1ti9bO24d75mhwyvJISSgMKdmp+oJVmgzEQHdY=";
   };
+
+  nativeBuildInputs = [
+    desktop-file-utils # for update-desktop-database
+    shared-mime-info   # for update-mime-info
+  ];
 
   buildInputs = [
     libX11 libXcursor libXext libXi
     freetype fontconfig
     libjpeg libpng libtiff libwebp
     zlib
-  ];
+  ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Full color painting software for illustration drawing";
-    homepage = "https://osdn.net/projects/azpainter";
+    homepage = "http://azsky2.html.xdomain.jp/soft/azpainter.html";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ dtzWill ];
     platforms = with platforms; linux ++ darwin;

--- a/pkgs/applications/graphics/azpainter/default.nix
+++ b/pkgs/applications/graphics/azpainter/default.nix
@@ -1,25 +1,25 @@
-{ lib, stdenv, fetchFromGitHub
-, libX11, libXext, libXi
+{ lib, stdenv, fetchFromGitLab
+, libX11, libXcursor, libXext, libXi
 , freetype, fontconfig
-, libpng, libjpeg
+, libjpeg, libpng, libtiff, libwebp
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "azpainter";
-  version = "2.1.6";
+  version = "3.0.4";
 
-  src = fetchFromGitHub {
-    owner = "Symbian9";
+  src = fetchFromGitLab {
+    owner = "azelpg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0i5g67s4ysnvbaxmi7dhan0hfcfk8an14xykkafl47pqfx33npva";
+    sha256 = "sha256-2gTTF1ti9bO24d75mhwyvJISSgMKdmp+oJVmgzEQHdY=";
   };
 
   buildInputs = [
-    libX11 libXext libXi
+    libX11 libXcursor libXext libXi
     freetype fontconfig
-    libpng libjpeg
+    libjpeg libpng libtiff libwebp
     zlib
   ];
 


### PR DESCRIPTION
###### Motivation for this change

* github -> gitlab
* 3.0 "remade as a whole" (translated)

Release notes (back to v2.1.7): https://gitlab.com/azelpg/azpainter/-/releases?#v3.0.4
(translated:
https://gitlab-com.translate.goog/azelpg/azpainter/-/releases?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en-US#v3.0.4
)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).