### PR TITLE
yarn2nix: Support for nested yarn workspaces

### DIFF
--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -196,7 +196,15 @@ in rec {
     # Path -> PathGlob -> [Path]
     expandGlob = base: glob: expandGlobList base (splitGlob glob);
 
-    packagePaths = lib.concatMap (expandGlob src) packageGlobs;
+    validPackage = path:
+      let
+        packageJSON = path+"/package.json";
+        package = lib.importJSON packageJSON;
+      in
+        builtins.pathExists (path+"/package.json") &&
+        builtins.hasAttr "name" package &&
+        builtins.hasAttr "version" package;
+    packagePaths = builtins.filter validPackage (lib.concatMap (expandGlob src) packageGlobs);
 
     packages = lib.listToAttrs (map (src:
       let


### PR DESCRIPTION
###### Motivation for this change
Builds on top of https://github.com/NixOS/nixpkgs/pull/151995 for yarn v2 support. Supports nesting workspaces as such:
```
"workspaces": {
  "packages": [
    "packages/*",
    "packages/subworkspace/*",
    "packages-2"
  ]
},
```
where `subworkspace` dir doesn't contain a `package.json`, but has subdirectories that do. 

Adapted from old `yarn2nix` repo PR:
https://github.com/nix-community/yarn2nix/pull/89

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
