### PR TITLE
python3Packages.androidtv: 0.0.60 -> 0.0.63

### DIFF
--- a/pkgs/development/python-modules/androidtv/default.nix
+++ b/pkgs/development/python-modules/androidtv/default.nix
@@ -3,37 +3,48 @@
 , aiofiles
 , buildPythonPackage
 , fetchFromGitHub
-, isPy3k
 , mock
 , pure-python-adb
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "androidtv";
-  version = "0.0.60";
+  version = "0.0.63";
+  format = "setuptools";
 
-  # pypi does not contain tests, using github sources instead
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "JeffLIrion";
     repo = "python-androidtv";
     rev = "v${version}";
-    sha256 = "sha256-GWCiRxZ6pHrcVkOKNGxSK8lUD0RohtED8czXIWUoVaM=";
+    hash = "sha256-Peg/agAb1lUBUBK1OkYVovE4pzM8iaQHVaSk/hr1plw=";
   };
 
-  propagatedBuildInputs = [ adb-shell pure-python-adb ]
-    ++ lib.optionals (isPy3k) [ aiofiles ];
+  propagatedBuildInputs = [
+    adb-shell
+    aiofiles
+    pure-python-adb
+  ];
 
   checkInputs = [
     mock
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "androidtv" ];
+  disabledTests = [
+    # Requires git but fails anyway
+    "test_no_underscores"
+  ];
+
+  pythonImportsCheck = [
+    "androidtv"
+  ];
 
   meta = with lib; {
-    description =
-      "Communicate with an Android TV or Fire TV device via ADB over a network";
+    description = "Communicate with an Android TV or Fire TV device via ADB over a network";
     homepage = "https://github.com/JeffLIrion/python-androidtv/";
     license = licenses.mit;
     maintainers = with maintainers; [ jamiemagee ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release 0.0.63

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
