### PR TITLE
mysql80: fix Darwin build

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -20,6 +20,8 @@ self = stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
     substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+    substituteInPlace cmake/fido2.cmake \
+    --replace ''$\{MY_PKG_CONFIG_EXECUTABLE\} "${pkg-config}/bin/pkg-config"
   '';
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Fixes build on Darwin. Fixes https://github.com/NixOS/nixpkgs/issues/159191.

Build failure:
```
-- Looking for fido.h
-- Looking for fido.h - found
-- FIDO_LIBRARY /nix/store/8z6sm8c2x5mdmqycarqd0rwib11nwqic-libfido2-1.9.0/lib/libfido2.dylib
-- FIDO_VERSION (system) is
CMake Error at cmake/fido2.cmake:156 (MESSAGE):
  FIDO version must be at least 1.4.0, found .

  Please use -DWITH_FIDO=bundled
Call Stack (most recent call first):
  CMakeLists.txt:1745 (MYSQL_CHECK_FIDO)
```

I'm not entirely sure why without this change it doesn't get a version number from the `pkg-build` command. The line in question for reference:
https://github.com/mysql/mysql-server/blob/6846e6b2f72931991cc9fd589dc9946ea2ab58c9/cmake/fido2.cmake#L38

After this change:
```
-- Looking for fido.h
-- Looking for fido.h - found
-- FIDO_LIBRARY /nix/store/8z6sm8c2x5mdmqycarqd0rwib11nwqic-libfido2-1.9.0/lib/libfido2.dylib
-- FIDO_VERSION (system) is 1.9.0
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).