### PR TITLE
python3Packages.garminconnect: 0.1.13 -> 0.1.44

### DIFF
--- a/pkgs/development/python-modules/garminconnect-aio/default.nix
+++ b/pkgs/development/python-modules/garminconnect-aio/default.nix
@@ -3,18 +3,22 @@
 , brotlipy
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
 , yarl
 }:
 
 buildPythonPackage rec {
   pname = "garminconnect-aio";
   version = "0.1.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
     repo = "python-garminconnect-aio";
     rev = version;
-    sha256 = "0s2gpy5hciv9akqqhxy0d2ywp6jp9mmdngx34q7fq3xn668kcrhr";
+    hash = "sha256-GWY2kTG2D+wOJqM/22pNV5rLvWjAd4jxVGlHBou/T2g=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +30,9 @@ buildPythonPackage rec {
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "garminconnect_aio" ];
+  pythonImportsCheck = [
+    "garminconnect_aio"
+  ];
 
   meta = with lib; {
     description = "Python module to interact with Garmin Connect";

--- a/pkgs/development/python-modules/garminconnect-ha/default.nix
+++ b/pkgs/development/python-modules/garminconnect-ha/default.nix
@@ -2,12 +2,16 @@
 , buildPythonPackage
 , cloudscraper
 , fetchFromGitHub
+, pythonOlder
 , requests
 }:
 
 buildPythonPackage rec {
   pname = "garminconnect-ha";
   version = "0.1.13";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
@@ -21,13 +25,15 @@ buildPythonPackage rec {
     requests
   ];
 
-  # Project has no tests
+  # Module has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "garminconnect_ha" ];
+  pythonImportsCheck = [
+    "garminconnect_ha"
+  ];
 
   meta = with lib; {
-    description = "Minimal Garmin Connect Python 3 API wrapper for Home Assistant";
+    description = "Garmin Connect Python API wrapper for Home Assistant";
     homepage = "https://github.com/cyberjunky/python-garminconnect-ha";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];

--- a/pkgs/development/python-modules/garminconnect/default.nix
+++ b/pkgs/development/python-modules/garminconnect/default.nix
@@ -8,16 +8,16 @@
 
 buildPythonPackage rec {
   pname = "garminconnect";
-  version = "0.1.13";
+  version = "0.1.44";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "cyberjunky";
-    repo = "python-garminconnect-ha";
+    repo = "python-garminconnect";
     rev = version;
-    hash = "sha256-1O1EcG5FvpwUvI8rwcdlQLzEEStyFAwvmkaL97u6hZ4=";
+    hash = "sha256-CUjMbh3eGPwoHW+oOjaVyr0g/txWmzGuP1usq2WCwZg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/garminconnect/default.nix
+++ b/pkgs/development/python-modules/garminconnect/default.nix
@@ -7,7 +7,7 @@
 }:
 
 buildPythonPackage rec {
-  pname = "garminconnect-ha";
+  pname = "garminconnect";
   version = "0.1.13";
   format = "setuptools";
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "cyberjunky";
     repo = "python-garminconnect-ha";
     rev = version;
-    sha256 = "sha256-1O1EcG5FvpwUvI8rwcdlQLzEEStyFAwvmkaL97u6hZ4=";
+    hash = "sha256-1O1EcG5FvpwUvI8rwcdlQLzEEStyFAwvmkaL97u6hZ4=";
   };
 
   propagatedBuildInputs = [
@@ -29,12 +29,12 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [
-    "garminconnect_ha"
+    "garminconnect"
   ];
 
   meta = with lib; {
-    description = "Garmin Connect Python API wrapper for Home Assistant";
-    homepage = "https://github.com/cyberjunky/python-garminconnect-ha";
+    description = "Garmin Connect Python API wrapper";
+    homepage = "https://github.com/cyberjunky/python-garminconnect";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -54,6 +54,7 @@ mapAliases ({
   dogpile-core = throw "dogpile-core is no longer maintained, use dogpile-cache instead"; # added 2021-11-20
   eebrightbox = throw "eebrightbox is unmaintained upstream and has therefore been removed"; # added 2022-02-03
   faulthandler = throw "faulthandler is built into ${python.executable}"; # added 2021-07-12
+  garminconnect-ha = garminconnect; # added 2022-02-05
   gitdb2 = throw "gitdb2 has been deprecated, use gitdb instead."; # added 2020-03-14
   glances = throw "glances has moved to pkgs.glances"; # added 2020-20-28
   google_api_python_client = google-api-python-client; # added 2021-03-19

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3131,7 +3131,7 @@ in {
 
   garminconnect-aio = callPackage ../development/python-modules/garminconnect-aio { };
 
-  garminconnect-ha = callPackage ../development/python-modules/garminconnect-ha { };
+  garminconnect = callPackage ../development/python-modules/garminconnect { };
 
   gast = callPackage ../development/python-modules/gast { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/cyberjunky/python-garminconnect/releases/tag/0.1.44

Rename from `garminconnect-ha`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
