### PR TITLE
irrlichtmt: init at 1.9.0mt4; minetest: use irrlichtmt, add deprecation warning aliases for _4

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1031,6 +1031,16 @@
       </listitem>
       <listitem>
         <para>
+          <literal>pkgs.minetestclient_4</literal> and
+          <literal>pkgs.minetestserver_4</literal> have been removed, as
+          the last 4.x release was in 2018.
+          <literal>pkgs.minetestclient</literal> (equivalent to
+          <literal>pkgs.minetest</literal> ) and
+          <literal>pkgs.minetestserver</literal> can be used instead.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.noto-fonts-cjk</literal> is now deprecated in
           favor of <literal>pkgs.noto-fonts-cjk-sans</literal> and
           <literal>pkgs.noto-fonts-cjk-serif</literal> because they each

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -379,6 +379,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `pkgs.pgadmin` now refers to `pkgs.pgadmin4`. `pgadmin3` has been removed.
 
+- `pkgs.minetestclient_4` and `pkgs.minetestserver_4` have been removed, as the last 4.x release was in 2018. `pkgs.minetestclient` (equivalent to `pkgs.minetest` ) and `pkgs.minetestserver` can be used instead.
+
 - `pkgs.noto-fonts-cjk` is now deprecated in favor of `pkgs.noto-fonts-cjk-sans`
   and `pkgs.noto-fonts-cjk-serif` because they each have different release
   schedules. To maintain compatibility with prior releases of Nixpkgs,

--- a/pkgs/development/libraries/irrlichtmt/default.nix
+++ b/pkgs/development/libraries/irrlichtmt/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, zlib
+, libpng
+, libjpeg
+, libGL
+, libX11
+, libXxf86vm
+, withTouchSupport ? false
+, libXi
+, libXext
+, Cocoa
+, Kernel
+}:
+stdenv.mkDerivation rec {
+  pname = "irrlichtmt";
+  version = "1.9.0mt4";
+
+  src = fetchFromGitHub {
+    owner = "minetest";
+    repo = "irrlicht";
+    rev = version;
+    sha256 = "sha256-YlXn9LrfGkjdb8+zQGDgrInolUYj9nVSF2AXWFpEEkw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  # https://github.com/minetest/minetest/pull/10729
+  postPatch = lib.optionalString withTouchSupport ''
+    substituteInPlace include/IrrCompileConfig.h \
+      --replace '//#define _IRR_LINUX_X11_XINPUT2_' '#define _IRR_LINUX_X11_XINPUT2_'
+  '';
+
+  buildInputs = [
+    zlib
+    libpng
+    libjpeg
+    libGL
+    libX11
+    libXxf86vm
+  ] ++ lib.optionals withTouchSupport [
+    libXi
+    libXext
+  ] ++ lib.optionals stdenv.isDarwin [
+    Cocoa
+    Kernel
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://github.com/minetest/irrlicht";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ DeeUnderscore ];
+    description = "Minetest project's fork of Irrlicht, a realtime 3D engine written in C++";
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -724,6 +724,8 @@ mapAliases ({
   mimms = throw "mimms has been removed from nixpkgs as the upstream project is stuck on python2"; # Added 2022-01-01
   minergate-cli = throw "minergatecli has been removed from nixpkgs, because the package is unmaintained and the site has a bad reputation"; # Added 2021-08-13
   minergate = throw "minergate has been removed from nixpkgs, because the package is unmaintained and the site has a bad reputation"; # Added 2021-08-13
+  minetestclient_4 = throw "minetestclient_4 has been removed from Nixpkgs; current version is available at minetest or minetestclient"; # added 2022-02-01
+  minetestserver_4 = throw "minetestserver_4 has been removed from Nixpkgs; current version is available at minetestserver"; # added 2022-02-01
   minetime = throw "minetime has been removed from nixpkgs, because it was discontinued 2021-06-22"; # Added 2021-10-14
   mist = throw "mist has been removed as the upstream project has been abandoned, see https://github.com/ethereum/mist#mist-browser-deprecated"; # Added 2020-08-15
   mlt-qt5 = throw "'mlt-qt5' has been renamed to/replaced by 'libsForQt5.mlt'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17704,6 +17704,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL IOKit;
   };
 
+  irrlichtmt = callPackage ../development/libraries/irrlichtmt {
+    inherit  (darwin.apple_sdk.frameworks) Cocoa Kernel;
+  };
+
   isocodes = callPackage ../development/libraries/iso-codes { };
 
   iso-flags = callPackage ../data/icons/iso-flags { };
@@ -31521,7 +31525,7 @@ with pkgs;
 
   inherit (callPackages ../games/minetest {
     inherit (darwin) libiconv;
-    inherit (darwin.apple_sdk.frameworks) OpenGL OpenAL Carbon Cocoa Kernel;
+    inherit (darwin.apple_sdk.frameworks) OpenGL OpenAL Carbon Cocoa;
   })
     minetestclient_5 minetestserver_5;
 


### PR DESCRIPTION
###### Motivation for this change
* Minetest release 5.5.0: https://github.com/minetest/minetest/releases/tag/5.5.0
* irrlichtmt is a fork of irrlicht by the Minetest project that Minetest switched to in 5.5.0
* Dropping `minetestclient_4` and `minetestserver_4`, since the Minetest 5.0.0 release was in 2019, and stuff saved in 4.x is compatible with versions 5.0.0 and up. The main reason to retain _4 otherwise would be to allow connecting to servers running the old version. Maintaining _4 would require refactoring the derivation, since the build inputs now differ between versions. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
