### PR TITLE
qgis, qgis-ltr: fix dependencies on darwin

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   makeWrapper,
   nixosTests,
   symlinkJoin,
@@ -40,7 +42,8 @@ symlinkJoin {
         --prefix PATH : $program_PATH \
         --set PYTHONPATH $program_PYTHONPATH
     done
-
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     ln -s ${qgis-unwrapped.man} $man
   '';
 

--- a/pkgs/applications/gis/qgis/ltr.nix
+++ b/pkgs/applications/gis/qgis/ltr.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   makeWrapper,
   nixosTests,
   symlinkJoin,
@@ -14,15 +16,13 @@
 }:
 let
   qgis-ltr-unwrapped = libsForQt5.callPackage ./unwrapped-ltr.nix {
-    withGrass = withGrass;
-    withServer = withServer;
-    withWebKit = withWebKit;
+    inherit withGrass withServer withWebKit;
   };
 in
 
 symlinkJoin {
-  inherit (qgis-ltr-unwrapped) version src;
-  pname = "qgis";
+  inherit (qgis-ltr-unwrapped) version outputs src;
+  pname = "qgis-ltr";
 
   paths = [ qgis-ltr-unwrapped ];
 
@@ -43,6 +43,9 @@ symlinkJoin {
         --prefix PATH : $program_PATH \
         --set PYTHONPATH $program_PYTHONPATH
     done
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    ln -s ${qgis-ltr-unwrapped.man} $man
   '';
 
   passthru = {

--- a/pkgs/applications/gis/qgis/unwrapped-ltr.nix
+++ b/pkgs/applications/gis/qgis/unwrapped-ltr.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
+  lndir,
   makeWrapper,
   mkDerivation,
   replaceVars,
@@ -11,6 +13,8 @@
   withServer,
   withWebKit,
 
+  darwin,
+  libtasn1,
   bison,
   cmake,
   draco,
@@ -40,6 +44,7 @@
   qtmultimedia,
   qtsensors,
   qtserialport,
+  qtsvg,
   qtwebkit,
   qtxmlpatterns,
   qwt,
@@ -68,6 +73,7 @@ let
     psycopg2
     pygments
     pyqt5
+    pyqt5-sip
     pyqt-builder
     python-dateutil
     pytz
@@ -83,6 +89,7 @@ in
 mkDerivation rec {
   version = "3.40.14";
   pname = "qgis-ltr-unwrapped";
+  outputs = [ "out" ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) "man";
 
   src = fetchFromGitHub {
     owner = "qgis";
@@ -105,6 +112,10 @@ mkDerivation rec {
     cmake
     flex
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
+    lndir
   ];
 
   buildInputs = [
@@ -131,6 +142,7 @@ mkDerivation rec {
     qtmultimedia
     qtsensors
     qtserialport
+    qtsvg
     qtxmlpatterns
     qwt
     sqlite
@@ -139,6 +151,7 @@ mkDerivation rec {
   ]
   ++ lib.optional withGrass grass
   ++ lib.optional withWebKit qtwebkit
+  ++ lib.optional stdenv.hostPlatform.isDarwin libtasn1
   ++ pythonBuildInputs;
 
   patches = [
@@ -165,6 +178,10 @@ mkDerivation rec {
     # See https://github.com/libspatialindex/libspatialindex/issues/276
     "-DWITH_INTERNAL_SPATIALINDEX=True"
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DQGIS_MACAPP_BUNDLE=0" # Don't copy Qt into bundle; we fix paths in postFixup
+    "-DSQLITE3_INCLUDE_DIR=${sqlite.dev}/include" # FindSqlite3.cmake incorrectly assumes framework
+  ]
   ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
   ++ lib.optional withServer [
     "-DWITH_SERVER=True"
@@ -183,18 +200,102 @@ mkDerivation rec {
   ];
 
   dontWrapGApps = true; # wrapper params passed below
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
-  postFixup = lib.optionalString withGrass ''
-    # GRASS has to be availble on the command line even though we baked in
-    # the path at build time using GRASS_PREFIX.
-    # Using wrapGAppsHook also prevents file dialogs from crashing the program
-    # on non-NixOS.
-    for program in $out/bin/*; do
-      wrapProgram $program \
-        "''${gappsWrapperArgs[@]}" \
-        --prefix PATH : ${lib.makeBinPath [ grass ]}
-    done
-  '';
+  postFixup =
+    lib.optionalString (withGrass && stdenv.hostPlatform.isLinux) ''
+      # GRASS has to be available on the command line even though we baked in
+      # the path at build time using GRASS_PREFIX.
+      # Using wrapGAppsHook also prevents file dialogs from crashing the program
+      # on non-NixOS.
+      for program in $out/bin/*; do
+        wrapProgram $program \
+          "''${gappsWrapperArgs[@]}" \
+          --prefix PATH : ${lib.makeBinPath [ grass ]}
+      done
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+            mkdir -p $out/Applications $out/bin
+            mv $out/QGIS.app $out/Applications/
+            ln -s $out/Applications/QGIS.app/Contents/MacOS/QGIS $out/bin/qgis
+
+            SHORT_VERSION=$(echo "${version}" | cut -d. -f1,2)
+            BUNDLE="$out/Applications/QGIS.app"
+            FRAMEWORKS="$BUNDLE/Contents/Frameworks"
+
+            fix_binary() {
+              local f="$1"
+              [[ -f "$f" ]] || return 0
+              file "$f" | grep -q "Mach-O" || return 0
+
+              install_name_tool \
+                -change "@loader_path/../lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@loader_path/../lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@loader_path/../lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@loader_path/../../Frameworks/qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../../MacOS/lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@loader_path/../../../../MacOS/lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@loader_path/../../../../MacOS/lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@executable_path/lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@executable_path/lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@executable_path/lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@executable_path/../Frameworks/qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../qgis_core.framework/qgis_core" "$FRAMEWORKS/qgis_core.framework/Versions/$SHORT_VERSION/qgis_core" \
+                -change "@loader_path/../../../qgis_gui.framework/qgis_gui" "$FRAMEWORKS/qgis_gui.framework/Versions/$SHORT_VERSION/qgis_gui" \
+                -change "@loader_path/../../../qgis_analysis.framework/qgis_analysis" "$FRAMEWORKS/qgis_analysis.framework/Versions/$SHORT_VERSION/qgis_analysis" \
+                -change "@loader_path/../../../qgis_3d.framework/qgis_3d" "$FRAMEWORKS/qgis_3d.framework/Versions/$SHORT_VERSION/qgis_3d" \
+                -change "@loader_path/../../../qgis_native.framework/qgis_native" "$FRAMEWORKS/qgis_native.framework/Versions/$SHORT_VERSION/qgis_native" \
+                "$f" 2>/dev/null || true
+            }
+
+            fix_binary "$BUNDLE/Contents/MacOS/QGIS"
+            for lib in "$BUNDLE/Contents/MacOS/lib"/*.dylib; do fix_binary "$lib"; done
+            for fw in qgis_core qgis_gui qgis_analysis qgis_3d qgis_native; do
+              fix_binary "$FRAMEWORKS/$fw.framework/Versions/$SHORT_VERSION/$fw"
+              [[ -f "$FRAMEWORKS/$fw.framework/$fw" && ! -L "$FRAMEWORKS/$fw.framework/$fw" ]] && \
+                fix_binary "$FRAMEWORKS/$fw.framework/$fw"
+            done
+            for plugin in "$BUNDLE/Contents/PlugIns/qgis"/*.so; do fix_binary "$plugin"; done
+
+            ${lib.optionalString withGrass ''
+              fix_binary "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8"
+              install_name_tool \
+                -change "@loader_path/../../../qgisgrass8.framework/qgisgrass8" "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8" \
+                "$BUNDLE/Contents/MacOS/QGIS" 2>/dev/null || true
+              for lib in "$BUNDLE/Contents/MacOS/lib"/*.dylib; do
+                install_name_tool \
+                  -change "@loader_path/../../../qgisgrass8.framework/qgisgrass8" "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8" \
+                  "$lib" 2>/dev/null || true
+              done
+            ''}
+
+            ${lib.optionalString withServer ''
+              fix_binary "$BUNDLE/Contents/MacOS/lib/libqgis_server.${version}.dylib"
+            ''}
+
+            # Merge Python packages (lndir handles namespace packages correctly)
+            QGIS_PYTHON="$BUNDLE/Contents/Resources/python"
+            for pkg in ${
+              lib.concatMapStringsSep " " (p: "${p}/${py.pkgs.python.sitePackages}") (
+                py.pkgs.requiredPythonModules pythonBuildInputs
+              )
+            }; do
+              [[ -d "$pkg" ]] && lndir -silent "$pkg" "$QGIS_PYTHON"
+            done
+            # Remove broken symlinks
+            find "$QGIS_PYTHON" -type l ! -exec test -e {} \; -delete
+
+            # Create merged Qt plugins directory in the bundle (LSEnvironment is unreliable)
+            mkdir -p "$BUNDLE/Contents/PlugIns"
+            lndir -silent "${qtbase}/${qtbase.qtPluginPrefix}" "$BUNDLE/Contents/PlugIns"
+            lndir -silent "${qtsvg.bin}/${qtbase.qtPluginPrefix}" "$BUNDLE/Contents/PlugIns"
+
+            cat > "$BUNDLE/Contents/Resources/qt.conf" << 'EOF'
+      [Paths]
+      Plugins = PlugIns
+      EOF
+    '';
 
   # >9k objects, >3h build time on a normal build slot
   requiredSystemFeatures = [ "big-parallel" ];
@@ -204,6 +305,6 @@ mkDerivation rec {
     homepage = "https://www.qgis.org";
     license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.geospatial ];
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -1,6 +1,8 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
+  lndir,
   makeWrapper,
   mkDerivation,
   replaceVars,
@@ -11,6 +13,8 @@
   withServer,
   withWebKit,
 
+  darwin,
+  libtasn1,
   bison,
   cmake,
   draco,
@@ -40,6 +44,7 @@
   qtmultimedia,
   qtsensors,
   qtserialport,
+  qtsvg,
   qtwebkit,
   qtxmlpatterns,
   qwt,
@@ -68,6 +73,7 @@ let
     psycopg2
     pygments
     pyqt5
+    pyqt5-sip
     pyqt-builder
     python-dateutil
     pytz
@@ -83,10 +89,7 @@ in
 mkDerivation rec {
   version = "3.44.6";
   pname = "qgis-unwrapped";
-  outputs = [
-    "out"
-    "man"
-  ];
+  outputs = [ "out" ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) "man";
 
   src = fetchFromGitHub {
     owner = "qgis";
@@ -109,6 +112,10 @@ mkDerivation rec {
     cmake
     flex
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
+    lndir
   ];
 
   buildInputs = [
@@ -135,6 +142,7 @@ mkDerivation rec {
     qtmultimedia
     qtsensors
     qtserialport
+    qtsvg
     qtxmlpatterns
     qwt
     sqlite
@@ -143,6 +151,7 @@ mkDerivation rec {
   ]
   ++ lib.optional withGrass grass
   ++ lib.optional withWebKit qtwebkit
+  ++ lib.optional stdenv.hostPlatform.isDarwin libtasn1
   ++ pythonBuildInputs;
 
   patches = [
@@ -165,6 +174,10 @@ mkDerivation rec {
     # See https://github.com/libspatialindex/libspatialindex/issues/276
     "-DWITH_INTERNAL_SPATIALINDEX=True"
   ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DQGIS_MACAPP_BUNDLE=0" # Don't copy Qt into bundle; we fix paths in postFixup
+    "-DSQLITE3_INCLUDE_DIR=${sqlite.dev}/include" # FindSqlite3.cmake incorrectly assumes framework
+  ]
   ++ lib.optional (!withWebKit) "-DWITH_QTWEBKIT=OFF"
   ++ lib.optional withServer [
     "-DWITH_SERVER=True"
@@ -183,18 +196,102 @@ mkDerivation rec {
   ];
 
   dontWrapGApps = true; # wrapper params passed below
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
-  postFixup = lib.optionalString withGrass ''
-    # GRASS has to be available on the command line even though we baked in
-    # the path at build time using GRASS_PREFIX.
-    # Using wrapGAppsHook also prevents file dialogs from crashing the program
-    # on non-NixOS.
-    for program in $out/bin/*; do
-      wrapProgram $program \
-        "''${gappsWrapperArgs[@]}" \
-        --prefix PATH : ${lib.makeBinPath [ grass ]}
-    done
-  '';
+  postFixup =
+    lib.optionalString (withGrass && stdenv.hostPlatform.isLinux) ''
+      # GRASS has to be available on the command line even though we baked in
+      # the path at build time using GRASS_PREFIX.
+      # Using wrapGAppsHook also prevents file dialogs from crashing the program
+      # on non-NixOS.
+      for program in $out/bin/*; do
+        wrapProgram $program \
+          "''${gappsWrapperArgs[@]}" \
+          --prefix PATH : ${lib.makeBinPath [ grass ]}
+      done
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+            mkdir -p $out/Applications $out/bin
+            mv $out/QGIS.app $out/Applications/
+            ln -s $out/Applications/QGIS.app/Contents/MacOS/QGIS $out/bin/qgis
+
+            SHORT_VERSION=$(echo "${version}" | cut -d. -f1,2)
+            BUNDLE="$out/Applications/QGIS.app"
+            FRAMEWORKS="$BUNDLE/Contents/Frameworks"
+
+            fix_binary() {
+              local f="$1"
+              [[ -f "$f" ]] || return 0
+              file "$f" | grep -q "Mach-O" || return 0
+
+              install_name_tool \
+                -change "@loader_path/../lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@loader_path/../lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@loader_path/../lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@loader_path/../../Frameworks/qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../../MacOS/lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@loader_path/../../../../MacOS/lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@loader_path/../../../../MacOS/lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@executable_path/lib/libqwt.dylib" "${qwt}/lib/libqwt.dylib" \
+                -change "@executable_path/lib/libqscintilla2_qt5.dylib" "${qscintilla}/lib/libqscintilla2_qt5.dylib" \
+                -change "@executable_path/lib/libqt5keychain.dylib" "${qtkeychain}/lib/libqt5keychain.dylib" \
+                -change "@executable_path/../Frameworks/qca-qt5.framework/qca-qt5" "${qca-qt5}/lib/qca-qt5.framework/qca-qt5" \
+                -change "@loader_path/../../../qgis_core.framework/qgis_core" "$FRAMEWORKS/qgis_core.framework/Versions/$SHORT_VERSION/qgis_core" \
+                -change "@loader_path/../../../qgis_gui.framework/qgis_gui" "$FRAMEWORKS/qgis_gui.framework/Versions/$SHORT_VERSION/qgis_gui" \
+                -change "@loader_path/../../../qgis_analysis.framework/qgis_analysis" "$FRAMEWORKS/qgis_analysis.framework/Versions/$SHORT_VERSION/qgis_analysis" \
+                -change "@loader_path/../../../qgis_3d.framework/qgis_3d" "$FRAMEWORKS/qgis_3d.framework/Versions/$SHORT_VERSION/qgis_3d" \
+                -change "@loader_path/../../../qgis_native.framework/qgis_native" "$FRAMEWORKS/qgis_native.framework/Versions/$SHORT_VERSION/qgis_native" \
+                "$f" 2>/dev/null || true
+            }
+
+            fix_binary "$BUNDLE/Contents/MacOS/QGIS"
+            for lib in "$BUNDLE/Contents/MacOS/lib"/*.dylib; do fix_binary "$lib"; done
+            for fw in qgis_core qgis_gui qgis_analysis qgis_3d qgis_native; do
+              fix_binary "$FRAMEWORKS/$fw.framework/Versions/$SHORT_VERSION/$fw"
+              [[ -f "$FRAMEWORKS/$fw.framework/$fw" && ! -L "$FRAMEWORKS/$fw.framework/$fw" ]] && \
+                fix_binary "$FRAMEWORKS/$fw.framework/$fw"
+            done
+            for plugin in "$BUNDLE/Contents/PlugIns/qgis"/*.so; do fix_binary "$plugin"; done
+
+            ${lib.optionalString withGrass ''
+              fix_binary "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8"
+              install_name_tool \
+                -change "@loader_path/../../../qgisgrass8.framework/qgisgrass8" "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8" \
+                "$BUNDLE/Contents/MacOS/QGIS" 2>/dev/null || true
+              for lib in "$BUNDLE/Contents/MacOS/lib"/*.dylib; do
+                install_name_tool \
+                  -change "@loader_path/../../../qgisgrass8.framework/qgisgrass8" "$FRAMEWORKS/qgisgrass8.framework/Versions/$SHORT_VERSION/qgisgrass8" \
+                  "$lib" 2>/dev/null || true
+              done
+            ''}
+
+            ${lib.optionalString withServer ''
+              fix_binary "$BUNDLE/Contents/MacOS/lib/libqgis_server.${version}.dylib"
+            ''}
+
+            # Merge Python packages (lndir handles namespace packages correctly)
+            QGIS_PYTHON="$BUNDLE/Contents/Resources/python"
+            for pkg in ${
+              lib.concatMapStringsSep " " (p: "${p}/${py.pkgs.python.sitePackages}") (
+                py.pkgs.requiredPythonModules pythonBuildInputs
+              )
+            }; do
+              [[ -d "$pkg" ]] && lndir -silent "$pkg" "$QGIS_PYTHON"
+            done
+            # Remove broken symlinks
+            find "$QGIS_PYTHON" -type l ! -exec test -e {} \; -delete
+
+            # Create merged Qt plugins directory in the bundle (LSEnvironment is unreliable)
+            mkdir -p "$BUNDLE/Contents/PlugIns"
+            lndir -silent "${qtbase}/${qtbase.qtPluginPrefix}" "$BUNDLE/Contents/PlugIns"
+            lndir -silent "${qtsvg.bin}/${qtbase.qtPluginPrefix}" "$BUNDLE/Contents/PlugIns"
+
+            cat > "$BUNDLE/Contents/Resources/qt.conf" << 'EOF'
+      [Paths]
+      Plugins = PlugIns
+      EOF
+    '';
 
   # >9k objects, >3h build time on a normal build slot
   requiredSystemFeatures = [ "big-parallel" ];
@@ -204,6 +301,6 @@ mkDerivation rec {
     homepage = "https://www.qgis.org";
     license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.geospatial ];
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Progress toward #71398. Builds on #150286, #150595, #156747, #156809, #156828.

###### Things done

@NixOS/darwin-maintainers I'm struggling with getting the final build of this to link and load correctly, though all the dependencies should finally be fixed. Even after fully disabling all of the `makeWrapper` work on darwin, I'm still getting mired down by being unable to get the dylibs to load. Pasting the end result here since building this derivation takes a while. 

Any suggestions would be MUCH appreciated.

```
$ /nix/store/fcr2r0dihgkqid9jv2c226k8jcpfvw1q-qgis-unwrapped-3.22.3/QGIS.app/Contents/MacOS/QGIS  
dyld[39783]: Library not loaded: @executable_path/lib/libqgis_app.3.22.3.dylib
  Referenced from: /nix/store/fcr2r0dihgkqid9jv2c226k8jcpfvw1q-qgis-unwrapped-3.22.3/QGIS.app/Contents/MacOS/.QGIS-wrapped
  Reason: tried: '/nix/store/fcr2r0dihgkqid9jv2c226k8jcpfvw1q-qgis-unwrapped-3.22.3/QGIS.app/Contents/MacOS/lib/libqgis_app.3.22.3.dylib' (not a mach-o file), '/usr/local/lib/libqgis_app.3.22.3.dylib' (no such file), '/usr/lib/libqgis_app.3.22.3.dylib' (no such file)
[1]    39783 abort      
➜  lib ls -al /nix/store/fcr2r0dihgkqid9jv2c226k8jcpfvw1q-qgis-unwrapped-3.22.3/QGIS.app/Contents/MacOS/lib 
total 26624
dr-xr-xr-x  9 root  wheel       288 Dec 31  1969 .
dr-xr-xr-x  8 root  wheel       256 Dec 31  1969 ..
-r-xr-xr-x  1 root  wheel  13502764 Dec 31  1969 .libqgis_app.3.22.3.dylib-wrapped
-r-xr-xr-x  1 root  wheel    115896 Dec 31  1969 .libqgispython.3.22.3.dylib-wrapped
-r-xr-xr-x  1 root  wheel      2485 Dec 31  1969 libqgis_app.3.22.3.dylib
lrwxr-xr-x  1 root  wheel        24 Dec 31  1969 libqgis_app.dylib -> libqgis_app.3.22.3.dylib
-r-xr-xr-x  1 root  wheel      2487 Dec 31  1969 libqgispython.3.22.3.dylib
lrwxr-xr-x  1 root  wheel        26 Dec 31  1969 libqgispython.dylib -> libqgispython.3.22.3.dylib
dr-xr-xr-x  5 root  wheel       160 Dec 31  1969 qgis
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
