### PR TITLE
nixUnstable: pre20220127 -> pre20220207

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -9,6 +9,7 @@
       rev = "9bce425c3304173548d8e822029644bb51d35263";
       sha256 = "sha256-tGzwKNW/odtAYcazWA9bPVSmVXMGKfXsqCA1UYaaxmU=";
     };
+    patches = [ ./eval.patch ];
     nix = nixVersions.unstable;
 
     tests = {

--- a/pkgs/development/tools/misc/hydra/eval.patch
+++ b/pkgs/development/tools/misc/hydra/eval.patch
@@ -1,0 +1,34 @@
+--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
++++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
+@@ -64,11 +64,11 @@
+ 
+ static std::string queryMetaStrings(EvalState & state, DrvInfo & drv, const string & name, const string & subAttribute)
+ {
+-    Strings res;
++    list<std::string_view> res;
+     std::function<void(Value & v)> rec;
+ 
+     rec = [&](Value & v) {
+-        state.forceValue(v);
++        state.forceValue(v, noPos);
+         if (v.type() == nString)
+             res.push_back(v.string.s);
+         else if (v.isList())
+@@ -112,7 +112,7 @@
+         callFlake(state, lockedFlake, *vFlake);
+ 
+         auto vOutputs = vFlake->attrs->get(state.symbols.create("outputs"))->value;
+-        state.forceValue(*vOutputs);
++        state.forceValue(*vOutputs, noPos);
+ 
+         auto aHydraJobs = vOutputs->attrs->get(state.symbols.create("hydraJobs"));
+         if (!aHydraJobs)
+@@ -191,7 +191,7 @@
+                     state.forceList(*a->value, *a->pos);
+                     for (unsigned int n = 0; n < a->value->listSize(); ++n) {
+                         auto v = a->value->listElems()[n];
+-                        state.forceValue(*v);
++                        state.forceValue(*v, noPos);
+                         if (v->type() == nString)
+                             job["namedConstituents"].push_back(state.forceStringNoCtx(*v));
+                     }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -66,12 +66,12 @@ in lib.makeExtensible (self: {
 
   unstable = lib.lowPrio (common rec {
     version = "2.7";
-    suffix = "pre20220127_${lib.substring 0 7 src.rev}";
+    suffix = "pre20220221_${lib.substring 0 7 src.rev}";
     src = fetchFromGitHub {
       owner = "NixOS";
       repo = "nix";
-      rev = "558c4ee3e370c9f9a6ea293df54ed6914a999f1c";
-      sha256 = "sha256-hMzKQflpgf3P7OdYKSnD1VMBSnF48XSRjaNX3bUJct4=";
+      rev = "caf51729450d4c57d48ddbef8e855e9bf65f8792";
+      sha256 = "sha256-2fbza6fWPjyTyVEqWIp0jk/Z4epjSDe1u4lbEu+v7Iw=";
     };
   });
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nix/issues/5985

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
