### PR TITLE
isabelle: Rebuild isabelle_setup.jar

### DIFF
--- a/pkgs/applications/science/logic/isabelle/default.nix
+++ b/pkgs/applications/science/logic/isabelle/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, coreutils, nettools, java, polyml, z3, veriT, vampire, eprover-ho, rlwrap, makeDesktopItem }:
+{ lib, stdenv, fetchurl, coreutils, nettools, java, scala, polyml, z3, veriT, vampire, eprover-ho, rlwrap, perl, makeDesktopItem }:
 # nettools needed for hostname
 
 stdenv.mkDerivation rec {
@@ -77,6 +77,10 @@ stdenv.mkDerivation rec {
     substituteInPlace lib/Tools/env \
       --replace /usr/bin/env ${coreutils}/bin/env
 
+    substituteInPlace src/Tools/Setup/src/Environment.java \
+      --replace 'cmd.add("/usr/bin/env");' "" \
+      --replace 'cmd.add("bash");' "cmd.add(\"$SHELL\");"
+
     rm -r heaps
   '' + (if ! stdenv.isLinux then "" else ''
     arch=${if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64-linux" else "x86-linux"}
@@ -90,6 +94,24 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     export HOME=$TMP # The build fails if home is not set
+    setup_name=$(basename contrib/isabelle_setup*)
+
+    #The following is adapted from https://isabelle.sketis.net/repos/isabelle/file/Isabelle2021-1/Admin/lib/Tools/build_setup
+    TARGET_DIR="contrib/$setup_name/lib"
+    rm -rf "$TARGET_DIR"
+    mkdir -p "$TARGET_DIR/isabelle/setup"
+    declare -a ARGS=("-Xlint:unchecked")
+
+    SOURCES="$(${perl}/bin/perl -e 'while (<>) { if (m/(\S+\.java)/)  { print "$1 "; } }' "src/Tools/Setup/etc/build.props")"
+    for SRC in $SOURCES
+    do
+      ARGS["''${#ARGS[@]}"]="src/Tools/Setup/$SRC"
+    done
+    ${java}/bin/javac -d "$TARGET_DIR" -classpath ${scala}/lib/scala-compiler.jar "''${ARGS[@]}"
+    ${java}/bin/jar -c -f "$TARGET_DIR/isabelle_setup.jar" -e "isabelle.setup.Setup" -C "$TARGET_DIR" isabelle
+    rm -rf "$TARGET_DIR/isabelle"
+
+    # Prebuild HOL Session
     bin/isabelle build -v -o system_heaps -b HOL
   '';
 


### PR DESCRIPTION
This jar contained a call to /usr/bin/env bash which was causing an
error during the build of the HOL session (which could be ignored) and
caused other errors during the development of https://github.com/NixOS/nixpkgs/pull/157515
 (which could not be ignored). This commit patches the java sources to
 call `bash` directly and rebuild the jar.

###### Motivation for this change

Fix the error during the build from #154272

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
