### PR TITLE
python3Packages.flowlogs_reader: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/flowlogs_reader/default.nix
+++ b/pkgs/development/python-modules/flowlogs_reader/default.nix
@@ -1,32 +1,48 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, isPy27
-, botocore
 , boto3
-, docutils
-, unittest2
-, mock
+, botocore
+, buildPythonPackage
+, fetchFromGitHub
+, parquet
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname = "flowlogs_reader";
-  version = "3.1.0";
-  disabled = isPy27;
+  pname = "flowlogs-reader";
+  version = "3.2.0";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "d99636423abc83bb4042d63edd56852ede9e2949cadcc3339eda8f3367826dd4";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "obsrvbl";
+    repo = pname;
+    # https://github.com/obsrvbl/flowlogs-reader/issues/57
+    rev = "fac4c6c63348ff67fd0a8f51d391ba7c9f59e5ed";
+    hash = "sha256-bGb2CLp33aIr0R/lBPWAF3CbtVTWpqmcvYgZ6bcARTc=";
   };
 
-  propagatedBuildInputs = [ botocore boto3 docutils ];
-  buildInputs = [ unittest2 mock ];
+  propagatedBuildInputs = [
+    botocore
+    boto3
+    parquet
+    python-dateutil
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "flowlogs_reader"
+  ];
 
   meta = with lib; {
     description = "Python library to make retrieving Amazon VPC Flow Logs from CloudWatch Logs a bit easier";
     homepage = "https://github.com/obsrvbl/flowlogs-reader";
-    maintainers = with maintainers; [ cransom ];
     license = licenses.asl20;
+    maintainers = with maintainers; [ cransom ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update to latest upstream release to 3.2.0.

Fix build (https://hydra.nixos.org/build/166305229)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
