### PR TITLE
rcs: 5.10.0 -> 5.10.1

### DIFF
--- a/pkgs/applications/version-management/rcs/default.nix
+++ b/pkgs/applications/version-management/rcs/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchurl, fetchpatch, buildPackages, diffutils, ed }:
+{ lib, stdenv, fetchurl, fetchpatch, buildPackages, diffutils, ed, lzip }:
 
 stdenv.mkDerivation rec {
   pname = "rcs";
-  version = "5.10.0";
+  version = "5.10.1";
 
   src = fetchurl {
-    url = "mirror://gnu/rcs/${pname}-${version}.tar.xz";
-    sha256 = "sha256-Og2flYx60wPkdehjRlSXTtvm3rOkVEkfOFfcGIm6xcU";
+    url = "mirror://gnu/rcs/${pname}-${version}.tar.lz";
+    sha256 = "sha256-Q93+EHJKi4XiRo9kA7YABzcYbwHmDgvWL95p2EIjTMU=";
   };
 
   ac_cv_path_ED = "${ed}/bin/ed";
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = "-std=c99";
 
   hardeningDisable = lib.optional stdenv.cc.isClang "format";
+
+  nativeBuildInputs = [ lzip ];
 
   meta = {
     homepage = "https://www.gnu.org/software/rcs/";


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/info-gnu/2022-02/msg00001.html
for release information.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
