### PR TITLE
lookatme: init at 2.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13824,4 +13824,10 @@
       fingerprint = "3586 3350 BFEA C101 DB1A 4AF0 1F81 112D 62A9 ADCE";
     }];
   };
+  ameer = {
+    name = "Ameer Taweel";
+    email = "ameertaweel2002@gmail.com";
+    github = "AmeerTaweel";
+    githubId = 20538273;
+  };
 }

--- a/pkgs/tools/misc/lookatme/default.nix
+++ b/pkgs/tools/misc/lookatme/default.nix
@@ -1,0 +1,57 @@
+{ lib, python3, fetchFromGitHub }:
+
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      self = py;
+      # use click 7
+      click = self.callPackage ../../../development/python2-modules/click/default.nix { };
+      # needs pyyaml 5
+      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
+        name = "${oldAttrs.pname}-${version}";
+        version = "5.4.1";
+        src = fetchFromGitHub {
+          owner = "yaml";
+          repo = "pyyaml";
+          rev = version;
+          sha256 = "sha256-VUqnlOF/8zSOqh6JoEYOsfQ0P4g+eYqxyFTywgCS7gM=";
+        };
+        checkPhase = ''
+          runHook preCheck
+          PYTHONPATH="tests/lib3:$PYTHONPATH" ${self.python.interpreter} -m test_all
+          runHook postCheck
+        '';
+      });
+    };
+  };
+in
+with py.pkgs;
+
+buildPythonApplication rec {
+  pname = "lookatme";
+  version = "2.3.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-qIZMkgOm5jXmxTFLTqMBhpLBhfCL8xvUxxqpS6NjcVw=";
+  };
+
+  checkInputs = [ pytest ];
+
+  propagatedBuildInputs = [
+    click
+    pyyaml
+    pygments
+    marshmallow
+    mistune
+    urwid
+  ];
+
+  meta = with lib; {
+    description = "An interactive, terminal-based markdown presenter";
+    homepage = "https://github.com/d0c-s4vage/lookatme";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ameer ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27256,6 +27256,8 @@ with pkgs;
     inherit (luajitPackages) luafilesystem;
   };
 
+  lookatme = callPackage ../tools/misc/lookatme {};
+
   looking-glass-client = callPackage ../applications/virtualization/looking-glass-client { };
 
   ltc-tools = callPackage ../applications/audio/ltc-tools { };


### PR DESCRIPTION
###### Motivation for this change

This is a very useful package.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
