### PR TITLE
treewide: rename name to pname&version

### DIFF
--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -13,8 +13,8 @@ let param =
 in
 
 stdenv.mkDerivation {
-
-  name = "ocaml${ocaml.version}-functory-${param.version}";
+  pname = "ocaml${ocaml.version}-functory";
+  inherit (param) version;
 
   src = fetchurl {
     url = "https://www.lri.fr/~filliatr/functory/download/functory-${param.version}.tar.gz";

--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   version = "2.3";
-  name = "ocaml${ocaml.version}-inotify-${version}";
+  pname = "ocaml${ocaml.version}-inotify";
 
   src = fetchFromGitHub {
     owner = "whitequark";

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -1,9 +1,8 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, uutf }:
 
-let version = "1.0.1"; in
-
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-jsonm-${version}";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-jsonm";
+  version = "1.0.1";
 
   src = fetchurl {
     url = "https://erratique.ch/software/jsonm/releases/jsonm-${version}.tbz";

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -7,7 +7,7 @@ else
 
 stdenv.mkDerivation rec {
   version = "1.6";
-  name = "ocaml${ocaml.version}-lablgtk-extras-${version}";
+  pname = "ocaml${ocaml.version}-lablgtk-extras";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -49,7 +49,7 @@ in
 
 stdenv.mkDerivation rec {
   inherit (param) version src;
-  name = "ocaml${ocaml.version}-labltk-${version}";
+  pname = "ocaml${ocaml.version}-labltk";
 
   buildInputs = [ ocaml findlib tcl tk makeWrapper ];
 

--- a/pkgs/development/ocaml-modules/lwt_react/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_react/default.nix
@@ -2,9 +2,9 @@
 
 stdenv.mkDerivation rec {
   version = "1.0.1";
-  name = "ocaml${ocaml.version}-lwt_react-${version}";
+  pname = "ocaml${ocaml.version}-lwt_react";
   src = fetchzip {
-    url = "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-1.0.1.tar.gz";
+    url = "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-${version}.tar.gz";
     sha256 = "1bbz7brvdskf4angzn3q2s2s6qdnx7x8m8syayysh23gwv4c7v31";
   };
 

--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, perl, ocaml, findlib, camlidl, gmp, mpfr }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-mlgmpidl-${version}";
+  pname = "ocaml${ocaml.version}-mlgmpidl";
   version = "1.2.12";
   src = fetchFromGitHub {
     owner = "nberth";

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -16,7 +16,8 @@ let param =
 in
 
 stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-mtime-${param.version}";
+  pname = "ocaml${ocaml.version}-mtime";
+  inherit (param) version;
 
   src = fetchurl {
     url = "https://erratique.ch/software/mtime/releases/mtime-${param.version}.tbz";

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -20,7 +20,7 @@ then throw "nocrypto is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-nocrypto-${version}";
+  pname = "ocaml${ocaml.version}-nocrypto";
   version = "0.5.4";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -12,7 +12,7 @@ let withLwt = lwt != null; in
 
 stdenv.mkDerivation rec {
   version = "0.2.2";
-  name = "ocaml${ocaml.version}-notty-${version}";
+  pname = "ocaml${ocaml.version}-notty";
 
   src = fetchurl {
     url = "https://github.com/pqwy/notty/releases/download/v${version}/notty-${version}.tbz";

--- a/pkgs/development/ocaml-modules/num/default.nix
+++ b/pkgs/development/ocaml-modules/num/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.1";
-  name = "ocaml${ocaml.version}-num-${version}";
+  pname = "ocaml${ocaml.version}-num";
   src = fetchFromGitHub {
     owner = "ocaml";
     repo = "num";

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -7,7 +7,7 @@ then throw "ocamlnet is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ocamlnet-${version}";
+  pname = "ocaml${ocaml.version}-ocamlnet";
   version = "4.1.9";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -5,7 +5,7 @@ then throw "ocp-ocamlres is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-ocp-ocamlres-${version}";
+  pname = "ocaml${ocaml.version}-ocp-ocamlres";
   version = "0.4";
   src = fetchFromGitHub {
     owner = "OCamlPro";

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -13,8 +13,8 @@ let param =
 }; in
 
 stdenv.mkDerivation {
-
-  name = "ocaml${ocaml.version}-pprint-${param.version}";
+  inherit (param) version;
+  pname = "ocaml${ocaml.version}-pprint";
 
   src = fetchurl {
     url = "http://gallium.inria.fr/~fpottier/pprint/pprint-${param.version}.tar.gz";

--- a/pkgs/development/ocaml-modules/process/default.nix
+++ b/pkgs/development/ocaml-modules/process/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-process-${version}";
+  pname = "ocaml${ocaml.version}-process";
   version = "0.2.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.8.5";
-  name = "ocaml${ocaml.version}-ptime-${version}";
+  pname = "ocaml${ocaml.version}-ptime";
 
   src = fetchurl {
     url = "https://erratique.ch/software/ptime/releases/ptime-${version}.tbz";

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -23,7 +23,8 @@ let param =
 in
 
 stdenv.mkDerivation ({
-  name = "ocaml${ocaml.version}-rope-${param.version}";
+  pname = "ocaml${ocaml.version}-rope";
+  inherit (param) version;
 
   src = fetchurl {
     inherit (param) url sha256;

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-rresult-${version}";
+  pname = "ocaml${ocaml.version}-rresult";
   version = "0.6.0";
   src = fetchurl {
     url = "https://erratique.ch/software/rresult/releases/rresult-${version}.tbz";

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -7,7 +7,7 @@ then throw "sosa is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-sosa-${version}";
+  pname = "ocaml${ocaml.version}-sosa";
   version = "0.3.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -27,7 +27,7 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-topkg-${version}";
+  pname = "ocaml${ocaml.version}-topkg";
   inherit (param) version;
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/wasm/default.nix
+++ b/pkgs/development/ocaml-modules/wasm/default.nix
@@ -5,7 +5,7 @@ then throw "wasm is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-wasm-${version}";
+  pname = "ocaml${ocaml.version}-wasm";
   version = "1.1.1";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
