### PR TITLE
python3Packages.geometric: init at 0.9.7.2

### DIFF
--- a/pkgs/development/python-modules/geometric/default.nix
+++ b/pkgs/development/python-modules/geometric/default.nix
@@ -1,0 +1,33 @@
+{ buildPythonPackage, lib, fetchFromGitHub
+, networkx, numpy, scipy, six
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "geometric";
+  version = "0.9.7.2";
+
+  src = fetchFromGitHub {
+    owner = "leeping";
+    repo = "geomeTRIC";
+    rev = version;
+    hash = "sha256-QFpfY6tWqcda6AJT17YBEuwu/4DYPbIMJU1c9/gHjaA=";
+  };
+
+  propagatedBuildInputs = [
+    networkx
+    numpy
+    scipy
+    six
+  ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Geometry optimization code for molecular structures";
+    homepage = "https://github.com/leeping/geomeTRIC";
+    license = [ licenses.bsd3 ];
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3193,6 +3193,8 @@ in {
 
   geomet = callPackage ../development/python-modules/geomet { };
 
+  geometric = callPackage ../development/python-modules/geometric { };
+
   geopandas = callPackage ../development/python-modules/geopandas { };
 
   geopy = callPackage ../development/python-modules/geopy { };


### PR DESCRIPTION
###### Motivation for this change
Geometry optimization code for molecular structures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
