### PR TITLE
emojipick: init at 2021-01-27

### DIFF
--- a/pkgs/applications/misc/emojipick/default.nix
+++ b/pkgs/applications/misc/emojipick/default.nix
@@ -1,0 +1,72 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, lib
+, python3
+, xclip
+, libnotify
+, dmenu
+, rofi
+, emojipick-use-rofi ? false
+, emojipick-copy-to-clipboard ? true
+, emojipick-show-notifications ? true
+, emojipick-print-emoji ? true
+, emojipick-font-family ? "Noto Color Emoji"
+, emojipick-font-size ? "18"
+}:
+
+let
+  boolToInt = b: if b then "1" else "0"; # Convert boolean to integer string
+in
+stdenvNoCC.mkDerivation {
+  pname = "emojipick";
+  version = "2021-01-27";
+
+  src = fetchFromGitHub {
+    owner = "thingsiplay";
+    repo = "emojipick";
+    rev = "20210127";
+    sha256 = "1kib3cyx6z9v9qw6yrfx5sklanpk5jbxjc317wi7i7ljrg0vdazp";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # Patch configuration
+  # notify-send has to be patched in a bash file
+  postPatch = with lib.strings; ''
+    substituteInPlace emojipick \
+      --replace "use_rofi=0" "use_rofi=${boolToInt emojipick-use-rofi}" \
+      --replace "copy_to_clipboard=1" "copy_to_clipboard=${boolToInt emojipick-copy-to-clipboard}" \
+      --replace "show_notification=1" "show_notification=${boolToInt emojipick-show-notifications}" \
+      --replace "print_emoji=1" "print_emoji=${boolToInt emojipick-print-emoji}" \
+      --replace "font_family='\"Noto Color Emoji\"'" "font_family='\"${emojipick-font-family}\"'" \
+      --replace 'font_size="18"' 'font_size="${emojipick-font-size}"' \
+      ${optionalString emojipick-use-rofi "--replace 'rofi ' '${rofi}/bin/rofi '"} \
+      --replace notify-send ${libnotify}/bin/notify-send
+
+  '';
+
+  buildInputs = with lib.lists; [
+    python3
+    xclip
+    libnotify
+  ] ++ (if emojipick-use-rofi then [rofi] else [dmenu]);
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ./emojipick $out/bin
+    cp ./emojiget.py $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Get a selection of emojis with dmenu or rofi";
+    homepage = "https://github.com/thingsiplay/emojipick";
+    license = licenses.mit;
+    maintainers = with maintainers; [ alexnortung ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/misc/emojipick/default.nix
+++ b/pkgs/applications/misc/emojipick/default.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation {
 
   # Patch configuration
   # notify-send has to be patched in a bash file
-  postPatch = with lib.strings; ''
+  postPatch = ''
     substituteInPlace emojipick \
       --replace "use_rofi=0" "use_rofi=${boolToInt emojipick-use-rofi}" \
       --replace "copy_to_clipboard=1" "copy_to_clipboard=${boolToInt emojipick-copy-to-clipboard}" \
@@ -41,12 +41,11 @@ stdenvNoCC.mkDerivation {
       --replace "print_emoji=1" "print_emoji=${boolToInt emojipick-print-emoji}" \
       --replace "font_family='\"Noto Color Emoji\"'" "font_family='\"${emojipick-font-family}\"'" \
       --replace 'font_size="18"' 'font_size="${emojipick-font-size}"' \
-      ${optionalString emojipick-use-rofi "--replace 'rofi ' '${rofi}/bin/rofi '"} \
+      ${lib.optionalString emojipick-use-rofi "--replace 'rofi ' '${rofi}/bin/rofi '"} \
       --replace notify-send ${libnotify}/bin/notify-send
-
   '';
 
-  buildInputs = with lib.lists; [
+  buildInputs = [
     python3
     xclip
     libnotify

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23687,6 +23687,8 @@ with pkgs;
     inherit (nodePackages) svgo;
   };
 
+  emojipick = callPackage ../applications/misc/emojipick { };
+
   encode-sans = callPackage ../data/fonts/encode-sans { };
 
   envypn-font = callPackage ../data/fonts/envypn-font


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adding emojipick for issue #148548

It adds support for configuration of the application by overriding it's arguments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
