### PR TITLE
polypane: init at 10.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15175,7 +15175,6 @@
     name = "Zoey de Souza Pessanha";
     email = "zoey.spessanha@outlook.com";
     keys = [{
-      longkeyid = "rsa4096/0x1E1E889CDBD6A315";
       fingerprint = "EAA1 51DB 472B 0122 109A  CB17 1E1E 889C DBD6 A315";
     }];
   };

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15175,6 +15175,7 @@
     name = "Zoey de Souza Pessanha";
     email = "zoey.spessanha@outlook.com";
     keys = [{
+      longkeyid = "rsa4096/0x1E1E889CDBD6A315";
       fingerprint = "EAA1 51DB 472B 0122 109A  CB17 1E1E 889C DBD6 A315";
     }];
   };

--- a/pkgs/applications/networking/browsers/polypane/default.nix
+++ b/pkgs/applications/networking/browsers/polypane/default.nix
@@ -1,0 +1,41 @@
+{ lib, fetchurl, appimageTools }:
+
+let
+  pname = "polypane";
+  version = "10.0.1";
+
+  src = fetchurl {
+    url = "https://github.com/firstversionist/${pname}/releases/download/v${version}/${pname}-${version}.AppImage";
+    name = "${pname}-${version}.AppImage";
+    sha256 = "eujv99L5svMhDIKHFOfm7sOwNZ4xiUaIsimfOf4BBik=";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname src version;
+  };
+in appimageTools.wrapType2 {
+  inherit pname src version;
+
+  multiPkgs = null;
+  extraPkgs = pkgs: appimageTools.defaultFhsEnvArgs.multiPkgs pkgs ++ [ pkgs.bash ];
+
+  extraInstallCommands = ''
+    ln -s $out/bin/${pname}-${version} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/${pname}.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/${pname}.png \
+      $out/share/icons/hicolor/512x512/apps/${pname}.png
+  '';
+
+  meta = with lib; {
+    description = "Browser with unified devtools targeting responsability and acessibility";
+    longDescription = ''
+      The stand-alone browser for ambitious developers that want to build responsive,
+      accessible and performant websites in a fraction of the time it takes with other browsers.
+    '';
+    homepage = "https://polypane.app/";
+    maintainers = with maintainers; [ zoedsoupe ];
+    platforms = [ "x86_64-linux" ];
+    changelog = "https://polypane.app/docs/changelog/";
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10140,6 +10140,8 @@ with pkgs;
 
   poly2tri-c = callPackage ../development/libraries/poly2tri-c { };
 
+  polypane = callPackage ../applications/networking/browsers/polypane { };
+
   ponysay = callPackage ../tools/misc/ponysay { };
 
   popfile = callPackage ../tools/text/popfile { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Polypane is a stand-alone browser that target web developers providing a rich support for responsive and acessible web developing tools.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
