### PR TITLE
chrome-remote-desktop: init at unstable-2022-02-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10873,6 +10873,12 @@
     githubId = 529649;
     name = "Raffael Mancini";
   };
+  sepiabrown = {
+    email = "bboxone@gmail.com";
+    github = "sepiabrown";
+    githubId = 35622998;
+    name = "Suwon Park";
+  };
   seppeljordan = {
     email = "sebastian.jordan.mail@googlemail.com";
     github = "seppeljordan";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -717,6 +717,7 @@
   ./services/networking/bitlbee.nix
   ./services/networking/blockbook-frontend.nix
   ./services/networking/charybdis.nix
+  ./services/networking/chrome-remote-desktop.nix
   ./services/networking/cjdns.nix
   ./services/networking/cntlm.nix
   ./services/networking/connman.nix

--- a/nixos/modules/services/networking/chrome-remote-desktop.nix
+++ b/nixos/modules/services/networking/chrome-remote-desktop.nix
@@ -1,0 +1,79 @@
+{ lib, config, options, pkgs, ... }:
+with lib;
+let 
+  cfg = config.services.chrome-remote-desktop;
+in {
+  options.services.chrome-remote-desktop = {
+    enable = mkEnableOption "Chrome Remote Desktop";
+    user = mkOption {
+      type = types.str;
+      description = ''
+        A user which the service will run as.
+      '';
+      example = "alice";
+    };
+    newSession = mkOption {
+      type = types.bool;
+      description = "Whether to start a new session";
+      default = false;
+      example = "true";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nixpkgs.overlays = [(final: prev: {
+      chrome-remote-desktop_final = final.chrome-remote-desktop.override {
+        enableNewSession = cfg.newSession;
+      };
+    })];
+
+    environment = {
+      etc = {
+        "chromium/native-messaging-hosts/com.google.chrome.remote_assistance.json".source = "${pkgs.chrome-remote-desktop_final}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_assistance.json";
+        "chromium/native-messaging-hosts/com.google.chrome.remote_desktop.json".source = "${pkgs.chrome-remote-desktop_final}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json";
+      };
+      systemPackages = [ pkgs.chrome-remote-desktop_final ];
+    };
+
+    security = {
+      wrappers.crd-user-session.source = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/user-session";
+      wrappers.crd-user-session.owner = cfg.user;
+      wrappers.crd-user-session.group = "chrome-remote-desktop";
+      pam.services.chrome-remote-desktop.text = ''
+        auth        required    pam_unix.so
+        account     required    pam_unix.so
+        password    required    pam_unix.so
+        session     required    pam_unix.so
+      '';
+    };
+
+    users.groups.chrome-remote-desktop = {};
+
+    users.users.${cfg.user}.extraGroups = [ "chrome-remote-desktop" ];
+
+    systemd.packages = [
+      pkgs.chrome-remote-desktop_final
+    ];
+    
+    # Reference : ${pkgs.chrome-remote-desktop}/lib/systemd/system/chrome-remote-desktop@.service
+    systemd.services."chrome-remote-desktop@${cfg.user}" = {
+      enable = true;
+      description = "Chrome Remote Desktop instance for ${cfg.user}";
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Environment = "XDG_SESSION_CLASS=user XDG_SESSION_TYPE=x11";
+        PAMName = "chrome-remote-desktop";
+        TTYPath = "/dev/chrome-remote-desktop";
+        ExecStart = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --start --new-session";
+        ExecReload = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --reload";
+        ExecStop = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --stop";
+        StandardOutput = "journal";
+        StandardError = "inherit";
+        RestartForceExitStatus = "41";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/nixos/modules/services/networking/chrome-remote-desktop.nix
+++ b/nixos/modules/services/networking/chrome-remote-desktop.nix
@@ -2,6 +2,7 @@
 with lib;
 let
   cfg = config.services.chrome-remote-desktop;
+  chrome-remote-desktop = pkgs.chrome-remote-desktop.override { enableNewSession = cfg.newSession; };
 in {
   options.services.chrome-remote-desktop = {
     enable = mkEnableOption "Chrome Remote Desktop";
@@ -21,22 +22,16 @@ in {
   };
 
   config = mkIf cfg.enable {
-    nixpkgs.overlays = [(final: prev: {
-      chrome-remote-desktop_final = final.chrome-remote-desktop.override {
-        enableNewSession = cfg.newSession;
-      };
-    })];
-
     environment = {
       etc = {
-        "chromium/native-messaging-hosts/com.google.chrome.remote_assistance.json".source = "${pkgs.chrome-remote-desktop_final}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_assistance.json";
-        "chromium/native-messaging-hosts/com.google.chrome.remote_desktop.json".source = "${pkgs.chrome-remote-desktop_final}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json";
+        "chromium/native-messaging-hosts/com.google.chrome.remote_assistance.json".source = "${chrome-remote-desktop}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_assistance.json";
+        "chromium/native-messaging-hosts/com.google.chrome.remote_desktop.json".source = "${chrome-remote-desktop}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json";
       };
-      systemPackages = [ pkgs.chrome-remote-desktop_final ];
+      systemPackages = [ chrome-remote-desktop ];
     };
 
     security = {
-      wrappers.crd-user-session.source = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/user-session";
+      wrappers.crd-user-session.source = "${chrome-remote-desktop}/opt/google/chrome-remote-desktop/user-session";
       wrappers.crd-user-session.owner = cfg.user;
       wrappers.crd-user-session.group = "chrome-remote-desktop";
       pam.services.chrome-remote-desktop.text = ''
@@ -52,7 +47,7 @@ in {
     users.users.${cfg.user}.extraGroups = [ "chrome-remote-desktop" ];
 
     systemd.packages = [
-      pkgs.chrome-remote-desktop_final
+      chrome-remote-desktop
     ];
 
     # Reference : ${pkgs.chrome-remote-desktop}/lib/systemd/system/chrome-remote-desktop@.service
@@ -66,9 +61,9 @@ in {
         Environment = "XDG_SESSION_CLASS=user XDG_SESSION_TYPE=x11";
         PAMName = "chrome-remote-desktop";
         TTYPath = "/dev/chrome-remote-desktop";
-        ExecStart = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --start --new-session";
-        ExecReload = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --reload";
-        ExecStop = "${pkgs.chrome-remote-desktop_final}/opt/google/chrome-remote-desktop/chrome-remote-desktop --stop";
+        ExecStart = "${chrome-remote-desktop}/opt/google/chrome-remote-desktop/chrome-remote-desktop --start --new-session";
+        ExecReload = "${chrome-remote-desktop}/opt/google/chrome-remote-desktop/chrome-remote-desktop --reload";
+        ExecStop = "${chrome-remote-desktop}/opt/google/chrome-remote-desktop/chrome-remote-desktop --stop";
         StandardOutput = "journal";
         StandardError = "inherit";
         RestartForceExitStatus = "41";

--- a/nixos/modules/services/networking/chrome-remote-desktop.nix
+++ b/nixos/modules/services/networking/chrome-remote-desktop.nix
@@ -1,6 +1,6 @@
 { lib, config, options, pkgs, ... }:
 with lib;
-let 
+let
   cfg = config.services.chrome-remote-desktop;
 in {
   options.services.chrome-remote-desktop = {
@@ -54,7 +54,7 @@ in {
     systemd.packages = [
       pkgs.chrome-remote-desktop_final
     ];
-    
+
     # Reference : ${pkgs.chrome-remote-desktop}/lib/systemd/system/chrome-remote-desktop@.service
     systemd.services."chrome-remote-desktop@${cfg.user}" = {
       enable = true;

--- a/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
+++ b/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
@@ -1,5 +1,5 @@
 { enableNewSession ? false, stdenv, pkgs, lib, config, fetchurl, fetchgit, dpkg, python3, glibc, glib, pam, nss
-, nspr, expat, gtk3, dconf, xorg, fontconfig, dbus_daemon, alsaLib, shadow, mesa, libdrm, libxkbcommon, wayland }:
+, nspr, expat, gtk3, dconf, xorg, fontconfig, dbus, alsaLib, shadow, mesa, libdrm, libxkbcommon, wayland }:
 stdenv.mkDerivation rec {
   pname = "chrome-remote-desktop";
   version = "unstable-2022-02-03";
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
       xorg.libxcb
       xorg.libXScrnSaver
       fontconfig
-      dbus_daemon.lib
+      dbus.daemon.lib
       alsaLib
       shadow
       mesa

--- a/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
+++ b/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
@@ -1,7 +1,9 @@
 { enableNewSession ? false, stdenv, pkgs, lib, config, fetchurl, fetchgit, dpkg, python3, glibc, glib, pam, nss
 , nspr, expat, gtk3, dconf, xorg, fontconfig, dbus_daemon, alsaLib, shadow, mesa, libdrm, libxkbcommon, wayland }:
 stdenv.mkDerivation rec {
-  name = "chrome-remote-desktop";
+  pname = "chrome-remote-desktop";
+  version = "unstable-2022-02-03";
+
   src = fetchurl {
     sha256 = "sha256-CNE3kvAj7Jp4cB5x2D/YUA1H9Ri397C6rxQBRmstz1c=";
     url = "https://dl.google.com/linux/direct/chrome-remote-desktop_current_amd64.deb";
@@ -24,7 +26,7 @@ stdenv.mkDerivation rec {
   replacePrefix = "/opt/google/chrome-remote-desktop";
   replaceTarget = "/run/current-system/sw/bin/./././";
 
-  patchPhase = 
+  patchPhase =
   ''
     sed \
     -e '/^.*sudo_command =/ s/"gksudo .*"/"pkexec"/' \

--- a/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
+++ b/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
@@ -1,5 +1,5 @@
 { enableNewSession ? false, stdenv, pkgs, lib, config, fetchurl, fetchgit, dpkg, python3, glibc, glib, pam, nss
-, nspr, expat, gtk3, dconf, xorg, fontconfig, dbus, alsaLib, shadow, mesa, libdrm, libxkbcommon, wayland }:
+, nspr, expat, gtk3, dconf, xorg, fontconfig, dbus, alsa-lib, shadow, mesa, libdrm, libxkbcommon, wayland }:
 stdenv.mkDerivation rec {
   pname = "chrome-remote-desktop";
   version = "unstable-2022-02-03";
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       xorg.libXScrnSaver
       fontconfig
       dbus.daemon.lib
-      alsaLib
+      alsa-lib
       shadow
       mesa
       libdrm

--- a/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
+++ b/pkgs/applications/networking/remote/chrome-remote-desktop/default.nix
@@ -1,0 +1,102 @@
+{ enableNewSession ? false, stdenv, pkgs, lib, config, fetchurl, fetchgit, dpkg, python3, glibc, glib, pam, nss
+, nspr, expat, gtk3, dconf, xorg, fontconfig, dbus_daemon, alsaLib, shadow, mesa, libdrm, libxkbcommon, wayland }:
+stdenv.mkDerivation rec {
+  name = "chrome-remote-desktop";
+  src = fetchurl {
+    sha256 = "sha256-CNE3kvAj7Jp4cB5x2D/YUA1H9Ri397C6rxQBRmstz1c=";
+    url = "https://dl.google.com/linux/direct/chrome-remote-desktop_current_amd64.deb";
+  };
+
+  buildInputs = [ pkgs.makeWrapper ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    ${dpkg}/bin/dpkg -x $src $out
+  '';
+
+  installPhase = ''
+    mkdir $out/bin
+    makeWrapper $out/opt/google/chrome-remote-desktop/chrome-remote-desktop $out/bin/chrome-remote-desktop
+  '';
+
+  replacePrefix = "/opt/google/chrome-remote-desktop";
+  replaceTarget = "/run/current-system/sw/bin/./././";
+
+  patchPhase = 
+  ''
+    sed \
+    -e '/^.*sudo_command =/ s/"gksudo .*"/"pkexec"/' \
+    -e '/^.*command =/ s/s -- sh -c/s sh -c/' \
+    -i $out/opt/google/chrome-remote-desktop/chrome-remote-desktop
+    substituteInPlace $out/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json --replace $replacePrefix/native-messaging-host $out/$replacePrefix/native-messaging-host
+    substituteInPlace $out/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_assistance.json --replace $replacePrefix/remote-assistance-host $out/$replacePrefix/remote-assistance-host
+
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "USER_SESSION_PATH = " "USER_SESSION_PATH = \"/run/wrappers/bin/crd-user-session\" #"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/bin/python3 ${python3.withPackages (ps: with ps; [ psutil ])}/bin/python3
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace '"Xvfb"' '"${xorg.xorgserver}/bin/Xvfb"'
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace '"Xorg"' '"${xorg.xorgserver}/bin/Xorg"'
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace '"xrandr"' '"${xorg.xrandr}/bin/xrandr"'
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/lib/xorg/modules ${xorg.xorgserver}/lib/xorg/modules
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace xdpyinfo ${xorg.xdpyinfo}/bin/xdpyinfo
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/bin/sudo /run/wrappers/bin/sudo
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/bin/pkexec /run/wrappers/bin/pkexec
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/bin/gpasswd ${shadow}/bin/gpasswd
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace /usr/sbin/groupadd ${shadow}/sbin/groupadd
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "os.path.isfile(DEBIAN_XSESSION_PATH)" "True"
+  '' + lib.optionalString (!enableNewSession) ''
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "FIRST_X_DISPLAY_NUMBER = 20" "FIRST_X_DISPLAY_NUMBER = 0"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "while os.path.exists(X_LOCK_FILE_TEMPLATE % display):" "# while os.path.exists(X_LOCK_FILE_TEMPLATE % display):"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "display += 1" "# display += 1"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "self._launch_x_server(x_args)" "display = self.get_unused_display_number()"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "if not self._launch_pre_session():" "self.child_env[\"DISPLAY\"] = \":%d\" % display"
+    substituteInPlace $out/$replacePrefix/chrome-remote-desktop --replace "self.launch_x_session()" "# self.launch_x_session()"
+  '';
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+      glib
+      pam
+      nss
+      nspr
+      expat
+      gtk3
+      dconf
+      xorg.libXext
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXrender
+      xorg.libXrandr
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXtst
+      xorg.libxcb
+      xorg.libXScrnSaver
+      fontconfig
+      dbus_daemon.lib
+      alsaLib
+      shadow
+      mesa
+      libdrm
+      libxkbcommon
+      wayland
+    ];
+  in ''
+        for i in $out/$replacePrefix/{chrome-remote-desktop-host,start-host,native-messaging-host,remote-assistance-host,user-session}; do
+          sed -i "s|$replacePrefix|$replaceTarget|g" $i
+          patchelf --set-rpath "${libPath}" $i
+          patchelf --set-interpreter ${glibc}/lib/ld-linux-x86-64.so.2 $i
+        done
+  '';
+
+  meta = with lib; {
+    description = "Chrome Remote Desktop";
+    homepage = "https://remotedesktop.google.com/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ sepiabrown ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24949,6 +24949,8 @@ with pkgs;
 
   CHOWTapeModel = callPackage ../applications/audio/CHOWTapeModel { };
 
+  chrome-remote-desktop = callPackage ../applications/networking/remote/chrome-remote-desktop { };
+
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
   chromiumBeta = lowPrio (chromium.override { channel = "beta"; });


### PR DESCRIPTION
###### Motivation for this change
#34084

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
