### PR TITLE
python3Packages.rokuecp: 0.12.0 -> 0.13.1

### DIFF
--- a/pkgs/development/python-modules/rokuecp/default.nix
+++ b/pkgs/development/python-modules/rokuecp/default.nix
@@ -1,9 +1,12 @@
 { lib
 , aiohttp
 , aresponses
+, awesomeversion
+, backoff
 , buildPythonPackage
 , cachetools
 , fetchFromGitHub
+, poetry
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
@@ -13,22 +16,29 @@
 
 buildPythonPackage rec {
   pname = "rokuecp";
-  version = "0.12.0";
-  format = "setuptools";
+  version = "0.13.1";
+  format = "pyproject";
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "ctalkington";
     repo = "python-rokuecp";
     rev = version;
-    sha256 = "1pqiba4zgx7knm1k53p6w6b9a81dalqfq2agdyrz3734nhl6gx1h";
+    hash = "sha256-6bHEg7bpqldLDr3UX42GUg7kIDHVxtnVnrFr8CvTJU4=";
   };
+
+  nativeBuildInputs = [
+    # Requires poetry not poetry-core
+    poetry
+  ];
 
   propagatedBuildInputs = [
     aiohttp
+    backoff
     cachetools
     xmltodict
+    awesomeversion
     yarl
   ];
 
@@ -37,6 +47,11 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-asyncio
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace " --cov" ""
+  '';
 
   disabledTests = [
     # https://github.com/ctalkington/python-rokuecp/issues/249


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ctalkington/python-rokuecp/releases/tag/0.13.0
https://github.com/ctalkington/python-rokuecp/releases/tag/0.13.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
