### PR TITLE
dvdisaster: 0.79.5 -> 0.79.9

### DIFF
--- a/pkgs/tools/cd-dvd/dvdisaster/default.nix
+++ b/pkgs/tools/cd-dvd/dvdisaster/default.nix
@@ -1,15 +1,21 @@
-{ lib, stdenv, fetchurl, pkg-config, gettext, which
-, glib, gtk2
+{ lib
+, stdenv
+, fetchurl
+, gettext
+, pkg-config
+, which
+, glib
+, gtk2
 , enableSoftening ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "dvdisaster";
-  version = "0.79.5";
+  version = "0.79.9";
 
   src = fetchurl {
-    url = "http://dvdisaster.net/downloads/${pname}-${version}.tar.bz2";
-    sha256 = "0f8gjnia2fxcbmhl8b3qkr5b7idl8m855dw7xw2fnmbqwvcm6k4w";
+    url = "https://dvdisaster.jcea.es/downloads/${pname}-${version}.tar.bz2";
+    hash = "sha256-eclOJ33pS2aP4F7RUHc84ynpH7sTv2dsO4vn5vB248M=";
   };
 
   nativeBuildInputs = [ gettext pkg-config which ];
@@ -40,6 +46,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
   checkPhase = ''
+    runHook preCheck
     pushd regtest
 
     mkdir -p "$TMP"/{log,regtest}
@@ -59,9 +66,11 @@ stdenv.mkDerivation rec {
     done
 
     popd
+    runHook postCheck
   '';
 
   postInstall = ''
+    rm -f $out/bin/dvdisaster-uninstall.sh
     mkdir -pv $out/share/applications
     cp contrib/dvdisaster.desktop $out/share/applications/
 
@@ -73,7 +82,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://dvdisaster.net/";
+    homepage = "https://dvdisaster.jcea.es/";
     description = "Data loss/scratch/aging protection for CD/DVD media";
     longDescription = ''
       Dvdisaster provides a margin of safety against data loss on CD and


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Upstream has moved

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
