### PR TITLE
wapanel: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/wapanel/default.nix
+++ b/pkgs/applications/misc/wapanel/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, ninja, pkg-config
+, gtk3, glib, gtk-layer-shell, gdk-pixbuf, librsvg
+, wayland, wayland-protocols, wayland-scanner
+, libpulseaudio, xdg-utils
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wapanel";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Firstbober";
+    repo = "wapanel";
+    rev = version;
+    hash = "sha256-sqVH/XXFIEdB3b19eHj0gqN/hjEltxKisT/UAdMmmXA=";
+    fetchSubmodules = true;
+  };
+
+  # Change to `true` once ToruNiina/toml11 is packaged
+  # and remove `fetchSubmodules` in the `fetchFromGitHub` call above
+  mesonFlags = [ "-Dsystem_toml11=false" ];
+
+  nativeBuildInputs = [ meson ninja pkg-config wayland-protocols wayland-scanner wrapGAppsHook ];
+
+  buildInputs = [ gdk-pixbuf glib.dev gtk-layer-shell gtk3 libpulseaudio librsvg wayland xdg-utils ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    "$out"/bin/wapanel --help >/dev/null
+  '';
+
+  meta = with lib; {
+    description = "Desktop-dedicated wayland bar for wayfire and other wlroots based compositors";
+    maintainers = with maintainers; [ berbiche ];
+    platforms = platforms.unix;
+    homepage = "https://github.com/Firstbober/wapanel";
+    license = licenses.mit;
+    mainProgram = "wapanel";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26191,6 +26191,8 @@ with pkgs;
 
   rootbar = callPackage ../applications/misc/rootbar {};
 
+  wapanel = callPackage ../applications/misc/wapanel { };
+
   waybar = callPackage ../applications/misc/waybar {};
 
   wbg = callPackage ../applications/misc/wbg { };


### PR DESCRIPTION
###### Motivation for this change

[wapanel](https://github.com/Firstbober/wapanel) is a status bar for wlroots based compositors.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
