### PR TITLE
btcpayserver: 1.4.3 -> 1.4.4

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -3,13 +3,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.4.3";
+  version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-CMa0+Djx07q77W/ezMhU+JP5EPXz4nfZ35TN8O6R/nc=";
+    sha256 = "sha256-PW5a1Bw21skpboWDtlZHGWtFwfImznD7nYI92RT7GGQ=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";


### PR DESCRIPTION
Things done:

* Tested with the [nix-bitcoin VM test](https://gist.github.com/nixbitcoin/997b79160286003380576d8f1fb6adf7).

Notes for reviewers: You can verify GPG signatures with `refetch=1 pkgs/applications/blockchains/btcpayserver/update.sh`.

cc @prusnak @erikarvstedt