### PR TITLE
python3Packages.cattrs: 1.8.0 -> 1.10.0

### DIFF
--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -11,23 +11,22 @@
 , pythonOlder
 , pyyaml
 , tomlkit
+, typing-extensions
 , ujson
 }:
 
 buildPythonPackage rec {
   pname = "cattrs";
-  version = "1.8.0";
+  version = "1.10.0";
   format = "pyproject";
 
-  # https://cattrs.readthedocs.io/en/latest/history.html#id33:
-  # "Python 2, 3.5 and 3.6 support removal. If you need it, use a version below 1.1.0."
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
-    owner = "Tinche";
+    owner = "python-attrs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CKAsvRKS8kmLcyPA753mh6d3S04ObzO7xLPpmlmxrxI=";
+    hash = "sha256-VbfQMMDO03eeUHAACxoX6a3DKmzoF9EfLuTpvaY6bWs=";
   };
 
   nativeBuildInputs = [
@@ -36,6 +35,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     attrs
+  ] ++ lib.optionals (pythonOlder "3.7") [
+    typing-extensions
   ];
 
   checkInputs = [
@@ -50,10 +51,10 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "-l --benchmark-sort=fullname --benchmark-warmup=true --benchmark-warmup-iterations=5  --benchmark-group-by=fullname" ""
     substituteInPlace pyproject.toml \
-      --replace 'orjson = "^3.5.2"' ""
+      --replace "-l --benchmark-sort=fullname --benchmark-warmup=true --benchmark-warmup-iterations=5  --benchmark-group-by=fullname" "" \
+      --replace 'orjson = "^3.5.2"' "" \
+      --replace "[tool.poetry.group.dev.dependencies]" "[tool.poetry.dev-dependencies]"
     substituteInPlace tests/test_preconf.py \
       --replace "from orjson import dumps as orjson_dumps" "" \
       --replace "from orjson import loads as orjson_loads" ""
@@ -76,11 +77,13 @@ buildPythonPackage rec {
     "test_orjson"
   ];
 
-  pythonImportsCheck = [ "cattr" ];
+  pythonImportsCheck = [
+    "cattr"
+  ];
 
   meta = with lib; {
     description = "Python custom class converters for attrs";
-    homepage = "https://github.com/Tinche/cattrs";
+    homepage = "https://github.com/python-attrs/cattrs";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://cattrs.readthedocs.io/en/latest/history.html#id2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
