### PR TITLE
hidpi: Use gray-scale antialiasing for fonts

### DIFF
--- a/nixos/modules/hardware/video/hidpi.nix
+++ b/nixos/modules/hardware/video/hidpi.nix
@@ -11,6 +11,14 @@ with lib;
     console.earlySetup = mkDefault true;
     boot.loader.systemd-boot.consoleMode = mkDefault "1";
 
+
+    # Grayscale anti-aliasing for fonts
+    fonts.fontconfig.antialias = mkDefault true;
+    fonts.fontconfig.subpixel = {
+      rgba = mkDefault "none";
+      lcdfilter = mkDefault "none";
+    };
+
     # TODO Find reasonable defaults X11 & wayland
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Long story short, for displays with many pixels, subpixel anti-aliasing is not really needed – grayscale is more than enough.
For example, Elementary OS 6 is opting for it:

> We’ve also revisited the default font rendering settings, opting for grayscale anti-aliasing over RGB; this addresses some issues we’ve seen with ghosting/leaking of colors around text, especially visible when using transparency.
>
> — <https://blog.elementary.io/look-and-feel-changes-elementary-os-6/>

It also makes scaled screenshots look less awkward, since white letters will remain white, possibly with gray edges, while with subpixel anti-aliasing edges can be e.g. red.

NixOS already has the `video.hidpi` option that is supposed to set better defaults (e.g. virtual console fonts), so let’s also make this option default to grayscale anti-aliasing.


###### Things  done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
