### PR TITLE
Consume self-deploy's startAt attribute

### DIFF
--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -128,6 +128,8 @@ in
     systemd.services.self-deploy = {
       wantedBy = [ "multi-user.target" ];
 
+      startAt = cfg.startAt;
+
       requires = lib.mkIf (!(isPathType cfg.repository)) [ "network-online.target" ];
 
       environment.GIT_SSH_COMMAND = lib.mkIf (!(isNull cfg.sshKeyFile))


### PR DESCRIPTION
As #157879 points-out, this attribute appears unused.

Fixes #157879
