### PR TITLE
steam: many fixes

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -62,6 +62,13 @@
       </listitem>
       <listitem>
         <para>
+          <literal>steam</literal> and <literal>lutris</literal> support
+          for nvidia cards has been improved, proton runtimes 5-7 now
+          work as expected.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           systemd services can now set
           <link linkend="opt-systemd.services">systemd.services.&lt;name&gt;.reloadTriggers</link>
           instead of <literal>reloadIfChanged</literal> for a more
@@ -1809,6 +1816,14 @@
           will be changed to <literal>false</literal> in 22.11.
           Configurations using this default will print a warning when
           rebuilt.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>services.xserver.videoDrivers = [ &quot;nvidia&quot; ];</literal>
+          will now also install
+          <literal>pkgs.nvidia-vaapi-driver</literal> as a driver as
+          well.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -23,6 +23,8 @@ In addition to numerous new and upgraded packages, this release has the followin
   Migrations may take a while, see the [changelog](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6-3-extended-support-release)
   and [important upgrade notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
 
+- `steam` and `lutris` support for nvidia cards has been improved, proton runtimes 5-7 now work as expected.
+
 - systemd services can now set [systemd.services.\<name\>.reloadTriggers](#opt-systemd.services) instead of `reloadIfChanged` for a more granular distinction between reloads and restarts.
 
 - Systemd has been upgraded to the version 250.
@@ -672,6 +674,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `services.unifi-video.openPorts` option default value of `true` is now deprecated and will be changed to `false` in 22.11.
   Configurations using this default will print a warning when rebuilt.
+
+- `services.xserver.videoDrivers = [ "nvidia" ];` will now also install `pkgs.nvidia-vaapi-driver` as a driver as well.
 
 - `security.acme` certificates will now correctly check for CA
   revokation before reaching their minimum age.

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -16,6 +16,7 @@ args @ {
 , unshareUts ? true
 , unshareCgroup ? true
 , dieWithParent ? true
+, extraLdConf ? ""
 , ...
 }:
 
@@ -26,6 +27,7 @@ let
   env = buildFHSEnv (removeAttrs args [
     "runScript" "extraInstallCommands" "meta" "passthru" "extraBwrapArgs" "dieWithParent"
     "unshareUser" "unshareCgroup" "unshareUts" "unshareNet" "unsharePid" "unshareIpc"
+    "extraLdConf"
   ]);
 
   etcBindFlags = let
@@ -78,6 +80,8 @@ let
   # issues running some binary with LD_LIBRARY_PATH
   createLdConfCache = ''
     cat > /etc/ld.so.conf <<EOF
+    /run/opengl-driver/lib
+    /run/opengl-driver-32/lib
     /lib
     /lib/x86_64-linux-gnu
     /lib64
@@ -88,6 +92,7 @@ let
     /lib32
     /usr/lib/i386-linux-gnu
     /usr/lib32
+  '' + extraLdConf + ''
     EOF
     ldconfig &> /dev/null
   '';

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -176,16 +176,16 @@ let
       # settled on being mounting one via bwrap.
       # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
       # of both architectures to work.
-      --tmpfs ${glibc}/etc \
-      --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
-      --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
-      --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
-      --remount-ro ${glibc}/etc \
-      --tmpfs ${pkgsi686Linux.glibc}/etc \
-      --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
-      --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
-      --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
-      --remount-ro ${pkgsi686Linux.glibc}/etc \
+      --tmpfs ${glibc}/etc
+      --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf
+      --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache
+      --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc
+      --remount-ro ${glibc}/etc
+      --tmpfs ${pkgsi686Linux.glibc}/etc
+      --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf
+      --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache
+      --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc
+      --remount-ro ${pkgsi686Linux.glibc}/etc
       ${etcBindFlags}
       "''${ro_mounts[@]}"
       "''${graphics_share[@]}"

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -112,6 +112,8 @@ let
     blacklist=(/nix /dev /proc /etc)
     ro_mounts=()
     symlinks=()
+    graphics_share=()
+
     for i in ${env}/*; do
       path="/''${i##*/}"
       if [[ $path == '/etc' ]]; then
@@ -136,6 +138,13 @@ let
         ro_mounts+=(--ro-bind "$i" "/etc$path")
       done
     fi
+
+    declare -a graphics_share
+    for dir in /run/opengl-driver{,-32}/share/*; do
+      if [[ -d "$dir" ]]; then
+        graphics_share+=(--bind "$dir" "/usr/share/$(basename $dir)")
+      fi
+    done
 
     declare -a auto_mounts
     # loop through all directories in the root
@@ -179,6 +188,7 @@ let
       --remount-ro ${pkgsi686Linux.glibc}/etc \
       ${etcBindFlags}
       "''${ro_mounts[@]}"
+      "''${graphics_share[@]}"
       "''${symlinks[@]}"
       "''${auto_mounts[@]}"
       ${concatStringsSep "\n  " extraBwrapArgs}

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/default.nix
@@ -81,7 +81,13 @@ let
   createLdConfCache = ''
     cat > /etc/ld.so.conf <<EOF
     /run/opengl-driver/lib
+    /run/opengl-driver/lib/dri
+    /run/opengl-driver/lib/gbm
+    /run/opengl-driver/lib/vdpau
     /run/opengl-driver-32/lib
+    /run/opengl-driver-32/lib/dri
+    /run/opengl-driver-32/lib/gbm
+    /run/opengl-driver-32/lib/vdpau
     /lib
     /lib/x86_64-linux-gnu
     /lib64

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -134,6 +134,8 @@ let
           # and compile them
           ${pkgs.glib.dev}/bin/glib-compile-schemas $out/share/glib-2.0/schemas
       fi
+
+      ln -s ${ldconfig}/bin/ldconfig $out/sbin/ldconfig
     '';
   };
 

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -222,6 +222,9 @@ in stdenv.mkDerivation {
     ${extraBuildCommands}
     cd $out
     ${if isMultiBuild then extraBuildCommandsMulti else ""}
+
+    # create potential mountpoints, should be union of mesa, nvidia, and intel drivers
+    mkdir -p $out/usr/share/{vulkan,egl,glvnd,drirc.d}
   '';
   preferLocalBuild = true;
   allowSubstitutes = false;

--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -68,6 +68,7 @@ let
     export LD_LIBRARY_PATH="/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
     export PATH="/run/wrappers/bin:/usr/bin:/usr/sbin:$PATH"
     export TZDIR='/etc/zoneinfo'
+    export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/run/opengl-driver/share:/run/opengl-driver-32/share
 
     # XDG_DATA_DIRS is used by pressure-vessel (steam proton) and vulkan loaders to find the corresponding icd
     export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}/run/opengl-driver/share:/run/opengl-driver-32/share

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -39,6 +39,7 @@
 , meta
 , extraBuildInputs ? []
 , extraNativeBuildInputs ? []
+, withFHS ? false # produce a glibc to be used in chroot environments
 , ...
 } @ args:
 
@@ -73,6 +74,7 @@ stdenv.mkDerivation ({
 
       /* Allow NixOS and Nix to handle the locale-archive. */
       ./nix-locale-archive.patch
+    ] ++ lib.optionals (!withFHS) [
 
       /* Don't use /etc/ld.so.cache, for non-NixOS systems.  */
       ./dont-use-system-ld-so-cache.patch
@@ -80,6 +82,7 @@ stdenv.mkDerivation ({
       /* Don't use /etc/ld.so.preload, but /etc/ld-nix.so.preload.  */
       ./dont-use-system-ld-so-preload.patch
 
+    ] ++ [
       /* The command "getconf CS_PATH" returns the default search path
          "/bin:/usr/bin", which is inappropriate on NixOS machines. This
          patch extends the search path by "/run/current-system/sw/bin". */
@@ -216,7 +219,7 @@ stdenv.mkDerivation ({
   passthru = { inherit version; minorRelease = version; };
 }
 
-// (removeAttrs args [ "withLinuxHeaders" "withGd" ]) //
+// (removeAttrs args [ "withLinuxHeaders" "withGd" "withFHS" ]) //
 
 {
   src = fetchurl {

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -2,6 +2,7 @@
 , withLinuxHeaders ? true
 , profilingLibraries ? false
 , withGd ? false
+, withFHS ? false
 , buildPackages
 }:
 
@@ -16,7 +17,7 @@ in
 callPackage ./common.nix { inherit stdenv; } {
     pname = "glibc" + lib.optionalString withGd "-gd";
 
-    inherit withLinuxHeaders profilingLibraries withGd;
+    inherit withLinuxHeaders profilingLibraries withGd withFHS;
 
     # Note:
     # Things you write here override, and do not add to,

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -85,6 +85,7 @@ in buildFHSUserEnv rec {
     harfbuzz
     libthai
     pango
+    libdbusmenu-gtk3 # system tray
 
     # Not formally in runtime but needed by some games
     at-spi2-atk

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -156,7 +156,7 @@ in buildFHSUserEnv rec {
     xorg.libSM
     xorg.libICE
     gnome2.GConf
-    (curl.override { gnutlsSupport = true; opensslSupport = false; })
+    curl
     nspr
     nss
     cups

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation {
     sha256 = "sha256-sO07g3j1Qejato2LWJ2FrW3AzfMCcBz46HEw7aKxojQ=";
   };
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
   postInstall = ''
     rm $out/bin/steamdeps
@@ -33,10 +33,6 @@ in stdenv.mkDerivation {
     cp ./subprojects/steam-devices/*.rules $out/etc/udev/rules.d/
     substituteInPlace $out/etc/udev/rules.d/60-steam-input.rules \
       --replace "/bin/sh" "${bash}/bin/bash"
-
-    # this just installs a link, "steam.desktop -> /lib/steam/steam.desktop"
-    rm $out/share/applications/steam.desktop
-    sed -e 's,/usr/bin/steam,steam,g' steam.desktop > $out/share/applications/steam.desktop
   '';
 
   meta = with lib; {

--- a/pkgs/games/steam/steam.nix
+++ b/pkgs/games/steam/steam.nix
@@ -33,6 +33,10 @@ in stdenv.mkDerivation {
     cp ./subprojects/steam-devices/*.rules $out/etc/udev/rules.d/
     substituteInPlace $out/etc/udev/rules.d/60-steam-input.rules \
       --replace "/bin/sh" "${bash}/bin/bash"
+
+    # Use PATH to find steam, as /usr/bin/ path will always fail
+    substituteInPlace $out/share/applications/steam.desktop \
+      --replace "/usr/bin/steam" "steam"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17237,6 +17237,10 @@ with pkgs;
     withGd = true;
   };
 
+  glibc-fhs = hiPrio (callPackage ../development/libraries/glibc {
+    withFHS = true;
+  });
+
   # Being redundant to avoid cycles on boot. TODO: find a better way
   glibcCross = callPackage ../development/libraries/glibc {
     stdenv = gccCrossLibcStdenv; # doesn't compile without gcc


### PR DESCRIPTION
###### Motivation for this change
This is an attempt to do a not-so-kind cleanup of nix's steam package.

related: https://github.com/ValveSoftware/Dota-2/issues/2018

Closes: NixOS/nixpkgs#161136 https://github.com/NixOS/nixpkgs/issues/157614  https://github.com/NixOS/nixpkgs/issues/148483 https://github.com/NixOS/nixpkgs/issues/140543 https://github.com/NixOS/nixpkgs/issues/135298 https://github.com/NixOS/nixpkgs/issues/126428 https://github.com/NixOS/nixpkgs/issues/108598 https://github.com/NixOS/nixpkgs/issues/83603 https://github.com/NixOS/nixpkgs/issues/73191 https://github.com/NixOS/nixpkgs/issues/69037 https://github.com/NixOS/nixpkgs/issues/69037

To test:
- run `nix run github:jonringer/nixpkgs/steam-fixes#steam`

TODO:
- [x] Get `csgo` to launch (opengl, native, older runtime)
- [x] Get dota2 to launch (vulkan, native, newer runtime)
- [x] Get proton game to launch (e.g. timberborn)
  - [x] Proton runtime 6
  - [x] Proton runtime 7
- [ ] Allow people to [mount their own steam directories](https://www.reddit.com/r/NixOS/comments/skqqoz/steam_doesnt_see_my_mounted_library_folder/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
