### PR TITLE
[21.11] python3Packages.pillow: add patches for CVE-2022-22817 (part 2) & CVE-2022-24303

### DIFF
--- a/pkgs/development/python-modules/pillow/default.nix
+++ b/pkgs/development/python-modules/pillow/default.nix
@@ -31,6 +31,26 @@ import ./generic.nix (rec {
       excludes = [ "docs/releasenotes/9.0.0.rst" ];
       sha256 = "13va7lmja9bkp1d8bnwpns9nh7p31kal89cvfky4r95lx0ckrnfv";
     })
+    (fetchpatch {
+      name = "CVE-2022-22817.part-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/c930be0758ac02cf15a2b8d5409d50d443550581.patch";
+      sha256 = "123ihfpg86zxlyvb22d5khkrqwv7q3chi2q7kkjyk1k6r84nz4ad";
+    })
+    (fetchpatch {
+      name = "CVE-2022-24303.part-1.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/427221ef5f19157001bf8b1ad7cfe0b905ca8c26.patch";
+      sha256 = "0i7sys6argz320fzyny6fzps9kwvni6i0j3wa97j04k0vigdd5rp";
+    })
+    (fetchpatch {
+      name = "CVE-2022-24303.part-2.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/ca0b58521881b95e47ea49d960d13d1c3dac823d.patch";
+      sha256 = "13f61ab6a6nnzhig0jbsnlmkzvbslpaycrc2iiqmw91glxbw57bh";
+    })
+    (fetchpatch {
+      name = "CVE-2022-24303.part-3.patch";
+      url = "https://github.com/python-pillow/Pillow/commit/02affaa491df37117a7562e6ba6ac52c4c871195.patch";
+      sha256 = "04n0l2k6ikhh15ix8f0dwxx2jk59r9y3z0ix6jz3vz1yq0as16c7";
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Backport of the patches fixing these issues in https://github.com/python-pillow/Pillow/releases/tag/9.0.1

See #158475 for unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
