### PR TITLE
gitlab: 14.7.0 -> 14.7.1

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "14.7.0",
-  "repo_hash": "0jam4krhwkbri99642vz4gjlnr7zfgd6mq7pgjyf00f6pggvhq79",
-  "yarn_hash": "1cv3lxfw4i9snlw5x6bcip1n97wg72v5zpz9mjxdpzd2i1bwp6da",
+  "version": "14.7.1",
+  "repo_hash": "1zph7a2mqwbmgc6isd0vl6w8j9lrlcnxyhabzpcms4v3q3agr4f3",
+  "yarn_hash": "12k2r1y7kw95kfsmy0s8rbsf0vldr8c2liah0rkc7pihr19gq3w7",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v14.7.0-ee",
+  "rev": "v14.7.1-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "14.7.0",
+    "GITALY_SERVER_VERSION": "14.7.1",
     "GITLAB_PAGES_VERSION": "1.51.0",
     "GITLAB_SHELL_VERSION": "13.22.2",
-    "GITLAB_WORKHORSE_VERSION": "14.7.0"
+    "GITLAB_WORKHORSE_VERSION": "14.7.1"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -23,7 +23,7 @@ let
     gemdir = ./.;
   };
 
-  version = "14.7.0";
+  version = "14.7.1";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/v${lib.versions.major version}";
 in
 
@@ -35,7 +35,7 @@ buildGoModule {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-hOtdeJSjZLGcPCZpu42lGtCtQoLE0/AQqfQWLUJ6Hf8=";
+    sha256 = "sha256-MGcqYbHHeYwjfnvrJG/ZtOnyxsj+w1kPHOkVHf2AeMQ=";
   };
 
   vendorSha256 = "sha256-eapqtSstc7d3R7A/5krKV0uVr9GhGkHHMrmsBOpWAbo=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "14.7.0";
+  version = "14.7.1";
 
   src = fetchFromGitLab {
     owner = data.owner;

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -1661,4 +1661,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.4.1)
 
 BUNDLED WITH
-   2.2.24
+   2.3.6


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://about.gitlab.com/releases/2022/02/03/security-release-gitlab-14-7-1-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
