### PR TITLE
sharness: use resholvePackage

### DIFF
--- a/pkgs/development/libraries/sharness/default.nix
+++ b/pkgs/development/libraries/sharness/default.nix
@@ -1,12 +1,19 @@
-{ stdenv
+{ resholvePackage
 , lib
 , fetchFromGitHub
 , fetchurl
 , perl
 , perlPackages
-, sharnessExtensions ? {} }:
+, sharnessExtensions ? {}
+, bash
+, coreutils
+, diffutils
+, findutils
+, ncurses
+, gnused
+}:
 
-stdenv.mkDerivation rec {
+resholvePackage rec {
   pname = "sharness";
   version = "1.1.0-dev";
 
@@ -40,6 +47,49 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
+
+  solutions = {
+    sharness = {
+      scripts = [
+        "share/sharness/sharness.sh"
+        "share/sharness/lib-sharness/functions.sh"
+        "share/sharness/lib-sharness/aggregate-results.sh"
+      ];
+      # not bash specific, but the source seems to ~prefer bash?
+      # it sounds like you just source it, so this is mostly doc anyways
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        coreutils
+        bash
+        diffutils
+        findutils
+        ncurses
+        gnused
+      ];
+      fix = {
+        "$SHELL_PATH" = [ "sh" ];
+        "$TEST_CMP" = [ "'diff -u'" ];
+      };
+      keep = {
+        source = [
+          /*
+          not 100% sure, but it looks like it'll dynamically locate either the
+          store directory it's running from, or similar ~override paths in the
+          code under test...
+          */
+          "$SHARNESS_TEST_SRCDIR"
+          # file == individual files loaded from srcdir above
+          "$file"
+        ];
+      };
+      # TODO: drop when diffutils & ncurses are triaged in binlore / resholve
+      # manually checked for likely-execed arguments for now
+      execer = [
+        "cannot:${diffutils}/bin/diff"
+        "cannot:${ncurses}/bin/tput"
+      ];
+    };
+  };
 
   meta = with lib; {
     description = "Portable shell library to write, run and analyze automated tests adhering to Test Anything Protocol (TAP)";


### PR DESCRIPTION
@spacefrogg opening this as a draft to start a conversation. 

This PR repackages sharness with resholve, a tool I develop to improve Shell packaging in Nixpkgs. resholve identifies unspecified dependencies, and rewrites external invocations to absolute paths so that end-users of Shell projects don't need to manually add dependencies to their system/user packages. 

I'm hoping to get to a simple yes/no on whether you're okay with the change (and confirmation that it isn't breaking any of your own uses, if you have some?), so I'm happy to field any questions you have to facilitate that.

For a little additional context, I made a gist of the 3 resholved output scripts: https://gist.github.com/abathur/651a926ec3bae29a11b5e147a54e3f74

###### Motivation for this change

Convert sharness to use resholvePackage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).