### PR TITLE
kde/gear: 21.12.1 -> 21.12.2

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.12.1/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/21.12.2/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1843 +4,1843 @@
 
 {
   akonadi = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-21.12.1.tar.xz";
-      sha256 = "1ih83d8rs1frzhx1i2fgd5ndq259xqqp8aylirswpal7wpqk6f6l";
-      name = "akonadi-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-21.12.2.tar.xz";
+      sha256 = "1i1q8zda3hl564w02478wyqv35wj8npkqayy7b13shkq9b9j3nj8";
+      name = "akonadi-21.12.2.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-calendar-21.12.1.tar.xz";
-      sha256 = "0371mda45nh49l9mmwz64s6qh1yv36khnvll2g2krj8955y7jhz7";
-      name = "akonadi-calendar-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-calendar-21.12.2.tar.xz";
+      sha256 = "001ndvgqn6x70s7gdya1f1vr080mfkypam3k6z0i2ivlpymc3wly";
+      name = "akonadi-calendar-21.12.2.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-calendar-tools-21.12.1.tar.xz";
-      sha256 = "1ksagjidqs5ja145wkrn3xq9hk9wc4v7n1747bin0c3ks2s685ri";
-      name = "akonadi-calendar-tools-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-calendar-tools-21.12.2.tar.xz";
+      sha256 = "0f0l6wj3h2afbmvnq60cg0x03a412849dg4l9dwgdn8yxvnxkhw6";
+      name = "akonadi-calendar-tools-21.12.2.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-contacts-21.12.1.tar.xz";
-      sha256 = "1yh3b5q7dkgg57048lm1lyy9yxs9fwia7m6d1359fck1flh8lna3";
-      name = "akonadi-contacts-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-contacts-21.12.2.tar.xz";
+      sha256 = "1aq81569kz529n66dl5jjzamy6kxw0xk5bcmjfvb3wpxznhiigqm";
+      name = "akonadi-contacts-21.12.2.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-import-wizard-21.12.1.tar.xz";
-      sha256 = "09dzs9sk2baa5xgb81qxswvfmm23v3w02w9b9yyxgs38xrwqjf2p";
-      name = "akonadi-import-wizard-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-import-wizard-21.12.2.tar.xz";
+      sha256 = "0b4mphxbqzf3akhafxc4fvil83l3z4qcf8xnblw23ficqqs8s0di";
+      name = "akonadi-import-wizard-21.12.2.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-mime-21.12.1.tar.xz";
-      sha256 = "1jigq9rdxz5s6sl72ms06y7516hpmsm637zpqdrrg2gsb2f6y0d6";
-      name = "akonadi-mime-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-mime-21.12.2.tar.xz";
+      sha256 = "1nd6bf26lb5wfhzh4kn37iwmb6savcq9wsaph5c7jg6m0bdix1fn";
+      name = "akonadi-mime-21.12.2.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-notes-21.12.1.tar.xz";
-      sha256 = "1l9cmb7jhqx5r6zyz21dzqfydisjjs23qcb0bp83byb3mqsq8jnv";
-      name = "akonadi-notes-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-notes-21.12.2.tar.xz";
+      sha256 = "1s3bxnqsjnlgsnia0nvqyc3m1ppzanzna9598lgwbmz053rgn7ck";
+      name = "akonadi-notes-21.12.2.tar.xz";
     };
   };
   akonadi-search = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadi-search-21.12.1.tar.xz";
-      sha256 = "0b8lz4l2iq5ihfwyccaxjiw9yykxi0z240lmd9aiq4rv1wxzy22n";
-      name = "akonadi-search-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-search-21.12.2.tar.xz";
+      sha256 = "1hp2x8y59azl59znrqhrjn4n1bs2iqnkdsldv1f2k1ima6z5f4qy";
+      name = "akonadi-search-21.12.2.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akonadiconsole-21.12.1.tar.xz";
-      sha256 = "1d2wclbjpbx0jr2r7nz0m4wxls9763vbpnbbidprwbap5p5njl9z";
-      name = "akonadiconsole-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akonadiconsole-21.12.2.tar.xz";
+      sha256 = "1rqfmhi1mzh6yzjg7jf6adf1xqvpbhcxgld2pp4rd9g5mi9rlxlk";
+      name = "akonadiconsole-21.12.2.tar.xz";
     };
   };
   akregator = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/akregator-21.12.1.tar.xz";
-      sha256 = "1yf7631v1qc2a3j4b8bm0997cpg04vr0cgkdfqd3gazm2b367vf4";
-      name = "akregator-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/akregator-21.12.2.tar.xz";
+      sha256 = "1srsm25qvbww0hl7r878n32b71g0p222zxyys7chzrg8izrh12b8";
+      name = "akregator-21.12.2.tar.xz";
     };
   };
   analitza = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/analitza-21.12.1.tar.xz";
-      sha256 = "0dldw4zg14ih4fj90xbl3x57wzmqjf0wayi78p95lzm323rxkyvm";
-      name = "analitza-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/analitza-21.12.2.tar.xz";
+      sha256 = "1ak2wyfx67cwx85d5053f6flxwas973mhnm25mf4jw0qll72vid4";
+      name = "analitza-21.12.2.tar.xz";
     };
   };
   ark = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ark-21.12.1.tar.xz";
-      sha256 = "1mkqp6pn259aadwcnw7nmsrn4kx957m6axq2hnj18xrxbapm8xm0";
-      name = "ark-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ark-21.12.2.tar.xz";
+      sha256 = "1g05lyv8ll85myw0i62bxr4kmfd3dhldvmbgpgym9r1rgan12q90";
+      name = "ark-21.12.2.tar.xz";
     };
   };
   artikulate = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/artikulate-21.12.1.tar.xz";
-      sha256 = "044xm6aqy7mnnm4hy2cczjrgfkwghsm4pdif66hyk2mlybs78g5x";
-      name = "artikulate-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/artikulate-21.12.2.tar.xz";
+      sha256 = "1g0h0dqqsf3x8q292hfhrizl9dlqzm8gjynzcyrzx0gvbfadj2l1";
+      name = "artikulate-21.12.2.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/audiocd-kio-21.12.1.tar.xz";
-      sha256 = "0j22dk41mc26g4qwy2f7xq32d17v03nk8f49a9v8afzpka6dmyfv";
-      name = "audiocd-kio-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/audiocd-kio-21.12.2.tar.xz";
+      sha256 = "07nk060vkyn94ihs9v054zhsckfwpn8z911gy3hnyf1wdmnpfh2n";
+      name = "audiocd-kio-21.12.2.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/baloo-widgets-21.12.1.tar.xz";
-      sha256 = "01kbg9biyrjc9704g6wnvgcq08ry7idsfxh5sv2y4ncsidgb3l4i";
-      name = "baloo-widgets-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/baloo-widgets-21.12.2.tar.xz";
+      sha256 = "1ax7pak9qb60yzdca8frkb8qs4khs6f2wbkwyb48s7zmdxqyw1bj";
+      name = "baloo-widgets-21.12.2.tar.xz";
     };
   };
   blinken = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/blinken-21.12.1.tar.xz";
-      sha256 = "06v2d9l2c4p7n1vmaz86hmdb4lancfm4244sczykygjkcd7qiy6f";
-      name = "blinken-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/blinken-21.12.2.tar.xz";
+      sha256 = "0h0nw79zr891f54y2r3d3n837bzn24pfvkxsab1f0a228kjakw09";
+      name = "blinken-21.12.2.tar.xz";
     };
   };
   bomber = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/bomber-21.12.1.tar.xz";
-      sha256 = "18ymdm1qb0k9vq7r27dlv146xjgp6gxb86nxhpcrgm18xicbidah";
-      name = "bomber-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/bomber-21.12.2.tar.xz";
+      sha256 = "1348mdiykfg1c3gr5fkcf71mxf7lyapwg5ym3jqp9vyc56vhwfjs";
+      name = "bomber-21.12.2.tar.xz";
     };
   };
   bovo = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/bovo-21.12.1.tar.xz";
-      sha256 = "035pyyvdmbagpqnlf7ngvjzssiy0y9f87vj9wdxdnyglcvhycrf4";
-      name = "bovo-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/bovo-21.12.2.tar.xz";
+      sha256 = "0i2i5ici9v402lrh83mhfsrxmqi0fs75rkfvhsbza3wab7b165kc";
+      name = "bovo-21.12.2.tar.xz";
     };
   };
   calendarsupport = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/calendarsupport-21.12.1.tar.xz";
-      sha256 = "0glb8s5byaywvk66428pkq0lq0myhf8dlpg52i9ysq5ph3qjijyh";
-      name = "calendarsupport-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/calendarsupport-21.12.2.tar.xz";
+      sha256 = "021rr06ln7l0v2xjzsij4r71jwpy1w1r761bjad0ywprwkdc93bm";
+      name = "calendarsupport-21.12.2.tar.xz";
     };
   };
   cantor = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/cantor-21.12.1.tar.xz";
-      sha256 = "0l4vlx2w8bv53j1pd0fbwkgzv1p4m24apinxv4z4ia4f93h93vg1";
-      name = "cantor-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/cantor-21.12.2.tar.xz";
+      sha256 = "0vq8yvdglf43y5r2f9bvamm9bp82q92hw9sr8xmgb5hqz5mkap78";
+      name = "cantor-21.12.2.tar.xz";
     };
   };
   cervisia = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/cervisia-21.12.1.tar.xz";
-      sha256 = "1q9pwqz9ps7dq29ywxyzbnbvy6676bd4q52d4jpq3aff4g2l9p98";
-      name = "cervisia-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/cervisia-21.12.2.tar.xz";
+      sha256 = "1vpm3cjknpa4s9mjdfngpvidqihfh5sb427yhnydr1q2dmllr9nn";
+      name = "cervisia-21.12.2.tar.xz";
     };
   };
   dolphin = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/dolphin-21.12.1.tar.xz";
-      sha256 = "0k15mxrxplfghya8mv42w53v06ag9msnrd2yqdxlnmri5db1cjva";
-      name = "dolphin-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/dolphin-21.12.2.tar.xz";
+      sha256 = "0c0gk1djgl1d1qzibw5f1w29cnlxl6kan8pkg0izaqvnbmmx53wn";
+      name = "dolphin-21.12.2.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/dolphin-plugins-21.12.1.tar.xz";
-      sha256 = "0y920vvybdsvnrngjsf9ikblmmzmlshrg1zrn44ikyz15b4ar8bw";
-      name = "dolphin-plugins-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/dolphin-plugins-21.12.2.tar.xz";
+      sha256 = "1mrsampq1zq5rri1kx77dz0afz4a6s8pvb1255q0pl7imgxhiaqc";
+      name = "dolphin-plugins-21.12.2.tar.xz";
     };
   };
   dragon = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/dragon-21.12.1.tar.xz";
-      sha256 = "04rz1pm6azrqy4nzs20g8wj4knd4yvd10alcypyxbcb08npwx51z";
-      name = "dragon-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/dragon-21.12.2.tar.xz";
+      sha256 = "07zn4ishffh9g8hvkpfgm7j9cimw3plcabzk9p157nhgxr62z4sb";
+      name = "dragon-21.12.2.tar.xz";
     };
   };
   elisa = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/elisa-21.12.1.tar.xz";
-      sha256 = "1n4hga9g4kqnn016mm4dnq5wslxy9yaxdgazf9n3119i4mi4mjhs";
-      name = "elisa-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/elisa-21.12.2.tar.xz";
+      sha256 = "0zwy0bi4s25y6adgjhrhw992i2c1kjwpgvp9yg902h8zpsdynwh5";
+      name = "elisa-21.12.2.tar.xz";
     };
   };
   eventviews = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/eventviews-21.12.1.tar.xz";
-      sha256 = "1g6bhp869ic12jz3dzjx2hsc435i9zfxbrys34sxsa0448kk3wd3";
-      name = "eventviews-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/eventviews-21.12.2.tar.xz";
+      sha256 = "1v3bpd0b3ph7v0kg8pyp4rr4j8cxy7y4csym5dlqn6l81db7d3gr";
+      name = "eventviews-21.12.2.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ffmpegthumbs-21.12.1.tar.xz";
-      sha256 = "1mg10gxyirjglxd0hcayyddi2z0kbig1k24ms77aqwaiy66z77g3";
-      name = "ffmpegthumbs-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ffmpegthumbs-21.12.2.tar.xz";
+      sha256 = "17cyrimlnf1npffmxinnj3q5ynqg3agx35b55iqnw3xixrz4snzr";
+      name = "ffmpegthumbs-21.12.2.tar.xz";
     };
   };
   filelight = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/filelight-21.12.1.tar.xz";
-      sha256 = "0rky4nmnlqzpf820kx2w3g9qi2x77x1advqzc21la2yc6f27m83z";
-      name = "filelight-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/filelight-21.12.2.tar.xz";
+      sha256 = "0khhwnms2ysy9ijpmmagm68w1zixmxs7svaaldd30xb3w52f78v2";
+      name = "filelight-21.12.2.tar.xz";
     };
   };
   granatier = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/granatier-21.12.1.tar.xz";
-      sha256 = "0dbhf6p0c2yihzkzn5ns4bq2n209c2234i6a9p8rffdd7x5n9pmm";
-      name = "granatier-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/granatier-21.12.2.tar.xz";
+      sha256 = "0j7yizbljqx1a4wd4prmb3463r67f3lk5gv5x8j1yx2zmiaq0qki";
+      name = "granatier-21.12.2.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/grantlee-editor-21.12.1.tar.xz";
-      sha256 = "1r3qh8z1f2ywm7qgqv9jca4l39p53nsc4i08rvdxhc85j1jj8cwb";
-      name = "grantlee-editor-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/grantlee-editor-21.12.2.tar.xz";
+      sha256 = "0wxkg56s83i61i17cb2y6ziminaq2gammynrwm5jvkpi5vqwvi2s";
+      name = "grantlee-editor-21.12.2.tar.xz";
     };
   };
   grantleetheme = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/grantleetheme-21.12.1.tar.xz";
-      sha256 = "0ij225hva80983b4sbl5apfh5jfq9ppy8db5rfi2514crkmva8p2";
-      name = "grantleetheme-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/grantleetheme-21.12.2.tar.xz";
+      sha256 = "0z1p0s7fakfbscppmrgp1irf3dm2ayadyd3yb5zdsr9xahs0b9md";
+      name = "grantleetheme-21.12.2.tar.xz";
     };
   };
   gwenview = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/gwenview-21.12.1.tar.xz";
-      sha256 = "1gm86h5srjym8ig1vbfyshnrpf7vwb9bvl6hb8nhfqhcmldawlnb";
-      name = "gwenview-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/gwenview-21.12.2.tar.xz";
+      sha256 = "1jkv34llga981dq08npk8alrg9h27prdpffcxkm368i77mvp9hv6";
+      name = "gwenview-21.12.2.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/incidenceeditor-21.12.1.tar.xz";
-      sha256 = "1iam11jmp6q2k7r558dawcqrq5f9sixixdnvhywxj8fnvkjs005k";
-      name = "incidenceeditor-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/incidenceeditor-21.12.2.tar.xz";
+      sha256 = "151jhn84d5amv3abvp6cd2q10mf4mmv3q5hn0inqrmapy3v6bn8i";
+      name = "incidenceeditor-21.12.2.tar.xz";
     };
   };
   itinerary = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/itinerary-21.12.1.tar.xz";
-      sha256 = "17xy62bcjrbf75hbjj417k7hbs9m1874bwi3h6iii848c3j98ppn";
-      name = "itinerary-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/itinerary-21.12.2.tar.xz";
+      sha256 = "02w6696kdzgz2r9677nr1jyhd9mfhc2zhmasy70nblz0jn22bcq7";
+      name = "itinerary-21.12.2.tar.xz";
     };
   };
   juk = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/juk-21.12.1.tar.xz";
-      sha256 = "00kvx7yj45cm4fzdni6sd1csb09f1xm92hpx3ii1dmdm7cy1rg17";
-      name = "juk-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/juk-21.12.2.tar.xz";
+      sha256 = "1qgxpy1ksrgvdik69vppzdl1crscn69284q4wvwc5qh9v6rhv1xn";
+      name = "juk-21.12.2.tar.xz";
     };
   };
   k3b = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/k3b-21.12.1.tar.xz";
-      sha256 = "03swyl3hxzwa73hsc223a7wcf3hq5p0wws7rjrzbazvy7pcac436";
-      name = "k3b-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/k3b-21.12.2.tar.xz";
+      sha256 = "0rjg3zs85gw62r3z3msp438jnf0ghc6y577br59ig19m10x33rz9";
+      name = "k3b-21.12.2.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kaccounts-integration-21.12.1.tar.xz";
-      sha256 = "15j9778r07zvqhv0hkh18h6fqq97is04sii0pxss6w2nqfghxzr8";
-      name = "kaccounts-integration-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kaccounts-integration-21.12.2.tar.xz";
+      sha256 = "0c4yxrhbas0wsmrxr0pwkpgw9gzdvvf5r5nxd15f656bwwhmqlwy";
+      name = "kaccounts-integration-21.12.2.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kaccounts-providers-21.12.1.tar.xz";
-      sha256 = "12ll5nilk3adw6ia23n7rcy4wz0sg59is5kkxiarl8mjzd9vw4v4";
-      name = "kaccounts-providers-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kaccounts-providers-21.12.2.tar.xz";
+      sha256 = "1srz43xf6kz7xfz8np94pdnhmvashk7y2f2a275rwpnlrl0yw1yd";
+      name = "kaccounts-providers-21.12.2.tar.xz";
     };
   };
   kaddressbook = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kaddressbook-21.12.1.tar.xz";
-      sha256 = "1nv23wvka273a6d63gz0s0rxsp4ck3nx6fvvgg5ba1wzdcgjfd16";
-      name = "kaddressbook-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kaddressbook-21.12.2.tar.xz";
+      sha256 = "04ac5z9603lxylc6x55chnc0w59mx3z92nyvfnvjvp1ga77si36b";
+      name = "kaddressbook-21.12.2.tar.xz";
     };
   };
   kajongg = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kajongg-21.12.1.tar.xz";
-      sha256 = "0z5npbvl0hn1gld60nfy1n8qk60gfxjh1a74s5y6vc4zvqmscl5q";
-      name = "kajongg-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kajongg-21.12.2.tar.xz";
+      sha256 = "04s3f8nj0rh1zy7sfa5kq0smbfsyylz9w3lxm2z69g7x5sb08k53";
+      name = "kajongg-21.12.2.tar.xz";
     };
   };
   kalarm = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kalarm-21.12.1.tar.xz";
-      sha256 = "167xv38rj8pidbqqbfygkxcsr4wyd6j1437i93fb6v2b87h6ixx1";
-      name = "kalarm-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kalarm-21.12.2.tar.xz";
+      sha256 = "0f3hcsql20lim9nqb0ha5lpsrbh131rwcla9i6aax5sgw4m6nyfh";
+      name = "kalarm-21.12.2.tar.xz";
     };
   };
   kalarmcal = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kalarmcal-21.12.1.tar.xz";
-      sha256 = "1r7pxy4fc5w3j0bwi79370rvmsl919swny48176fg7kwvmjdv3z5";
-      name = "kalarmcal-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kalarmcal-21.12.2.tar.xz";
+      sha256 = "15l893iv4smlppk7k682m9hwrph84p5chx5mgxixjxl28c1blcc8";
+      name = "kalarmcal-21.12.2.tar.xz";
     };
   };
   kalgebra = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kalgebra-21.12.1.tar.xz";
-      sha256 = "1scqqrlznjl8j59fy24wfk84ysk3gvxw87cpl4wa4qhgb0q64m4b";
-      name = "kalgebra-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kalgebra-21.12.2.tar.xz";
+      sha256 = "0w1h3as6dip4hrp2ay61sz9gixf4s887jp42v7zjajwwhjs6xs1m";
+      name = "kalgebra-21.12.2.tar.xz";
     };
   };
   kalzium = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kalzium-21.12.1.tar.xz";
-      sha256 = "0sx10g2qmmvfm1ilmxr2xyf04mhcyr0ysjn6nw5c3rfnv8l42zh0";
-      name = "kalzium-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kalzium-21.12.2.tar.xz";
+      sha256 = "0kvrmvd2vgl6fklxq9sr46p6nnh0fk0l6licj9b5q9rz82xwbr50";
+      name = "kalzium-21.12.2.tar.xz";
     };
   };
   kamera = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kamera-21.12.1.tar.xz";
-      sha256 = "0hzsip822dsddf42x5lk88nlz4kr4khlh240wbvxrxz0hasgjxbc";
-      name = "kamera-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kamera-21.12.2.tar.xz";
+      sha256 = "07n1xlmg7m6p5ca0i4hjjyv564cqrn4p6h5yqx4pw3pcq8nizqfz";
+      name = "kamera-21.12.2.tar.xz";
     };
   };
   kamoso = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kamoso-21.12.1.tar.xz";
-      sha256 = "0a3lvqmm4kjj9v56mvzf2rfdmijahd32n7lc9agjca9hll59y31q";
-      name = "kamoso-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kamoso-21.12.2.tar.xz";
+      sha256 = "09qn1px0mmcjhw9ikaz8xcjbdabh657ij3sa4ps37jbfzyyv45fb";
+      name = "kamoso-21.12.2.tar.xz";
     };
   };
   kanagram = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kanagram-21.12.1.tar.xz";
-      sha256 = "00nyb23fyjxqxqin962j8av88xb2kcnhga9nd3l36i5mndh3axrm";
-      name = "kanagram-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kanagram-21.12.2.tar.xz";
+      sha256 = "1l4j2fy8mwdywp0prswng1f06rpwkfi54dc8z5z02b13p47hz5cy";
+      name = "kanagram-21.12.2.tar.xz";
     };
   };
   kapman = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kapman-21.12.1.tar.xz";
-      sha256 = "064qiza0zjjm9skclfzksnfhmk21d6zn221jbx3zc9s11c0ba81l";
-      name = "kapman-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kapman-21.12.2.tar.xz";
+      sha256 = "0n1iz9jfgzpcpavb4ijfqp3hym7z53wzp5a5hiad8i6nws408grn";
+      name = "kapman-21.12.2.tar.xz";
     };
   };
   kapptemplate = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kapptemplate-21.12.1.tar.xz";
-      sha256 = "16d0iwymxssxhj90dyrxp4yl3w15xzs4hrs9ryxqxf1n733b5zjq";
-      name = "kapptemplate-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kapptemplate-21.12.2.tar.xz";
+      sha256 = "1sjyji533x9ph9l63zf0llsb0m5fzb1lka03h5blm7fdyw570bad";
+      name = "kapptemplate-21.12.2.tar.xz";
     };
   };
   kate = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kate-21.12.1.tar.xz";
-      sha256 = "04d00nihzg05yfp1aahfys5cimhnvdiz5mmmcqjjahcanpywqj3y";
-      name = "kate-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kate-21.12.2.tar.xz";
+      sha256 = "0r59rfyrbs50w9brl4rrq1wdfmrr3sz7plw2pqlc5xpzngrdlhs1";
+      name = "kate-21.12.2.tar.xz";
     };
   };
   katomic = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/katomic-21.12.1.tar.xz";
-      sha256 = "0yblg7j3y67wkzjbsyr4q3h88h9jbv4ndkkwcg45g2f1vvkc9ny1";
-      name = "katomic-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/katomic-21.12.2.tar.xz";
+      sha256 = "123ls2p6az9bpy741xg85azs0p1qbssgcg4fh8cqazkz0kgzr0hf";
+      name = "katomic-21.12.2.tar.xz";
     };
   };
   kbackup = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kbackup-21.12.1.tar.xz";
-      sha256 = "1nxq1l8smrhgvay08xsr68nw2x6fkv2ms5pvqp6wws0zb7gy7df9";
-      name = "kbackup-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kbackup-21.12.2.tar.xz";
+      sha256 = "1yadxlqfz2a4lirxf2xmivggvdpbjiaw5zn7aw72jb3yjs7x6j03";
+      name = "kbackup-21.12.2.tar.xz";
     };
   };
   kblackbox = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kblackbox-21.12.1.tar.xz";
-      sha256 = "159y83ljw5m231n9xnjq41c0q1jk6h27xpb0h9rngdz98rkrh1xi";
-      name = "kblackbox-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kblackbox-21.12.2.tar.xz";
+      sha256 = "1y5l5l5p3s2gf69rih3mjdv42h9ydfk66v10ad5na3b4sqbi2qi7";
+      name = "kblackbox-21.12.2.tar.xz";
     };
   };
   kblocks = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kblocks-21.12.1.tar.xz";
-      sha256 = "0ac9yykql8rhq07has2dz7b93z9vj69qdk42r28nnpc117ncki5d";
-      name = "kblocks-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kblocks-21.12.2.tar.xz";
+      sha256 = "13anvyy3br7ybl74jcrnjmw5qjfyk4z6s7ncziw8l37ggg4k7n91";
+      name = "kblocks-21.12.2.tar.xz";
     };
   };
   kbounce = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kbounce-21.12.1.tar.xz";
-      sha256 = "1x2d8l8gxb2fj6sdwb9whl9360qmn895yzg3bc6q9zjbpn8rwq8m";
-      name = "kbounce-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kbounce-21.12.2.tar.xz";
+      sha256 = "07k5vmfkh9l4b4sb4an5qlnq0b9hmhh6dax0bjgia0ng9vxd011q";
+      name = "kbounce-21.12.2.tar.xz";
     };
   };
   kbreakout = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kbreakout-21.12.1.tar.xz";
-      sha256 = "0kcr39ylq3axzjh9r5zy7dhv0q3a8m7pimg1l5vjlpgffnhhlvk5";
-      name = "kbreakout-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kbreakout-21.12.2.tar.xz";
+      sha256 = "08rykfi82hgzg5l2bhs8nvh8si06nisy60653n6r7m8g327yyn1m";
+      name = "kbreakout-21.12.2.tar.xz";
     };
   };
   kbruch = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kbruch-21.12.1.tar.xz";
-      sha256 = "0b84a4k4ahi3xwc9h3qivbfi2is7vd0ng7rd1nk25135yfqwz5j0";
-      name = "kbruch-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kbruch-21.12.2.tar.xz";
+      sha256 = "0vvl2rk636zpg27hj2jly1awg4z3fm6mk75qrda3hl6gm8rddw1v";
+      name = "kbruch-21.12.2.tar.xz";
     };
   };
   kcachegrind = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcachegrind-21.12.1.tar.xz";
-      sha256 = "0ix589lsrv71akmnln71brl2878kgiybgsbjgch1kn1k1pz6jmij";
-      name = "kcachegrind-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcachegrind-21.12.2.tar.xz";
+      sha256 = "1fg7fn8a3bjbjr6bi298gqr4mr838v96bz9773pd7rnhffvvip8z";
+      name = "kcachegrind-21.12.2.tar.xz";
     };
   };
   kcalc = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcalc-21.12.1.tar.xz";
-      sha256 = "0p7lxja6hhsnjihc94s9j7f210ag7i50gslifjh9cfk2ry1nqpnn";
-      name = "kcalc-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcalc-21.12.2.tar.xz";
+      sha256 = "037xk57gjfbjpw1q4gm9k1xkc3x5xxjr4d8xmnrnc6ni090648q4";
+      name = "kcalc-21.12.2.tar.xz";
     };
   };
   kcalutils = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcalutils-21.12.1.tar.xz";
-      sha256 = "1ikwkgr2nki8vxvmv0vggm9x3900piq1wx6zps2zi6wqrs4d1hrm";
-      name = "kcalutils-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcalutils-21.12.2.tar.xz";
+      sha256 = "0i474by8pyv64b7i807kym2q4wkhnyyn21vn56dbgp1awpi198i8";
+      name = "kcalutils-21.12.2.tar.xz";
     };
   };
   kcharselect = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcharselect-21.12.1.tar.xz";
-      sha256 = "10vrkaisim24mdqa9vz0i7gkm0qgshjcnbdqkgprnkx5xnsp30dm";
-      name = "kcharselect-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcharselect-21.12.2.tar.xz";
+      sha256 = "1czkni7wrl2l5v0zpvxfwdaqd5i0x6knzbjhzh8shdg3h19sgqrm";
+      name = "kcharselect-21.12.2.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcolorchooser-21.12.1.tar.xz";
-      sha256 = "1cmyr94kxl6kmzx10w6ixi3q3czpc1wsspwsz5j5chwrwqzlrcx3";
-      name = "kcolorchooser-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcolorchooser-21.12.2.tar.xz";
+      sha256 = "12s2vfa3i7b5dh8c10xbqsy1xi9pq13vdj2xcpm5chkgw22595hv";
+      name = "kcolorchooser-21.12.2.tar.xz";
     };
   };
   kcron = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kcron-21.12.1.tar.xz";
-      sha256 = "095wwvm4b24d7nbx4mqlysiwpdjqs3f3qvv54adaj507z5b3wac7";
-      name = "kcron-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kcron-21.12.2.tar.xz";
+      sha256 = "0ddgl61vw4mj8sa6zg1m4s6qagwygdkvw9pjmfs8fsa1anhlillk";
+      name = "kcron-21.12.2.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kde-dev-scripts-21.12.1.tar.xz";
-      sha256 = "00gsvra8gvfv6mwrvvna9rskh264svclr8h7zjspwvch0qgq0pqa";
-      name = "kde-dev-scripts-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kde-dev-scripts-21.12.2.tar.xz";
+      sha256 = "1vdssqwyi25j3saz5cw8n40y2i6bhq5l0rxbarh8m3iwcvx4ki3c";
+      name = "kde-dev-scripts-21.12.2.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kde-dev-utils-21.12.1.tar.xz";
-      sha256 = "1pcxbyaz700jicahccpsy7kjrp30nmjf5cqqk7nyqaf07spbrd9i";
-      name = "kde-dev-utils-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kde-dev-utils-21.12.2.tar.xz";
+      sha256 = "0flzc0kl252imng2mpg9mp71k8jrxc3yy7dzqlfdnpjz36dwpaqf";
+      name = "kde-dev-utils-21.12.2.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdebugsettings-21.12.1.tar.xz";
-      sha256 = "12axjffxg5ap7yh9s573vyz4q7xi9nr4ggibvk8mxawwczmg9xyj";
-      name = "kdebugsettings-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdebugsettings-21.12.2.tar.xz";
+      sha256 = "0cimipq45c36nwk3alg738jl93zxja3xi77zjqk0k28ffn6qn7c2";
+      name = "kdebugsettings-21.12.2.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdeconnect-kde-21.12.1.tar.xz";
-      sha256 = "1mw1nihy9b47msw23cr1chyrgwcm3cbf5sv90nmd9cc1ypnblw2c";
-      name = "kdeconnect-kde-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdeconnect-kde-21.12.2.tar.xz";
+      sha256 = "0crw0navhdsix0rpsya4vhffj35vlascpcflrs04vyws3v8xr026";
+      name = "kdeconnect-kde-21.12.2.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdeedu-data-21.12.1.tar.xz";
-      sha256 = "1kbxhrlc64aqr0shik9p22fm6ldvy5jpk50x2nh5zkw4jylc8zh3";
-      name = "kdeedu-data-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdeedu-data-21.12.2.tar.xz";
+      sha256 = "1cpbi5gkbq7xrv276vm0jlcjc5y9x1kw8l8x0z7syy06s4s3pvg9";
+      name = "kdeedu-data-21.12.2.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdegraphics-mobipocket-21.12.1.tar.xz";
-      sha256 = "0m8clh313186nc3pmlii0020gv7612236nwww8sgqc3fsd4va91x";
-      name = "kdegraphics-mobipocket-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdegraphics-mobipocket-21.12.2.tar.xz";
+      sha256 = "0zbiz47mqa176gcina8v03fw2qqrc5v1l8mg2fcpnl5dxc9d56c4";
+      name = "kdegraphics-mobipocket-21.12.2.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdegraphics-thumbnailers-21.12.1.tar.xz";
-      sha256 = "0y2619lcins553pmvigmgajfkrrvy2kqc2sbvacpl4r74qsdhax6";
-      name = "kdegraphics-thumbnailers-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdegraphics-thumbnailers-21.12.2.tar.xz";
+      sha256 = "09adinkdfbn5hfic92zbdhq9ldxpnbgf9pybsp4ibpw2097l2k5f";
+      name = "kdegraphics-thumbnailers-21.12.2.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdenetwork-filesharing-21.12.1.tar.xz";
-      sha256 = "04z720q8nmylrh2rx1q8scaklcf7xaxiqvghkn0pfr0dd3vci3cy";
-      name = "kdenetwork-filesharing-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdenetwork-filesharing-21.12.2.tar.xz";
+      sha256 = "0q7gndwvki3r9vhkxmwr8xzc54cjpk9nzhk2665wsk1msfp3xqw6";
+      name = "kdenetwork-filesharing-21.12.2.tar.xz";
     };
   };
   kdenlive = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdenlive-21.12.1.tar.xz";
-      sha256 = "1r3gxyx45531v79644q17lbl2ribiij4m5v39jfpys6vn8c6gmfw";
-      name = "kdenlive-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdenlive-21.12.2.tar.xz";
+      sha256 = "1h668q91pcq3km7pq75krgq06x8gglmp8al52b0imyc9g9wy28z6";
+      name = "kdenlive-21.12.2.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdepim-addons-21.12.1.tar.xz";
-      sha256 = "1ksf05wagka9hr6p35j9r6r9hdmfx83mkv1v5blxbk9zq9mx3lhq";
-      name = "kdepim-addons-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdepim-addons-21.12.2.tar.xz";
+      sha256 = "00j67rvkvm1sri6ij5ziqjh340cmpsyfwwmw8hr1dsi3vlva4gk1";
+      name = "kdepim-addons-21.12.2.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdepim-runtime-21.12.1.tar.xz";
-      sha256 = "1pv9z0l3aafpcxgs98lc2dr4il8sp9v3p8xpqdi0ags478gi3x1x";
-      name = "kdepim-runtime-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdepim-runtime-21.12.2.tar.xz";
+      sha256 = "0y1hgab16h9ypqh9isabbb4km2907vzdydfkd1m5b63vfbambz0j";
+      name = "kdepim-runtime-21.12.2.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdesdk-kioslaves-21.12.1.tar.xz";
-      sha256 = "0xxz9f9m5pxfmxnwqz1ygjz4m7gsrmh6jj54ha0k70jj4r43vq8i";
-      name = "kdesdk-kioslaves-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdesdk-kioslaves-21.12.2.tar.xz";
+      sha256 = "0vz6dk5an0bhnyglyqdgf3lqxdlc61k4vsbh8a4fky1zpvpwya84";
+      name = "kdesdk-kioslaves-21.12.2.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdesdk-thumbnailers-21.12.1.tar.xz";
-      sha256 = "0snncw0fgh5z1y6dkaaj45sf1r404123vxp4p16i06c8imbg50w5";
-      name = "kdesdk-thumbnailers-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdesdk-thumbnailers-21.12.2.tar.xz";
+      sha256 = "1w90zjnwnqh1a47kgmijr8xp6z096f6ij250qfcl3bwvhxqmsrb0";
+      name = "kdesdk-thumbnailers-21.12.2.tar.xz";
     };
   };
   kdev-php = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdev-php-21.12.1.tar.xz";
-      sha256 = "1p1aq10613jifspnzmc92sq7bsyxc3z21dffrmz2a18iqharmgzv";
-      name = "kdev-php-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdev-php-21.12.2.tar.xz";
+      sha256 = "0ghxfllh8pkyrvsaz4iwc9bm98mkq6z3wr558w4wjykgjp69r08j";
+      name = "kdev-php-21.12.2.tar.xz";
     };
   };
   kdev-python = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdev-python-21.12.1.tar.xz";
-      sha256 = "1d97bz06vncs15dclhclwqwc6da63c38qkla2z7yhf0iv3byb8kq";
-      name = "kdev-python-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdev-python-21.12.2.tar.xz";
+      sha256 = "05jj7q7agkgpbrxzwh0n2ipc854cgm8skjyjkqmxp2kdf3fdm8lj";
+      name = "kdev-python-21.12.2.tar.xz";
     };
   };
   kdevelop = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdevelop-21.12.1.tar.xz";
-      sha256 = "1a2j79hw16ia1j6s6gs23d7jzkpx14hjgygsggxnjb0pxamyvxw7";
-      name = "kdevelop-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdevelop-21.12.2.tar.xz";
+      sha256 = "13kgkxvbjcb60ckapqrcr4m0y5kyag948xx6gwrvzhrhn46ynfgz";
+      name = "kdevelop-21.12.2.tar.xz";
     };
   };
   kdf = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdf-21.12.1.tar.xz";
-      sha256 = "191gpfpd4x86vcx8g6yhz90xshfgsiw1374f06fn02mbd6fpswni";
-      name = "kdf-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdf-21.12.2.tar.xz";
+      sha256 = "1fs8bab6q7imfpqqgasvr98k57nm68ignfch2i76rdcywhx3q268";
+      name = "kdf-21.12.2.tar.xz";
     };
   };
   kdialog = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdialog-21.12.1.tar.xz";
-      sha256 = "171aghc4fqkc5ac851wcpb6c49k53n9ba0g0ka6pr3k00jh4vsws";
-      name = "kdialog-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdialog-21.12.2.tar.xz";
+      sha256 = "1k6zlh1gbpj0y40h1i8pan28d8chqjsnhd6pvsvr95b91d0pj2xn";
+      name = "kdialog-21.12.2.tar.xz";
     };
   };
   kdiamond = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kdiamond-21.12.1.tar.xz";
-      sha256 = "1hx9c7a5kqaqpk89dfb2m8bqzvpar1ra7pfavxsqbxqyy9rvhiv1";
-      name = "kdiamond-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kdiamond-21.12.2.tar.xz";
+      sha256 = "08b2a13bmxw3h6rhip619jvzgjrjgpz2v83i2azbqccfynisjnyh";
+      name = "kdiamond-21.12.2.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/keditbookmarks-21.12.1.tar.xz";
-      sha256 = "1xbl9bp1blvhjhdsdc2w4smxz6pysh09ad9rjprm7mfx9sfwzlm1";
-      name = "keditbookmarks-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/keditbookmarks-21.12.2.tar.xz";
+      sha256 = "1fxm0mm3sqp2frk2fcs2jw86wjxb2j5z9vyb34x7g80k5j17j57m";
+      name = "keditbookmarks-21.12.2.tar.xz";
     };
   };
   kfind = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kfind-21.12.1.tar.xz";
-      sha256 = "1366l63q476ch1f3mvfk20m3j90ili4l3r7dzxmsnivl0im1s1qh";
-      name = "kfind-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kfind-21.12.2.tar.xz";
+      sha256 = "0kx6p4hyyalx5i8g4aq81aj30c9ac0380xvia9130g95pgkzd96c";
+      name = "kfind-21.12.2.tar.xz";
     };
   };
   kfloppy = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kfloppy-21.12.1.tar.xz";
-      sha256 = "0vxzhzk9jmrlxqn6pnnb5mvml6jr9q5dyh5dr8568i1bc08dcfwp";
-      name = "kfloppy-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kfloppy-21.12.2.tar.xz";
+      sha256 = "10245c87379576n11xcjkll3rkvzv815qsavr4alsj1jr8w6zyg8";
+      name = "kfloppy-21.12.2.tar.xz";
     };
   };
   kfourinline = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kfourinline-21.12.1.tar.xz";
-      sha256 = "17lq16z97kzq4fnwarfz5d5m5n1jb2vzn7aizmw3p4ddqmg214sb";
-      name = "kfourinline-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kfourinline-21.12.2.tar.xz";
+      sha256 = "1kz7ff31h8lvz7snqmjs6cma9i3py7dyd91i6ik2pwiar80sin1x";
+      name = "kfourinline-21.12.2.tar.xz";
     };
   };
   kgeography = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kgeography-21.12.1.tar.xz";
-      sha256 = "1frx4d3zga8pk56hpb7r13kd466iy7ihdda4gk98j59n4blvrqmx";
-      name = "kgeography-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kgeography-21.12.2.tar.xz";
+      sha256 = "09h5zp8pxzr47s7j50l6xfssvk9zk56cqgnsjx75yh1n077z1d0j";
+      name = "kgeography-21.12.2.tar.xz";
     };
   };
   kget = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kget-21.12.1.tar.xz";
-      sha256 = "1jbnyx0bnvvgbglwnhv0y3lh12id7d80aixrxp6w13pcm3k21s3v";
-      name = "kget-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kget-21.12.2.tar.xz";
+      sha256 = "0jmy2yxzrgq592dq075k7gp7ynk42i899jsbw0gbn79x69cxlkmv";
+      name = "kget-21.12.2.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kgoldrunner-21.12.1.tar.xz";
-      sha256 = "01may4xghilyk6vkv8g2n9bfvb2binyfv7qpm0fv0b4aqbv90ql8";
-      name = "kgoldrunner-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kgoldrunner-21.12.2.tar.xz";
+      sha256 = "0by6cq31jsls3qaqn4agrdhvd9jqg84plm6nbgh3rc85pnj5h22p";
+      name = "kgoldrunner-21.12.2.tar.xz";
     };
   };
   kgpg = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kgpg-21.12.1.tar.xz";
-      sha256 = "0qxd1pfm4fx37xc6v06j0k5ykqxs2p2x4r4ip4l95yhvgxixhy0i";
-      name = "kgpg-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kgpg-21.12.2.tar.xz";
+      sha256 = "1f193fyn1azwhm7b8gd5ffyb11acg1269mh1d2ly60ax83qjs48c";
+      name = "kgpg-21.12.2.tar.xz";
     };
   };
   khangman = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/khangman-21.12.1.tar.xz";
-      sha256 = "11acf9i65jqi1cmqbc13wfpdnnwws7srzzdq35np9hpghiw2rj1l";
-      name = "khangman-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/khangman-21.12.2.tar.xz";
+      sha256 = "0xih54w33vigvm3x2xp5lf29k4aga4yil0qv263965nxn9djnlaw";
+      name = "khangman-21.12.2.tar.xz";
     };
   };
   khelpcenter = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/khelpcenter-21.12.1.tar.xz";
-      sha256 = "0nc555ap4nk7xijxz46cx7v0li3g8k5hxymlyqlw7lcapsk7l98l";
-      name = "khelpcenter-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/khelpcenter-21.12.2.tar.xz";
+      sha256 = "09ddkc7kiayx852mpgdmv04l19vrrc0yrf30hnyzkci58kbavvcq";
+      name = "khelpcenter-21.12.2.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kidentitymanagement-21.12.1.tar.xz";
-      sha256 = "1r3aac6k1dd85gc1qbzr1k1l7bj9kgmf0mmns2ba1g6zshnicdww";
-      name = "kidentitymanagement-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kidentitymanagement-21.12.2.tar.xz";
+      sha256 = "00fwjax3kfvr8jsy04hp1jyihvskvprbg83z2avhcy6lvr7g25kk";
+      name = "kidentitymanagement-21.12.2.tar.xz";
     };
   };
   kig = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kig-21.12.1.tar.xz";
-      sha256 = "0245xlplgfc0nbxn5ppjg16gbcbdlkzyc600bngwjjhcw0psqqls";
-      name = "kig-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kig-21.12.2.tar.xz";
+      sha256 = "100ds4728lfnb6r6c52rdzk2n4rcpc5jiv35q5qd7d6cszmxvhvx";
+      name = "kig-21.12.2.tar.xz";
     };
   };
   kigo = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kigo-21.12.1.tar.xz";
-      sha256 = "0a9fwbnr1z56lcmv2cgkv1l1spfr5kc4flf9xi1223xjzi31mkmx";
-      name = "kigo-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kigo-21.12.2.tar.xz";
+      sha256 = "0g1sl7bw9aln7fm2786sgh0m44da6vfxc9g0rizw31ff8papnyb8";
+      name = "kigo-21.12.2.tar.xz";
     };
   };
   killbots = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/killbots-21.12.1.tar.xz";
-      sha256 = "0szy101shr2zir1alc21ylv746w2pgczh2cl9hg9g9gg9fkj4f06";
-      name = "killbots-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/killbots-21.12.2.tar.xz";
+      sha256 = "1qryy2g2i6iqc6rsw8jz4c14x67glpm3zvcx2dghyll6q9hns43z";
+      name = "killbots-21.12.2.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kimagemapeditor-21.12.1.tar.xz";
-      sha256 = "1rgd3qsfsf1kdlidhp43kvkqjlfnjr7vdzl8wdgsl4z01xb3yy59";
-      name = "kimagemapeditor-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kimagemapeditor-21.12.2.tar.xz";
+      sha256 = "11j55jvfxdpam3gkfv7355av9d6mz8z6djhplhmfd56llkmvw4n2";
+      name = "kimagemapeditor-21.12.2.tar.xz";
     };
   };
   kimap = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kimap-21.12.1.tar.xz";
-      sha256 = "1wkygpxdz6407pdllcdw36p83p6jk0j8jf3jzqak9ksql5qdg04p";
-      name = "kimap-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kimap-21.12.2.tar.xz";
+      sha256 = "0sdas8knk6wa8hhgc3w62famdpq6pcxfhl4vmpw0r3aqskaci4q3";
+      name = "kimap-21.12.2.tar.xz";
     };
   };
   kio-extras = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kio-extras-21.12.1.tar.xz";
-      sha256 = "0pshm9pjssj5drzg2q5351442h9izbmp41d3fxjx431cc1jm8zfc";
-      name = "kio-extras-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kio-extras-21.12.2.tar.xz";
+      sha256 = "0133cww4k2svn7cvw0fbdcwwv0zg09d27gz59gkpfswjmpsxdqj4";
+      name = "kio-extras-21.12.2.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kio-gdrive-21.12.1.tar.xz";
-      sha256 = "018lr2mp1km5ki650bmmkjm94a6i0h5a898vhwxgl9a7yfpr52j6";
-      name = "kio-gdrive-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kio-gdrive-21.12.2.tar.xz";
+      sha256 = "1n3khrx5fczffwzg4bzxjhzy2kxf72dmb7fqs9hqfn1qkaahfv49";
+      name = "kio-gdrive-21.12.2.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kipi-plugins-21.12.1.tar.xz";
-      sha256 = "1dadrg8dd1plawsq3h3vn4g7a640qh6pb1wp3l8vcsmiqkabrfkh";
-      name = "kipi-plugins-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kipi-plugins-21.12.2.tar.xz";
+      sha256 = "11f3qmgqxdlzvv2zldjawn7a3kdigj5pb535rc9v9a8fp8mjvk88";
+      name = "kipi-plugins-21.12.2.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kirigami-gallery-21.12.1.tar.xz";
-      sha256 = "0s5pj18sc2hm2nggwbqp4x6f56ca1dqx1nbcspwfq287i0csl82k";
-      name = "kirigami-gallery-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kirigami-gallery-21.12.2.tar.xz";
+      sha256 = "0rg9lg4iqxycfbhs62qs4ms4qadz1ii1dcv3ykkgn3w2brx77wad";
+      name = "kirigami-gallery-21.12.2.tar.xz";
     };
   };
   kiriki = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kiriki-21.12.1.tar.xz";
-      sha256 = "09r40sq0sa6w4pwc6fl13dfxlc0nns7j5d4fdnv8i2wiqx6jc1cg";
-      name = "kiriki-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kiriki-21.12.2.tar.xz";
+      sha256 = "1blj3vl87jdrr8qv2cyng20nr4d54gbk7w72z9rl02l62c9gkw5j";
+      name = "kiriki-21.12.2.tar.xz";
     };
   };
   kiten = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kiten-21.12.1.tar.xz";
-      sha256 = "091l4r97ps9xmca499y9c95qihdcf2jcrfgahgzp4mkcps09w5ac";
-      name = "kiten-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kiten-21.12.2.tar.xz";
+      sha256 = "18kxqrhfgch32583ra4422h7csd5ajijf9989bxz9hwi9mn3r2vl";
+      name = "kiten-21.12.2.tar.xz";
     };
   };
   kitinerary = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kitinerary-21.12.1.tar.xz";
-      sha256 = "0dirkp2qd2ihyjj0nwqpakwvh3par0m3z5q2z7qjz1527k0k00ww";
-      name = "kitinerary-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kitinerary-21.12.2.tar.xz";
+      sha256 = "0g7z6408nhrv54h6xxd2rd9wj2hmwzc3lg5risyqbg2zii9j0sp2";
+      name = "kitinerary-21.12.2.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kjumpingcube-21.12.1.tar.xz";
-      sha256 = "0bnvvhnqcx767j6kmi19mgvab8srrzbw8y6w1qbqj85lq91wq1dr";
-      name = "kjumpingcube-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kjumpingcube-21.12.2.tar.xz";
+      sha256 = "1abv3yi716n88b19rmimhw0vnnwyw28ab6fbcy9g1lgpbi69g5ax";
+      name = "kjumpingcube-21.12.2.tar.xz";
     };
   };
   kldap = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kldap-21.12.1.tar.xz";
-      sha256 = "12hcls5g80s0y0nlnp0jcd7q0bxx9wq39v44x5a011rivkab8qbx";
-      name = "kldap-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kldap-21.12.2.tar.xz";
+      sha256 = "1xda42f1q5ih3hdhmcbdz0fx2nchirlwips3gq0jb6lfzi5dbqpl";
+      name = "kldap-21.12.2.tar.xz";
     };
   };
   kleopatra = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kleopatra-21.12.1.tar.xz";
-      sha256 = "0hk7af4gsy63vjbn16lp7b6qr15cnygxjic6p98bd5zajnx77899";
-      name = "kleopatra-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kleopatra-21.12.2.tar.xz";
+      sha256 = "1b2nq823gq1v20dnh3hm298fva7cmbn9hh0kmbq22kh98kv8chhh";
+      name = "kleopatra-21.12.2.tar.xz";
     };
   };
   klettres = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/klettres-21.12.1.tar.xz";
-      sha256 = "04mwl6n0361vgyb6p9xp5m3223h7f09w6sr90998smws98bmgpd4";
-      name = "klettres-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/klettres-21.12.2.tar.xz";
+      sha256 = "1wi1byr36x7z9scsy1gffna36m8x9vyfcqzndvx6042i2y0smhwz";
+      name = "klettres-21.12.2.tar.xz";
     };
   };
   klickety = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/klickety-21.12.1.tar.xz";
-      sha256 = "1mzvgjdxm2y34w37s548cg7ri2yjqn49rmqyaafw7bnv9qfyky3v";
-      name = "klickety-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/klickety-21.12.2.tar.xz";
+      sha256 = "19rn9p7cbxhn471b65nhwhpnfnhykjwj6n5lrsd431391dyhvshc";
+      name = "klickety-21.12.2.tar.xz";
     };
   };
   klines = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/klines-21.12.1.tar.xz";
-      sha256 = "18lbnfsx05vnmzjw9iqdi5kck9zrkrdknk6bysa5pc16cgmai9z8";
-      name = "klines-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/klines-21.12.2.tar.xz";
+      sha256 = "1r004rsy98lxh5vd3r4bc0l4d7ymija13barg9xglj53xzbyij3k";
+      name = "klines-21.12.2.tar.xz";
     };
   };
   kmag = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmag-21.12.1.tar.xz";
-      sha256 = "1v5zmy3q3ipi9nd8yrrv84x1mk4mpb770r833pwwn6bwdfr8xq8h";
-      name = "kmag-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmag-21.12.2.tar.xz";
+      sha256 = "03kzahsr80wnbx6ky112ka3zm01pnc5h85l28a4186617swx344l";
+      name = "kmag-21.12.2.tar.xz";
     };
   };
   kmahjongg = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmahjongg-21.12.1.tar.xz";
-      sha256 = "02nfgqlhzph1svf54ph3avhx7wvplqgzqhazvrrsz7ikj5qcq9pl";
-      name = "kmahjongg-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmahjongg-21.12.2.tar.xz";
+      sha256 = "1w8v6fchrkvsbyvnx8vvs801cvg52pr78ihvdjv6c0vpd0q7z9rz";
+      name = "kmahjongg-21.12.2.tar.xz";
     };
   };
   kmail = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmail-21.12.1.tar.xz";
-      sha256 = "17wyrdl6lxcds4whh2nlacq0m6mmw13z6a79j8047svmnpz97nrx";
-      name = "kmail-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmail-21.12.2.tar.xz";
+      sha256 = "003bnp00figa09qcp2hl45sivdk3d0j3amxdidyrn47q9vy40554";
+      name = "kmail-21.12.2.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmail-account-wizard-21.12.1.tar.xz";
-      sha256 = "1i2jd50c5scd6vxfxc975lvyqxifmjz4a1cz0hk67smcdh8nbqkn";
-      name = "kmail-account-wizard-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmail-account-wizard-21.12.2.tar.xz";
+      sha256 = "1nmg8qns3iglcc4l4g5nffnji1vgg43a9fa9rz1hacvlkarm98m4";
+      name = "kmail-account-wizard-21.12.2.tar.xz";
     };
   };
   kmailtransport = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmailtransport-21.12.1.tar.xz";
-      sha256 = "0mng5q0xvlbj9cx5myf65i0056s2l5mhsqycp13x6b2kyvna5bd2";
-      name = "kmailtransport-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmailtransport-21.12.2.tar.xz";
+      sha256 = "0rs6qihzy8q2n204zkhakgnjxwqy9pz9i0kv1j3amw2xv3f51rvw";
+      name = "kmailtransport-21.12.2.tar.xz";
     };
   };
   kmbox = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmbox-21.12.1.tar.xz";
-      sha256 = "1d5wwb1m0zic8lhnn6aiyhwihzh527xpjswdriq4ngkil95y994a";
-      name = "kmbox-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmbox-21.12.2.tar.xz";
+      sha256 = "1mfwaw4d480kbb60wb0kvl5z35ly2hn6h73kx9wdb5y7mz05rvn1";
+      name = "kmbox-21.12.2.tar.xz";
     };
   };
   kmime = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmime-21.12.1.tar.xz";
-      sha256 = "0821zvgsfmv5ijjz1ih9irik46j1yaqwzccmfggdvd7nc5nc1x61";
-      name = "kmime-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmime-21.12.2.tar.xz";
+      sha256 = "0qxb0gf4pqfa0540fsbnf24nh9qwiamwl65q7vaanb80b211qp2g";
+      name = "kmime-21.12.2.tar.xz";
     };
   };
   kmines = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmines-21.12.1.tar.xz";
-      sha256 = "1pp1ynj7i4859r4rab5xph4glrlihn9ig465jlqh5jz0cg8w58zc";
-      name = "kmines-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmines-21.12.2.tar.xz";
+      sha256 = "0dsqlqmbaggab38zzjyhnx318sn2mw6y51k52c7blm2l53a8zp3j";
+      name = "kmines-21.12.2.tar.xz";
     };
   };
   kmix = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmix-21.12.1.tar.xz";
-      sha256 = "1c9ing19g27d7qqm5m171lff0a35vcn3yn4spwx1bm7y9md44964";
-      name = "kmix-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmix-21.12.2.tar.xz";
+      sha256 = "0fyjzzv6x9xf0g222jjsvrywnm3blhbzm2zwhxagrfkjvjpb2cvk";
+      name = "kmix-21.12.2.tar.xz";
     };
   };
   kmousetool = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmousetool-21.12.1.tar.xz";
-      sha256 = "0ivk9rdwy7hgi4j4bxm5padlw6w0ldij29yjcpc0501ld9jjkyzx";
-      name = "kmousetool-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmousetool-21.12.2.tar.xz";
+      sha256 = "1hh7sql04hpwvb8hbi7snvh2d6922a2yraah9hd1jiwniv3cv175";
+      name = "kmousetool-21.12.2.tar.xz";
     };
   };
   kmouth = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmouth-21.12.1.tar.xz";
-      sha256 = "1mkdgidyvfci9hilfnilvc3ymzyzknib5bbqf4bn87xjnhkv68sy";
-      name = "kmouth-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmouth-21.12.2.tar.xz";
+      sha256 = "0vxssxchh23bl237qw9pznbrkwyqx1bhbnp2fq9baw1bn88d18i5";
+      name = "kmouth-21.12.2.tar.xz";
     };
   };
   kmplot = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kmplot-21.12.1.tar.xz";
-      sha256 = "1dn3sxqi8k3p28q4076bjsxb0qlmrvw8jk045axi2q7yc1f343r5";
-      name = "kmplot-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kmplot-21.12.2.tar.xz";
+      sha256 = "025n51s7i5nr63knsd78pg48wfs4cldhplr68jmwv2k8pb5w9kxs";
+      name = "kmplot-21.12.2.tar.xz";
     };
   };
   knavalbattle = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/knavalbattle-21.12.1.tar.xz";
-      sha256 = "1a5gpy601842kd9ybwbsxajmj09pmmna6k6wq6crbhzca0i4hgby";
-      name = "knavalbattle-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/knavalbattle-21.12.2.tar.xz";
+      sha256 = "1z1qqr5jjinm49p7rhr0pzf8ir2nvdq157zqxnnr6i11xqk2mnkj";
+      name = "knavalbattle-21.12.2.tar.xz";
     };
   };
   knetwalk = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/knetwalk-21.12.1.tar.xz";
-      sha256 = "1ifgc89sfjd98g34vg2aqwhmpb63w75kh9yi7dkb9vlv8c90v46h";
-      name = "knetwalk-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/knetwalk-21.12.2.tar.xz";
+      sha256 = "1gnir7h1iam51frdajp4h6xw4biz545nljdfcck17jiw6ad9py4j";
+      name = "knetwalk-21.12.2.tar.xz";
     };
   };
   knights = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/knights-21.12.1.tar.xz";
-      sha256 = "1nfb096859r47c1n7bifsc23qfqx7xvl9wdhp8lgyc7hv85mz10j";
-      name = "knights-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/knights-21.12.2.tar.xz";
+      sha256 = "0k9hqgz3zw7vhrgbwnmy0v3j9kflz6wx8wavckg1i2l4qadprc1y";
+      name = "knights-21.12.2.tar.xz";
     };
   };
   knotes = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/knotes-21.12.1.tar.xz";
-      sha256 = "15yvddywsfybdyqhv90hs2c51vn9vcvdp79wfcz197hn98pswidw";
-      name = "knotes-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/knotes-21.12.2.tar.xz";
+      sha256 = "0f8ra6nkgndgkfnw194y5976kkrm7qdj1w7l27znwalzaydnxvjg";
+      name = "knotes-21.12.2.tar.xz";
     };
   };
   kolf = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kolf-21.12.1.tar.xz";
-      sha256 = "073kzsr561fs2kf98chbkhzp84c9fpgr9wja5bq3d9xm937bad69";
-      name = "kolf-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kolf-21.12.2.tar.xz";
+      sha256 = "0as18rc45daak3xsmwn6k789yni46nsdkv83bfmbj3jcjhzv9x5k";
+      name = "kolf-21.12.2.tar.xz";
     };
   };
   kollision = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kollision-21.12.1.tar.xz";
-      sha256 = "11z65wcxqz7mczy4h6yyfafd1d8cl4cvh2hv3i3vwnvks21853cy";
-      name = "kollision-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kollision-21.12.2.tar.xz";
+      sha256 = "1ycim9gjn9p6w6yyzsipqn7zpvi946s287mp4br35zavsf25gzn0";
+      name = "kollision-21.12.2.tar.xz";
     };
   };
   kolourpaint = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kolourpaint-21.12.1.tar.xz";
-      sha256 = "0k3whydhkgwjk3rs9jjcxphdb6p1yc1crjb5sn3izhr2xmnvinsr";
-      name = "kolourpaint-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kolourpaint-21.12.2.tar.xz";
+      sha256 = "0z53hp31sq4ksarvpzqmx9f3gac8ygrcj0ncppgbwwjkq63wr6v1";
+      name = "kolourpaint-21.12.2.tar.xz";
     };
   };
   kompare = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kompare-21.12.1.tar.xz";
-      sha256 = "0zd7hnsvx4mnnva6lvffmlgawnvjqzyz06hy466wlwckn08hrap1";
-      name = "kompare-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kompare-21.12.2.tar.xz";
+      sha256 = "0ps6ng77kzcqf6b2sh8xmqh5d4jwkmj3qnbyxh4v4xxjbwy0mrwm";
+      name = "kompare-21.12.2.tar.xz";
     };
   };
   konqueror = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/konqueror-21.12.1.tar.xz";
-      sha256 = "1v0f1snxc3i7pabn53dyzw7zpc2hjqj64xdqyfz0fy79myfrpx39";
-      name = "konqueror-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/konqueror-21.12.2.tar.xz";
+      sha256 = "0ia8qqas9x261ixa6jzih273ypqhdv5hijk042bcdmqd1z1s4n55";
+      name = "konqueror-21.12.2.tar.xz";
     };
   };
   konquest = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/konquest-21.12.1.tar.xz";
-      sha256 = "0515wkdpw4cxxsddw4a7n5hl7n2qw487qalpzjrsmm5vfn0sjzay";
-      name = "konquest-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/konquest-21.12.2.tar.xz";
+      sha256 = "1arxp4x8pcmv8yqg1xy5b23avh5a7x660vvh6kaviimysad5wmc5";
+      name = "konquest-21.12.2.tar.xz";
     };
   };
   konsole = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/konsole-21.12.1.tar.xz";
-      sha256 = "0pasxvvjhgg2cl3nfsd6wrpd40jw3rjfcgzgzsr5npflkpqnhszl";
-      name = "konsole-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/konsole-21.12.2.tar.xz";
+      sha256 = "00gyzhcacd3467sv5ijihqva7pnvcy1chywfpy8qh2hcdkkvyfxa";
+      name = "konsole-21.12.2.tar.xz";
     };
   };
   kontact = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kontact-21.12.1.tar.xz";
-      sha256 = "0dhnrw87z80xf801mq1cm2slbqrhsfnkd0xfbfaan3vc1h5gsw0x";
-      name = "kontact-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kontact-21.12.2.tar.xz";
+      sha256 = "16ld08sx5lvrm9r0ync7r8bpd540gxsssvhxj5p43chq6b9hr5lm";
+      name = "kontact-21.12.2.tar.xz";
     };
   };
   kontactinterface = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kontactinterface-21.12.1.tar.xz";
-      sha256 = "04zp5kz8l3dbxzdxaw3s11hqn3lg01n6saijp1l2sivkgf80wpna";
-      name = "kontactinterface-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kontactinterface-21.12.2.tar.xz";
+      sha256 = "1qvjm27v797hcdqbr6jwdkwn3vpsy3f1i92slrwks03zj498ydlj";
+      name = "kontactinterface-21.12.2.tar.xz";
     };
   };
   kontrast = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kontrast-21.12.1.tar.xz";
-      sha256 = "16gry5mq7qkwdhwqrhd1hwf6q8v4j76di37kyphxzhsf6csx5zsz";
-      name = "kontrast-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kontrast-21.12.2.tar.xz";
+      sha256 = "0mk2i2x1yz0ykbnqvdbdpi9kplyzjxlwhhsvl4rbq0726g3q6pas";
+      name = "kontrast-21.12.2.tar.xz";
     };
   };
   konversation = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/konversation-21.12.1.tar.xz";
-      sha256 = "0scc7xy4clicd6y037fv5cvifankam415cdbn3z56l10bg4h1f1f";
-      name = "konversation-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/konversation-21.12.2.tar.xz";
+      sha256 = "0lpkah6z12c4f77z6r5z31q5np3xwyb3y6xnsv1iq1rdzj0daxch";
+      name = "konversation-21.12.2.tar.xz";
     };
   };
   kopeninghours = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kopeninghours-21.12.1.tar.xz";
-      sha256 = "1i1s6xafnna87qn9asnkvaqq22b33jwcdh3s8d8ymvzcd9nch9ck";
-      name = "kopeninghours-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kopeninghours-21.12.2.tar.xz";
+      sha256 = "1s4wcnk7p0vjqdhyf8131l3s6bn86gfkwl45zwpi7lpyacwgdf6k";
+      name = "kopeninghours-21.12.2.tar.xz";
     };
   };
   kopete = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kopete-21.12.1.tar.xz";
-      sha256 = "13bc63xaq65bpa3dxjxhg96dvd6kvzj3dis8270saj8cw9kjxhv7";
-      name = "kopete-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kopete-21.12.2.tar.xz";
+      sha256 = "1py45nk6bv5x2hnfzh5srq17lprkqrmpqr2h0fpmkmffx66njz5q";
+      name = "kopete-21.12.2.tar.xz";
     };
   };
   korganizer = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/korganizer-21.12.1.tar.xz";
-      sha256 = "0r61v3vis7accnd6irap9ifcld0cd49qfk5h7ajc7vywq1vwjg6d";
-      name = "korganizer-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/korganizer-21.12.2.tar.xz";
+      sha256 = "1kablp0x65jmdz5n3y19rgplcvvmq8vxz0ljw7lkrwr3pvvhyv3q";
+      name = "korganizer-21.12.2.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kosmindoormap-21.12.1.tar.xz";
-      sha256 = "0zrj0cigyy4hgq8lz1kbs7xyjz9b63c37h3r4avq0fpvfqgqzx8k";
-      name = "kosmindoormap-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kosmindoormap-21.12.2.tar.xz";
+      sha256 = "0max3mfwd5x8m3kqybnkrb4v93rdk1r007xw31l52j2rq2gh8pj2";
+      name = "kosmindoormap-21.12.2.tar.xz";
     };
   };
   kpat = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kpat-21.12.1.tar.xz";
-      sha256 = "14jx595y3r19g4szks5jkxgl307qicdvwqc594k3xwghn1xcajy2";
-      name = "kpat-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kpat-21.12.2.tar.xz";
+      sha256 = "0vra8n9xsba67as0ybmbjy235v3s7dmrwlf18avnb3ygxy0h8swf";
+      name = "kpat-21.12.2.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kpimtextedit-21.12.1.tar.xz";
-      sha256 = "1ljs4cs8ld9bv7xkw6jlbrhrl3f908pcj4z8g1i0rd1q9ygcwanr";
-      name = "kpimtextedit-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kpimtextedit-21.12.2.tar.xz";
+      sha256 = "06d42k433dvkfrnzfdx0b1qarrnmhnb4gyq7vgy6251ah8smild8";
+      name = "kpimtextedit-21.12.2.tar.xz";
     };
   };
   kpkpass = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kpkpass-21.12.1.tar.xz";
-      sha256 = "0ah5gc8d9j3x7y7l93ga63yqp9v77xwmnrx9xs45jlq07vzwcnbw";
-      name = "kpkpass-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kpkpass-21.12.2.tar.xz";
+      sha256 = "0p2l1z4blfq1iz3x9cnwwx2p9cs6bb4vw1csj29s09i6237ippzx";
+      name = "kpkpass-21.12.2.tar.xz";
     };
   };
   kpmcore = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kpmcore-21.12.1.tar.xz";
-      sha256 = "16kk135bdlbi897ly5spjmqvkx9ikps002lcij98n89k95c8qzkp";
-      name = "kpmcore-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kpmcore-21.12.2.tar.xz";
+      sha256 = "1iyirvf04br0r8vclcpx0qrlm8wgqm9ww6xds3h9qjyqj1w8ng41";
+      name = "kpmcore-21.12.2.tar.xz";
     };
   };
   kpublictransport = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kpublictransport-21.12.1.tar.xz";
-      sha256 = "1vjgzrli8h5h9kykj2lz4la3k4cm45bvvar3qky8p1x21d4snmzf";
-      name = "kpublictransport-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kpublictransport-21.12.2.tar.xz";
+      sha256 = "02ffpgki4mdyczxa5bqb9wmg2c6anwxnsmlfdn1k47ry7ny2k9sl";
+      name = "kpublictransport-21.12.2.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kqtquickcharts-21.12.1.tar.xz";
-      sha256 = "0dh14ajprxxk7w2bi8hiqs5a7mdf6fvhdzipz608ic9bjg845avs";
-      name = "kqtquickcharts-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kqtquickcharts-21.12.2.tar.xz";
+      sha256 = "1sjm1vaksvp73866w09xadd1d0lakh00fwiic498siws4dvhhpif";
+      name = "kqtquickcharts-21.12.2.tar.xz";
     };
   };
   krdc = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/krdc-21.12.1.tar.xz";
-      sha256 = "0azm1jwqlf2dz8kd8zi0iasy84kdy87p6r7896nsxlhqc4igcz2l";
-      name = "krdc-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/krdc-21.12.2.tar.xz";
+      sha256 = "005i3a7l9aq63nxsivj28kzjy2zdl759snwm56cgwq9rgc6sc003";
+      name = "krdc-21.12.2.tar.xz";
     };
   };
   kreversi = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kreversi-21.12.1.tar.xz";
-      sha256 = "1wdzf8zdhxy7azbainvq69wjc847ixd2lmqvnhfdrvgz66flrzsg";
-      name = "kreversi-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kreversi-21.12.2.tar.xz";
+      sha256 = "03b4c28297dzdzplmg818r27r9gpqj48rha9884h22fz9davgmhw";
+      name = "kreversi-21.12.2.tar.xz";
     };
   };
   krfb = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/krfb-21.12.1.tar.xz";
-      sha256 = "0l7g43scycr95b9rfm5rqidqz8f15mhadp1avgr6nr0r86h2pgvy";
-      name = "krfb-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/krfb-21.12.2.tar.xz";
+      sha256 = "1989q0mig516hz0lbq2m8p85x8ikpyrhj36cvq4c32sd2nasxkvc";
+      name = "krfb-21.12.2.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kross-interpreters-21.12.1.tar.xz";
-      sha256 = "08gdfrf2g9z74zlp3mnqsl0x47a173ibzfxy80kar1hzf0r87gkm";
-      name = "kross-interpreters-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kross-interpreters-21.12.2.tar.xz";
+      sha256 = "14j7z6lwl0j7zdz29c1kjyhw0my6qfgnyxibwn9z87paxl8nv6z0";
+      name = "kross-interpreters-21.12.2.tar.xz";
     };
   };
   kruler = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kruler-21.12.1.tar.xz";
-      sha256 = "09cypq0yrrm5075p1y9js26qcy582w9gx2xzif2sr8fi77fsxfd2";
-      name = "kruler-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kruler-21.12.2.tar.xz";
+      sha256 = "1w5dw3qda69d4ycbiaj18gfn6w28dj2lc37x2d86kx5skv8adxbw";
+      name = "kruler-21.12.2.tar.xz";
     };
   };
   kshisen = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kshisen-21.12.1.tar.xz";
-      sha256 = "0nh25l9prhq1lzh2dafj84pry726441m6iqhbcyswr5g0cbl16qf";
-      name = "kshisen-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kshisen-21.12.2.tar.xz";
+      sha256 = "0wjr9fnkmbylfq13zy3hifr4byj4y46f8cwh0w61ypgc0wjxnhhg";
+      name = "kshisen-21.12.2.tar.xz";
     };
   };
   ksirk = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksirk-21.12.1.tar.xz";
-      sha256 = "1qx0s2svvb3db9724pvm9cpqby5mqhyfl138q67qr9sr4bg10znm";
-      name = "ksirk-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksirk-21.12.2.tar.xz";
+      sha256 = "1lif8n8n2pj4vaf7zifqj7mjv5dbhki75wbwjd4q061wpr434vfj";
+      name = "ksirk-21.12.2.tar.xz";
     };
   };
   ksmtp = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksmtp-21.12.1.tar.xz";
-      sha256 = "128c6bfqpmaqaz95vlrhszavyp0dyk0bvakj2v5aliwgzzpp64lq";
-      name = "ksmtp-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksmtp-21.12.2.tar.xz";
+      sha256 = "0hg5g401map67kjcgrd1a07iwyss5jnryhpsajffwz19sra855jp";
+      name = "ksmtp-21.12.2.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksnakeduel-21.12.1.tar.xz";
-      sha256 = "08wb50ryrygggc0hhk8nsb8bqh8i4r0p90g8mq4698pnjzkwxmdl";
-      name = "ksnakeduel-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksnakeduel-21.12.2.tar.xz";
+      sha256 = "0rdbsyfd3bink5cb0k5l713jw4syhz82kchn95cbg5zgc2iclfw4";
+      name = "ksnakeduel-21.12.2.tar.xz";
     };
   };
   kspaceduel = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kspaceduel-21.12.1.tar.xz";
-      sha256 = "1qnqs0vn469syhxjw811s1r9nk803ilprfmhz64d9hzr2vjj75jc";
-      name = "kspaceduel-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kspaceduel-21.12.2.tar.xz";
+      sha256 = "1kmwn55a4555g5m21jcr88k3f9aj87yifgrab6sx6gcw5q51d7vz";
+      name = "kspaceduel-21.12.2.tar.xz";
     };
   };
   ksquares = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksquares-21.12.1.tar.xz";
-      sha256 = "011xgs4fjf05sa268jx1026xxfkhn5gv3nzzcdp5b7gjz3ml8imv";
-      name = "ksquares-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksquares-21.12.2.tar.xz";
+      sha256 = "12k09lasxyaxq4bp4fhczj8bpi8l6h1gn4nj6ka3zbc4mxxz34yc";
+      name = "ksquares-21.12.2.tar.xz";
     };
   };
   ksudoku = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksudoku-21.12.1.tar.xz";
-      sha256 = "05annym6898p2db209zdvs8y1an5mdj4750166wbki2kwblbmy2s";
-      name = "ksudoku-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksudoku-21.12.2.tar.xz";
+      sha256 = "1din2i3d9lhca5kw06ivixgk2prh1kfy8ikm0byl8qaqj4v89lji";
+      name = "ksudoku-21.12.2.tar.xz";
     };
   };
   ksystemlog = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ksystemlog-21.12.1.tar.xz";
-      sha256 = "1rq99fy5c3asvrldwvbg2qblicij3jswbj3vddbqs1zfdcxfy55l";
-      name = "ksystemlog-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ksystemlog-21.12.2.tar.xz";
+      sha256 = "0cvx13859bm4kfz75iia3chzi5pbbv70lkmspvjpa6cpsn05zy53";
+      name = "ksystemlog-21.12.2.tar.xz";
     };
   };
   kteatime = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kteatime-21.12.1.tar.xz";
-      sha256 = "13apl34vz40gh8h3p7l8a3hmlc19gil5kkfayg5lnzbikmzvc82y";
-      name = "kteatime-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kteatime-21.12.2.tar.xz";
+      sha256 = "1m7ni3w82lqykgs5qfi0a43p9973244k8lr6rk30x7w551rc7yyw";
+      name = "kteatime-21.12.2.tar.xz";
     };
   };
   ktimer = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktimer-21.12.1.tar.xz";
-      sha256 = "0rmji8z5skj73rnibicy4awa12iylhy1j63c9rf31l3sqvc6dbdm";
-      name = "ktimer-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktimer-21.12.2.tar.xz";
+      sha256 = "0jprayxn54pw7brrcb1b70y5sal9j6pfpwrphd2nyw5rkb2a484l";
+      name = "ktimer-21.12.2.tar.xz";
     };
   };
   ktnef = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktnef-21.12.1.tar.xz";
-      sha256 = "0iql7nxh1hlpv8f5qa0w566jibvbfhzmc7qzcady06i6wzvbvivs";
-      name = "ktnef-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktnef-21.12.2.tar.xz";
+      sha256 = "0cl589z0v6h1z3aszk4160y99gpihpk203rn73dmb7c6qsk11cbl";
+      name = "ktnef-21.12.2.tar.xz";
     };
   };
   ktorrent = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktorrent-21.12.1.tar.xz";
-      sha256 = "0bldsl3ikdypis2vjzzk137spy9hsqj74vkq376klzyn3pjnnxj7";
-      name = "ktorrent-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktorrent-21.12.2.tar.xz";
+      sha256 = "1zwakqp5j2795j4pln4sq595bc2zlw8cy8qdzwj365clfbpcbyc3";
+      name = "ktorrent-21.12.2.tar.xz";
     };
   };
   ktouch = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktouch-21.12.1.tar.xz";
-      sha256 = "0875iiaa7c3ij1cgdd5lyj69rzpgwhvwm19iycjbq7pn4254qz3l";
-      name = "ktouch-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktouch-21.12.2.tar.xz";
+      sha256 = "1rq2n8395sb17rqd295axv2pbwzhqs8ikjqx5ryn4lv1713alabl";
+      name = "ktouch-21.12.2.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-accounts-kcm-21.12.1.tar.xz";
-      sha256 = "06zakwv6vxs5my79n4gxq0m2ha5358kpp8s57zyh59cfsz42gi0b";
-      name = "ktp-accounts-kcm-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-accounts-kcm-21.12.2.tar.xz";
+      sha256 = "14niidb9kza6sms9rhhnvrba6rdwhc890b5inmlhdllnqbdrrcbl";
+      name = "ktp-accounts-kcm-21.12.2.tar.xz";
     };
   };
   ktp-approver = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-approver-21.12.1.tar.xz";
-      sha256 = "0dkqd3apzmip5kilws9zx922skz31g1rz158ayxnf64mw1wqbb9g";
-      name = "ktp-approver-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-approver-21.12.2.tar.xz";
+      sha256 = "11scv978silxrprkyd66b4xkdww05xpgk8kvrknlwp33rmhm05sn";
+      name = "ktp-approver-21.12.2.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-auth-handler-21.12.1.tar.xz";
-      sha256 = "1i83rzv7f581ly4baqqfgn6hnvyq7a8pp5wpwz6fqk8nhqsk1fi0";
-      name = "ktp-auth-handler-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-auth-handler-21.12.2.tar.xz";
+      sha256 = "006an8bva8zawnirv3ai3kjb59ffgany124ip546r5wg06zkk069";
+      name = "ktp-auth-handler-21.12.2.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-call-ui-21.12.1.tar.xz";
-      sha256 = "0wlyrdn55zwpfxm9mdf8w01z2v2j35va9k35bg8ih4rq4dq4dgrz";
-      name = "ktp-call-ui-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-call-ui-21.12.2.tar.xz";
+      sha256 = "0n8yirlsig37839rl73azg8vf8ppdxlf1dqgkf5bz8g3jcs92gcm";
+      name = "ktp-call-ui-21.12.2.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-common-internals-21.12.1.tar.xz";
-      sha256 = "0lsa2fsd84pq14xlij5951j9szwq7afffx2zkmx4ssfaiqhm048b";
-      name = "ktp-common-internals-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-common-internals-21.12.2.tar.xz";
+      sha256 = "0c7kfrgf8bqm7q9hp9fd8q49vakiihzl0dgdklpvgly48zfa2yan";
+      name = "ktp-common-internals-21.12.2.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-contact-list-21.12.1.tar.xz";
-      sha256 = "1w42pm6k5sil1ylmzsl615q7kkw7kjl3bjj5xcz8ysf2m9w6c3xc";
-      name = "ktp-contact-list-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-contact-list-21.12.2.tar.xz";
+      sha256 = "0pw5kl0lh0ph3y9hyws7h7phh475lw07gydxxjsfxsd4nb70hkz8";
+      name = "ktp-contact-list-21.12.2.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-contact-runner-21.12.1.tar.xz";
-      sha256 = "0rlvavvdpa8bqv494b7dsrdib1f2xvic4l67v4z07bj9c53dj4x2";
-      name = "ktp-contact-runner-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-contact-runner-21.12.2.tar.xz";
+      sha256 = "0as41gba7ra65i6ml8j8fqh70x165cnmp9ry13ijrdf9vx21a45k";
+      name = "ktp-contact-runner-21.12.2.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-desktop-applets-21.12.1.tar.xz";
-      sha256 = "1aig58wv6lrz9x2rmjd2qk9hff91bkjqw6ixn9f12yh7vgckp1ba";
-      name = "ktp-desktop-applets-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-desktop-applets-21.12.2.tar.xz";
+      sha256 = "0675hlcjq6xyzl1sz3a45inc3g69z5ilxyhhicxns8by3ydmb82x";
+      name = "ktp-desktop-applets-21.12.2.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-filetransfer-handler-21.12.1.tar.xz";
-      sha256 = "16h0ysg7y71sxdg0n535dhh9gsb32bbgjdizmpqn3cwcr75z9h9c";
-      name = "ktp-filetransfer-handler-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-filetransfer-handler-21.12.2.tar.xz";
+      sha256 = "1cw2y06zcdfm9vixw99gbipgkl63vpkf73giq5ibal2g2yq9c2r5";
+      name = "ktp-filetransfer-handler-21.12.2.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-kded-module-21.12.1.tar.xz";
-      sha256 = "0a0khk48whf2cmxsjfc5lajnbrz3m9gpcvdgqlyyi21v2z4rshj5";
-      name = "ktp-kded-module-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-kded-module-21.12.2.tar.xz";
+      sha256 = "1mwmdnr2c6ilhhjlq8bwd7gwvjmiq1k3lph5vlb5hy8nrp9x2p1r";
+      name = "ktp-kded-module-21.12.2.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-send-file-21.12.1.tar.xz";
-      sha256 = "03k9mylyhanxbkzzcsv8z2mjx98qzghvbcwy8193259xrxshmlix";
-      name = "ktp-send-file-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-send-file-21.12.2.tar.xz";
+      sha256 = "0083z5al3jgl1szmzddzkjln9ci37906mmnrcy9f0yxfq5v2gr44";
+      name = "ktp-send-file-21.12.2.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktp-text-ui-21.12.1.tar.xz";
-      sha256 = "1n075fhqwk2522a7xc8z30j12d2sqkyybflidbs4kmbr915xh1zi";
-      name = "ktp-text-ui-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktp-text-ui-21.12.2.tar.xz";
+      sha256 = "0lhbsmhp23sil3rckk51156qhz15hjyp943mgh4s3w49lwxgjpc8";
+      name = "ktp-text-ui-21.12.2.tar.xz";
     };
   };
   ktuberling = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/ktuberling-21.12.1.tar.xz";
-      sha256 = "0q6jm8m97zfj10q90s44a19x1aijbnysmnm0am26hzh84r3d1mq6";
-      name = "ktuberling-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/ktuberling-21.12.2.tar.xz";
+      sha256 = "0w9gx0i895vd0gi8wgd6hqikqjz5ir4li14i15k4akc7i7niy46r";
+      name = "ktuberling-21.12.2.tar.xz";
     };
   };
   kturtle = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kturtle-21.12.1.tar.xz";
-      sha256 = "053bf9w5isqmi95spyy1a88iaw2f3zfr6xh5axwdycni4fnax9hx";
-      name = "kturtle-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kturtle-21.12.2.tar.xz";
+      sha256 = "0xkl12albs66vnsbilkwpnw5qaqx2ss8wldsnigmf0x5d5hd554k";
+      name = "kturtle-21.12.2.tar.xz";
     };
   };
   kubrick = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kubrick-21.12.1.tar.xz";
-      sha256 = "1gwa8r7jy132zxzdr24shkpq7c7rawirrs7np7khhavm0g0nmk21";
-      name = "kubrick-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kubrick-21.12.2.tar.xz";
+      sha256 = "1sd8biyndnc7y4d3zsy4bmi409js9viyd4q5ql6fd2wcz656y1im";
+      name = "kubrick-21.12.2.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kwalletmanager-21.12.1.tar.xz";
-      sha256 = "1qf8sizzdszvfskg8i0qmzb81292qm5jpcryl43b1bzh3yc6wx8c";
-      name = "kwalletmanager-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kwalletmanager-21.12.2.tar.xz";
+      sha256 = "0d2ma7dzn0nc25fj7lwaysfjfgqfl5nsisc01lp42n9k1bg0s0i5";
+      name = "kwalletmanager-21.12.2.tar.xz";
     };
   };
   kwave = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kwave-21.12.1.tar.xz";
-      sha256 = "0qc8l72nly01pyn7sk3c3hm1a1iia733gam4jzf04dcs0x3l3iw5";
-      name = "kwave-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kwave-21.12.2.tar.xz";
+      sha256 = "01bjsm3aj7m1mq3nr6iwmcxswq8sxdxhhdyc5zlgffifpym53dc5";
+      name = "kwave-21.12.2.tar.xz";
     };
   };
   kwordquiz = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/kwordquiz-21.12.1.tar.xz";
-      sha256 = "083r0n1x75bh82aysi5n7lk3x7r3in93fcavjpklxr4dvzl28qs5";
-      name = "kwordquiz-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/kwordquiz-21.12.2.tar.xz";
+      sha256 = "1na113adrd9djxk016riz3ajwrn9rbpc0ib34adfvp6nw48d9snp";
+      name = "kwordquiz-21.12.2.tar.xz";
     };
   };
   libgravatar = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libgravatar-21.12.1.tar.xz";
-      sha256 = "0lhlxxg2il435sz3j0sa8x4ydr0fz7idvzp27qqjgrjsxfqn1gbf";
-      name = "libgravatar-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libgravatar-21.12.2.tar.xz";
+      sha256 = "0xj3v0cknkvr8ac5iipxpz1azr0hk42zgaaip5ivn7qjfhp0zvv0";
+      name = "libgravatar-21.12.2.tar.xz";
     };
   };
   libkcddb = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkcddb-21.12.1.tar.xz";
-      sha256 = "02j6j44dgsyxdj83qhf2lr4l297184v63s8qwn0pxqjxjidcsajb";
-      name = "libkcddb-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkcddb-21.12.2.tar.xz";
+      sha256 = "07bcbmf3z5l0v5b6ra1h36yvbjpim1kzz1npd2h30iq09ibx6dr8";
+      name = "libkcddb-21.12.2.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkcompactdisc-21.12.1.tar.xz";
-      sha256 = "1am11g39jafy77av7ddc5yimfd07yvh7czaipamydw7lshcscjrq";
-      name = "libkcompactdisc-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkcompactdisc-21.12.2.tar.xz";
+      sha256 = "08abnybd0fa0vvpaixi18ljfz0s8a5pmbblzpcc8rvwzdjc7az6q";
+      name = "libkcompactdisc-21.12.2.tar.xz";
     };
   };
   libkdcraw = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkdcraw-21.12.1.tar.xz";
-      sha256 = "1g2fgw1dx4wvb7x1d5z5qqys348jnrjyvs2iad4ls54l1ci20sws";
-      name = "libkdcraw-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkdcraw-21.12.2.tar.xz";
+      sha256 = "0mzq0nha7mq5v3lb03xbspc0y2a7mg1mzlwbp3706ph6jp4m7mwa";
+      name = "libkdcraw-21.12.2.tar.xz";
     };
   };
   libkdegames = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkdegames-21.12.1.tar.xz";
-      sha256 = "0h5d7yf56x52ibm4yq14rbq8ha65x0isgpnw0jxgw5mrfz9m4wcy";
-      name = "libkdegames-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkdegames-21.12.2.tar.xz";
+      sha256 = "1m1qz59fb82bsj9ri3b8a1ph2ihgs97wlqq91pbgqw0kgvyvka1j";
+      name = "libkdegames-21.12.2.tar.xz";
     };
   };
   libkdepim = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkdepim-21.12.1.tar.xz";
-      sha256 = "0g5vb2iwqclbrbl19vlzx1ppra6mj454574nakw900qkzrp6rbfn";
-      name = "libkdepim-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkdepim-21.12.2.tar.xz";
+      sha256 = "0qqz9b17fz3kgh3gcyq30ds8fq7zkm14k85g4mywsn3lnn8bj6z9";
+      name = "libkdepim-21.12.2.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkeduvocdocument-21.12.1.tar.xz";
-      sha256 = "1wa81hh607hk0h930rr95zff8pzpsvjz1vaygfcfpf8h3gcwc418";
-      name = "libkeduvocdocument-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkeduvocdocument-21.12.2.tar.xz";
+      sha256 = "16vh1bycq92bh47phv7nk62r5vjaiv1p8fvq5p5idsz9ipzb1wzp";
+      name = "libkeduvocdocument-21.12.2.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkexiv2-21.12.1.tar.xz";
-      sha256 = "1yxa28hawyqm9s94p5qrcb2g9ly68i4cfj99xbzg3yl9simbhc5b";
-      name = "libkexiv2-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkexiv2-21.12.2.tar.xz";
+      sha256 = "1j1p1pw2l32q7lk8kp6r0nz9mzjdw6mxr2gi0p770k3k0arrsg87";
+      name = "libkexiv2-21.12.2.tar.xz";
     };
   };
   libkgapi = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkgapi-21.12.1.tar.xz";
-      sha256 = "0rwr37fy21d3jx35yv06kl29wd64sp21yg3rdhhv1bnbpsipk51k";
-      name = "libkgapi-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkgapi-21.12.2.tar.xz";
+      sha256 = "0n6x0vdirv5qbi9qmd8956i307dz0lp80bw5cqxgk4gr4f8hzi8w";
+      name = "libkgapi-21.12.2.tar.xz";
     };
   };
   libkipi = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkipi-21.12.1.tar.xz";
-      sha256 = "06p53h72d7mbqdv5zsrbwc7k4xjxmbirqvfyxgc5h7y46lcr5dby";
-      name = "libkipi-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkipi-21.12.2.tar.xz";
+      sha256 = "0zlga9gy45cs3icx56gvq2nab7i3z5ydrmisa46vpca63w8swmys";
+      name = "libkipi-21.12.2.tar.xz";
     };
   };
   libkleo = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkleo-21.12.1.tar.xz";
-      sha256 = "0f5nwc7w3m204j8a2cf0nclxak12l2vrssd1wnnv1r4a7pp33w4p";
-      name = "libkleo-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkleo-21.12.2.tar.xz";
+      sha256 = "0vqgycmj2v91car7ckksnjxbq3b5nzk31p4x3577dgck9jmi30zd";
+      name = "libkleo-21.12.2.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkmahjongg-21.12.1.tar.xz";
-      sha256 = "0255mfa15v2mawvhrhv2yr1lmv5vfnil3nqxwv85l67m8d227y84";
-      name = "libkmahjongg-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkmahjongg-21.12.2.tar.xz";
+      sha256 = "10fgk8nhcr3rbdnh8az46jvl6w6xankdxzw4djj3qs4dpkl52vk4";
+      name = "libkmahjongg-21.12.2.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libkomparediff2-21.12.1.tar.xz";
-      sha256 = "03wcfhnb4q72140rgkf1rpsa6chhz55jpjj1dfhjxzjfh2pd0r5w";
-      name = "libkomparediff2-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libkomparediff2-21.12.2.tar.xz";
+      sha256 = "07yzzc6ns1yx92gpcvhnxw0xna6ly1j4l4lx1rbw3d94z796694z";
+      name = "libkomparediff2-21.12.2.tar.xz";
     };
   };
   libksane = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libksane-21.12.1.tar.xz";
-      sha256 = "1jlc04jx66rkip723szwl38r61n2rwg07d20yx6ahx6bmsdgznwx";
-      name = "libksane-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libksane-21.12.2.tar.xz";
+      sha256 = "1iksfjwkibn1i8n541nngalrp8krc94qy9in801q10d291clwz9i";
+      name = "libksane-21.12.2.tar.xz";
     };
   };
   libksieve = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libksieve-21.12.1.tar.xz";
-      sha256 = "1d1aibkcn1xagmr03sadffvwz3q8idpva6dbgngwyyanj9hjs74i";
-      name = "libksieve-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libksieve-21.12.2.tar.xz";
+      sha256 = "03aaqqb5g9iv49crrf7zbmsri8jjszn5wfvmcw559swalmmyzb4i";
+      name = "libksieve-21.12.2.tar.xz";
     };
   };
   libktorrent = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/libktorrent-21.12.1.tar.xz";
-      sha256 = "02bkwypfrfx114yh9hjxy6kwb2crbl9xvk61287yg4ww0zdprdgv";
-      name = "libktorrent-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/libktorrent-21.12.2.tar.xz";
+      sha256 = "06ak3bsy5x6a0r3l9hbfih9m41y3l357rpd42x8qp08djbs11xbf";
+      name = "libktorrent-21.12.2.tar.xz";
     };
   };
   lokalize = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/lokalize-21.12.1.tar.xz";
-      sha256 = "08ipsp09d14vqk25jrv690757h9iy6d0mysgcv9jss5jacng6c3z";
-      name = "lokalize-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/lokalize-21.12.2.tar.xz";
+      sha256 = "1x6sb1fw0fqvk3vg299xvih1v2xm9hviv5h1b624maasw071nfyy";
+      name = "lokalize-21.12.2.tar.xz";
     };
   };
   lskat = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/lskat-21.12.1.tar.xz";
-      sha256 = "1hxpb4p39mnfs6z7s9a2yq7qjs9lr1kxxdw3a8as7xqahhw1b1jz";
-      name = "lskat-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/lskat-21.12.2.tar.xz";
+      sha256 = "0v16rg6d2l41xgkrkj8ibh5a0zjyb4jn7am6rbgl6k9g9mfqwdx7";
+      name = "lskat-21.12.2.tar.xz";
     };
   };
   mailcommon = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/mailcommon-21.12.1.tar.xz";
-      sha256 = "04kyli2f684wbq7n1zjrajqlvdzz058klpa9wxad73l7xni9sa33";
-      name = "mailcommon-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/mailcommon-21.12.2.tar.xz";
+      sha256 = "01kirl4lk1xq7y474438jv0av3ccg18krlchllcigd9c0vcp67qj";
+      name = "mailcommon-21.12.2.tar.xz";
     };
   };
   mailimporter = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/mailimporter-21.12.1.tar.xz";
-      sha256 = "14kb4wdgs2snmni87zdah4l8ga67bg06wiqx0y2gv2yhibgap7p3";
-      name = "mailimporter-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/mailimporter-21.12.2.tar.xz";
+      sha256 = "1ng8w4byq4iiwfzh4acl2glndlr7r9hr62qpj10kpn4fi0qblakb";
+      name = "mailimporter-21.12.2.tar.xz";
     };
   };
   marble = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/marble-21.12.1.tar.xz";
-      sha256 = "0j8whcbiwaal7wrqg99wn5zdnrnayjm8v9sfraigd0wnnfd6v2sn";
-      name = "marble-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/marble-21.12.2.tar.xz";
+      sha256 = "093drig77dyxwfavx30h2nzdqkn52h6pjn54j7fnwygz4742qv7n";
+      name = "marble-21.12.2.tar.xz";
     };
   };
   markdownpart = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/markdownpart-21.12.1.tar.xz";
-      sha256 = "02w137hqjsryb4dv5h1vmbd1c55imkwcy5r7ax5zvisclr4ylxfz";
-      name = "markdownpart-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/markdownpart-21.12.2.tar.xz";
+      sha256 = "0g7j15s15blqr0lfagmhvxxggdplvmnkf8g2b9ysjkrr49lgk7b6";
+      name = "markdownpart-21.12.2.tar.xz";
     };
   };
   mbox-importer = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/mbox-importer-21.12.1.tar.xz";
-      sha256 = "0y10pd8sjn0j4cdl7z773y5cral8lbmw42czzp4ig8yrlpbfs71j";
-      name = "mbox-importer-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/mbox-importer-21.12.2.tar.xz";
+      sha256 = "0qakmg86978zjm2m98602zbaiyiryrmlx2vk93yyv5xg352gphjb";
+      name = "mbox-importer-21.12.2.tar.xz";
     };
   };
   messagelib = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/messagelib-21.12.1.tar.xz";
-      sha256 = "1aywrhxw1ibx5dk68rv66h55fqipdcs0mdxw0jvfyrpfsvq4nbdc";
-      name = "messagelib-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/messagelib-21.12.2.tar.xz";
+      sha256 = "0ln473gdwsscjpsh50h2cbazxbc8qy1mmll9lsfngfw1qq49dwsp";
+      name = "messagelib-21.12.2.tar.xz";
     };
   };
   minuet = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/minuet-21.12.1.tar.xz";
-      sha256 = "1pqik8mp3p628xz0q1pd82f8l1g3wrlz5lzsh1fnyj2mc8fwi4nw";
-      name = "minuet-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/minuet-21.12.2.tar.xz";
+      sha256 = "050pmw3srfb800h91x6pqn1vz7s6458w94r2innwc1j04pr8jaxv";
+      name = "minuet-21.12.2.tar.xz";
     };
   };
   okular = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/okular-21.12.1.tar.xz";
-      sha256 = "189b47ysmvykpyjdh5jpzk7ahy3pvg2gf71qyvhcr55pqb763g84";
-      name = "okular-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/okular-21.12.2.tar.xz";
+      sha256 = "1k0bwyhk73gshc7f0j6mply2m9ykfd07mhkxwnzj874sby5rxhv9";
+      name = "okular-21.12.2.tar.xz";
     };
   };
   palapeli = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/palapeli-21.12.1.tar.xz";
-      sha256 = "032702k31psyr7fy5i6f2r4a56f4m9zawjamyr0jwwq4faydj6y6";
-      name = "palapeli-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/palapeli-21.12.2.tar.xz";
+      sha256 = "0v5456hm56c7f9d49l5zjql6f4ap72wmkf8in8s95lqmpn42dl17";
+      name = "palapeli-21.12.2.tar.xz";
     };
   };
   parley = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/parley-21.12.1.tar.xz";
-      sha256 = "1h9jasmi96i1rmxqg7gps8fy03al4042x89h9yca57sfj3966iy0";
-      name = "parley-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/parley-21.12.2.tar.xz";
+      sha256 = "1cwnlv57yqjm52i0jwl33pz4h9h448h0ljrg598ghby8p3b2i5w7";
+      name = "parley-21.12.2.tar.xz";
     };
   };
   partitionmanager = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/partitionmanager-21.12.1.tar.xz";
-      sha256 = "1szidy2vwcqzygkw232k5bvk6zr0h0z8349is69q4zvrbamcwawf";
-      name = "partitionmanager-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/partitionmanager-21.12.2.tar.xz";
+      sha256 = "0rr7ic2ivm7lp3lj20b8rfbx1sr91s24fzxfzfwnw9znl9vj410q";
+      name = "partitionmanager-21.12.2.tar.xz";
     };
   };
   picmi = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/picmi-21.12.1.tar.xz";
-      sha256 = "0jdadh33f9byljwlxxs268j8crhagg2xx6wsyb2ssyms95qmfd50";
-      name = "picmi-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/picmi-21.12.2.tar.xz";
+      sha256 = "0qp8b1di3qnv4xrnpcmyi6myrrwzdlijhvxmacx4ijv7b7wlg4r7";
+      name = "picmi-21.12.2.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/pim-data-exporter-21.12.1.tar.xz";
-      sha256 = "1l748ndf4jgn39ij4g2dm54599ygnz3492fpd8i02d2bgm5d3339";
-      name = "pim-data-exporter-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/pim-data-exporter-21.12.2.tar.xz";
+      sha256 = "0m4dq3x5kbncnvixjigb85j6siws6q600piw53qabiwd6w6rp1xy";
+      name = "pim-data-exporter-21.12.2.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/pim-sieve-editor-21.12.1.tar.xz";
-      sha256 = "0cnlbalmabycpiy3cmq7j6jz9h3fdfq0md25rr6ri2gvvx1gp0if";
-      name = "pim-sieve-editor-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/pim-sieve-editor-21.12.2.tar.xz";
+      sha256 = "1cpazs6q6hv15ib6isif5syvpywxfdi7d3w8vc4pnfj94wkcq3gm";
+      name = "pim-sieve-editor-21.12.2.tar.xz";
     };
   };
   pimcommon = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/pimcommon-21.12.1.tar.xz";
-      sha256 = "1rg4c8bvfrr7rzpxwvjw07phalmxvj592cjcxywnbb4i3hlr9c8g";
-      name = "pimcommon-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/pimcommon-21.12.2.tar.xz";
+      sha256 = "1pnhjhnjx98wdc3dg71qgjjj3dsncl56d86cagkk2spicv901p69";
+      name = "pimcommon-21.12.2.tar.xz";
     };
   };
   poxml = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/poxml-21.12.1.tar.xz";
-      sha256 = "1pnqhv059q79g8gwkln9lrvwby96262vamyblrjq1qx2bb4y1038";
-      name = "poxml-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/poxml-21.12.2.tar.xz";
+      sha256 = "1zzw9jwwd5nx12ma2ihffj6nhr3zlpahnj8k0r8mxcyn99j51kyn";
+      name = "poxml-21.12.2.tar.xz";
     };
   };
   print-manager = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/print-manager-21.12.1.tar.xz";
-      sha256 = "0yxivldalzharaq2ghrz2j8vlkylp91la36aaqwly396jxaij3w3";
-      name = "print-manager-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/print-manager-21.12.2.tar.xz";
+      sha256 = "0xqv7f9p27maa0p20nc92g6240qkcin9s3dldr5b5q944hkkxizq";
+      name = "print-manager-21.12.2.tar.xz";
     };
   };
   rocs = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/rocs-21.12.1.tar.xz";
-      sha256 = "0m4l2sm3mgkici2jvsvzi8pv3cx3i7a7yvh5c0w1ajs34vx0y6ki";
-      name = "rocs-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/rocs-21.12.2.tar.xz";
+      sha256 = "1mjrgh0vfc1kvici5m1dx23s1c7qpvfx1br91yglgll1biajzqlq";
+      name = "rocs-21.12.2.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/signon-kwallet-extension-21.12.1.tar.xz";
-      sha256 = "09j2i1kwinskylww78nhnrkh31p5yizv6jp5lf2igvhd4dpfgxxk";
-      name = "signon-kwallet-extension-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/signon-kwallet-extension-21.12.2.tar.xz";
+      sha256 = "0qfim8ahklwkixpxcm9sj1w49cmb0wz5r8np6ga3r2rh4vlqdxbf";
+      name = "signon-kwallet-extension-21.12.2.tar.xz";
     };
   };
   skanlite = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/skanlite-21.12.1.tar.xz";
-      sha256 = "0s53wcm80xp9p5cli9bkharwv4qvhlc10pdb0aysgg76jlqrj78x";
-      name = "skanlite-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/skanlite-21.12.2.tar.xz";
+      sha256 = "1fvdrzyvps0iqb9irnpdn81gmlmfhgfsfb5mg4i259sms6rq3h8m";
+      name = "skanlite-21.12.2.tar.xz";
     };
   };
   spectacle = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/spectacle-21.12.1.tar.xz";
-      sha256 = "13qpsxy2v51xvdxml0c9zp62d9lasg76m0ff86kqavwklywc9h72";
-      name = "spectacle-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/spectacle-21.12.2.tar.xz";
+      sha256 = "1966ynfdkaya1iydi2hfmcr13adk7agjr9ndz2hjrwgjagd29pyr";
+      name = "spectacle-21.12.2.tar.xz";
     };
   };
   step = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/step-21.12.1.tar.xz";
-      sha256 = "1vh2yw5zyy42jfn9i326x01v34xgnq5d5wyxy6k75v5p5hwsbr64";
-      name = "step-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/step-21.12.2.tar.xz";
+      sha256 = "1paq5wpya82s92zwacwbjf96nj52gy1sydk0gndyqi8jdplhlnps";
+      name = "step-21.12.2.tar.xz";
     };
   };
   svgpart = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/svgpart-21.12.1.tar.xz";
-      sha256 = "03ivjg1n1g4bqwrdq38hw2pvh1gk1s00azmnlz3x40fd1xcg3mww";
-      name = "svgpart-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/svgpart-21.12.2.tar.xz";
+      sha256 = "15624gfcn85xkh6lypkw73iidnclprhqhpxrjggbng1x22jg2iwc";
+      name = "svgpart-21.12.2.tar.xz";
     };
   };
   sweeper = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/sweeper-21.12.1.tar.xz";
-      sha256 = "0m8k17x90avbw4zay1zkbkpdw809axhvl3c0kjiymyan4a3mi86y";
-      name = "sweeper-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/sweeper-21.12.2.tar.xz";
+      sha256 = "07rqshzjjzqgmm5z0fn1hjd09prcwlnyilp3s61nl5fciby6m8fh";
+      name = "sweeper-21.12.2.tar.xz";
     };
   };
   umbrello = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/umbrello-21.12.1.tar.xz";
-      sha256 = "0z4hnrd055f1i7hasrgrqv7chzyy7cscmi0lvjak12mngykckrs9";
-      name = "umbrello-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/umbrello-21.12.2.tar.xz";
+      sha256 = "07bp3rf31x5c1vag6pw0lal9b6zmvsqa8wg8a30kj7k9wabvjprb";
+      name = "umbrello-21.12.2.tar.xz";
     };
   };
   yakuake = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/yakuake-21.12.1.tar.xz";
-      sha256 = "1nr28w01bcnhw33s17daps8g040hwnvwxjz4p1gv3xngapqrf6zl";
-      name = "yakuake-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/yakuake-21.12.2.tar.xz";
+      sha256 = "1xkdyn944ga1xvwbbblnffvlnwgypspr909yvdy6xf5j0qaldsdk";
+      name = "yakuake-21.12.2.tar.xz";
     };
   };
   zanshin = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/zanshin-21.12.1.tar.xz";
-      sha256 = "0z54w5c5mdmfw4cv6099jlf4kz40b3gxl4wi5z92zxn3d71ck1l5";
-      name = "zanshin-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/zanshin-21.12.2.tar.xz";
+      sha256 = "1ilgswm4jbjk1mbvcrdi451f1w4vwx3ah6y32a3y5a9blbh9bh6c";
+      name = "zanshin-21.12.2.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "21.12.1";
+    version = "21.12.2";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.1/src/zeroconf-ioslave-21.12.1.tar.xz";
-      sha256 = "16by90pdmbn7kw7aq2jf9sl67r2ydhp8i9drpznvfxmq99qsk7b6";
-      name = "zeroconf-ioslave-21.12.1.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.2/src/zeroconf-ioslave-21.12.2.tar.xz";
+      sha256 = "0b59npqhmf3yvp9x0jm29bwzlyl0vm9l56jlsgwgiq7pwis5njwd";
+      name = "zeroconf-ioslave-21.12.2.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump KDE Applications/Gear to 21.12.2, released in 02/Feb/2022.
The rebuild is actually smaller than 500 pkgs, so this should be fine in `master` (as well for being just a patch release), but the tag there is mostly due to broken versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
