### PR TITLE
python3Packages.quart: init at 0.16.2

### DIFF
--- a/pkgs/development/python-modules/quart/default.nix
+++ b/pkgs/development/python-modules/quart/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, poetry
+, itsdangerous
+, aiofiles
+, blinker
+, click
+, hypercorn
+, jinja2
+, toml
+, werkzeug
+, hypothesis
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "quart";
+  version = "0.16.2";
+  format = "pyproject";
+
+  src = fetchFromGitLab {
+    owner = "pgjones";
+    repo = pname;
+    rev = version;
+    sha256 = "1zdlcm9jnpaj4fqjir45rrjc362nfrphiy7arpz844l7h6pjh1mw";
+  };
+
+  disabled = pythonOlder "3.7";
+
+  nativeBuildInputs = [
+    poetry
+  ];
+
+  propagatedBuildInputs = [
+    itsdangerous
+    aiofiles
+    blinker
+    click
+    hypercorn
+    jinja2
+    toml
+    werkzeug
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "--no-cov-on-fail" ""
+  '';
+
+  checkInputs = [
+    hypothesis
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "quart" ];
+
+  meta = with lib; {
+    description = "Quart is a Python ASGI web microframework with the same API as Flask";
+    homepage = "https://gitlab.com/pgjones/quart";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ozkutuk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8521,6 +8521,8 @@ in {
 
   quantum-gateway = callPackage ../development/python-modules/quantum-gateway { };
 
+  quart = callPackage ../development/python-modules/quart { };
+
   querystring_parser = callPackage ../development/python-modules/querystring-parser { };
 
   questionary = callPackage ../development/python-modules/questionary { };


### PR DESCRIPTION
###### Motivation for this change
Closes  #157341

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
