### PR TITLE
[21.11] quassel: apply patches to fix CVE-2021-34825

### DIFF
--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -4,7 +4,7 @@
 , tag ? "-kf5" # tag added to the package name
 , static ? false # link statically
 
-, lib, stdenv, fetchFromGitHub, cmake, makeWrapper, dconf
+, lib, stdenv, fetchFromGitHub, fetchpatch, cmake, makeWrapper, dconf
 , mkDerivation, qtbase, qtscript
 , phonon, libdbusmenu, qca-qt5
 
@@ -46,6 +46,16 @@ in (if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
     # fixes build with Qt 5.14
     # source: https://github.com/quassel/quassel/pull/518/commits/8a46d983fc99204711cdff1e4c542e272fef45b9
     ./0001-common-Disable-enum-type-stream-operators-for-Qt-5.1.patch
+    (fetchpatch {
+      url = "https://github.com/quassel/quassel/commit/f20d380a36e11a7591dacbf0a62d7c11d997f9db.patch";
+      sha256 = "sha256-ffQoDWNtupv+Jr9zMyCjY1Yl+LwGh0rr0chSHsiSgUk=";
+      name = "CVE-2021-34825.patch";
+    })
+    (fetchpatch {
+      url = "https://github.com/quassel/quassel/commit/0674fae039bbc79bfe3f7e42b12ec9015b9b879b.patch";
+      sha256 = "sha256-pimA7a44KNVe09s9G09664mn08zf8p9+cg6fEegHuUU=";
+      name = "CVE-2021-34825-2.patch";
+    })
   ];
 
   # Prevent ``undefined reference to `qt_version_tag''' in SSL check


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Patches come from the PR fixing the issue quassel/quassel#581

Follow up to #157412

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
