### PR TITLE
python3Packages.ipython: enable tests, reformat

### DIFF
--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -3,67 +3,77 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
+
 # Build dependencies
 , glibcLocales
-# Test dependencies
-, nose
-, pygments
+
 # Runtime dependencies
-, black
-, jedi
-, decorator
-, matplotlib-inline
-, pickleshare
-, traitlets
-, prompt-toolkit
-, pexpect
 , appnope
 , backcall
+, black
+, decorator
+, jedi
+, matplotlib-inline
+, pexpect
+, pickleshare
+, prompt-toolkit
+, pygments
 , stack-data
+, traitlets
+
+# Test dependencies
+, pytestCheckHook
+, testpath
 }:
 
 buildPythonPackage rec {
   pname = "ipython";
   version = "8.0.1";
-  disabled = pythonOlder "3.7";
+  format = "pyproject";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "0x19sj4dlq7r4p1mqnpx9245r8dwvpjwd8n34snfm37a452lsmmb";
   };
 
-  prePatch = lib.optionalString stdenv.isDarwin ''
-    substituteInPlace setup.py --replace "'gnureadline'" " "
-  '';
-
-  buildInputs = [ glibcLocales ];
-
-  checkInputs = [ nose pygments ];
+  buildInputs = [
+    glibcLocales
+  ];
 
   propagatedBuildInputs = [
+    backcall
     black
-    jedi
     decorator
+    jedi
     matplotlib-inline
+    pexpect
     pickleshare
-    stack-data
-    traitlets
     prompt-toolkit
     pygments
-    pexpect
-    backcall
-  ] ++ lib.optionals stdenv.isDarwin [appnope];
+    stack-data
+    traitlets
+  ] ++ lib.optionals stdenv.isDarwin [
+    appnope
+  ];
 
   LC_ALL="en_US.UTF-8";
 
-  doCheck = false; # Circular dependency with ipykernel
-
-  checkPhase = ''
-    nosetests
-  '';
-
   pythonImportsCheck = [
     "IPython"
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+
+    # doctests try to fetch an image from the internet
+    substituteInPlace pytest.ini \
+      --replace "--ipdoctest-modules" "--ipdoctest-modules --ignore=IPython/core/display.py"
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+    testpath
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests again, as the ipykernel infinite recursion has been
resolved. Reformat!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
