### PR TITLE
[DRAFT] fragments: 1.5 -> 2.0

### DIFF
--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -1,78 +1,120 @@
-{ lib
+{ rustPlatform
 , stdenv
+, lib
 , fetchFromGitLab
 , meson
-, vala
-, ninja
-, pkg-config
-, wrapGAppsHook
+, cmake
 , desktop-file-utils
-, appstream-glib
-, python3
-, glib
-, gtk3
-, libhandy
-, libtransmission
-, libb64
-, libutp
-, miniupnpc
-, dht
-, libnatpmp
+, ninja
+, automake
+, autoconf
+, libtool
 , libevent
-, curl
 , openssl
 , zlib
+, pkg-config
+, libgee
+, curl
+, vala
+, glib
+, python3
+, gtk3
+, libhandy
+, sqlite
+, dbus
+, gtk4
+, libadwaita
+, git
+, cargo
+, gettext
+, rustc
+, transmission
+, hicolor-icon-theme
+, libtransmission
+, libb64
+, wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
+rustPlatform.buildRustPackage rec {
   pname = "fragments";
-  version = "1.5";
+  version = "2.0.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Fragments";
     rev = version;
-    sha256 = "0x1kafhlgyi65l4w67c24r8mpvasg3q3c4wlgnjc9sxvp6ki7xbn";
+    fetchSubmodules = true;
+    sha256 = "sha256-3/v+MK7Zzn2tnUOe5cW35I5nJ+EsMUaqzTr25EloJ/k=";
   };
 
-  patches = [
-    # Fix dependency resolution
-    ./dependency-resolution.patch
-  ];
+  cargoSha256 = "sha256-Js1UOPIegmQ8rJSPRen1knv0ngoVZXgAHsMbsm0tLcM=";
 
   nativeBuildInputs = [
-    meson
-    vala
-    ninja
-    pkg-config
-    wrapGAppsHook
+    autoconf
+    automake
+    cmake
     desktop-file-utils
-    appstream-glib
+    libtool
+    meson
+    pkg-config
     python3
+    vala
+    wrapGAppsHook
+    gettext
+    glib
+    ninja
   ];
 
   buildInputs = [
-    glib
-    gtk3
-    libhandy
-    libtransmission
-    libb64
-    libutp
-    miniupnpc
-    dht
-    libnatpmp
-    libevent
+    meson
     curl
+    gtk3
+    hicolor-icon-theme
+    libevent
+    libgee
+    libhandy
     openssl
     zlib
+    libtransmission
+    libb64
+    sqlite
+    dbus
+    gtk4
+    libadwaita
+    git
+    rustc
+    cargo
   ];
 
+  # Don't use buildRustPackage phases, only use it for rust deps setup
+  configurePhase = null;
+  buildPhase = null;
+  doCheck = true;
+  checkPhase = null;
+  installPhase = null;
+
+  postPatch = ''
+    chmod +x build-aux/*
+    patchShebangs build-aux
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/fragments \
+        --set PATH ${lib.makeBinPath [ transmission ]}
+  '';
+
   meta = with lib; {
-    homepage = "https://gitlab.gnome.org/World/Fragments";
-    description = "A GTK3 BitTorrent Client";
-    maintainers = with maintainers; [ angustrau ];
+    homepage = https://gitlab.gnome.org/World/Fragments;
+    description = "A GTK BitTorrent Client";
+    maintainers = with maintainers; [
+      onny
+      angustrau
+    ];
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }
+


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update version to 2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
