### PR TITLE
qtile: restore restart patch

### DIFF
--- a/pkgs/applications/window-managers/qtile/default.nix
+++ b/pkgs/applications/window-managers/qtile/default.nix
@@ -12,6 +12,10 @@ let
       sha256 = "TRmul3t//izJRdViTvxFz29JZeGYsWc7WsJjagQ35nw=";
     };
 
+    patches = [
+      ./fix-restart.patch # https://github.com/NixOS/nixpkgs/issues/139568
+    ];
+
     postPatch = ''
       substituteInPlace libqtile/pangocffi.py \
         --replace libgobject-2.0.so.0 ${glib.out}/lib/libgobject-2.0.so.0 \

--- a/pkgs/applications/window-managers/qtile/fix-restart.patch
+++ b/pkgs/applications/window-managers/qtile/fix-restart.patch
@@ -1,0 +1,22 @@
+diff --git a/libqtile/core/lifecycle.py b/libqtile/core/lifecycle.py
+index 0d4d119d..c37d1799 100644
+--- a/libqtile/core/lifecycle.py
++++ b/libqtile/core/lifecycle.py
+@@ -25,7 +25,7 @@ class LifeCycle:
+ 
+     def _atexit(self) -> None:
+         if self.behavior is Behavior.RESTART:
+-            argv = [sys.executable] + sys.argv
++            argv = sys.argv
+             if "--no-spawn" not in argv:
+                 argv.append("--no-spawn")
+             argv = [s for s in argv if not s.startswith("--with-state")]
+@@ -33,7 +33,7 @@ class LifeCycle:
+                 argv.append("--with-state=" + self.state_file)
+             logger.warning("Restarting Qtile with os.execv(...)")
+             # No other code will execute after the following line does
+-            os.execv(sys.executable, argv)
++            os.execv(sys.argv[0], argv)
+         elif self.behavior is Behavior.TERMINATE:
+             logger.warning("Qtile will now terminate")
+         elif self.behavior is Behavior.NONE:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes #139568

I have been using this patch for a while now and have encountered no issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
