### PR TITLE
darwin.cctools-apple: init at 973.0.1-609

### DIFF
--- a/pkgs/os-specific/darwin/cctools/apple.nix
+++ b/pkgs/os-specific/darwin/cctools/apple.nix
@@ -1,0 +1,118 @@
+{ lib, stdenv, fetchurl, symlinkJoin, xcbuildHook, tcsh, libobjc, libtapi, libunwind, llvm, memstreamHook, xar }:
+
+let
+
+cctools = stdenv.mkDerivation rec {
+  pname = "cctools";
+  version = "973.0.1";
+
+  src = fetchurl {
+    url = "https://opensource.apple.com/tarballs/cctools/cctools-${version}.tar.gz";
+    hash = "sha256-r/6tsyyfi3R/0cLl+lN/B9ZaOaVF+Z7vJ6xj4LzSgiQ=";
+  };
+
+  patches = [
+    ./cctools-add-missing-vtool-libstuff-dep.patch
+  ];
+
+  postPatch = ''
+    for file in libstuff/writeout.c misc/libtool.c misc/lipo.c; do
+      substituteInPlace "$file" \
+        --replace '__builtin_available(macOS 10.12, *)' '0'
+    done
+    substituteInPlace libmacho/swap.c \
+      --replace '#ifndef RLD' '#if 1'
+  '';
+
+  nativeBuildInputs = [ xcbuildHook memstreamHook ];
+  buildInputs = [ libobjc llvm ];
+
+  xcbuildFlags = [
+    "MACOSX_DEPLOYMENT_TARGET=10.12"
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    Products/Release/libstuff_test
+    rm Products/Release/libstuff_test
+
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf "$out/usr"
+    mkdir -p "$out/bin"
+    find Products/Release -maxdepth 1 -type f -perm 755 -exec cp {} "$out/bin/" \;
+    cp -r include "$out/"
+
+    ln -s ./nm-classic "$out"/bin/nm
+    ln -s ./otool-classic "$out"/bin/otool
+
+    runHook postInstall
+  '';
+};
+
+ld64 = stdenv.mkDerivation rec {
+  pname = "ld64";
+  version = "609";
+
+  src = fetchurl {
+    url = "https://opensource.apple.com/tarballs/ld64/ld64-${version}.tar.gz";
+    hash = "sha256-SqQ7SqmK+uOPijzxOTqtkEu3qYmcth6H7rrQ03R1Q+4=";
+  };
+
+  postPatch = ''
+    substituteInPlace ld64.xcodeproj/project.pbxproj \
+      --replace "/bin/csh" "${tcsh}/bin/tcsh" \
+      --replace 'F9E8D4BE07FCAF2A00FD5801 /* PBXBuildRule */,' "" \
+      --replace 'F9E8D4BD07FCAF2000FD5801 /* PBXBuildRule */,' ""
+
+    sed -i src/ld/Options.cpp -e '1iconst char ldVersionString[] = "${version}";'
+  '';
+
+  nativeBuildInputs = [ xcbuildHook ];
+  buildInputs = [
+    libtapi
+    libunwind
+    llvm
+    xar
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    find Products/Release-assert -maxdepth 1 -type f -perm 755 -exec cp {} "$out/bin/" \;
+
+    runHook postInstall
+  '';
+};
+
+in
+
+symlinkJoin rec {
+  name = "cctools-${version}";
+  version = "${cctools.version}-${ld64.version}";
+
+  paths = [
+    cctools
+    ld64
+  ];
+
+  # workaround for the fetch-tarballs script
+  passthru = {
+    inherit (cctools) src;
+    ld64_src = ld64.src;
+  };
+
+  meta = with lib; {
+    description = "MacOS Compiler Tools";
+    homepage = "http://www.opensource.apple.com/source/cctools/";
+    license = licenses.apsl20;
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/os-specific/darwin/cctools/cctools-add-missing-vtool-libstuff-dep.patch
+++ b/pkgs/os-specific/darwin/cctools/cctools-add-missing-vtool-libstuff-dep.patch
@@ -1,0 +1,11 @@
+diff -ru a/cctools.xcodeproj/project.pbxproj b/cctools.xcodeproj/project.pbxproj
+--- a/cctools.xcodeproj/project.pbxproj	2021-02-24 20:30:55.000000000 -0500
++++ b/cctools.xcodeproj/project.pbxproj	2022-01-31 20:01:09.000000000 -0500
+@@ -2558,6 +2558,7 @@
+ 			isa = PBXFrameworksBuildPhase;
+ 			buildActionMask = 2147483647;
+ 			files = (
++				DE97E92421F3B86100C7947D /* libstuff.a in Frameworks */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 0;
+ 		};

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -98,6 +98,10 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
   };
 
+  cctools-apple = callPackage ../os-specific/darwin/cctools/apple.nix {
+    stdenv = if stdenv.isDarwin then stdenv else pkgs.libcxxStdenv;
+  };
+
   # TODO: remove alias.
   cf-private = self.apple_sdk.frameworks.CoreFoundation;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

May be useful for cross checking for possible bugs in the port version of cctools

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
