### PR TITLE
archivebox: refactor and fix

### DIFF
--- a/pkgs/applications/misc/archivebox/default.nix
+++ b/pkgs/applications/misc/archivebox/default.nix
@@ -1,42 +1,34 @@
 { lib
-, buildPythonApplication
-, fetchPypi
-, requests
-, mypy-extensions
-, django_3
-, django-extensions
-, dateparser
-, youtube-dl
-, python-crontab
-, croniter
-, w3lib
-, ipython
+, python3
 }:
 
 let
-  django_3' = django_3.overridePythonAttrs (old: rec {
-    pname = "Django";
-    version = "3.1.7";
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-Ms55Lum2oMu+w0ASPiKayfdl3/jCpK6SR6FLK6OjZac=";
+  python = python3.override {
+    packageOverrides = self: super: {
+      django = super.django_3.overridePythonAttrs (old: rec {
+        version = "3.1.7";
+        src = old.src.override {
+          inherit version;
+          sha256 = "sha256-Ms55Lum2oMu+w0ASPiKayfdl3/jCpK6SR6FLK6OjZac=";
+        };
+      });
     };
-  });
+  };
 in
 
-buildPythonApplication rec {
+python.pkgs.buildPythonApplication rec {
   pname = "archivebox";
   version = "0.6.2";
 
-  src = fetchPypi {
+  src = python.pkgs.fetchPypi {
     inherit pname version;
     sha256 = "sha256-zHty7lTra6yab9d0q3EqsPG3F+lrnZL6PjQAbL1A2NY=";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python.pkgs; [
     requests
     mypy-extensions
-    django_3'
+    django
     django-extensions
     dateparser
     youtube-dl

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1332,7 +1332,7 @@ with pkgs;
 
   ArchiSteamFarm = callPackage ../applications/misc/ArchiSteamFarm { };
 
-  archivebox = python3Packages.callPackage ../applications/misc/archivebox { };
+  archivebox = callPackage ../applications/misc/archivebox { };
 
   archivemount = callPackage ../tools/filesystems/archivemount { };
 


### PR DESCRIPTION
###### Motivation for this change
Archivebox didn't build due to conflicting dependency on django.
Possibly related to Issue https://github.com/NixOS/nixpkgs/issues/154950 that was closed by PR https://github.com/NixOS/nixpkgs/pull/154153 

###### Things done
Resolves conflict by overriding django dependency for all dependencies.
Updated commit message and using packageOverrides as requested by reviewers on previous now closed PR https://github.com/NixOS/nixpkgs/pull/156520

Basic functionality tested and working.
Nothing else should depend on archivebox.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))

- [ ] Tested, as applicable:
  - [X] NixOS
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
