### PR TITLE
gnomeExtensions.pop-shell: fix executables

### DIFF
--- a/pkgs/desktops/gnome/extensions/pop-shell/default.nix
+++ b/pkgs/desktops/gnome/extensions/pop-shell/default.nix
@@ -26,6 +26,16 @@ stdenv.mkDerivation rec {
     extensionPortalSlug = "pop-shell";
   };
 
+  postPatch = ''
+    for file in */main.js; do
+      substituteInPlace $file --replace "gjs" "${gjs}/bin/gjs"
+    done
+  '';
+
+  preFixup = ''
+    chmod +x $out/share/gnome-shell/extensions/pop-shell@system76.com/*/main.js
+  '';
+
   meta = with lib; {
     description = "Keyboard-driven layer for GNOME Shell";
     license = licenses.gpl3Only;

--- a/pkgs/desktops/gnome/extensions/pop-shell/fix-gjs.patch
+++ b/pkgs/desktops/gnome/extensions/pop-shell/fix-gjs.patch
@@ -1,20 +1,3 @@
-diff --git a/src/color_dialog/src/main.ts b/src/color_dialog/src/main.ts
-index 9522499..9911530 100644
---- a/src/color_dialog/src/main.ts
-+++ b/src/color_dialog/src/main.ts
-@@ -1,4 +1,4 @@
--#!/usr/bin/gjs
-+#!/usr/bin/env gjs
- 
- imports.gi.versions.Gtk = '3.0';
- 
-@@ -84,4 +84,4 @@ function launch_color_dialog() {
- 
- Gtk.init(null);
- 
--launch_color_dialog()
-\ No newline at end of file
-+launch_color_dialog()
 diff --git a/src/extension.ts b/src/extension.ts
 index 7417c46..00d5829 100644
 --- a/src/extension.ts
@@ -28,23 +11,6 @@ index 7417c46..00d5829 100644
  
          if (ipc) {
              const generator = (stdout: any, res: any) => {
-diff --git a/src/floating_exceptions/src/main.ts b/src/floating_exceptions/src/main.ts
-index f298ec7..87a6bc4 100644
---- a/src/floating_exceptions/src/main.ts
-+++ b/src/floating_exceptions/src/main.ts
-@@ -1,4 +1,4 @@
--#!/usr/bin/gjs
-+#!/usr/bin/env gjs
- 
- imports.gi.versions.Gtk = '3.0'
- 
-@@ -329,4 +329,4 @@ function main() {
-     Gtk.main()
- }
- 
--main()
-\ No newline at end of file
-+main()
 diff --git a/src/panel_settings.ts b/src/panel_settings.ts
 index 83ff56c..1bc1e98 100644
 --- a/src/panel_settings.ts


### PR DESCRIPTION
The "Floating Window Exceptions" and "Show Active Hint" features of pop-shell are currently broken because the floating_exceptions and color_dialog scripts have an unpatched shebang and unset executable bit. 
This fixes the shebang and sets the executable bit for the color_dialog and floating_exceptions executables. Fixes #156033

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
