### PR TITLE
python3Packages.httpcore: 0.14.3 -> 0.14.6

### DIFF
--- a/pkgs/development/python-modules/httpcore/default.nix
+++ b/pkgs/development/python-modules/httpcore/default.nix
@@ -11,7 +11,9 @@
 , pytestCheckHook
 , pytest-cov
 , pytest-httpbin
+, pytest-trio
 , sniffio
+, socksio
 , trio
 , trustme
 , uvicorn
@@ -19,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "httpcore";
-  version = "0.14.4";
+  version = "0.14.6";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = version;
-    sha256 = "19zsg8ijw0s1722ka67mjxx5z07lx9jq36z97l1fa6z1129wq240";
+    sha256 = "sha256-eqUkzK6UNpu8/mOmy4o53z3q/05m7t0bWtpeDfAHuJU=";
   };
 
   propagatedBuildInputs = [
@@ -35,6 +37,7 @@ buildPythonPackage rec {
     h11
     h2
     sniffio
+    socksio
   ];
 
   checkInputs = [
@@ -43,6 +46,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-cov
     pytest-httpbin
+    pytest-trio
     trio
     trustme
     uvicorn

--- a/pkgs/development/python-modules/socksio/default.nix
+++ b/pkgs/development/python-modules/socksio/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "socksio";
+  version = "1.0.0";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "sethmlarson";
+    repo = "socksio";
+    rev = version;
+    sha256 = "sha256-Q5EFEyRXbhMzJbKGwkZxW7Trs43BpumgOhx5360TKJ8=";
+  };
+
+  checkInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [
+    # clear coverage options from default options
+    "--override-ini addopts="
+  ];
+
+  meta = with lib; {
+    description = "Sans-I/O implementation of SOCKS4, SOCKS4A, and SOCKS5";
+    homepage = "https://github.com/sethmlarson/socksio";
+    license = licenses.mit;
+    maintainers = with maintainers; [ drewrisinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9182,6 +9182,8 @@ in {
 
   sockjs-tornado = callPackage ../development/python-modules/sockjs-tornado { };
 
+  socksio = callPackage ../development/python-modules/socksio { };
+
   socksipy-branch = callPackage ../development/python-modules/socksipy-branch { };
 
   soco = callPackage ../development/python-modules/soco { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update httpcore to latest version, found it when looking at downstream package.

Adds new dependency: python3Packages.socksio
- python3Packages.socksio: init at 1.0.0
- python3Packages.httpcore: 0.14.3 -> 0.14.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
