### PR TITLE
biblatex-check: 2019-11-09 -> 1.0.1

### DIFF
--- a/pkgs/tools/typesetting/biblatex-check/default.nix
+++ b/pkgs/tools/typesetting/biblatex-check/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, python3 }:
+{ lib, stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "biblatex-check";

--- a/pkgs/tools/typesetting/biblatex-check/default.nix
+++ b/pkgs/tools/typesetting/biblatex-check/default.nix
@@ -2,29 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "biblatex-check";
-  version = "1.0.0";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "Pezmc";
     repo = "BibLatex-Check";
     rev = "v${version}";
-    sha256 = "sha256-SNftPSwkG8mOddwHJCguyPPOjQ3/tBYFsEUbr0Z7cuk=";
+    sha256 = "sha256-Pe6Ume7vH8WJG2EqOw31g3VYilfFsDBmNHtHcUXxqf0=";
   };
 
   buildInputs = [ python3 ];
-
-  patches = [
-    # Merged, but not in tagged release yet
-    (fetchpatch {
-      url = "https://github.com/Pezmc/BibLatex-Check/pull/55.patch";
-      sha256 = "sha256-W2CpYAGrWVYALe55H7Q2GtGiN+6EGU2Y3wLldFo+BAY=";
-    })
-    # Submitted
-    (fetchpatch {
-      url = "https://github.com/Pezmc/BibLatex-Check/pull/56.patch";
-      sha256 = "sha256-Xp/8HZHZMjgyl66GlLBNFslo8fVXgUE+VNvy2XHwQC8=";
-    })
-  ];
 
   strictDeps = true;
 

--- a/pkgs/tools/typesetting/biblatex-check/default.nix
+++ b/pkgs/tools/typesetting/biblatex-check/default.nix
@@ -1,17 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, python3 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, python3 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "biblatex-check";
-  version = "2019-11-09";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "Pezmc";
     repo = "BibLatex-Check";
-    rev = "2db50bf94d1480f37edf1b3619e73baf4ef85938";
-    sha256 = "1bq0yqckhssazwkivipdjmn1jpsf301i4ppyl88qhc5igx39wg25";
+    rev = "v${version}";
+    sha256 = "sha256-SNftPSwkG8mOddwHJCguyPPOjQ3/tBYFsEUbr0Z7cuk=";
   };
 
   buildInputs = [ python3 ];
+
+  patches = [
+    # Merged, but not in tagged release yet
+    (fetchpatch {
+      url = "https://github.com/Pezmc/BibLatex-Check/pull/55.patch";
+      sha256 = "sha256-W2CpYAGrWVYALe55H7Q2GtGiN+6EGU2Y3wLldFo+BAY=";
+    })
+    # Submitted
+    (fetchpatch {
+      url = "https://github.com/Pezmc/BibLatex-Check/pull/56.patch";
+      sha256 = "sha256-Xp/8HZHZMjgyl66GlLBNFslo8fVXgUE+VNvy2XHwQC8=";
+    })
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
###### Motivation for this change

Update to tagged + official release!

https://github.com/Pezmc/BibLatex-Check/compare/2db50bf94d1480f37edf1b3619e73baf4ef85938...v1.0.1

~While it works as-is on provided test file `input.bib`, also apply a fix
for python3 that is needed to run on various bib files I have around.
(PR submitted)~

EDIT: included in 1.0.1 :tada:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).