### PR TITLE
ventoy-bin: 1.0.56 -> 1.0.72

### DIFF
--- a/pkgs/tools/cd-dvd/ventoy-bin/add-mips64.patch
+++ b/pkgs/tools/cd-dvd/ventoy-bin/add-mips64.patch
@@ -1,0 +1,5 @@
+--- VentoyPlugson.sh
++++ VentoyPlugson.sh
+@@ -27,0 +28,2 @@ elif echo $machine | egrep -q 'x86_64|am
++elif echo $machine | egrep -q 'mips64'; then
++    TOOLDIR=mips64el

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -1,40 +1,55 @@
 { lib, stdenv, fetchurl, fetchpatch
 , autoPatchelfHook, makeWrapper
-, hexdump, exfat, dosfstools, e2fsprogs, xz, util-linux, bash, parted
-, withGtk3 ? true, gtk3
+, bash, coreutils, dosfstools, exfat, gawk, gnugrep, gnused, hexdump, parted
+, procps, util-linux, which, xz
+, withCryptsetup ? false, cryptsetup
+, withXfs ? false, xfsprogs
+, withExt4 ? false, e2fsprogs
+, withNtfs ? false, ntfs3g
+, withGtk3 ? false, gtk3
 , withQt5 ? false, qt5
+, defaultGuiType ? ""
 }:
 
-let arch = {
-  x86_64-linux = "x86_64";
-  i686-linux = "i386";
-  aarch64-linux = "aarch64";
-  mipsel-linux = "mips64el";
-}.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
-defaultGuiType = if withGtk3 then "gtk3"
-                 else if withQt5 then "qt5"
-                 else "";
+assert lib.elem defaultGuiType ["" "gtk3" "qt5"];
+assert defaultGuiType == "gtk3" -> withGtk3;
+assert defaultGuiType == "qt5" -> withQt5;
+
+let
+  arch = {
+    x86_64-linux = "x86_64";
+    i686-linux = "i386";
+    aarch64-linux = "aarch64";
+    mipsel-linux = "mips64el";
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported platform ${stdenv.hostPlatform.system}");
 in stdenv.mkDerivation rec {
   pname = "ventoy-bin";
-  version = "1.0.56";
+  version = "1.0.72";
 
   nativeBuildInputs = [ autoPatchelfHook makeWrapper ]
     ++ lib.optional withQt5 qt5.wrapQtAppsHook;
-  buildInputs = [ hexdump exfat dosfstools e2fsprogs xz util-linux bash parted ]
+  buildInputs = [
+    bash coreutils dosfstools exfat gawk gnugrep gnused hexdump parted procps
+    util-linux which xz
+  ] ++ lib.optional withCryptsetup cryptsetup
+    ++ lib.optional withXfs xfsprogs
+    ++ lib.optional withExt4 e2fsprogs
+    ++ lib.optional withNtfs ntfs3g
     ++ lib.optional withGtk3 gtk3
     ++ lib.optional withQt5 qt5.qtbase;
 
   src = fetchurl {
     url = "https://github.com/ventoy/Ventoy/releases/download/v${version}/ventoy-${version}-linux.tar.gz";
-    sha256 = "da53d51e653092a170c11dd560e0ad6fb27c497dd77ad0ba483c32935c069dea";
+    sha256 = "sha256-1mfe6ZnqkeBNGNjI7Qx7jG5FLgfn6rVwr0VQvSOG7Ow=";
   };
   patches = [
     (fetchpatch {
       name = "sanitize.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/sanitize.patch?h=ventoy-bin&id=ce4c26c67a1de4b761f9448bf92e94ffae1c8148";
-      sha256 = "c00f9f9cd5b4f81c566267b7b2480fa94d28dda43a71b1e47d6fa86f764e7038";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/sanitize.patch?h=19f8922b3d96c5ff55eeefc269ae43369a0748e8";
+      sha256 = "sha256-RDdxPCmrfNMwXNuJwQW48fAiJPbMjdHiBmF03fKqm2o=";
     })
     ./fix-for-read-only-file-system.patch
+    ./add-mips64.patch
   ];
   patchFlags = [ "-p0" ];
   postPatch = ''
@@ -42,7 +57,8 @@ in stdenv.mkDerivation rec {
     find -type f -name \*.sh -exec chmod a+x '{}' \;
 
     # Fix path to log.
-    sed -i 's:[lL]og\.txt:/var/log/ventoy\.log:g' WebUI/static/js/languages.js
+    sed -i 's:log\.txt:/var/log/ventoy\.log:g' \
+        WebUI/static/js/languages.js tool/languages.json
   '';
   installPhase = ''
     # Setup variables.
@@ -66,8 +82,8 @@ in stdenv.mkDerivation rec {
         aarch64) rm -r {tool/,VentoyGUI.}{x86_64,i386,mips64el};;
         mips64el) rm -r {tool/,VentoyGUI.}{x86_64,i386,aarch64};;
     esac
-    rm README
-    rm tool/"$ARCH"/Ventoy2Disk.gtk2
+    rm README tool/VentoyWorker.sh.orig
+    rm tool/"$ARCH"/Ventoy2Disk.gtk2 || true  # For aarch64 and mips64el.
 
     # Copy from "$src" to "$out".
     mkdir -p "$out"/bin "$VENTOY_PATH"
@@ -76,20 +92,24 @@ in stdenv.mkDerivation rec {
     # Fill bin dir.
     for f in Ventoy2Disk.sh_ventoy VentoyWeb.sh_ventoy-web \
              CreatePersistentImg.sh_ventoy-persistent \
-             ExtendPersistentImg.sh_ventoy-extend-persistent; do
-        makeWrapper "$VENTOY_PATH/''${f%_*}" "$out/bin/''${f#*_}" \
+             ExtendPersistentImg.sh_ventoy-extend-persistent \
+             VentoyPlugson.sh_ventoy-plugson; do
+        local bin="''${f%_*}" wrapper="''${f#*_}"
+        makeWrapper "$VENTOY_PATH/$bin" "$out/bin/$wrapper" \
                     --prefix PATH : "${lib.makeBinPath buildInputs}" \
                     --run "cd '$VENTOY_PATH' || exit 1"
     done
   '' + lib.optionalString (withGtk3 || withQt5) ''
+    # VentoGUI uses the `ventoy_gui_type` file to determine the type of GUI.
+    # See <https://github.com/ventoy/Ventoy/blob/471432fc50ffad80bde5de0b22e4c30fa3aac41b/LinuxGUI/Ventoy2Disk/ventoy_gui.c#L1044>.
     echo "${defaultGuiType}" > "$VENTOY_PATH/ventoy_gui_type"
     makeWrapper "$VENTOY_PATH/VentoyGUI.$ARCH" "$out/bin/ventoy-gui" \
                 --prefix PATH : "${lib.makeBinPath buildInputs}" \
                 --run "cd '$VENTOY_PATH' || exit 1"
   '' + lib.optionalString (!withGtk3) ''
-    rm "$out"/share/ventoy/tool/"$ARCH"/Ventoy2Disk.gtk3
+    rm "$VENTOY_PATH/tool/$ARCH/Ventoy2Disk.gtk3"
   '' + lib.optionalString (!withQt5) ''
-    rm "$out"/share/ventoy/tool/"$ARCH"/Ventoy2Disk.qt5
+    rm "$VENTOY_PATH/tool/$ARCH/Ventoy2Disk.qt5"
   '';
 
   meta = with lib; {
@@ -99,10 +119,14 @@ in stdenv.mkDerivation rec {
       ISO/WIM/IMG/VHD(x)/EFI files.  With ventoy, you don't need to format the
       disk over and over, you just need to copy the ISO/WIM/IMG/VHD(x)/EFI
       files to the USB drive and boot them directly.  You can copy many files
-      at a time and ventoy will give you a boot menu to select them
-      (screenshot).  x86 Legacy BIOS, IA32 UEFI, x86_64 UEFI, ARM64 UEFI and
-      MIPS64EL UEFI are supported in the same way.  Most type of OS supported
-      (Windows/WinPE/Linux/Unix/VMware/Xen...).
+      at a time and ventoy will give you a boot menu to select them.  You can
+      also browse ISO/WIM/IMG/VHD(x)/EFI files in local disk and boot them.
+      x86 Legacy BIOS, IA32 UEFI, x86_64 UEFI, ARM64 UEFI and MIPS64EL UEFI are
+      supported in the same way.  Most type of OS supported
+      (Windows/WinPE/Linux/ChromeOS/Unix/VMware/Xen...).  With ventoy you can
+      also browse ISO/WIM/IMG/VHD(x)/EFI files in local disk and boot them.
+      800+ image files are tested.  90%+ distros in <distrowatch.com>
+      supported.
     '';
     homepage = "https://www.ventoy.net";
     changelog = "https://www.ventoy.net/doc_news.html";

--- a/pkgs/tools/cd-dvd/ventoy-bin/fix-for-read-only-file-system.patch
+++ b/pkgs/tools/cd-dvd/ventoy-bin/fix-for-read-only-file-system.patch
@@ -1,7 +1,6 @@
-diff -Naurp0 old/CreatePersistentImg.sh new/CreatePersistentImg.sh
---- CreatePersistentImg.sh	2021-07-17 13:13:51.000000000 +0300
-+++ CreatePersistentImg.sh	2021-07-20 17:37:53.605911754 +0300
-@@ -94,7 +94,3 @@ if [ -n "$config" ]; then
+--- CreatePersistentImg.sh
++++ CreatePersistentImg.sh
+@@ -110,7 +110,3 @@ if [ -n "$config" ]; then
 -    if [ -d ./persist_tmp_mnt ]; then
 -        rm -rf ./persist_tmp_mnt
 -    fi
@@ -9,110 +8,47 @@ diff -Naurp0 old/CreatePersistentImg.sh new/CreatePersistentImg.sh
 -    mkdir ./persist_tmp_mnt
 -    if mount $freeloop ./persist_tmp_mnt; then
 -        echo '/ union' > ./persist_tmp_mnt/$config
-+    path_to_persist_mnt="$(mktemp -d)"
++    path_to_persist_mnt="`mktemp -d`"
 +    if mount $freeloop "$path_to_persist_mnt"; then
 +        echo '/ union' > "$path_to_persist_mnt"/$config
-@@ -102 +98 @@ if [ -n "$config" ]; then
+@@ -118 +114 @@ if [ -n "$config" ]; then
 -        umount ./persist_tmp_mnt
 +        umount "$path_to_persist_mnt"
-@@ -104 +100 @@ if [ -n "$config" ]; then
+@@ -120 +116 @@ if [ -n "$config" ]; then
 -    rm -rf ./persist_tmp_mnt
 +    rm -rf "$path_to_persist_mnt"
-diff -Naurp0 old/tool/VentoyWorker.sh new/tool/VentoyWorker.sh
---- tool/VentoyWorker.sh	2021-07-17 13:13:51.000000000 +0300
-+++ tool/VentoyWorker.sh	2021-07-20 17:27:10.885452119 +0300
-@@ -153,12 +152,0 @@ fi
+--- tool/VentoyWorker.sh
++++ tool/VentoyWorker.sh
+@@ -162,12 +161,0 @@ fi
 -#check tmp_mnt directory
 -if [ -d ./tmp_mnt ]; then
 -    vtdebug "There is a tmp_mnt directory, now delete it."
 -    umount ./tmp_mnt >/dev/null 2>&1
 -    rm -rf ./tmp_mnt
 -    if [ -d ./tmp_mnt ]; then
--        vterr "tmp_mnt directory exits, please delete it first."
+-        vterr "tmp_mnt directory exists, please delete it first."
 -        exit 1
 -    fi
 -fi
 -
 -
-@@ -322 +310 @@ if [ "$MODE" = "install" ]; then
--        mkdir ./tmp_mnt
-+        path_to_mnt="$(mktemp -d)"
-@@ -326 +314 @@ if [ "$MODE" = "install" ]; then
--            if mount ${PART2} ./tmp_mnt > /dev/null 2>&1; then
-+            if mount ${PART2} "$path_to_mnt" > /dev/null 2>&1; then
-@@ -335,9 +323,9 @@ if [ "$MODE" = "install" ]; then
--        rm -f ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
--        rm -f ./tmp_mnt/EFI/BOOT/grubx64.efi
--        rm -f ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
--        rm -f ./tmp_mnt/EFI/BOOT/grubia32.efi
--        rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
--        rm -f ./tmp_mnt/EFI/BOOT/mmia32.efi
--        rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
--        mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
--        mv ./tmp_mnt/EFI/BOOT/grubia32_real.efi  ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/grubx64.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/grubia32.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/MokManager.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/mmia32.efi
-+        rm -f "$path_to_mnt"/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
-+        mv "$path_to_mnt"/EFI/BOOT/grubx64_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
-+        mv "$path_to_mnt"/EFI/BOOT/grubia32_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
-@@ -348 +336 @@ if [ "$MODE" = "install" ]; then
--            if umount ./tmp_mnt; then
-+            if umount "$path_to_mnt"; then
-@@ -350 +338 @@ if [ "$MODE" = "install" ]; then
--                rm -rf ./tmp_mnt
-+                rm -rf "$path_to_mnt"
-@@ -407,2 +395,2 @@ else
+@@ -569,2 +557,2 @@ else
 -    rm -f ./diskuuid.bin
 -    dd status=none conv=fsync if=${DISK} skip=384 bs=1 count=16 of=./diskuuid.bin
-+    path_to_diskuuid="$(mktemp)"
++    path_to_diskuuid="`mktemp`"
 +    dd status=none conv=fsync if=${DISK} skip=384 bs=1 count=16 of="$path_to_diskuuid"
-@@ -411,2 +399,2 @@ else
+@@ -573,2 +561,2 @@ else
 -    dd status=none conv=fsync if=./diskuuid.bin of=$DISK bs=1 count=16 seek=384
 -    rm -f ./diskuuid.bin
 +    dd status=none conv=fsync if="$path_to_diskuuid" of=$DISK bs=1 count=16 seek=384
 +    rm -f "$path_to_diskuuid"
-@@ -415,2 +403,2 @@ else
+@@ -577,2 +565,2 @@ else
 -    rm -f ./rsvdata.bin
 -    dd status=none conv=fsync if=${DISK} skip=2040 bs=512 count=8 of=./rsvdata.bin
-+    path_to_rsvdata="$(mktemp)"
++    path_to_rsvdata="`mktemp`"
 +    dd status=none conv=fsync if=${DISK} skip=2040 bs=512 count=8 of="$path_to_rsvdata"
-@@ -438,2 +426,2 @@ else
+@@ -600,2 +588,2 @@ else
 -    dd status=none conv=fsync if=./rsvdata.bin seek=2040 bs=512 count=8 of=${DISK}
 -    rm -f ./rsvdata.bin
 +    dd status=none conv=fsync if="$path_to_rsvdata" seek=2040 bs=512 count=8 of=${DISK}
 +    rm -f "$path_to_rsvdata"
-@@ -448 +436 @@ else
--        mkdir ./tmp_mnt
-+        path_to_mnt="$(mktemp -d)"
-@@ -454 +442 @@ else
--            if mount ${PART2} ./tmp_mnt > /dev/null 2>&1; then
-+            if mount ${PART2} "$path_to_mnt" > /dev/null 2>&1; then
-@@ -463,9 +451,9 @@ else
--        rm -f ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
--        rm -f ./tmp_mnt/EFI/BOOT/grubx64.efi
--        rm -f ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
--        rm -f ./tmp_mnt/EFI/BOOT/grubia32.efi
--        rm -f ./tmp_mnt/EFI/BOOT/MokManager.efi
--        rm -f ./tmp_mnt/EFI/BOOT/mmia32.efi
--        rm -f ./tmp_mnt/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
--        mv ./tmp_mnt/EFI/BOOT/grubx64_real.efi  ./tmp_mnt/EFI/BOOT/BOOTX64.EFI
--        mv ./tmp_mnt/EFI/BOOT/grubia32_real.efi  ./tmp_mnt/EFI/BOOT/BOOTIA32.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/grubx64.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
-+        rm -f "$path_to_mnt"/EFI/BOOT/grubia32.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/MokManager.efi
-+        rm -f "$path_to_mnt"/EFI/BOOT/mmia32.efi
-+        rm -f "$path_to_mnt"/ENROLL_THIS_KEY_IN_MOKMANAGER.cer
-+        mv "$path_to_mnt"/EFI/BOOT/grubx64_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTX64.EFI
-+        mv "$path_to_mnt"/EFI/BOOT/grubia32_real.efi  "$path_to_mnt"/EFI/BOOT/BOOTIA32.EFI
-@@ -476 +464 @@ else
--            if umount ./tmp_mnt > /dev/null 2>&1; then
-+            if umount "$path_to_mnt" > /dev/null 2>&1; then
-@@ -478 +466 @@ else
--                rm -rf ./tmp_mnt
-+                rm -rf "$path_to_mnt"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Ref: https://github.com/NixOS/nixpkgs/issues/158264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
