### PR TITLE
matrix-conduit: 0.2.0 -> 0.3.0

### DIFF
--- a/nixos/modules/services/misc/matrix-conduit.nix
+++ b/nixos/modules/services/misc/matrix-conduit.nix
@@ -86,6 +86,15 @@ in
                 and is set to be read only.
               '';
             };
+            global.database_backend = mkOption {
+              type = types.enum [ "sqlite" "rocksdb" ];
+              default = "sqlite";
+              example = "rocksdb";
+              description = ''
+                The database backend for the service. Switching it on an existing
+                instance will require manual migration of data.
+              '';
+            };
           };
         };
         default = {};

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -1,17 +1,35 @@
-{ stdenv, lib, fetchFromGitLab, rustPlatform, }:
+{ stdenv, lib, fetchFromGitLab, rustPlatform, pkgs }:
 
 rustPlatform.buildRustPackage rec {
   pname = "matrix-conduit";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitLab {
     owner = "famedly";
     repo = "conduit";
     rev = "v${version}";
-    sha256 = "0k3313bnv399v738j1xja9hngsmi39r3vzvgwssl5c24yvkvskdr";
+    sha256 = "sha256-jCBvenwXPgYms5Tbu16q/F8UNpvaw0Shao9kLEZLbHM=";
   };
 
-  cargoSha256 = "0379dvc8m8clc9lrxd1x0aciqvcgv3hjq7xfspz3bh8aq2a43pcs";
+  cargoSha256 = "sha256-fpjzc2HiWP6nV8YZOwxsIOhy4ht/tQqcvCkcLMIFUaQ=";
+
+  nativeBuildInputs = with pkgs; [
+    clang
+    llvmPackages.libclang
+  ];
+
+  buildInputs = with pkgs; [
+    pkg-config
+    clangStdenv
+    llvmPackages.libclang.lib
+    rocksdb
+  ];
+
+  preBuild = with pkgs; ''
+    export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+  '';
+
+  cargoBuildFlags = "--bin conduit";
 
   meta = with lib; {
     description = "A Matrix homeserver written in Rust";

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -17,6 +17,6 @@ rustPlatform.buildRustPackage rec {
     description = "A Matrix homeserver written in Rust";
     homepage = "https://conduit.rs/";
     license = licenses.asl20;
-    maintainers = with maintainers; [ pstn piegames ];
+    maintainers = with maintainers; [ pstn piegames pimeys ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Changelog: https://gitlab.com/famedly/conduit/-/releases/v0.3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
