### PR TITLE
nixpkgs-basic-release-checks.nix: print errors

### DIFF
--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -30,12 +30,22 @@ pkgs.runCommand "nixpkgs-release-checks" { src = nixpkgs; buildInputs = [nix]; }
         # Relies on impure eval
         export NIX_ABORT_ON_WARN=true
 
-        nix-env -f $src \
-            --show-trace --argstr system "$platform" \
-            --arg config '{ allowAliases = false; }' \
-            --option experimental-features 'no-url-literals' \
-            -qa --drv-path --system-filter \* --system \
-            "''${opts[@]}" 2> eval-warnings.log > packages1
+        set +e
+        (
+          set -x
+          nix-env -f $src \
+              --show-trace --argstr system "$platform" \
+              --arg config '{ allowAliases = false; }' \
+              --option experimental-features 'no-url-literals' \
+              -qa --drv-path --system-filter \* --system \
+              "''${opts[@]}" 2> eval-warnings.log > packages1
+        )
+        rc=$?
+        set -e
+        if [ "$rc" != "0" ]; then
+          cat eval-warnings.log
+          exit $rc
+        fi
 
         s1=$(sha1sum packages1 | cut -c1-40)
         echo $s1


### PR DESCRIPTION
print error from "Basic evaluation checks" in nixpkgs github CI

also print the exact command for nix-env

part of #141883 

before: silent fail

```
$ nix-build  pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin"  ]' 
this derivation will be built:
  /nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv
building '/nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv'...
checking Nixpkgs on aarch64-darwin
error: builder for '/nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv' failed with exit code 1;
```

after: print error

```
$ nix-build  pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin"  ]' 
this derivation will be built:
  /nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv
building '/nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv'...
checking Nixpkgs on aarch64-darwin
++ nix-env -f /nix/store/74pjdpkdq8p3diawxnp9js9n3g2gbrfx-source --show-trace --argstr system aarch64-darwin --arg config '{ allowAliases = false; }' --option experimental-features no-url-literals -qa --drv-path --system-filter '*' --system --option build-users-group ''
error: anonymous function at /nix/store/74pjdpkdq8p3diawxnp9js9n3g2gbrfx-source/pkgs/development/libraries/qt-6/modules/qtbase.nix:1:1 called without required argument 'xlibs'

       at /nix/store/74pjdpkdq8p3diawxnp9js9n3g2gbrfx-source/lib/customisation.nix:69:16:
[ ... nix trace ... ]
error: builder for '/nix/store/v19salxyq9zmyqqd100j5kyr4azn2bq7-nixpkgs-release-checks.drv' failed with exit code 1;
```

detail: the `( set -x; ... )` pattern is used to trace only one command. src https://stackoverflow.com/a/17366594/10440128

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
