### PR TITLE
fetchurl - add wrapper with output derivation overridable

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -643,6 +643,20 @@ with pkgs;
       });
     };
 
+  /* If you want convenient syntax to override the derivation produced by `fetchurl`, for instance
+     to override just the hash of a `src` whose `url` is computed, you can replace the `fetchurl`
+     dependency of the outer package derivation with this one.
+
+     Example:
+     tk869 = (pkgs.tk-8_6.override {
+       fetchurl = fetchurlOverridableOutput;
+       tcl = tcl869; # Something overriding `tcl-8_6 to an older version
+     }).overrideAttrs (self: rec {
+       src = self.src.override { sha256 = "1d7bfkxpacy33w5nahf73lkwxqpff44w1jplg7i2gmwgiaawvjwg"; };
+     });
+  */
+  fetchurlOverridableOutput = args: (makeOverridable fetchurl args);
+
   fetchRepoProject = callPackage ../build-support/fetchrepoproject { };
 
   fetchipfs = import ../build-support/fetchipfs {


### PR DESCRIPTION
Make the output of `fetchurl` overridable.

Currently, the `fetchurl` function _itself_ is overridable, but not the output derivation.  This change fixes that, so the output derivation itself is _also_ overridable.

Motivating example:
Oftentimes a package uses `fetchurl` to set the value for the derivation's `src` attribute. Sometimes the `url` parameter to `fetchurl` is computed.  As an example, the `tk` package accepts `tcl` as a parameter for package dependency, and computes its own `url` from the version attribute defined in the `tcl` package.  If one passes in a different version of `tcl` to `tk` via something like
```
my_tk = pkgs.tk.override { tcl = my_tcl-8_6; };
```
it would be very convenient to just update the `sha256` for `tk`'s sources without having to muck around with recreating the computed URL for the sources.  With this change, it's pretty easy:
```
my_tk = (pkgs.tk.override { tcl = my_tcl-8_6; }).overrideAttrs (oldAttrs: {
  src = oldAttrs.src.override { sha256 = "<something>"; };
});
```
Without this change, one has to manually construct the entire `fetchurl` args, which is much uglier.

Alternatively, this makes it possible to easily substitute an internal mirror URL for a particular package.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
