### PR TITLE
odoo: 15.0.20211029 -> 15.0.20220126

### DIFF
--- a/pkgs/applications/finance/odoo/default.nix
+++ b/pkgs/applications/finance/odoo/default.nix
@@ -5,9 +5,14 @@
 , python3Packages
 , nodePackages
 , wkhtmltopdf
+, callPackage
 }:
 
 with python3Packages;
+
+let
+  werkzeug = python3Packages.callPackage ../../../development/python-modules/werkzeug/1.nix {};
+in
 
 buildPythonApplication rec {
   pname = "odoo";

--- a/pkgs/applications/finance/odoo/default.nix
+++ b/pkgs/applications/finance/odoo/default.nix
@@ -14,7 +14,7 @@ buildPythonApplication rec {
 
   major = "15";
   minor = "0";
-  patch = "20211029";
+  patch = "20220126";
 
   version = "${major}.${minor}.${patch}";
 
@@ -22,7 +22,7 @@ buildPythonApplication rec {
   src = fetchurl {
     url = "https://nightly.odoo.com/${major}.${minor}/nightly/src/odoo_${version}.tar.gz";
     name = "${pname}-${version}";
-    sha256 = "sha256-/E+bLBbiz7fRyTwP+0AMpqbuRkOpE4B4P6kREIB4m1Q=";
+    hash = "sha256-mofV0mNCdyzJecp0XegZBR/5NzHjis9kbpsUA/KJbZg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/werkzeug/1.nix
+++ b/pkgs/development/python-modules/werkzeug/1.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, buildPythonPackage, fetchPypi
+, itsdangerous, hypothesis
+, pytestCheckHook, requests
+, pytest-timeout
+, isPy3k
+ }:
+
+buildPythonPackage rec {
+  pname = "Werkzeug";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c";
+  };
+
+  propagatedBuildInputs = [ itsdangerous ];
+  checkInputs = [ pytestCheckHook requests hypothesis pytest-timeout ];
+
+  postPatch = ''
+    # ResourceWarning causes tests to fail
+    rm tests/test_routing.py
+  '';
+
+  disabledTests = [
+    "test_save_to_pathlib_dst"
+    "test_cookie_maxsize"
+    "test_cookie_samesite_attribute"
+    "test_cookie_samesite_invalid"
+    "test_range_parsing"
+    "test_content_range_parsing"
+    "test_http_date_lt_1000"
+    "test_best_match_works"
+    "test_date_to_unix"
+    "test_easteregg"
+
+    # Seems to be a problematic test-case:
+    #
+    # > warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
+    # E pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
+    # E
+    # E Traceback (most recent call last):
+    # E   File "/nix/store/cwv8aj4vsqvimzljw5dxsxy663vjgibj-python3.9-Werkzeug-1.0.1/lib/python3.9/site-packages/werkzeug/formparser.py", line 318, in parse_multipart_headers
+    # E     return Headers(result)
+    # E ResourceWarning: unclosed file <_io.FileIO name=11 mode='rb+' closefd=True>
+    "test_basic_routing"
+    "test_merge_slashes_match"
+    "test_merge_slashes_build"
+    "TestMultiPart"
+    "TestHTTPUtility"
+  ] ++ lib.optionals stdenv.isDarwin [
+    "test_get_machine_id"
+  ];
+
+  meta = with lib; {
+    homepage = "https://palletsprojects.com/p/werkzeug/";
+    description = "A WSGI utility library for Python";
+    license = licenses.bsd3;
+    maintainers = [ ];
+  };
+}
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix and upgrade

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
