### PR TITLE
[backport release-21.11] python39Packages.types-typed-ast: init 1.5.1

### DIFF
--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -5,17 +5,20 @@
 
 buildPythonPackage rec {
   pname = "types-typed-ast";
-  version = "1.5.0";
+  version = "1.5.1";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-2Op5y/vFIL6Nm8jeSHL0SzQtvbwJFmfi8hsDu9eWkVA=";
+    hash = "sha256-UQ876qlUkrNUTWfoFYGvopA8dktwiJ/82yhubGJn0pc=";
   };
 
   # Module doesn't have tests
   doCheck = false;
 
-  pythonImportsCheck = [ "typed_ast-stubs" ];
+  pythonImportsCheck = [
+    "typed_ast-stubs"
+  ];
 
   meta = with lib; {
     description = "Typing stubs for typed-ast";

--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-typed-ast";
+  version = "1.4.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "ffa0471e0ba19c4ea0cba0436d660871b5f5215854ea9ead3cb5b60f525af75a";
+  };
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "typed_ast-stubs" ];
+
+  meta = with lib; {
+    description = "Typing stubs for typed-ast";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ superherointj veehaitch ];
+  };
+}

--- a/pkgs/development/python-modules/types-typed-ast/default.nix
+++ b/pkgs/development/python-modules/types-typed-ast/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "types-typed-ast";
-  version = "1.4.4";
+  version = "1.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ffa0471e0ba19c4ea0cba0436d660871b5f5215854ea9ead3cb5b60f525af75a";
+    sha256 = "sha256-2Op5y/vFIL6Nm8jeSHL0SzQtvbwJFmfi8hsDu9eWkVA=";
   };
 
   # Module doesn't have tests
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Typing stubs for typed-ast";
     homepage = "https://github.com/python/typeshed";
     license = licenses.asl20;
-    maintainers = with maintainers; [ superherointj veehaitch ];
+    maintainers = with maintainers; [ SuperSandro2000 veehaitch ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9613,6 +9613,8 @@ in {
 
   types-toml = callPackage ../development/python-modules/types-toml { };
 
+  types-typed-ast = callPackage ../development/python-modules/types-typed-ast { };
+
   typesentry = callPackage ../development/python-modules/typesentry { };
 
   typesystem = callPackage ../development/python-modules/typesystem { };


### PR DESCRIPTION
###### Motivation for this change
This is required to native compile mypy which can be useful out-of-tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
