### PR TITLE
nodenv: init at 1.4.0

### DIFF
--- a/pkgs/development/tools/nodenv/default.nix
+++ b/pkgs/development/tools/nodenv/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nodenv";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "nodenv";
+    repo = "nodenv";
+    rev = "v${version}";
+    sha256 = "0fgc23jd95rjll3dy5hnli8ksfc7rwscw53sdgss4yaharwlg8l2";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    bash src/configure
+    make -C src
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r libexec $out/
+    cp -r bin $out/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Manage multiple NodeJS versions";
+    homepage = "https://github.com/nodenv/nodenv/";
+    changelog = "https://github.com/nodenv/nodenv/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alexnortung ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7341,6 +7341,8 @@ with pkgs;
 
   nixnote2 = libsForQt514.callPackage ../applications/misc/nixnote2 { };
 
+  nodenv = callPackage ../development/tools/nodenv { };
+
   nodejs = hiPrio nodejs-16_x;
 
   nodejs-slim = nodejs-slim-16_x;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This commit adds nodenv which was requested in #153845

I think this package feels pretty clonky on NixOS, especially since node-build should be installed to use the `nodenv install` command. Also node-build has to be installed inside `"$(nodenv root)"/plugins/node-build`, which by defualt is in the home directory and would not be reproducible with NixOS.

However I think that this could be extended as a module such that `nodenv root` can be set declaratively  and it could have an option for plugins. Not sure if this is the way to do it, let me know if you have any input for this.

Anyway, the package works and the commands can be run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
