### PR TITLE
graphite-gtk-theme: unstable-2022-01-07 -> unstable-2022-02-04

### DIFF
--- a/pkgs/data/themes/graphite-gtk-theme/default.nix
+++ b/pkgs/data/themes/graphite-gtk-theme/default.nix
@@ -10,6 +10,8 @@
 , sizeVariants ? [] # default: standard
 , tweaks ? []
 , wallpapers ? false
+, withGrub ? false
+, grubScreens ? [] # default: 1080p
 }:
 
 let
@@ -20,16 +22,17 @@ lib.checkListOfEnum "${pname}: theme variants" [ "default" "purple" "pink" "red"
 lib.checkListOfEnum "${pname}: color variants" [ "standard" "light" "dark" ] colorVariants
 lib.checkListOfEnum "${pname}: size variants" [ "standard" "compact" ] sizeVariants
 lib.checkListOfEnum "${pname}: tweaks" [ "nord" "black" "midblack" "rimless" "normal" ] tweaks
+lib.checkListOfEnum "${pname}: grub screens" [ "1080p" "2k" "4k" ] grubScreens
 
 stdenvNoCC.mkDerivation {
   inherit pname;
-  version = "unstable-2022-01-07";
+  version = "unstable-2022-02-04";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
-    rev = "78e5421fee63b4c2a2a3d2e321538367b01a24ec";
-    sha256 = "1vfvv1gfbr9yr9mz0kb7c7ij6pxcryni1fjs87gn4hpyzns431wk";
+    rev = "7ab6a1b7eda81e914405a9931408b1d5c73e6891";
+    sha256 = "09xixd6cz2iyyyg6vskyk0wj2mahfsg21dlfcvi862h8w01hg9lr";
   };
 
   nativeBuildInputs = [
@@ -63,6 +66,18 @@ stdenvNoCC.mkDerivation {
       ${lib.optionalString (builtins.elem "nord" tweaks) ''
         cp -a wallpaper/Graphite-nord/*.png $out/share/backgrounds/
       ''}
+    ''}
+
+    ${lib.optionalString withGrub ''
+      (
+      cd other/grub2
+
+      patchShebangs install.sh
+
+      ./install.sh --justcopy --dest $out/share/grub/themes \
+        ${lib.optionalString (builtins.elem "nord" tweaks) "--theme nord"} \
+        ${lib.optionalString (grubScreens != []) "--screen " + builtins.toString grubScreens}
+      )
     ''}
 
     jdupes -L -r $out/share

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23738,7 +23738,7 @@ with pkgs;
 
   go-font = callPackage ../data/fonts/go-font { };
 
-  graphite-gtk-theme = callPackage ../data/themes/graphite { };
+  graphite-gtk-theme = callPackage ../data/themes/graphite-gtk-theme { };
 
   graphite-kde-theme = callPackage ../data/themes/graphite-kde-theme { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to version [unstable-2022-02-04](https://github.com/vinceliuice/Graphite-gtk-theme/commits/main)
- Optionally install grub theme
- Move to `pkgs/data/themes/graphite-gtk-theme`, as there is also `graphite-kde-theme` in nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
