### PR TITLE
karate: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6601,6 +6601,12 @@
     githubId = 2029444;
     name = "James Kent";
   };
+  kephasp = {
+    email = "pierre@nothos.net";
+    github = "kephas";
+    githubId = 762421;
+    name = "Pierre Thierry";
+  };
   ketzacoatl = {
     email = "ketzacoatl@protonmail.com";
     github = "ketzacoatl";

--- a/pkgs/development/tools/karate/default.nix
+++ b/pkgs/development/tools/karate/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenvNoCC, fetchurl, jre, makeWrapper }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "karate";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/karatelabs/karate/releases/download/v${version}/karate-${version}.jar";
+    sha256 = "69b9ba1cd9563cbad802471e7250dd46828df7ad176706577389dfe6e604e5ec";
+  };
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    makeWrapper ${jre}/bin/java $out/bin/karate --add-flags "-jar $src"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "API Test Automation Made Simple";
+    longDescription = ''
+      Karate is the only open-source tool to combine API
+      test-automation, mocks, performance-testing and even UI
+      automation into a single, unified framework. The BDD syntax
+      popularized by Cucumber is language-neutral, and easy for even
+      non-programmers. Assertions and HTML reports are built-in, and
+      you can run tests in parallel for speed.
+    '';
+    homepage = "https://github.com/karatelabs/karate";
+    changelog = "https://github.com/karatelabs/karate/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = [ maintainers.kephasp ];
+    platforms = jre.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15715,6 +15715,8 @@ with pkgs;
 
   kamid = callPackage ../servers/ftp/kamid { };
 
+  karate = callPackage ../development/tools/karate { };
+
   kati = callPackage ../development/tools/build-managers/kati { };
 
   kcat = callPackage ../development/tools/kcat { };


### PR DESCRIPTION
Co-authored-by: maxime.a.didier@gmail.com

###### Motivation for this change

Add a new tool

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
