### PR TITLE
libcbor: 0.8.0 -> 0.9.0, libfido2: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libcbor";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "PJK";
     repo = pname;
     rev = "v${version}";
-    sha256 = "01dv4vxcmbvpphqy16vqiwh25wx11x630js5wfnx7cryarsh9ld7";
+    sha256 = "sha256-Wp/48yQA17mf/dTgeMcMDvPpKOPkfLhQkCnzgGLpLtk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
-  version = "1.9.0";
+  version = "1.10.0";
 
   # releases on https://developers.yubico.com/libfido2/Releases/ are signed
   src = fetchurl {
     url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.gz";
-    sha256 = "sha256-ujnjrzc20t/IrT0ctuO+fszAlYhhCjsHyGXQ7T5YwtI=";
+    sha256 = "sha256-Um79PVavcGwF0J89IfGO47CxWsDB9cXaGsvCfCcwuZs=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];


### PR DESCRIPTION
###### Motivation for this change

#149317
https://github.com/Yubico/libfido2/blob/1.10.0/NEWS

Combining updates to avoid rebuilding everything that depends on
libfido2 twice.

Also, since libfido2 is only in-tree user of libcbor
(and uses 0.9.0 with this release)
this makes more sense than it might otherwise :).

I've only build-tested up through libfido2 itself.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).