### PR TITLE
paperless-ng: disable broken "slow_write_pdf" tests

### DIFF
--- a/pkgs/applications/office/paperless-ng/default.nix
+++ b/pkgs/applications/office/paperless-ng/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchurl
+, fetchpatch
 , nixosTests
 , python3
 , ghostscript
@@ -53,6 +54,15 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     url = "https://github.com/jonaswinkler/paperless-ng/releases/download/ng-${version}/${pname}-${version}.tar.xz";
     sha256 = "oVSq0AWksuWC81MF5xiZ6ZbdKKtqqphmL+xIzJLaDMw=";
   };
+
+  patches = [
+    # Fix the `slow_write_pdf` test:
+    # https://github.com/NixOS/nixpkgs/issues/136626
+    (fetchpatch {
+      url = "https://github.com/paperless-ngx/paperless-ngx/commit/4fbabe43ea12811864e9676b04d82a82b38e799d.patch";
+      sha256 = "sha256-8ULep5aeW3wJAQGy2OEAjFYybELNq1DzCC1uBrZx36I=";
+    })
+  ];
 
   format = "other";
 

--- a/pkgs/applications/office/paperless-ng/default.nix
+++ b/pkgs/applications/office/paperless-ng/default.nix
@@ -165,27 +165,6 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     zope_interface
   ];
 
-  doCheck = true;
-  checkInputs = with py.pkgs.pythonPackages; [
-    pytest
-    pytest-cov
-    pytest-django
-    pytest-env
-    pytest-sugar
-    pytest-xdist
-    factory_boy
-  ];
-
-  # The tests require:
-  # - PATH with runtime binaries
-  # - A temporary HOME directory for gnupg
-  # - XDG_DATA_DIRS with test-specific fonts
-  checkPhase = ''
-    pushd src
-    PATH="${path}:$PATH" HOME=$(mktemp -d) XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS" pytest
-    popd
-  '';
-
   installPhase = ''
     mkdir -p $out/lib
     cp -r . $out/lib/paperless-ng
@@ -193,6 +172,31 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     makeWrapper $out/lib/paperless-ng/src/manage.py $out/bin/paperless-ng \
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --prefix PATH : "${path}"
+  '';
+
+  checkInputs = with py.pkgs.pythonPackages; [
+    pytest-django
+    pytest-env
+    pytest-sugar
+    pytest-xdist
+    factory_boy
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "src" ];
+
+  # The tests require:
+  # - PATH with runtime binaries
+  # - A temporary HOME directory for gnupg
+  # - XDG_DATA_DIRS with test-specific fonts
+  preCheck = ''
+    export PATH="${path}:$PATH"
+    export HOME=$(mktemp -d)
+    export XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS"
+
+    # Disable unneeded code coverage test
+    substituteInPlace src/setup.cfg \
+      --replace "--cov --cov-report=html" ""
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

The [test_slow_write_pdf test](https://github.com/jonaswinkler/paperless-ng/blob/ng-1.5.0/src/documents/tests/test_management_consumer.py#L135) fails to compare the "slowly" generated file in https://github.com/jonaswinkler/paperless-ng/blob/ng-1.5.0/src/documents/tests/test_management_consumer.py#L79

Depends on #158111
See also #136626

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
