### PR TITLE
ginkgo: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/tools/ginkgo/default.nix
+++ b/pkgs/development/tools/ginkgo/default.nix
@@ -2,21 +2,36 @@
 
 buildGoModule rec {
   pname = "ginkgo";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "onsi";
     repo = "ginkgo";
     rev = "v${version}";
-    sha256 = "sha256-GF96AOyQcVI01dP6yqMwyPmXMDRVxrScu1UL76jF2qA=";
+    sha256 = "sha256-iAXqPbNBNNR6PGhIjrDqTYUu0XYgvS5aM8n68qQNurQ=";
   };
   vendorSha256 = "sha256-kMQ60HdsorZU27qoOY52DpwFwP+Br2bp8mRx+ZwnQlI=";
-  doCheck = false;
+
+  # integration tests expect more file changes
+  # types tests are missing CodeLocation
+  excludedPackages = "\\(integration\\|types\\)";
 
   meta = with lib; {
-    description = "BDD Testing Framework for Go";
-    homepage = "https://github.com/onsi/ginkgo";
+    homepage = "https://onsi.github.io/ginkgo/";
+    changelog = "https://github.com/onsi/ginkgo/blob/master/CHANGELOG.md";
+    description = "A Modern Testing Framework for Go";
+    longDescription = ''
+      Ginkgo is a testing framework for Go designed to help you write expressive
+      tests. It is best paired with the Gomega matcher library. When combined,
+      Ginkgo and Gomega provide a rich and expressive DSL
+      (Domain-specific Language) for writing tests.
+
+      Ginkgo is sometimes described as a "Behavior Driven Development" (BDD)
+      framework. In reality, Ginkgo is a general purpose testing framework in
+      active use across a wide variety of testing contexts: unit tests,
+      integration tests, acceptance test, performance tests, etc.
+    '';
     license = licenses.mit;
-    maintainers = with maintainers; [ saschagrunert ];
+    maintainers = with maintainers; [ saschagrunert jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump ginkgo to `2.1.1`

> Suites that only import the new dsl packages are now correctly identified as Ginkgo suites [ec17e17]
https://github.com/onsi/ginkgo/blob/master/CHANGELOG.md#211

Enabled tests excluding the broken ones
Tweaked meta
Added myself as a maintainer

cc: @saschagrunert

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
