### PR TITLE
vimgolf: init at 0.5.0

### DIFF
--- a/pkgs/games/vimgolf/Gemfile
+++ b/pkgs/games/vimgolf/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'vimgolf'

--- a/pkgs/games/vimgolf/Gemfile.lock
+++ b/pkgs/games/vimgolf/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    highline (2.0.3)
+    json_pure (2.6.1)
+    thor (1.2.1)
+    vimgolf (0.5.0)
+      highline (~> 2.0, >= 2.0.3)
+      json_pure (~> 2.3, >= 2.3.1)
+      thor (~> 1.0, >= 1.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  vimgolf
+
+BUNDLED WITH
+   2.1.4

--- a/pkgs/games/vimgolf/default.nix
+++ b/pkgs/games/vimgolf/default.nix
@@ -7,12 +7,11 @@ bundlerApp {
 
   passthru.updateScript = bundlerUpdateScript "vimgolf";
 
-  meta = with lib;
-    {
-      description = "A game that tests Vim efficiency";
-      homepage = "https://vimgolf.com";
-      license = licenses.mit;
-      maintainers = with maintainers; [ leungbk ];
-      platforms = platforms.unix;
-    };
+  meta = with lib; {
+    description = "A game that tests Vim efficiency";
+    homepage = "https://vimgolf.com";
+    license = licenses.mit;
+    maintainers = with maintainers; [ leungbk ];
+    platforms = platforms.unix;
+  };
 }

--- a/pkgs/games/vimgolf/default.nix
+++ b/pkgs/games/vimgolf/default.nix
@@ -1,0 +1,18 @@
+{ lib, bundlerApp, bundlerUpdateScript }:
+
+bundlerApp {
+  pname = "vimgolf";
+  gemdir = ./.;
+  exes = [ "vimgolf" ];
+
+  passthru.updateScript = bundlerUpdateScript "vimgolf";
+
+  meta = with lib;
+    {
+      description = "A game that tests Vim efficiency";
+      homepage = "https://vimgolf.com";
+      license = licenses.mit;
+      maintainers = with maintainers; [ leungbk ];
+      platforms = platforms.unix;
+    };
+}

--- a/pkgs/games/vimgolf/gemset.nix
+++ b/pkgs/games/vimgolf/gemset.nix
@@ -1,0 +1,43 @@
+{
+  highline = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  json_pure = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05ddn30jkpw6anfakfm7lffnrl2i0265ryrrwa4j0ivihjr95y82";
+      type = "gem";
+    };
+    version = "2.6.1";
+  };
+  thor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0inl77jh4ia03jw3iqm5ipr76ghal3hyjrd6r8zqsswwvi9j2xdi";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  vimgolf = {
+    dependencies = ["highline" "json_pure" "thor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "190dzqkvshd4i6jf30xnpm4sczraw6rdh4wvfh6qnmg0czmj0sny";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29511,6 +29511,8 @@ with pkgs;
 
   qtile = callPackage ../applications/window-managers/qtile { };
 
+  vimgolf = callPackage ../games/vimgolf { };
+
   vimpc = callPackage ../applications/audio/vimpc { };
 
   # this is a lower-level alternative to wrapNeovim conceived to handle


### PR DESCRIPTION
-------

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).