### PR TITLE
furnace: init at 0.5.6

### DIFF
--- a/pkgs/applications/audio/furnace/default.nix
+++ b/pkgs/applications/audio/furnace/default.nix
@@ -1,0 +1,99 @@
+{ stdenv
+, lib
+, nix-update-script
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, pkg-config
+, makeWrapper
+, fmt_8
+, libsndfile
+, SDL2
+, zlib
+, withJACK ? stdenv.hostPlatform.isUnix
+, libjack2
+, withGUI ? true
+, Cocoa
+}:
+
+stdenv.mkDerivation rec {
+  pname = "furnace";
+  version = "0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "tildearrow";
+    repo = "furnace";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-BcaPQuDFkAaxFQKwoI6xdSWcyHo5VsqZcwf++JISqRs=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-furnace-fix-wrong-include-path.patch";
+      url = "https://github.com/tildearrow/furnace/commit/456db22f9d9f0ed40d74fe50dde492e69e901fcc.patch";
+      sha256 = "17ikb1z9ldm7kdj00m4swsrq1qx94vlzhc6h020x3ryzwnglc8d3";
+    })
+  ];
+
+  postPatch = ''
+    # rtmidi is not used yet
+    sed -i -e '/add_subdirectory(extern\/rtmidi/d' -e '/DEPENDENCIES_LIBRARIES rtmidi/d' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    fmt_8
+    libsndfile
+    SDL2
+    zlib
+  ] ++ lib.optionals withJACK [
+    libjack2
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Cocoa
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_GUI=${if withGUI then "ON" else "OFF"}"
+    "-DSYSTEM_FMT=ON"
+    "-DSYSTEM_LIBSNDFILE=ON"
+    "-DSYSTEM_ZLIB=ON"
+    "-DSYSTEM_SDL2=ON"
+    "-DWITH_JACK=${if withJACK then "ON" else "OFF"}"
+    "-DWARNINGS_ARE_ERRORS=ON"
+  ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Normal CMake install phase on Darwin only installs the binary, the user is expected to use CPack to build a
+    # bundle. That adds alot of overhead for not much benefit (CPack is currently abit broken, and needs impure access
+    # to /usr/bin/hdiutil). So we'll manually assemble & install everything instead.
+
+    mkdir -p $out/{Applications/Furnace.app/Contents/{MacOS,Resources},share/{,doc,licenses}/furnace}
+    mv $out/{bin,Applications/Furnace.app/Contents/MacOS}/furnace
+    makeWrapper $out/{Applications/Furnace.app/Contents/MacOS,bin}/furnace
+
+    install -m644 {../res,$out/Applications/Furnace.app/Contents}/Info.plist
+    install -m644 ../res/icon.icns $out/Applications/Furnace.app/Contents/Resources/Furnace.icns
+    install -m644 {..,$out/share/licenses/furnace}/LICENSE
+    cp -r ../papers $out/share/doc/furnace/
+    cp -r ../demos $out/share/furnace/
+  '';
+
+  passthru.updateScript = nix-update-script {
+    attrPath = pname;
+  };
+
+  meta = with lib; {
+    description = "Multi-system chiptune tracker compatible with DefleMask modules";
+    homepage = "https://github.com/tildearrow/furnace";
+    license = with licenses; [ gpl2Plus ];
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25303,6 +25303,10 @@ with pkgs;
 
   fnott = callPackage ../applications/misc/fnott { };
 
+  furnace = callPackage ../applications/audio/furnace {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
   gg-scm = callPackage ../applications/version-management/git-and-tools/gg { };
 
   gigalixir = with python3Packages; toPythonApplication gigalixir;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/tildearrow/furnace, a very new, FOSS & actively developed alternative to the closed-source music tracker DefleMask.

(https://github.com/NixOS/nixpkgs/issues/81815, ping @fgaz)

We need to use the vendored SDL2 because the minimum supported version is 2.0.18, which we don't have packaged (https://github.com/NixOS/nixpkgs/issues/154137).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
