### PR TITLE
python39Packages.waitress-django: update meta, set version to 1.0.0, …

### DIFF
--- a/pkgs/development/python-modules/waitress-django/default.nix
+++ b/pkgs/development/python-modules/waitress-django/default.nix
@@ -1,11 +1,16 @@
-{ buildPythonPackage, django, waitress }:
+{ lib, buildPythonPackage, django, waitress }:
 
 buildPythonPackage {
   pname = "waitress-django";
-  version = "0.0.0";
+  version = "1.0.0";
 
   src = ./.;
   pythonPath = [ django waitress ];
   doCheck = false;
-  meta.description = "A waitress WSGI server serving django";
+
+  meta = with lib; {
+    description = "A waitress WSGI server serving django";
+    license = licenses.mit;
+    maintainers = with maintainers; [ basvandijk ];
+  };
 }

--- a/pkgs/development/python-modules/waitress-django/setup.py
+++ b/pkgs/development/python-modules/waitress-django/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup( name         = "waitress-django"
-     , version      = "0.0.0"
+     , version      = "1.0.0"
      , description  = "A waitress WSGI server serving django"
      , author       = "Bas van Dijk"
      , author_email = "v.dijk.bas@gmail.com"


### PR DESCRIPTION
…add maintainer

0.0.0 is a bad default because it indicates the package is packaged wrong and has no version at all set.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
