### PR TITLE
dwl: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/applications/window-managers/dwl/default.nix
+++ b/pkgs/applications/window-managers/dwl/default.nix
@@ -1,19 +1,18 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , fetchFromGitHub
-, pkg-config
 , libinput
 , libxcb
 , libxkbcommon
 , pixman
+, pkg-config
 , wayland
 , wayland-protocols
 , wlroots
-, enable-xwayland ? true, xwayland, libX11
-, patches ? [ ]
-, conf ? null
 , writeText
-, fetchpatch
+, enable-xwayland ? true, xwayland, libX11
+, conf ? null
+, patches ? [ ]
 }:
 
 let
@@ -22,16 +21,17 @@ in
 
 stdenv.mkDerivation rec {
   pname = "dwl";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "djpohly";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-lfUAymLA4+E9kULZIueA+9gyVZYgaVS0oTX0LJjsSEs=";
+    hash = "sha256-T2GqDehBNO8eublqZUmA5WADjnwElzT+bp9Dp1bqSgg=";
   };
 
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
     libinput
     libxcb
@@ -60,6 +60,11 @@ stdenv.mkDerivation rec {
                  else writeText "config.def.h" conf;
   in lib.optionalString (conf != null) "cp ${configFile} config.def.h";
 
+  NIX_CFLAGS_COMPILE = [
+    # https://github.com/djpohly/dwl/issues/186
+    "-Wno-error=unused-result"
+  ];
+
   dontConfigure = true;
 
   installPhase = ''
@@ -85,8 +90,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = with platforms; linux;
+    inherit (wayland.meta) platforms;
   };
 }
 # TODO: custom patches from upstream website
-# TODO: investigate the modifications in the upstream unstable version

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25229,9 +25229,7 @@ with pkgs;
     buildGoModule = buildGo117Module;
   };
 
-  dwl = callPackage ../applications/window-managers/dwl {
-    wlroots = wlroots_0_14;
-  };
+  dwl = callPackage ../applications/window-managers/dwl { };
 
   dwm = callPackage ../applications/window-managers/dwm {
     # dwm is configured entirely through source modification. Allow users to


### PR DESCRIPTION
Now with new wlroots!

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
