### PR TITLE
pantum-driver: init at 1.1.84

### DIFF
--- a/pkgs/misc/drivers/pantum-driver/default.nix
+++ b/pkgs/misc/drivers/pantum-driver/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchzip
+, libusb1
+, cups
+, dpkg
+, libjpeg8
+, makeWrapper
+, autoPatchelfHook
+, enablePtqpdf ? false # Pantum's version of qpdf
+}:
+
+let
+  architecture = {
+    i686-linux = "i386";
+    x86_64-linux = "amd64";
+  }.${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation rec {
+  pname = "pantum-driver";
+  version = "1.1.84";
+
+  src = fetchzip {
+    url = "https://drivers.pantum.com/Pantum_Ubuntu_Driver_V${version}_1.zip";
+    sha256 = "sha256-UJzYBsGj/TMhQoMourx7UPGBpN0MPi4pEN8m1sXLw/g=";
+  };
+
+  buildInputs = [ libusb1 libjpeg8 cups ];
+  nativeBuildInputs = [ dpkg autoPatchelfHook ];
+
+  installPhase = ''
+    dpkg-deb -x ./Resources/pantum_${version}-1_${architecture}.deb .
+
+    mkdir -p $out $out/lib
+    cp -r etc $out/
+    cp -r usr/lib/cups $out/lib/
+    cp -r usr/local/lib/* $out/lib/
+    cp -r usr/share $out/
+    cp Resources/locale/en_US.UTF-8/* $out/share/doc/pantum/
+  '' + lib.optionalString enablePtqpdf ''
+    cp -r opt/pantum/* $out/
+    ln -s $out/lib/libqpdf.so* $out/lib/libqpdf.so
+    ln -s $out/lib/libqpdf.so $out/lib/libqpdf.so.21
+  '';
+
+  meta = {
+    description = "Pantum universal driver";
+    homepage = "https://global.pantum.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9428,6 +9428,10 @@ with pkgs;
 
   poretools = callPackage ../applications/science/biology/poretools { };
 
+  pantum-driver = callPackage ../misc/drivers/pantum-driver {
+    libjpeg8 = libjpeg.override { enableJpeg8 = true; };
+  };
+
   postscript-lexmark = callPackage ../misc/drivers/postscript-lexmark { };
 
   povray = callPackage ../tools/graphics/povray {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Printing and scanning works on Pantum M6500 MFP so far.
URL link is stable but manufacturer don't use CI so typos are expected between versions.
I packaged this driver for i686 version of NixOS, should work but i didn't have a chance to test this. (Is there any need for this anyway?)

###### Motivation for this change

This commit adds a cups and sane drivers for most Pantum devices.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
