### PR TITLE
roon-{bridge,server}: updates

### DIFF
--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -2,71 +2,80 @@
 , alsa-utils
 , autoPatchelfHook
 , fetchurl
+, ffmpeg
 , lib
 , makeWrapper
+, openssl
 , stdenv
 , zlib
 }:
-let
-  inherit (stdenv.targetPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
-in
 stdenv.mkDerivation rec {
   pname = "roon-bridge";
-  version = "1.8-814";
+  version = "1.8-880";
 
   src =
     let
       urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "00" ] version;
+      inherit (stdenv.targetPlatform) system;
+      noSuchSystem = throw "Unsupposed system: ${system}";
     in
       {
         x86_64-linux = fetchurl {
           url = "http://download.roonlabs.com/builds/RoonBridge_linuxx64_${urlVersion}.tar.bz2";
-          sha256 = "sha256-dersaP/8qkl9k81FrgMieB0P4nKmDwjLW5poqKhEn7A=";
+          sha256 = "sha256-YTLy3D1CQR1hlsGw2MmZtxHT82T0PCYZxD4adt2m1+o=";
         };
         aarch64-linux = fetchurl {
           url = "http://download.roonlabs.com/builds/RoonBridge_linuxarmv8_${urlVersion}.tar.bz2";
-          sha256 = "sha256-zZj7PkLUYYHo3dngqErv1RqynSXi6/D5VPZWfrppX5U=";
+          sha256 = "sha256-aCQtYMUIzwhmYJW4a8cFzIRuxyMVIkeaJH4w1Lasp3M=";
         };
-      }.${system} or throwSystem;
+      }.${system} or noSuchSystem;
+
+  dontConfigure = true;
+  dontBuild = true;
 
   buildInputs = [
     alsa-lib
-    alsa-utils
     zlib
+    stdenv.cc.cc.lib
   ];
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out
-    mv * $out
-    runHook postInstall
-  '';
-
-  postFixup =
+  installPhase =
     let
-      linkFix = bin: ''
-        sed -i '/ulimit/d' ${bin}
-        sed -i '/ln -sf/d' ${bin}
-        ln -sf $out/RoonMono/bin/mono-sgen $out/RoonMono/bin/${builtins.baseNameOf bin}
-      '';
-      wrapFix = bin: ''
-        wrapProgram ${bin} --prefix PATH : ${lib.makeBinPath [ alsa-utils ]}
+      fixBin = binPath: ''
+        (
+          sed -i '/ulimit/d' ${binPath}
+          sed -i 's@^SCRIPT=.*@SCRIPT="$(basename "${binPath}")"@' ${binPath}
+          wrapProgram ${binPath} \
+            --argv0 "$(basename ${binPath})" \
+            --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ alsa-lib ffmpeg openssl ]}" \
+            --prefix PATH : "${lib.makeBinPath [ alsa-utils ffmpeg ]}"
+        )
       '';
     in
     ''
-      ${linkFix "$out/Bridge/RAATServer"}
-      ${linkFix "$out/Bridge/RoonBridge"}
-      ${linkFix "$out/Bridge/RoonBridgeHelper"}
+      runHook preInstall
+      mkdir -p $out
+      mv * $out
 
-      ${wrapFix "$out/check.sh"}
-      ${wrapFix "$out/start.sh"}
+      rm $out/check.sh
+      rm $out/start.sh
+      rm $out/VERSION
+
+      ${fixBin "${placeholder "out"}/Bridge/RAATServer"}
+      ${fixBin "${placeholder "out"}/Bridge/RoonBridge"}
+      ${fixBin "${placeholder "out"}/Bridge/RoonBridgeHelper"}
+
+      mkdir -p $out/bin
+      makeWrapper "$out/Bridge/RoonBridge" "$out/bin/RoonBridge" --run "cd $out"
+
+      runHook postInstall
     '';
 
   meta = with lib; {
     description = "The music player for music lovers";
+    changelog = "https://community.roonlabs.com/c/roon/software-release-notes/18";
     homepage = "https://roonlabs.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ lovesegfault ];

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -15,7 +15,7 @@
 }:
 stdenv.mkDerivation rec {
   pname = "roon-server";
-  version = "1.8-880";
+  version = "1.8-898";
 
   src =
     let
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     in
     fetchurl {
       url = "http://download.roonlabs.com/builds/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-      sha256 = "sha256-Td3iRYGmTg8Vx9c4e4ugIIbAqhDFPax9vR2BsCIQCZA=";
+      sha256 = "sha256-khp2E5BYb7bGEW6xfCKEqYDqAdElOFLbAkaHjILfyqo=";
     };
 
   dontConfigure = true;


### PR DESCRIPTION
- roon-server: 1.8-880 -> 1.8-898
- roon-bridge: 1.8-814 -> 1.8-880

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
