### PR TITLE
numatop: 2.1 -> 2.2, fix build, string ops, meta.platforms

### DIFF
--- a/pkgs/os-specific/linux/numatop/default.nix
+++ b/pkgs/os-specific/linux/numatop/default.nix
@@ -1,16 +1,31 @@
-{ lib, stdenv, fetchurl, pkg-config, numactl, ncurses, check }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config, numactl, ncurses, check }:
 
 stdenv.mkDerivation rec {
   pname = "numatop";
-  version = "2.1";
-  src = fetchurl {
-    url = "https://github.com/intel/${pname}/releases/download/v${version}/${pname}-v${version}.tar.xz";
-    sha256 = "1s7psq1xyswj0lpx10zg5lnppav2xy9safkfx3rssrs9c2fp5d76";
+  version = "2.2";
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "numatop";
+    rev = "v${version}";
+    sha256 = "sha256-GJvTwqgx34ZW10eIJj/xiKe3ZkAfs7GlJImz8jrnjfI=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ numactl ncurses ];
   checkInputs = [ check ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/intel/numatop/pull/54.patch";
+      sha256 = "sha256-TbMLv7TT9T8wE4uJ1a/AroyPPwrwL0eX5IBLsh9GTTM=";
+      name = "fix-string-operations.patch";
+    })
+    (fetchpatch {
+      url = "https://github.com/intel/numatop/pull/64.patch";
+      sha256 = "sha256-IevbSFJRTS5iQ5apHOVXzF67f3LJaW6j7DySFmVuyiM=";
+      name = "fix-format-strings-mvwprintw.patch";
+    })
+  ];
 
   doCheck  = true;
 

--- a/pkgs/os-specific/linux/numatop/default.nix
+++ b/pkgs/os-specific/linux/numatop/default.nix
@@ -20,8 +20,8 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ dtzWill ];
     platforms = [
-      { kernel.name = "linux"; cpu.family = "x86"; }
-      { kernel.name = "linux"; cpu.family = "power"; }
+      "i686-linux" "x86_64-linux"
+      "powerpc64-linux" "powerpc64le-linux"
     ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

numatop no longer would build due to format string errors, which I've
fixed via PR submitted upstream as the fix is trivial.

Additionally, change the meta.platforms so that (at least) this is
marked as supported on x86_64-linux.

I'm not sure why what was here (no longer) works, but since that doesn't
appear to be used much anymore instead just enumerate the supported
platforms.

Finally, grab a patch from upstream PR to resolve some string
operations.
I have not personally vetted this but it's from CK, if that helps.


I'm unable to test the functionality as I presently do not have access
to a suitable NUMA machine, so help checking this is appreciated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - The binary 'runs' but complains my CPU is not supported, which is
    expected :innocent:.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).