### PR TITLE
terraform-providers: wrap mkProvider in lib.makeOverridable

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -10,42 +10,42 @@ let
   # Our generic constructor to build new providers.
   #
   # Is designed to combine with the terraform.withPlugins implementation.
-  mkProvider =
-    { owner
-    , repo
-    , rev
-    , version
-    , sha256
-    , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
-    , deleteVendor ? false
-    , proxyVendor ? false
-    , # Looks like "registry.terraform.io/vancluever/acme"
-      provider-source-address
-    }@attrs:
-    buildGoModule {
-      pname = repo;
-      inherit vendorSha256 version deleteVendor proxyVendor;
-      subPackages = [ "." ];
-      doCheck = false;
-      # https://github.com/hashicorp/terraform-provider-scaffolding/blob/a8ac8375a7082befe55b71c8cbb048493dd220c2/.goreleaser.yml
-      # goreleaser (used for builds distributed via terraform registry) requires that CGO is disabled
-      CGO_ENABLED = 0;
-      ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${rev}" ];
-      src = fetchFromGitHub {
-        inherit owner repo rev sha256;
-      };
+  mkProvider = lib.makeOverridable
+    ({ owner
+     , repo
+     , rev
+     , version
+     , sha256
+     , vendorSha256 ? throw "vendorSha256 missing: please use `buildGoModule`" /* added 2022/01 */
+     , deleteVendor ? false
+     , proxyVendor ? false
+     , # Looks like "registry.terraform.io/vancluever/acme"
+       provider-source-address
+     }@attrs:
+      buildGoModule {
+        pname = repo;
+        inherit vendorSha256 version deleteVendor proxyVendor;
+        subPackages = [ "." ];
+        doCheck = false;
+        # https://github.com/hashicorp/terraform-provider-scaffolding/blob/a8ac8375a7082befe55b71c8cbb048493dd220c2/.goreleaser.yml
+        # goreleaser (used for builds distributed via terraform registry) requires that CGO is disabled
+        CGO_ENABLED = 0;
+        ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${rev}" ];
+        src = fetchFromGitHub {
+          inherit owner repo rev sha256;
+        };
 
-      # Move the provider to libexec
-      postInstall = ''
-        dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/''${GOOS}_''${GOARCH}
-        mkdir -p "$dir"
-        mv $out/bin/* "$dir/terraform-provider-$(basename ${provider-source-address})_${version}"
-        rmdir $out/bin
-      '';
+        # Move the provider to libexec
+        postInstall = ''
+          dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/''${GOOS}_''${GOARCH}
+          mkdir -p "$dir"
+          mv $out/bin/* "$dir/terraform-provider-$(basename ${provider-source-address})_${version}"
+          rmdir $out/bin
+        '';
 
-      # Keep the attributes around for later consumption
-      passthru = attrs;
-    };
+        # Keep the attributes around for later consumption
+        passthru = attrs;
+      });
 
   list = lib.importJSON ./providers.json;
 


### PR DESCRIPTION
This allows for an easier interface for doing things like overriding
the version of a specific Terraform provider, which is a fairly common
use-case.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
