### PR TITLE
Revert "Merge pull request #155048 from mweinelt/python2-must-die"

### DIFF
--- a/pkgs/applications/misc/grip/default.nix
+++ b/pkgs/applications/misc/grip/default.nix
@@ -2,10 +2,15 @@
 , stdenv
 , fetchurl
 , gtk2
+, glib
 , pkg-config
+, libgnome
+, libgnomeui
+, vte
 , curl
 , cdparanoia
 , libid3tag
+, ncurses
 , libtool
 }:
 
@@ -21,9 +26,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config libtool ];
   buildInputs = [
     gtk2
+    glib
+    libgnome
+    libgnomeui
+    vte
     curl
     cdparanoia
     libid3tag
+    ncurses
   ];
   enableParallelBuilding = true;
 

--- a/pkgs/applications/terminal-emulators/evilvte/default.nix
+++ b/pkgs/applications/terminal-emulators/evilvte/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchgit, makeWrapper, pkg-config,
+  gnome2, gtk2, glib, pango, cairo, gdk-pixbuf, atk, freetype, xorg,
+  configH ? ""
+}:
+
+stdenv.mkDerivation {
+  pname = "evilvte";
+  version = "0.5.2-20140827";
+
+  src = fetchgit {
+    url = "https://github.com/caleb-/evilvte.git";
+    rev = "8dfa41e26bc640dd8d8c7317ff7d04e3c01ded8a";
+    sha256 = "70f1d4234d077121e2223a735d749d1b53f0b84393507b635b8a37c3716e94d3";
+  };
+
+  buildInputs = [
+    gnome2.vte glib pango gtk2 cairo gdk-pixbuf atk freetype xorg.libX11
+    xorg.xorgproto xorg.libXext makeWrapper pkg-config
+  ];
+
+  buildPhase = ''
+    cat >src/config.h <<EOF
+    ${configH}
+    EOF
+    make
+  '';
+
+  meta = with lib; {
+    description = "VTE based, highly customizable terminal emulator";
+    homepage = "http://www.calno.com/evilvte";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bodil ];
+    platforms = platforms.linux;
+    knownVulnerabilities = [
+      "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=854585"
+    ];
+  };
+}

--- a/pkgs/applications/terminal-emulators/lilyterm/default.nix
+++ b/pkgs/applications/terminal-emulators/lilyterm/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, lib, fetchurl, fetchFromGitHub
+, pkg-config
+, autoconf, automake, intltool, gettext
+, gtk, vte
+, flavour ? "stable"
+}:
+
+assert lib.assertOneOf "flavour" flavour [ "stable"  "git" ];
+
+let
+  pname = "lilyterm";
+  stuff =
+    if flavour == "stable"
+    then rec {
+        version = "0.9.9.4";
+        src = fetchurl {
+          url = "https://lilyterm.luna.com.tw/file/${pname}-${version}.tar.gz";
+          sha256 = "0x2x59qsxq6d6xg5sd5lxbsbwsdvkwqlk17iw3h4amjg3m1jc9mp";
+        };
+      }
+    else {
+        version = "2019-07-25";
+        src = fetchFromGitHub {
+          owner = "Tetralet";
+          repo = pname;
+          rev = "faf1254f46049edfb1fd6e9191e78b1b23b9c51d";
+          sha256 = "054450gk237c62b677365bcwrijr63gd9xm8pv68br371wdzylz7";
+        };
+      };
+
+in
+with lib;
+stdenv.mkDerivation rec {
+  inherit pname;
+
+  inherit (stuff) src version;
+
+  nativeBuildInputs = [ pkg-config autoconf automake intltool gettext ];
+  buildInputs = [ gtk vte ];
+
+  preConfigure = "sh autogen.sh";
+
+  configureFlags = [
+    "--enable-nls"
+    "--enable-safe-mode"
+  ];
+
+  meta = with lib; {
+    description = "A fast, lightweight terminal emulator";
+    longDescription = ''
+      LilyTerm is a terminal emulator based off of libvte that aims to be fast and lightweight.
+    '';
+    homepage = "https://lilyterm.luna.com.tw/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ AndersonTorres Profpatsch ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -62,6 +62,12 @@ lib.makeScope pkgs.newScope (self: with self; {
     autoreconfHook = pkgs.autoreconfHook269;
   };
 
+  vte = callPackage ./desktop/vte { };
+
+#### BINDINGS
+
+  libglademm = callPackage ./bindings/libglademm { };
+
 } // lib.optionalAttrs (config.allowAliases or true) {
   inherit (pkgs)
     # GTK Libs

--- a/pkgs/desktops/gnome-2/desktop/vte/alt.patch
+++ b/pkgs/desktops/gnome-2/desktop/vte/alt.patch
@@ -1,0 +1,50 @@
+From a9d6a34708f846952f423d078397352858f7b1a4 Mon Sep 17 00:00:00 2001
+From: Christian Persch <chpe@gnome.org>
+Date: Sat, 12 May 2012 18:48:05 +0200
+Subject: [PATCH] keymap: Treat ALT as META
+
+https://bugzilla.gnome.org/show_bug.cgi?id=663779
+---
+ src/vte.c |   23 ++++++++++++++---------
+ 1 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/src/vte.c b/src/vte.c
+index dd27e9a..0657921 100644
+--- a/src/vte.c
++++ b/src/vte.c
+@@ -5170,19 +5170,24 @@ static void
+ vte_terminal_read_modifiers (VteTerminal *terminal,
+ 			     GdkEvent *event)
+ {
++        GdkKeymap *keymap;
+ 	GdkModifierType modifiers;
+ 
+ 	/* Read the modifiers. */
+-	if (gdk_event_get_state((GdkEvent*)event, &modifiers)) {
+-		GdkKeymap *keymap;
+-#if GTK_CHECK_VERSION (2, 90, 8)
+-                keymap = gdk_keymap_get_for_display(gdk_window_get_display(((GdkEventAny*)event)->window));
+-#else
+-                keymap = gdk_keymap_get_for_display(gdk_drawable_get_display(((GdkEventAny*)event)->window));
++	if (!gdk_event_get_state((GdkEvent*)event, &modifiers))
++                return;
++
++        keymap = gdk_keymap_get_for_display(gdk_window_get_display(((GdkEventAny*)event)->window));
++
++        gdk_keymap_add_virtual_modifiers (keymap, &modifiers);
++
++#if 1
++        /* HACK! Treat ALT as META; see bug #663779. */
++        if (modifiers & GDK_MOD1_MASK)
++                modifiers |= VTE_META_MASK;
+ #endif
+-                gdk_keymap_add_virtual_modifiers (keymap, &modifiers);
+-		terminal->pvt->modifiers = modifiers;
+-	}
++
++        terminal->pvt->modifiers = modifiers;
+ }
+ 
+ /* Read and handle a keypress event. */
+-- 
+1.7.5.1.217.g4e3aa.dirty

--- a/pkgs/desktops/gnome-2/desktop/vte/change-scroll-region.patch
+++ b/pkgs/desktops/gnome-2/desktop/vte/change-scroll-region.patch
@@ -1,0 +1,67 @@
+Index: vte-0.26.0/src/vte.c
+===================================================================
+--- vte-0.26.0.orig/src/vte.c	2010-11-30 23:04:53.000000000 -0800
++++ vte-0.26.0/src/vte.c	2010-12-07 20:05:07.865548000 -0800
+@@ -3862,6 +3862,7 @@ vte_terminal_process_incoming(VteTermina
+ 	long wcount, start, delta;
+ 	gboolean leftovers, modified, bottom, again;
+ 	gboolean invalidated_text;
++	gboolean in_scroll_region;
+ 	GArray *unichars;
+ 	struct _vte_incoming_chunk *chunk, *next_chunk, *achunk = NULL;
+ 
+@@ -3881,6 +3882,10 @@ vte_terminal_process_incoming(VteTermina
+ 	cursor = screen->cursor_current;
+ 	cursor_visible = terminal->pvt->cursor_visible;
+ 
++	in_scroll_region = screen->scrolling_restricted
++	    && (screen->cursor_current.row >= (screen->insert_delta + screen->scrolling_region.start))
++	    && (screen->cursor_current.row <= (screen->insert_delta + screen->scrolling_region.end));
++
+ 	/* We should only be called when there's data to process. */
+ 	g_assert(terminal->pvt->incoming ||
+ 		 (terminal->pvt->pending->len > 0));
+@@ -3979,6 +3984,8 @@ skip_chunk:
+ 		 * points to the first character which isn't part of this
+ 		 * sequence. */
+ 		if ((match != NULL) && (match[0] != '\0')) {
++			gboolean new_in_scroll_region;
++
+ 			/* Call the right sequence handler for the requested
+ 			 * behavior. */
+ 			_vte_terminal_handle_sequence(terminal,
+@@ -3989,12 +3996,20 @@ skip_chunk:
+ 			start = (next - wbuf);
+ 			modified = TRUE;
+ 
+-			/* if we have moved during the sequence handler, restart the bbox */
++			new_in_scroll_region = screen->scrolling_restricted
++			    && (screen->cursor_current.row >= (screen->insert_delta + screen->scrolling_region.start))
++			    && (screen->cursor_current.row <= (screen->insert_delta + screen->scrolling_region.end));
++
++			delta = screen->scroll_delta;	/* delta may have changed from sequence. */
++
++			/* if we have moved greatly during the sequence handler, or moved into a scroll_region
++                         * from outside it, restart the bbox */
+ 			if (invalidated_text &&
+-					(screen->cursor_current.col > bbox_bottomright.x + VTE_CELL_BBOX_SLACK ||
+-					 screen->cursor_current.col < bbox_topleft.x - VTE_CELL_BBOX_SLACK     ||
+-					 screen->cursor_current.row > bbox_bottomright.y + VTE_CELL_BBOX_SLACK ||
+-					 screen->cursor_current.row < bbox_topleft.y - VTE_CELL_BBOX_SLACK)) {
++					((new_in_scroll_region && !in_scroll_region) ||
++					 (screen->cursor_current.col > bbox_bottomright.x + VTE_CELL_BBOX_SLACK ||
++					  screen->cursor_current.col < bbox_topleft.x - VTE_CELL_BBOX_SLACK     ||
++					  screen->cursor_current.row > bbox_bottomright.y + VTE_CELL_BBOX_SLACK ||
++					  screen->cursor_current.row < bbox_topleft.y - VTE_CELL_BBOX_SLACK))) {
+ 				/* Clip off any part of the box which isn't already on-screen. */
+ 				bbox_topleft.x = MAX(bbox_topleft.x, 0);
+ 				bbox_topleft.y = MAX(bbox_topleft.y, delta);
+@@ -4014,6 +4029,8 @@ skip_chunk:
+ 				bbox_bottomright.x = bbox_bottomright.y = -G_MAXINT;
+ 				bbox_topleft.x = bbox_topleft.y = G_MAXINT;
+ 			}
++
++			in_scroll_region = new_in_scroll_region;
+ 		} else
+ 		/* Second, we have a NULL match, and next points to the very
+ 		 * next character in the buffer.  Insert the character which

--- a/pkgs/desktops/gnome-2/desktop/vte/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/vte/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, fetchurl, fetchpatch, intltool, pkg-config, glib, gtk2, ncurses
+, pythonSupport ? false, python27Packages}:
+
+let
+  inherit (python27Packages) python pygtk;
+in stdenv.mkDerivation rec {
+  name = "vte-0.28.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/vte/0.28/${name}.tar.bz2";
+    sha256 = "00zrip28issgmz2cqk5k824cbqpbixi5x7k88zxksdqpnq1f414d";
+  };
+
+  patches = [
+    ./alt.patch
+    ./change-scroll-region.patch
+    # CVE-2012-2738
+    # fixed in upstream version 0.32.2
+    (fetchpatch{
+      name = "CVE-2012-2738-1.patch";
+      url = "https://gitlab.gnome.org/GNOME/vte/commit/feeee4b5832b17641e505b7083e0d299fdae318e.patch";
+      sha256 = "1455i6zxcx4rj2cz639s8qdc04z2nshprwl7k00mcsw49gv3hk5n";
+    })
+    (fetchpatch{
+      name = "CVE-2012-2738-2.patch";
+      url = "https://gitlab.gnome.org/GNOME/vte/commit/98ce2f265f986fb88c38d508286bb5e3716b9e74.patch";
+      sha256 = "0n24vw49h89w085ggq23iwlnnb6ajllfh2dg4vsar21d82jxc0sn";
+    })
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ intltool glib gtk2 ncurses ] ++
+                lib.optionals pythonSupport [python pygtk];
+
+  configureFlags = [
+    (lib.enableFeature pythonSupport "python")
+  ];
+
+  postInstall = lib.optionalString pythonSupport ''
+    cd $(toPythonPath $out)/gtk-2.0
+    for n in *; do
+      ln -s "gtk-2.0/$n" "../$n"
+    done
+  '';
+
+  meta = {
+    homepage = "https://www.gnome.org/";
+    description = "A library implementing a terminal emulator widget for GTK";
+    longDescription = ''
+      VTE is a library (libvte) implementing a terminal emulator widget for
+      GTK, and a minimal sample application (vte) using that.  Vte is
+      mainly used in gnome-terminal, but can also be used to embed a
+      console/terminal in games, editors, IDEs, etc. VTE supports Unicode and
+      character set conversion, as well as emulating any terminal known to
+      the system's terminfo database.
+    '';
+    license = lib.licenses.lgpl2;
+    maintainers = with lib.maintainers; [ astsmtl ];
+    platforms = with lib.platforms; linux;
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -257,7 +257,6 @@ mapAliases ({
   euca2tools = throw "euca2ools has been removed because it is unmaintained upstream and still uses python2."; # added 2022-01-01
   evolution_data_server = evolution-data-server; # added 2018-02-25
   etcdctl = etcd; # added 2018-04-25
-  evilvte = throw "evilvte has been removed from nixpkgs for being unmaintained with security issues and dependant on an old version of vte which was removed."; # added 2022-01-14
   exfat-utils = exfat;                  # 2015-09-11
   facette = throw "facette has been removed."; # added 2020-01-06
   fast-neural-doodle = throw "fast-neural-doodle has been removed, as the upstream project has been abandoned"; # added 2020-03-28
@@ -515,8 +514,6 @@ mapAliases ({
   libqmatrixclient = throw "libqmatrixclient was renamed to libquotient"; # added 2020-04-09
   libwnck3 = libwnck;
   lilypond-unstable = lilypond; # added 2021-03-11
-  lilyterm = throw "lilyterm has been removed from nixpkgs, because it was relying on a vte version that depended on python2."; # added 2022-01-14
-  lilyterm-git = throw "lilyterm-git has been removed from nixpkgs, because it was relying on a vte version that depended on python2."; # added 2022-01-14
   links = links2; # added 2016-01-31
   linuxband = throw "linuxband has been removed from nixpkgs, as it's abandoned upstream."; # added 2021-12-09
   linux_rpi0 = linuxKernel.kernels.linux_rpi1;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1121,6 +1121,8 @@ with pkgs;
 
   eterm = callPackage ../applications/terminal-emulators/eterm { };
 
+  evilvte = callPackage ../applications/terminal-emulators/evilvte (config.evilvte or {});
+
   foot = callPackage ../applications/terminal-emulators/foot { };
 
   germinal = callPackage ../applications/terminal-emulators/germinal { };
@@ -1143,6 +1145,16 @@ with pkgs;
   lifecycled = callPackage ../tools/misc/lifecycled { };
 
   lilo = callPackage ../tools/misc/lilo { };
+
+  lilyterm = callPackage ../applications/terminal-emulators/lilyterm {
+    inherit (gnome2) vte;
+    gtk = gtk2;
+    flavour = "stable";
+  };
+
+  lilyterm-git = lilyterm.override {
+    flavour = "git";
+  };
 
   logseq = callPackage ../applications/misc/logseq { };
 
@@ -15458,6 +15470,7 @@ with pkgs;
   r10k = callPackage ../tools/system/r10k { };
 
   radare2 = callPackage ../development/tools/analysis/radare2 ({
+    inherit (gnome2) vte;
     lua = lua5;
   } // (config.radare or {}));
 
@@ -25779,7 +25792,9 @@ with pkgs;
 
   grip-search = callPackage ../tools/text/grip-search { };
 
-  grip = callPackage ../applications/misc/grip { };
+  grip = callPackage ../applications/misc/grip {
+    inherit (gnome2) libgnome libgnomeui vte;
+  };
 
   gsimplecal = callPackage ../applications/misc/gsimplecal { };
 


### PR DESCRIPTION
No. You can’t just delete software people depend on as their daily
driver based on a skewed idea of deprecation.

This reverts commit a97ae545f3a2f74d18affe058db97bfb95990b5a, reversing
changes made to 37d3f7569dfb45182d62849ef5ac871c4a16f462.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
