### PR TITLE
cl-wordle: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/games/cl-wordle/default.nix
+++ b/pkgs/games/cl-wordle/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cl-wordle";
-  version = "0.1.2";
+  version = "0.2.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-mcPC2Lj+Vsytfl3+ghYn74QRfM6U4dQLUybtCqkjKlk=";
+    sha256 = "sha256-M2ljFrfIOyM1Slwsk7ZJ+PhJIVSUvFcFck2Q2e9nOwc=";
   };
 
-  cargoSha256 = "sha256-3Ef8gLFWIAYpKdPixvILvDee5Gezh68hc9TR5+zRX0I=";
+  cargoSha256 = "sha256-bB6MzpJc8QS2+8GSS8RbSF5QcJyRT8FkmChpf1x2i/E=";
 
   patches = [ ./rust-1-57.diff ];
 

--- a/pkgs/games/cl-wordle/rust-1-57.diff
+++ b/pkgs/games/cl-wordle/rust-1-57.diff
@@ -1,13 +1,13 @@
-diff --git a/src/bin/wordle/game.rs b/src/bin/wordle/game.rs
-index 8500732..6f26e2a 100644
---- a/src/bin/wordle/game.rs
-+++ b/src/bin/wordle/game.rs
-@@ -235,7 +235,7 @@ impl Display for GameShare {
-             score = self.score
-         )?;
-         for m in &self.matches {
--            write!(f, "\n{m}")?;
-+            write!(f, "\n{}", m)?;
+diff --git a/src/state.rs b/src/state.rs
+index 5fac0a3..41cbde4 100644
+--- a/src/state.rs
++++ b/src/state.rs
+@@ -74,7 +74,7 @@ impl State {
+             'X'
+         };
+ 
+-        write!(w, "{score}/6",)?;
++        write!(w, "{:?}/6", score)?;
+         for Guess(_, m) in self.guesses() {
+             write!(w, "\n{}", m)?;
          }
-         Ok(())
-     }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
