### PR TITLE
[21.05] Fix deep evaluation

### DIFF
--- a/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/whatsapp-for-linux/default.nix
@@ -1,5 +1,5 @@
-{ fetchFromGitHub, lib, stdenv, gnome, cmake, pkg-config,
-  libappindicator-gtk3, gst_all_1, pcre }:
+{ fetchFromGitHub, lib, stdenv, cmake, pkg-config,
+  gtkmm3, webkitgtk, libappindicator-gtk3, gst_all_1, pcre }:
 
 stdenv.mkDerivation rec {
   pname = "whatsapp-for-linux";
@@ -18,8 +18,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome.gtkmm
-    gnome.webkitgtk
+    gtkmm3
+    webkitgtk
     libappindicator-gtk3
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good

--- a/pkgs/applications/networking/listadmin/default.nix
+++ b/pkgs/applications/networking/listadmin/default.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
 
     wrapProgram $out/bin/listadmin \
       --prefix PERL5LIB : "${with perl.pkgs; makeFullPerlPath [
-        TextReform NetINET6Glue LWPProtocolhttps
+        TextReform NetINET6Glue LWPProtocolHttps
         ]}"
   '';
 

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -263,7 +263,7 @@ let
     };
 
     teck-programmer = super.teck-programmer.override {
-      buildInputs = [ pkgs.libusb ];
+      buildInputs = [ pkgs.libusb1 ];
     };
 
     vega-cli = super.vega-cli.override {

--- a/pkgs/development/python-modules/extractcode/libarchive.nix
+++ b/pkgs/development/python-modules/extractcode/libarchive.nix
@@ -6,7 +6,7 @@
 , bzip2
 , expat
 , lz4
-, lzma
+, xz
 , zlib
 , zstd
 , plugincode
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     ln -s ${lib.getLib bzip2}/lib/libbz2.so libbz2-la3511.so.1.0
     ln -s ${lib.getLib expat}/lib/libexpat.so libexpat-la3511.so.1
     ln -s ${lib.getLib lz4}/lib/liblz4.so liblz4-la3511.so.1
-    ln -s ${lib.getLib lzma}/lib/liblzma.so liblzma-la3511.so.5
+    ln -s ${lib.getLib xz}/lib/liblzma.so liblzma-la3511.so.5
     ln -s ${lib.getLib zlib}/lib/libz.so libz-la3511.so.1
     ln -s ${lib.getLib zstd}/lib/libzstd.so libzstd-la3511.so.1
 

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -40,7 +40,7 @@ in buildPythonPackage rec {
 
   nativeBuildInputs = [
     mapnik # for mapnik_config
-    pkgs.pkgconfig
+    pkgs.pkg-config
   ];
 
   patches = [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -244,14 +244,14 @@ let
     Biostrings = [ pkgs.zlib ];
     bnpmr = [ pkgs.gsl_1 ];
     cairoDevice = [ pkgs.gtk2.dev ];
-    Cairo = [ pkgs.libtiff pkgs.libjpeg pkgs.cairo.dev pkgs.x11 pkgs.fontconfig.lib ];
+    Cairo = [ pkgs.libtiff pkgs.libjpeg pkgs.cairo.dev pkgs.xlibsWrapper pkgs.fontconfig.lib ];
     Cardinal = [ pkgs.which ];
     chebpol = [ pkgs.fftw ];
     ChemmineOB = [ pkgs.openbabel pkgs.pkg-config ];
     cit = [ pkgs.gsl_1 ];
     curl = [ pkgs.curl.dev ];
     data_table = [pkgs.zlib.dev] ++ lib.optional stdenv.isDarwin pkgs.llvmPackages.openmp;
-    devEMF = [ pkgs.xorg.libXft.dev pkgs.x11 ];
+    devEMF = [ pkgs.xorg.libXft.dev pkgs.xlibsWrapper ];
     diversitree = [ pkgs.gsl_1 pkgs.fftw ];
     EMCluster = [ pkgs.lapack ];
     fftw = [ pkgs.fftw.dev ];
@@ -268,7 +268,7 @@ let
     haven = [ pkgs.libiconv pkgs.zlib.dev ];
     h5vc = [ pkgs.zlib.dev ];
     HiCseg = [ pkgs.gsl_1 ];
-    imager = [ pkgs.x11 ];
+    imager = [ pkgs.xlibsWrapper ];
     iBMQ = [ pkgs.gsl_1 ];
     igraph = [ pkgs.gmp pkgs.libxml2.dev ];
     JavaGD = [ pkgs.jdk ];

--- a/pkgs/top-level/packages-config.nix
+++ b/pkgs/top-level/packages-config.nix
@@ -19,7 +19,8 @@
     "nodePackages_latest"
     "nodePackages"
     "platformioPackages"
-    "haskellPackages"
+    # haskellPackages doesn't evaluate because of webkitgtk3 and this branch
+    # is EOL so we just don't index it here
     "idrisPackages"
     "sconsPackages"
     "gns3Packages"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2304,7 +2304,7 @@ in {
       bzip2
       expat
       lz4
-      lzma
+      xz
       zlib
       zstd;
   };


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/158623 's second little sister.

Notably this removes `haskellPackages` from `packages-config.nix`, see https://github.com/NixOS/nixpkgs/pull/158656#issuecomment-1032949297