### PR TITLE
http-parser: fix build on armv7l-linux

### DIFF
--- a/pkgs/development/libraries/http-parser/default.nix
+++ b/pkgs/development/libraries/http-parser/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "http-parser";
@@ -12,7 +12,14 @@ stdenv.mkDerivation rec {
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error";
-  patches = [ ./build-shared.patch ];
+  patches = [
+    ./build-shared.patch
+    # https://github.com/nodejs/http-parser/pull/510
+    (fetchpatch {
+      url = "https://github.com/nodejs/http-parser/commit/4f15b7d510dc7c6361a26a7c6d2f7c3a17f8d878.patch";
+      sha256 = "sha256-rZZMJeow3V1fTnjadRaRa+xTq3pdhZn/eJ4xjxEDoU4=";
+    })
+  ];
   makeFlags = [ "DESTDIR=" "PREFIX=$(out)" ];
   buildFlags = [ "library" ];
   doCheck = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Trying to build `mobile-nixos` system on an armv7l device leads to

```
...
http_parser v2.9.4 (0x020904)
sizeof(http_parser) = 32
test_g: test.c:4224: main: Assertion `sizeof(http_parser) == 4 + 4 + 8 + 2 + 2 + 4 + sizeof(void *)' failed.
qemu: uncaught target signal 6 (Aborted) - core dumped
checking for sys/types.h... yes
make: *** [Makefile:76: test] Aborted (core dumped)
error: builder for '/nix/store/d1qbck4cki8mx207360aq9i2rl1nq22y-http-parser-2.9.4.drv' failed with exit code 2;
       last 10 log lines:
       > gcc -Wall -Wextra -Werror -O0 -g   http_parser_g.o test_g.o -o test_g
       > gcc -I. -DHTTP_PARSER_STRICT=0  -Wall -Wextra -Werror -O3  -c http_parser.c
       > gcc -I. -DHTTP_PARSER_STRICT=0  -Wall -Wextra -Werror -O3  -c test.c -o test.o
       > gcc -Wall -Wextra -Werror -O3   http_parser.o test.o -o test_fast
       > ./test_g
       > http_parser v2.9.4 (0x020904)
       > sizeof(http_parser) = 32
       > test_g: test.c:4224: main: Assertion `sizeof(http_parser) == 4 + 4 + 8 + 2 + 2 + 4 + sizeof(void *)' failed.
       > qemu: uncaught target signal 6 (Aborted) - core dumped
       > make: *** [Makefile:76: test] Aborted (core dumped)
       For full logs, run 'nix log /nix/store/d1qbck4cki8mx207360aq9i2rl1nq22y-http-parser-2.9.4.drv'.
waiting for lock on '/nix/store/7hwdaw0ylqf4vx4b2fl23p3iffmqrnjv-keyutils-1.6.3-lib', '/nix/store/kbzvs1ch16a5js95pcak146mlj7d52ch-keyutils-1.6.3', '/nix/store/lad7a023ana63w5apbwmzjp64xbh5aqp-keyutils-1.6.3-dev'...
error: 1 dependencies of derivation '/nix/store/6c3qfscz5fmrhfnjvkgbsi0vsz1ifiww-nodejs-14.18.1.drv' failed to build
building '/nix/store/b8dindd1ing614yc3wb9sciy69iv0xwi-icu4c-67.1.drv'...
error: 1 dependencies of derivation '/nix/store/wjdnq0bh7h3r8pf89ar1jd1f30yyhg7y-svgo-2.8.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/vsaqw36zyqmfq6q3p84wqlghdvjgq5ph-gui-assets.drv' failed to build
error: 1 dependencies of derivation '/nix/store/7h06spmr7fz85z7qxrnm5y068h86w2a3-boot-recovery-menu.mrb.drv' failed to build
...
```

Fixed upstream by https://github.com/nodejs/http-parser/issues/507

@samueldr 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
