### PR TITLE
improve: command-not-found print `--run` with `nix-shell -p`

### DIFF
--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -7,6 +7,7 @@ use String::ShellQuote;
 use Config;
 
 my $program = $ARGV[0];
+my $cmd = shell_quote("exec", @ARGV);
 
 my $dbPath = "@dbPath@";
 
@@ -26,20 +27,19 @@ if (!defined $res || scalar @$res == 0) {
 } elsif (scalar @$res == 1) {
     my $package = @$res[0]->{package};
     if ($ENV{"NIX_AUTO_RUN"} // "") {
-        exec("nix-shell", "-p", $package, "--run", shell_quote("exec", @ARGV));
+        exec("nix-shell", "-p", $package, "--run", $cmd);
     } else {
         print STDERR <<EOF;
-The program '$program' is not in your PATH. You can make it available in an
-ephemeral shell by typing:
-  nix-shell -p $package
+The program '$program' is not in your PATH. You can run it by typing:
+  nix-shell -p $package --run \"$cmd\"
 EOF
     }
 } else {
     print STDERR <<EOF;
 The program '$program' is not in your PATH. It is provided by several packages.
-You can make it available in an ephemeral shell by typing one of the following:
+You can run it by typing one of the following:
 EOF
-    print STDERR "  nix-shell -p $_->{package}\n" foreach @$res;
+    print STDERR "  nix-shell -p $_->{package} --run \"$cmd\"\n" foreach @$res;
 }
 
 exit 127;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Make the behavior of `command-not-found` more consistent between `NIX_AUTO_RUN` on and off.

Which means, when `NIX_AUTO_RUN` set on, execute the command directly,  and when `NIX_AUTO_RUN` set off, print the command to execute, not just print the command to enter a shell which contains the expected command in PATH.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
