### PR TITLE
python3Packages.pycfmodel: 0.13.0 -> 0.16.0

### DIFF
--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "pycfmodel";
-  version = "0.14.0";
+  version = "0.15.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Skyscanner";
     repo = pname;
     rev = version;
-    hash = "sha256-8h6cml3C3mrRgnqgfLbt9I46rja5rlYL1uWMk9/pnpc=";
+    hash = "sha256-qXLdRf+45tc0PA74Jho45h4d+63GyseTfzDWjOqDpLk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "pycfmodel";
-  version = "0.15.0";
+  version = "0.16.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Skyscanner";
     repo = pname;
     rev = version;
-    hash = "sha256-qXLdRf+45tc0PA74Jho45h4d+63GyseTfzDWjOqDpLk=";
+    hash = "sha256-44G1H6bOtqVkplaX/sHxEzErlunclLh97OPO0m6n9eM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pycfmodel/default.nix
+++ b/pkgs/development/python-modules/pycfmodel/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "pycfmodel";
-  version = "0.13.0";
+  version = "0.14.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Skyscanner";
     repo = pname;
     rev = version;
-    hash = "sha256-BlnLf0C/wxPXhoAH0SRB22eGWbbZ05L20rNy6qfOI+A=";
+    hash = "sha256-8h6cml3C3mrRgnqgfLbt9I46rja5rlYL1uWMk9/pnpc=";
   };
 
   propagatedBuildInputs = [
@@ -33,6 +33,9 @@ buildPythonPackage rec {
   disabledTests = [
     # Test require network access
     "test_cloudformation_actions"
+    "test_auxiliar_cast"
+    "test_valid_es_domain_from_aws_documentation_examples_resource_can_be_built"
+    "test_valid_opensearch_domain_from_aws_documentation_examples_resource_can_be_built"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/tools/security/cfripper/default.nix
+++ b/pkgs/tools/security/cfripper/default.nix
@@ -3,7 +3,27 @@
 , python3
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+
+      # pycfmodel is pinned, https://github.com/Skyscanner/cfripper/issues/204
+      pycfmodel = super.pycfmodel.overridePythonAttrs (oldAttrs: rec {
+        version = "0.13.0";
+
+        src = fetchFromGitHub {
+          owner = "Skyscanner";
+          repo = "pycfmodel";
+          rev = version;
+          hash = "sha256-BlnLf0C/wxPXhoAH0SRB22eGWbbZ05L20rNy6qfOI+A=";
+        };
+      });
+    };
+  };
+in
+with py.pkgs;
+
+buildPythonApplication rec {
   pname = "cfripper";
   version = "1.3.3";
 
@@ -14,7 +34,7 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-y3h/atfFl/wDmr+YBdsWrCez4PQBEcl3xNDyTwXZIp4=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with py.pkgs; [
     boto3
     cfn-flip
     click
@@ -25,7 +45,7 @@ python3.pkgs.buildPythonApplication rec {
     setuptools
   ];
 
-  checkInputs = with python3.pkgs; [
+  checkInputs = with py.pkgs; [
     moto
     pytestCheckHook
   ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/Skyscanner/pycfmodel/releases/tag/0.16.0
https://github.com/Skyscanner/pycfmodel/releases/tag/0.15.0
https://github.com/Skyscanner/pycfmodel/releases/tag/0.14.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
