### PR TITLE
tiatracker: init at 1.3

### DIFF
--- a/pkgs/applications/audio/tiatracker/default.nix
+++ b/pkgs/applications/audio/tiatracker/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, mkDerivation
+, fetchFromBitbucket
+, makeDesktopItem
+, copyDesktopItems
+, qmake
+, qtbase
+, SDL2
+}:
+
+let
+  description = "Music tracker for making Atari VCS 2600 music";
+  desktopItem = makeDesktopItem {
+    name = "TIATracker";
+    desktopName = "TIATracker";
+    comment = description;
+    exec = "TIATracker";
+    icon = "tiatracker";
+    type = "Application";
+    categories = "AudioVideo;AudioVideoEditing;";
+    extraEntries = "Keywords=tracker;music;";
+  };
+
+in mkDerivation rec {
+  pname = "tiatracker";
+  version = "1.3";
+
+  src = fetchFromBitbucket {
+    owner = "kylearan";
+    repo = "tiatracker";
+    rev = "ca0bb54ef67d2614f7a0fd70a3c912782d673af3";
+    sha256 = "sha256-koQJTCqJD12KRdtE9C17f9qTyyRyHebnrpSwyZyO8wo=";
+  };
+
+  # Fix darwin
+  postPatch = ''
+    substituteInPlace TIATracker.pro \
+      --replace 'linux:' 'unix:'
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    qtbase
+    SDL2
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 TIATracker $out/bin/TIATracker
+    install -Dm644 manual/tt_icon.png $out/share/icons/hicolor/256x256/tiatracker.png
+    install -Dm644 data/keymap.cfg $out/share/tiatracker/keymap.cfg.sample
+    cp -r songs $out/share/tiatracker/songs
+    install -Dm644 data/TIATracker_manual.pdf $out/share/doc/tiatracker/TIATracker_manual.pdf
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    inherit description;
+    inherit (src.meta) homepage;
+    license = with licenses; [ gpl2Only asl20 ];
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29311,6 +29311,8 @@ with pkgs;
 
   thunderbolt = callPackage ../os-specific/linux/thunderbolt {};
 
+  tiatracker = libsForQt5.callPackage ../applications/audio/tiatracker { };
+
   ticpp = callPackage ../development/libraries/ticpp { };
 
   ticker = callPackage ../applications/misc/ticker {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

#81815 cc @OPNA2608 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
