### PR TITLE
hylafaxplus: 7.0.4 -> 7.0.5

### DIFF
--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -3,7 +3,7 @@
 let
 
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.types) bool enum ints lines attrsOf nullOr path str submodule;
+  inherit (lib.types) bool enum ints lines attrsOf nonEmptyStr nullOr path str submodule;
   inherit (lib.modules) mkDefault mkIf mkMerge;
 
   commonDescr = ''
@@ -16,8 +16,6 @@ let
     The default contains some reasonable
     configuration to yield an operational system.
   '';
-
-  str1 = lib.types.addCheck str (s: s!="");  # non-empty string
 
   configAttrType =
     # Options in HylaFAX configuration files can be
@@ -37,7 +35,7 @@ let
   modemConfigOptions = { name, config, ... }: {
     options = {
       name = mkOption {
-        type = str1;
+        type = nonEmptyStr;
         example = "ttyS1";
         description = ''
           Name of modem device,
@@ -45,7 +43,7 @@ let
         '';
       };
       type = mkOption {
-        type = str1;
+        type = nonEmptyStr;
         example = "cirrus";
         description = ''
           Name of modem configuration file,
@@ -135,14 +133,14 @@ in
     };
 
     countryCode = mkOption {
-      type = nullOr str1;
+      type = nullOr nonEmptyStr;
       default = null;
       example = "49";
       description = "Country code for server and all modems.";
     };
 
     areaCode = mkOption {
-      type = nullOr str1;
+      type = nullOr nonEmptyStr;
       default = null;
       example = "30";
       description = "Area code for server and all modems.";
@@ -279,7 +277,7 @@ in
       each time the spooling area is initialized.
     '';
     faxcron.enable.frequency = mkOption {
-      type = nullOr str1;
+      type = nullOr nonEmptyStr;
       default = null;
       example = "daily";
       description = ''
@@ -319,7 +317,7 @@ in
       each time the spooling area is initialized.
     '';
     faxqclean.enable.frequency = mkOption {
-      type = nullOr str1;
+      type = nullOr nonEmptyStr;
       default = null;
       example = "daily";
       description = ''

--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation {
   postInstall = ". ${postInstall}";
   postInstallCheck = ". ${./post-install-check.sh}";
   meta = {
+    changelog = "https://hylafax.sourceforge.io/news/${version}.php";
     description = "enterprise-class system for sending and receiving facsimiles";
     downloadPage = "https://hylafax.sourceforge.io/download.php";
     homepage = "https://hylafax.sourceforge.io";

--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -30,8 +30,8 @@
 let
 
   pname = "hylafaxplus";
-  version = "7.0.4";
-  sha256 = "1y4b178rxa4ivxm8cnypnnyc8db7cjqyyzy60hiw215x4cyyj4i5";
+  version = "7.0.5";
+  sha256 = "1blv251r0yhnhxk9wgkjgr35al50q23hiskjkcbs8lmqqrz0cm8f";
 
   configSite = substituteAll {
     name = "${pname}-config.site";


### PR DESCRIPTION
###### Motivation for this change

Update to most recent version, released Feb 4 2022.

Release notes: https://hylafax.sourceforge.io/news/7.0.5.php

I didn't spot any breaking changes in the release notes.  My tests were successful (see below).

Using the opportunity, this pull-request also introduces the option type `nonEmptyStr` to the hylafax module and adds the `meta.changelog` attribute to the `hylafaxplus` package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- tested with asterisk/iaxmodem
  - [x] send/receive normal fax from pdf file
  - [x] send/receive normal fax from text file
  - [x] send/receive fax with custom TSI
  - [x] handling of busy/unresponsive/non-modem/flaky destination
- [x] tested with `conexant-1.0` modem: send/receive normal fax from pdf file

##### More

Notifying recent contributor @ajs124: If you are a hylafax user and can spare the the time, maybe you can drop a review.  Thanks in either case!
