### PR TITLE
passExtensions.pass-audit: 1.1 -> 1.2

### DIFF
--- a/pkgs/tools/security/pass/extensions/audit/0001-Set-base-to-an-empty-value.patch
+++ b/pkgs/tools/security/pass/extensions/audit/0001-Set-base-to-an-empty-value.patch
@@ -1,0 +1,43 @@
+From a2d5d973f53efb11bdcaecbd0099df9714bc287f Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Tue, 8 Feb 2022 19:35:35 +0100
+Subject: [PATCH] Set `base` to an empty value
+
+`DESTDIR` ensures that everything lands in the correct location (i.e.
+the target store-path on Nix), within this path, everything should be
+moved into `/lib` and `/share`.
+---
+ setup.py | 17 ++---------------
+ 1 file changed, 2 insertions(+), 15 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 1f0a58b..f7baa41 100644
+--- a/setup.py
++++ b/setup.py
+@@ -8,21 +8,8 @@ from pathlib import Path
+ 
+ from setuptools import setup
+ 
+-share = Path(sys.prefix, 'share')
+-base = '/usr'
+-if os.uname().sysname == 'Darwin':
+-    base = '/usr/local'
+-lib = Path(base, 'lib', 'password-store', 'extensions')
+-
+-if '--user' in sys.argv:
+-    if 'PASSWORD_STORE_EXTENSIONS_DIR' in os.environ:
+-        lib = Path(os.environ['PASSWORD_STORE_EXTENSIONS_DIR'])
+-    else:
+-        lib = Path.home() / '.password-store' / '.extensions'
+-    if 'XDG_DATA_HOME' in os.environ:
+-        share = Path(os.environ['XDG_DATA_HOME'])
+-    else:
+-        share = Path.home() / '.local' / 'share'
++share = Path('share')
++lib = Path('lib', 'password-store', 'extensions')
+ 
+ setup(
+     data_files=[
+-- 
+2.33.1
+

--- a/pkgs/tools/security/pass/extensions/audit/default.nix
+++ b/pkgs/tools/security/pass/extensions/audit/default.nix
@@ -5,16 +5,17 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "pass-audit";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "roddhjav";
     repo = "pass-audit";
     rev = "v${version}";
-    sha256 = "1vapymgpab91kh798mirgs1nb7j9qln0gm2d3321cmsghhb7xs45";
+    sha256 = "sha256-xigP8LxRXITLF3X21zhWx6ooFNSTKGv46yFSt1dd4vs=";
   };
 
   patches = [
+    ./0001-Set-base-to-an-empty-value.patch
     ./0002-Fix-audit.bash-setup.patch
   ];
 
@@ -40,7 +41,8 @@ in stdenv.mkDerivation rec {
   installFlags = [ "DESTDIR=${placeholder "out"}" "PREFIX=" ];
   postInstall = ''
     wrapProgram $out/lib/password-store/extensions/audit.bash \
-      --prefix PYTHONPATH : "$out/lib/${pythonEnv.libPrefix}/site-packages"
+      --prefix PYTHONPATH : "$out/lib/${pythonEnv.libPrefix}/site-packages" \
+      --run "export COMMAND"
   '';
 
   meta = with lib; {


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLog: https://github.com/roddhjav/pass-audit/blob/v1.2/CHANGELOG.md#12---2022-01-30

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
