### PR TITLE
treewide: rename name to pname&version

### DIFF
--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, perl, gmp, mpfr, ppl, ocaml, findlib, camlidl, mlgmpidl }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-apron-${version}";
+  pname = "ocaml${ocaml.version}-apron";
   version = "0.9.13";
   src = fetchFromGitHub {
     owner = "antoinemine";

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -14,7 +14,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-astring-${param.version}";
+  pname = "ocaml${ocaml.version}-astring";
   inherit (param) version;
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -15,7 +15,7 @@ then throw "BAP is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-bap-${version}";
+  pname = "ocaml${ocaml.version}-bap";
   version = "2.2.0";
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
@@ -32,8 +32,8 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   setupHook = writeText "setupHook.sh" ''
-    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}/"
-    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${name}-llvm-plugins/"
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/ocaml${ocaml.version}-bap-${version}/"
+    export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/ocaml${ocaml.version}-bap-${version}-llvm-plugins/"
   '';
 
   nativeBuildInputs = [ which makeWrapper ];

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -6,10 +6,10 @@ if !lib.versionAtLeast ocaml.version "4.02"
 then throw "batteries is not available for OCaml ${ocaml.version}"
 else
 
-let version = "3.4.0"; in
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-batteries-${version}";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-batteries";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "ocaml-batteries-team";

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -6,7 +6,6 @@ if !lib.versionAtLeast ocaml.version "4.02"
 then throw "batteries is not available for OCaml ${ocaml.version}"
 else
 
-
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-batteries";
   version = "3.4.0";

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -1,9 +1,9 @@
 { stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ocaml_pcre }:
 
-let version = "1.4"; in
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-benchmark-${version}";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-benchmark";
+  version = "1.4";
 
   src = fetchzip {
     url = "https://github.com/Chris00/ocaml-benchmark/releases/download/${version}/benchmark-${version}.tar.gz";

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -1,6 +1,5 @@
 { stdenv, lib, fetchzip, ocaml, findlib, ocamlbuild, ocaml_pcre }:
 
-
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-benchmark";
   version = "1.4";

--- a/pkgs/development/ocaml-modules/bos/default.nix
+++ b/pkgs/development/ocaml-modules/bos/default.nix
@@ -3,8 +3,9 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-bos-${version}";
+  pname = "ocaml${ocaml.version}-bos";
   version = "0.2.0";
+
   src = fetchurl {
     url = "https://erratique.ch/software/bos/releases/bos-${version}.tbz";
     sha256 = "1s10iqx8rgnxr5n93lf4blwirjf8nlm272yg5sipr7lsr35v49wc";

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -6,7 +6,8 @@ else
 
 stdenv.mkDerivation rec {
   version = "2.5";
-  name = "ocaml${ocaml.version}-camlpdf-${version}";
+  pname = "ocaml${ocaml.version}-camlpdf";
+
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "camlpdf";

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -4,7 +4,6 @@ if !lib.versionAtLeast ocaml.version "4.10"
 then throw "cpdf is not available for OCaml ${ocaml.version}"
 else
 
-
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-cpdf";
   version = "2.5";

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -4,10 +4,10 @@ if !lib.versionAtLeast ocaml.version "4.10"
 then throw "cpdf is not available for OCaml ${ocaml.version}"
 else
 
-let version = "2.5"; in
 
-stdenv.mkDerivation {
-  name = "ocaml${ocaml.version}-cpdf-${version}";
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-cpdf";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "johnwhitington";

--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-dum-${version}";
+  pname = "ocaml${ocaml.version}-dum";
   version = "1.0.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   version = "1.1";
-  name = "ocaml${ocaml.version}-elina-${version}";
+  pname = "ocaml${ocaml.version}-elina";
   src = fetchurl {
     url = "http://files.sri.inf.ethz.ch/elina-${version}.tar.gz";
     sha256 = "1nymykskq1yx87y4xl6hl9i4q6kv0qaq25rniqgl1bfn883p1ysc";

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   version = "0.3+20200317";
-  name = "ocaml${ocaml.version}-erm_xmpp-${version}";
+  pname = "ocaml${ocaml.version}-erm_xmpp";
 
   src = fetchFromGitHub {
     owner  = "hannesm";

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, expat, ocaml, findlib, ounit }:
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-expat-${version}";
+  pname = "ocaml${ocaml.version}-expat";
   version = "1.1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/ocaml-modules/farfadet/default.nix
+++ b/pkgs/development/ocaml-modules/farfadet/default.nix
@@ -7,7 +7,7 @@ then throw "farfadet is not available for OCaml ${ocaml.version}"
 else
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-farfadet-${version}";
+  pname = "ocaml${ocaml.version}-farfadet";
   version = "0.3";
 
   src = fetchurl {

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -8,13 +8,13 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-FrontC-${version}";
+  pname = "ocaml${ocaml.version}-FrontC";
   version = "3.4.1";
 
   src = fetchFromGitHub {
     owner = "BinaryAnalysisPlatform";
     repo = "FrontC";
-    rev = "V_3_4_1";
+    rev = "V_${lib.replaceStrings ["."] ["_"] version}";
     sha256 = "1dq5nks0c9gsbr1m8k39m1bniawr5hqcy1r8x5px7naa95ch06ak";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
