### PR TITLE
bakelite: unstable-2021-10-19 -> unstable-2022-02-12

### DIFF
--- a/pkgs/tools/backup/bakelite/default.nix
+++ b/pkgs/tools/backup/bakelite/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/richfelker/bakelite";
     description = "Incremental backup with strong cryptographic confidentality";
     license = licenses.gpl2;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ mvs ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/backup/bakelite/default.nix
+++ b/pkgs/tools/backup/bakelite/default.nix
@@ -2,17 +2,21 @@
 
 stdenv.mkDerivation rec {
   pname = "bakelite";
-  version = "unstable-2021-10-19";
+  version = "unstable-2022-02-12";
 
   src = fetchFromGitHub {
     owner = "richfelker";
     repo = pname;
-    rev = "5fc3cf9704dbaa191b95f97d2a700588ea878a36";
-    sha256 = "xoGor8KMG1vU6hP6v6gHcADKjVpaClvkivxkcPUJtss=";
+    rev = "373901734d114e42aa385e6a7843745674e4ca08";
+    hash = "sha256-HBnYlUyTkvPTbdsZD02yCq5C7yXOHYK4l4mDRUkcN5I=";
   };
 
   hardeningEnable = [ "pie" ];
-  buildFlags = [ "CFLAGS=-D_GNU_SOURCE" ];
+  preBuild = ''
+    # pipe2() is only exposed with _GNU_SOURCE
+    # Upstream makefile explicitly uses -O3 to improve SHA-3 performance
+    makeFlagsArray+=( CFLAGS="-D_GNU_SOURCE -g -O3" )
+  '';
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Relevant development activity in upstream repository: https://github.com/richfelker/bakelite/commits/main

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] ~Tested, as applicable:~
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
