### PR TITLE
nixos/1password-gui: init at 8.6.0

### DIFF
--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -1,0 +1,48 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs._1password-gui;
+
+in {
+  options = {
+    programs._1password-gui = {
+      enable = mkEnableOption "The 1Password Desktop application with browser integration";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs._1password-gui;
+        defaultText = literalExpression "pkgs._1password-gui";
+        example = literalExpression "pkgs._1password-gui";
+        description = ''
+          The 1Password derivation to use. This can be used to upgrade from the stable release that we keep in nixpkgs to the betas.
+          '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    users.groups.onepassword = {};
+
+    security.wrappers = {
+      "1Password-BrowserSupport" =
+        { source = "${cfg.package}/share/1password/1Password-BrowserSupport";
+          owner = "root";
+          group = "onepassword";
+          setuid = false;
+          setgid = true;
+        };
+
+      "1Password-KeyringHelper" =
+        { source = "${cfg.package}/share/1password/1Password-KeyringHelper";
+          owner = "root";
+          group = "onepassword";
+          setuid = true;
+          setgid = true;
+        };
+    };
+
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

The Browser Integration feature in 1password gui requires a few setuid and setgid applications. This new module provides those applications and the a new onepassword group for their home.

This feature does not work on the current 8.5.0 release of 1Password, but does work on the 8.6.0 beta. Users will need to override the 1password-gui package like so:

```
let
  _1password-gui = let ver = "8.6.0-6.BETA";
    in pkgs._1password-gui.overrideAttrs ({ ... }: {
      version = ver;
      src = pkgs.fetchurl {
        url = "https://downloads.1password.com/linux/tar/beta/x86_64/1password-${ver}.x64.tar.gz";
        sha256 = "KJM2D9jwxzu9AYgVbbPbKYFM4hcuyPmxu7Gh83JcfhU=";
      };
    });
in
     programs._1password-gui = {
    enable = true;
    package = _1password-gui;
  };

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
