### PR TITLE
Unbreak xine-lib, xine-ui and dvdstyler

### DIFF
--- a/pkgs/applications/video/dvdstyler/default.nix
+++ b/pkgs/applications/video/dvdstyler/default.nix
@@ -3,17 +3,21 @@
 , fetchurl
 , bison
 , cdrtools
-, docbook5
+, docbook_xml_dtd_412
+, docbook-xsl-nons
 , dvdauthor
 , dvdplusrwtools
 , ffmpeg
 , flex
 , fontconfig
 , gettext
+, glib
+, gobject-introspection
 , libexif
-, makeWrapper
+, libjpeg
 , pkg-config
-, wxGTK30
+, wrapGAppsHook
+, wxGTK30-gtk3 # crash with wxGTK30 with GTK2 compat
 , wxSVG
 , xine-ui
 , xmlto
@@ -37,43 +41,50 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    bison
+    docbook_xml_dtd_412
+    docbook-xsl-nons
+    flex
+    gettext
+    gobject-introspection
     pkg-config
+    wrapGAppsHook
+    xmlto
+    zip
   ];
   buildInputs = [
-    bison
     cdrtools
-    docbook5
     dvdauthor
     dvdplusrwtools
     ffmpeg
-    flex
     fontconfig
-    gettext
+    glib
     libexif
-    makeWrapper
+    libjpeg
     wxSVG
-    wxGTK30
+    wxGTK30-gtk3
     xine-ui
-    xmlto
-    zip
  ]
   ++ optionals dvdisasterSupport [ dvdisaster ]
   ++ optionals udevSupport [ udev ]
   ++ optionals dbusSupport [ dbus ]
   ++ optionals thumbnailSupport [ libgnomeui ];
 
+  enableParallelBuilding = true;
 
-  postInstall = let
-    binPath = makeBinPath [
+  preFixup = let
+    binPath = makeBinPath ([
       cdrtools
       dvdauthor
       dvdplusrwtools
-    ]; in
+    ] ++ optionals dvdisasterSupport [ dvdisaster ]);
+    in
     ''
-       wrapProgram $out/bin/dvdstyler --prefix PATH ":" "${binPath}"
-    '';
+      gappsWrapperArgs+=(
+        --prefix PATH : "${binPath}"
+      )
+   '';
 
-  enableParallelBuilding = true;
 
   meta = with lib; {
     homepage = "https://www.dvdstyler.org/";

--- a/pkgs/applications/video/xine-ui/default.nix
+++ b/pkgs/applications/video/xine-ui/default.nix
@@ -1,6 +1,8 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
+, autoreconfHook
 , curl
 , libjpeg
 , libpng
@@ -22,7 +24,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sjgtB1xysbEAOeDpAxDMhsjZEDWMU1We2C09WEIB9cU=";
   };
 
+  patches = [
+    (fetchpatch {
+      # Fix build on aarch64
+      name = "xine-ui_FTBS_aarch64.patch";
+      url = "https://salsa.debian.org/debian/xine-ui/-/raw/b2f04f64947a8975a805950e7e67b15cb44007ef/debian/patches/backport/0003-Fix-build.patch";
+      sha256 = "03f8nkm7q11v5vssl1bj500ja4ljz4y752mfk22k2g4djkwimx62";
+    })
+  ];
+
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
     shared-mime-info
   ];
@@ -57,7 +69,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "http://xinehq.de/";
+    homepage = "http://xine.sourceforge.net/";
     description = "Xlib-based frontend for Xine video player";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];

--- a/pkgs/development/libraries/xine-lib/default.nix
+++ b/pkgs/development/libraries/xine-lib/default.nix
@@ -1,8 +1,10 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , aalib
 , alsa-lib
+, autoconf
 , ffmpeg
 , flac
 , libGL
@@ -33,7 +35,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-71GyHRDdoQRfp9cRvZFxz9rwpaKHQjO88W/98o7AcAU=";
   };
 
+  patches = [
+    # Fix build with libcaca 0.99.beta20 ; remove for xine-lib 1.2.12
+    (fetchpatch {
+      name = "xine-lib-libcaca-0.99.beta20-fix.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/209ae10d59d29c13633b75aa327cf937f3ff0725/trunk/010-xine-lib-libcaca-0.99.beta20-fix.patch";
+      sha256 = "088141x1yp84y09x3s01v21yzas2bwavxz9v30z5hyq6c3syrmgr";
+    })
+    # Fix build with ffmpeg 5.0 ; remove for xine-lib 1.2.12
+    (fetchpatch {
+      name = "xine-lib-ffmpeg-5.0-fix.patch";
+      url = "https://raw.githubusercontent.com/archlinux/svntogit-community/209ae10d59d29c13633b75aa327cf937f3ff0725/trunk/020-xine-lib-ffmpeg-5.0-fix.patch";
+      sha256 = "15ff15bqxq1nqqazfbmfq6swrdjr2raxyq7hx6k0r61izhf0g8ld";
+    })
+  ];
+
   nativeBuildInputs = [
+    autoconf
     pkg-config
     perl
   ];
@@ -71,7 +89,7 @@ stdenv.mkDerivation rec {
 
 
   meta = with lib; {
-    homepage = "http://www.xinehq.de/";
+    homepage = "http://xine.sourceforge.net/";
     description = "A high-performance, portable and reusable multimedia playback engine";
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     maintainers = with maintainers; [ AndersonTorres ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`xine-lib` is currently broken on master since the latest libcaca bump. And it will also break with ffmpeg 5.x which is currently on staging.
This reuses patches from Arch for both problems.

`dvdstyler` is broken on master and on 21.11 because it crashes on startup because of a symbols conflict between GTK2 and GTK3. It works only with wxGTK30 without GTK2.
It was also missing wrapping for Gnome apps.
(I will later backport the second commit)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
