### PR TITLE
python3Packages.graphene: disable failing tests on Python 3.10

### DIFF
--- a/pkgs/development/python-modules/graphene/default.nix
+++ b/pkgs/development/python-modules/graphene/default.nix
@@ -1,14 +1,16 @@
 { lib
+, aniso8601
 , buildPythonPackage
 , fetchFromGitHub
-, aniso8601
 , graphql-core
 , graphql-relay
 , promise
-, pytestCheckHook
 , pytest-asyncio
 , pytest-benchmark
 , pytest-mock
+, pytestCheckHook
+, pythonAtLeast
+, pythonOlder
 , pytz
 , snapshottest
 }:
@@ -16,6 +18,9 @@
 buildPythonPackage rec {
   pname = "graphene";
   version = "3.0.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "graphql-python";
@@ -40,15 +45,22 @@ buildPythonPackage rec {
     snapshottest
   ];
 
-  pytestFlagsArray = [ "--benchmark-disable" ];
+  pytestFlagsArray = [
+    "--benchmark-disable"
+  ];
 
   disabledTests = [
     # Expects different Exeception classes, but receives none of them
     # https://github.com/graphql-python/graphene/issues/1346
     "test_unexpected_error"
+  ] ++ lib.optionals (pythonAtLeast "3.10") [
+    "test_objecttype_as_container_extra_args"
+    "test_objecttype_as_container_invalid_kwargs"
   ];
 
-  pythonImportsCheck = [ "graphene" ];
+  pythonImportsCheck = [
+    "graphene"
+  ];
 
   meta = with lib; {
     description = "GraphQL Framework for Python";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/166303434)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
