### PR TITLE
pure-modules: rename name to pname&version

### DIFF
--- a/pkgs/development/pure-modules/audio/default.nix
+++ b/pkgs/development/pure-modules/audio/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, portaudio, fftw, libsndfile, libsamplerate }:
 
 stdenv.mkDerivation rec {
-  baseName = "audio";
+  pname = "pure-audio";
   version = "0.6";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-audio-${version}.tar.gz";
     sha256 = "c1f2a5da73983efb5a54f86d57ba93713ebed20ff0c72de9b3467f10f2904ee0";
   };
 

--- a/pkgs/development/pure-modules/avahi/default.nix
+++ b/pkgs/development/pure-modules/avahi/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, avahi }:
 
 stdenv.mkDerivation rec {
-  baseName = "avahi";
+  pname = "pure-avahi";
   version = "0.3";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-avahi-${version}.tar.gz";
     sha256 = "5fac8a6e3a54e45648ceb207ee0061b22eac8c4e668b8d53f13eb338b09c9160";
   };
 

--- a/pkgs/development/pure-modules/csv/default.nix
+++ b/pkgs/development/pure-modules/csv/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "csv";
+  pname = "pure-csv";
   version = "1.6";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-csv-${version}.tar.gz";
     sha256 = "fe7c4edebe8208c54d5792a9eefaeb28c4a58b9094d161a6dda8126f0823ab3c";
   };
 

--- a/pkgs/development/pure-modules/doc/default.nix
+++ b/pkgs/development/pure-modules/doc/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "doc";
+  pname = "pure-doc";
   version = "0.7";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-doc-${version}.tar.gz";
     sha256 = "cfa880573941f37868269bcc443a09fecd2a141a78556383d2213f6c9f45ddd9";
   };
 

--- a/pkgs/development/pure-modules/fastcgi/default.nix
+++ b/pkgs/development/pure-modules/fastcgi/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, fcgi }:
 
 stdenv.mkDerivation rec {
-  baseName = "fastcgi";
+  pname = "pure-fastcgi";
   version = "0.6";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-fastcgi-${version}.tar.gz";
     sha256 = "aa5789cc1e17521c01f349ee82ce2a00500e025b3f8494f89a7ebe165b5aabc7";
   };
 

--- a/pkgs/development/pure-modules/faust/default.nix
+++ b/pkgs/development/pure-modules/faust/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, faust, libtool }:
 
 stdenv.mkDerivation rec {
-  baseName = "faust";
+  pname = "pure-faust";
   version = "0.11";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-faust-${version}.tar.gz";
     sha256 = "51278a3b0807c4770163dc2ce423507dcf0ffec9cd1c1fbc08426d07294f6ae0";
   };
 

--- a/pkgs/development/pure-modules/ffi/default.nix
+++ b/pkgs/development/pure-modules/ffi/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, libffi }:
 
 stdenv.mkDerivation rec {
-  baseName = "ffi";
+  pname = "pure-ffi";
   version = "0.14";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-ffi-${version}.tar.gz";
     sha256 = "0331f48efaae40af21b23cf286fd7eac0ea0a249d08fd97bf23246929c0ea71a";
   };
 

--- a/pkgs/development/pure-modules/gen/default.nix
+++ b/pkgs/development/pure-modules/gen/default.nix
@@ -2,12 +2,11 @@
   pkg-config, pure, haskellPackages }:
 
 stdenv.mkDerivation rec {
-  baseName = "gen";
+  pname = "pure-gen";
   version = "0.20";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-gen-${version}.tar.gz";
     sha256 = "cfadd99a378b296325937d2492347611cc1e1d9f24594f91f3c2293eca01a4a8";
   };
 

--- a/pkgs/development/pure-modules/gl/default.nix
+++ b/pkgs/development/pure-modules/gl/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, freeglut, libGLU, libGL, xlibsWrapper }:
 
 stdenv.mkDerivation rec {
-  baseName = "gl";
+  pname = "pure-gl";
   version = "0.9";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-gl-${version}.tar.gz";
     sha256 = "edd594222f89ae372067eda6679a37488986b9739b5b79b4a25ac48255d31bba";
   };
 

--- a/pkgs/development/pure-modules/glpk/default.nix
+++ b/pkgs/development/pure-modules/glpk/default.nix
@@ -2,12 +2,11 @@
   pkg-config, pure, glpk, gmp, libtool, libmysqlclient, libiodbc }:
 
 stdenv.mkDerivation rec {
-  baseName = "glpk";
+  pname = "pure-glpk";
   version = "0.5";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-glpk-${version}.tar.gz";
     sha256 = "5d6dc11706985dda02d96d481ea5f164c9e95ee446432fc4fc3d0db61a076346";
   };
 

--- a/pkgs/development/pure-modules/gplot/default.nix
+++ b/pkgs/development/pure-modules/gplot/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, gnuplot }:
 
 stdenv.mkDerivation rec {
-  baseName = "gplot";
+  pname = "pure-gplot";
   version = "0.1";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-gplot-${version}.tar.gz";
     sha256 = "841ded98e4d1cdfaf78f95481e5995d0440bfda2d5df533d6741a6e7058a882c";
   };
 

--- a/pkgs/development/pure-modules/gsl/default.nix
+++ b/pkgs/development/pure-modules/gsl/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pure, pkg-config, gsl }:
 
 stdenv.mkDerivation rec {
-  baseName = "gsl";
+  pname = "pure-gsl";
   version = "0.12";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-gsl-${version}.tar.gz";
     sha256 = "06bdd873d5417d90ca35093056a060b77365123ed24c3ac583cd3922d4c78a75";
   };
 

--- a/pkgs/development/pure-modules/gtk/default.nix
+++ b/pkgs/development/pure-modules/gtk/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, pure-ffi, gtk2 }:
 
 stdenv.mkDerivation rec {
-  baseName = "gtk";
+  pname = "pure-gtk";
   version = "0.13";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-gtk-${version}.tar.gz";
     sha256 = "e659ff1bc5809ce35b810f8ac3fb7e8cadaaef13996537d8632e2f86ed76d203";
   };
 

--- a/pkgs/development/pure-modules/liblo/default.nix
+++ b/pkgs/development/pure-modules/liblo/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, liblo }:
 
 stdenv.mkDerivation rec {
-  baseName = "liblo";
+  pname = "pure-liblo";
   version = "0.9";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-liblo-${version}.tar.gz";
     sha256 = "c2ba4d6f94489acf8a8fac73982ae03d5ad4113146eb1f7d6558a956c57cb8ee";
   };
 

--- a/pkgs/development/pure-modules/lilv/default.nix
+++ b/pkgs/development/pure-modules/lilv/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, lilv, lv2, serd, sord, sratom }:
 
 stdenv.mkDerivation rec {
-  baseName = "lilv";
+  pname = "pure-lilv";
   version = "0.4";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-lilv-${version}.tar.gz";
     sha256 = "af20982fe43e8dce62d50bf7a78e461ab36c308325b123cddbababf0d3beaf9f";
   };
 

--- a/pkgs/development/pure-modules/lv2/default.nix
+++ b/pkgs/development/pure-modules/lv2/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, lv2 }:
 
 stdenv.mkDerivation rec {
-  baseName = "lv2";
+  pname = "pure-lv2";
   version = "0.2";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-lv2-${version}.tar.gz";
     sha256 = "721cacd831781d8309e7ecabb0ee7c01da17e75c5642a5627cf158bfb36093e1";
   };
 

--- a/pkgs/development/pure-modules/midi/default.nix
+++ b/pkgs/development/pure-modules/midi/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, portmidi }:
 
 stdenv.mkDerivation rec {
-  baseName = "midi";
+  pname = "pure-midi";
   version = "0.6";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-midi-${version}.tar.gz";
     sha256 = "817ae9fa5f443a8c478a6770f36091e3cf99f3515c74e00d09ca958dead1e7eb";
   };
 

--- a/pkgs/development/pure-modules/mpfr/default.nix
+++ b/pkgs/development/pure-modules/mpfr/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "mpfr";
+  pname = "pure-mpfr";
   version = "0.5";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-mpfr-${version}.tar.gz";
     sha256 = "39d2255c2c0c2d60ce727be178b5e5a06f7c92eb365976c49c4a34b1edc576e7";
   };
 

--- a/pkgs/development/pure-modules/octave/default.nix
+++ b/pkgs/development/pure-modules/octave/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, octave }:
 
 stdenv.mkDerivation rec {
-  baseName = "octave";
+  pname = "pure-octave";
   version = "0.9";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-octave-${version}.tar.gz";
     sha256 = "0l1mvmi3rpabzjcrk6p04rdn922mvdm9x67zby3dha5iiccc47q0";
   };
 

--- a/pkgs/development/pure-modules/odbc/default.nix
+++ b/pkgs/development/pure-modules/odbc/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, libiodbc }:
 
 stdenv.mkDerivation rec {
-  baseName = "odbc";
+  pname = "pure-odbc";
   version = "0.10";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-odbc-${version}.tar.gz";
     sha256 = "1907e9ebca11cc68762cf7046084b31e9e2bf056df85c40ccbcbe9f02221ff8d";
   };
 

--- a/pkgs/development/pure-modules/pandoc/default.nix
+++ b/pkgs/development/pure-modules/pandoc/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, pandoc, gawk, getopt }:
 
 stdenv.mkDerivation rec {
-  baseName = "pandoc";
+  pname = "pure-pandoc";
   version = "0.1";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-pandoc-${version}.tar.gz";
     sha256 = "0f23a17549048ca3a8f4936ea9e931feb05997390b486850936b746996350cda";
   };
 

--- a/pkgs/development/pure-modules/rational/default.nix
+++ b/pkgs/development/pure-modules/rational/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "rational";
+  pname = "pure-rational";
   version = "0.1";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-rational-${version}.tar.gz";
     sha256 = "62cb4079a0dadd232a859e577e97e50e9718ccfcc5983c4d9c4c32cac7a9bafa";
   };
 

--- a/pkgs/development/pure-modules/readline/default.nix
+++ b/pkgs/development/pure-modules/readline/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, readline }:
 
 stdenv.mkDerivation rec {
-  baseName = "readline";
+  pname = "pure-readline";
   version = "0.3";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-readline-${version}.tar.gz";
     sha256 = "db8e6663b1c085466c09662fe86d952b6f4ffdafeecffe805c681ab91c910886";
   };
 

--- a/pkgs/development/pure-modules/sockets/default.nix
+++ b/pkgs/development/pure-modules/sockets/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "sockets";
+  pname = "pure-sockets";
   version = "0.7";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-sockets-${version}.tar.gz";
     sha256 = "4f2769618ae5818cf6005bb08bcf02fe359a2e31998d12dc0c72f0494e9c0420";
   };
 

--- a/pkgs/development/pure-modules/sql3/default.nix
+++ b/pkgs/development/pure-modules/sql3/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, sqlite }:
 
 stdenv.mkDerivation rec {
-  baseName = "sql3";
+  pname = "pure-sql3";
   version = "0.5";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-sql3-${version}.tar.gz";
     sha256 = "b9f79dd443c8ffc5cede51e2af617f24726f5c0409aab4948c9847e6adb53c37";
   };
 

--- a/pkgs/development/pure-modules/stldict/default.nix
+++ b/pkgs/development/pure-modules/stldict/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "stldict";
+  pname = "pure-stldict";
   version = "0.8";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-stldict-${version}.tar.gz";
     sha256 = "5b894ae6dc574c7022258e2732bea649c82c959ec4d0be13fb5a3e8ba8488f28";
   };
 

--- a/pkgs/development/pure-modules/stllib/default.nix
+++ b/pkgs/development/pure-modules/stllib/default.nix
@@ -1,9 +1,8 @@
 { lib, stdenv, fetchurl, pkg-config, pure }:
 
 stdenv.mkDerivation rec {
-  baseName = "stllib";
+  pname = "pure-stllib";
   version = "0.6";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
     url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-stllib-${version}.tar.gz";

--- a/pkgs/development/pure-modules/tk/default.nix
+++ b/pkgs/development/pure-modules/tk/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, tcl, tk, xlibsWrapper }:
 
 stdenv.mkDerivation rec {
-  baseName = "tk";
+  pname = "pure-tk";
   version = "0.5";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-tk-${version}.tar.gz";
     sha256 = "3b6e97e2d723d5a05bf25f4ac62068ac17a1fd81db03e1986366097bf071a516";
   };
 

--- a/pkgs/development/pure-modules/xml/default.nix
+++ b/pkgs/development/pure-modules/xml/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, pure, libxml2, libxslt }:
 
 stdenv.mkDerivation rec {
-  baseName = "xml";
+  pname = "pure-xml";
   version = "0.7";
-  name = "pure-${baseName}-${version}";
 
   src = fetchurl {
-    url = "https://bitbucket.org/purelang/pure-lang/downloads/${name}.tar.gz";
+    url = "https://bitbucket.org/purelang/pure-lang/downloads/pure-xml-${version}.tar.gz";
     sha256 = "e862dec060917a285bc3befc90f4eb70b6cc33136fb524ad3aa173714a35b0f7";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997
since the packages are broken it is not possible to test the compilation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
