### PR TITLE
cryptopp: add an option to build with OpenMP

### DIFF
--- a/pkgs/development/libraries/crypto++/default.nix
+++ b/pkgs/development/libraries/crypto++/default.nix
@@ -1,6 +1,12 @@
-{ lib, stdenv, fetchFromGitHub
+{ lib
+, stdenv
+, fetchFromGitHub
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableShared ? !enableStatic
+# Multi-threading with OpenMP is disabled by default
+# more info on https://www.cryptopp.com/wiki/OpenMP
+, withOpenMP ? false
+, llvmPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -19,17 +25,22 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace GNUmakefile \
-      --replace "AR = libtool" "AR = ar" \
+      --replace "AR = /usr/bin/libtool" "AR = ar" \
       --replace "ARFLAGS = -static -o" "ARFLAGS = -cru"
   '';
 
+  buildInputs = lib.optionals (stdenv.cc.isClang && withOpenMP) [ llvmPackages.openmp ];
+
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
   buildFlags =
        lib.optional enableStatic "static"
     ++ lib.optional enableShared "shared"
     ++ [ "libcryptopp.pc" ];
+
   enableParallelBuilding = true;
   hardeningDisable = [ "fortify" ];
+  CXXFLAGS = lib.optionals (withOpenMP) [ "-fopenmp" ];
 
   doCheck = true;
 
@@ -38,17 +49,21 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install-lib" ];
   installFlags = [ "LDCONF=true" ];
+  # TODO: remove postInstall hook with v8.7 -> https://github.com/weidai11/cryptopp/commit/230c558a
   postInstall = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.majorMinor version}
     ln -sr $out/lib/libcryptopp.so.${version} $out/lib/libcryptopp.so.${lib.versions.major version}
   '';
 
-  meta = {
-    description = "Crypto++, a free C++ class library of cryptographic schemes";
+  meta = with lib; {
+    description = "A free C++ class library of cryptographic schemes";
     homepage = "https://cryptopp.com/";
-    changelog = "https://raw.githubusercontent.com/weidai11/cryptopp/CRYPTOPP_${underscoredVersion}/History.txt";
-    license = with lib.licenses; [ boost publicDomain ];
-    platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ c0bw3b ];
+    changelog = [
+      "https://raw.githubusercontent.com/weidai11/cryptopp/CRYPTOPP_${underscoredVersion}/History.txt"
+      "https://github.com/weidai11/cryptopp/releases/tag/CRYPTOPP_${underscoredVersion}"
+    ];
+    license = with licenses; [ boost publicDomain ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ c0bw3b ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Some user of the lib may need the multi-threading support (CryFS for example)
\+ (attempt to) fix Darwin build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
