### PR TITLE
php80: 8.0.14 -> 8.0.15

### DIFF
--- a/pkgs/development/interpreters/php/8.0.nix
+++ b/pkgs/development/interpreters/php/8.0.nix
@@ -2,10 +2,9 @@
 
 let
   base = callPackage ./generic.nix (_args // {
-    version = "8.0.14";
-    sha256 = "0jydl388mpysrrxa7h9sxf3fpp38mmygg9ryq8j7rb8p93giyf5v";
+    version = "8.0.15";
+    sha256 = "sha256-iBFxyQq6dG0o33aPPZn6MmGZnlBkFb5Mc1IHimT+Wdw=";
   });
-
 in
 base.withExtensions ({ all, ... }: with all; ([
   bcmath

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -258,6 +258,7 @@ let
             # Don't record the configure flags since this causes unnecessary
             # runtime dependencies
             ''
+              set -x
               for i in main/build-defs.h.in scripts/php-config.in; do
                 substituteInPlace $i \
                   --replace '@CONFIGURE_COMMAND@' '(omitted)' \

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -321,7 +321,7 @@ let
           };
 
           # Temporary build step to debug an issue
-          postBuild = ''
+          checkPhase = ''
             make test TESTS='--show-diff tests/blacklist.phpt'
           '';
 

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -258,7 +258,6 @@ let
             # Don't record the configure flags since this causes unnecessary
             # runtime dependencies
             ''
-              set -x
               for i in main/build-defs.h.in scripts/php-config.in; do
                 substituteInPlace $i \
                   --replace '@CONFIGURE_COMMAND@' '(omitted)' \
@@ -282,10 +281,13 @@ let
               fi
             '' + lib.optionalString stdenv.isDarwin ''
               substituteInPlace configure --replace "-lstdc++" "-lc++"
-            '' + ''
-              make test TESTS='--show-diff tests/blacklist.phpt'
             '';
-            # Temporary build step to debug an issue
+
+          checkPhase = ''
+            runHook preCheck
+            make test TESTS='--show-diff'
+            runHook postCheck
+          '';
 
           postInstall = ''
             test -d $out/etc || mkdir $out/etc

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -320,6 +320,11 @@ let
             inherit ztsSupport;
           };
 
+          # Temporary build step to debug an issue
+          postBuild = ''
+            make test TESTS='--show-diff tests/blacklist.phpt'
+          '';
+
           meta = with lib; {
             description = "An HTML-embedded scripting language";
             homepage = "https://www.php.net/";

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -281,7 +281,10 @@ let
               fi
             '' + lib.optionalString stdenv.isDarwin ''
               substituteInPlace configure --replace "-lstdc++" "-lc++"
+            '' + ''
+              make test TESTS='--show-diff tests/blacklist.phpt'
             '';
+            # Temporary build step to debug an issue
 
           postInstall = ''
             test -d $out/etc || mkdir $out/etc
@@ -319,11 +322,6 @@ let
               php;
             inherit ztsSupport;
           };
-
-          # Temporary build step to debug an issue
-          checkPhase = ''
-            make test TESTS='--show-diff tests/blacklist.phpt'
-          '';
 
           meta = with lib; {
             description = "An HTML-embedded scripting language";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -545,10 +545,14 @@ lib.makeScope pkgs.newScope (self: with self; {
         {
           name = "sockets";
           doCheck = false;
-          patches = lib.optional (php.version == "8.1.2")
+          patches = lib.optional (php.version == "8.1.2" || php.version == "8.0.15")
+            # This patch fix compilation issues, see https://github.com/php/php-src/issues/7978
+            # The patch has been committed upstream and should not be required for upper versions of PHP.
             (fetchpatch {
+              name = "fix-bug-gh7978-socket-ext-compilation-errors.patch";
               url = "https://github.com/php/php-src/commit/07aaa34cd418c44f7bc653fafbf49f07fc71b2bf.patch";
-              sha256 = "sha256-EwVb09/zV2vJ8PuyLpKFCovxe6yKct0UBvishZaordM=";
+              excludes = [ "NEWS" ];
+              sha256 = "sha256-WCdHQIKBg24AWLAftHuCLZ+QqRVZXWdHFqZhmRSJ7+Y=";
             });
         }
         { name = "sodium"; buildInputs = [ libsodium ]; }


### PR DESCRIPTION
PHP 8.0.15 suffer from the same bug from PHP 8.1.2. It has been fixed upstream.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
