### PR TITLE
slack: fix deb URL pattern

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -69,7 +69,7 @@ let
       sha256 = x86_64-darwin-sha256;
     };
     x86_64-linux = fetchurl {
-      url = "${base}/linux_releases/slack-desktop-${version}-amd64.deb";
+      url = "${base}/releases/linux/${version}/prod/x64/slack-desktop-${version}-amd64.deb";
       sha256 = x86_64-linux-sha256;
     };
     aarch64-darwin = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Slack changed the URL where their deb file release are published.

URL sourced from: https://slack.com/downloads/instructions/ubuntu

Fixes:
```shell
[bweeks@z2:/etc/nixos]$ sudo nixos-rebuild switch 
building the system configuration...
trace: warning: The option `nix.autoOptimiseStore' defined in `/nix/store/qqndk32vv45r9n0l8yqndzjbigl9s1l2-source/hosts/z2' has been renamed to `nix.settings.auto-optimise-store'.
trace: warning: The option `nix.allowedUsers' defined in `/nix/store/qqndk32vv45r9n0l8yqndzjbigl9s1l2-source/hosts/z2' has been renamed to `nix.settings.allowed-users'.
error: builder for '/nix/store/l80yalj232y8yki8ppc0791ripdx5lla-slack-desktop-4.23.0-amd64.deb.drv' failed with exit code 1;
       last 7 log lines:
       >
       > trying https://downloads.slack-edge.com/linux_releases/slack-desktop-4.23.0-amd64.deb
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > error: cannot download slack-desktop-4.23.0-amd64.deb from any mirror
       For full logs, run 'nix log /nix/store/l80yalj232y8yki8ppc0791ripdx5lla-slack-desktop-4.23.0-amd64.deb.drv'.
error: 1 dependencies of derivation '/nix/store/p1m6awlp3qzad02ixb7ncbjjlf150rki-slack-4.23.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/r6zksq2jfpiyk216k6bkl7dbjg7vj6pa-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/v6r7zvx0a1g3qmblj9q6pjwvs5wimwd3-slack-4.23.0-fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/1d7awszj4jqc0nnvkpzggpqbqa1gaayl-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/0h5na3cgcbp6l2av0gj9qpq29xmhymwh-unit-home-manager-bweeks.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/i69mvrcp55l36pdwlzgwpqpk34a9fpbc-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jkhy8an0r96ysm4jvgdpfq14fqyqq0bh-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/vmxnmgjy8c1qjbmdh3qw62n7vj1ca6wj-nixos-system-z2-22.05.19700101.dirty.drv' failed to build
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
