### PR TITLE
libosmium: 2.17.3 → 2.18.0, osmium-tool: 1.13.2 → 1.14.0

### DIFF
--- a/pkgs/applications/misc/osmium-tool/default.nix
+++ b/pkgs/applications/misc/osmium-tool/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osmium-tool";
-  version = "1.13.2";
+  version = "1.14.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
     rev = "v${version}";
-    sha256 = "sha256-dLYmY2bS+DycYBLZdLw8CsRIIE8EfDJEx6RZ/r9yMS8=";
+    sha256 = "sha256-xedunFzar44o+b/45isXWacDcC81wWkxgGwnpLPH/n0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libosmium/default.nix
+++ b/pkgs/development/libraries/libosmium/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libosmium";
-  version = "2.17.3";
+  version = "2.18.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "libosmium";
     rev = "v${version}";
-    sha256 = "sha256-XpC5gb19jPakYS3QSgOU6WnGad+VEoEtxyT38d9Beug=";
+    sha256 = "sha256-IPdaBT6hRNHo8kuOsiKdyiQkRxA/l+44U3qGGG89BTo=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change
* libosmium: [Changelog](https://github.com/osmcode/libosmium/releases/tag/v2.18.0)
* osmium-tool: [Changelog](https://github.com/osmcode/osmium-tool/releases/tag/v1.14.0)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
