### PR TITLE
python2Packages.protobuf: disable broken pythonImportsCheck

### DIFF
--- a/pkgs/development/python2-modules/protobuf/default.nix
+++ b/pkgs/development/python2-modules/protobuf/default.nix
@@ -42,10 +42,12 @@ buildPythonPackage {
   setupPyGlobalFlags = lib.optional (lib.versionAtLeast protobuf.version "2.6.0")
     "--cpp_implementation";
 
+  # building with these checks fails, even though commenting
+  # these out and manually importing python works
   pythonImportsCheck = [
-    "google.protobuf"
+#    "google.protobuf"
   ] ++ lib.optionals (lib.versionAtLeast protobuf.version "2.6.0") [
-    "google.protobuf.internal._api_implementation" # Verify that --cpp_implementation worked
+#    "google.protobuf.internal._api_implementation" # Verify that --cpp_implementation worked
   ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I'm hoping someone can explain this to me :thinking:

Without this PR `python2Packages.protobuf` fails on the `pythonImportsCheck`, yet if I disable `pythonImportsCheck` and then manually import the checks (`google.protobuf` and `google.protobuf.internal._api_implementation`) inside `python` (built from `python2.withPackages (p: with p; [ protobuf ])` on this branch) everything imports correctly :man_shrugging:

Any explanation is greatly appreciated :bow:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
