### PR TITLE
pass: use resholvePackage

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -1,27 +1,45 @@
-{ stdenv, lib, pkgs, fetchurl, buildEnv
-, coreutils, findutils, gnugrep, gnused, getopt, git, tree, gnupg, openssl
-, which, procps , qrencode , makeWrapper, pass, symlinkJoin
+{ stdenv
+, lib
+, pkgs
+, fetchurl
+, buildEnv
+, coreutils
+, findutils
+, gnugrep
+, gnused
+, getopt
+, git
+, tree
+, gnupg
+, openssl
+, which
+, procps
+, qrencode
+, makeWrapper
+, pass
+, symlinkJoin
 
-, xclip ? null, xdotool ? null, dmenu ? null
-, x11Support ? !stdenv.isDarwin , dmenuSupport ? (x11Support || waylandSupport)
-, waylandSupport ? false, wl-clipboard ? null
-, ydotool ? null, dmenu-wayland ? null
+, xclip ? null
+, xdotool ? null
+, dmenu ? null
+, x11Support ? !stdenv.isDarwin
+, dmenuSupport ? (x11Support || waylandSupport)
+, waylandSupport ? false
+, wl-clipboard ? null
+, ydotool ? null
+, dmenu-wayland ? null
 
-# For backwards-compatibility
+  # For backwards-compatibility
 , tombPluginSupport ? false
+
+, resholvePackage
+, bash
+, libsForQt5
+, feh
+, graphicsmagick
+, imagemagick
+, diffutils
 }:
-
-with lib;
-
-assert x11Support -> xclip != null;
-assert waylandSupport -> wl-clipboard != null;
-
-assert dmenuSupport -> x11Support || waylandSupport;
-assert dmenuSupport && x11Support
-  -> dmenu != null && xdotool != null;
-assert dmenuSupport && waylandSupport
-  -> dmenu-wayland != null && ydotool != null;
-
 
 let
   passExtensions = import ./extensions { inherit pkgs; };
@@ -30,10 +48,11 @@ let
     let
       selected = [ pass ] ++ extensions passExtensions
         ++ lib.optional tombPluginSupport passExtensions.tomb;
-    in buildEnv {
+    in
+    buildEnv {
       name = "pass-extensions-env";
       paths = selected;
-      buildInputs = [ makeWrapper ] ++ concatMap (x: x.buildInputs) selected;
+      buildInputs = [ makeWrapper ] ++ lib.concatMap (x: x.buildInputs) selected;
 
       postBuild = ''
         files=$(find $out/bin/ -type f -exec readlink -f {} \;)
@@ -54,12 +73,12 @@ let
     };
 in
 
-stdenv.mkDerivation rec {
+resholvePackage rec {
   version = "1.7.4";
   pname = "password-store";
 
   src = fetchurl {
-    url    = "https://git.zx2c4.com/password-store/snapshot/${pname}-${version}.tar.xz";
+    url = "https://git.zx2c4.com/password-store/snapshot/${pname}-${version}.tar.xz";
     sha256 = "1h4k6w7g8pr169p5w9n6mkdhxl3pw51zphx7www6pvgjb7vgmafg";
   };
 
@@ -77,51 +96,170 @@ stdenv.mkDerivation rec {
     # dependencies (s.el) here. The user has to do this themselves.
     mkdir -p "$out/share/emacs/site-lisp"
     cp "contrib/emacs/password-store.el" "$out/share/emacs/site-lisp/"
-  '' + optionalString dmenuSupport ''
+  '' + lib.optionalString dmenuSupport ''
     cp "contrib/dmenu/passmenu" "$out/bin/"
   '';
 
-  wrapperPath = with lib; makeBinPath ([
-    coreutils
-    findutils
-    getopt
-    git
-    gnugrep
-    gnupg
-    gnused
-    tree
-    which
-    qrencode
-    procps
-  ] ++ optional stdenv.isDarwin openssl
-    ++ optional x11Support xclip
-    ++ optional waylandSupport wl-clipboard
-    ++ optionals (waylandSupport && dmenuSupport) [ ydotool dmenu-wayland ]
-    ++ optionals (x11Support && dmenuSupport) [ xdotool dmenu ]
-  );
+  solutions = {
+    pass = {
+      scripts = [ "bin/pass" ] ++ lib.optional (!stdenv.isLinux) "lib/password-store/platform.sh";
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        gnused
+        gnupg
+        coreutils
+        getopt
+        which
+        git
+        gnugrep
+        findutils
+        procps
+        bash
+        libsForQt5.qt5.qttools.bin
+        qrencode
+        feh
+        graphicsmagick
+        imagemagick
+        tree
+        diffutils
+        # TODO: I assume linux builds will pop w/o below
+      ] ++ lib.optionals waylandSupport [
+        wl-clipboard
+      ] ++ lib.optionals (x11Support && !waylandSupport) [
+        xclip
+      ];
+      fake = { } // lib.optionalAttrs stdenv.isDarwin {
+        # caution: these will still be fragile if PATH is bad
+        # TODO: fixable once we figure out how to handle
+        # this entire class of problem...
+        external = [
+          # procps doesn't contain pkill/pgrep on macOS
+          "pkill"
+          # the rest of these are in platform.sh only
+          "pgrep"
+          "pbpaste" "pbcopy" # also system/impure
+          # setuid https://github.com/abathur/resholve/issues/29
+          "umount"
+          "diskutil"
+          "hdid"
+          "newfs_hfs"
+          "mount"
+
+          # TODO: used to display a QR code, but neither imgcat in
+          # nixpkgs works when used like this. It's possible that this
+          # is https://iterm2.com/utilities/imgcat, but I'm not going
+          # to tack that on for now--qrencode still emits a visible
+          # representation of the QR code even without this.
+          "imgcat"
+        ];
+      };
+      fix = {
+        "$GPG" = [ "gpg2" ];
+        "$BASE64" = [ "base64" ];
+        "$GETOPT" = [ "getopt" ];
+        # inner quotes re: https://github.com/abathur/resholve/issues/32
+        "$SHRED" = [ "'shred -f -z'" ];
+      };
+      keep = {
+        "$paste_cmd" = true; # dynamic, depends on user env
+        "$copy_cmd" = true; # dynamic, depends on user env
+        "$EDITOR" = true; # dynamic, depends on user env
+
+        source = [
+          "$extension" # internal, for pass extensions
+          # `make install` bakes in $out into the source statement
+          # easier to let it slide than to patch it...
+          "${placeholder "out"}/lib/password-store/platform.sh"
+        ];
+      };
+
+      /*
+      These are all a _bit_ of a lie. There's a chicken-and-egg problem w/
+      having enough human bandwidth to triage these for special-casing in
+      binlore and resholve, and getting enough packages resholved to spread
+      the word... for now, I just hand-audit invocations of potential execers
+      and add override the lore to say it can't exec if it seems safe.
+      */
+      execer = [
+        /*
+        One git invocation here is a genuinely tricky case:
+        https://github.com/zx2c4/password-store/blob/eea24967a002a2a81ae9b97a1fe972b5287f3a09/src/password-store.sh#L662
+
+        It looks like the config value will get execed later, but since it's
+        getting added to the local config of the pass repo on init, it seems
+        like a store path could end up breaking later once the version that
+        initialized the pass repo is no longer present? I don't know how
+        critical this specific behavior is.
+
+        (since git is so massive, it's likely to linger on the to-do list
+        until others can step up to help sort it out...)
+        */
+        "cannot:${git}/bin/git"
+        "cannot:${gnupg}/bin/gpg2"
+        "cannot:${procps}/bin/pkill"
+        "cannot:${feh}/bin/feh"
+        "cannot:${tree}/bin/tree"
+        "cannot:${diffutils}/bin/diff"
+      ];
+    };
+
+  } // lib.optionalAttrs dmenuSupport {
+    passmenu = {
+      scripts = [ "bin/passmenu" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [ ] ++ lib.optionals waylandSupport [
+        dmenu-wayland
+        ydotool
+      ] ++ lib.optionals (x11Support && !waylandSupport) [
+        dmenu
+        xdotool
+      ];
+      fake = {
+        # TODO: temporary until package-internal deps have a better fix
+        external = [ "pass" ];
+      };
+      fix = {} // lib.optionalAttrs waylandSupport {
+        "$dmenu" = [ "dmenu-wl" ];
+        "$xdotool" = [ "'ydotool type --file -'" ];
+      } // lib.optionalAttrs (x11Support && !waylandSupport) {
+        "$dmenu" = [ "dmenu" ];
+        "$xdotool" = [ "'xdotool type --clearmodifiers --file -'" ];
+      } // lib.optionalAttrs (!x11Support && !waylandSupport) {
+        # I'm not sure this condition is "real"; I see it while
+        # forcing dmenuSupport=true to test from macOS :)
+      };
+      keep = {} // lib.optionalAttrs (!x11Support && !waylandSupport) {
+        # I'm not sure this condition is "real"; I see it while
+        # forcing dmenuSupport=true to test from macOS :)
+        "$dmenu" = true;
+        "$xdotool" = true;
+      };
+      execer = [ ] ++ lib.optionals waylandSupport [
+        # I didn't actually confirm this one is necessary
+        # just guessing per xdotool below
+        "cannot:${ydotool}/bin/ydotool"
+      ] ++ lib.optionals (x11Support && !waylandSupport) [
+        "cannot:${xdotool}/bin/xdotool"
+      ];
+    };
+  };
 
   postFixup = ''
     # Fix program name in --help
     substituteInPlace $out/bin/pass \
       --replace 'PROGRAM="''${0##*/}"' "PROGRAM=pass"
-
-    # Ensure all dependencies are in PATH
-    wrapProgram $out/bin/pass \
-      --prefix PATH : "${wrapperPath}"
-  '' + lib.optionalString dmenuSupport ''
-    # We just wrap passmenu with the same PATH as pass. It doesn't
-    # need all the tools in there but it doesn't hurt either.
-    wrapProgram $out/bin/passmenu \
-      --prefix PATH : "$out/bin:${wrapperPath}"
+  ''
+  # TODO: drop below after resholve has a way to handle intra-package
+  # executable invocations; https://github.com/abathur/resholve/issues/26
+  + lib.optionalString dmenuSupport ''
+    substituteInPlace $out/bin/passmenu \
+      --replace "pass show" "$out/pass/show"
   '';
 
   # Turn "check" into "installcheck", since we want to test our pass,
   # not the one before the fixup.
   postPatch = ''
     patchShebangs tests
-
-    substituteInPlace src/password-store.sh \
-      --replace "@out@" "$out"
 
     # the turning
     sed -i -e 's@^PASS=.*''$@PASS=$out/bin/pass@' \
@@ -152,10 +290,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";
-    homepage    = "https://www.passwordstore.org/";
-    license     = licenses.gpl2Plus;
+    homepage = "https://www.passwordstore.org/";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ lovek323 fpletz tadfisher globin ma27 ];
-    platforms   = platforms.unix;
+    platforms = platforms.unix;
 
     longDescription = ''
       pass is a very simple password store that keeps passwords inside gpg2


### PR DESCRIPTION
Opening this as a draft to start a conversation (I'm hopefully over-@ing--feel free to opt out):
- Package maintainers: @lovek323 @fpletz @tadfisher @globin @ma27
- pass contributors that I recognize from nixpkgs: @zx2c4 @svend @phryneas @mbakke @DamienCassou @sternenseemann

This PR repackages pass with resholve, a tool I develop to improve Shell packaging in Nixpkgs. resholve identifies unspecified dependencies, and rewrites external invocations to absolute paths so that end-users of Shell projects don't need to manually add dependencies to their system/user packages. 

> Aside: I also want to thank @cole-h, who did much of the work here back in August/September. (Fair warning that I'm not a pass user; I asked Cole about this and he said he's not using pass anymore--so I'm trying to see if I can pick up that patch to keep the work from going to waste...) 

I'm hoping to (eventually) get to a simple yes/no on the change (and confirmation that it isn't breaking any of your own uses), so I'm happy to field any questions you have to help you decide. 

(If we move forward, I'm happy to pick at any style/format/organization complaints you have :)

### For reference
- I've created [a gist w/ some of the resholved linux and macOS outputs](https://gist.github.com/abathur/967a0c897e3b9845d332d4f8fa12a2ec) (I haven't tried to replicate all option combinations)
- `nixpkgs-review` reports:
    - Result of `nixpkgs-review` run on x86_64-darwin [1](https://github.com/Mic92/nixpkgs-review)

        <details>
          <summary>1 package failed to build:</summary>
          <ul>
            <li>qtpass</li>
          </ul>
        </details>
        <details>
          <summary>3 packages built:</summary>
          <ul>
            <li>pass (pass-nodmenu)</li>
            <li>passExtensions.pass-import</li>
            <li>passff-host</li>
          </ul>
        </details>

        (Note: qtpass failure is unrelated. It fails on segfaults in localization when sandbox is enabled. Here's [my log](https://github.com/NixOS/nixpkgs/files/7975717/qtpass.log) and [hydra's](https://hydra.nixos.org/log/hh0ggjlbwb8ns74nmzf271v1wpy3ys2k-qtpass-1.3.2.drv). It sounds like this is the same impurity issue as https://github.com/NixOS/nixpkgs/pull/82815#pullrequestreview-378020216)

    - Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
        <details>
          <summary>9 packages built:</summary>
          <ul>
            <li>krunner-pass</li>
            <li>pass</li>
            <li>pass-nodmenu</li>
            <li>pass-wayland</li>
            <li>passExtensions.pass-audit</li>
            <li>passExtensions.pass-import</li>
            <li>passff-host</li>
            <li>qtpass</li>
            <li>rofi-pass</li>
          </ul>
        </details>
---

###### Motivation for this change

Convert  pass to use `resholvePackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

