### PR TITLE
7kaa: init at 2.15.4p1

### DIFF
--- a/pkgs/games/7kaa/default.nix
+++ b/pkgs/games/7kaa/default.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, gccStdenv
+, autoreconfHook
+, pkg-config
+, fetchurl
+, fetchFromGitHub
+, openal
+, libtool
+, enet
+, SDL2
+, curl
+, gettext
+, libiconv
+}:
+
+let
+
+  name = "7kaa";
+  versionMajor = "2.15";
+  versionMinor = "4p1";
+
+  music = stdenv.mkDerivation rec {
+    pname = "${name}-music";
+    version = "${versionMajor}";
+
+    src = fetchurl {
+      url = "https://www.7kfans.com/downloads/${name}-music-${versionMajor}.tar.bz2";
+      sha256 = "sha256-sNdntuJXGaFPXzSpN0SoAi17wkr2YnW+5U38eIaVwcM=";
+    };
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r * $out/
+    '';
+
+    meta.license = lib.licenses.unfree;
+
+  };
+
+in
+
+gccStdenv.mkDerivation rec {
+  pname = "${name}";
+  version = "v${versionMajor}.${versionMinor}";
+
+  src = fetchFromGitHub {
+    owner = "the3dfxdude";
+    repo = pname;
+    rev = "9db2a43e1baee25a44b7aa7e9cedde9a107ed34b";
+    sha256 = "sha256-OAKaRuPP0/n8pO3wIUvGKs6n+U+EmZXUTywXYDAan1o=";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+  buildInputs = [ openal enet SDL2 curl gettext libiconv ];
+
+  preAutoreconf = ''
+    autoupdate
+  '';
+
+  hardeningDisable = lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
+
+  postInstall = ''
+    mkdir $out/share/7kaa/MUSIC
+    cp -R ${music}/MUSIC $out/share/7kaa/
+    cp ${music}/COPYING-Music.txt $out/share/7kaa/MUSIC
+    cp ${music}/COPYING-Music.txt $out/share/doc/7kaa
+  '';
+
+  # Multiplayer is auto-disabled for non-x86 system
+
+  meta = with lib; {
+    homepage = "https://www.7kfans.com";
+    description = "GPL release of the Seven Kingdoms with multiplayer (available only on x86 platforms)";
+    license = licenses.gpl2Only;
+    platforms = platforms.x86_64 ++ platforms.aarch64;
+    maintainers = with maintainers; [ _1000101 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31766,6 +31766,8 @@ with pkgs;
 
   _0verkill = callPackage ../games/0verkill { };
 
+  _7kaa = callPackage ../games/7kaa { };
+
   hhexen = callPackage ../games/hhexen { };
 
   wyvern = callPackage ../games/wyvern { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
:)

[multiplayer doesn't work on arm though](https://github.com/the3dfxdude/7kaa/blob/master/README#L27) :(

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
