### PR TITLE
easyeffects: init module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -207,6 +207,14 @@
           <link xlink:href="options.html#opt-services.headscale.enable">services.headscale</link>
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/wwmm/easyeffects">easyeffects</link>,
+          an audio effects filter for PipeWire applications. Available
+          as
+          <link xlink:href="options.html#opt-services.pipewire.easyeffects.enable">services.pipewire.easyeffects</link>
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-incompatibilities">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -62,6 +62,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [headscale](https://github.com/juanfont/headscale), an Open Source implementation of the [Tailscale](https://tailscale.io) Control Server. Available as [services.headscale](options.html#opt-services.headscale.enable)
 
+- [easyeffects](https://github.com/wwmm/easyeffects), an audio effects filter for PipeWire applications. Available as [services.pipewire.easyeffects](options.html#opt-services.pipewire.easyeffects.enable)
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -362,6 +362,7 @@
   ./services/desktops/gsignond.nix
   ./services/desktops/gvfs.nix
   ./services/desktops/malcontent.nix
+  ./services/desktops/pipewire/easyeffects.nix
   ./services/desktops/pipewire/pipewire.nix
   ./services/desktops/pipewire/pipewire-media-session.nix
   ./services/desktops/pipewire/wireplumber.nix

--- a/nixos/modules/services/desktops/pipewire/easyeffects.nix
+++ b/nixos/modules/services/desktops/pipewire/easyeffects.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.pipewire.easyeffects;
+in
+{
+  meta.maintainers = with lib.maintainers; [ starcraft66 ];
+
+  options = {
+    services.pipewire.easyeffects = {
+      enable = lib.mkEnableOption "Audio effects for PipeWire applications.";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.easyeffects;
+        defaultText = lib.literalExpression "pkgs.easyeffects";
+        description = ''
+          The easyeffects derivation to use.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.pipewire.enable && !config.hardware.pulseaudio.enable;
+        message = "Easyeffects requires Pipewire to be enabled and is not compatible with PulseAudio.";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+
+    systemd.user.services.easyeffects = {
+      wantedBy = [ "pipewire.service" ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "com.github.wwmm.easyeffects";
+        ExecStart = "${cfg.package}/bin/easyeffects --gapplication-service";
+        Restart = "always";
+      };
+    };
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I found out about [easyeffects](https://github.com/wwmm/easyeffects) after switching from PulseAudio to PipeWire and really liked it. Always having the program open for it to function sucks so I created a module to spawn it as a user service instead. The GUI can still be used to control the filters but the audio processing happens all the time in the background.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
