### PR TITLE
blas/lapack: increase flexibility of wrappers

### DIFF
--- a/pkgs/build-support/alternatives/blas/default.nix
+++ b/pkgs/build-support/alternatives/blas/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv
-, lapack-reference, openblasCompat, openblas
+, lapack-reference, openblas
 , isILP64 ? false
-, blasProvider ? if isILP64 then openblas else openblasCompat }:
+, blasProvider ? openblas }:
 
 let
   blasFortranSymbols = [
@@ -32,10 +32,13 @@ let
 
 
   blasImplementation = lib.getName blasProvider;
+  blasProvider' = if blasImplementation == "mkl"
+                  then blasProvider
+                  else blasProvider.override { blas64 = isILP64; };
 
 in
 
-assert isILP64 -> (blasImplementation == "openblas" && blasProvider.blas64) || blasImplementation == "mkl";
+assert isILP64 -> blasImplementation == "mkl" || blasProvider'.blas64;
 
 stdenv.mkDerivation {
   pname = "blas";
@@ -43,13 +46,13 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
-  meta = (blasProvider.meta or {}) // {
+  meta = (blasProvider'.meta or {}) // {
     description = "${lib.getName blasProvider} with just the BLAS C and FORTRAN ABI";
   };
 
   passthru = {
     inherit isILP64;
-    provider = blasProvider;
+    provider = blasProvider';
     implementation = blasImplementation;
   };
 
@@ -62,10 +65,10 @@ stdenv.mkDerivation {
   installPhase = (''
   mkdir -p $out/lib $dev/include $dev/lib/pkgconfig
 
-  libblas="${lib.getLib blasProvider}/lib/libblas${canonicalExtension}"
+  libblas="${lib.getLib blasProvider'}/lib/libblas${canonicalExtension}"
 
   if ! [ -e "$libblas" ]; then
-    echo "$libblas does not exist, ${blasProvider.name} does not provide libblas."
+    echo "$libblas does not exist, ${blasProvider'.name} does not provide libblas."
     exit 1
   fi
 
@@ -79,11 +82,11 @@ stdenv.mkDerivation {
 
 '' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
   patchelf --set-soname libblas${canonicalExtension} $out/lib/libblas${canonicalExtension}
-  patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libblas${canonicalExtension}):${lib.getLib blasProvider}/lib" $out/lib/libblas${canonicalExtension}
+  patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libblas${canonicalExtension}):${lib.getLib blasProvider'}/lib" $out/lib/libblas${canonicalExtension}
 '' else if stdenv.hostPlatform.isDarwin then ''
   install_name_tool \
     -id $out/lib/libblas${canonicalExtension} \
-    -add_rpath ${lib.getLib blasProvider}/lib \
+    -add_rpath ${lib.getLib blasProvider'}/lib \
     $out/lib/libblas${canonicalExtension}
 '' else "") + ''
 
@@ -99,10 +102,10 @@ Libs: -L$out/lib -lblas
 Cflags: -I$dev/include
 EOF
 
-  libcblas="${lib.getLib blasProvider}/lib/libcblas${canonicalExtension}"
+  libcblas="${lib.getLib blasProvider'}/lib/libcblas${canonicalExtension}"
 
   if ! [ -e "$libcblas" ]; then
-    echo "$libcblas does not exist, ${blasProvider.name} does not provide libcblas."
+    echo "$libcblas does not exist, ${blasProvider'.name} does not provide libcblas."
     exit 1
   fi
 
@@ -111,11 +114,11 @@ EOF
 
 '' + (if stdenv.hostPlatform.parsed.kernel.execFormat.name == "elf" then ''
   patchelf --set-soname libcblas${canonicalExtension} $out/lib/libcblas${canonicalExtension}
-  patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libcblas${canonicalExtension}):${lib.getLib blasProvider}/lib" $out/lib/libcblas${canonicalExtension}
+  patchelf --set-rpath "$(patchelf --print-rpath $out/lib/libcblas${canonicalExtension}):${lib.getLib blasProvider'}/lib" $out/lib/libcblas${canonicalExtension}
 '' else if stdenv.hostPlatform.isDarwin then ''
   install_name_tool \
     -id $out/lib/libcblas${canonicalExtension} \
-    -add_rpath ${lib.getLib blasProvider}/lib \
+    -add_rpath ${lib.getLib blasProvider'}/lib \
     $out/lib/libcblas${canonicalExtension}
 '' else "") + ''
   if [ "$out/lib/libcblas${canonicalExtension}" != "$out/lib/libcblas${stdenv.hostPlatform.extensions.sharedLibrary}" ]; then
@@ -135,6 +138,6 @@ EOF
   mkdir -p $out/nix-support
   echo 'export MKL_INTERFACE_LAYER=${lib.optionalString isILP64 "I"}LP64,GNU' > $out/nix-support/setup-hook
   ln -s $out/lib/libblas${canonicalExtension} $out/lib/libmkl_rt${stdenv.hostPlatform.extensions.sharedLibrary}
-  ln -sf ${blasProvider}/include/* $dev/include
+  ln -sf ${blasProvider'}/include/* $dev/include
 '');
 }

--- a/pkgs/development/libraries/science/math/amd-blis/default.nix
+++ b/pkgs/development/libraries/science/math/amd-blis/default.nix
@@ -64,7 +64,7 @@ in stdenv.mkDerivation rec {
     description = "BLAS-compatible library optimized for AMD CPUs";
     homepage = "https://developer.amd.com/amd-aocl/blas-library/";
     license = licenses.bsd3;
-    maintainers = [ ];
+    maintainers = [ maintainers.markuskowa ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/development/libraries/science/math/amd-libflame/default.nix
+++ b/pkgs/development/libraries/science/math/amd-libflame/default.nix
@@ -6,7 +6,11 @@
 , amd-blis
 
 , withOpenMP ? true
+, blas64 ? false
 }:
+
+# right now only LP64 is supported
+assert !blas64;
 
 stdenv.mkDerivation rec {
   pname = "amd-libflame";
@@ -25,6 +29,8 @@ stdenv.mkDerivation rec {
     # This patch adds lapacke.a to the shared library as well.
     ./add-lapacke.diff
   ];
+
+  passthru = { inherit blas64; };
 
   nativeBuildInputs = [ gfortran python3 ];
 

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, gfortran }:
+{ lib, stdenv, fetchurl, cmake, gfortran
+# Wether to build with ILP64 interface
+, blas64 ? false
+}:
 
 stdenv.mkDerivation rec {
   pname = "blas";
@@ -9,50 +12,19 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LjYNmcm9yEB6YYiMQKqFP7QhlCDruCZNtIbLiGBGirM=";
   };
 
-  nativeBuildInputs = [ gfortran ];
+  passthru = { inherit blas64; };
 
-  configurePhase = ''
-    echo >make.inc  "SHELL = ${stdenv.shell}"
-    echo >>make.inc "PLAT = _LINUX"
-    echo >>make.inc "FORTRAN = gfortran"
-    echo >>make.inc "OPTS = -O2 -fPIC"
-    echo >>make.inc "DRVOPTS = $$(OPTS)"
-    echo >>make.inc "NOOPT = -O0 -fPIC"
-    echo >>make.inc "LOADER = gfortran"
-    echo >>make.inc "LOADOPTS ="
-    echo >>make.inc "AR = gfortran"
-    echo >>make.inc "ARFLAGS = -shared -o"
-    echo >>make.inc "RANLIB = echo"
-    echo >>make.inc "BLASLIB = libblas.so.${version}"
-  '';
+  nativeBuildInputs = [ cmake gfortran ];
 
-  buildPhase = ''
-    make
-    echo >>make.inc "ARFLAGS = "
-    echo >>make.inc "BLASLIB = libblas.a"
-    echo >>make.inc "AR = ar rcs"
-    echo >>make.inc "RANLIB = ranlib"
-    make
-  '';
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ]
+    ++ lib.optional blas64 "-DBUILD_INDEX64=ON";
 
-  installPhase =
-    # FreeBSD's stdenv doesn't use Coreutils.
-    let dashD = if stdenv.isFreeBSD then "" else "-D"; in
-    (lib.optionalString stdenv.isFreeBSD "mkdir -p $out/lib ;")
-    + ''
-    install ${dashD} -m755 libblas.a "$out/lib/libblas.a"
-    install ${dashD} -m755 libblas.so.${version} "$out/lib/libblas.so.${version}"
-    ln -s libblas.so.${version} "$out/lib/libblas.so.3"
-    ln -s libblas.so.${version} "$out/lib/libblas.so"
-    # Write pkg-config alias.
-    # See also openblas/default.nix
-    mkdir $out/lib/pkgconfig
-    cat <<EOF > $out/lib/pkgconfig/blas.pc
-Name: blas
-Version: ${version}
-Description: blas provided by the BLAS package.
-Libs: -L$out/lib -lblas
-EOF
+  postInstall = let
+    canonicalExtension = if stdenv.hostPlatform.isLinux
+                       then "${stdenv.hostPlatform.extensions.sharedLibrary}.${lib.versions.major version}"
+                       else stdenv.hostPlatform.extensions.sharedLibrary;
+  in lib.optionalString blas64 ''
+    ln -s $out/lib/libblas64${canonicalExtension} $out/lib/libblas${canonicalExtension}
   '';
 
   preFixup = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/science/math/blas/default.nix
+++ b/pkgs/development/libraries/science/math/blas/default.nix
@@ -34,10 +34,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Basic Linear Algebra Subprograms";
-    license = lib.licenses.publicDomain;
+    license = licenses.publicDomain;
+    maintainers = [ maintainers.markuskowa ];
     homepage = "http://www.netlib.org/blas/";
-    platforms = lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Linear Algebra PACKage";
     homepage = "http://www.netlib.org/lapack/";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ markuskowa ];
     license = licenses.bsd3;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/science/math/liblapack/default.nix
+++ b/pkgs/development/libraries/science/math/liblapack/default.nix
@@ -5,6 +5,8 @@
 , gfortran
 , cmake
 , shared ? true
+# Compile with ILP64 interface
+, blas64 ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -36,7 +38,19 @@ stdenv.mkDerivation rec {
     "-DLAPACKE=ON"
     "-DCBLAS=ON"
     "-DBUILD_TESTING=ON"
-  ] ++ lib.optional shared "-DBUILD_SHARED_LIBS=ON";
+  ] ++ lib.optional shared "-DBUILD_SHARED_LIBS=ON"
+    ++ lib.optional blas64 "-DBUILD_INDEX64=ON";
+
+  passthru = { inherit blas64; };
+
+  postInstall =  let
+    canonicalExtension = if stdenv.hostPlatform.isLinux
+                       then "${stdenv.hostPlatform.extensions.sharedLibrary}.${lib.versions.major version}"
+                       else stdenv.hostPlatform.extensions.sharedLibrary;
+  in lib.optionalString blas64 ''
+    ln -s $out/lib/liblapack64${canonicalExtension} $out/lib/liblapack${canonicalExtension}
+    ln -s $out/lib/liblapacke64${canonicalExtension} $out/lib/liblapacke${canonicalExtension}
+  '';
 
   doCheck = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32196,6 +32196,8 @@ with pkgs;
 
   blas = callPackage ../build-support/alternatives/blas { };
 
+  blas-ilp64 = blas.override { isILP64 = true; };
+
   blas-reference = callPackage ../development/libraries/science/math/blas { };
 
   brial = callPackage ../development/libraries/science/math/brial { };
@@ -32217,6 +32219,8 @@ with pkgs;
   jags = callPackage ../applications/science/math/jags { };
 
   lapack = callPackage ../build-support/alternatives/lapack { };
+
+  lapack-ilp64 = lapack.override { isILP64 = true; };
 
   lapack-reference = callPackage ../development/libraries/science/math/liblapack { };
   liblapack = lapack-reference;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/83888 was a big step forward to provide a simple interface for switching BLAS/LAPACK implementations. This PR fine-tunes the wrapper to extend the number of implementations that can be used by the wrapper. So far, only OpenBLAS and MKL were valid. After cleaning up `amd-blis`, `amd-libflame`,  `blas-reference`, and `lapack-reference`  these implementations can now also be exposed through the wrapper. While it may not seem necessary for `blas-reference`, `lapack-reference` it allows for a clean interface, where now all implementations can be swapped in exactly the same way.

This PR is also one step in cleaning up the handling of the ILP64/LP64 interfaces that these libraries support. All packages that provide blas/lapack implementations (except  MKL), now support the `blas64` boolean input parameter, which switches the interface at build time. Overrides now work for all above-mentioned implementations according to the following scheme:
```
 myblas = self.blas.override { isILP64=true; blasProvider = self.amd-blis; };
 mylapack = self.lapack.override { isILP64=true; lapackProvider = self.mkl; };
```

We now also build the attributes `blas-ilp64` and `lapack-ilp64` to have these 64 bit interfaces available right away. This will make it easier to build scientific applications that rely on it. Note, that while some applications decide at build time which interface to use, others only support either one and can not switch.

###### Things done
* Added `blas-ilp64` and `lapack-ilp64` to provide the 64 bit interfaces separately.
* Added the `blas64` flag to `amd-blis`, `amd-libflame`,  `blas-reference`, and `lapack-reference` and adapted the nix expressions to honor this flag. Note, that `amd-libflame` accepts only  `blas64 = false` at the moment.
* Fixed the BLAS/LAPACK wrappers to hand down the `isILP64` flag to the underlying implementation via `blas64`.
* Use `cmake` to build  `blas-reference`.
* Adopt blas/lapack-reference and amd-blis as a maintainer.
* Added a sentence to the manual mentioning the `blas/lapack-ilp64` attributes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
