### PR TITLE
displaylink: add dependency on required-file source to avoid unchanged manual interactions needed

### DIFF
--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dt $out/lib/displaylink *.spkg
     install -Dm755 ${bins}/DisplayLinkManager $out/bin/DisplayLinkManager
-    mkdir -p $out/lib/udev/rules.d
+    mkdir -p $out/lib/udev/rules.d $out/share
     cp ${./99-displaylink.rules} $out/lib/udev/rules.d/99-displaylink.rules
     patchelf \
       --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
@@ -59,6 +59,9 @@ stdenv.mkDerivation rec {
       $out/bin/DisplayLinkManager
     wrapProgram $out/bin/DisplayLinkManager \
       --run "cd $out/lib/displaylink"
+
+    # We introduce a dependency on the source file so that it need not be redownloaded everytime
+    echo $src >> "$out/share/workspace_dependencies.pin"
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change
Avoid downloading/pre-fetching drivers after garbage-collect.

###### Things done
Added dependency to $out/share (found in https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/networking/remote/citrix-workspace/generic.nix#L193, kudos to @Ma27 ;)) 

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
