### PR TITLE
python3Packages.wandb: 0.12.9 -> 0.12.10

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -1,4 +1,5 @@
-{ bokeh
+{ azure-core
+, bokeh
 , buildPythonPackage
 , click
 , configparser
@@ -11,6 +12,7 @@
 , jsonschema
 , lib
 , matplotlib
+, nbformat
 , pandas
 , pathtools
 , promise
@@ -35,13 +37,13 @@
 
 buildPythonPackage rec {
   pname = "wandb";
-  version = "0.12.9";
+  version = "0.12.10";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "client";
     rev = "v${version}";
-    sha256 = "0704iv5dlsjs0gj6l4nx9hk9kzq46wlgd67ifw7i3qk6v4ljfs6y";
+    sha256 = "198c6zx7xih74cw0dwfqw7s7b7whik7wv4nfq6x6xw0kw86r6hby";
   };
 
   # The wandb requirements.txt does not distinguish python2/3 dependencies. We
@@ -74,10 +76,6 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
-    # Tests that require docker access, not possible in the nix build environment.
-    "tests/launch/test_launch.py"
-    "tests/launch/test_launch_cli.py"
-
     # Tests that try to get chatty over sockets or spin up servers, not possible in the nix build environment.
     "tests/test_cli.py"
     "tests/test_data_types.py"
@@ -92,7 +90,6 @@ buildPythonPackage rec {
     "tests/test_metric_internal.py"
     "tests/test_mode_disabled.py"
     "tests/test_mp_full.py"
-    "tests/test_notebooks.py"
     "tests/test_public_api.py"
     "tests/test_redir.py"
     "tests/test_runtime.py"
@@ -110,14 +107,19 @@ buildPythonPackage rec {
 
     # Fails and borks the pytest runner as well.
     "tests/wandb_test.py"
+
+    # Tries to access /homeless-shelter
+    "tests/test_tables.py"
   ];
 
   checkInputs = [
+    azure-core
     bokeh
     flask
     jsonref
     jsonschema
     matplotlib
+    nbformat
     pandas
     pydantic
     pytest-mock


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade `python3Packages.wandb`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
