### PR TITLE
deskew: 1.25 -> 1.30

### DIFF
--- a/pkgs/applications/graphics/deskew/default.nix
+++ b/pkgs/applications/graphics/deskew/default.nix
@@ -3,33 +3,35 @@
 stdenv.mkDerivation rec {
 
   pname = "deskew";
-  version = "1.25";
+  version = "1.30";
 
   src = fetchFromGitHub {
     owner = "galfar";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0zjjj66qhgqkmfxl3q7p78dv4xl4ci918pgl4d5259pqdj1bfgc8";
+    hash = "sha256-xghVOEMkQ/mXpOzJqMaT3SII7xneMNoFqRlqjtzmDnA=";
   };
 
   nativeBuildInputs = [ fpc ];
   buildInputs = [ libtiff ];
 
   buildPhase = ''
-    rm -r Bin # Remove pre-compiled binary
-    mkdir Bin
-    chmod +x compile.sh
-    ./compile.sh
+    runHook preBuild
+    patchShebangs ./Scripts
+    pushd Scripts && ./compile.sh && popd
+    runHook postBuild
   '';
 
   installPhase = ''
-    install -Dt $out/bin Bin/*
+    runHook preInstall
+    install -Dt $out/bin Bin/deskew
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "A command line tool for deskewing scanned text documents";
-    homepage = "https://bitbucket.org/galfar/app-deskew/overview";
-    license = licenses.mit;
+    homepage = "https://galfar.vevb.net/deskew";
+    license = with licenses; [ mit mpl11 ];
     maintainers = with maintainers; [ryantm];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Pkg update
and update homepage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
