### PR TITLE
simgrid: 3.28 -> 3.30 + python + clean

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchFromGitLab, fetchpatch, cmake, perl, python3, boost, valgrind
-# Optional requirements
-# Lua 5.3 needed and not available now
-#, luaSupport ? false, lua5
+{ stdenv, lib, fetchFromGitLab, cmake, perl, python3, boost
 , fortranSupport ? false, gfortran
 , buildDocumentation ? false, fig2dev, ghostscript, doxygen
 , buildJavaBindings ? false, openjdk
+, buildPythonBindings ? true, python3Packages
 , modelCheckingSupport ? false, libunwind, libevent, elfutils # Inside elfutils: libelf and libdw
+, minimalBindings ? false
 , debug ? false
+, optimize ? (!debug)
 , moreTests ? false
+, withoutBin ? false
 }:
 
 with lib;
@@ -18,54 +19,35 @@ in
 
 stdenv.mkDerivation rec {
   pname = "simgrid";
-  version = "3.28";
+  version = "3.30";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0vylwgd4i89bvhbgfay0wq953324dwfmmr8jp9b4vvlc9m0017r9";
+    sha256 = "1dg8ywqif20g0fs8dnd6364n080nvwx7f444zcfwqwz6iax61qv1";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "fix-smpi-dirs-absolute.patch";
-      url = "https://framagit.org/simgrid/simgrid/-/commit/71f01e667577be1076646eb841e0a57bd5388545.patch";
-      sha256 = "0x3y324b6269687zfy43ilc48bwrs4nb7svh2mpg88lrz53rky15";
-    })
-  ];
-
   propagatedBuildInputs = [ boost ];
-  nativeBuildInputs = [ cmake perl python3 valgrind ]
-      ++ optionals fortranSupport [ gfortran ]
-      ++ optionals buildJavaBindings [ openjdk ]
-      ++ optionals buildDocumentation [ fig2dev ghostscript doxygen ]
-      ++ optionals modelCheckingSupport [ libunwind libevent elfutils ];
+  nativeBuildInputs = [ cmake perl python3 ]
+    ++ optionals fortranSupport [ gfortran ]
+    ++ optionals buildJavaBindings [ openjdk ]
+    ++ optionals buildPythonBindings [ python3Packages.pybind11 ]
+    ++ optionals buildDocumentation [ fig2dev ghostscript doxygen ]
+    ++ optionals modelCheckingSupport [ libunwind libevent elfutils ];
 
-  #buildInputs = optional luaSupport lua5;
+  outputs = [ "out" ]
+    ++ optionals buildPythonBindings [ "python" ];
 
-  # Make it so that libsimgrid.so will be found when running programs from
-  # the build dir.
-  preConfigure = ''
-    export LD_LIBRARY_PATH="$PWD/build/lib"
-  '';
-
-  # Release mode is not supported in SimGrid
+  # "Release" does not work. non-debug mode is Debug compiled with optimization
   cmakeBuildType = "Debug";
-
-  # Disable/Enable functionality
-  # Note: those packages are not packaged in Nixpkgs yet so some options
-  # are disabled:
-  # - papi:   for enable_smpi_papi
-  # - ns3:    for enable_ns3
-  # - lua53:  for enable_lua
-  #
-  # For more information see:
-  # https://simgrid.org/doc/3.22/Installing_SimGrid.html#simgrid-compilation-options)
   cmakeFlags = [
     "-Denable_documentation=${optionOnOff buildDocumentation}"
     "-Denable_java=${optionOnOff buildJavaBindings}"
+    "-Denable_python=${optionOnOff buildPythonBindings}"
+    "-DSIMGRID_PYTHON_LIBDIR=./" # prevents CMake to install in ${python3} dir
+    "-Denable_msg=${optionOnOff buildJavaBindings}"
     "-Denable_fortran=${optionOnOff fortranSupport}"
     "-Denable_model-checking=${optionOnOff modelCheckingSupport}"
     "-Denable_ns3=off"
@@ -75,27 +57,28 @@ stdenv.mkDerivation rec {
     "-Denable_mallocators=on"
     "-Denable_debug=on"
     "-Denable_smpi=on"
+    "-Dminimal-bindings=${optionOnOff minimalBindings}"
     "-Denable_smpi_ISP_testsuite=${optionOnOff moreTests}"
     "-Denable_smpi_MPICH3_testsuite=${optionOnOff moreTests}"
-    "-Denable_compile_warnings=${optionOnOff debug}"
-    "-Denable_compile_optimizations=${optionOnOff (!debug)}"
-    "-Denable_lto=${optionOnOff (!debug)}"
-    # "-Denable_lua=${optionOnOff luaSupport}"
-    # "-Denable_smpi_papi=${optionOnOff moreTests}"
+    "-Denable_compile_warnings=off"
+    "-Denable_compile_optimizations=${optionOnOff optimize}"
+    "-Denable_lto=${optionOnOff optimize}"
   ];
-
   makeFlags = optional debug "VERBOSE=1";
 
-  # Some Perl scripts are called to generate test during build which
-  # is before the fixupPhase, so do this manualy here:
+  # needed to run tests and to ensure correct shabangs in output scripts
   preBuild = ''
     patchShebangs ..
   '';
 
-  doCheck = true;
+  # needed by tests (so libsimgrid.so is found)
+  preConfigure = ''
+    export LD_LIBRARY_PATH="$PWD/build/lib"
+  '';
 
-  # Prevent the execution of tests known to fail.
+  doCheck = true;
   preCheck = ''
+    # prevent the execution of tests known to fail
     cat <<EOW >CTestCustom.cmake
     SET(CTEST_CUSTOM_TESTS_IGNORE smpi-replay-multiple)
     EOW
@@ -103,6 +86,20 @@ stdenv.mkDerivation rec {
     # make sure tests are built in parallel (this can be long otherwise)
     make tests -j $NIX_BUILD_CORES
   '';
+
+  postInstall = lib.optionalString withoutBin ''
+    # remove bin from output if requested.
+    # having a specific bin output would be cleaner but it does not work currently (circular references)
+    rm -rf $out/bin
+  '' + lib.optionalString buildPythonBindings ''
+    # manually install the python binding if requested.
+    mkdir -p $python/lib/python${lib.versions.majorMinor python3.version}/site-packages/
+    cp ./lib/simgrid.cpython*.so $python/lib/python${lib.versions.majorMinor python3.version}/site-packages/
+   '';
+
+  # improve debuggability if requested
+  hardeningDisable = lib.optionals debug [ "fortify" ];
+  dontStrip = debug;
 
   meta = {
     description = "Framework for the simulation of distributed applications";

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -115,5 +115,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ mickours mpoquet ];
     platforms = platforms.all;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
This commit does the following.
- use latest SimGrid release
- enable the python binding (in new output "python")
- reviews from #141040 have been applied

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
