### PR TITLE
python3Packages.snakemake: init at 6.15.2

### DIFF
--- a/pkgs/development/python-modules/snakemake/default.nix
+++ b/pkgs/development/python-modules/snakemake/default.nix
@@ -1,0 +1,76 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, appdirs
+, configargparse
+, connection-pool
+, datrie
+, filelock
+, GitPython
+, jsonschema
+, nbformat
+, psutil
+, pulp
+, pyyaml
+, ratelimiter
+, smart-open
+, stopit
+, tabulate
+, toposort
+, wrapt
+, pandas
+, pytestCheckHook
+, requests-mock
+}:
+
+buildPythonPackage rec {
+  pname = "snakemake";
+  version = "6.15.2";
+
+  src = fetchFromGitHub {
+    owner = "snakemake";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1s56gv5bzf0y5dfzr4mh5m6b7nxqvbawnbw5h01pa9gfd7ppjrdr";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    configargparse
+    connection-pool
+    datrie
+    filelock
+    GitPython
+    jsonschema
+    nbformat
+    psutil
+    pulp
+    pyyaml
+    ratelimiter
+    smart-open
+    stopit
+    tabulate
+    toposort
+    wrapt
+  ];
+
+  checkInputs = [
+    pandas
+    pytestCheckHook
+    requests-mock
+  ];
+
+  disabledTestPaths = [
+    "tests/test_tes.py"
+    "tests/test_tibanna.py"
+  ];
+
+  pythonImportsCheck = [ "snakemake" ];
+
+  meta = with lib; {
+    homepage = "https://snakemake.readthedocs.io/";
+    description = "The Snakemake workflow management system is a tool to create reproducible and scalable data analyses.";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wd15 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9161,6 +9161,8 @@ in {
 
   snakebite = callPackage ../development/python-modules/snakebite { };
 
+  snakemake = callPackage ../development/python-modules/snakemake { };
+
   snakeviz = callPackage ../development/python-modules/snakeviz { };
 
   snapcast = callPackage ../development/python-modules/snapcast { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add Snakemake workflow tool, see https://snakemake.readthedocs.io

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
