### PR TITLE
yabridge: Add upstream fix for recent wine 7.1 update

### DIFF
--- a/pkgs/tools/audio/yabridge/default.nix
+++ b/pkgs/tools/audio/yabridge/default.nix
@@ -1,6 +1,7 @@
 { lib
 , multiStdenv
 , fetchFromGitHub
+, fetchpatch
 , substituteAll
 , pkgsi686Linux
 , libnotify
@@ -77,6 +78,14 @@ in multiStdenv.mkDerivation rec {
       libxcb32 = pkgsi686Linux.xorg.libxcb;
       inherit libnotify wine;
     })
+    # Remove with next yabridge update
+   (fetchpatch {
+      name = "fix-for-wine-7.1.patch";
+      url = "https://github.com/robbert-vdh/yabridge/commit/de470d345ab206b08f6d4a147b6af1d285a4211f.patch";
+      sha256 = "sha256-xJx1zvxD+DIjbkm7Ovoy4RaAvjx936/j/7AYUPh/kOo=";
+      includes = [ "src/wine-host/xdnd-proxy.cpp" ];
+    })
+
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

Upstream has fixed a compatibility issue with wine 7.1.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
