### PR TITLE
fakeroot: 1.23 -> 1.27

### DIFF
--- a/pkgs/tools/system/fakeroot/default.nix
+++ b/pkgs/tools/system/fakeroot/default.nix
@@ -1,47 +1,28 @@
-{ lib, stdenv, fetchurl, fetchpatch, getopt, libcap, gnused, nixosTests }:
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, getopt
+, libcap
+, gnused
+, nixosTests
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.23";
+  version = "1.27";
   pname = "fakeroot";
 
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/main/f/fakeroot/fakeroot_${version}.orig.tar.xz";
-    sha256 = "1xpl0s2yjyjwlf832b6kbkaa5921liybaar13k7n45ckd9lxd700";
+    url = "http://http.debian.net/debian/pool/main/f/fakeroot/fakeroot_${version}.orig.tar.gz";
+    sha256 = "1p5d3jq6l1pzk96agkf05dck7dbgvldx5sg2d4h7d8h230nyni9w";
   };
 
   patches = lib.optionals stdenv.isLinux [
     ./einval.patch
-
-    # glibc 2.33 patches from ArchLinux
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-1.patch";
-      sha256 = "sha256-F6BcxYInSLu7Fxg6OmMZDhTWoLqsc//yYPlTZqQQl68=";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-2.patch";
-      sha256 = "sha256-ifpJxhk6MyQpFolC1hIAAUjcHmOHVU1D25tRwpu2S/k=";
-    })
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/archlinux/svntogit-packages/15b01cf37ff64c487f7440df4e09b090cd93b58f/fakeroot/trunk/fakeroot-1.25.3-glibc-2.33-fix-3.patch";
-      sha256 = "sha256-o2Xm4C64Ny9TL8fjsZltjO1CdJ4VGwqZ+LnufVL5Sq8=";
-    })
-  ]
-  # patchset from brew
-  ++ lib.optionals stdenv.isDarwin [
-    (fetchpatch {
-      name = "0001-Implement-openat-2-wrapper-which-handles-optional-ar.patch";
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=0001-Implement-openat-2-wrapper-which-handles-optional-ar.patch;att=1;bug=766649";
-      sha256 = "1m6ggrqwqy0in264sxqk912vniipiw629dxq7kibakvsswfk6bkk";
-    })
-    (fetchpatch {
-      name = "0002-OS-X-10.10-introduced-id_t-int-in-gs-etpriority.patch";
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=0002-OS-X-10.10-introduced-id_t-int-in-gs-etpriority.patch;att=2;bug=766649";
-      sha256 = "0rhayp42x4i1a6yc4d28kpshmf7lrmaprq64zfrjpdn4kbs0rkln";
-    })
-    (fetchpatch {
-      name = "fakeroot-always-pass-mode.patch";
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=2;bug=766649;filename=fakeroot-always-pass-mode.patch;msg=20";
-      sha256 = "0i3zaca1v449dm9m1cq6wq4dy6hc2y04l05m9gg8d4y4swld637p";
+      name = "also-wrap-stat-library-call.patch";
+      url = "https://sources.debian.org/data/main/f/fakeroot/1.27-1/debian/patches/also-wrap-stat-library-call.patch";
+      sha256 = "0p7lq6m31k3rqsnjbi06a8ykdqa3cp4y5ngsjyk3q1269gx59x8b";
     })
   ];
 
@@ -51,18 +32,6 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     sed -i -e "s@getopt@$(type -p getopt)@g" -e "s@sed@$(type -p sed)@g" ${pname}-${version}/scripts/fakeroot.in
-  '';
-
-  postConfigure = let
-    # additional patch from brew, but needs to be applied to a generated file
-    patch-wraptmpf = fetchpatch {
-      name = "fakeroot-patch-wraptmpf-h.patch";
-      url = "https://bugs.debian.org/cgi-bin/bugreport.cgi?att=3;bug=766649;filename=fakeroot-patch-wraptmpf-h.patch;msg=20";
-      sha256 = "1jhsi4bv6nnnjb4vmmmbhndqg719ckg860hgw98bli8m05zwbx6a";
-    };
-  in lib.optional stdenv.isDarwin ''
-    make wraptmpf.h
-    patch -p1 < ${patch-wraptmpf}
   '';
 
   passthru = {
@@ -79,5 +48,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [viric];
     platforms = lib.platforms.unix;
   };
-
 }


### PR DESCRIPTION
###### Motivation for this change

Resolves #140138, closes #154367

I was able to verify most patches were applied upstream, all that remains is:
- A hack related to EINVAL in namespaces
  - #25901
- An additional glibc 2.33 patch also [applied](https://sources.debian.org/patches/fakeroot/1.27-1/also-wrap-stat-library-call.patch/) by Debian
  - This fully integrates #154367 

This fixes fakeroot on RISC-V (#101651)

**Before merging**

One patch (Darwin only) which was dropped
- Patch `patch-wraptmpf` no longer applies. Might be rendered obsolete by upstream changes, it might not be.
  - #122832

*Someone running Darwin should investigate whether this is still required. If it is, please provide an updated patch*

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] riscv64-linux (qemu)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
