### PR TITLE
easyeffects: 6.1.3 -> 6.2.3

### DIFF
--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
     # https://github.com/wwmm/easyeffects/pull/1205
-    substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
+    # substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   preFixup =

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -77,8 +77,6 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
-    # https://github.com/wwmm/easyeffects/pull/1205
-    # substituteInPlace meson_post_install.py --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   preFixup =

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -6,9 +6,7 @@
 , fftwFloat
 , fmt
 , glib
-, glibmm
 , gtk4
-, gtkmm4
 , itstool
 , libadwaita
 , libbs2b
@@ -60,9 +58,7 @@ stdenv.mkDerivation rec {
     fftwFloat
     fmt
     glib
-    glibmm
     gtk4
-    gtkmm4
     libadwaita
     libbs2b
     libebur128

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -50,7 +50,6 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    tbb
     wrapGAppsHook4
   ];
 
@@ -71,6 +70,7 @@ stdenv.mkDerivation rec {
     rnnoise
     rubberband
     speexdsp
+    tbb
     zita-convolver
   ];
 

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -12,7 +12,7 @@
 , libbs2b
 , libebur128
 , libsamplerate
-, libsigcxx
+, libsigcxx30
 , libsndfile
 , lilv
 , lsp-plugins
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     libbs2b
     libebur128
     libsamplerate
-    libsigcxx
+    libsigcxx30
     libsndfile
     lilv
     lv2

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -6,6 +6,7 @@
 , fftwFloat
 , fmt
 , glib
+, glibmm
 , gtk4
 , itstool
 , libadwaita
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
     fftwFloat
     fmt
     glib
+    glibmm
     gtk4
     libadwaita
     libbs2b

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -4,11 +4,13 @@
 , fetchFromGitHub
 , calf
 , fftwFloat
+, fmt
 , glib
 , glibmm
 , gtk4
 , gtkmm4
 , itstool
+, libadwaita
 , libbs2b
 , libebur128
 , libsamplerate
@@ -26,6 +28,7 @@
 , rnnoise
 , rubberband
 , speexdsp
+, tbb
 , wrapGAppsHook4
 , zam-plugins
 , zita-convolver
@@ -33,13 +36,13 @@
 
 stdenv.mkDerivation rec {
   pname = "easyeffects";
-  version = "6.1.3";
+  version = "6.2.3";
 
   src = fetchFromGitHub {
     owner = "wwmm";
     repo = "easyeffects";
     rev = "v${version}";
-    sha256 = "sha256-1UfeqPJxY4YT98UdqTZtG+QUBOZlKfK+7WbszhO22A0=";
+    sha256 = "sha256-A1UanrAbmZFGCmDNIr1h+v5RVMsIl4qgM/veBirudQM=";
   };
 
   nativeBuildInputs = [
@@ -49,15 +52,18 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
+    tbb
     wrapGAppsHook4
   ];
 
   buildInputs = [
     fftwFloat
+    fmt
     glib
     glibmm
     gtk4
     gtkmm4
+    libadwaita
     libbs2b
     libebur128
     libsamplerate

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -12,6 +12,7 @@
 , libbs2b
 , libebur128
 , libsamplerate
+, libsigcxx
 , libsndfile
 , lilv
 , lsp-plugins
@@ -62,6 +63,7 @@ stdenv.mkDerivation rec {
     libbs2b
     libebur128
     libsamplerate
+    libsigcxx
     libsndfile
     lilv
     lv2

--- a/pkgs/applications/audio/easyeffects/default.nix
+++ b/pkgs/applications/audio/easyeffects/default.nix
@@ -6,7 +6,6 @@
 , fftwFloat
 , fmt
 , glib
-, glibmm
 , gtk4
 , itstool
 , libadwaita
@@ -59,7 +58,6 @@ stdenv.mkDerivation rec {
     fftwFloat
     fmt
     glib
-    glibmm
     gtk4
     libadwaita
     libbs2b

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21653,9 +21653,7 @@ with pkgs;
 
   libpulseaudio = libpulseaudio-vanilla;
 
-  easyeffects = callPackage ../applications/audio/easyeffects {
-    glibmm = glibmm_2_68;
-  };
+  easyeffects = callPackage ../applications/audio/easyeffects { };
 
   pulseeffects-legacy = callPackage ../applications/audio/pulseeffects-legacy {
     boost = boost172;


### PR DESCRIPTION
1. Updated to the newest version.
2. Added some build and runtime dependencies according to build errors.

###### Motivation for this change
Fixes: #158476
Fixes: https://github.com/NixOS/nixpkgs/issues/155588

https://github.com/wwmm/easyeffects/blob/v6.2.3/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
