### PR TITLE
dune_2: 2.9.2 → 2.9.3

### DIFF
--- a/pkgs/development/ocaml-modules/bigarray-compat/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-compat/default.nix
@@ -6,7 +6,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.02";
 
   src = fetchFromGitHub {
     owner = "mirage";

--- a/pkgs/development/tools/ocaml/dune/2.nix
+++ b/pkgs/development/tools/ocaml/dune/2.nix
@@ -6,11 +6,11 @@ else
 
 stdenv.mkDerivation rec {
   pname = "dune";
-  version = "2.9.2";
+  version = "2.9.3";
 
   src = fetchurl {
     url = "https://github.com/ocaml/dune/releases/download/${version}/dune-site-${version}.tbz";
-    sha256 = "sha256-uOfMUH+5eLRfb9yDnysyAdLB5hHkqOlyyMjP2FIudEc=";
+    sha256 = "sha256:1ml8bxym8sdfz25bx947al7cvsi2zg5lcv7x9w6xb01cmdryqr9y";
   };
 
   nativeBuildInputs = [ ocaml findlib ];

--- a/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/ocamlbuild.nix
@@ -7,7 +7,7 @@ buildDunePackage {
 
   inherit (js_of_ocaml-compiler) version src meta useDune2;
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.02";
 
   propagatedBuildInputs = [ ocamlbuild ];
 }


### PR DESCRIPTION
###### Motivation for this change

Bugfix release: https://github.com/ocaml/dune/releases/tag/2.9.3

cc maintainer @marsam

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
