### PR TITLE
scalapack: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -1,22 +1,24 @@
 { lib, stdenv, fetchFromGitHub, cmake, openssh
-, gfortran, mpi, blas, lapack
+, mpi, blas, lapack
 } :
 
 assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation rec {
   pname = "scalapack";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "Reference-ScaLAPACK";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1c10d18gj3kvpmyv5q246x35hjxaqn4ygy1cygaydhyxnm4klzdj";
+    sha256 = "0hiap5i9ik6xpvl721n2slanlqygagc1pg2bcjb27ans6balhsfh";
   };
 
-  nativeBuildInputs = [ cmake openssh gfortran ];
-  buildInputs = [ mpi blas lapack ];
+  nativeBuildInputs = [ cmake ];
+  checkInputs = [ openssh ];
+  buildInputs = [ blas lapack ];
+  propagatedBuildInputs = [ mpi ];
 
   doCheck = true;
 
@@ -25,6 +27,7 @@ stdenv.mkDerivation rec {
       -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF
       -DLAPACK_LIBRARIES="-llapack"
       -DBLAS_LIBRARIES="-lblas"
+      -DCMAKE_Fortran_COMPILER=${mpi}/bin/mpif90
       )
   '';
 

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -2,7 +2,7 @@
 , mpi, blas, lapack
 } :
 
-assert (!blas.isILP64) && (!lapack.isILP64);
+assert blas.isILP64 == lapack.isILP64;
 
 stdenv.mkDerivation rec {
   pname = "scalapack";
@@ -14,6 +14,18 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0hiap5i9ik6xpvl721n2slanlqygagc1pg2bcjb27ans6balhsfh";
   };
+
+  passthru = { inherit (blas) isILP64; };
+
+  # Required to activate ILP64.
+  # See https://github.com/Reference-ScaLAPACK/scalapack/pull/19
+  postPatch = lib.optionalString passthru.isILP64 ''
+    sed -i 's/INTSZ = 4/INTSZ = 8/g'   TESTING/EIG/* TESTING/LIN/*
+    sed -i 's/INTGSZ = 4/INTGSZ = 8/g' TESTING/EIG/* TESTING/LIN/*
+
+    # These tests are not adapted to ILP64
+    sed -i '/xssep/d;/xsgsep/d;/xssyevr/d' TESTING/CMakeLists.txt
+  '';
 
   nativeBuildInputs = [ cmake ];
   checkInputs = [ openssh ];
@@ -28,6 +40,10 @@ stdenv.mkDerivation rec {
       -DLAPACK_LIBRARIES="-llapack"
       -DBLAS_LIBRARIES="-lblas"
       -DCMAKE_Fortran_COMPILER=${mpi}/bin/mpif90
+      ${lib.optionalString passthru.isILP64 ''
+        -DCMAKE_Fortran_FLAGS="-fdefault-integer-8"
+        -DCMAKE_C_FLAGS="-DInt=long"
+      ''}
       )
   '';
 
@@ -55,5 +71,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ costrouc markuskowa ];
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change
Changelog: http://netlib.org/scalapack/scalapack-2.2.0.html
Enable optional build with ILP64 interface.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
