### PR TITLE
flare: 1.12 -> 1.13

### DIFF
--- a/pkgs/games/flare/default.nix
+++ b/pkgs/games/flare/default.nix
@@ -1,7 +1,7 @@
 { lib, buildEnv, callPackage, makeWrapper, Cocoa }:
 
 buildEnv {
-  name = "flare-1.12";
+  name = "flare-1.13";
 
   paths = [
     (callPackage ./engine.nix { inherit Cocoa; })
@@ -17,7 +17,7 @@ buildEnv {
   meta = with lib; {
     description = "Fantasy action RPG using the FLARE engine";
     homepage = "https://flarerpg.org/";
-    maintainers = [ maintainers.aanderse ];
+    maintainers = with maintainers; [ aanderse McSinyx ];
     license = [ licenses.gpl3 licenses.cc-by-sa-30 ];
     platforms = platforms.unix;
   };

--- a/pkgs/games/flare/engine.nix
+++ b/pkgs/games/flare/engine.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flare-engine";
-  version = "1.12";
+  version = "1.13";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0swav6fzz970wj4iic3b7y06haa05720s2wivc8w7wcw9nzcac7j";
+    sha256 = "sha256-53JCjVu6vG4js5UryQIccpD8qdS+EfxSyV4v2LOYe+c=";
   };
 
   patches = [ ./desktop.patch ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Free/Libre Action Roleplaying Engine";
     homepage = "https://github.com/flareteam/flare-engine";
-    maintainers = [ maintainers.aanderse ];
+    maintainers = with maintainers; [ aanderse McSinyx ];
     license = [ licenses.gpl3 ];
     platforms = platforms.unix;
   };

--- a/pkgs/games/flare/game.nix
+++ b/pkgs/games/flare/game.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flare-game";
-  version = "1.12";
+  version = "1.13";
 
   src = fetchFromGitHub {
     owner = "flareteam";
     repo = pname;
     rev = "v${version}";
-    sha256 = "15k9r7w587pvkzrln0670hhq5fzif8k7xmrhb0nl3z3fi6dw3mmc";
+    sha256 = "sha256-zfZTHw8obq5/z9+mCY0LIq9suvyh91ypqpxc3dNxI4o=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Fantasy action RPG using the FLARE engine";
     homepage = "https://github.com/flareteam/flare-game";
-    maintainers = [ maintainers.aanderse ];
+    maintainers = with maintainers; [ aanderse McSinyx ];
     license = [ licenses.cc-by-sa-30 ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Also add myself as a maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
