### PR TITLE
nixos/tests/k3s: remove stale test reference

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -237,7 +237,6 @@ in
   jibri = handleTest ./jibri.nix {};
   jirafeau = handleTest ./jirafeau.nix {};
   jitsi-meet = handleTest ./jitsi-meet.nix {};
-  k3s = handleTest ./k3s.nix {};
   k3s-single-node = handleTest ./k3s-single-node.nix {};
   k3s-single-node-docker = handleTest ./k3s-single-node-docker.nix {};
   kafka = handleTest ./kafka.nix {};


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/142706 renamed this test, but the old 'k3s' one wasn't removed from all-tests.

Fix that.


###### Things done

- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

Tested via:

```
$ nix-build -A nixosTests.k3s-single-node
$ nix-build -A nixosTests.k3s-single-node-docker
```

and verified both passed on my machine.

ty for the pointer on the other issue @zowoq, much appreciated!