### PR TITLE
atlas: init at 0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -435,6 +435,12 @@
     github = "akho";
     githubId = 104951;
   };
+  akirak = {
+    email = "akira.komamura@gmail.com";
+    github = "akirak";
+    githubId = 6270544;
+    name = "Akira Komamura";
+  };
   akru = {
     email = "mail@akru.me";
     github = "akru";

--- a/pkgs/tools/misc/atlas/default.nix
+++ b/pkgs/tools/misc/atlas/default.nix
@@ -1,12 +1,12 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 buildGoPackage rec {
   pname = "atlas";
-  version = "0.3.2";
+  version = "0.3.3";
   src = fetchFromGitHub {
     owner = "ariga";
     repo = "atlas";
     rev = "v${version}";
-    sha256 = "1wxfji28r100qnmryfixhg2n2mcvvl65vv50fqzhh2q576c0sh5h";
+    sha256 = "18ilqrnhm48bi511l9wb2vhcyyp12ajn9ks4s3jk567v0j8bph6b";
   };
 
   goPackagePath = "ariga.io/atlas";

--- a/pkgs/tools/misc/atlas/default.nix
+++ b/pkgs/tools/misc/atlas/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoPackage, fetchFromGitHub }:
+buildGoPackage rec {
+  pname = "atlas";
+  version = "0.3.2";
+  src = fetchFromGitHub {
+    owner = "ariga";
+    repo = "atlas";
+    rev = "v${version}";
+    sha256 = "1wxfji28r100qnmryfixhg2n2mcvvl65vv50fqzhh2q576c0sh5h";
+  };
+
+  goPackagePath = "ariga.io/atlas";
+  goDeps = ./deps.nix;
+  subPackages = [ "cmd/atlas" ];
+
+  meta = with lib; {
+    description = "A database toolkit";
+    homepage = "https://atlasgo.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ akirak ];
+  };
+}

--- a/pkgs/tools/misc/atlas/deps.nix
+++ b/pkgs/tools/misc/atlas/deps.nix
@@ -1,0 +1,1953 @@
+# file generated from go.mod using vgo2nix (https://github.com/nix-community/vgo2nix)
+[
+  {
+    goPackagePath = "cloud.google.com/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "v0.99.0";
+      sha256 = "1h5w5rnfaifg6frgyh7pz6604zhdacy0jmha0i0vvmb8n2vadx2n";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "cloud.google.com/go/bigquery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "bigquery/v1.8.0";
+      sha256 = "1127ha4r0xjsfl04mdb134b6kvpc6yz5bx4bba8m1jmb4k3vyg3j";
+      moduleDir = "bigquery";
+    };
+  }
+  {
+    goPackagePath = "cloud.google.com/go/datastore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "datastore/v1.1.0";
+      sha256 = "18f1l28665x1a8j8a5bh2i7wb2vrwj050d1g5qda50isgqaybixd";
+      moduleDir = "datastore";
+    };
+  }
+  {
+    goPackagePath = "cloud.google.com/go/firestore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "firestore/v1.6.1";
+      sha256 = "0bgkcivkq1gsz1017mlxlxy9dv39jxmb9pf5djrp3wq0pf7z65l7";
+      moduleDir = "firestore";
+    };
+  }
+  {
+    goPackagePath = "cloud.google.com/go/pubsub";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "pubsub/v1.3.1";
+      sha256 = "1fxsj63d773yf6mjas5gwsq2caa6iqxmss6mms0yfdcc6krg6zkf";
+      moduleDir = "pubsub";
+    };
+  }
+  {
+    goPackagePath = "cloud.google.com/go/storage";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-cloud-go";
+      rev = "storage/v1.10.0";
+      sha256 = "10fp6galzz8jwx35159xdcrwsqaz95xw78iwv1z5n67vhglwi5nf";
+      moduleDir = "storage";
+    };
+  }
+  {
+    goPackagePath = "dmitri.shuralyov.com/gpu/mtl";
+    fetch = {
+      type = "git";
+      url = "https://dmitri.shuralyov.com/gpu/mtl";
+      rev = "666a987793e9";
+      sha256 = "1isd03hgiwcf2ld1rlp0plrnfz7r4i7c5q4kb6hkcd22axnmrv0z";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/BurntSushi/xgb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/xgb";
+      rev = "27f122750802";
+      sha256 = "18lp2x8f5bljvlz0r7xn744f0c9rywjsb9ifiszqqdcpwhsa0kvj";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/DATA-DOG/go-sqlmock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DATA-DOG/go-sqlmock";
+      rev = "v1.5.0";
+      sha256 = "19vn6xf3wqam312g30f7qdcrh8km3wzqsa43qipyz2y5ma2l7pd4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/DataDog/datadog-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/DataDog/datadog-go";
+      rev = "v3.2.0";
+      sha256 = "1m8anll166rwcprjyv3bb0l450p35m0gzn6fs7bcd3ck2s527k7x";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/OneOfOne/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/OneOfOne/xxhash";
+      rev = "v1.2.2";
+      sha256 = "1mjfhrwhvxa48rycjnqpqzm521i38h1hdyz6pdwmhd7xb8j6gwi6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/agext/levenshtein";
+    fetch = {
+      type = "git";
+      url = "https://github.com/agext/levenshtein";
+      rev = "v1.2.1";
+      sha256 = "1gin9ddp7l98s2w6m81v2a4znjs945wjlx3bgyw66a3vzak61qaa";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev = "fb15b899a751";
+      sha256 = "1vlasv4dgycydh5wx6jdcvz40zdv90zz1h7836z7lhsi2ymvii26";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev = "c3de453c63f4";
+      sha256 = "0js37zlgv37y61j4a2d46jh72xm5kxmpaiw0ya9v944bjpc386my";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/antihax/optional";
+    fetch = {
+      type = "git";
+      url = "https://github.com/antihax/optional";
+      rev = "v1.0.0";
+      sha256 = "1ix08vl49qxr58rc6201cl97g1yznhhkwvqldslawind99js4rj0";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/apparentlymart/go-dump";
+    fetch = {
+      type = "git";
+      url = "https://github.com/apparentlymart/go-dump";
+      rev = "23540a00eaa3";
+      sha256 = "02pgvk00n4y04kj7vcm98885aj8kfl3fv98k5qxx7v3adsahacaw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/apparentlymart/go-textseg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/apparentlymart/go-textseg";
+      rev = "v1.0.0";
+      sha256 = "0n9xcyj7p5y8mbqilk9zprfyqvgm2y9f1g440wqw9dnn3s4fi1k4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/apparentlymart/go-textseg/v13";
+    fetch = {
+      type = "git";
+      url = "https://github.com/apparentlymart/go-textseg";
+      rev = "v13.0.0";
+      sha256 = "0gdgi0d52rq1xsdn9icc8lghn0f2q927cifmrlfxflf7bf21vism";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/circbuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/circbuf";
+      rev = "bbbad097214e";
+      sha256 = "1idpr0lzb2px2p3wgfq2276yl7jpaz43df6n91kf790404s4zmk3";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-metrics";
+      rev = "v0.3.10";
+      sha256 = "07ycr1qswxx2r30r1dr27ggnjwxllcab17193sy2hfyps2ka31s2";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/armon/go-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/go-radix";
+      rev = "v1.0.0";
+      sha256 = "1m1k0jz9gjfrk4m7hjm7p03qmviamfgxwm2ghakqxw3hdds8v503";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "v1.0.1";
+      sha256 = "17n4yygjxa6p499dj3yaqzfww2g7528165cl13haj97hlx94dgl7";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/bgentry/speakeasy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bgentry/speakeasy";
+      rev = "v0.1.0";
+      sha256 = "02dfrj0wyphd3db9zn2mixqxwiz1ivnyc5xc7gkz58l5l27nzp8s";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/census-instrumentation/opencensus-proto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-proto";
+      rev = "v0.3.0";
+      sha256 = "1ngp6jb345xahsijjpwwlcy2giymyzsy7kdhkrvgjafqssk6aw6f";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/cespare/xxhash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cespare/xxhash";
+      rev = "v1.1.0";
+      sha256 = "1qyzlcdcayavfazvi03izx83fvip8h36kis44zr2sg7xf6sx6l4x";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/cespare/xxhash/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cespare/xxhash";
+      rev = "v2.1.2";
+      sha256 = "1f3wyr9msnnz94szrkmnfps9wm40s5sp9i4ak0kl92zcrkmpy29a";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/logex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/logex";
+      rev = "v1.1.10";
+      sha256 = "08pbjj3wx9acavlwyr055isa8a5hnmllgdv5k6ra60l5y1brmlq4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/readline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/readline";
+      rev = "2972be24d48e";
+      sha256 = "104q8dazj8yf6b089jjr82fy9h1g80zyyzvp3g8b44a7d8ngjj6r";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/chzyer/test";
+    fetch = {
+      type = "git";
+      url = "https://github.com/chzyer/test";
+      rev = "a1ea475d72b1";
+      sha256 = "0rns2aqk22i9xsgyap0pq8wi4cfaxsri4d9q6xxhhyma8jjsnj2k";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/circonus-labs/circonus-gometrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/circonus-labs/circonus-gometrics";
+      rev = "v2.3.1";
+      sha256 = "0s2wir711h0k2h8xsypgpzshccnx8jkwjfni7n32l7wd8yng9ngs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/circonus-labs/circonusllhist";
+    fetch = {
+      type = "git";
+      url = "https://github.com/circonus-labs/circonusllhist";
+      rev = "v0.1.3";
+      sha256 = "127js92p5gx84vfj3vdmf7nn6dmqmkrxg927z0jh91fdkipmmv3i";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/client9/misspell";
+    fetch = {
+      type = "git";
+      url = "https://github.com/client9/misspell";
+      rev = "v0.3.4";
+      sha256 = "1vwf33wsc4la25zk9nylpbp9px3svlmldkm0bha4hp56jws4q9cs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/cncf/udpa/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cncf/udpa";
+      rev = "04548b0d99d4";
+      sha256 = "16z9iqs7g6c084fh6y9v3skdbxnpyqw3d1y19v42llyl9hzx361v";
+      moduleDir = "go";
+    };
+  }
+  {
+    goPackagePath = "github.com/cncf/xds/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cncf/xds";
+      rev = "a8f946100490";
+      sha256 = "1r1qhzv8nccjdaipf6klvsf262n7dqjzzww23pzzk9nyw9nsz55i";
+      moduleDir = "go";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-semver";
+      rev = "v0.3.0";
+      sha256 = "0770h1mpig2j5sbiha3abnwaw8p6dg9i87r8pc7cf6m4kwml3sc9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-systemd/v22";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "v22.3.2";
+      sha256 = "1ndi86b8va84ha93njqgafypz4di7yxfd5r5kf1r0s3y3ghcjajq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/cpuguy83/go-md2man/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cpuguy83/go-md2man";
+      rev = "v2.0.1";
+      sha256 = "051ljpzf1f5nh631lvn53ziclkzmx5lza8545mkk6wxdfnfdcx8f";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/go-control-plane";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/go-control-plane";
+      rev = "v0.10.1";
+      sha256 = "0amjw4x1904r14ps07l3wi5vdph5v2m9c97kkrr567kxr5xpjsv3";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/envoyproxy/protoc-gen-validate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/envoyproxy/protoc-gen-validate";
+      rev = "v0.6.2";
+      sha256 = "15n0iimdvirxmd1kyysss8fcnlds316dzh3rfzmcz4k3ip26npw5";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.13.0";
+      sha256 = "029qkxsdpblhrpgbv4fcmqwkqnjhx08hwiqp19pd7zz6l8a373ay";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.5.1";
+      sha256 = "0xpdprvab4zgn5igymc5468hk5s429cqyxml9xjsk0cn53rikj87";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/ghodss/yaml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ghodss/yaml";
+      rev = "v1.0.0";
+      sha256 = "0skwmimpy7hlh7pva2slpcplnm912rp3igs98xnqmn859kwa5v8g";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-gl/glfw";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-gl/glfw";
+      rev = "e6da0acd62b1";
+      sha256 = "0prvx5r7q8yrhqvnwibv4xz3dayjbq36yajzqvh0z4lqsh4hyhch";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-gl/glfw/v3.3/glfw";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-gl/glfw";
+      rev = "6f7a984d4dc4";
+      sha256 = "1nyv7h08qf4dp8w9pmcnrc6vv9bkwj8fil6pz0mkbss5hf4i8xcq";
+      moduleDir = "v3.3/glfw";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-kit/kit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-kit/kit";
+      rev = "v0.9.0";
+      sha256 = "09038mnw705h7isbjp8dzgp2i04bp5rqkmifxvwc5xkh75s00qpw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-logfmt/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-logfmt/logfmt";
+      rev = "v0.4.0";
+      sha256 = "06smxc112xmixz78nyvk3b2hmc7wasf2sl5vxj1xz62kqcq9lzm9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-openapi/inflect";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-openapi/inflect";
+      rev = "v0.19.0";
+      sha256 = "1bsv7cb9ylkgglcn5nk99v417c1120523v2pgp5nqir8sgsplbwd";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev = "v1.6.0";
+      sha256 = "1f1ard42y0a1jah93bmigl0pi06d0l1k2rcp79c7qlapvr825hlq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-stack/stack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-stack/stack";
+      rev = "v1.8.0";
+      sha256 = "0wk25751ryyvxclyp8jdk5c3ar0cmfr8lrjb66qbg4808x66b96v";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-test/deep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-test/deep";
+      rev = "v1.0.3";
+      sha256 = "0bpcrx505nc208ixjj3j65n23rfjkcgbnc4zjhh37rgqjm5yv6sz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus/v5";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.0.4";
+      sha256 = "0znax8kskb5gmp5fj75w56bc9p7b22wrdswzlh4d04sprlc471yi";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "v1.3.2";
+      sha256 = "0dfv1bhx5zhb5bsj5sj757nkacf2swp1ajpcyj9d0b37n602m18a";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/groupcache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/groupcache";
+      rev = "41bb18bfe9da";
+      sha256 = "07amgr8ji4mnq91qbsw2jlcmw6hqiwdf4kzfdrj8c4b05w4knszc";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.6.0";
+      sha256 = "1hara8j0x431njjhqxfrg1png7xa1gbrpwza6ya4mwlx76hppap4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.5.2";
+      sha256 = "1mh5fyim42dn821nsd3afnmgscrzzhn3h8rag635d2jnr23r1zhk";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "v0.0.3";
+      sha256 = "1dc8sdca0nrqb8wri91mi2xcjm16wyawm4y0fwc5gp24ahjbrg7g";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/btree";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/btree";
+      rev = "v1.0.0";
+      sha256 = "0ba430m9fbnagacp57krgidsyrgp3ycw5r7dj71brgp5r52g82p6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.5.6";
+      sha256 = "0lrb0pacv5iy3m6fn1qb3nv7zwimfhpzqq8f6hwpwx88cx3g6p1s";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/gofuzz";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/gofuzz";
+      rev = "v1.0.0";
+      sha256 = "0qz439qvccm91w0mmjz4fqgx48clxdwagkvvx89cr43q1d4iry36";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/martian";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/martian";
+      rev = "v2.1.0";
+      sha256 = "197hil6vrjk50b9wvwyzf61csid83whsjj6ik8mc9r2lryxlyyrp";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/martian/v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/martian";
+      rev = "v3.2.1";
+      sha256 = "0ylsicpiaprq6yvgbl4qiclvj4xsnsmjsjmyi21rqgxhnvyjbfyf";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/pprof";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/pprof";
+      rev = "4bb14d4b1be1";
+      sha256 = "15lgdlblmw0f0cj0k7qn8bbk15k5b61n4r3vm2gaac2zribxk47b";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/renameio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/renameio";
+      rev = "v0.1.0";
+      sha256 = "1ki2x5a9nrj17sn092d6n4zr29lfg5ydv4xz5cp58z6cw8ip43jx";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.1.2";
+      sha256 = "1rbpfa0v0ly9sdnixcxhf79swki54ikgm1zkwwkj64p1ws66syqd";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/googleapis/gax-go/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/gax-go";
+      rev = "v2.1.1";
+      sha256 = "0y959pdc2yqajhk5wxdsvfjkz3pb5ppi6yrcmpy2dkviwhx2kz73";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/grpc-ecosystem/grpc-gateway";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc-ecosystem/grpc-gateway";
+      rev = "v1.16.0";
+      sha256 = "0dzq1qbgzz2c6vnh8anx0j3py34sd72p35x6s2wrl001q68am5cc";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/consul/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/consul";
+      rev = "api/v1.11.0";
+      sha256 = "10ynwaa9zqnk732i470pfslq54nbzqjq7brbd7x46y14aq45aya0";
+      moduleDir = "api";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/consul/sdk";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/consul";
+      rev = "sdk/v0.8.0";
+      sha256 = "0ddh1w6820v65lyq7snhkip33jpxff4v8496725a0lhmha9qcl0w";
+      moduleDir = "sdk";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev = "v1.0.0";
+      sha256 = "0slfb6w3b61xz04r32bi0a1bygc82rjzhqkxj2si2074wynqnr1c";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-cleanhttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-cleanhttp";
+      rev = "v0.5.2";
+      sha256 = "1i5xslizzwd966w81bz6dxjwzgml4q9bwqa186bsxd1vi8lqxl9p";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-hclog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-hclog";
+      rev = "v1.0.0";
+      sha256 = "1bhpqrjjfsr97wkr8dkwzxsvfvxbbmwq6z4cfpgq7zaccda76n9r";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-immutable-radix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-immutable-radix";
+      rev = "v1.3.1";
+      sha256 = "0s7sf8y5lj8rx4gdymrz29gg6y2xwksfpgniaz32yzcmg3c817zb";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-msgpack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-msgpack";
+      rev = "v0.5.3";
+      sha256 = "00jv0ajqd58pkb2yyhlrjp0rv1mvb1ijx3yqjyikcmzvk9jb4h5m";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev = "v1.1.0";
+      sha256 = "0pmjpzpra7lqgikxzwlcp5mh01b46j2vhyxkixz0v86fr9kf0k3k";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-retryablehttp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-retryablehttp";
+      rev = "v0.5.3";
+      sha256 = "008mimxs8a970rdhvgmc5v1wk0gmpcl96mrkwz7wq6ik6fhg1sjl";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-rootcerts";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-rootcerts";
+      rev = "v1.0.2";
+      sha256 = "06z1bxcnr0rma02b6r52m6y0q7niikqjs090vm1i8xi3scyaw1qa";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-sockaddr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-sockaddr";
+      rev = "v1.0.0";
+      sha256 = "1yn1xq8ysn0lszmkygz3a9lgpswbz1p91jv7q8l20s4749a22xgi";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-syslog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-syslog";
+      rev = "v1.0.0";
+      sha256 = "09vccqggz212cg0jir6vv708d6mx0f9w5bxrcdah3h6chgmal6v1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-uuid";
+      rev = "v1.0.1";
+      sha256 = "0jvb88m0rq41bwgirsadgw7mnayl27av3gd2vqa3xvxp3fy0hp5k";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.4";
+      sha256 = "1sdbymypp9vrnzp8ashw0idlxvaq0rb0alwxx3x8g27yjlqi9jfn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "v1.0.0";
+      sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "v2.10.0";
+      sha256 = "1cgvmgllsyc3s7y8avvfgvbka31f9nkvx745bapqxmbxhskwv8zq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/logutils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/logutils";
+      rev = "v1.0.0";
+      sha256 = "076wf4sh5p3f953ndqk1cc0x7jhmlqrxak9953rz79rcdw77rjvv";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/mdns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/mdns";
+      rev = "v1.0.4";
+      sha256 = "1r0l8akczckyzdrp2jjhqwrn5a55nahhxdvnxzy58ad31k9ig1xr";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/memberlist";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/memberlist";
+      rev = "v0.3.0";
+      sha256 = "1b75nh8k0xgfypczvai5f9x0np1flby3rvlvwllcs3blmbyqvmdz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/serf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/serf";
+      rev = "v0.9.6";
+      sha256 = "1j2p6rdggzyynizd9c48f4g0zkf1h4635jam8cd61a9h458jksv6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/iancoleman/strcase";
+    fetch = {
+      type = "git";
+      url = "https://github.com/iancoleman/strcase";
+      rev = "v0.2.0";
+      sha256 = "0rgfn6zz1r9h7yic3b0dcqq900bi638d6qgcyy9jhvk00f4dlg5j";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/ianlancetaylor/demangle";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ianlancetaylor/demangle";
+      rev = "28f6c0f3b639";
+      sha256 = "0rsq3622gd40f1x1l7caidsxrmzg1993ich2higwd94fqbxs1r83";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/inconshreveable/mousetrap";
+      rev = "v1.0.0";
+      sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/json-iterator/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/json-iterator/go";
+      rev = "v1.1.12";
+      sha256 = "1c8f0hxm18wivx31bs615x3vxs2j3ba0v6vxchsjhldc8kl311bz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/jstemmer/go-junit-report";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jstemmer/go-junit-report";
+      rev = "v0.9.1";
+      sha256 = "1knip80yir1cdsjlb3rzy0a4w3kl4ljpiciaz6hjzwqlfhnv7bkw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/julienschmidt/httprouter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/julienschmidt/httprouter";
+      rev = "v1.2.0";
+      sha256 = "1k8bylc9s4vpvf5xhqh9h246dl1snxrzzz0614zz88cdh8yzs666";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/errcheck";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/errcheck";
+      rev = "v1.5.0";
+      sha256 = "0ci3jz2px74pfmr42jv7dpx7fdzx08vai4czp9fkiyb0gcaiqsk6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "v1.0.0";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.1";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/fs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/fs";
+      rev = "v0.1.0";
+      sha256 = "11zg176x9hr9q7fsk95r6q0wf214gg4czy02slax4x56n79g6a7q";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/logfmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/logfmt";
+      rev = "b84e30acd515";
+      sha256 = "02ldzxgznrfdzvghfraslhgp19la1fczcbzh7wm2zdc6lmpd1qq9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.2.0";
+      sha256 = "1ywbfzz1h3a3qd8rpkiqwi1dm4w8ls9ijb4x1b7567grns9f0vnp";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/kylelemons/godebug";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kylelemons/godebug";
+      rev = "d65d576e9348";
+      sha256 = "0bc8j9kwkp0hrsz0sm7hav7cm5jp9d6ql8r2b3mz78xb1g65xhbc";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev = "v1.10.3";
+      sha256 = "1kb7369xmkbxdw06ldcfxmscrq25wscmjdzcmd4521wyv2dj4nnn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/lyft/protoc-gen-star";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lyft/protoc-gen-star";
+      rev = "v0.5.3";
+      sha256 = "0xzwh1q27c22ja7ixnsal838f638jxljb5hs1z1rn6dxb87wxkz9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev = "v1.8.5";
+      sha256 = "0v4agnkhc30fblbmhs0gq2bikhdnnmqmpp4phrnza68m04j5hxbn";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/manifoldco/promptui";
+    fetch = {
+      type = "git";
+      url = "https://github.com/manifoldco/promptui";
+      rev = "v0.9.0";
+      sha256 = "1nnlj1ahwq4ar5gbvxg8dqjl1wl5r8mhcm0bixg1c4wiihz8xv8m";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.1.12";
+      sha256 = "09pm6ccaxj4f524fnvmbaj1j0pj9gpp6h3bwa32craqiw5bmi93i";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.14";
+      sha256 = "015zc3j60vb85d7f2al15la24wn45piazxlagqhzrbgfdyqci60z";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "v1.14.10";
+      sha256 = "1wxbcc2540gsbkb30hm9mi627401rkvhi5wygphj90h7vr3vjymm";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "v1.0.1";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.1.41";
+      sha256 = "052zx26y62zx0ihpkb0bkynpd5h2s52wldm52ja48iyisd2zhcjb";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/cli";
+      rev = "v1.1.0";
+      sha256 = "1x1jq0amsa0jpd4w19saz1wahmd8fb9mzs2ii4wk0mckr30n8nki";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-testing-interface";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-testing-interface";
+      rev = "v1.0.0";
+      sha256 = "1dl2js8di858bawg7dadlf1qjpkl2g3apziihjyf5imri3znyfpw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-wordwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-wordwrap";
+      rev = "ad45545899c7";
+      sha256 = "0ny1ddngvwfj3njn7pmqnf3l903lw73ynddw15x8ymp7hidv27v9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "v1.4.3";
+      sha256 = "0crp7zd5qlvka5pyr42i16ag4dh1swdlzw6pc67i441b33yqbnys";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/concurrent";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/concurrent";
+      rev = "bacd9c7ef1dd";
+      sha256 = "0s0fxccsyb8icjmiym5k7prcqx36hvgdwl588y0491gi18k5i4zs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/modern-go/reflect2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/modern-go/reflect2";
+      rev = "v1.0.2";
+      sha256 = "05a89f9j4nj8v1bchfkv2sy8piz746ikj831ilbp54g8dqhl8vzr";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/mwitkow/go-conntrack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mwitkow/go-conntrack";
+      rev = "cc309e4a2223";
+      sha256 = "0nbrnpk7bkmqg9mzwsxlm0y8m7s9qd9phr1q30qlx2qmdmz7c1mf";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pascaldekloe/goe";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pascaldekloe/goe";
+      rev = "v0.1.0";
+      sha256 = "1dqd3mfb4z2vmv6pg6fhgvfc53vhndk24wcl9lj1rz02n6m279fq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "v1.9.4";
+      sha256 = "0f2d9m19dadl18i2baf57xygvn9vprm6wb8chvpx8kipx94nchyl";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/sftp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/sftp";
+      rev = "v1.10.1";
+      sha256 = "0iw6lijdljwh5xw5hsy0b578cr52h6vvm7hbnzlrvciwhh4sfhhp";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/posener/complete";
+    fetch = {
+      type = "git";
+      url = "https://github.com/posener/complete";
+      rev = "v1.2.3";
+      sha256 = "0nri6hkfb0z3dkxf2fsfidr4bxbn91rjsqhg5s0c2jplf0aclppz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "v1.4.0";
+      sha256 = "102x5qvnja9y3qx9vyr85rp3y63imk0rk73r91xzyhpp6mrcqfbh";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "v0.2.0";
+      sha256 = "0jffnz94d6ff39fr96b5w8i8yk26pwnrfggzz8jhi8k0yihg2c9d";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "v0.9.1";
+      sha256 = "12pyywb02p7d30ccm41mwn69qsgqnsgv1w9jlqrrln2f1svnbqch";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "v0.0.8";
+      sha256 = "076wblhz8fjdc73fmz1lg0hafbwg1xv8hszm78lbg9anjpfgacvq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/rogpeppe/fastuuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rogpeppe/fastuuid";
+      rev = "v1.2.0";
+      sha256 = "028acdg63zkxpjz3l639nlhki2l0canr2v5jglrmwa1wpjqcfff8";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/rogpeppe/go-internal";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rogpeppe/go-internal";
+      rev = "v1.3.0";
+      sha256 = "0mcdh1licgnnahwml9y2iq6xy5x9xmjw5frcnds2s3wpjyqrl216";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v2.1.0";
+      sha256 = "0d1rg1drrfmabilqjjayklsz5d0n3hkf979sr3wsrw92bfbkivs7";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/ryanuber/columnize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ryanuber/columnize";
+      rev = "9b3edd62028f";
+      sha256 = "1ya1idkbb0a9fjlhkcnh5a9yvpwzwfmbyg7d56lpplwr9rqi1da4";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/sagikazarmark/crypt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sagikazarmark/crypt";
+      rev = "v0.3.0";
+      sha256 = "005hjyg903mz89hb2jizyb07ry9d35niamymj5bjwyx1i58x29zz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/sean-/seed";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sean-/seed";
+      rev = "e2103e2c3529";
+      sha256 = "0glir8jxi1w7aga2jwdb63pp1h8q4whknili7xixsqzwyy716125";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev = "v1.0.0";
+      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.4.2";
+      sha256 = "087k2lxrr9p9dh68yw71d05h5g9p5v26zbwd6j7lghinjfaw334x";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spaolacci/murmur3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spaolacci/murmur3";
+      rev = "f09979ecbc72";
+      sha256 = "1lv3zyz3jy2d76bhvvs8svygx66606iygdvwy5cwc0p5z8yghq25";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev = "v1.6.0";
+      sha256 = "0yi8p0yxiidpcg4cagxg2iyqcaapsng89rak4qyxmgails2fqg37";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev = "v1.4.1";
+      sha256 = "06qsfpvcbgkf2pvcvf9l46fj55kmbhp2yz382fkj5gll2bykx9ld";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "v1.3.0";
+      sha256 = "0j3kj6yxrl2aigixapjl6bi2gmghrj52763wbd7jc079f38wz94n";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev = "v1.1.0";
+      sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.5";
+      sha256 = "0gpmacngd0gpslnbkzi263f5ishigzgh6pbdv9hp092rnjl4nd31";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev = "v1.10.0";
+      sha256 = "10s6frknmfcy0xx4035w2cnsmqvff34nw5a43ikwz3dab3vmmh92";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "6241f9ab9942";
+      sha256 = "1fv70qpvahxqjb9li9s9ldfgnr6p2sfl76fh0psj4rrzxrpjxhkq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/subosito/gotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/subosito/gotenv";
+      rev = "v1.2.0";
+      sha256 = "0mav91j7r4arjkpq5zcf9j74f6pww8ic53x43wy7kg3ibw31yjs5";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/tv42/httpunix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tv42/httpunix";
+      rev = "b75d8614f926";
+      sha256 = "1sd9nnyyjm7n96fa18l0shlnapld4m0yj5ij2ba0l9yaaa2byqm9";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/vmihailenco/msgpack";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vmihailenco/msgpack";
+      rev = "v3.3.3";
+      sha256 = "1csz6y2xx065hlc947ai0273vclvji81wkqq2kr7h16spr15ipj3";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/vmihailenco/msgpack/v4";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vmihailenco/msgpack";
+      rev = "v4.3.12";
+      sha256 = "0aiavk7b5fn050bbc0naldk2bsl60f8wil5i6a1cfp3lxxnvmvng";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/vmihailenco/tagparser";
+    fetch = {
+      type = "git";
+      url = "https://github.com/vmihailenco/tagparser";
+      rev = "v0.1.1";
+      sha256 = "0r834b3xhz2n6fhil80qfndrps2v5vhcvfb2fkw3qwbicn9wrzbh";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/yuin/goldmark";
+    fetch = {
+      type = "git";
+      url = "https://github.com/yuin/goldmark";
+      rev = "v1.3.5";
+      sha256 = "08rrhfji92hixiv3v0wvamwcy56f90wsw84w7lyvad7g90kbsknx";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/zclconf/go-cty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/zclconf/go-cty";
+      rev = "v1.8.0";
+      sha256 = "0060ld0bwcbdmbll3d8wh2pzaq6a9bhighl7lniqpdli7slvgdqs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "github.com/zclconf/go-cty-debug";
+    fetch = {
+      type = "git";
+      url = "https://github.com/zclconf/go-cty-debug";
+      rev = "b22d67c1ba0b";
+      sha256 = "12cgr4lwbnvgdnf9j1z99fnd003wfjplnw50jlafz2al48zja50p";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "go.etcd.io/etcd/api/v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/etcd";
+      rev = "api/v3.5.1";
+      sha256 = "0szqasja7mwm8glhaz9wisrr62g56hngkpf5y0f9f1frcq0wk7i2";
+      moduleDir = "api";
+    };
+  }
+  {
+    goPackagePath = "go.etcd.io/etcd/client/pkg/v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/etcd";
+      rev = "client/pkg/v3.5.1";
+      sha256 = "0szqasja7mwm8glhaz9wisrr62g56hngkpf5y0f9f1frcq0wk7i2";
+      moduleDir = "client/pkg";
+    };
+  }
+  {
+    goPackagePath = "go.etcd.io/etcd/client/v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/etcd-io/etcd";
+      rev = "client/v2.305.1";
+      sha256 = "0szqasja7mwm8glhaz9wisrr62g56hngkpf5y0f9f1frcq0wk7i2";
+      moduleDir = "client";
+    };
+  }
+  {
+    goPackagePath = "go.opencensus.io";
+    fetch = {
+      type = "git";
+      url = "https://github.com/census-instrumentation/opencensus-go";
+      rev = "v0.23.0";
+      sha256 = "0gw4f7inf8y2ik00yfb36xganiq9rl4w2d1a41bsjqsh83ajz2km";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "go.opentelemetry.io/proto/otlp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/open-telemetry/opentelemetry-proto-go";
+      rev = "otlp/v0.7.0";
+      sha256 = "003p1yjh48sfgq7b2k1hxn8jdpdps17zfhn427lbfpd1z7gd2cdq";
+      moduleDir = "otlp";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/atomic";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/atomic";
+      rev = "v1.7.0";
+      sha256 = "0yxvb5sixh76cl9j8dpa97gznj0p8pmg2cdw0ypfwhd3ipx9wph1";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/multierr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/multierr";
+      rev = "v1.6.0";
+      sha256 = "162941s8f6a9x2w04qm4qa3zz0zylwag9149hywrj9ibp2nzcsqz";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "go.uber.org/zap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/uber-go/zap";
+      rev = "v1.17.0";
+      sha256 = "14mr66h7vxirpvb12106372apw1w3ppymbf89lprxkkg03srkfy8";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "32db794688a5";
+      sha256 = "0arh5rhahrjzmlifmbgswwc0kjkgmhps6g4hzia0i6ismsk74n48";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/exp";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/exp";
+      rev = "6cc2880d07d6";
+      sha256 = "1iia6hiif6hcp0cg1i6nq63qg0pmvm2kq24pf2r2il3597rfmlgy";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/image";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/image";
+      rev = "cff245a6509b";
+      sha256 = "0hiznlkiaay30acwvvyq8g6bm32r7bc6gv47pygrcxqpapasbz84";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/lint";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/lint";
+      rev = "6edffad5e616";
+      sha256 = "1n7lrr3282q3li4f06afms444qy13rfd316za0drqihakwyki2jk";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mobile";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mobile";
+      rev = "d2bd2a29d028";
+      sha256 = "1nv6vvhnjr01nx9y06q46ww87dppdwpbqrlsfg1xf2587wxl8xiv";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/mod";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mod";
+      rev = "v0.5.0";
+      sha256 = "0pl0jc5jvg7hxj4z66zg6kglnq5g7li09f3k9klwvyr4jx5dw88k";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "60bc85c4be6d";
+      sha256 = "1yjd8rg6hjcsjid9gfj1hrcvyp2kjbp7315yyqhpqzsi9qlb45lv";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/oauth2";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/oauth2";
+      rev = "d3ed0bb246c8";
+      sha256 = "1vwkvx9kicl0sx27a41r5nfhaw3r5ni94xrvdg5mdihb0g57skwq";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "036812b2e83c";
+      sha256 = "1gl202py3s4gl6arkaxlf8qa6f0jyyg2f95m6f89qnfmr416h85b";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "97ca703d548d";
+      sha256 = "0xhavf3h51zq7d5ckhl77nfvmrzhfv8faqmicc6k03wk91xnj9bg";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/term";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/term";
+      rev = "7de9c90e9dd1";
+      sha256 = "1ba252xmv6qsvf1w1gcy98mngrj0vd4inbjw0lsklqvva65nljna";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.7";
+      sha256 = "0xkw0qvfjyifdqd25y7nxdqkdh92inymw3q7841nricc9s01p4jy";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/time";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/time";
+      rev = "555d28b269f0";
+      sha256 = "1rhl4lyz030kwfsg63yk83yd3ivryv1afmzdz9sxbhcj84ym6h4r";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "v0.1.5";
+      sha256 = "1wzbbcja1q0gn8ahxvzvpl4nzj2icwmc0pppgipmx5rdnngqw80l";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "5ec99f83aff1";
+      sha256 = "1dbzc3gmf2haazpv7cgmv97rq40g2xzwbglc17vas8dwhgwgwrzb";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/google-api-go-client";
+      rev = "v0.62.0";
+      sha256 = "10gcj0363ar039zh4bjp7z7kk2v9chwjj28gn1zsn2vyxw4r5cdd";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.6.7";
+      sha256 = "1wkipg7xxc0ha5p6c3bj0vpgq38l18441n5l6zxdhx0gzvz5z1hs";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/googleapis/go-genproto";
+      rev = "3a66f561d7aa";
+      sha256 = "1021gpy2753zffim3sh2mi723pvnnpl8mpabsyp18k1880zgxham";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "v1.42.0";
+      sha256 = "0k5k762licfzs56nk817g83qji4np32z0gwnfbwr95y70klvs76q";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/grpc/grpc-go";
+      rev = "cmd/protoc-gen-go-grpc/v1.1.0";
+      sha256 = "14rjb8j6fm07rnns3dpwgkzf3y6rmia6i9n7ns6cldc5mbf7nwi3";
+      moduleDir = "cmd/protoc-gen-go-grpc";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/protobuf";
+      rev = "v1.27.1";
+      sha256 = "0aszb7cv8fq1m8akgd4kjyg5q7g5z9fdqnry6057ygq9r8r2yif2";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/alecthomas/kingpin.v2";
+      rev = "v2.2.6";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "41f04d3bba15";
+      sha256 = "0vfk9czmlxmp6wndq8k17rhnjxal764mxfhrccza7nwlia760pjy";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/errgo.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/errgo.v2";
+      rev = "v2.1.0";
+      sha256 = "065mbihiy7q67wnql0bzl9y1kkvck5ivra68254zbih52jxwrgr2";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/ini.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/ini.v1";
+      rev = "v1.66.2";
+      sha256 = "1q67prlvr5rv6lmpdg18qlqd3k84g73v1zriln12ipwq0ynjv0ds";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.4.0";
+      sha256 = "1pbmrpj7gcws34g8vwna4i2nhm9p6235piww36436xhyaa10cldr";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v3";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v3";
+      rev = "496545a6307b";
+      sha256 = "06f4lnrp494wqaygv09dggr2dwf3z2bawqhnlnnwiamg5y787k4g";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "honnef.co/go/tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dominikh/go-tools";
+      rev = "v0.0.1-2020.1.4";
+      sha256 = "182j3zzx1bj4j4jiamqn49v9nd3vcrx727f7i9zgcrgmiscvw3mh";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "rsc.io/binaryregexp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rsc/binaryregexp";
+      rev = "v0.2.0";
+      sha256 = "1kar0myy85waw418zslviwx8846zj0m9cmqkxjx0fvgjdi70nc4b";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "rsc.io/quote/v3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rsc/quote";
+      rev = "v3.1.0";
+      sha256 = "0nvv97hwwrl1mx5gzsbdm1ndnwpg3m7i2jb10ig9wily7zmvki0i";
+      moduleDir = "";
+    };
+  }
+  {
+    goPackagePath = "rsc.io/sampler";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rsc/sampler";
+      rev = "v1.3.0";
+      sha256 = "0byxk2ynba50py805kcvbvjzh59l1r308i1xgyzpw6lff4xx9xjh";
+      moduleDir = "";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24619,6 +24619,8 @@ with pkgs;
 
   artha = callPackage ../applications/misc/artha { };
 
+  atlas = callPackage ../tools/misc/atlas { };
+
   atlassian-cli = callPackage ../applications/office/atlassian-cli { };
 
   atomEnv = callPackage ../applications/editors/atom/env.nix {


### PR DESCRIPTION
###### Motivation for this change

Add a new package [atlas](https://github.com/ariga/atlas). Atlas is a Terraform-like  CLI program that lets you manage database schemas in HCL.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
