### PR TITLE
Add exe attribute to packages

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -146,14 +146,14 @@ rec {
       outputs = drv.outputs or [ "out" ];
 
       commonAttrs = drv
-        // (builtins.listToAttrs outputsList)
-        // ({
+        // builtins.listToAttrs outputsList
+        // {
           all = map (x: x.value) outputsList;
           exe =
               if passthru?meta.mainProgram
               then "${lib.getBin drv}/bin/${passthru.meta.mainProgram}"
               else drv.exe or (throw "Package ${drv.name} at ${passthru.meta.position} does not define meta.mainProgram, which is required for the exe attribute. If the package does not have an unambiguous main program, use \"\${pkg}/bin/command\" syntax instead.");
-          })
+          }
         // passthru;
 
       outputToAttrListElement = outputName:

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -145,8 +145,13 @@ rec {
     let
       outputs = drv.outputs or [ "out" ];
 
-      commonAttrs = drv // (builtins.listToAttrs outputsList) //
-        ({ all = map (x: x.value) outputsList; }) // passthru;
+      commonAttrs = drv
+        // (builtins.listToAttrs outputsList)
+        // ({ all = map (x: x.value) outputsList; })
+        // lib.optionalAttrs (passthru?meta.mainProgram) {
+          exe = "${lib.getBin drv}/bin/${passthru.meta.mainProgram}";
+        }
+        // passthru;
 
       outputToAttrListElement = outputName:
         { name = outputName;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -152,7 +152,7 @@ rec {
           exe =
               if passthru?meta.mainProgram
               then "${lib.getBin drv}/bin/${passthru.meta.mainProgram}"
-              else throw "Package ${drv.name} at ${passthru.meta.position} does not define meta.mainProgram, which is required for the exe attribute. If the package does not have an unambiguous main program, use \"\${pkg}/bin/command\" syntax instead.";
+              else drv.exe or (throw "Package ${drv.name} at ${passthru.meta.position} does not define meta.mainProgram, which is required for the exe attribute. If the package does not have an unambiguous main program, use \"\${pkg}/bin/command\" syntax instead.");
           })
         // passthru;
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -147,10 +147,13 @@ rec {
 
       commonAttrs = drv
         // (builtins.listToAttrs outputsList)
-        // ({ all = map (x: x.value) outputsList; })
-        // lib.optionalAttrs (passthru?meta.mainProgram) {
-          exe = "${lib.getBin drv}/bin/${passthru.meta.mainProgram}";
-        }
+        // ({
+          all = map (x: x.value) outputsList;
+          exe =
+              if passthru?meta.mainProgram
+              then "${lib.getBin drv}/bin/${passthru.meta.mainProgram}"
+              else throw "Package ${drv.name} at ${passthru.meta.position} does not define meta.mainProgram, which is required for the exe attribute. If the package does not have an unambiguous main program, use \"\${pkg}/bin/command\" syntax instead.";
+          })
         // passthru;
 
       outputToAttrListElement = outputName:

--- a/nixos/tests/3proxy.nix
+++ b/nixos/tests/3proxy.nix
@@ -143,13 +143,13 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     # test none auth
     peer0.succeed(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://216.58.211.112:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://216.58.211.112:9999"
     )
     peer0.succeed(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://192.168.0.2:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://192.168.0.2:9999"
     )
     peer0.succeed(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://127.0.0.1:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.2:3128 -S -O /dev/null http://127.0.0.1:9999"
     )
 
     peer2.wait_for_unit("3proxy.service")
@@ -157,13 +157,13 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     # test iponly auth
     peer0.succeed(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://216.58.211.113:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://216.58.211.113:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://192.168.0.3:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://192.168.0.3:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://127.0.0.1:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.3:3128 -S -O /dev/null http://127.0.0.1:9999"
     )
 
     peer3.wait_for_unit("3proxy.service")
@@ -171,19 +171,19 @@ import ./make-test-python.nix ({ pkgs, ...} : {
 
     # test strong auth
     peer0.succeed(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://admin:bigsecret\@192.168.0.4:3128 -S -O /dev/null http://216.58.211.114:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://admin:bigsecret\@192.168.0.4:3128 -S -O /dev/null http://216.58.211.114:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://admin:bigsecret\@192.168.0.4:3128 -S -O /dev/null http://192.168.0.4:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://admin:bigsecret\@192.168.0.4:3128 -S -O /dev/null http://192.168.0.4:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://216.58.211.114:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://216.58.211.114:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://192.168.0.4:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://192.168.0.4:9999"
     )
     peer0.fail(
-        "${pkgs.wget}/bin/wget -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://127.0.0.1:9999"
+        "${pkgs.wget.exe} -e use_proxy=yes -e http_proxy=http://192.168.0.4:3128 -S -O /dev/null http://127.0.0.1:9999"
     )
   '';
 })

--- a/nixos/tests/acme.nix
+++ b/nixos/tests/acme.nix
@@ -9,9 +9,9 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: let
     set -euo pipefail
     echo '[INFO]' "[$2]" 'dns-hook.sh' $*
     if [ "$1" = "present" ]; then
-      ${pkgs.curl}/bin/curl --data '{"host": "'"$2"'", "value": "'"$3"'"}' http://${dnsAddress}:8055/set-txt
+      ${pkgs.curl.exe} --data '{"host": "'"$2"'", "value": "'"$3"'"}' http://${dnsAddress}:8055/set-txt
     else
-      ${pkgs.curl}/bin/curl --data '{"host": "'"$2"'"}' http://${dnsAddress}:8055/clear-txt
+      ${pkgs.curl.exe} --data '{"host": "'"$2"'"}' http://${dnsAddress}:8055/clear-txt
     fi
   '';
 

--- a/nixos/tests/apparmor.nix
+++ b/nixos/tests/apparmor.nix
@@ -68,14 +68,14 @@ import ./make-test-python.nix ({ pkgs, ... } : {
                   r ${pkgs.libunistring}/share/**,
                   x ${pkgs.libunistring}/foo/**,
               ''} ${pkgs.runCommand "actual.rules" { preferLocalBuild = true; } ''
-                  ${pkgs.gnused}/bin/sed -e 's:^[^ ]* ${builtins.storeDir}/[^,/-]*-\([^/,]*\):\1 \0:' ${
+                  ${pkgs.gnused.exe} -e 's:^[^ ]* ${builtins.storeDir}/[^,/-]*-\([^/,]*\):\1 \0:' ${
                       pkgs.apparmorRulesFromClosure {
                         name = "ping";
                         additionalRules = ["x $path/foo/**"];
                       } [ pkgs.libcap ]
                   } |
                   ${pkgs.coreutils}/bin/sort -n -k1 |
-                  ${pkgs.gnused}/bin/sed -e 's:^[^ ]* ::' >$out
+                  ${pkgs.gnused.exe} -e 's:^[^ ]* ::' >$out
               ''}"
           )
     '';

--- a/nixos/tests/leaps.nix
+++ b/nixos/tests/leaps.nix
@@ -26,7 +26,7 @@ import ./make-test-python.nix ({ pkgs,  ... }:
       server.wait_for_open_port(6666)
       client.wait_for_unit("network.target")
       assert "leaps" in client.succeed(
-          "${pkgs.curl}/bin/curl -f http://server:6666/leaps/"
+          "${pkgs.curl.exe} -f http://server:6666/leaps/"
       )
     '';
 })

--- a/nixos/tests/magnetico.nix
+++ b/nixos/tests/magnetico.nix
@@ -29,11 +29,11 @@ in
       machine.wait_for_unit("magneticow")
       machine.wait_for_open_port(${toString port})
       machine.succeed(
-          "${pkgs.curl}/bin/curl --fail "
+          "${pkgs.curl.exe} --fail "
           + "-u user:password http://localhost:${toString port}"
       )
       machine.fail(
-          "${pkgs.curl}/bin/curl --fail "
+          "${pkgs.curl.exe} --fail "
           + "-u user:wrongpwd http://localhost:${toString port}"
       )
       machine.shutdown()

--- a/nixos/tests/podman/dnsname.nix
+++ b/nixos/tests/podman/dnsname.nix
@@ -28,7 +28,7 @@ import ../make-test-python.nix (
         podman.succeed("podman ps | grep webserver")
         podman.succeed("""
           for i in `seq 0 120`; do
-            podman run --rm --name=client -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg ${curl}/bin/curl http://webserver:8000 >/dev/console \
+            podman run --rm --name=client -v /nix/store:/nix/store -v /run/current-system/sw/bin:/bin scratchimg ${curl.exe} http://webserver:8000 >/dev/console \
               && exit 0
             sleep 0.5
           done

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -510,14 +510,14 @@ let
         };
         # initialize wallet, creates macaroon needed by exporter
         systemd.services.lnd.postStart = ''
-          ${pkgs.curl}/bin/curl \
+          ${pkgs.curl.exe} \
             --retry 20 \
             --retry-delay 1 \
             --retry-connrefused \
             --cacert /var/lib/lnd/tls.cert \
             -X GET \
             https://localhost:8080/v1/genseed | ${pkgs.jq}/bin/jq -c '.cipher_seed_mnemonic' > /tmp/seed
-          ${pkgs.curl}/bin/curl \
+          ${pkgs.curl.exe} \
             --retry 20 \
             --retry-delay 1 \
             --retry-connrefused \

--- a/nixos/tests/searx.nix
+++ b/nixos/tests/searx.nix
@@ -96,7 +96,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
           base.wait_for_open_port(8080)
           base.wait_for_unit("searx")
           base.succeed(
-              "${pkgs.curl}/bin/curl --fail http://localhost:8080"
+              "${pkgs.curl.exe} --fail http://localhost:8080"
           )
           base.shutdown()
 
@@ -105,10 +105,10 @@ import ./make-test-python.nix ({ pkgs, ...} :
           fancy.wait_for_open_port(80)
           fancy.wait_for_unit("uwsgi")
           fancy.succeed(
-              "${pkgs.curl}/bin/curl --fail http://localhost/searx >&2"
+              "${pkgs.curl.exe} --fail http://localhost/searx >&2"
           )
           fancy.succeed(
-              "${pkgs.curl}/bin/curl --fail http://localhost/searx/static/themes/oscar/js/bootstrap.min.js >&2"
+              "${pkgs.curl.exe} --fail http://localhost/searx/static/themes/oscar/js/bootstrap.min.js >&2"
           )
     '';
 })

--- a/nixos/tests/shadowsocks/common.nix
+++ b/nixos/tests/shadowsocks/common.nix
@@ -72,11 +72,11 @@ import ../make-test-python.nix ({ pkgs, lib, ... }: {
       client.wait_for_unit("shadowsocks-client.service")
 
       client.fail(
-          "${pkgs.curl}/bin/curl 192.168.0.1:80"
+          "${pkgs.curl.exe} 192.168.0.1:80"
       )
 
       msg = client.succeed(
-          "${pkgs.curl}/bin/curl --socks5 localhost:1080 192.168.0.1:80"
+          "${pkgs.curl.exe} --socks5 localhost:1080 192.168.0.1:80"
       )
       assert msg == "It works!", "Could not connect through shadowsocks"
     '';

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -16,7 +16,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     machine.succeed("journalctl --grep=systemd")
 
     machine.succeed(
-        "${pkgs.curl}/bin/curl -s localhost:19531/machine | ${pkgs.jq}/bin/jq -e '.hostname == \"machine\"'"
+        "${pkgs.curl.exe} -s localhost:19531/machine | ${pkgs.jq}/bin/jq -e '.hostname == \"machine\"'"
     )
   '';
 })

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -160,6 +160,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "A command line tool for transferring files with URL syntax";
+    mainProgram = "curl";
     homepage    = "https://curl.se/";
     license = licenses.curl;
     maintainers = with maintainers; [ lovek323 ];

--- a/pkgs/tools/networking/wget/default.nix
+++ b/pkgs/tools/networking/wget/default.nix
@@ -54,6 +54,8 @@ stdenv.mkDerivation rec {
          scripts, cron jobs, terminals without X-Windows support, etc.
       '';
 
+    mainProgram = "wget";
+
     license = licenses.gpl3Plus;
 
     homepage = "https://www.gnu.org/software/wget/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Adds an `exe` attribute as a shorthand for the main executable of a package.

Closes https://github.com/NixOS/nixpkgs/pull/138418

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] evaluates to the same, so no build required
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
