### PR TITLE
python39Packages.folium: fix version number, run tests, cleanups

### DIFF
--- a/pkgs/development/python-modules/folium/default.nix
+++ b/pkgs/development/python-modules/folium/default.nix
@@ -1,37 +1,60 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
-, pytest
-, numpy
-, nbconvert
-, pandas
-, mock
-, jinja2
+, pytestCheckHook
 , branca
+, jinja2
+, nbconvert
+, numpy
+, pandas
+, pillow
 , requests
+, selenium
+, setuptools-scm
 }:
 
 buildPythonPackage rec {
   pname = "folium";
   version = "0.12.1.post1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e91e57d8298f3ccf4cce3c5e065bea6eb17033e3c5432b8a22214009c266b2ab";
-  };
-
   disabled = pythonOlder "3.5";
 
-  checkInputs = [ pytest nbconvert pandas mock ];
-  propagatedBuildInputs = [ jinja2 branca requests numpy ];
+  src = fetchFromGitHub {
+    owner = "python-visualization";
+    repo = "folium";
+    rev = "v${version}";
+    sha256 = "sha256-4UseN/3ojZdDUopwZLpHZEBon1qDDvCWfdzxodi/BeA=";
+  };
 
-  # No tests in archive
-  doCheck = false;
+  SETUPTOOLS_SCM_PRETEND_VERSION = "v${version}";
 
-  checkPhase = ''
-    py.test
-  '';
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    branca
+    jinja2
+    numpy
+    requests
+  ];
+
+  checkInputs = [
+    nbconvert
+    pytestCheckHook
+    pandas
+    pillow
+    selenium
+  ];
+
+  disabledTests = [
+    # requires internet connection
+    "test_geojson"
+    "test_heat_map_with_weights"
+    "test_json_request"
+    "test_notebook"
+  ];
 
   meta = {
     description = "Make beautiful maps with Leaflet.js & Python";


### PR DESCRIPTION
Fetching from GitHub is required to have the tests.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
