### PR TITLE
tauon: 6.7.1 -> 7.0.1

### DIFF
--- a/pkgs/applications/audio/tauon/default.nix
+++ b/pkgs/applications/audio/tauon/default.nix
@@ -5,6 +5,7 @@
 , python3Packages
 , ffmpeg
 , flac
+, librsvg
 , gobject-introspection
 , gtk3
 , libnotify
@@ -20,23 +21,22 @@
 
 stdenv.mkDerivation rec {
   pname = "tauon";
-  version = "6.7.1";
+  version = "7.0.1";
 
   src = fetchFromGitHub {
     owner = "Taiko2k";
     repo = "TauonMusicBox";
     rev = "v${version}";
-    sha256 = "1hm82yfq7q2akrrvff3vmwrd3bz34d2dk8jzhnizhnhar6xc6fzp";
+    sha256 = "sha256-Sw9w6vFXk2Cx7LdfMsou9IDheVckdusc0iGWkVsVtCQ=";
   };
 
   postPatch = ''
     substituteInPlace tauon.py \
       --replace 'install_mode = False' 'install_mode = True' \
-      --replace 'install_directory = os.path.dirname(__file__)' 'install_directory = "${placeholder "out"}/share/tauon"'
+      --replace 'install_directory = os.path.dirname(os.path.abspath(__file__))' 'install_directory = "${placeholder "out"}/share/tauon"'
 
     substituteInPlace t_modules/t_main.py \
       --replace 'install_mode = False' 'install_mode = True' \
-      --replace 'install_directory = sys.path[0]' 'install_directory = "${placeholder "out"}/share/tauon"' \
       --replace 'libopenmpt.so' '${lib.getLib libopenmpt}/lib/libopenmpt.so' \
       --replace 'lib/libphazor.so' '../../lib/libphazor.so'
 
@@ -61,6 +61,7 @@ stdenv.mkDerivation rec {
     gtk3
     libnotify
     libopenmpt
+    librsvg
     libsamplerate
     libvorbis
     mpg123
@@ -70,11 +71,14 @@ stdenv.mkDerivation rec {
   ];
 
   pythonPath = with python3Packages; [
+    beautifulsoup4
+    gst-python
     dbus-python
     isounidecode
     musicbrainzngs
     mutagen
     pillow
+    plexapi
     pulsectl
     pycairo
     pylast
@@ -83,6 +87,7 @@ stdenv.mkDerivation rec {
     pysdl2
     requests
     send2trash
+    setproctitle
   ] ++ lib.optional withDiscordRPC pypresence;
 
   makeWrapperArgs = [

--- a/pkgs/applications/audio/tauon/default.nix
+++ b/pkgs/applications/audio/tauon/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
       --replace 'lib/libphazor.so' '../../lib/libphazor.so'
 
     patchShebangs compile-phazor.sh
+
+    substituteInPlace extra/tauonmb.desktop --replace 'Exec=/opt/tauon-music-box/tauonmb.sh' 'Exec=${placeholder "out"}/bin/tauon'
   '';
 
   postBuild = ''
@@ -103,7 +105,12 @@ stdenv.mkDerivation rec {
     cp -r assets input.txt t_modules theme $out/share/tauon
 
     wrapPythonPrograms
-  '';
+
+    mkdir -p $out/share/applications
+    install -Dm755 extra/tauonmb.desktop $out/share/applications/tauonmb.desktop
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    install -Dm644 extra/tauonmb{,-symbolic}.svg $out/share/icons/hicolor/scalable/apps
+'';
 
   meta = with lib; {
     description = "The Linux desktop music player from the future";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Fixes #158150 

###### Motivation for this change

https://github.com/Taiko2k/TauonMusicBox/releases/tag/v7.0.1
https://github.com/Taiko2k/TauonMusicBox/releases/tag/v7.0.0
https://github.com/Taiko2k/TauonMusicBox/releases/tag/v6.8.0

NOTE: 6.8.0 breaks backwards-compatibility of config files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
