### PR TITLE
python3Packages.nats-py: 0.11.5 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/nats-py/default.nix
+++ b/pkgs/development/python-modules/nats-py/default.nix
@@ -9,15 +9,17 @@
 }:
 
 buildPythonPackage rec {
-  pname = "asyncio-nats-client";
-  version = "0.11.5";
-  disabled = pythonOlder "3.6";
+  pname = "nats-py";
+  version = "2.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "nats-io";
     repo = "nats.py";
     rev = "v${version}";
-    sha256 = "0zwiijaswmfdk71diqmdpb6nx54fmgi8hy0vwx2m3ihhsyjxj82h";
+    hash = "sha256-BraT30J7OIcW2NXAwjcg9PYu+kgf8f1iDjKiN9J6l7Y=";
   };
 
   propagatedBuildInputs = [
@@ -38,12 +40,24 @@ buildPythonPackage rec {
   disabledTests = [
     # RuntimeError: Event loop is closed
     "test_subscribe_no_echo"
-    "test_reconnect_to_new_server_with_auth"
-    "test_drain_connection"
-    "test_discover_servers_on_first_connect"
+    "test_publish"
+    "test_publish_verbose"
+    "test_fetch_max_waiting_fetch_one"
+    "test_fetch_n"
+    "test_consumer_management"
+    "test_ephemeral_subscribe"
+    "test_queue_subscribe_deliver_group"
+    "test_subscribe_push_bound"
+    "test_double_acking_subscribe"
+    "test_flow_control"
+    "test_ordered_consumer"
+    "test_ordered_consumer_single_loss"
+    "test_kv_simple"
   ];
 
-  pythonImportsCheck = [ "nats.aio" ];
+  pythonImportsCheck = [
+    "nats"
+  ];
 
   meta = with lib; {
     description = "Python client for NATS.io";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -33,6 +33,7 @@ in
   ### Deprecated aliases - for backward compatibility
 
 mapAliases ({
+  asyncio-nats-client = nats-py; # added 2022-02-08
   blockdiagcontrib-cisco = throw "blockdiagcontrib-cisco is not compatible with blockdiag 2.0.0 and has been removed."; # added 2020-11-29
   bt_proximity = bt-proximity; # added 2021-07-02
   bugseverywhere = throw "bugseverywhere has been removed: Abandoned by upstream."; # added 2019-11-27

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -692,8 +692,6 @@ in {
 
   asyncio-mqtt = callPackage ../development/python-modules/asyncio_mqtt { };
 
-  asyncio-nats-client = callPackage ../development/python-modules/asyncio-nats-client { };
-
   asyncio-rlock = callPackage ../development/python-modules/asyncio-rlock { };
 
   asyncmy = callPackage ../development/python-modules/asyncmy { };
@@ -5318,6 +5316,8 @@ in {
   napari-svg = callPackage ../development/python-modules/napari-svg { };
 
   nassl = callPackage ../development/python-modules/nassl { };
+
+  nats-py = callPackage ../development/python-modules/nats-py { };
 
   nats-python = callPackage ../development/python-modules/nats-python { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/nats-io/nats.py/releases/tag/v2.0.0

- Rename from `asyncio-nats-client`
- Fix build (https://hydra.nixos.org/build/166441114)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
