### PR TITLE
picom: 8.2 -> 9, picom-next: unstable-2021-11-19 -> unstable-2022-02-05

### DIFF
--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation rec {
   pname = "picom";
-  version = "8.2";
+  version = "9";
 
   src = fetchFromGitHub {
     owner = "yshui";
     repo = "picom";
     rev = "v${version}";
-    sha256 = "0gjksayz2xpmgglvw17ppsan2imrd1fijs579kbf27xwp503xgfl";
+    sha256 = "sha256-ym4fWOcZFlHkLUQEanC+thQLbPial7ZNzxfCWSlweWg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/window-managers/picom/picom-next.nix
+++ b/pkgs/applications/window-managers/picom/picom-next.nix
@@ -2,12 +2,12 @@
 
 picom.overrideAttrs (oldAttrs: rec {
   pname = "picom-next";
-  version = "unstable-2021-11-19";
+  version = "unstable-2022-02-05";
   src = fetchFromGitHub {
     owner = "yshui";
     repo = "picom";
-    rev = "1c7a4ff5a3cd5f3e25abcac0196896eea5939dce";
-    sha256 = "sha256-2uy2ofXhEWKuM+nEUqU16c85UGt6fJGtPZj+az907aw=";
+    rev = "928963721c8789fc5f27949e8b0730771aab940d";
+    sha256 = "sha256-qu9HnUG5VQbiSgduW1oR/tVvzEckaD2TWzds4R5zI+Y=";
   };
   meta.maintainers = with lib.maintainers; oldAttrs.meta.maintainers ++ [ GKasparov ];
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Not ran yet since I'm running picom, I'll rebuild soon

https://github.com/yshui/picom/releases/tag/v9-rc1

- picom: 8.2 -> 9
- picom-next: unstable-2021-11-19 -> unstable-2022-02-05


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
