### PR TITLE
wlgreet: 0.3 -> 2022-01-25

### DIFF
--- a/pkgs/os-specific/linux/wlgreet/default.nix
+++ b/pkgs/os-specific/linux/wlgreet/default.nix
@@ -4,17 +4,17 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "wlgreet";
-  version = "0.3";
+  pname = "wlgreet-unstable";
+  version = "2022-01-25";
 
   src = fetchFromSourcehut {
     owner = "~kennylevinsen";
-    repo = pname;
-    rev = version;
-    sha256 = "0n0lzg3y1z5s9s6kfkdj5q8w67bqpw08hqfccc5kz0ninzy9j0cc";
+    repo = "wlgreet";
+    rev = "8517e578cb64a8fb3bd8f8a438cdbe46f208b87c";
+    sha256 = "0la4xlikw61cxvbkil1d22dgvazi7rs17n5i2z02090fvnfxxzxh";
   };
 
-  cargoSha256 = "1lwy8xmkl9n3fj3wlf80wp728nn9p5rjnbgmm2cbpqxklcgbmxhm";
+  cargoSha256 = "651d2bf01612534f1c4b0472c812095a86eb064d16879380c87f684c04fe0d8d";
 
   meta = with lib; {
     description = "Raw wayland greeter for greetd, to be run under sway or similar";


### PR DESCRIPTION
###### Motivation for this change
wlgreet is broken on wlroots 0.15.5 or later (#151234) due to a protocol negotiation bug in wlgreet. The bug has been fixed upstream in [8517e57](https://git.sr.ht/~kennylevinsen/wlgreet/commit/8517e578cb64a8fb3bd8f8a438cdbe46f208b87c).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
