### PR TITLE
paperwork: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/applications/office/paperwork/openpaperwork-core.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-core.nix
@@ -39,5 +39,6 @@ buildPythonPackage rec {
     homepage = "https://openpaper.work/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ aszlig symphorien ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/openpaperwork-gtk.nix
@@ -49,5 +49,6 @@ buildPythonPackage rec {
     homepage = "https://openpaper.work/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ aszlig symphorien ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -16,6 +16,7 @@
 , texlive
 , imagemagick
 , perlPackages
+, writeScript
 }:
 
 let
@@ -27,11 +28,18 @@ let
     imagemagick
     perlPackages.Po4a
   ];
+  inherit (import ./src.nix { inherit fetchFromGitLab; }) version src sample_documents;
 in
 
 python3Packages.buildPythonApplication rec {
-  inherit (import ./src.nix { inherit fetchFromGitLab; }) version src sample_documents;
+  inherit src version;
   pname = "paperwork";
+
+  sample_docs = sample_documents // {
+    # a trick for the update script
+    name = "sample_documents";
+    src = sample_documents;
+  };
 
   sourceRoot = "source/paperwork-gtk";
 
@@ -69,7 +77,7 @@ python3Packages.buildPythonApplication rec {
 
     export XDG_DATA_DIRS=$XDG_DATA_DIRS:${gnome.adwaita-icon-theme}/share
     # build the user manual
-    PATH=$out/bin:$PATH PAPERWORK_TEST_DOCUMENTS=${sample_documents} make data
+    PATH=$out/bin:$PATH PAPERWORK_TEST_DOCUMENTS=${sample_docs} make data
     for i in src/paperwork_gtk/model/help/out/*.pdf; do
       install -Dt $site/model/help/out $i
     done
@@ -127,6 +135,15 @@ python3Packages.buildPythonApplication rec {
   ];
 
   disallowedRequisites = documentation_deps;
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl common-updater-scripts
+    version=$(list-git-tags https://gitlab.gnome.org/World/OpenPaperwork/paperwork.git | sed 's/^v//' | sort -V | tail -n1)
+    update-source-version paperwork "$version" --file=pkgs/applications/office/paperwork/src.nix
+    docs_version="$(curl https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/raw/$version/paperwork-gtk/src/paperwork_gtk/model/help/screenshot.sh | grep TEST_DOCS_TAG= | cut -d'"' -f2)"
+    update-source-version paperwork.sample_docs "$docs_version" --file=pkgs/applications/office/paperwork/src.nix --version-key=rev
+  '';
 
   meta = {
     description = "A personal document manager for scanned documents";

--- a/pkgs/applications/office/paperwork/paperwork-gtk.nix
+++ b/pkgs/applications/office/paperwork/paperwork-gtk.nix
@@ -130,7 +130,6 @@ python3Packages.buildPythonApplication rec {
     openpaperwork-core
     pypillowfight
     pyxdg
-    python-dateutil
     setuptools
   ];
 

--- a/pkgs/applications/office/paperwork/src.nix
+++ b/pkgs/applications/office/paperwork/src.nix
@@ -1,13 +1,13 @@
 {fetchFromGitLab}:
 rec {
-  version = "2.1.0";
+  version = "2.1.1";
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     repo = "paperwork";
     group = "World";
     owner = "OpenPaperwork";
     rev = version;
-    sha256 = "0d1cw6k1giqs8ji8h3h97ckb134s8pszgip0nac5hmw0mvqq84xa";
+    sha256 = "2M2eMP54F3RRDMBuAZ1gBiBoMmTRJaHTUwtTjj4ZU+4=";
   };
   sample_documents = fetchFromGitLab {
     domain = "gitlab.gnome.org";


### PR DESCRIPTION
###### Motivation for this change

Update. I also add an update script.

Changelog: https://gitlab.gnome.org/World/OpenPaperwork/paperwork/-/blob/develop/paperwork-gtk/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
