### PR TITLE
rcshist: init at 1.04

### DIFF
--- a/pkgs/applications/version-management/rcshist/default.nix
+++ b/pkgs/applications/version-management/rcshist/default.nix
@@ -2,21 +2,21 @@
 , stdenv
 , fetchurl
 }:
-stdenv.mkDerivation
-  {
-    pname = "rcshist";
-    version = "1.04";
-    src =
-      fetchurl
-        {
-          url = "https://invisible-island.net/datafiles/release/rcshist.tar.gz";
-          sha256 = "01ab3xwgm934lxr8bm758am3vxwx4hxx7cc9prbgqj5nh30vdg1n";
-        };
-    meta = {
-      description = "Utitity to display complete revision history of a set of RCS files";
-      homepage = "https://invisible-island.net/rcshist/rcshist.html";
-      license = lib.licenses.bsd2;
-      maintainers = [ lib.maintainers.kaction ];
-      platforms = lib.platforms.unix;
-    };
-  }
+
+stdenv.mkDerivation {
+  pname = "rcshist";
+  version = "1.04";
+
+  src = fetchurl {
+    url = "https://invisible-island.net/datafiles/release/rcshist.tar.gz";
+    sha256 = "01ab3xwgm934lxr8bm758am3vxwx4hxx7cc9prbgqj5nh30vdg1n";
+  };
+
+  meta = {
+    description = "Utitity to display complete revision history of a set of RCS files";
+    homepage = "https://invisible-island.net/rcshist/rcshist.html";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.kaction ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/version-management/rcshist/default.nix
+++ b/pkgs/applications/version-management/rcshist/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+stdenv.mkDerivation
+  {
+    pname = "rcshist";
+    version = "1.04";
+    src =
+      fetchurl
+        {
+          url = "https://invisible-island.net/datafiles/release/rcshist.tar.gz";
+          sha256 = "01ab3xwgm934lxr8bm758am3vxwx4hxx7cc9prbgqj5nh30vdg1n";
+        };
+    meta = {
+      description = "Utitity to display complete revision history of a set of RCS files";
+      homepage = "https://invisible-island.net/rcshist/rcshist.html";
+      license = lib.licenses.bsd2;
+      maintainers = [ lib.maintainers.kaction ];
+      platforms = lib.platforms.unix;
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28633,6 +28633,8 @@ with pkgs;
 
   rcs = callPackage ../applications/version-management/rcs { };
 
+  rcshist = callPackage ../applications/version-management/rcshist { };
+
   rdesktop = callPackage ../applications/networking/remote/rdesktop { };
 
   rdedup = callPackage ../tools/backup/rdedup {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
