### PR TITLE
fluxcd: 0.26.1 -> 0.26.2

### DIFF
--- a/pkgs/applications/networking/cluster/fluxcd/default.nix
+++ b/pkgs/applications/networking/cluster/fluxcd/default.nix
@@ -1,9 +1,9 @@
 { lib, buildGoModule, fetchFromGitHub, fetchzip, installShellFiles }:
 
 let
-  version = "0.26.1";
-  sha256 = "10l02cw0ypci9vaman1nm9z36fshqwwf0gk16rvsc82d02lv4iq5";
-  manifestsSha256 = "0gffjmcxsf9c4f6g60nwq88snm6lar0qd53xp0csr4n5sy7zg6dm";
+  version = "0.26.2";
+  sha256 = "1p99bjqlwyibycpby9fnzfmfd826zaw7k7d4f4p4gjpd7dphlrp1";
+  manifestsSha256 = "1s1hx754xa63s7in7gcrr146nkyvadba6vmy1bagjcxibxc3qdqy";
 
   manifests = fetchzip {
     url =
@@ -23,7 +23,7 @@ in buildGoModule rec {
     inherit sha256;
   };
 
-  vendorSha256 = "sha256-IJGp4QWZbTzPHeawyjJI0aN4LP5ZV2mb5pUusfQ4rfE=";
+  vendorSha256 = "sha256-9MMEqJiplg7kmMmbHnTBEQ+GF+dBL7bpzs5Q0IYcMXU=";
 
   postUnpack = ''
     cp -r ${manifests} source/cmd/flux/manifests


### PR DESCRIPTION
fluxcd: 0.26.1 -> 0.26.2

This patch is important to fix (https://github.com/fluxcd/flux2/issues/2351):

`"✗ Kustomization/flux-system/flux-system dry-run failed, error: no matches for kind \"Kustomization\" in version \"kustomize.toolkit.fluxcd.io/v1beta2\"`

