### PR TITLE
 dosbox: use desktopItems machinery;  munt: 2.5.0 -> 2.5.3

### DIFF
--- a/pkgs/applications/audio/munt/default.nix
+++ b/pkgs/applications/audio/munt/default.nix
@@ -1,50 +1,52 @@
 { lib
-, mkDerivation
 , stdenv
+, mkDerivation
 , fetchFromGitHub
-, makeDesktopItem
+, alsa-lib
 , cmake
+, glib
 , pkg-config
 , qtbase
-, glib
-, alsa-lib
 , withJack ? stdenv.hostPlatform.isUnix, jack
 }:
 
-let
-  mainProgram = "mt32emu-qt";
-in
 mkDerivation rec {
   pname = "munt";
-  version = "2.5.0";
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "munt_${lib.replaceChars [ "." ] [ "_" ] version}";
-    sha256 = "1lknq2a72gv1ddhzr7f967wpa12lh805jj4gjacdnamgrc1h22yn";
+    rev = "libmt32emu_${lib.replaceChars [ "." ] [ "_" ] version}";
+    hash = "sha256-n5VV5Swh1tOVQGT3urEKl64A/w7cY95/0y5wC5ZuLm4=";
   };
 
   dontFixCmake = true;
 
-  nativeBuildInputs = [ cmake pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
-  buildInputs = [ qtbase glib ]
-    ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib
-    ++ lib.optional withJack jack;
+  buildInputs = [
+    glib
+    qtbase
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux alsa-lib
+  ++ lib.optional withJack jack;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
-    mv $out/bin/${mainProgram}.app $out/Applications/
-    ln -s $out/{Applications/${mainProgram}.app/Contents/MacOS,bin}/${mainProgram}
+    mv $out/bin/${meta.mainProgram}.app $out/Applications/
+    ln -s $out/{Applications/${meta.mainProgram}.app/Contents/MacOS,bin}/${meta.mainProgram}
   '';
 
   meta = with lib; {
-    inherit mainProgram;
-    description = "Multi-platform software synthesiser emulating Roland MT-32, CM-32L, CM-64 and LAPC-I devices";
     homepage = "http://munt.sourceforge.net/";
+    description = "An emulator of Roland MT-32, CM-32L, CM-64 and LAPC-I devices";
     license = with licenses; [ lgpl21 gpl3 ];
-    platforms = platforms.all;
     maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+    mainProgram = "mt32emu-qt";
   };
 }

--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -1,4 +1,16 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU, libGL, libpng, graphicsmagick }:
+{ lib
+, stdenv
+, fetchurl
+, SDL
+, SDL_net
+, SDL_sound
+, copyDesktopItems
+, graphicsmagick
+, libGL
+, libGLU
+, libpng
+, makeDesktopItem
+}:
 
 stdenv.mkDerivation rec {
   pname = "dosbox";
@@ -6,31 +18,40 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/dosbox/dosbox-${version}.tar.gz";
-    sha256 = "02i648i50dwicv1vaql15rccv4g8h5blf5g6inv67lrfxpbkvlf0";
+    hash = "sha256-wNE91+0u02O2jeYVR1eB6JHNWC6BYrXDZpE3UCIiJgo=";
   };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    graphicsmagick
+  ];
+
+  buildInputs = [
+    SDL
+    SDL_net
+    SDL_sound
+    libGL
+    libGLU
+    libpng
+  ];
 
   hardeningDisable = [ "format" ];
 
-  buildInputs = [ SDL SDL_net SDL_sound libGLU libGL libpng ];
-
-  nativeBuildInputs = [ graphicsmagick ];
-
   configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
 
-  desktopItem = makeDesktopItem {
-    name = "dosbox";
-    exec = "dosbox";
-    icon = "dosbox";
-    comment = "x86 emulator with internal DOS";
-    desktopName = "DOSBox";
-    genericName = "DOS emulator";
-    categories = "Emulator;";
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dosbox";
+      exec = "dosbox";
+      icon = "dosbox";
+      comment = "x86 dos emulator";
+      desktopName = "DOSBox";
+      genericName = "DOS emulator";
+      categories = "Emulator;Game;";
+    })
+  ];
 
   postInstall = ''
-     mkdir -p $out/share/applications
-     cp ${desktopItem}/share/applications/* $out/share/applications
-
      mkdir -p $out/share/icons/hicolor/256x256/apps
      gm convert src/dosbox.ico $out/share/icons/hicolor/256x256/apps/dosbox.png
   '';
@@ -40,8 +61,15 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.dosbox.com/";
     description = "A DOS emulator";
-    platforms = platforms.unix;
+    longDescription = ''
+      DOSBox is an emulator that recreates a MS-DOS compatible environment
+      (complete with Sound, Input, Graphics and even basic networking). This
+      environment is complete enough to run many classic MS-DOS games completely
+      unmodified. In order to utilize all of DOSBox's features you need to first
+      understand some basic concepts about the MS-DOS environment.
+    '';
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ matthewbauer ];
-    license = licenses.gpl2;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- dosbox: use desktopItems machinery

- munt: 2.5.0 -> 2.5.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
