### PR TITLE
hadoop: add aarch64 support

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -187,9 +187,9 @@ in
   grocy = handleTest ./grocy.nix {};
   grub = handleTest ./grub.nix {};
   gvisor = handleTest ./gvisor.nix {};
-  hadoop.all = handleTestOn [ "x86_64-linux" ] ./hadoop/hadoop.nix {};
-  hadoop.hdfs = handleTestOn [ "x86_64-linux" ] ./hadoop/hdfs.nix {};
-  hadoop.yarn = handleTestOn [ "x86_64-linux" ] ./hadoop/yarn.nix {};
+  hadoop = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hadoop.nix {};
+  hadoop-hdfs = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hdfs.nix {};
+  hadoop-yarn = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/yarn.nix {};
   haka = handleTest ./haka.nix {};
   haproxy = handleTest ./haproxy.nix {};
   hardened = handleTest ./hardened.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -187,9 +187,9 @@ in
   grocy = handleTest ./grocy.nix {};
   grub = handleTest ./grub.nix {};
   gvisor = handleTest ./gvisor.nix {};
-  hadoop = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hadoop.nix {};
-  hadoop-hdfs = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hdfs.nix {};
-  hadoop-yarn = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/yarn.nix {};
+  hadoop.all = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hadoop.nix {};
+  hadoop.hdfs = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/hdfs.nix {};
+  hadoop.yarn = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./hadoop/yarn.nix {};
   haka = handleTest ./haka.nix {};
   haproxy = handleTest ./haproxy.nix {};
   hardened = handleTest ./hardened.nix {};

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -77,7 +77,7 @@ in
   # https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions
   hadoop_3_3 =
     common
-      rec {
+      (rec {
         pname = "hadoop";
         version = "3.3.1";
         untarDir = "${pname}-${version}";
@@ -97,14 +97,14 @@ in
         '';
         jdk = jdk11_headless;
       } // optionalAttrs stdenv.isDarwin {
-      sha256 = {
-        x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-        aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
-      };
-      openssl = null;
-      nativeLibs = [ ];
-      libPatches = "";
-    };
+        sha256 = {
+          x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+          aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+        };
+        openssl = null;
+        nativeLibs = [ ];
+        libPatches = "";
+      });
   hadoop_3_2 = common rec {
     pname = "hadoop";
     version = "3.2.2";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -19,6 +19,8 @@
 
 with lib;
 
+assert elem stdenv.system [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
 let
   common = { pname, version, untarDir ? "${pname}-${version}", sha256, jdk, openssl, nativeLibs ? [ ], libPatches ? "" }:
     let
@@ -81,9 +83,11 @@ in
         pname = "hadoop";
         version = "3.3.1";
         untarDir = "${pname}-${version}";
-        sha256 = {
+        sha256 = rec {
           x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+          x86_64-darwin = x86_64-linux;
           aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+          aarch64-darwin = aarch64-linux;
         };
         inherit openssl;
         nativeLibs = [ stdenv.cc.cc.lib protobuf3_7 zlib snappy ];
@@ -97,10 +101,6 @@ in
         '';
         jdk = jdk11_headless;
       } // optionalAttrs stdenv.isDarwin {
-        sha256 = {
-          x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-          aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
-        };
         openssl = null;
         nativeLibs = [ ];
         libPatches = "";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -75,34 +75,34 @@ in
 {
   # Different version of hadoop support different java runtime versions
   # https://cwiki.apache.org/confluence/display/HADOOP/Hadoop+Java+Versions
-  hadoop_3_3 = common
-    rec {
-      pname = "hadoop";
-      version = "3.3.1";
-      sha256 = {
-        x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-        x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-        aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
-        aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
-      };
-      jdk = jdk11_headless;
-      untarDir = "${pname}-${version}";
+  hadoop_3_3 =
+    common
+      rec {
+        pname = "hadoop";
+        version = "3.3.1";
+        untarDir = "${pname}-${version}";
+        sha256 = {
+          x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+          x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+          aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+          aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+        };
+        inherit openssl;
+        nativeLibs = [ stdenv.cc.cc.lib protobuf3_7 zlib snappy ];
+        libPatches = ''
+          ln -s ${getLib cyrus_sasl}/lib/libsasl2.so $out/lib/${untarDir}/lib/native/libsasl2.so.2
+          ln -s ${getLib openssl}/lib/libcrypto.so $out/lib/${untarDir}/lib/native/
+          ln -s ${getLib zlib}/lib/libz.so.1 $out/lib/${untarDir}/lib/native/
+          ln -s ${getLib zstd}/lib/libzstd.so.1 $out/lib/${untarDir}/lib/native/
+          ln -s ${getLib bzip2}/lib/libbz2.so.1 $out/lib/${untarDir}/lib/native/
+          patchelf --add-rpath ${jdk.home}/lib/server $out/lib/${untarDir}/lib/native/libnativetask.so.1.0.0
+        '';
+        jdk = jdk11_headless;
+      } // optionalAttrs stdenv.isAarch64 {
       openssl = null;
-    } // optionalAttrs stdenv.isLinux {
-    # Only include native libraries if we're using Linux.
-    # TODO: Figure out how to get the libraries to link properly for darwin.
-    inherit openssl;
-    # TODO: Package and add Intel Storage Acceleration Library
-    nativeLibs = [ stdenv.cc.cc.lib protobuf3_7 zlib snappy ];
-    libPatches = ''
-      ln -s ${getLib cyrus_sasl}/lib/libsasl2.so $out/lib/${untarDir}/lib/native/libsasl2.so.2
-      ln -s ${getLib openssl}/lib/libcrypto.so $out/lib/${untarDir}/lib/native/
-      ln -s ${getLib zlib}/lib/libz.so.1 $out/lib/${untarDir}/lib/native/
-      ln -s ${getLib zstd}/lib/libzstd.so.1 $out/lib/${untarDir}/lib/native/
-      ln -s ${getLib bzip2}/lib/libbz2.so.1 $out/lib/${untarDir}/lib/native/
-      patchelf --add-rpath ${jdk.home}/lib/server $out/lib/${untarDir}/lib/native/libnativetask.so.1.0.0
-    '';
-  };
+      nativeLibs = [ ];
+      libPatches = "";
+    };
   hadoop_3_2 = common rec {
     pname = "hadoop";
     version = "3.2.2";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -83,9 +83,7 @@ in
         untarDir = "${pname}-${version}";
         sha256 = {
           x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-          x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
           aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
-          aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
         };
         inherit openssl;
         nativeLibs = [ stdenv.cc.cc.lib protobuf3_7 zlib snappy ];
@@ -98,7 +96,11 @@ in
           patchelf --add-rpath ${jdk.home}/lib/server $out/lib/${untarDir}/lib/native/libnativetask.so.1.0.0
         '';
         jdk = jdk11_headless;
-      } // optionalAttrs stdenv.isAarch64 {
+      } // optionalAttrs stdenv.isDarwin {
+      sha256 = {
+        x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
+        aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+      };
       openssl = null;
       nativeLibs = [ ];
       libPatches = "";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -22,13 +22,7 @@ with lib;
 let
   common = { pname, version, untarDir ? "${pname}-${version}", sha256, jdk, openssl, nativeLibs ? [ ], libPatches ? "" }:
     let
-      platformUrlSuffix =
-        if stdenv.isx86_64 && (stdenv.isLinux || stdenv.isDarwin)
-        then ""
-        else
-          if stdenv.isAarch64 && (stdenv.isLinux || stdenv.isDarwin)
-          then "-aarch64"
-          else throw "Hadoop does not currently support ${stdenv.system}.";
+      platformUrlSuffix = optionalString stdenv.isAarch64 "-aarch64";
     in
     stdenv.mkDerivation rec {
       inherit pname version jdk libPatches untarDir openssl;

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -82,8 +82,8 @@ in
       sha256 = {
         x86_64-linux = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
         x86_64-darwin = "1b3v16ihysqaxw8za1r5jlnphy8dwhivdx2d0z64309w57ihlxxd";
-        aarch64-linux = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
-        aarch64-darwin = "sha256-v1Om2pk0wsgKBghRD2wgTSHJoKd3jkm1wPKAeDcKlgI=";
+        aarch64-linux = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
+        aarch64-darwin = "00ln18vpi07jq2slk3kplyhcj8ad41n0yl880q5cihilk7daclxz";
       };
       jdk = jdk11_headless;
       untarDir = "${pname}-${version}";

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -23,13 +23,10 @@ assert elem stdenv.system [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarc
 
 let
   common = { pname, version, untarDir ? "${pname}-${version}", sha256, jdk, openssl ? null, nativeLibs ? [ ], libPatches ? "" }:
-    let
-      platformUrlSuffix = optionalString stdenv.isAarch64 "-aarch64";
-    in
     stdenv.mkDerivation rec {
       inherit pname version jdk libPatches untarDir openssl;
       src = fetchurl {
-        url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}${platformUrlSuffix}.tar.gz";
+        url = "mirror://apache/hadoop/common/hadoop-${version}/hadoop-${version}" + optionalString stdenv.isAarch64 "-aarch64" + ".tar.gz";
         sha256 = sha256.${stdenv.system};
       };
       doCheck = true;
@@ -69,9 +66,8 @@ let
           computers, each of which may be prone to failures.
         '';
         maintainers = with maintainers; [ volth illustris ];
-        platforms = builtins.attrNames sha256;
+        platforms = attrNames sha256;
       };
-
     };
 in
 {
@@ -104,9 +100,7 @@ in
   hadoop_3_2 = common rec {
     pname = "hadoop";
     version = "3.2.2";
-    sha256 = {
-      x86_64-linux = "1hxq297cqvkfgz2yfdiwa3l28g44i2abv5921k2d6b4pqd33prwp";
-    };
+    sha256.x86_64-linux = "1hxq297cqvkfgz2yfdiwa3l28g44i2abv5921k2d6b4pqd33prwp";
     jdk = jdk8_headless;
     # not using native libs because of broken openssl_1_0_2 dependency
     # can be manually overriden
@@ -114,9 +108,7 @@ in
   hadoop2 = common rec {
     pname = "hadoop";
     version = "2.10.1";
-    sha256 = {
-      x86_64-linux = "1w31x4bk9f2swnx8qxx0cgwfg8vbpm6cy5lvfnbbpl3rsjhmyg97";
-    };
+    sha256.x86_64-linux = "1w31x4bk9f2swnx8qxx0cgwfg8vbpm6cy5lvfnbbpl3rsjhmyg97";
     jdk = jdk8_headless;
   };
 }


### PR DESCRIPTION
This commit also changes the names of the tests for Hadoop so they use dashes instead of dots,
and makes the default `hadoop` test what would have been `hadoop-all` after the rename.

This change should mean that we're able to run

`nix build github:nixos/nixpkgs/master#nixosTests.hadoop`

which I was unable to do prior to this change.

I've built this change on `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`. I've run the NixOS tests for Hadoop on `aarch64-linux`, and `x86_64-linux`. On `aarch64-darwin` I just ran `hadoop version` and `hadoop checknative`.

I made a flake to spin up an AWS EC2 instance on a bare-metal instance (required because NixOS tests need KVM), create a ramdisk (to avoid provisioning a larger amount of disk space), and build and test the change there: <https://github.com/ConnorBaker/nix-hadoop-aarch64-test>.

I've seen some posts discussing getting the native libraries working for macOS, but I wasn't sure how to do that. I'm not familiar with `patchelf` or `install_name_tool` or how linking works, so any help would be appreciated!

###### Motivation for this change

Spark requires Hadoop, so adding Hadoop's aarch64 distribution allows us to use Spark on that platform.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
