### PR TITLE
TensorFlow ecosystem: `tensorflow` should never be in `propagatedBuildInputs`

### DIFF
--- a/pkgs/development/python-modules/baselines/default.nix
+++ b/pkgs/development/python-modules/baselines/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage {
     sha256 = "0j2ck7rsrcyny9qbmrw9aqvzfhv70nbign8iva2dsisa2x24gbcl";
   };
 
+  buildInputs = [ tensorflow ];
+
   propagatedBuildInputs = [
     gym
     scipy
@@ -37,7 +39,6 @@ buildPythonPackage {
     progressbar2
     mpi4py
     cloudpickle
-    tensorflow
     click
   ];
 

--- a/pkgs/development/python-modules/mask-rcnn/default.nix
+++ b/pkgs/development/python-modules/mask-rcnn/default.nix
@@ -56,8 +56,9 @@ buildPythonPackage rec {
     pillow
     scikitimage
     scipy
-    tensorflow
   ];
+
+  checkInputs = [ tensorflow ];
 
   meta = with lib; {
     description = "Mask R-CNN for object detection and instance segmentation on Keras and TensorFlow";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This is a followup to https://github.com/NixOS/nixpkgs/pull/156808 to provide the same benefits to the tensorflow package. The tl;dr is that including `tensorflow` in `propagatedBuildInputs` makes it extremely difficult for users wanting to use `tensorflowWithCuda`, effectively forcing them to use overlays. The solution is simple: never put `tensorflow` in `propagatedBuildInputs` and instead let users pick `tensorflow` or `tensorflowWithCuda` as they see fit.

I updated all of the offending, non-broken packages in nixpkgs. The following packages include `tensorflow` in their `propagatedBuildInputs` but are marked as broken, so they were left unchanged:
* https://cs.github.com/NixOS/nixpkgs/blob/54cbee8d9700668eaa51219f6c852b4019cfd2ba/pkgs/development/python-modules/rl-coach/default.nix?q=repo%3Anixos%2Fnixpkgs+tensorflow+language%3ANix#L34
* https://cs.github.com/NixOS/nixpkgs/blob/54cbee8d9700668eaa51219f6c852b4019cfd2ba/pkgs/development/python-modules/graph_nets/default.nix?q=repo%3Anixos%2Fnixpkgs+tensorflow+language%3ANix#L29 (graph_nets is not itself marked as broken but depends on dm-sonnet which is broken)

Assuming this PR is accepted, I'll update https://nixos.wiki/wiki/Tensorflow with a section noting that this is best practice for future packages depending on `tensorflow`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
