### PR TITLE
ocamlPackages.printbox: 0.5 → 0.6; ocamlPackages.printbox-text: init at 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -11,7 +11,7 @@
 , lacaml
 , menhir
 , menhirLib
-, printbox
+, printbox-text
 }:
 
 buildDunePackage rec {
@@ -25,6 +25,11 @@ buildDunePackage rec {
     sha256 = "sha256:0knfh2s0jfnsc0vsq5yw5xla7m7i98xd0qv512dyh3jhkh7m00l9";
   };
 
+  # Ensure compatibility with printbox ≥ 0.6
+  preConfigure = ''
+    substituteInPlace lib/dune --replace printbox printbox-text
+  '';
+
   minimalOCamlVersion = "4.08";
 
   checkInputs = [ alcotest bppsuite ];
@@ -37,7 +42,7 @@ buildDunePackage rec {
     lacaml
     menhirLib
     ppx_deriving
-    printbox
+    printbox-text
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/printbox/default.nix
+++ b/pkgs/development/ocaml-modules/printbox/default.nix
@@ -1,21 +1,21 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, uucp, uutf, mdx }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, mdx }:
 
 buildDunePackage rec {
   pname = "printbox";
-  version = "0.5";
+  version = "0.6";
 
   useDune2 = true;
 
-  minimumOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.03";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = pname;
-    rev = version;
-    sha256 = "099yxpp7d9bms6dwzp9im7dv1qb801hg5rx6awpx3rpfl4cvqfn2";
+    rev = "v${version}";
+    sha256 = "sha256:0vqp8j1vp8h8par699nnh31hnikzh6pqn07lqyxw65axqy3sc9dp";
   };
 
-  checkInputs = [ uucp uutf mdx.bin ];
+  checkInputs = [ mdx.bin ];
 
   # mdx is not available for OCaml < 4.07
   doCheck = lib.versionAtLeast ocaml.version "4.07";

--- a/pkgs/development/ocaml-modules/printbox/text.nix
+++ b/pkgs/development/ocaml-modules/printbox/text.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, printbox, uucp, uutf, mdx }:
+
+buildDunePackage {
+  pname = "printbox-text";
+  inherit (printbox) src version useDune2 doCheck;
+
+  propagatedBuildInputs = [ printbox uucp uutf ];
+
+  checkInputs = [ mdx.bin ];
+
+  meta = printbox.meta // {
+    description = "Text renderer for printbox, using unicode edges";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1179,6 +1179,8 @@ let
 
     printbox = callPackage ../development/ocaml-modules/printbox { };
 
+    printbox-text = callPackage ../development/ocaml-modules/printbox/text.nix { };
+
     process = callPackage ../development/ocaml-modules/process { };
 
     prof_spacetime = callPackage ../development/ocaml-modules/prof_spacetime { };


### PR DESCRIPTION
###### Motivation for this change

Compatibility with `mdx` ≥ 2.0

cc maintainer @romildo.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
