### PR TITLE
idrisPackages.protobuf: move to alias set

### DIFF
--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, idris-no-deps, overrides ? (self: super: {}) }: let
+{ pkgs, config, idris-no-deps, overrides ? (self: super: {}) }: let
   inherit (pkgs.lib) callPackageWith fix' extends;
 
   /* Taken from haskell-modules/default.nix, should probably abstract this away */
@@ -145,8 +145,6 @@
 
     posix = callPackage ./posix.nix {};
 
-    protobuf = throw "idrisPackages.protobuf has been removed: abandoned by upstream"; # added 2022-02-06
-
     quantities = callPackage ./quantities.nix {};
 
     rationals = callPackage ./rationals.nix {};
@@ -207,5 +205,8 @@
 
     yampa = callPackage ./yampa.nix {};
 
-  } // builtins_;
+  } // builtins_ // pkgs.lib.optionalAttrs (config.allowAliases or true) {
+    # removed packages
+    protobuf = throw "idrisPackages.protobuf has been removed: abandoned by upstream"; # Added 2022-02-06
+  };
 in fix' (extends overrides idrisPackages)


### PR DESCRIPTION
###### Motivation for this change
Currently breaking nixpkgs-review in some cases

follow up to: #158412
```
$ git merge --no-commit --no-ff 830435ccc39f9ee6c816bf63c2c4eac455437203
Automatic merge went well; stopped before committing as requested
error: idrisPackages.protobuf has been removed: abandoned by upstream
(use '--show-trace' to show detailed location information)
nix --experimental-features nix-command --system x86_64-linux eval --json --impure --expr (import /nix/store/pgfvdpfvqjwmh7d25bzzv3dxd6najlxv-nixpkgs-review-2.6.4/lib/python3.9/site-packages/nixpkgs_review/nix/evalAttrs.nix { allowAliases = false; attr-json = /run/user/1000/tmpxqjp_pis; }) failed to run, /run/user/1000/tmpxqjp_pis was stored inspection
https://github.com/NixOS/nixpkgs/pull/157688 failed to build
```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
