### PR TITLE
buf: 1.0.0-rc11 -> 1.0.0-rc12

### DIFF
--- a/pkgs/development/tools/buf/default.nix
+++ b/pkgs/development/tools/buf/default.nix
@@ -5,19 +5,20 @@
 , git
 , testVersion
 , buf
+, installShellFiles
 }:
 
 buildGoModule rec {
   pname = "buf";
-  version = "1.0.0-rc11";
+  version = "1.0.0-rc12";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-V6xaGnSoKuJC59uZLW8uSLqwseJHvLGjrvhzE8o9fho=";
+    sha256 = "sha256-UqyWQdlCDTSjW348f87W7g2kwB5nzIOviSE5/1T1soY=";
   };
-  vendorSha256 = "sha256-442NHTREM2zC8VA7zAV35YSwX1lM/BXnx6p8a+avzps=";
+  vendorSha256 = "sha256-qBgGZTok3G0Pgku76uiV9bZperhiSNoWSrzxrHe4QXw=";
 
   patches = [
     # Skip a test that requires networking to be available to work.
@@ -26,7 +27,7 @@ buildGoModule rec {
     ./skip_test_requiring_dotgit.patch
   ];
 
-  nativeBuildInputs = [ protobuf ];
+  nativeBuildInputs = [ protobuf installShellFiles ];
   # Required for TestGitCloner
   checkInputs = [ git ];
 
@@ -42,6 +43,7 @@ buildGoModule rec {
   installPhase = ''
     runHook preInstall
 
+    # Binaries
     mkdir -p "$out/bin"
     # Only install required binaries, don't install testing binaries
     for FILE in \
@@ -50,6 +52,16 @@ buildGoModule rec {
       "protoc-gen-buf-lint"; do
       cp "$GOPATH/bin/$FILE" "$out/bin/"
     done
+
+    # Completions
+    installShellCompletion --cmd buf \
+      --bash <($GOPATH/bin/buf bash-completion) \
+      --fish <($GOPATH/bin/buf fish-completion) \
+      --zsh <($GOPATH/bin/buf zsh-completion)
+
+    # Man Pages
+    mkdir man && $GOPATH/bin/buf manpages man
+    installManPage man/*
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/bufbuild/buf/releases/tag/v1.0.0-rc12


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).