### PR TITLE
nixos/systemd: Custom error when mixing list/non-list defs

### DIFF
--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -20,10 +20,15 @@ in rec {
     merge = loc: defs:
       let
         defs' = filterOverrides defs;
-        defs'' = getValues defs';
       in
-        if isList (head defs'')
-        then concatLists defs''
+        if isList (head defs').value
+        then concatMap (def:
+          if builtins.typeOf def.value == "list"
+          then def.value
+          else
+            throw "The definitions for systemd unit options should be either all lists, representing repeatable options, or all non-lists, but for the option ${showOption loc}, the definitions are a mix of list and non-list ${lib.options.showDefs defs'}"
+        ) defs'
+
         else mergeEqualOption loc defs';
   };
 


### PR DESCRIPTION
###### Motivation for this change

Provide context for an otherwise incomprehensible error and stack trace.

Before

```
error: value is a set while a list was expected
```

After

```
error: The definitions for systemd unit options should be either all lists, representing repeatable options, or all non-lists, but for the option systemd.services.postgresql.serviceConfig.ExecStartPre, the definitions are a mix of list and non-list
       - In `/nix/store/8nby8xsm4zf05nb1samj8gr8ya6xjq10-bi4hb1h745xlilain27syz9017a1a2l3-source/nixos/modules/system/boot/systemd.nix':
           [
             "/nix/store/74jkxldlh08njc5c8r24pw8rp5jmrvlw-unit-script-postgresql-pre-start/bin/postgresql-pre-start"
           ]
       - In `/home/user/proj/modules/postgresql.nix': <derivation /nix/store/bbd9zgis92iyaxn81m7l6zadb40rj0gd-postgres-standby-setup.drv>

```

This is a partial solution to https://github.com/NixOS/nixpkgs/issues/158606. 
Ideally, I think we should have all systemd options modeled in NixOS, as this is not really a solution to the underlying problem, but it's not feasible until #158594 and perhaps even https://github.com/NixOS/nixpkgs/issues/158598 for performance (not sure).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @NixOS/systemd-committers 