### PR TITLE
lswt: init at 1.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3932,6 +3932,16 @@
     github = "edlimerkaj";
     githubId = 71988351;
   };
+  edrex = {
+    email = "ericdrex@gmail.com";
+    github = "edrex";
+    githubId = 14615;
+    keys = [{
+      fingerprint = "AC47 2CCC 9867 4644 A9CF  EB28 1C5C 1ED0 9F66 6824";
+    }];
+    matrix = "@edrex:matrix.org";
+    name = "Eric Drechsel";
+  };
   ehllie = {
     email = "me@ehllie.xyz";
     github = "ehllie";

--- a/pkgs/applications/misc/lswt/default.nix
+++ b/pkgs/applications/misc/lswt/default.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromSourcehut, nixos, wayland }:
+
+stdenv.mkDerivation rec {
+  pname = "lswt";
+  version = "1.0.4";
+
+  src = fetchFromSourcehut {
+    owner = "~leon_plickat";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Orwa7sV56AeznEcq/Xj5qj4PALMxq0CI+ZnXuY4JYE0=";
+  };
+
+  buildInputs = [ wayland ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  meta = with lib; {
+    description = "A command that lists Wayland toplevels";
+    homepage = "https://sr.ht/~leon_plickat/lswt";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ edrex ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30352,6 +30352,8 @@ with pkgs;
 
   lscolors = callPackage ../applications/misc/lscolors { };
 
+  lswt = callPackage ../applications/misc/lswt { };
+
   luddite = with python3Packages; toPythonApplication luddite;
 
   goobook = with python3Packages; toPythonApplication goobook;


### PR DESCRIPTION

###### Motivation for this change

lswt is useful for writing scripts that interact with existing windows, such as "raise or run". It currently only works with river afaik since sway uses an older version of the protocol (@Leon-Plickat?)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

ping @colemickens @imMaturana