### PR TITLE
nomad: 1.2.3 -> 1.2.6

### DIFF
--- a/pkgs/applications/networking/cluster/nomad/1.2.nix
+++ b/pkgs/applications/networking/cluster/nomad/1.2.nix
@@ -6,7 +6,7 @@
 
 callPackage ./generic.nix {
   inherit buildGoModule nvidia_x11 nvidiaGpuSupport;
-  version = "1.2.3";
-  sha256 = "0qjj1pnq2yv4r8dv03m08ii4118drjnswf4n1r95dqh8j3bymv5i";
-  vendorSha256 = "0djh2184yg4b656wbhzxg1q1hsdnbrwsk79vc0426d0mqbzyy7dx";
+  version = "1.2.6";
+  sha256 = "1ik8v1jznky9y4m85bzxgyba256zqmm5fs6d5xsvp5rzcylcdwgd";
+  vendorSha256 = "1mbvpssf7haaxzx6ka9qzixm49jck8i89w8ymkaddgmxhlbxjv05";
 }


### PR DESCRIPTION
###### Motivation for this change
New version of nomad out (1.2.5), probably will need backporting

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
