### PR TITLE
cudnn: init cudnn_8_3 at 8.3.0

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -1,60 +1,77 @@
-{ callPackage, cudatoolkit_10_0, cudatoolkit_10_1, cudatoolkit_10_2, cudatoolkit_11_0, cudatoolkit_11_1, cudatoolkit_11_2
-, cudatoolkit_11_3, cudatoolkit_11_4
+# The following version combinations are supported:
+#  * cuDNN 7.4.2, cudatoolkit 10.0
+#  * cuDNN 7.6.5, cudatoolkit 10.2
+#  * cuDNN 8.1.1, cudatoolkit 11.0-11.2
+#  * cuDNN 8.3.0, cudatoolkit 11.0-11.5
+{ callPackage
+, cudatoolkit_10_0
+, cudatoolkit_10_2
+, cudatoolkit_11_0
+, cudatoolkit_11_1
+, cudatoolkit_11_2
+, cudatoolkit_11_3
+, cudatoolkit_11_4
+, cudatoolkit_11_5
 }:
 
 let
-  generic = args: callPackage (import ./generic.nix (removeAttrs args ["cudatoolkit"])) {
+  generic = args: callPackage (import ./generic.nix (removeAttrs args [ "cudatoolkit" ])) {
     inherit (args) cudatoolkit;
   };
-
-in rec {
-  cudnn_cudatoolkit_10_0 = generic rec {
+in
+rec {
+  # cuDNN 7.x
+  # Still used by libtensorflow-bin. It should be upgraded at some point.
+  cudnn_7_4_cudatoolkit_10_0 = generic rec {
     version = "7.4.2";
     cudatoolkit = cudatoolkit_10_0;
     srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.4.2.24.tgz";
     sha256 = "18ys0apiz9afid2s6lvy9qbyi8g66aimb2a7ikl1f3dm09mciprf";
   };
 
-  cudnn_cudatoolkit_10_1 = generic rec {
-    version = "7.6.3";
-    cudatoolkit = cudatoolkit_10_1;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.6.3.30.tgz";
-    sha256 = "0qc9f1xpyfibwqrpqxxq2v9h6w90j0dbx564akwy44c1dls5f99m";
-  };
-
-  cudnn_cudatoolkit_10_2 = generic rec {
+  # The `cudnn` alias still points to this in all-packages.nix. It should be
+  # upgraded at some point.
+  cudnn_7_6_cudatoolkit_10_2 = generic rec {
     version = "7.6.5";
     cudatoolkit = cudatoolkit_10_2;
     srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.6.5.32.tgz";
     sha256 = "084c13vzjdkb5s1996yilybg6dgav1lscjr1xdcgvlmfrbr6f0k0";
   };
 
-  cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_2;
+  cudnn_7_6_cudatoolkit_10 = cudnn_7_6_cudatoolkit_10_2;
 
-  cudnn_cudatoolkit_11_0 = generic rec {
+  # cuDNN 8.x
+  # cuDNN 8.1 is still used by tensorflow at the time of writing (2022-02-17).
+  # See https://github.com/NixOS/nixpkgs/pull/158218 for more info.
+  cudnn_8_1_cudatoolkit_11_0 = generic rec {
     version = "8.1.1";
     cudatoolkit = cudatoolkit_11_0;
-    # 8.1.0 is compatible with CUDA 11.0, 11.1, and 11.2:
-    # https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html#cudnn-cuda-hardware-versions
+    # 8.1.0 is compatible with CUDA 11.0-11.2:
+    # https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-811/support-matrix/index.html
     srcName = "cudnn-11.2-linux-x64-v8.1.1.33.tgz";
     hash = "sha256-mKh4TpKGLyABjSDCgbMNSgzZUfk2lPZDPM9K6cUCumo=";
   };
+  cudnn_8_1_cudatoolkit_11_1 = cudnn_8_1_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_1; };
+  cudnn_8_1_cudatoolkit_11_2 = cudnn_8_1_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_2; };
+  cudnn_8_1_cudatoolkit_11 = cudnn_8_1_cudatoolkit_11_2;
 
-  cudnn_cudatoolkit_11_1 = cudnn_cudatoolkit_11_0.override {
-    cudatoolkit = cudatoolkit_11_1;
+  # cuDNN 8.3 is necessary for the latest jaxlib, esp. jaxlib-bin. See
+  # https://github.com/google/jax/discussions/9455 for more info.
+  cudnn_8_3_cudatoolkit_11_0 = generic rec {
+    # 8.3.0 is the last version to respect the folder structure that generic.nix
+    # expects. Later versions have files in a subdirectory `local_installers`.
+    # See eg https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.1/.
+    version = "8.3.0";
+    cudatoolkit = cudatoolkit_11_0;
+    # 8.3.0 is compatible with CUDA 11.0-11.5:
+    # https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-830/support-matrix/index.html
+    srcName = "cudnn-11.5-linux-x64-v8.3.0.98.tgz";
+    hash = "sha256-RMb1rVyxL7dPoMmh58qvTwTXVa3xGi5bbJ5BfaN2srI=";
   };
-
-  cudnn_cudatoolkit_11_2 = cudnn_cudatoolkit_11_0.override {
-    cudatoolkit = cudatoolkit_11_2;
-  };
-
-  cudnn_cudatoolkit_11_3 = cudnn_cudatoolkit_11_0.override {
-    cudatoolkit = cudatoolkit_11_3;
-  };
-
-  cudnn_cudatoolkit_11_4 = cudnn_cudatoolkit_11_0.override {
-    cudatoolkit = cudatoolkit_11_4;
-  };
-
-  cudnn_cudatoolkit_11 = cudnn_cudatoolkit_11_4;
+  cudnn_8_3_cudatoolkit_11_1 = cudnn_8_3_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_1; };
+  cudnn_8_3_cudatoolkit_11_2 = cudnn_8_3_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_2; };
+  cudnn_8_3_cudatoolkit_11_3 = cudnn_8_3_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_3; };
+  cudnn_8_3_cudatoolkit_11_4 = cudnn_8_3_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_4; };
+  cudnn_8_3_cudatoolkit_11_5 = cudnn_8_3_cudatoolkit_11_0.override { cudatoolkit = cudatoolkit_11_5; };
+  cudnn_8_3_cudatoolkit_11 = cudnn_8_3_cudatoolkit_11_5;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2269,7 +2269,7 @@ with pkgs;
   libtensorflow-bin = callPackage ../development/libraries/science/math/tensorflow/bin.nix {
     cudaSupport = config.cudaSupport or false;
     cudatoolkit = cudatoolkit_10_0;
-    cudnn = cudnn_cudatoolkit_10_0;
+    cudnn = cudnn_7_4_cudatoolkit_10_0;
   };
 
   libtensorflow =
@@ -4500,18 +4500,22 @@ with pkgs;
 
   cudnnPackages = callPackages ../development/libraries/science/math/cudnn { };
   inherit (cudnnPackages)
-    cudnn_cudatoolkit_10
-    cudnn_cudatoolkit_10_0
-    cudnn_cudatoolkit_10_1
-    cudnn_cudatoolkit_10_2
-    cudnn_cudatoolkit_11
-    cudnn_cudatoolkit_11_0
-    cudnn_cudatoolkit_11_1
-    cudnn_cudatoolkit_11_2
-    cudnn_cudatoolkit_11_3
-    cudnn_cudatoolkit_11_4;
+    cudnn_7_4_cudatoolkit_10_0
+    cudnn_7_6_cudatoolkit_10_2
+    cudnn_7_6_cudatoolkit_10
+    cudnn_8_1_cudatoolkit_11_0
+    cudnn_8_1_cudatoolkit_11_1
+    cudnn_8_1_cudatoolkit_11_2
+    cudnn_8_1_cudatoolkit_11
+    cudnn_8_3_cudatoolkit_11_0
+    cudnn_8_3_cudatoolkit_11_1
+    cudnn_8_3_cudatoolkit_11_2
+    cudnn_8_3_cudatoolkit_11_3
+    cudnn_8_3_cudatoolkit_11_4
+    cudnn_8_3_cudatoolkit_11_5
+    cudnn_8_3_cudatoolkit_11;
 
-  cudnn = cudnn_cudatoolkit_10;
+  cudnn = cudnn_7_6_cudatoolkit_10;
 
   cutensorPackages = callPackages ../development/libraries/science/math/cutensor { };
   inherit (cutensorPackages)
@@ -30932,7 +30936,7 @@ with pkgs;
 
   katagoWithCuda = katago.override {
     enableCuda = true;
-    cudnn = cudnn_cudatoolkit_11;
+    cudnn = cudnn_8_3_cudatoolkit_11;
     cudatoolkit = cudatoolkit_11;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -100,7 +100,7 @@ let
   # CUDA-related packages that are compatible with the currently packaged version
   # of TensorFlow, used to keep these versions in sync in related packages like `jaxlib`.
   tensorflow_compat_cudatoolkit = pkgs.cudatoolkit_11_2;
-  tensorflow_compat_cudnn = pkgs.cudnn_cudatoolkit_11_2;
+  tensorflow_compat_cudnn = pkgs.cudnn_8_1_cudatoolkit_11_2;
   tensorflow_compat_nccl = pkgs.nccl_cudatoolkit_11;
 
 in {
@@ -1929,7 +1929,7 @@ in {
 
   cupy = callPackage ../development/python-modules/cupy {
     cudatoolkit = pkgs.cudatoolkit_11;
-    cudnn = pkgs.cudnn_cudatoolkit_11;
+    cudnn = pkgs.cudnn_8_1_cudatoolkit_11;
     nccl = pkgs.nccl_cudatoolkit_11;
     cutensor = pkgs.cutensor_cudatoolkit_11;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Followup to https://github.com/NixOS/nixpkgs/pull/158186. This is a necessary step towards addressing the bug https://github.com/google/jax/discussions/9455. This, In conjunction with a bump to the cudnn82 variant of the jaxlib wheel, fixes that issue.

Version 8.3.2 is the latest at the time of writing but the directory structure for the download changed after 8.3.0 so I'll leave updating to 8.3.1 or 8.3.2 to a future PR...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
