### PR TITLE
djvu2pdf: use resholvePackage

### DIFF
--- a/pkgs/tools/typesetting/djvu2pdf/default.nix
+++ b/pkgs/tools/typesetting/djvu2pdf/default.nix
@@ -1,6 +1,17 @@
-{ lib, stdenv, makeWrapper, fetchurl, djvulibre, ghostscript, which }:
+{ lib
+, resholve
+, fetchurl
+, bash
+, ncurses
+, coreutils
+, which
+, gawk
+, djvulibre
+, gnugrep
+, ghostscript
+}:
 
-stdenv.mkDerivation rec {
+resholve.mkDerivation rec {
   version = "0.9.2";
   pname = "djvu2pdf";
 
@@ -9,16 +20,32 @@ stdenv.mkDerivation rec {
     sha256 = "0v2ax30m7j1yi4m02nzn9rc4sn4vzqh5vywdh96r64j4pwvn5s5g";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   installPhase = ''
     mkdir -p $out/bin
     cp -p djvu2pdf $out/bin
-    wrapProgram $out/bin/djvu2pdf --prefix PATH : ${lib.makeBinPath [ ghostscript djvulibre which ]}
 
     mkdir -p $out/man/man1
     cp -p djvu2pdf.1.gz $out/man/man1
   '';
+
+  solutions = {
+    default = {
+      scripts = [ "bin/djvu2pdf" ];
+      interpreter = "${bash}/bin/sh";
+      inputs = [
+        ncurses
+        coreutils
+        which
+        gawk
+        gnugrep
+        djvulibre
+        ghostscript
+      ];
+      fix = {
+        "$SEQ" = [ "seq" ];
+      };
+    };
+  };
 
   meta = {
     description = "Convert DjVu files to PDF files";


### PR DESCRIPTION
@jwiegley opening this as a draft to start a conversation (I realize you aren't the listed maintainer--feel free to dodge. Just guessing at who'd care, and I see you added the expression.)

This PR repackages djvu2pdf with resholve, a tool I develop to improve Shell packaging in Nixpkgs. resholve identifies unspecified dependencies, and rewrites external invocations to absolute paths so that end-users of Shell projects don't need to manually add dependencies to their system/user packages. 

I'm hoping to get to a simple yes/no on whether you're okay with the change (and confirmation that it isn't breaking any of your own uses, if you have some?), so I'm happy to field any questions you have to help you decide. 

(If we move forward, I'm happy to pick at any style/format/organization complaints you have :)

For a little additional context, I posted [a gist of the ~built script](https://gist.github.com/abathur/8cc26608febfba6159deda1562823dde)

---

###### Motivation for this change

Convert djvu2pdf to use `resholvePackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
