### PR TITLE
etcher: 1.6.0 -> 1.7.3, downgrade electron to v12

### DIFF
--- a/pkgs/tools/misc/etcher/default.nix
+++ b/pkgs/tools/misc/etcher/default.nix
@@ -14,8 +14,8 @@ let
   throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
 
   sha256 = {
-    "x86_64-linux" = "sha256-n8i4ZqjugeUfXpTzVgIwVomfPk6HvPEbTZLe/jFgwFg=";
-    "i686-linux" = "sha256-lLGfhW6el2ZOcaykH1kTjGldXo7/0q5O8QnslnDlWAQ=";
+    "x86_64-linux" = "1yj6ybc99nqpzv2wjmvi7khfb5viwlb2rbjdpvgr4pmlzmiv7n2k";
+    "i686-linux" = "09ddcqxw1jhl8v461ngdgj2l4infn2xiwvaqxi6qp3swci627vmz";
   }."${system}" or throwSystem;
 
   arch = {
@@ -27,7 +27,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "etcher";
-  version = "1.6.0";
+  version = "1.7.3";
 
   src = fetchurl {
     url = "https://github.com/balena-io/etcher/releases/download/v${version}/balena-etcher-electron_${version}_${arch}.deb";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5142,7 +5142,7 @@ with pkgs;
   escrotum = callPackage ../tools/graphics/escrotum { };
 
   etcher = callPackage ../tools/misc/etcher {
-    electron = electron_14;
+    electron = electron_12;
   };
 
   ethercalc = callPackage ../servers/web-apps/ethercalc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
* the package needed to be updated to the latest upstream version (1.7.3).
* on 1.6.0, as well as 1.7.3 there was a white screen and the application was unusable:

Relevant issues (nixpkgs):
- #153537

Relevant issues (upstream):
- https://github.com/balena-io/etcher/issues/3558
- https://github.com/balena-io/etcher/issues/2866
- https://github.com/balena-io/etcher/issues/3536
- https://github.com/balena-io/etcher/issues/3675

###### Things done

* According to [a dev from upstream repo](https://github.com/balena-io/etcher/pull/3697#issuecomment-1031674053), their master branch is not yet ready for the Electron 13, due to breaking changes regarding remote (relevant documentation: https://stackoverflow.com/questions/37884130/electron-remote-is-undefined ). Considering this, changed `electron` version for `etcher` from 14 to 12.

* On a `master` build, it appears that Electron version 12.2.3 is marked EOL. This makes the package “insecure”, however there are no other alternatives at the moment since the issue has to be fixed upstream (see https://github.com/balena-io/etcher/pull/3697#issuecomment-1031674053)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
