### PR TITLE
openresty: default more explicitly to no modules

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21548,6 +21548,7 @@ with pkgs;
 
   openresty = callPackage ../servers/http/openresty {
     withPerl = false;
+    modules = [];
   };
 
   opensmtpd = callPackage ../servers/mail/opensmtpd { };


### PR DESCRIPTION
###### Motivation for this change

Set modules explicitly for the openresty package. Otherwise, the use of
`callPackage ../nginx/generic.nix` will take 'modules' from the
top-level, which may include a 'modules' variable set in an overlay...
which can lead to some nicely confusing error messages.

Fixes #158324

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - `nix-build -A nixosTests.openresty-lua` succeeds
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

