### PR TITLE
python3Packages.websockets: disable time-sentitive test

### DIFF
--- a/pkgs/development/python-modules/websockets/default.nix
+++ b/pkgs/development/python-modules/websockets/default.nix
@@ -23,11 +23,25 @@ buildPythonPackage rec {
   # Tests fail on Darwin with `OSError: AF_UNIX path too long`
   doCheck = !stdenv.isDarwin;
 
-  # Disable all tests that need to terminate within a predetermined amount of
-  # time. This is nondeterministic.
   patchPhase = ''
+    # Disable all tests that need to terminate within a predetermined amount of
+    # time. This is nondeterministic.
     sed -i 's/with self.assertCompletesWithin.*:/if True:/' \
       tests/legacy/test_protocol.py
+
+    # Disables tests relying on tight timeouts to avoid failures like:
+    #   File "/build/source/tests/legacy/test_protocol.py", line 1270, in test_keepalive_ping_with_no_ping_timeout
+    #     ping_1_again, ping_2 = tuple(self.protocol.pings)
+    #   ValueError: too many values to unpack (expected 2)
+    for t in \
+             test_keepalive_ping_stops_when_connection_closing \
+             test_keepalive_ping_does_not_crash_when_connection_lost \
+             test_keepalive_ping \
+             test_keepalive_ping_not_acknowledged_closes_connection \
+             test_keepalive_ping_with_no_ping_timeout \
+      ; do
+      sed -i "s/def $t(/def skip_$t(/" tests/legacy/test_protocol.py
+    done
   '';
 
   checkPhase = ''


### PR DESCRIPTION
Without the change python3Packages.websockets fails tests on
machines under load:

    python3.9-websockets> ERROR: test_keepalive_ping_with_no_ping_timeout (tests.legacy.test_protocol.ServerTests)
    python3.9-websockets> Traceback (most recent call last):
    python3.9-websockets>   File "/build/source/tests/legacy/test_protocol.py", line 1270, in test_keepalive_ping_with_no_ping_timeout
    python3.9-websockets>     ping_1_again, ping_2 = tuple(self.protocol.pings)
    python3.9-websockets> ValueError: too many values to unpack (expected 2)

The change disables the test.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
