### PR TITLE
zeitgeist: 1.0.3 → 1.0.4

### DIFF
--- a/pkgs/development/libraries/zeitgeist/default.nix
+++ b/pkgs/development/libraries/zeitgeist/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitLab
-, fetchpatch
 , pkg-config
 , glib
 , sqlite
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation rec {
   pname = "zeitgeist";
-  version = "1.0.3";
+  version = "1.0.4";
 
   outputs = [ "out" "lib" "dev" "man" ] ++ lib.optional pythonSupport "py";
 
@@ -29,16 +29,8 @@ stdenv.mkDerivation rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0y6fyzxl5np4yskcxibd0p03h619w9ir907nhf40h02y0pk1kgkp";
+    sha256 = "kG1N8DXgjYAJ8fbrGHsp7eTqB20H5smzRnW0PSRUYR0=";
   };
-
-  patches = [
-    # Fix build with Vala 0.52
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/zeitgeist/zeitgeist/commit/64ac3a6f94cd299e5e14945dc31b48f009dec152.patch";
-      sha256 = "Dw1kNE3JoFdmgcQ0eFoFLYvmxlPjXNj56Jkn2meINz4=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoconf


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.freedesktop.org/zeitgeist/zeitgeist/-/blob/v1.0.4/NEWS
https://gitlab.freedesktop.org/zeitgeist/zeitgeist/-/compare/v1.0.3...v1.0.4

... and unfinished https://github.com/orgs/elementary/projects/56 :crying_cat_face: 
(elementary-music is completely rewritten in Pantheon 7, zeitgeist is still needed in elementary-music 5.1.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] See whether zeitgeist.service starts.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
