### PR TITLE
confluent-cli: init at 2.4.0

### DIFF
--- a/pkgs/development/tools/confluent-cli/default.nix
+++ b/pkgs/development/tools/confluent-cli/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, autoPatchelfHook, fetchurl, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "confluent-cli";
+  version = "2.4.0";
+
+  # To get the latest version:
+  # curl -L https://cnfl.io/cli | sh -s -- -l | grep -v latest | sort -V | tail -n1
+  src = fetchurl (if stdenv.hostPlatform.isDarwin then {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_v${version}_darwin_amd64.tar.gz";
+      sha256 = "1xkf7p9cn37k8j57cgbzxhqgnmchf86jyiza91bf6ddvm6jsm2gd";
+    } else {
+      url = "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/${version}/confluent_v${version}_linux_amd64.tar.gz";
+      sha256 = "1wvy7x56cc7imycf0d83mxcqzdvv56cc0zbp913xgghjn9dl2z7a";
+    });
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  dontStrip = stdenv.isDarwin;
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/doc/confluent-cli}
+    cp confluent $out/bin/
+    cp LICENSE $out/share/doc/confluent-cli/
+    cp -r legal $out/share/doc/confluent-cli/
+  '';
+
+  meta = with lib; {
+    description = "Confluent CLI";
+    homepage = "https://docs.confluent.io/confluent-cli/current/overview.html";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ rguevara84 ];
+
+    # TODO: There's support for i686 systems but I do not have any such system
+    # to build it locally on, it's also unfree so I cannot rely on ofborg to
+    # build it. Get the list of supported system by looking at the list of
+    # files in the S3 bucket:
+    #
+    #   https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=confluent-cli/archives/1.25.0/&delimiter=/%27
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15018,6 +15018,8 @@ with pkgs;
 
   ccloud-cli = callPackage ../development/tools/ccloud-cli { };
 
+  confluent-cli = callPackage ../development/tools/confluent-cli { };
+
   htmlunit-driver = callPackage ../development/tools/selenium/htmlunit-driver { };
 
   hyenae = callPackage ../tools/networking/hyenae { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The ccloud-cli package in confluent will be deprecated in favor of confluent-cli that applies for confluent cloud and confluent platform

The Confluent Cloud CLI is deprecated and will stop working on May 9, 2022. All ccloud features have been moved to the [Confluent CLI](https://docs.confluent.io/confluent-cli/current/index.html). To update to the new CLI, run ccloud update –major. See the [Migrate to Confluent CLI v2](https://docs.confluent.io/ccloud-cli/current/migrate.html#cli-migrate) for more details.

###### Things done

I'm just mimicking the last implementation of the ccloud-cli package since it follows the same installation method

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
