### PR TITLE
phinger-cursors: fix installPhase including env-vars in output

### DIFF
--- a/pkgs/data/icons/phinger-cursors/default.nix
+++ b/pkgs/data/icons/phinger-cursors/default.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share/icons
-    cp -r ./ $out/share/icons
+    cp -r ./phinger-cursors* $out/share/icons
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`phinger-cursors` currently has the following `installPhase`:

https://github.com/NixOS/nixpkgs/blob/554d2d8aa25b6e583575459c297ec23750adb6cb/pkgs/data/icons/phinger-cursors/default.nix#L14-L19

Running `cp -r ./ $out/share/icons` to copy the icon files to `$out/share/icons` ends up copying the `env-vars` file as well (since `sourceRoot = "."`), which resulted in a collision for me when building the system path:

```
1 ~ λ nix build github:nixos/nixpkgs/554d2d8aa25b6e583575459c297ec23750adb6cb#phinger-cursors
1 ~ λ ll result/share/icons/
dr-xr-xr-x    - root 31 Dec  1969 phinger-cursors
dr-xr-xr-x    - root 31 Dec  1969 phinger-cursors-light
.r--r--r-- 4.2k root 31 Dec  1969 env-vars
1 ~ λ sudo nixos-rebuild switch
building the system configuration...
error: builder for '/nix/store/an3a40zhnxb4aq3sw91fqafs9dy401vn-user-environment.drv' failed with exit code 1;
       last 2 log lines:
       > created 1876 symlinks in user environment
       > ln: failed to create symbolic link './env-vars': File exists
       For full logs, run 'nix log /nix/store/an3a40zhnxb4aq3sw91fqafs9dy401vn-user-environment.drv'.
error: 1 dependencies of derivation '/nix/store/v75afgng5508r867kswh2n7d4k8b5cl1-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ph24hylafi1gr012phkjwj33fzbpjqcr-nixos-system-prism-22.05.20220202.554d2d8.drv' failed to build
```

This uses a wildcard to copy the variants instead, which relies on the assumption that all variants start with `phinger-cursors`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
