### PR TITLE
haskell-language-server: make linking configureable in wrapper

### DIFF
--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -2,6 +2,7 @@
 , stdenv
 , supportedGhcVersions ? [ "884" "8107" "902" ]
     ++ lib.optionals (!stdenv.hostPlatform.isAarch64) [ "921" ]
+, dynamic ? true
 , haskellPackages
 , haskell
 }:
@@ -13,19 +14,25 @@
 # for example. Read more about this in the haskell-language-server section of the nixpkgs manual.
 #
 let
-  inherit (lib) concatStringsSep concatMapStringsSep take splitString;
+  inherit (lib) concatStringsSep concatMapStringsSep take splitString pipe optionals;
+  inherit (haskell.lib.compose) justStaticExecutables overrideCabal enableCabalFlag disableCabalFlag;
   getPackages = version: haskell.packages."ghc${version}";
   tunedHls = hsPkgs:
-    haskell.lib.compose.justStaticExecutables
-    (haskell.lib.compose.overrideCabal (old: {
-      postInstall = ''
-        remove-references-to -t ${hsPkgs.ghc} $out/bin/haskell-language-server
-        remove-references-to -t ${hsPkgs.shake.data} $out/bin/haskell-language-server
-        remove-references-to -t ${hsPkgs.js-jquery.data} $out/bin/haskell-language-server
-        remove-references-to -t ${hsPkgs.js-dgtable.data} $out/bin/haskell-language-server
-        remove-references-to -t ${hsPkgs.js-flot.data} $out/bin/haskell-language-server
-      '';
-    }) hsPkgs.haskell-language-server);
+    lib.pipe hsPkgs.haskell-language-server ([
+      (haskell.lib.compose.overrideCabal (old: {
+        enableSharedExecutables = dynamic;
+        postInstall = ''
+          remove-references-to -t ${hsPkgs.ghc} $out/bin/haskell-language-server
+          remove-references-to -t ${hsPkgs.shake.data} $out/bin/haskell-language-server
+          remove-references-to -t ${hsPkgs.js-jquery.data} $out/bin/haskell-language-server
+          remove-references-to -t ${hsPkgs.js-dgtable.data} $out/bin/haskell-language-server
+          remove-references-to -t ${hsPkgs.js-flot.data} $out/bin/haskell-language-server
+        '';
+      }))
+      ((if dynamic then enableCabalFlag else disableCabalFlag) "dynamic")
+    ] ++ optionals (!dynamic) [
+      justStaticExecutables
+    ]);
   targets = version:
     let packages = getPackages version;
     in [

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -21,14 +21,10 @@ let
     lib.pipe hsPkgs.haskell-language-server ([
       (haskell.lib.compose.overrideCabal (old: {
         enableSharedExecutables = dynamic;
-        postInstall = ''
+        ${if !dynamic then "postInstall" else null} = ''
           ${old.postInstall or ""}
 
           remove-references-to -t ${hsPkgs.ghc} $out/bin/haskell-language-server
-          remove-references-to -t ${hsPkgs.shake.data} $out/bin/haskell-language-server
-          remove-references-to -t ${hsPkgs.js-jquery.data} $out/bin/haskell-language-server
-          remove-references-to -t ${hsPkgs.js-dgtable.data} $out/bin/haskell-language-server
-          remove-references-to -t ${hsPkgs.js-flot.data} $out/bin/haskell-language-server
         '';
       }))
       ((if dynamic then enableCabalFlag else disableCabalFlag) "dynamic")

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -22,6 +22,8 @@ let
       (haskell.lib.compose.overrideCabal (old: {
         enableSharedExecutables = dynamic;
         postInstall = ''
+          ${old.postInstall or ""}
+
           remove-references-to -t ${hsPkgs.ghc} $out/bin/haskell-language-server
           remove-references-to -t ${hsPkgs.shake.data} $out/bin/haskell-language-server
           remove-references-to -t ${hsPkgs.js-jquery.data} $out/bin/haskell-language-server

--- a/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
+++ b/pkgs/development/tools/haskell/haskell-language-server/withWrapper.nix
@@ -2,7 +2,7 @@
 , stdenv
 , supportedGhcVersions ? [ "884" "8107" "902" ]
     ++ lib.optionals (!stdenv.hostPlatform.isAarch64) [ "921" ]
-, dynamic ? true
+, dynamic ? false
 , haskellPackages
 , haskell
 }:


### PR DESCRIPTION
haskell-language-server will now default to building a shared
executable, as upstream does, complete with a huge closure. By passing
{ dynamic = false; } via override, it is still possible to build a
"statically linked" variant of HLS, as it used to be.

Note: Before this change HLS would fail to compile on aarch64.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
