### PR TITLE
xlayoutdisplay: 1.1.2 -> 1.3.0

### DIFF
--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -15,13 +15,15 @@ stdenv.mkDerivation rec {
   checkInputs = [ gtest ];
 
   doCheck = true;
+  checkTarget = "gtest";
 
   # Fixup reference to hardcoded boost path, dynamically link as seems fine and we don't have static for this
   postPatch = ''
     substituteInPlace config.mk --replace '/usr/lib/libboost_program_options.a' '-lboost_program_options'
   '';
 
-  makeFlags = [ "DESTDIR=/" "PREFIX=${placeholder "out"}" ];
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Detects and arranges linux display outputs, using XRandR for detection and xrandr for arrangement";

--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -1,30 +1,27 @@
-{ lib, stdenv, fetchFromGitHub, xorg, boost, cmake, gtest }:
+{ lib, stdenv, fetchFromGitHub, xorg, boost, gtest }:
 
 stdenv.mkDerivation rec {
   pname = "xlayoutdisplay";
-  version = "1.1.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "alex-courtis";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0n3vg25gzwn1pcg6caxyyd1xf2w6n98m6jpxc70kqpxfqldxwl0m";
+    sha256 = "sha256-8K9SoZToJTk/sL4PC4Fcsu9XzGLYfNIZlbIyxc9jf84=";
   };
 
-  nativeBuildInputs = [ cmake ];
   buildInputs = with xorg; [ libX11 libXrandr libXcursor boost ];
   checkInputs = [ gtest ];
 
   doCheck = true;
 
-  # format security fixup
+  # Fixup reference to hardcoded boost path, dynamically link as seems fine and we don't have static for this
   postPatch = ''
-    substituteInPlace test/test-Monitors.cpp \
-      --replace 'fprintf(lidStateFile, contents);' \
-                'fputs(contents, lidStateFile);'
-
-    substituteInPlace CMakeLists.txt --replace "set(Boost_USE_STATIC_LIBS ON)" ""
+    substituteInPlace config.mk --replace '/usr/lib/libboost_program_options.a' '-lboost_program_options'
   '';
+
+  makeFlags = [ "DESTDIR=/" "PREFIX=${placeholder "out"}" ];
 
   meta = with lib; {
     description = "Detects and arranges linux display outputs, using XRandR for detection and xrandr for arrangement";


### PR DESCRIPTION
* no more cmake
* format string fixup was merged upstream, hooray
* continue to fixup boost linking, but altered for new build system


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).