### PR TITLE
levuaska-gtk-theme: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10842,6 +10842,12 @@
     githubId = 17243347;
     name = "Sebastian Sellmeier";
   };
+  selene57 = {
+    email = "selene57.dev@gmail.com";
+    github = "selene57";
+    githubId = 46847208;
+    name = "Selene Hines";
+  };
   sellout = {
     email = "greg@technomadic.org";
     github = "sellout";

--- a/pkgs/data/themes/levuaska-gtk-theme/default.nix
+++ b/pkgs/data/themes/levuaska-gtk-theme/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenvNoCC, fetchFromGitHub, autoreconfHook, gtk_engines }:
+
+stdenvNoCC.mkDerivation rec {
+  version = "unstable-2021-01-31";
+  pname = "levuaska-gtk-theme";
+
+  src = fetchFromGitHub {
+    owner = "selene57";
+    repo = pname;
+    rev = "eaf668545d2450a7cc1b9f8a1fbfcd50df8fa5d8";
+    sha256 = "M43YyquFwwzxdhS9D+4nkaebHs1SDAz8cA+LcuU72LI=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  buildInputs = [ gtk_engines ];
+
+  postPatch = ''
+    substituteInPlace Makefile.am --replace '$(DESTDIR)'/usr $out
+  '';
+
+  preferLocalBuild = true;
+
+  meta = with lib; {
+    description = "A flat material dark gtk theme by saimoomedits inspired by owl4ce's fleon theme";
+    homepage = "https://github.com/saimoomedits/levuaska";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.selene57 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23830,6 +23830,8 @@ with pkgs;
 
   ledger-udev-rules = callPackage ../os-specific/linux/ledger-udev-rules {};
 
+  levuaska-gtk-theme = callPackage ../data/themes/levuaska-gtk-theme {  };
+
   inherit (callPackages ../data/fonts/liberation-fonts { })
     liberation_ttf_v1
     liberation_ttf_v2


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding a new theme gtk theme package that allows users to quickly deploy the levuaska gtk theme on their own machines.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
