### PR TITLE
python-validity: init at 0.12

### DIFF
--- a/pkgs/tools/security/python-validity/default.nix
+++ b/pkgs/tools/security/python-validity/default.nix
@@ -1,0 +1,45 @@
+{ lib, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "python-validity";
+  version = "0.12";
+
+  src = fetchFromGitHub {
+    owner = "uunicorn";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-s0o99CRW9gwxCv3AMKrtXh8mrblVAA9r9IIPgy6fv4U=";
+  };
+
+  buildInputs = with python3.pkgs; [ cryptography pyyaml pyusb ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    dbus-python
+    pygobject3
+    cryptography
+    pyyaml
+    pyusb
+  ];
+
+  postInstall = ''
+    install -D -m 644 debian/python3-validity.service \
+      $out/lib/systemd/system/python3-validity.service
+    substituteInPlace $out/lib/python-validity/dbus-service \
+      --replace /usr/share/python-validity/backoff /tmp/backoff
+    substituteInPlace $out/${python3.sitePackages}/validitysensor/sensor.py \
+      --replace /usr/share/python-validity/calib-data.bin /tmp/calib-data.bin
+    substituteInPlace $out/lib/systemd/system/python3-validity.service \
+      --replace /usr/lib/python-validity "$out/lib/python-validity"
+  '';
+
+  postFixup = ''
+    wrapPythonProgramsIn "$out/lib/python-validity" "$out $pythonPath"
+  '';
+
+  meta = with lib; {
+    description = "Validity fingerprint sensor driver";
+    homepage = "https://github.com/uunicorn/python-validity";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9118,6 +9118,8 @@ with pkgs;
 
   py-spy = callPackage ../development/tools/py-spy { };
 
+  python-validity = callPackage ../tools/security/python-validity { };
+
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
   pywal = with python3Packages; toPythonApplication pywal;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves #157770

Import python-validity package to provide drivers for Validity fingerprint readers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
