### PR TITLE
curlHTTP3: enable darwin build

### DIFF
--- a/pkgs/development/libraries/nghttp3/default.nix
+++ b/pkgs/development/libraries/nghttp3/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
 , autoreconfHook, pkg-config
-, cunit, file
+, cunit, file, ncurses
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pV1xdQa5RBz17jDINC2uN1Q+jpa2edDwqTqf8D5VU3E=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config cunit file ];
+  nativeBuildInputs = [ autoreconfHook pkg-config file ];
+  checkInputs = [ cunit ncurses ];
 
   preConfigure = ''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
@@ -23,12 +24,13 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   doCheck = true;
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://github.com/ngtcp2/nghttp3";
     description = "nghttp3 is an implementation of HTTP/3 mapping over QUIC and QPACK in C.";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ izorkin ];
   };
 }

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub
 , autoreconfHook, pkg-config
-, cunit, file
+, cunit, file, ncurses
 , jemalloc, libev, nghttp3, quictls
 }:
 
@@ -15,8 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-uBmD26EYT8zxmHD5FuHCbEuTdWxer/3uhRp8PhUT87M=";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config cunit file ];
+  nativeBuildInputs = [ autoreconfHook pkg-config file ];
   buildInputs = [ jemalloc libev nghttp3 quictls ];
+  checkInputs = [ cunit ncurses ];
 
   preConfigure = ''
     substituteInPlace ./configure --replace /usr/bin/file ${file}/bin/file
@@ -25,12 +26,13 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   doCheck = true;
+  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://github.com/ngtcp2/ngtcp2";
     description = "ngtcp2 project is an effort to implement QUIC protocol which is now being discussed in IETF QUICWG for its standardization.";
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = with maintainers; [ izorkin ];
   };
 }

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -1,7 +1,8 @@
 { lib, stdenv, fetchFromGitHub
 , autoreconfHook, pkg-config
 , cunit, file, ncurses
-, jemalloc, libev, nghttp3, quictls
+, libev, nghttp3, quictls
+, withJemalloc ? false, jemalloc
 }:
 
 stdenv.mkDerivation rec {
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config file ];
-  buildInputs = [ jemalloc libev nghttp3 quictls ];
+  buildInputs = [ libev nghttp3 quictls ] ++ lib.optional withJemalloc jemalloc;
   checkInputs = [ cunit ncurses ];
 
   preConfigure = ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This makes the `curlHTTP3` package available for Darwin by making its dependencies available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
