### PR TITLE
toppler: 1.1.6 -> 1.3

### DIFF
--- a/pkgs/games/toppler/default.nix
+++ b/pkgs/games/toppler/default.nix
@@ -1,34 +1,61 @@
-{ lib, stdenv
-, fetchurl
-, SDL
-, SDL_mixer
+{ lib
+, stdenv
+, fetchFromGitLab
+
+, pkg-config
+, gettext
+, povray
+, imagemagick
+, gimp
+
+, SDL2
+, SDL2_mixer
+, SDL2_image
+, libpng
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "toppler";
-  version = "1.1.6";
+  version = "1.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "0ifccissd8sh78kpwh7dafx4ah7hkhqz6nf4z2hdnalw702jkg3x";
+  src = fetchFromGitLab {
+    owner = "roever";
+    repo = "toppler";
+    rev = "v${version}";
+    sha256 = "sha256-ecEaELu52Nmov/BD9VzcUw6wyWeHJcsKQkEzTnaW330=";
   };
 
+  nativeBuildInputs = [
+    pkg-config
+    gettext
+    povray
+    imagemagick
+    gimp
+  ];
+
   buildInputs = [
-    SDL
-    SDL_mixer
+    SDL2
+    SDL2_mixer
+    SDL2_image
+    libpng
     zlib
   ];
 
-  # The conftest hangs on Hydra runners, because they are not logged in.
-  configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
+  # GIMP needs a writable home
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  hardeningDisable = [ "format" ];
 
   meta = with lib; {
     description = "Jump and run game, reimplementation of Tower Toppler/Nebulus";
-    homepage = "http://toppler.sourceforge.net/";
-    license = licenses.gpl2;
+    homepage = "https://gitlab.com/roever/toppler";
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
 }
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
