### PR TITLE
obconf: Re-init at unstable-2015-02-13

### DIFF
--- a/pkgs/tools/X11/obconf/default.nix
+++ b/pkgs/tools/X11/obconf/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchgit, autoreconfHook, pkg-config, gtk3, openbox,
+  imlib2, libxml2, libstartup_notification, makeWrapper, libSM }:
+
+stdenv.mkDerivation rec {
+  pname = "obconf";
+  version = "unstable-2015-02-13";
+
+  src = fetchgit {
+    url = "git://git.openbox.org/dana/obconf";
+    rev = "63ec47c5e295ad4f09d1df6d92afb7e10c3fec39";
+    sha256 = "sha256-qwm66VA/ueRMFtSUcrmuObNkz+KYgWRnmR7TnQwpxiE=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    imlib2
+    libSM
+    libstartup_notification
+    libxml2
+    makeWrapper
+    openbox
+  ];
+
+  postPatch = ''
+    substituteInPlace configure.ac --replace 2.0.4 ${version}
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/obconf --prefix XDG_DATA_DIRS : ${openbox}/share/
+  '';
+
+  meta = {
+    description = "GUI configuration tool for openbox";
+    homepage = "http://openbox.org/wiki/ObConf";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.sfrijters ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -687,7 +687,6 @@ mapAliases ({
   nylas-mail-bin = throw "nylas-mail-bin was deprecated on 2019-09-11: abandoned by upstream";
   oauth2_proxy = oauth2-proxy; # added 2021-04-18
   opencascade_oce = opencascade; # added 2018-04-25
-  obconf = throw "obconf has been removed"; # added 2022-01-16
   oblogout = throw "oblogout has been removed from nixpkgs, as it's archived upstream."; # added 2019-12-10
   octoprint-plugins = throw "octoprint-plugins are now part of the octoprint.python.pkgs package set."; # added 2021-01-24
   ofp = throw "ofp is not compatible with odp-dpdk";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28011,6 +28011,8 @@ with pkgs;
 
   nvpy = callPackage ../applications/editors/nvpy { };
 
+  obconf = callPackage ../tools/X11/obconf { };
+
   oberon-risc-emu = callPackage ../misc/emulators/oberon-risc-emu { };
 
   obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {};


### PR DESCRIPTION
###### Motivation for this change

This package was removed in #155061, but more recent versions use gtk3 and no libglade, so it can still be maintained.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
