### PR TITLE
hivemind: 1.0.6 -> 1.1.0

### DIFF
--- a/pkgs/applications/misc/hivemind/default.nix
+++ b/pkgs/applications/misc/hivemind/default.nix
@@ -1,9 +1,8 @@
-{ lib, buildGoPackage, fetchFromGitHub, runtimeShell }:
+{ lib, buildGoModule, fetchFromGitHub, runtimeShell }:
 
-buildGoPackage rec {
+buildGoModule rec {
   pname = "hivemind";
-  version = "1.0.6";
-  goPackagePath = "github.com/DarthSim/hivemind";
+  version = "1.1.0";
 
   postPatch = ''
     substituteInPlace process.go --replace \"/bin/sh\" \"${runtimeShell}\"
@@ -13,8 +12,9 @@ buildGoPackage rec {
     owner = "DarthSim";
     repo = "hivemind";
     rev = "v${version}";
-    sha256 = "0afcnd03wsdphbbpha65rv5pnv0x6ldnnm6rnv1m6xkkywgnzx95";
+    sha256 = "YUR9OwRuH1xSPs8iTsSIjLCt2TyYH357IAYULGTyYUc=";
   };
+  vendorSha256 = "KweFhT8Zueg45Q/vw3kNET35hB+0WbUPfz0FYaAiIA8=";
 
   meta = with lib; {
     homepage = "https://github.com/DarthSim/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest release: https://github.com/DarthSim/hivemind/releases/tag/v1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
