### PR TITLE
python3Packages.img2pdf: disable tests with Pillow 9

### DIFF
--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , isPy27
 , fetchPypi
+, fetchpatch
 , pikepdf
 , pillow
 , stdenv
@@ -25,6 +26,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-jlHFBD76lddRSBtRYHGgBvh8KkBZlhqaxD7COJFd4J8=";
   };
+
+  patches = [
+    # Disable tests broken by Pillow 9.0.0
+    # https://gitlab.mister-muffin.de/josch/img2pdf/issues/130#issuecomment-586
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/img2pdf/-/raw/f77fefc81e7c4b235c47ae6777d222d391c59536/debian/patches/pillow9";
+      sha256 = "sha256-8giZCuv5PzSbrBQqslNqiLOhgxbg3LsdBVwt+DWnvh4=";
+    })
+  ];
 
   propagatedBuildInputs = [
     pikepdf


### PR DESCRIPTION
###### Motivation for this change

`img2pdf` fails to run its tests since the update of Pillow:

```
python3.9-img2pdf> =========================== short test summary info ============================
python3.9-img2pdf> FAILED src/img2pdf_test.py::test_general[animation.gif-internal] - AssertionE...
python3.9-img2pdf> FAILED src/img2pdf_test.py::test_general[animation.gif-pikepdf] - AssertionEr...
python3.9-img2pdf> ERROR src/img2pdf_test.py::test_gif_animation[internal] - TypeError: object i...
python3.9-img2pdf> ERROR src/img2pdf_test.py::test_gif_animation[pikepdf] - TypeError: object is...
```

Now pulling a patch from upstream (https://gitlab.mister-muffin.de/josch/img2pdf/issues/130#issuecomment-586) to disable the tests when using Pillow 9 until a proper fix is available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>paperless-ng</li>
  </ul>
</details>
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>img2pdf (python39Packages.img2pdf)</li>
    <li>ocrmypdf (python39Packages.ocrmypdf)</li>
    <li>pdfarranger</li>
    <li>python310Packages.img2pdf</li>
    <li>python310Packages.ocrmypdf</li>
  </ul>
</details>