### PR TITLE
python3Packages.aresponses: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/development/python-modules/aresponses/default.nix
+++ b/pkgs/development/python-modules/aresponses/default.nix
@@ -2,24 +2,24 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
-, isPy3k
+, pythonOlder
 , pytest
 , pytest-asyncio
-, pytest-cov
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aresponses";
-  version = "2.1.4";
+  version = "2.1.5";
+  format = "setuptools";
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "CircleUp";
     repo = pname;
     rev = version;
-    sha256 = "sha256-crMiMZ2IDuYDFt8Bixg3NRhlUa2tqmfzd7ZeHM+2Iu4=";
+    sha256 = "sha256-9ZzIrj87TwxQi0YMlTHFPAp0V1oxfuL0+RMGXxUxFoE=";
   };
 
   propagatedBuildInputs = [
@@ -34,19 +34,20 @@ buildPythonPackage rec {
   checkInputs = [
     aiohttp
     pytest-asyncio
-    pytest-cov
     pytestCheckHook
   ];
 
-  # Disable tests which requires network access
   disabledTests = [
+    # Disable tests which requires network access
     "test_foo"
     "test_passthrough"
   ];
 
   __darwinAllowLocalNetworking = true;
 
-  pythonImportsCheck = [ "aresponses" ];
+  pythonImportsCheck = [
+    "aresponses"
+  ];
 
   meta = with lib; {
     description = "Asyncio testing server";
@@ -55,3 +56,4 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ makefu ];
   };
 }
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/aresponses/aresponses#changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
