### PR TITLE
haskell.packages.ghc901.generic-lens*: 2.2.0.0 -> 2.2.1.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -71,8 +71,8 @@ self: super: {
   vector-th-unbox = doJailbreak super.vector-th-unbox;
   zlib = doJailbreak super.zlib;
   weeder = self.weeder_2_3_0;
-  generic-lens-core = self.generic-lens-core_2_2_0_0;
-  generic-lens = self.generic-lens_2_2_0_0;
+  generic-lens-core = self.generic-lens-core_2_2_1_0;
+  generic-lens = self.generic-lens_2_2_1_0;
   th-desugar = self.th-desugar_1_13;
   # 2021-11-08: Fixed in autoapply-0.4.2
   autoapply = doJailbreak self.autoapply_0_4_1_1;
@@ -83,7 +83,7 @@ self: super: {
   });
 
   # Upstream also disables test for GHC 9: https://github.com/kcsongor/generic-lens/pull/130
-  generic-lens_2_2_0_0 = dontCheck super.generic-lens_2_2_0_0;
+  generic-lens_2_2_1_0 = dontCheck super.generic-lens_2_2_1_0;
 
   # Apply patches from head.hackage.
   alex = appendPatch (pkgs.fetchpatch {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

hackage-packages.nix doesn't have generic-lens_2_2_0_0, perhaps this got missed in the last update.
Building things caused this error:

```
error: attribute 'generic-lens_2_2_0_0' missing

       at /nix/store/fbcgjqs34vllzzppa1y213fbxx01sxn7-source/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix:86:36:

           85|   # Upstream also disables test for GHC 9: https://github.com/kcsongor/generic-lens/pull/130
           86|   generic-lens_2_2_0_0 = dontCheck super.generic-lens_2_2_0_0;
             |                                    ^
           87|
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
