### PR TITLE
epm: 4.4 -> 5.0.0

### DIFF
--- a/pkgs/development/tools/misc/epm/default.nix
+++ b/pkgs/development/tools/misc/epm/default.nix
@@ -1,26 +1,40 @@
-{lib, stdenv, fetchFromGitHub, rpm}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, rpm
+}:
 
 stdenv.mkDerivation rec {
   pname = "epm";
-  version = "4.4";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
-    repo = "epm";
-    owner = "michaelrsweet";
+    owner = "jimjag";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0kaw7v2m20qirapkps4dna6nf9xibnwljvvv0l9vpvi920kw7j7p";
+    hash = "sha256-o4B5lWBeve+U70FDgF1DrtNrXxaEY4etkPpwbqF7fmc=";
   };
+
+  patches = [
+    # Makefile fix: INSTALL command
+    (fetchpatch {
+      url = "https://github.com/jimjag/epm/commit/dc5fcd6fa6e3a74baa28be060769a2b47f9368e7.patch";
+      sha256 = "1gfyz493w0larin841xx3xalb7m3sp1r2vv1xki6rz35ybrnb96c";
+    })
+    # Makefile fix: man pages filenames and docdir target
+    (fetchpatch {
+      url = "https://github.com/jimjag/epm/commit/96bb48d4d7b463a09d5a25debfb51c88dcd7398c.patch";
+      sha256 = "11aws0qac6vyy3w5z39vkjy4symmfzxfq9qgbgkk74fvx9vax42a";
+    })
+  ];
 
   buildInputs = [ rpm ];
 
-  preInstall = ''
-    sed -i 's/README/README.md/' Makefile
-  '';
-
   meta = with lib; {
     description = "The ESP Package Manager generates distribution archives for a variety of platforms";
-    homepage = "https://www.msweet.org/projects.php?Z2";
-    license = licenses.gpl2;
+    homepage = "https://jimjag.github.io/epm/";
+    license = licenses.asl20;
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.unix;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- upstream has moved (new maintainer)
- license has changed to Apache 2.0


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
