### PR TITLE
Fix irssi missing symbols on Apple Silicon

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -1,16 +1,24 @@
-{ lib, stdenv, fetchurl, pkg-config, ncurses, glib, openssl, perl, libintl, libgcrypt, libotr }:
+{ lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config, ncurses, glib, openssl, perl, libintl, libgcrypt, libotr, git }:
 
 stdenv.mkDerivation rec {
   pname = "irssi";
   version = "1.2.3";
 
-  src = fetchurl {
-    url = "https://github.com/irssi/irssi/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "09cwz5ff1i5lp35qhhmw6kbw5dwcn9pl16gpzkc92xg5sx3bgjr9";
+
+  src = fetchFromGitHub {
+    "owner" = "irssi";
+    "repo" = "irssi";
+    "rev" = "91dc3e4dfa1a9558c5a7fe0ea982cb9df0e2de65";
+    "sha256" = "efnE4vuDd7TnOBxMPduiV0/nez1jVhTjbJ0vzN4ZMcg=";
+    "leaveDotGit" = true;
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake libtool git ];
   buildInputs = [ ncurses glib openssl perl libintl libgcrypt libotr ];
+
+  preConfigure = ''
+    NOCONFIGURE=1 ./autogen.sh
+  '';
 
   configureFlags = [
     "--with-proxy"

--- a/pkgs/applications/networking/irc/irssi/fish/default.nix
+++ b/pkgs/applications/networking/irc/irssi/fish/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   preConfigure = ''
-    tar xf ${irssi.src}
+    cp -a "${irssi.src}" "./${irssi.name}"
     configureFlags="$configureFlags --with-irssi-source=`pwd`/${irssi.name}"
 
     ./regen.sh


### PR DESCRIPTION
I've just switched irssi to build from the 1.2.3 tag in the git tree, as
the build was failing on apple silicon when linking libirc_proxy.la in
dir `src/irc/proxy`

I kinda just switched it and it built. I did not dig very deep on the
reasons behind why this fixed things. I am hoping that Linux still
builds, as i have not tested it. Some notes:

- The sys_lib_search_path done by fixLibtool in the configure phase now
  no longer seems to update with the NIX_LDFLAGS. It appears that this
  is because the newer libtool script does not start the line with
  'eval', so the sed does not match.
- My system still builds, despite the previous item. I noticed that on
  this new build, my system defines `allow_undefined_flag` in the
  libtool script to something nonempty. I guess that may be the reason
  everything still builds and works at runtime.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Broken build of irssi on apple silicon

###### Things done
Switch source to git and the tag for 1.2.3

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
