### PR TITLE
nixos/pam: add pwquality

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -54,6 +54,8 @@
 
 - [Linyaps](https://linyaps.org.cn/), a cross-distribution package manager with sandboxed apps and shared runtime. Available as [services.linyaps](#opt-services.linyaps.enable).
 
+- The [PAM module for libpwquality](https://github.com/libpwquality/libpwquality/) is available for use. One can enable it globally using the [security.pam.pwquality.enable](#opt-security.pam.pwquality.enable) or per service. Configuration of `pwquality` can be done globally ([](#opt-security.pwquality.settings)), globally for just PAM ([](#opt-security.pam.pwquality.settings)), or per service ([](#opt-security.pam.services._name_.pwquality.settings)).
+
 - [tlsrpt-reporter](https://github.com/sys4/tlsrpt-reporter), an application suite to generate and deliver TLSRPT reports. Available as [services.tlsrpt](#opt-services.tlsrpt.enable).
 
 - [Chhoto URL](https://github.com/SinTan1729/chhoto-url), a simple, blazingly fast, selfhosted URL shortener with no unnecessary features, written in Rust. Available as [services.chhoto-url](#opt-services.chhoto-url.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -397,6 +397,7 @@
   ./security/pam_mount.nix
   ./security/please.nix
   ./security/polkit.nix
+  ./security/pwquality
   ./security/rngd.nix
   ./security/rtkit.nix
   ./security/soteria.nix

--- a/nixos/modules/security/pwquality/default.nix
+++ b/nixos/modules/security/pwquality/default.nix
@@ -1,0 +1,53 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib) types;
+  cfg = config.security.pwquality;
+
+  conf = import ./pwquality-conf-format.nix { inherit pkgs lib; };
+in
+{
+  options = {
+    security.pwquality = {
+      package = lib.mkPackageOption pkgs "libpwquality" { };
+
+      writeGlobalSettings = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Writes libpwquality config to {file}`/etc/security/pwquality.conf` for
+          use globally.
+        '';
+      };
+
+      settings = lib.mkOption {
+        description = ''
+          Config options for libpwquality components to reference and
+          additionally write to {file}`/etc/security/pwquality.conf` file if
+          [`writeGlobalSettings`](#opt-security.pwquality.settings) is used.
+          See {manpage}`pwquality.conf(5)` man page for available options.
+        '';
+        default = { };
+        example = lib.literalExpression ''
+          {
+            minlen = 10;
+            # require each class: lowercase uppercase digit and symbol/other
+            minclass = 4;
+            badwords = [ "foobar" "hunter42" "password" ];
+            enforce_for_root = true;
+          }
+        '';
+        type = conf.type;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.writeGlobalSettings {
+    environment.etc."security/pwquality.conf".source = conf.generate "pwquality.conf" cfg.settings;
+  };
+}

--- a/nixos/modules/security/pwquality/pwquality-conf-format.nix
+++ b/nixos/modules/security/pwquality/pwquality-conf-format.nix
@@ -1,0 +1,316 @@
+{ pkgs, lib, ... }:
+
+let
+  inherit (lib) types;
+in
+
+{
+  type = types.submodule {
+    freeformType =
+      with types;
+      (attrsOf (
+        nullOr (oneOf [
+          str
+          int
+          bool
+          (listOf str)
+        ])
+      ))
+      // {
+        description = "settings option";
+      };
+
+    options = {
+      difok = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 1;
+        description = ''
+          Number of characters in the new password that must not be present in
+          the old password.
+
+          The special value of `0` disables all checks of similarity of the new
+          password with the old password except the new password being exactly
+          the same as the old one.
+        '';
+      };
+
+      minlen = lib.mkOption {
+        type = types.nullOr (
+          types.addCheck types.int (x: x >= 6)
+          // {
+            name = "positiveIntMinSix";
+            description = "positive integer >= 6";
+          }
+        );
+        default = null;
+        example = 8;
+        description = ''
+          The minimum acceptable size for the new password. In addition to the
+          number of characters in the new password, credit (up to the individual
+          credit setting in length) is given for each different kind of
+          character (other, upper, lower and digit). Set the individual credit
+          settings to `0` or negative to have `minlen` count as true length of
+          the new password in characters.
+
+          Note that there is a pair of length limits also in Cracklib, which is
+          used for dictionary checking, a "way too short" limit of `4` which is
+          hard coded in and a build time defined limit (`6`) that will be checked
+          without reference to `minlen`.
+
+          Cannot be set to lower value than `6`.
+
+        '';
+      };
+
+      dcredit = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum credit for having digits in the new password. If less than
+          `0` it is the minimum number of digits in the new password.
+        '';
+      };
+
+      ucredit = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum credit for having uppercase characters in the new
+          password. If less than `0` it is the minimum number of uppercase
+          characters in the new password.
+        '';
+      };
+
+      lcredit = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum credit for having lowercase characters in the new
+          password. If less than `0` it is the minimum number of lowercase
+          characters in the new password.
+        '';
+      };
+
+      ocredit = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum credit for having other characters in the new password. If
+          less than `0` it is the minimum number of other characters in the new
+          password.
+        '';
+      };
+
+      minclass = lib.mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        example = 0;
+        description = ''
+          The minimum number of required classes of characters for the new
+          password (digits, uppercase, lowercase, others).
+        '';
+      };
+
+      maxrepeat = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum number of allowed same consecutive characters in the new
+          password.
+
+          The check is disabled if the value is `0`.
+        '';
+      };
+
+      maxsequence = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum length of monotonic character sequences in the new
+          password. Examples of such sequence are '12345' or 'fedcb'. Note that
+          most such passwords will not pass the simplicity check unless the
+          sequence is only a minor part of the password.
+
+          The check is disabled if the value is `0`.
+        '';
+      };
+
+      maxclassrepeat = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 0;
+        description = ''
+          The maximum number of allowed consecutive characters of the same class
+          in the new password.
+
+          The check is disabled if the value is `0`.
+        '';
+      };
+
+      gecoscheck = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 0;
+        description = ''
+          If nonzero, check whether the words longer than `3` characters from
+          the *GECOS* field of the user's {manpage}`passwd(5)` entry are
+          contained in the new password.
+
+          The check is disabled if the value is `0`.
+        '';
+      };
+
+      dictcheck = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 1;
+        description = ''
+          If nonzero, check whether the password (with possible modifications)
+          matches a word in a dictionary.
+
+          Currently the dictionary check is performed using the `cracklib`
+          library.
+        '';
+      };
+
+      usercheck = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 1;
+        description = ''
+          If nonzero, check whether the password (with possible modifications)
+          contains the user name in some form.
+
+          It is not performed for user names shorter than `3` characters.
+        '';
+      };
+
+      usersubstr = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 0;
+        description = ''
+          If greater than `3` (due to the minimum length in `usercheck`), check
+          whether the password contains a substring of at least *N* length in
+          some form.
+        '';
+      };
+
+      # as the description suggests internally it's only used for pam, but
+      # other tooling could rely upon it so best to keep in all pwquality config
+      enforcing = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 1;
+        description = ''
+          If nonzero, reject the password if it fails the checks, otherwise only
+          print the warning.
+
+          This setting applies only to the `pam_pwquality` module and possibly
+          other applications that explicitly change their behavior based on it.
+          It does not affect {manpage}`pwmake(1)` and {manpage}`pwscore(1)`.
+        '';
+      };
+
+      badwords = lib.mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        example = [
+          "password"
+          "pass"
+          "hunter42"
+        ];
+        # adjust the description from "space separated" to reflect an actual
+        # list within nix
+        description = ''
+          A list of words that must not be contained in the password. These are
+          additional words to the `cracklib` dictionary check. This setting can
+          be also used by applications to emulate the `gecos` check for user
+          accounts that are not created yet.
+        '';
+      };
+
+      dictpath = lib.mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/usr/local/lib/pw_dict";
+        description = ''
+          Path to the `cracklib` dictionaries.
+          Default is to use the `cracklib` default.
+        '';
+      };
+
+      retry = lib.mkOption {
+        type = types.nullOr types.ints.unsigned;
+        default = null;
+        example = 1;
+        description = ''
+          Prompt user at most *N* times before returning with error.
+        '';
+      };
+
+      enforce_for_root = lib.mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        example = false;
+        description = ''
+          The module will return error on failed check even if the user
+          changing the password is `root`.
+
+          This option is off by default which means that just the message about
+          the failed check is printed but `root` can change the password anyway.
+          Note that `root` is not asked for an old password so the checks that
+          compare the old and new password are not performed.
+        '';
+      };
+
+      local_users_only = lib.mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        example = false;
+        description = ''
+          The module will not test the password quality for users that are not
+          present in the {file}`/etc/passwd` file. The module still asks for the
+          password so the following modules in the stack can use the
+          `use_authtok` ({manpage}`pam_unix(8)`) option.
+        '';
+      };
+    };
+  };
+
+  # filter out "unset" null cases and false which isn't a part of the format
+  baseFilter = settings: (lib.filterAttrs (_: v: v != null && v != false) settings);
+
+  generate =
+    name: settings:
+    # concatMapStrings rather than concatStringsSep to ensure last line also
+    # gets trailing newline for EOF
+    pkgs.writeText name (
+      lib.concatMapStrings (x: x + "\n") (
+        lib.mapAttrsToList (
+          name: value:
+          if value == true then
+            # just include name
+            name
+          else
+            # assert to be safe that false has been filtered
+            assert value != false;
+            # key value, toString handles lists in the correct way as simply
+            # space separated
+            "${name} = ${toString value}"
+        ) (baseFilter settings)
+      )
+    );
+
+  # explicitly convert internal lists to space separated strings matching
+  # internal pam config expectations in `moduleSettingsType` at the top of
+  # `nixos/modules/security/pam.nix`
+  pamApply = d: lib.mapAttrs (_: v: if lib.isList v then toString v else v) (baseFilter d);
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1154,6 +1154,7 @@ in
   pam-file-contents = runTest ./pam/pam-file-contents.nix;
   pam-lastlog = runTest ./pam/pam-lastlog.nix;
   pam-oath-login = runTest ./pam/pam-oath-login.nix;
+  pam-pwquality = runTest ./pam/pam-pwquality.nix;
   pam-u2f = runTest ./pam/pam-u2f.nix;
   pam-ussh = runTest ./pam/pam-ussh.nix;
   pam-zfs-key = runTest ./pam/zfs-key.nix;

--- a/nixos/tests/pam/pam-pwquality.nix
+++ b/nixos/tests/pam/pam-pwquality.nix
@@ -1,0 +1,132 @@
+{ lib, ... }:
+let
+  # matches settings in pwquality format unit tests, keep in sync
+  settings = {
+    minlen = 10;
+
+    # require each class: lowercase uppercase digit and symbol/other
+    minclass = 4;
+
+    badwords = [
+      "foobar"
+      "hunter42"
+      "password"
+    ];
+
+    enforce_for_root = true;
+  };
+in
+{
+  name = "pam-pwquality";
+
+  nodes.machine = {
+    security.pam.pwquality = {
+      enable = true;
+      inherit settings;
+    };
+  };
+
+  nodes.machine_global_conf = {
+    security.pwquality = {
+      writeGlobalSettings = true;
+      inherit settings;
+    };
+  };
+
+  # only runs when entering a new password so not necessary to test login with
+  # existing password that violates rules
+  testScript = ''
+    import re
+
+    # Helper functions
+
+    def expect_contains(cmdOut, expectedOut):
+      assert (expectedOut in cmdOut), f"\nExpected:\n{expectedOut}\nWithin:\n{cmdOut}"
+
+    def login_as_alice(pw):
+      machine.wait_until_tty_matches(1, "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches(1, "Password: ")
+      machine.send_chars(f"{pw}\n")
+      machine.wait_until_tty_matches(1, r"alice\@machine")
+
+
+    def logout():
+      machine.send_chars("logout\n")
+      machine.wait_until_tty_matches(1, "login: ")
+
+    gen_change_pw_command = lambda pw: f"(echo '{pw}'; echo '{pw}') | passwd alice 2>&1"
+    test_change_pw_succeed = lambda pw: machine.succeed(gen_change_pw_command(pw))
+    test_change_pw_fail = lambda pw: machine.fail(gen_change_pw_command(pw))
+
+
+    # Consts
+
+    short_password_error = "BAD PASSWORD: The password is shorter than 10 characters"
+    missing_class_error = "BAD PASSWORD: The password contains less than 4 character classes"
+    banned_word_error = "BAD PASSWORD: The password contains forbidden words in some form"
+    password_change_success = "password updated successfully"
+
+    pwquality_conf = "/etc/security/pwquality.conf"
+
+    # "fake" passwords purely for testing
+    # if these are your passwords please change them :)
+    pw = "aB2$Nk4AW2"
+    long_pw = "Nk4AW2wDkrXgcrNftdpKHpwqkRff7db@!96ubQCf-4H2q!d@9vP_EzAt@p*W*QqP"
+
+    minlen = ${toString settings.minlen}
+    banned_words = [ ${lib.concatStringsSep ", " (builtins.map (str: "\"${str}\"") settings.badwords)} ]
+
+
+    # Testing
+    machine_global_conf.wait_for_unit("multi-user.target")
+    with subtest(f"{pwquality_conf} is configured as expected"):
+      machine_global_conf.succeed(f"egrep '^minlen = {minlen}$' {pwquality_conf}")
+      machine_global_conf.succeed(f"egrep '^enforce_for_root$' {pwquality_conf}")
+      print(machine_global_conf.succeed(f"cat {pwquality_conf}"))
+      for banned_word in banned_words:
+        machine_global_conf.succeed(rf"egrep '^badwords =.*\s{banned_word}(\s.*|$)$' {pwquality_conf}")
+
+    machine.wait_for_unit("multi-user.target")
+    machine.succeed("useradd -m alice")
+
+    with subtest("/etc/pam.d is configured as expected"):
+      machine.succeed("egrep 'password required .*/lib/security/pam_pwquality.so' /etc/pam.d/ -R")
+
+
+    with subtest("Test configuring passwords"):
+      with subtest("Fail with complex but short password"):
+        # good password shortened
+        expect_contains(test_change_pw_fail(pw[:9]), short_password_error)
+
+      with subtest("Fail with missing character type"):
+        with subtest("No lowercase"):
+          # good password all upper
+          expect_contains(test_change_pw_fail(pw.upper()), missing_class_error)
+        with subtest("No uppercase"):
+          # good password all lower
+          expect_contains(test_change_pw_fail(pw.lower()), missing_class_error)
+        with subtest("No digits"):
+          # good password no digets
+          expect_contains(test_change_pw_fail(re.sub(r"\d", "Z", pw)), missing_class_error)
+        with subtest("No symbols"):
+          # good password no symbols
+          expect_contains(test_change_pw_fail(pw.replace("$", "Z")), missing_class_error)
+
+      with subtest("Fail with banned words"):
+        for banned_word in banned_words:
+          expect_contains(test_change_pw_fail(pw + banned_word), banned_word_error)
+          expect_contains(test_change_pw_fail(banned_word + pw), banned_word_error)
+          expect_contains(test_change_pw_fail(pw[:5] + banned_word + pw[5:]), banned_word_error)
+
+      with subtest("Pass with sufficient passwords"):
+        expect_contains(test_change_pw_succeed(pw), password_change_success)
+        login_as_alice(pw)
+        logout()
+
+        expect_contains(test_change_pw_succeed(long_pw), password_change_success)
+        login_as_alice(long_pw)
+        logout()
+
+  '';
+}

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
       (callPackage ../../../../nixos/modules/security/pwquality/pwquality-conf-format.nix { }).tests;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/libpwquality/libpwquality";
     description = "Password quality checking and random password generation library";
     longDescription = ''
@@ -106,12 +106,14 @@ stdenv.mkDerivation (finalAttrs: {
       function and PAM module that can be used instead of pam_cracklib. The
       module supports all the options of pam_cracklib.
     '';
-    license = with licenses; [
+    license = with lib.licenses; [
       bsd3
       # or
       gpl2Plus
     ];
-    maintainers = with maintainers; [ jk ];
-    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -18,7 +18,7 @@
 # python binding generates a shared library which are unavailable with musl build
 assert enablePython -> !stdenv.hostPlatform.isStatic;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libpwquality";
   version = "1.4.5";
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "libpwquality";
     repo = "libpwquality";
-    rev = "${pname}-${version}";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
     sha256 = "sha256-YjvHzd4iEBvg+qHOVJ7/y9HqyeT+QDalNE/jdNM9BNs=";
   };
 
@@ -114,4 +114,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ jk ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libpwquality";
     repo = "libpwquality";
-    rev = "${finalAttrs.pname}-${finalAttrs.version}";
+    tag = "${finalAttrs.pname}-${finalAttrs.version}";
     sha256 = "sha256-YjvHzd4iEBvg+qHOVJ7/y9HqyeT+QDalNE/jdNM9BNs=";
   };
 

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -10,6 +10,8 @@
   pam,
   enablePython ? false,
   python3,
+
+  nixosTests,
 }:
 
 # python binding generates a shared library which are unavailable with musl build
@@ -82,6 +84,10 @@ stdenv.mkDerivation rec {
       # change to `--enable-python-bindings=no` in the future
       # leave for now to avoid rebuilds on !enablePython before 24.11 fully lands
       [ "--disable-python-bindings" ];
+
+  passthru.tests = {
+    pam = nixosTests.pam-pwquality;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/libpwquality/libpwquality";

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -12,6 +12,7 @@
   python3,
 
   nixosTests,
+  callPackage,
 }:
 
 # python binding generates a shared library which are unavailable with musl build
@@ -87,6 +88,8 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     pam = nixosTests.pam-pwquality;
+    format =
+      (callPackage ../../../../nixos/modules/security/pwquality/pwquality-conf-format.nix { }).tests;
   };
 
   meta = with lib; {

--- a/pkgs/by-name/li/libpwquality/package.nix
+++ b/pkgs/by-name/li/libpwquality/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "libpwquality";
     repo = "libpwquality";
-    tag = "${finalAttrs.pname}-${finalAttrs.version}";
+    tag = "libpwquality-${finalAttrs.version}";
     sha256 = "sha256-YjvHzd4iEBvg+qHOVJ7/y9HqyeT+QDalNE/jdNM9BNs=";
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

An attempt at adding libpwquality to the pam config

reference: https://deer-run.com/users/hal/linux_passwords_pam.html

`/etc/security/pwquality.conf` docs: https://github.com/libpwquality/libpwquality/blob/master/doc/man/pwquality.conf.5.pod

depends on #161652

---

Should the config be under `pam`? or no? It certainly didn't feel like an option to go under `pam.services.<name>.enablePWQuality` but maybe I'm wrong

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
