### PR TITLE
graphicsmagick: fix use of delegates in conversions

### DIFF
--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   # Remove CFLAGS from the binaries to avoid closure bloat.
   # In the past we have had -dev packages in the closure of the binaries soley due to the string references.
   postConfigure = ''
-    nuke-refs ./magick/magick_config.h
+    nuke-refs -e $out ./magick/magick_config.h
   '';
 
   postInstall = ''

--- a/pkgs/applications/graphics/graphicsmagick/default.nix
+++ b/pkgs/applications/graphics/graphicsmagick/default.nix
@@ -1,6 +1,9 @@
 { lib, stdenv, fetchurl, bzip2, freetype, graphviz, ghostscript
 , libjpeg, libpng, libtiff, libxml2, zlib, libtool, xz, libX11
-, libwebp, quantumdepth ? 8, fixDarwinDylibNames, nukeReferences }:
+, libwebp, quantumdepth ? 8, fixDarwinDylibNames, nukeReferences
+, runCommand
+, graphicsmagick  # for passthru.tests
+}:
 
 stdenv.mkDerivation rec {
   pname = "graphicsmagick";
@@ -39,6 +42,16 @@ stdenv.mkDerivation rec {
   postInstall = ''
     sed -i 's/-ltiff.*'\'/\'/ $out/bin/*
   '';
+
+  passthru = {
+    tests = {
+      issue-157920 = runCommand "issue-157920-regression-test" {
+        buildInputs = [ graphicsmagick ];
+      } ''
+        gm convert ${graphviz}/share/graphviz/doc/pdf/neatoguide.pdf jpg:$out
+      '';
+    };
+  };
 
   meta = {
     homepage = "http://www.graphicsmagick.org";


### PR DESCRIPTION
###### Motivation for this change
Firstly fix #157920

Nuking the references in `magick_config.h` also nuked the references to the package's own `delegates.mgk`, needed for determining which external tools to use for handling of e.g. pdf files.

Then add a regression test for #157920. Use a pdf from the documentation of `graphviz` as it's already a dependency.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
