### PR TITLE
ocamlPackages.pprint: 20171003 → 20220103

### DIFF
--- a/pkgs/development/compilers/mezzo/default.nix
+++ b/pkgs/development/compilers/mezzo/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation {
   prePatch = lib.optionalString (check-ocaml-version "4.02") ''
     substituteInPlace myocamlbuild.pre.ml \
     --replace '@1..3' '@1..2+3'
+  ''
+  # Compatibility with PPrint ≥ 20220103
+  + ''
+    substituteInPlace typing/Fact.ml --replace PPrintOCaml PPrint.OCaml
   '';
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/crowbar/default.nix
+++ b/pkgs/development/ocaml-modules/crowbar/default.nix
@@ -14,7 +14,10 @@ buildDunePackage rec {
     sha256 = "0wjfc9irvirfkic32ivvj6qb7r838w08b0d3vmngigbjpjyc9b14";
   };
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
+
+  # Fix tests with pprint ≥ 20220103
+  patches = [ ./pprint.patch ];
 
   # disable xmldiff tests, so we don't need to package unmaintained and legacy pkgs
   postPatch = "rm -rf examples/xmldiff";

--- a/pkgs/development/ocaml-modules/crowbar/pprint.patch
+++ b/pkgs/development/ocaml-modules/crowbar/pprint.patch
@@ -1,0 +1,22 @@
+commit 77b5e54d33a66445f45ddc48577d835207be8cef
+Author: Stephen Dolan <stephen.dolan@cl.cam.ac.uk>
+Date:   Fri Jun 12 19:34:51 2020 +0100
+
+    Unbreak small example logic
+
+diff --git a/examples/pprint/test_pprint.ml b/examples/pprint/test_pprint.ml
+index 77789ef..44124e7 100644
+--- a/examples/pprint/test_pprint.ml
++++ b/examples/pprint/test_pprint.ml
+@@ -1,9 +1,9 @@
+-open Crowbar
+ open PPrint
++open Crowbar
+ type t = (string * PPrint.document)
+ let doc = fix (fun doc -> choose [
+   const ("", empty);
+-  const ("a", char 'a');
++  const ("a", PPrint.char 'a');
+   const ("123", string "123");
+   const ("Hello", string "Hello");
+   const ("awordwhichisalittlebittoolong",

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -1,38 +1,22 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild }:
+{ lib, fetchFromGitHub, buildDunePackage }:
 
-assert lib.versionAtLeast (lib.getVersion ocaml) "3.12";
+buildDunePackage rec {
+  pname = "pprint";
+  version = "20220103";
 
-let param =
-  if lib.versionAtLeast ocaml.version "4.02"
-  then {
-    version = "20171003";
-    sha256 = "06zwsskri8kaqjdszj9360nf36zvwh886xwf033aija8c9k4w6cx";
-  } else {
-    version = "20140424";
-    sha256 = "0sc9q89dnyarcg24czyhr6ams0ylqvia3745s6rfwd2nldpygsdk";
-}; in
+  useDune2 = true;
 
-stdenv.mkDerivation {
-
-  name = "ocaml${ocaml.version}-pprint-${param.version}";
-
-  src = fetchurl {
-    url = "http://gallium.inria.fr/~fpottier/pprint/pprint-${param.version}.tar.gz";
-    inherit (param) sha256;
+  src = fetchFromGitHub {
+    owner = "fpottier";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:09y6nwnjldifm47406q1r9987njlk77g4ifqg6qs54dckhr64vax";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-
-  createFindlibDestdir = true;
-
-  dontBuild = true;
-  installFlags = [ "-C" "src" ];
-
   meta = with lib; {
-    homepage = "http://gallium.inria.fr/~fpottier/pprint/";
-    description = "An OCaml adaptation of Wadler’s and Leijen’s prettier printer";
-    license = licenses.cecill-c;
+    inherit (src.meta) homepage;
+    description = "An OCaml library for pretty-printing textual documents";
+    license = licenses.lgpl2Only;
     maintainers = [ maintainers.vbgl ];
-    platforms = ocaml.meta.platforms or [];
   };
 }

--- a/pkgs/development/ocaml-modules/pprint/default.nix
+++ b/pkgs/development/ocaml-modules/pprint/default.nix
@@ -13,8 +13,8 @@ let param =
 }; in
 
 stdenv.mkDerivation {
-  inherit (param) version;
-  pname = "ocaml${ocaml.version}-pprint";
+
+  name = "ocaml${ocaml.version}-pprint-${param.version}";
 
   src = fetchurl {
     url = "http://gallium.inria.fr/~fpottier/pprint/pprint-${param.version}.tar.gz";


### PR DESCRIPTION
###### Motivation for this change

Improvements: https://github.com/fpottier/pprint/blob/master/CHANGES.md

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
