### PR TITLE
Fix alsa, pulseaudio (and jack, pipewire, steam) on x86_64

### DIFF
--- a/pkgs/os-specific/linux/alsa-project/alsa-lib/alsa-plugin-conf-multilib.patch
+++ b/pkgs/os-specific/linux/alsa-project/alsa-lib/alsa-plugin-conf-multilib.patch
@@ -1,0 +1,232 @@
+diff --git a/src/control/control.c b/src/control/control.c
+index d66ed75..42cecad 100644
+--- a/src/control/control.c
++++ b/src/control/control.c
+@@ -838,6 +838,10 @@ static int snd_ctl_open_conf(snd_ctl_t **ctlp, const char *name,
+ #ifndef PIC
+ 	extern void *snd_control_open_symbols(void);
+ #endif
++
++	snd_config_t *libs = NULL;
++	const char *libs_lib = NULL;
++
+ 	if (snd_config_get_type(ctl_conf) != SND_CONFIG_TYPE_COMPOUND) {
+ 		if (name)
+ 			SNDERR("Invalid type for CTL %s definition", name);
+@@ -879,6 +883,19 @@ static int snd_ctl_open_conf(snd_ctl_t **ctlp, const char *name,
+ 					SNDERR("Invalid type for %s", id);
+ 					goto _err;
+ 				}
++
++				continue;
++			}
++			// Handle an array of extra libs.
++			if (strcmp(id, "libs") == 0) {
++				if (snd_config_get_type(n) != SND_CONFIG_TYPE_COMPOUND) {
++					SNDERR("Invalid type for libs definition in CTL %s definition",
++						str);
++					goto _err;
++				}
++
++				libs = n;
++
+ 				continue;
+ 			}
+ 			if (strcmp(id, "open") == 0) {
+@@ -903,7 +920,62 @@ static int snd_ctl_open_conf(snd_ctl_t **ctlp, const char *name,
+ 		open_name = buf;
+ 		sprintf(buf, "_snd_ctl_%s_open", str);
+ 	}
+-	if (!lib) {
++
++#ifndef PIC
++	snd_control_open_symbols();
++#endif
++
++	// Normal alsa behaviour when there is no libs array.
++	if (!libs) {
++		if (lib) {
++			open_func = snd_dlobj_cache_get(lib, open_name,
++				SND_DLSYM_VERSION(SND_CONTROL_DLSYM_VERSION), 1);
++		}
++	}
++	// Handle libs array.
++	// Suppresses error messages if any function is loaded successfully.
++	else {
++		if (lib) {
++			open_func = snd_dlobj_cache_get(lib, open_name,
++				SND_DLSYM_VERSION(SND_CONTROL_DLSYM_VERSION), 0);
++		}
++
++		if (!open_func) {
++			snd_config_for_each(i, next, libs) {
++				snd_config_t *n = snd_config_iterator_entry(i);
++
++				err = snd_config_get_string(n, &libs_lib);
++				if (err < 0) {
++					SNDERR("Invalid entry in CTL %s libs definition", str);
++					goto _err;
++				}
++
++				if (!open_func) {
++					open_func = snd_dlobj_cache_get(libs_lib, open_name,
++						SND_DLSYM_VERSION(SND_CONTROL_DLSYM_VERSION), 0);
++				}
++			}
++		}
++
++		// Print error messages.
++		if (!open_func) {
++			if (lib) {
++				SNDERR("Either %s cannot be opened or %s was not defined inside",
++					lib, open_name);
++			}
++
++			snd_config_for_each(i, next, libs) {
++				snd_config_t *n = snd_config_iterator_entry(i);
++
++				snd_config_get_string(n, &libs_lib);
++				SNDERR("Either %s cannot be opened or %s was not defined inside",
++					libs_lib, open_name);
++			}
++		}
++	}
++
++	// Look in ALSA_PLUGIN_DIR iff we found nowhere else to look.
++	if (!lib && (!libs || !libs_lib)) {
+ 		const char *const *build_in = build_in_ctls;
+ 		while (*build_in) {
+ 			if (!strcmp(*build_in, str))
+@@ -919,12 +991,11 @@ static int snd_ctl_open_conf(snd_ctl_t **ctlp, const char *name,
+ 			lib = buf1;
+ 			sprintf(buf1, "%s/libasound_module_ctl_%s.so", ALSA_PLUGIN_DIR, str);
+ 		}
+-	}
+-#ifndef PIC
+-	snd_control_open_symbols();
+-#endif
+-	open_func = snd_dlobj_cache_get(lib, open_name,
++
++		open_func = snd_dlobj_cache_get(lib, open_name,
+ 			SND_DLSYM_VERSION(SND_CONTROL_DLSYM_VERSION), 1);
++	}
++
+ 	if (open_func) {
+ 		err = open_func(ctlp, name, ctl_root, ctl_conf, mode);
+ 		if (err >= 0) {
+diff --git a/src/pcm/pcm.c b/src/pcm/pcm.c
+index 2e24338..7f489f4 100644
+--- a/src/pcm/pcm.c
++++ b/src/pcm/pcm.c
+@@ -2116,6 +2116,10 @@ static int snd_pcm_open_conf(snd_pcm_t **pcmp, const char *name,
+ #ifndef PIC
+ 	extern void *snd_pcm_open_symbols(void);
+ #endif
++
++	snd_config_t *libs = NULL;
++	const char *libs_lib = NULL;
++
+ 	if (snd_config_get_type(pcm_conf) != SND_CONFIG_TYPE_COMPOUND) {
+ 		char *val;
+ 		id = NULL;
+@@ -2160,6 +2164,19 @@ static int snd_pcm_open_conf(snd_pcm_t **pcmp, const char *name,
+ 					SNDERR("Invalid type for %s", id);
+ 					goto _err;
+ 				}
++
++				continue;
++			}
++			// Handle an array of extra libs.
++			if (strcmp(id, "libs") == 0) {
++				if (snd_config_get_type(n) != SND_CONFIG_TYPE_COMPOUND) {
++					SNDERR("Invalid type for libs definition in PCM %s definition",
++						str);
++					goto _err;
++				}
++
++				libs = n;
++
+ 				continue;
+ 			}
+ 			if (strcmp(id, "open") == 0) {
+@@ -2184,7 +2201,62 @@ static int snd_pcm_open_conf(snd_pcm_t **pcmp, const char *name,
+ 		open_name = buf;
+ 		sprintf(buf, "_snd_pcm_%s_open", str);
+ 	}
+-	if (!lib) {
++
++#ifndef PIC
++	snd_pcm_open_symbols();	/* this call is for static linking only */
++#endif
++
++	// Normal alsa behaviour when there is no libs array.
++	if (!libs) {
++		if (lib) {
++			open_func = snd_dlobj_cache_get(lib, open_name,
++				SND_DLSYM_VERSION(SND_PCM_DLSYM_VERSION), 1);
++		}
++	}
++	// Handle libs array.
++	// Suppresses error messages if any function is loaded successfully.
++	else {
++		if (lib) {
++			open_func = snd_dlobj_cache_get(lib, open_name,
++				SND_DLSYM_VERSION(SND_PCM_DLSYM_VERSION), 0);
++		}
++
++		if (!open_func) {
++			snd_config_for_each(i, next, libs) {
++				snd_config_t *n = snd_config_iterator_entry(i);
++
++				err = snd_config_get_string(n, &libs_lib);
++				if (err < 0) {
++					SNDERR("Invalid entry in PCM %s libs definition", str);
++					goto _err;
++				}
++
++				if (!open_func) {
++					open_func = snd_dlobj_cache_get(libs_lib, open_name,
++						SND_DLSYM_VERSION(SND_PCM_DLSYM_VERSION), 0);
++				}
++			}
++		}
++
++		// Print error messages.
++		if (!open_func) {
++			if (lib) {
++				SNDERR("Either %s cannot be opened or %s was not defined inside",
++					lib, open_name);
++			}
++
++			snd_config_for_each(i, next, libs) {
++				snd_config_t *n = snd_config_iterator_entry(i);
++
++				snd_config_get_string(n, &libs_lib);
++				SNDERR("Either %s cannot be opened or %s was not defined inside",
++					libs_lib, open_name);
++			}
++		}
++	}
++
++	// Look in ALSA_PLUGIN_DIR iff we found nowhere else to look.
++	if (!lib && (!libs || !libs_lib)) {
+ 		const char *const *build_in = build_in_pcms;
+ 		while (*build_in) {
+ 			if (!strcmp(*build_in, str))
+@@ -2200,12 +2272,11 @@ static int snd_pcm_open_conf(snd_pcm_t **pcmp, const char *name,
+ 			lib = buf1;
+ 			sprintf(buf1, "%s/libasound_module_pcm_%s.so", ALSA_PLUGIN_DIR, str);
+ 		}
+-	}
+-#ifndef PIC
+-	snd_pcm_open_symbols();	/* this call is for static linking only */
+-#endif
+-	open_func = snd_dlobj_cache_get(lib, open_name,
++
++		open_func = snd_dlobj_cache_get(lib, open_name,
+ 			SND_DLSYM_VERSION(SND_PCM_DLSYM_VERSION), 1);
++	}
++
+ 	if (open_func) {
+ 		err = open_func(pcmp, name, pcm_root, pcm_conf, stream, mode);
+ 		if (err >= 0) {

--- a/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
@@ -14,6 +14,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-rVgpk9Us21+xWaC+q2CmrFfqsMwb34XcTbbWGX8CMz8=";
   };
 
+  patches = [
+    ./alsa-plugin-conf-multilib.patch
+  ];
+
   enableParallelBuilding = true;
 
   postInstall = ''

--- a/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
+++ b/pkgs/os-specific/linux/alsa-project/alsa-lib/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Add a "libs" field to the syntax recognized in the /etc/asound.conf file.
+    # The nixos modules for pulseaudio, jack, and pipewire are leveraging this
+    # "libs" field to declare locations for both native and 32bit plugins, in
+    # order to support apps with 32bit sound running on x86_64 architecture.
     ./alsa-plugin-conf-multilib.patch
   ];
 


### PR DESCRIPTION
###### Motivation for this change

A recent alsa-lib upgrade (#154276) removed a patch without understanding its purpose, leaving alsa-lib unable to parse the /etc/asound.conf generated by pulseaudio, jack, or pipewire.

As a result, ALSA utils (e.g. `alsactl`, `alsamixer`, `speaker-test`) are failing on x86_64 architecture for some configurations (e.g. if pulseaudio is enabled).
```
$ alsactl monitor default
alsa-lib control.c:1464:(snd_ctl_open_conf) Unknown field libs
Cannot open ctl default
```

The patch was originally added in 2014 to support running apps with 32bit sound on 64bit architecture. The patch itself adds a "libs" field to the syntax recognized in /etc/asound.conf: ab8ef63ff49dd6276f765cce10d88b3e5b86b837. The "libs" field is used by pulseaudio ([link](https://github.com/NixOS/nixpkgs/blob/016e9e5a7f9d6f0f0e4284aeaa982850ed6c921a/nixos/modules/config/pulseaudio.nix#L64-L77)), jack ([link](https://github.com/NixOS/nixpkgs/blob/016e9e5a7f9d6f0f0e4284aeaa982850ed6c921a/nixos/modules/services/audio/jack.nix#L131-L135)), and pipewire ([link](https://github.com/NixOS/nixpkgs/blob/016e9e5a7f9d6f0f0e4284aeaa982850ed6c921a/nixos/modules/services/desktops/pipewire/pipewire.nix#L188-L197)) to declare locations for both native and 32bit plugins.

Re-adding the patch fixes what's currently broken.

**Note**: It's debatable whether the 32bit use-case warrants patching alsa-lib. I don't have an opinion on the matter, but if it's to be removed, the removal should start by deprecating the relevant options and informing users of an alternative solution, if one exists. I'll leave that to someone more knowledgeable on the subject. (I can see how to remove the option, but I don't know what alternative to suggest in a deprecation warning.) My first priority is to fix what's currently broken. 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
