### PR TITLE
ocamlPackages.lwt_react: 1.0.1 → 1.1.5

### DIFF
--- a/pkgs/development/ocaml-modules/lwt_react/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_react/default.nix
@@ -1,22 +1,24 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild, lwt, react }:
+{ lib, buildDunePackage, fetchFromGitHub, cppo, lwt, react }:
 
-stdenv.mkDerivation rec {
-  version = "1.0.1";
-  name = "ocaml${ocaml.version}-lwt_react-${version}";
-  src = fetchzip {
-    url = "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-1.0.1.tar.gz";
-    sha256 = "1bbz7brvdskf4angzn3q2s2s6qdnx7x8m8syayysh23gwv4c7v31";
+buildDunePackage {
+  pname = "lwt_react";
+  version = "1.1.5";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = "lwt";
+    rev = "5.5.0";
+    sha256 = "sha256:1jbjz2rsz3j56k8vh5qlmm87hhkr250bs2m3dvpy9vsri8rkzj9z";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ cppo ];
 
   propagatedBuildInputs = [ lwt react ];
-
-  createFindlibDestdir = true;
 
   meta = {
     description = "Helpers for using React with Lwt";
     inherit (lwt.meta) homepage license maintainers;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/lwt_react/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_react/default.nix
@@ -2,9 +2,9 @@
 
 stdenv.mkDerivation rec {
   version = "1.0.1";
-  pname = "ocaml${ocaml.version}-lwt_react";
+  name = "ocaml${ocaml.version}-lwt_react-${version}";
   src = fetchzip {
-    url = "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-${version}.tar.gz";
+    url = "https://github.com/ocsigen/lwt/releases/download/3.0.0/lwt_react-1.0.1.tar.gz";
     sha256 = "1bbz7brvdskf4angzn3q2s2s6qdnx7x8m8syayysh23gwv4c7v31";
   };
 


### PR DESCRIPTION
###### Motivation for this change

Cleaning; bug fixes.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
