### PR TITLE
pdf2odt: use resholvePackage

### DIFF
--- a/pkgs/tools/typesetting/pdf2odt/default.nix
+++ b/pkgs/tools/typesetting/pdf2odt/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, lib, makeWrapper, fetchFromGitHub
-, bc, coreutils, file, gawk, ghostscript, gnused, imagemagick, zip }:
+{ lib
+, resholvePackage
+, fetchFromGitHub
+, bc
+, coreutils
+, file
+, gawk
+, ghostscript
+, gnused
+, imagemagick
+, zip
+, bash
+, findutils
+}:
 
-let
-  path = lib.makeBinPath [
-    bc
-    coreutils
-    file
-    gawk
-    ghostscript
-    gnused
-    imagemagick
-    zip
-  ];
-
-in stdenv.mkDerivation rec {
+resholvePackage rec {
   pname = "pdf2odt";
   version = "20170207";
 
@@ -24,8 +24,6 @@ in stdenv.mkDerivation rec {
     sha256 = "14f9r5f0g6jzanl54jv86ls0frvspka1p9c8dy3fnriqpm584j0r";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   patches = [ ./use_mktemp.patch ];
 
   installPhase = ''
@@ -33,10 +31,24 @@ in stdenv.mkDerivation rec {
     install -Dm0644 README.md LICENSE -t $out/share/doc/pdf2odt
 
     ln -rs $out/bin/pdf2odt $out/bin/pdf2ods
-
-    wrapProgram $out/bin/pdf2odt \
-      --prefix PATH : ${path}
   '';
+  solutions = {
+    default = {
+      scripts = [ "bin/pdf2odt" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = [
+        coreutils
+        bc
+        file
+        imagemagick
+        gawk
+        gnused
+        ghostscript
+        zip
+        findutils
+      ];
+    };
+  };
 
   meta = with lib; {
     description = "PDF to ODT format converter";


### PR DESCRIPTION
@peterhoeg opening this as a draft to start a conversation. 

This PR repackages pdf2odt with resholve, a tool I develop to improve Shell packaging in Nixpkgs. resholve identifies unspecified dependencies, and rewrites external invocations to absolute paths so that end-users of Shell projects don't need to manually add dependencies to their system/user packages. 

I'm hoping to get to a simple yes/no on whether you're okay with the change (and confirmation that it isn't breaking any of your own uses, if you have some?), so I'm happy to field any questions you have to help you decide. 

(If we move forward, I'm happy to pick at any style/format/organization complaints you have :)

For a little additional context, I posted [a gist of the ~built script](https://gist.github.com/abathur/a3ae3ceeb0b9d3f8d6b2741b3b10ee61)

---

###### Motivation for this change

Convert pdf2odt to use `resholvePackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
