### PR TITLE
[haskell-updates] haskell-language-server: 1.5 -> 1.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2038,13 +2038,13 @@ self: super: {
   # 2021-08-18: streamly-posix was released with hspec 2.8.2, but it works with older versions too.
   streamly-posix = doJailbreak super.streamly-posix;
 
-  # 2021-09-13: hls 1.3 needs a newer lsp than stackage-lts. (lsp >= 1.2.0.1)
+  # 2021-09-13: hls 1.6 needs a newer lsp than stackage-lts. (lsp >= 1.2.0.1)
   # (hls is nearly the only consumer, but consists of 18 packages, so we bump lsp globally.)
-  lsp = doDistribute self.lsp_1_2_0_1;
-  lsp-types = doDistribute self.lsp-types_1_3_0_1;
+  lsp = doDistribute self.lsp_1_4_0_0;
+  lsp-types = doDistribute self.lsp-types_1_4_0_1;
   # Not running the "example" test because it requires a binary from lsps test
   # suite which is not part of the output of lsp.
-  lsp-test = doDistribute (overrideCabal (old: { testTarget = "tests func-test"; }) self.lsp-test_0_14_0_1);
+  lsp-test = doDistribute (overrideCabal (old: { testTarget = "tests func-test"; }) self.lsp-test_0_14_0_2);
 
   # 2021-09-14: Tests are flaky.
   hls-splice-plugin = dontCheck super.hls-splice-plugin;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -150,23 +150,14 @@ self: super: {
   # Fixes a bug triggered on GHC 9.0.1
   text-short = self.text-short_0_1_5;
 
-  # 2021-09-18: The following plugins don‘t work yet on ghc9.
-  haskell-language-server = appendConfigureFlags [
-    "-f-tactic"
-    "-f-splice"
-    "-f-refineimports"
-    "-f-class"
+  fourmolu = doJailbreak self.fourmolu_0_4_0_0;
 
-    "-f-fourmolu"
+  # 2022-02-05: The following plugins don‘t work yet on ghc9.
+  # Compare: https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html
+  haskell-language-server = appendConfigureFlags [
     "-f-brittany"
     "-f-stylishhaskell"
   ] (super.haskell-language-server.override {
-    hls-tactics-plugin = null; # No upstream support, generic-lens-core fail
-    hls-splice-plugin = null; # No upstream support in hls 1.4.0, should be fixed in 1.5
-    hls-refine-imports-plugin = null; # same issue es splice-plugin
-    hls-class-plugin = null; # No upstream support
-
-    hls-fourmolu-plugin = null; # No upstream support, needs new fourmolu release
     hls-stylish-haskell-plugin = null; # No upstream support
     hls-brittany-plugin = null; # Dependencies don't build with 9.0.1
   });

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -138,7 +138,7 @@ self: super: {
   quickcheck-instances = super.quickcheck-instances_0_3_27;
   regex-posix = doJailbreak super.regex-posix;
   resolv = doJailbreak super.resolv;
-  retrie = doDistribute self.retrie_1_2_0_1;
+  retrie = doDistribute (dontCheck self.retrie_1_2_0_1);
   semialign = super.semialign_1_2_0_1;
   singleton-bool = doJailbreak super.singleton-bool;
   scientific = doJailbreak super.scientific;
@@ -241,4 +241,37 @@ self: super: {
   # need bytestring >= 0.11 which is only bundled with GHC >= 9.2
   regex-rure = doDistribute (markUnbroken super.regex-rure);
   jacinda = doDistribute super.jacinda;
+  some = doJailbreak super.some;
+  fourmolu = super.fourmolu_0_5_0_1;
+  implicit-hie-cradle = doJailbreak super.implicit-hie-cradle;
+  lucid = doJailbreak super.lucid;
+  hashtables = doJailbreak super.hashtables;
+  primitive-extras = super.primitive-extras_0_10_1_4;
+  hiedb = doJailbreak super.hiedb;
+
+  # 2022-02-05: The following plugins don‘t work yet on ghc9.2.
+  # Compare: https://haskell-language-server.readthedocs.io/en/latest/supported-versions.html
+  haskell-language-server = appendConfigureFlags [
+    "-f-alternateNumberFormat"
+    "-f-class"
+    "-f-eval"
+    "-f-haddockComments"
+    "-f-hlint"
+    "-f-retrie"
+    "-f-splice"
+    "-f-tactics"
+    "-f-brittany"
+    "-f-stylish-haskell"
+  ] (super.haskell-language-server.override {
+    hls-alternate-number-format-plugin = null;
+    hls-class-plugin = null;
+    hls-eval-plugin = null;
+    hls-haddock-comments-plugin = null;
+    hls-hlint-plugin = null;
+    hls-retrie-plugin = null;
+    hls-splice-plugin = null;
+    hls-tactics-plugin = null;
+    hls-brittany-plugin = null;
+    hls-stylish-haskell-plugin = null;
+  });
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -82,8 +82,6 @@ default-package-overrides:
   - reflex-dom-pandoc < 1.0.0.0
   # 2021-09-07: pin to our current GHC version
   - ghc-api-compat == 8.10.7
-  # 2021-09-14: Pin hiedb to version needed by ghcide
-  - hiedb == 0.4.0.*
   # 2021-10-13: weeder 2.3.0 require GHC == 9.0.*; remove pin when GHC version changes
   - weeder < 2.3.0
   # 2021-10-10: taskwarrior 0.4 requires aeson > 2.0.1.0
@@ -169,10 +167,6 @@ extra-packages:
   - brick == 0.64.*                     # 2021-12-03: matterhorn depends on brick < 0.65
   - path == 0.9.0                       # 2021-12-03: path version building with stackage genvalidity and GHC 9.0.2
   - ormolu == 0.3.*                     # 2021-12-03: for HLS with GHC 9.0.2
-  # 2022-01-08 hls-plugin-api 1.2.0.2 needs lsp < 1.3, but newer than stackage
-  - lsp < 1.3
-  - lsp-types < 1.4
-  - lsp-test < 0.14.0.2
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -167,6 +167,7 @@ extra-packages:
   - brick == 0.64.*                     # 2021-12-03: matterhorn depends on brick < 0.65
   - path == 0.9.0                       # 2021-12-03: path version building with stackage genvalidity and GHC 9.0.2
   - ormolu == 0.3.*                     # 2021-12-03: for HLS with GHC 9.0.2
+  - fourmolu == 0.4.*                   # 2022-02-05: for HLS with GHC 9.0.2
 
 package-maintainers:
   abbradar:

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -804,90 +804,11 @@ self: super: builtins.intersectAttrs super {
     '' + drv.postInstall or "";
   }) super.hlint;
 
-  hls-brittany-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-brittany-plugin;
-  hls-class-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-class-plugin;
-  hls-ormolu-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-ormolu-plugin;
-  hls-fourmolu-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-fourmolu-plugin;
-  hls-module-name-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-module-name-plugin;
-  hls-rename-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '' + (drv.preCheck or "");
-  }) super.hls-rename-plugin;
-  hls-splice-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-splice-plugin;
-  hls-floskell-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-floskell-plugin;
-  hls-pragmas-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-pragmas-plugin;
-  hls-hlint-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-hlint-plugin;
   hiedb = overrideCabal (drv: {
     preCheck = ''
       export PATH=$PWD/dist/build/hiedb:$PATH
     '';
   }) super.hiedb;
-  hls-call-hierarchy-plugin = overrideCabal (drv: {
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-call-hierarchy-plugin;
-  # Tests have file permissions expections that don‘t work with the nix store.
-  hls-stylish-haskell-plugin = dontCheck super.hls-stylish-haskell-plugin;
-  hls-haddock-comments-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-haddock-comments-plugin;
-  hls-eval-plugin = overrideCabal (drv: {
-    testToolDepends = [ pkgs.git ];
-    preCheck = ''
-      export HOME=$TMPDIR/home
-    '';
-  }) super.hls-eval-plugin;
 
   taglib = overrideCabal (drv: {
     librarySystemDepends = [
@@ -1052,4 +973,33 @@ self: super: builtins.intersectAttrs super {
       install -Dm644 test/examples/*.jac -t "$docDir/examples"
     '';
   }) super.jacinda;
+
+# haskell-language-server plugins all use the same test harness so we give them what we want in this loop.
+} // pkgs.lib.mapAttrs
+  (_: overrideCabal (drv: {
+    testToolDepends = (drv.testToolDepends or [ ]) ++ [ pkgs.git ];
+    preCheck = ''
+      export HOME=$TMPDIR/home
+    '' + (drv.preCheck or "");
+  }))
+{
+  inherit (super)
+    hls-alternate-number-format-plugin
+    hls-brittany-plugin
+    hls-call-hierarchy-plugin
+    hls-class-plugin
+    hls-eval-plugin
+    hls-floskell-plugin
+    hls-fourmolu-plugin
+    hls-haddock-comments-plugin
+    hls-module-name-plugin
+    hls-ormolu-plugin
+    hls-pragmas-plugin
+    hls-qualify-imported-names-plugin
+    hls-rename-plugin
+    hls-selection-range-plugin
+    hls-splice-plugin;
+  # Tests have file permissions expections that don‘t work with the nix store.
+  hls-stylish-haskell-plugin = dontCheck super.hls-stylish-haskell-plugin;
+  hls-hlint-plugin = dontCheck super.hls-hlint-plugin;
 }

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -1,4 +1,4 @@
-{ lib, supportedGhcVersions ? [ "884" "8107" "902" ], stdenv, haskellPackages
+{ lib, supportedGhcVersions ? [ "884" "8107" "902" "921" ], stdenv, haskellPackages
 , haskell }:
 #
 # The recommended way to override this package is

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -311,11 +311,7 @@ let
       cabal2nix = released;
       cabal2nix-unstable = released;
       funcmp = released;
-      haskell-language-server = [
-        compilerNames.ghc884
-        compilerNames.ghc8107
-        compilerNames.ghc902
-      ];
+      haskell-language-server = released;
       hoogle = released;
       hlint = released;
       hsdns = released;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

* Fix build for 1.6
* Fix build on ghc 9.2
* Enable all supported plugins on 9.0 and 9.2
* Refactor overrides in configuration-nix because every hls-*-plugin test needs the same override.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
