### PR TITLE
chromium: no need to eval makeWrapper

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -182,8 +182,8 @@ in stdenv.mkDerivation {
   in with lib; ''
     mkdir -p "$out/bin"
 
-    eval makeWrapper "${browserBinary}" "$out/bin/chromium" \
-      --add-flags ${escapeShellArg (escapeShellArg commandLineArgs)} \
+    makeWrapper "${browserBinary}" "$out/bin/chromium" \
+      --add-flags ${escapeShellArg commandLineArgs} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--enable-features=UseOzonePlatform --ozone-platform=wayland}}"
 
     ed -v -s "$out/bin/chromium" << EOF


### PR DESCRIPTION
###### Motivation for this change

In #147557, it turned out that the change for chromium doesn't work because it evals makeWrapper. This doesn't seem to be necessary.