### PR TITLE
rust-bindgen: fix finding c++ stdlib

### DIFF
--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -7,6 +7,13 @@ let
       inherit bash;
       unwrapped = rust-bindgen-unwrapped;
       libclang = clang.cc.lib;
+      meta = rust-bindgen-unwrapped.meta // {
+        longDescription = rust-bindgen-unwrapped.meta.longDescription + ''
+          This version of bindgen is wrapped with the required compiler flags
+          required to find the c and c++ standard libary, as well as the libraries
+          specified in the buildInputs of your derivation.
+        '';
+      };
       passthru.tests = {
         simple-c = runCommandCC "simple-c-bindgen-tests" { } ''
           echo '#include <stdlib.h>' > a.c

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -1,78 +1,18 @@
-{ lib, fetchFromGitHub, rustPlatform, clang, rustfmt, writeTextFile
-, runtimeShell
-, bash
-}:
-
-rustPlatform.buildRustPackage rec {
-  pname = "rust-bindgen";
-  version = "0.59.2";
-
-  RUSTFLAGS = "--cap-lints warn"; # probably OK to remove after update
-
-  src = fetchFromGitHub {
-    owner = "rust-lang";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-bJYdyf5uZgWe7fQ80/3QsRV0qyExYn6P9UET3tzwPFs=";
-  };
-
-  cargoSha256 = "sha256-zhENlrqj611RkKDvpDtDFWc58wfQVamkJnpe2nvRieE=";
-
+{ rust-bindgen-unwrapped, bash, runCommand }:
+let
+  clang = rust-bindgen-unwrapped.clang;
+in
+runCommand "rust-bindgen-${rust-bindgen-unwrapped.version}"
+{
   #for substituteAll
-  libclang = clang.cc.lib; # use the same version of clang for cxxincludes and libclang
   inherit bash;
+  unwrapped = rust-bindgen-unwrapped;
+  libclang = clang.cc.lib;
+} ''
+  mkdir -p $out/bin
+  export cincludes="$(< ${clang}/nix-support/cc-cflags) $(< ${clang}/nix-support/libc-cflags)"
+  export cxxincludes="$(< ${clang}/nix-support/libcxx-cxxflags)"
+  substituteAll ${./wrapper.sh} $out/bin/bindgen
+  chmod +x $out/bin/bindgen
+''
 
-  buildInputs = [ libclang ];
-
-  preConfigure = ''
-    export LIBCLANG_PATH="${lib.getLib libclang}/lib"
-  '';
-
-  postInstall = ''
-    mv $out/bin/{bindgen,.bindgen-wrapped};
-    export cincludes="$(< ${clang}/nix-support/cc-cflags) $(< ${clang}/nix-support/libc-cflags)"
-    export cxxincludes="$(< ${clang}/nix-support/libcxx-cxxflags)"
-    substituteAll ${./wrapper.sh} $out/bin/bindgen
-    chmod +x $out/bin/bindgen
-  '';
-
-  doCheck = true;
-  checkInputs =
-    let fakeRustup = writeTextFile {
-      name = "fake-rustup";
-      executable = true;
-      destination = "/bin/rustup";
-      text = ''
-        #!${runtimeShell}
-        shift
-        shift
-        exec "$@"
-      '';
-    };
-  in [
-    rustfmt
-    fakeRustup # the test suite insists in calling `rustup run nightly rustfmt`
-    clang
-  ];
-  preCheck = ''
-    # for the ci folder, notably
-    patchShebangs .
-  '';
-
-  meta = with lib; {
-    description = "Automatically generates Rust FFI bindings to C (and some C++) libraries";
-    longDescription = ''
-      Bindgen takes a c or c++ header file and turns them into
-      rust ffi declarations.
-      As with most compiler related software, this will only work
-      inside a nix-shell with the required libraries as buildInputs.
-      This version of bindgen is wrapped with the required compiler flags
-      required to find the c and c++ standard libary of the input clang
-      derivation.
-    '';
-    homepage = "https://github.com/rust-lang/rust-bindgen";
-    license = with licenses; [ bsd3 ];
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ johntitor ralith ];
-  };
-}

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -54,11 +54,6 @@ rustPlatform.buildRustPackage rec {
     longDescription = ''
       Bindgen takes a c or c++ header file and turns them into
       rust ffi declarations.
-      As with most compiler related software, this will only work
-      inside a nix-shell with the required libraries as buildInputs.
-      This version of bindgen is wrapped with the required compiler flags
-      required to find the c and c++ standard libary of the input clang
-      derivation.
     '';
     homepage = "https://github.com/rust-lang/rust-bindgen";
     license = with licenses; [ bsd3 ];

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -1,0 +1,68 @@
+{ lib, fetchFromGitHub, rustPlatform, clang, rustfmt, writeTextFile
+, runtimeShell
+, bash
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rust-bindgen-unwrapped";
+  version = "0.59.2";
+
+  RUSTFLAGS = "--cap-lints warn"; # probably OK to remove after update
+
+  src = fetchFromGitHub {
+    owner = "rust-lang";
+    repo = "rust-bindgen";
+    rev = "v${version}";
+    sha256 = "sha256-bJYdyf5uZgWe7fQ80/3QsRV0qyExYn6P9UET3tzwPFs=";
+  };
+
+  cargoSha256 = "sha256-RKZY5vf6CSFaKweuuNkeFF0ZXlSUibAkcL/YhkE0MoQ=";
+
+  buildInputs = [ clang.cc.lib ];
+
+  preConfigure = ''
+    export LIBCLANG_PATH="${clang.cc.lib}/lib"
+  '';
+
+  doCheck = true;
+  checkInputs =
+    let fakeRustup = writeTextFile {
+      name = "fake-rustup";
+      executable = true;
+      destination = "/bin/rustup";
+      text = ''
+        #!${runtimeShell}
+        shift
+        shift
+        exec "$@"
+      '';
+    };
+  in [
+    rustfmt
+    fakeRustup # the test suite insists in calling `rustup run nightly rustfmt`
+    clang
+  ];
+  preCheck = ''
+    # for the ci folder, notably
+    patchShebangs .
+  '';
+
+  passthru = { inherit clang; };
+
+  meta = with lib; {
+    description = "Automatically generates Rust FFI bindings to C (and some C++) libraries";
+    longDescription = ''
+      Bindgen takes a c or c++ header file and turns them into
+      rust ffi declarations.
+      As with most compiler related software, this will only work
+      inside a nix-shell with the required libraries as buildInputs.
+      This version of bindgen is wrapped with the required compiler flags
+      required to find the c and c++ standard libary of the input clang
+      derivation.
+    '';
+    homepage = "https://github.com/rust-lang/rust-bindgen";
+    license = with licenses; [ bsd3 ];
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ johntitor ralith ];
+  };
+}

--- a/pkgs/development/tools/rust/bindgen/wrapper.sh
+++ b/pkgs/development/tools/rust/bindgen/wrapper.sh
@@ -30,7 +30,7 @@ fi;
 export LIBCLANG_PATH="@libclang@/lib"
 # shellcheck disable=SC2086
 # cxxflags and NIX_CFLAGS_COMPILE should be word-split
-exec -a "$0" @out@/bin/.bindgen-wrapped "$@" $sep $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
+exec -a "$0" @unwrapped@/bin/bindgen "$@" $sep $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
 # note that we add the flags after $@ which is incorrect. This is only for the sake
 # of simplicity.
 

--- a/pkgs/development/tools/rust/bindgen/wrapper.sh
+++ b/pkgs/development/tools/rust/bindgen/wrapper.sh
@@ -22,7 +22,7 @@ for e in "$@"; do
 done;
 cxxflags=
 if [[ $cxx -eq 1 ]]; then
-  cxxflags=$NIX_CXXSTDLIB_COMPILE
+  cxxflags="@cxxincludes@"
 fi;
 if [[ -n "$NIX_DEBUG" ]]; then
   set -x;
@@ -30,7 +30,7 @@ fi;
 export LIBCLANG_PATH="@libclang@/lib"
 # shellcheck disable=SC2086
 # cxxflags and NIX_CFLAGS_COMPILE should be word-split
-exec -a "$0" @out@/bin/.bindgen-wrapped "$@" $sep $cxxflags $NIX_CFLAGS_COMPILE
+exec -a "$0" @out@/bin/.bindgen-wrapped "$@" $sep $cxxflags @cincludes@ $NIX_CFLAGS_COMPILE
 # note that we add the flags after $@ which is incorrect. This is only for the sake
 # of simplicity.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13151,6 +13151,7 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
   rust-analyzer = callPackage ../development/tools/rust/rust-analyzer/wrapper.nix { };
+  rust-bindgen-unwrapped = callPackage ../development/tools/rust/bindgen/unwrapped.nix { };
   rust-bindgen = callPackage ../development/tools/rust/bindgen { };
   rust-cbindgen = callPackage ../development/tools/rust/cbindgen {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Motivation for this change

NIX_CXXSTDLIB_COMPILE has been removed in https://github.com/NixOS/nixpkgs/pull/85189
and https://github.com/NixOS/nixpkgs/pull/85189#commitcomment-40987154
remommends using the files in ${clang}/nix-support to find the correct
flags to pass to libclang.

Also add tests and separate rust-bindgen-unwrapped from the wrapper (I compiled rust-bindgen way too many times).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
