### PR TITLE
wpa_supplicant: use unique IDs for networks and credentials

### DIFF
--- a/pkgs/os-specific/linux/wpa_supplicant/Use-unique-IDs-for-networks-and-credentials.patch
+++ b/pkgs/os-specific/linux/wpa_supplicant/Use-unique-IDs-for-networks-and-credentials.patch
@@ -1,0 +1,32 @@
+The id and cred_id variables are reset to 0 every time the
+wpa_config_read function is called, which is fine as long as it is only
+called once. However, this is not the case when using both the -c and -I
+options to specify two config files.
+
+This is a problem because the GUI, since eadfeb0e93748eb396ae62012b92d21a7f533646,
+relies on the network IDs being unique (and increasing), and might get
+into an infinite loop otherwise.
+
+This is solved by simply making the variables static.
+---
+ wpa_supplicant/config_file.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wpa_supplicant/config_file.c b/wpa_supplicant/config_file.c
+index 6db5010db..c996e3916 100644
+--- a/wpa_supplicant/config_file.c
++++ b/wpa_supplicant/config_file.c
+@@ -297,8 +297,8 @@ struct wpa_config * wpa_config_read(const char *name, struct wpa_config *cfgp)
+ 	struct wpa_ssid *ssid, *tail, *head;
+ 	struct wpa_cred *cred, *cred_tail, *cred_head;
+ 	struct wpa_config *config;
+-	int id = 0;
+-	int cred_id = 0;
++	static int id = 0;
++	static int cred_id = 0;
+
+ 	if (name == NULL)
+ 		return NULL;
+--
+2.34.1
+

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -18,6 +18,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Fix a bug when using two config files
+    ./Use-unique-IDs-for-networks-and-credentials.patch
   ] ++ lib.optionals readOnlyModeSSIDs [
     # Allow read-only networks
     ./0001-Implement-read-only-mode-for-ssids.patch


### PR DESCRIPTION
Fixes the bug described at https://github.com/NixOS/nixpkgs/pull/155266#issuecomment-1031711094


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
