### PR TITLE
protoc-gen-twirp_php: 0.8.0 -> 0.8.1

### DIFF
--- a/pkgs/development/tools/protoc-gen-twirp_php/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_php/default.nix
@@ -15,6 +15,10 @@ buildGoModule rec {
 
   subPackages = [ "protoc-gen-twirp_php" ];
 
+  ldflags = [
+    "-X main.version=${version}"
+  ];
+
   meta = with lib; {
     description = "PHP port of Twitch's Twirp RPC framework";
     homepage = "https://github.com/twirphp/twirp";

--- a/pkgs/development/tools/protoc-gen-twirp_php/default.nix
+++ b/pkgs/development/tools/protoc-gen-twirp_php/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "protoc-gen-twirp_php";
-  version = "0.8.0";
+  version = "0.8.1";
 
   # fetchFromGitHub currently not possible, because go.mod and go.sum are export-ignored
   src = fetchgit {
     url = "https://github.com/twirphp/twirp.git";
     rev = "v${version}";
-    sha256 = "sha256-TaHfyYoWsA/g5xZFxIMNwE1w6Dd9Cq5bp1gpQudYLs0=";
+    sha256 = "sha256-5PACgKqc8rWqaA6Syj5NyxHm3827yd67tm0mwVSMnWQ=";
   };
 
   vendorSha256 = "sha256-qQFlBviRISEnPBt0q5391RqUrPTI/QDxg3MNfwWE8MI=";


### PR DESCRIPTION
###### Motivation for this change
Update to latest release https://github.com/twirphp/twirp/releases/tag/v0.8.1

[changes](https://github.com/twirphp/twirp/compare/v0.8.0...v0.8.1)

Also added `ldflags` to set the version for `protoc-gen-twirp_php -version`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
