### PR TITLE
cc-wrapper: pass always -B and -L together to avoid mixing parts of libc

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -33,6 +33,20 @@ NIX_CFLAGS_COMPILE_@suffixSalt@="-B@out@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
 # Export and assign separately in order that a failing $(..) will fail
 # the script.
 
+# Currently bootstrap-tools does not split glibc, and gcc files into
+# separate directories. As a workaround we want resulting cflags to be
+# ordered as: crt1-cflags libc-cflags cc-cflags. Otherwise we mix crt/libc.so
+# from different libc as seen in
+#   https://github.com/NixOS/nixpkgs/issues/158042
+#
+# Note that below has reverse ordering as we prepend flags one-by-one.
+# Once bootstrap-tools is split into different directories we can stop
+# relying on flag ordering below.
+
+if [ -e @out@/nix-support/cc-cflags ]; then
+    NIX_CFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE_@suffixSalt@"
+fi
+
 if [[ "$cInclude" = 1 ]] && [ -e @out@/nix-support/libc-cflags ]; then
     NIX_CFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/libc-cflags) $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
@@ -47,10 +61,6 @@ fi
 
 if [ -e @out@/nix-support/libcxx-ldflags ]; then
     NIX_CXXSTDLIB_LINK_@suffixSalt@+=" $(< @out@/nix-support/libcxx-ldflags)"
-fi
-
-if [ -e @out@/nix-support/cc-cflags ]; then
-    NIX_CFLAGS_COMPILE_@suffixSalt@="$(< @out@/nix-support/cc-cflags) $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
 
 if [ -e @out@/nix-support/gnat-cflags ]; then


### PR DESCRIPTION
###### Motivation for this change

Before this change cc-wrapper was mixing crt1.o and libc.so.6
from different libc during bootstrap:

    expand-response-params>   -B/...-bootstrap-tools/lib
    expand-response-params>   -B/...-glibc-2.35/lib/
    ...
    expand-response-params>   -L/...-glibc-2.35/lib
    expand-response-params>   -L/...-bootstrap-tools/lib

Normally it's not a problem as `crt1.o` did not change for
quite a few releases. But `glibc-2.35` dropped `__libc_csu_fini` symbol:

    expand-response-params> ld: ...-bootstrap-tools/lib/crt1.o: in function `_start':
    expand-response-params> ...glibc-2.27/csu/../sysdeps/x86_64/start.S:101: undefined reference to `__libc_csu_fini'
    expand-response-params> ld: /build/glibc-2.27/csu/../sysdeps/x86_64/start.S:102: undefined reference to `__libc_csu_init'
    expand-response-params> collect2: error: ld returned 1 exit status

The change always passes -B/-L together to have a higher chance
to override both parts of libc. It allows bootstrapping toolchain
on glibc-2.35.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
