### PR TITLE
abseil-cpp: provide multiple versions

### DIFF
--- a/pkgs/development/libraries/abseil-cpp/20210324.nix
+++ b/pkgs/development/libraries/abseil-cpp/20210324.nix
@@ -1,0 +1,12 @@
+import ./generic.nix {
+  version = "20210324.2";
+  sha256 = "sha256-fcxPhuI2eL/fnd6nT11p8DpUNwGNaXZmd03yOiZcOT0=";
+  patches = fetchpatch: [
+    # Use CMAKE_INSTALL_FULL_{LIBDIR,INCLUDEDIR}
+    # https://github.com/abseil/abseil-cpp/pull/963
+    (fetchpatch {
+      url = "https://github.com/abseil/abseil-cpp/commit/5bfa70c75e621c5d5ec095c8c4c0c050dcb2957e.patch";
+      sha256 = "0nhjxqfxpi2pkfinnqvd5m4npf9l1kg39mjx9l3087ajhadaywl5";
+    })
+  ];
+}

--- a/pkgs/development/libraries/abseil-cpp/default.nix
+++ b/pkgs/development/libraries/abseil-cpp/default.nix
@@ -1,45 +1,4 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, fetchpatch
-, cmake
-, static ? stdenv.hostPlatform.isStatic
-, cxxStandard ? null
-}:
-
-stdenv.mkDerivation rec {
-  pname = "abseil-cpp";
-  version = "20210324.2";
-
-  src = fetchFromGitHub {
-    owner = "abseil";
-    repo = "abseil-cpp";
-    rev = version;
-    sha256 = "0g9rbhk3mwjdfxk7cscd04vm8fphd5flz9yykpgvyy1nwa34zk3x";
-  };
-
-  patches = [
-    # Use CMAKE_INSTALL_FULL_{LIBDIR,INCLUDEDIR}
-    # https://github.com/abseil/abseil-cpp/pull/963
-    (fetchpatch {
-      url = "https://github.com/abseil/abseil-cpp/commit/5bfa70c75e621c5d5ec095c8c4c0c050dcb2957e.patch";
-      sha256 = "0nhjxqfxpi2pkfinnqvd5m4npf9l1kg39mjx9l3087ajhadaywl5";
-    })
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
-  ] ++ lib.optionals (cxxStandard != null) [
-    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
-  ];
-
-  nativeBuildInputs = [ cmake ];
-
-  meta = with lib; {
-    description = "An open-source collection of C++ code designed to augment the C++ standard library";
-    homepage = "https://abseil.io/";
-    license = licenses.asl20;
-    platforms = platforms.all;
-    maintainers = [ maintainers.andersk ];
-  };
+import ./generic.nix {
+  version = "20211102.0";
+  sha256 = "sha256-sSXT6D4JSrk3dA7kVaxfKkzOMBpqXQb0WbMYWG+nGwk=";
 }

--- a/pkgs/development/libraries/abseil-cpp/generic.nix
+++ b/pkgs/development/libraries/abseil-cpp/generic.nix
@@ -1,0 +1,41 @@
+# Version specific attributes
+{ version, sha256, patches ? (_: [ ]) }:
+# Generic attributes
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, static ? stdenv.hostPlatform.isStatic
+, cxxStandard ? null
+}:
+
+stdenv.mkDerivation {
+  pname = "abseil-cpp";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    rev = version;
+    inherit sha256;
+  };
+
+  patches = patches fetchpatch;
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+  ] ++ lib.optionals (cxxStandard != null) [
+    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "An open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.andersk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2297,7 +2297,9 @@ with pkgs;
     cudaSupport = config.cudaSupport or false;
   };
 
-  tensorflow-lite = callPackage ../development/libraries/science/math/tensorflow-lite { };
+  tensorflow-lite = callPackage ../development/libraries/science/math/tensorflow-lite {
+    abseil-cpp = abseil-cpp_20210324;
+  };
 
   tezos-rust-libs = callPackage ../development/libraries/tezos-rust-libs { };
 
@@ -15947,6 +15949,7 @@ with pkgs;
   aalib = callPackage ../development/libraries/aalib { };
 
   abseil-cpp = callPackage ../development/libraries/abseil-cpp { };
+  abseil-cpp_20210324 = callPackage ../development/libraries/abseil-cpp/20210324.nix { };
 
   accountsservice = callPackage ../development/libraries/accountsservice { };
 
@@ -21950,6 +21953,7 @@ with pkgs;
 
   # Fails to compile with boost <= 1.72
   rippled = callPackage ../servers/rippled {
+    abseil-cpp = abseil-cpp_20210324;
     boost = boost172;
   };
 
@@ -32239,7 +32243,7 @@ with pkgs;
     python = python3;
     # or-tools builds with -std=c++17, so abseil-cpp must
     # also be built that way
-    abseil-cpp = abseil-cpp.override {
+    abseil-cpp = abseil-cpp_20210324.override {
       static = true;
       cxxStandard = "17";
     };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Based on https://github.com/NixOS/nixpkgs/pull/113796. Blocks https://github.com/NixOS/nixpkgs/pull/158191

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
