### PR TITLE
python39Packages.pyopenssl: add meta, adopt to myself, 20.0.1 -> 22.0.0

### DIFF
--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -57,6 +57,8 @@ buildPythonPackage rec {
     "test_hosts_no_network"
     "test_leakage_from_tracebacks"
     "test_patcher_existing_locks_locked"
+    # broken with pyopenssl 22.0.0
+    "test_sendall_timeout"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -6,63 +6,12 @@
 , cryptography
 , pyasn1
 , idna
-, pytest
+, pytestCheckHook
 , pretend
 , flaky
 , glibcLocales
 , six
 }:
-
-let
-  # https://github.com/pyca/pyopenssl/issues/791
-  # These tests, we disable in the case that libressl is passed in as openssl.
-  failingLibresslTests = [
-    "test_op_no_compression"
-    "test_npn_advertise_error"
-    "test_npn_select_error"
-    "test_npn_client_fail"
-    "test_npn_success"
-    "test_use_certificate_chain_file_unicode"
-    "test_use_certificate_chain_file_bytes"
-    "test_add_extra_chain_cert"
-    "test_set_session_id_fail"
-    "test_verify_with_revoked"
-    "test_set_notAfter"
-    "test_set_notBefore"
-  ];
-
-  # these tests are extremely tightly wed to the exact output of the openssl cli tool,
-  # including exact punctuation.
-  failingOpenSSL_1_1Tests = [
-    "test_dump_certificate"
-    "test_dump_privatekey_text"
-    "test_dump_certificate_request"
-    "test_export_text"
-  ];
-
-  disabledTests = [
-    # https://github.com/pyca/pyopenssl/issues/692
-    # These tests, we disable always.
-    "test_set_default_verify_paths"
-    "test_fallback_default_verify_paths"
-    # https://github.com/pyca/pyopenssl/issues/768
-    "test_wantWriteError"
-    # https://github.com/pyca/pyopenssl/issues/1043
-    "test_alpn_call_failure"
-  ] ++ (
-    lib.optionals (lib.hasPrefix "libressl" openssl.meta.name) failingLibresslTests
-  ) ++ (
-    lib.optionals (lib.versionAtLeast (lib.getVersion openssl.name) "1.1") failingOpenSSL_1_1Tests
-  ) ++ (
-    # https://github.com/pyca/pyopenssl/issues/974
-    lib.optionals stdenv.is32bit [ "test_verify_with_time" ]
-  );
-
-  # Compose the final string expression, including the "-k" and the single quotes.
-  testExpression = lib.optionalString (disabledTests != [])
-    "-k 'not ${lib.concatStringsSep " and not " disabledTests}'";
-
-in
 
 buildPythonPackage rec {
   pname = "pyopenssl";
@@ -76,13 +25,6 @@ buildPythonPackage rec {
 
   outputs = [ "out" "dev" ];
 
-  checkPhase = ''
-    runHook preCheck
-    export LANG="en_US.UTF-8"
-    py.test tests ${testExpression}
-    runHook postCheck
-  '';
-
   # Seems to fail unpredictably on Darwin. See https://hydra.nixos.org/build/49877419/nixlog/1
   # for one example, but I've also seen ContextTests.test_set_verify_callback_exception fail.
   doCheck = !stdenv.isDarwin;
@@ -90,7 +32,46 @@ buildPythonPackage rec {
   nativeBuildInputs = [ openssl ];
   propagatedBuildInputs = [ cryptography pyasn1 idna six ];
 
-  checkInputs = [ pytest pretend flaky glibcLocales ];
+  checkInputs = [ pytestCheckHook pretend flaky glibcLocales ];
+
+  preCheck = ''
+    export LANG="en_US.UTF-8"
+  '';
+
+  disabledTests = [
+    # https://github.com/pyca/pyopenssl/issues/692
+    # These tests, we disable always.
+    "test_set_default_verify_paths"
+    "test_fallback_default_verify_paths"
+    # https://github.com/pyca/pyopenssl/issues/768
+    "test_wantWriteError"
+    # https://github.com/pyca/pyopenssl/issues/1043
+    "test_alpn_call_failure"
+  ] ++ lib.optionals (lib.hasPrefix "libressl" openssl.meta.name) [
+    # https://github.com/pyca/pyopenssl/issues/791
+    # These tests, we disable in the case that libressl is passed in as openssl.
+    "test_op_no_compression"
+    "test_npn_advertise_error"
+    "test_npn_select_error"
+    "test_npn_client_fail"
+    "test_npn_success"
+    "test_use_certificate_chain_file_unicode"
+    "test_use_certificate_chain_file_bytes"
+    "test_add_extra_chain_cert"
+    "test_set_session_id_fail"
+    "test_verify_with_revoked"
+    "test_set_notAfter"
+    "test_set_notBefore"
+  ] ++ lib.optionals (lib.versionAtLeast (lib.getVersion openssl.name) "1.1") [
+    # these tests are extremely tightly wed to the exact output of the openssl cli tool, including exact punctuation.
+    "test_dump_certificate"
+    "test_dump_privatekey_text"
+    "test_dump_certificate_request"
+    "test_export_text"
+  ] ++ lib.optionals stdenv.is32bit [
+    # https://github.com/pyca/pyopenssl/issues/974
+    "test_verify_with_time"
+  ];
 
   meta = with lib; {
     description = "Python wrapper around the OpenSSL library";

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -91,4 +91,11 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ cryptography pyasn1 idna six ];
 
   checkInputs = [ pytest pretend flaky glibcLocales ];
+
+  meta = with lib; {
+    description = "Python wrapper around the OpenSSL library";
+    homepage = "https://github.com/pyca/pyopenssl";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
 }

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -15,12 +15,12 @@
 
 buildPythonPackage rec {
   pname = "pyopenssl";
-  version = "21.0.0";
+  version = "22.0.0";
 
   src = fetchPypi {
     pname = "pyOpenSSL";
     inherit version;
-    sha256 = "5e2d8c5e46d0d865ae933bef5230090bdaf5506281e9eec60fa250ee80600cb3";
+    sha256 = "sha256-ZgsbFCWqxKG+odlBaKhdmfCzFEyGndQ5DSdinQCH8b8=";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
