### PR TITLE
(vscode|vscodium)-fhs: fix missing desktop icon

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -161,12 +161,9 @@ let
       krb5
     ]) ++ additionalPkgs pkgs;
 
-    # restore desktop item icons
+    # symlink shared assets, including icons and desktop entries
     extraInstallCommands = ''
-      mkdir -p "$out/share/applications"
-      for item in ${unwrapped}/share/applications/*.desktop; do
-        ln -s "$item" "$out/share/applications/"
-      done
+      ln -s "${unwrapped}/share" "$out/"
     '';
 
     runScript = "${unwrapped}/bin/${executableName}";


### PR DESCRIPTION
Fixes: #129955

The issue was that only `share/application/*.desktop` were symlinked, but not the icon which was in `share/pixmap`.

I choose to symlink the whole `share` directory instead of explicitly listing `share/applications/*` and `share/pixmaps/*` for future proofing. New versions might add man pages, autocompletions, vector icons etc, so this way, it'll work fine.

If this PR is good, I'd like to backport it to `release-21.11`.

Maintainers and relevant contributors:
@eadwu @synthetica @maxeaubrey @bobby285271  @turion @jonringer


