### PR TITLE
dogdns: 0.1.0 -> unstable-2021-10-07, install man pages

### DIFF
--- a/pkgs/tools/networking/dogdns/default.nix
+++ b/pkgs/tools/networking/dogdns/default.nix
@@ -5,6 +5,8 @@
 , stdenv
 , pkg-config
 , openssl
+, just
+, pandoc
 , Security
 }:
 
@@ -19,15 +21,22 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-y3T0vXg7631FZ4bzcbQjz3Buui/DFxh9LG8BZWwynp0=";
   };
 
-  nativeBuildInputs = [ installShellFiles ]
+  nativeBuildInputs = [ installShellFiles just pandoc ]
     ++ lib.optionals stdenv.isLinux [ pkg-config ];
   buildInputs = lib.optionals stdenv.isLinux [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ Security ];
+
+  outputs = [ "out" "man" ];
+
+  postBuild = ''
+    just man
+  '';
 
   cargoSha256 = "sha256-agepQVJbqbjzFbEBKbM7BNxc8FlklOrCsTgCAOcuptc=";
 
   postInstall = ''
     installShellCompletion completions/dog.{bash,fish,zsh}
+    installManPage ./target/man/*.1
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/dogdns/default.nix
+++ b/pkgs/tools/networking/dogdns/default.nix
@@ -10,13 +10,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "dogdns";
-  version = "0.1.0";
+  version = "unstable-2021-10-07";
 
   src = fetchFromGitHub {
     owner = "ogham";
     repo = "dog";
-    rev = "v${version}";
-    sha256 = "088ib0sncv0vrvnqfvxf5zc79v7pnxd2cmgp4378r6pmgax9z9zy";
+    rev = "721440b12ef01a812abe5dc6ced69af6e221fad5";
+    sha256 = "sha256-y3T0vXg7631FZ4bzcbQjz3Buui/DFxh9LG8BZWwynp0=";
   };
 
   nativeBuildInputs = [ installShellFiles ]
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optionals stdenv.isLinux [ openssl ]
     ++ lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "0zgzaq303zy8lymhldm6dpm5hwsxi2ph42zw5brvsdjmgm9ga0rb";
+  cargoSha256 = "sha256-agepQVJbqbjzFbEBKbM7BNxc8FlklOrCsTgCAOcuptc=";
 
   postInstall = ''
     installShellCompletion completions/dog.{bash,fish,zsh}
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
     description = "Command-line DNS client";
     homepage = "https://dns.lookup.dog";
     license = licenses.eupl12;
-    maintainers = with maintainers; [ bbigras ];
+    maintainers = with maintainers; [ bbigras ma27 ];
     mainProgram = "dog";
   };
 }


### PR DESCRIPTION

###### Motivation for this change

Basically what I initially did in #154954.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
