### PR TITLE
zathura: improve overridability; set plugin dir through the environment

### DIFF
--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -30,4 +30,4 @@ let
     };
   };
 
-in self.zathuraWrapper
+in self

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -11,7 +11,7 @@ symlinkJoin {
   in ''
     makeWrapper ${zathura_core.bin}/bin/zathura $out/bin/zathura \
       --prefix PATH ":" "${lib.makeBinPath [ file ]}" \
-      --add-flags --plugins-dir="$out/lib/zathura"
+      --prefix ZATHURA_PLUGINS_PATH : "$out/lib/zathura"
 
     # zathura fish completion references the zathura_core derivation to
     # check for supported plugins which live in the wrapper derivation,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30233,7 +30233,8 @@ with pkgs;
 
   zanshin = libsForQt5.callPackage ../applications/office/zanshin { };
 
-  zathura = callPackage ../applications/misc/zathura { };
+  zathuraPkgs = callPackage ../applications/misc/zathura { };
+  zathura = zathuraPkgs.zathuraWrapper;
 
   zdns = callPackage ../tools/security/zdns { };
 


### PR DESCRIPTION

###### Motivation for this change
The current package setup has two issues:

* You can only access `pkgs.zathura` which is the "final" derivation,
  i.e. a wrapper. This is a problem if you want to apply a patch to
  `zathura(1)` in an overlay. To make this a bit easier, I decided to
  expose `zathuraPkgs` entirely and `zathura` is now
  `zathuraPkgs.zathuraWrapper`.

  With this change, patches can now be added like this:

  ```
  with import ./. {
    overlays = [
      (self: super: {
        zathura = super.zathura.override {
          zathura_core = super.zathuraPkgs.zathura_core.overrideAttrs (_: {
            patches = [
              ~/Projects/zathura/0001-Fix-remote-link-resolution-in-zathura.patch
            ];
          });
        };
      })
    ];
  };
  zathura
  ```

* As soon as you open another window in `zathura` from `zathura` (e.g.
  to follow a PDF-embedded link to another PDF), it currently fails
  because `--plugins-dir=` isn't passed along. This is because `zathura`
  uses `argv[0]`[1] to open another process and the GApps-wrapper inside
  `zathuraPkgs.zathura_core` does a `exec -a "$0"` which isn't the
  `bin/zathura` from the wrapper that appends `--plugins-dir=`:

  ```
  execve("/nix/var/nix/profiles/per-user/ma27/home-manager-140-link/home-path/bin/zathura", ["/nix/var/nix/profiles/per-user/ma27/home-manager-140-link/home-path/bin/zathura", "/home/ma27/Documents/Uni/Studium/Notepad/Aktuell/Index.pdf"], 0x7ffd7a4bf4b0 /* 108 vars */) = 0
  execve("/nix/store/2wjhxbgzcnn0qqdwqy0m01hw39dxwfmk-zathura-0.4.8-bin/bin/zathura", ["/nix/store/2wjhxbgzcnn0qqdwqy0m01hw39dxwfmk-zathura-0.4.8-bin/bin/zathura", "--plugins-dir=/nix/store/wcch63yzwykc9x5393dzjfdxsf80mrb8-zathura-with-plugins-0.4.8/lib/zathura", "/home/ma27/Documents/Uni/Studium/Notepad/Aktuell/Index.pdf"], 0x1442010 /* 107 vars */) = 0
  execve("/nix/store/2wjhxbgzcnn0qqdwqy0m01hw39dxwfmk-zathura-0.4.8-bin/bin/.zathura-wrapped", ["/nix/store/2wjhxbgzcnn0qqdwqy0m01hw39dxwfmk-zathura-0.4.8-bin/bin/zathura", "--plugins-dir=/nix/store/wcch63yzwykc9x5393dzjfdxsf80mrb8-zathura-with-plugins-0.4.8/lib/zathura", "/home/ma27/Documents/Uni/Studium/Notepad/Aktuell/Index.pdf"], 0x81d010 /* 108 vars */) = 0
  ```

  I figured it's way simpler to actually use the environment variable
  `ZATHURA_PLUGINS_PATH` for that purpose as the environment is
  inherited when a new process is started.

[1] https://git.pwmt.org/pwmt/zathura/-/blob/242329b534af9cf04b423bf1e4fa7a7f8bac9030/zathura/links.c#L205-215



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
