### PR TITLE
python39Packages.pytest-celery: switch to correct versioned github tarball

### DIFF
--- a/pkgs/development/python-modules/pytest-celery/default.nix
+++ b/pkgs/development/python-modules/pytest-celery/default.nix
@@ -1,21 +1,30 @@
-{ lib, buildPythonPackage, fetchPypi }:
+{ lib, buildPythonPackage, fetchFromGitHub }:
 
 buildPythonPackage rec {
   pname = "pytest-celery";
-  version = "0.0.0";
+  version = "0.1.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "cfd060fc32676afa1e4f51b2938f903f7f75d952186b8c6cf631628c4088f406";
+  format = "flit";
+
+  src = fetchFromGitHub {
+    owner = "celery";
+    repo = "pytest-celery";
+    rev = "v${version}";
+    sha256 = "sha256-vzWwkOS3BLOInaFDk+PegvEmC88ZZ1sG1CmHwhn7r9w=";
   };
 
-  patches = [ ./no-celery.patch ];
+  postPatch = ''
+    # avoid infinite recursion with celery
+    substituteInPlace pyproject.toml \
+      --replace '"celery >= 4.4.0"' ""
+  '';
 
-  doCheck = false; # This package has nothing to test or import.
+  # This package has nothing to test or import.
+  doCheck = false;
 
   meta = with lib; {
-    description = "pytest plugin for unittest subTest() support and subtests fixture";
-    homepage = "https://github.com/pytest-dev/pytest-subtests";
+    description = "Pytest plugin to enable celery.contrib.pytest";
+    homepage = "https://github.com/celery/pytest-celery";
     license = licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/pytest-celery/no-celery.patch
+++ b/pkgs/development/python-modules/pytest-celery/no-celery.patch
@@ -1,9 +1,0 @@
-This plugin is needed to test celery itself, so it can't depend on celery.
-
---- a/setup.py
-+++ b/setup.py
-@@ -6,3 +6,3 @@ from distutils.core import setup
- install_requires = \
--['celery >= 4.4.0']
-+[]
- 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
