### PR TITLE
contrast: 0.0.3 → 0.0.5

### DIFF
--- a/pkgs/applications/accessibility/contrast/default.nix
+++ b/pkgs/applications/accessibility/contrast/default.nix
@@ -2,25 +2,23 @@
 , lib
 , fetchFromGitLab
 , cairo
-, dbus
 , desktop-file-utils
 , gettext
 , glib
-, gtk3
-, libhandy_0
-, libsass
+, gtk4
+, libadwaita
 , meson
 , ninja
 , pango
 , pkg-config
 , python3
 , rustPlatform
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "contrast";
-  version = "0.0.3";
+  version = "0.0.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -28,13 +26,13 @@ stdenv.mkDerivation rec {
     owner = "design";
     repo = "contrast";
     rev = version;
-    sha256 = "0kk3mv7a6y258109xvgicmsi0lw0rcs00gfyivl5hdz7qh47iccy";
+    sha256 = "cypSbqLwSmauOoWOuppWpF3hvrxiqmkLspxAWzvlUC0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-ePkPiWGn79PHrMsSEql5OXZW5uRMdTP+w0/DCcm2KG4=";
+    hash = "sha256-W4FyqwJpimf0isQRCq9TegpTQPQfsumx40AFQCFG5VQ=";
   };
 
   nativeBuildInputs = [
@@ -47,29 +45,31 @@ stdenv.mkDerivation rec {
     rustPlatform.rust.cargo
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
-    wrapGAppsHook
+    wrapGAppsHook4
     glib # for glib-compile-resources
   ];
 
   buildInputs = [
     cairo
-    dbus
     glib
-    gtk3
-    libhandy_0
-    libsass
+    gtk4
+    libadwaita
     pango
   ];
 
   postPatch = ''
     patchShebangs build-aux/meson_post_install.py
+    # https://gitlab.gnome.org/World/design/contrast/-/merge_requests/23
+    substituteInPlace build-aux/meson_post_install.py \
+      --replace "gtk-update-icon-cache" "gtk4-update-icon-cache"
   '';
 
   meta = with lib; {
     description = "Checks whether the contrast between two colors meet the WCAG requirements";
     homepage = "https://gitlab.gnome.org/World/design/contrast";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.unix;
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change

https://gitlab.gnome.org/World/design/contrast/-/compare/0.0.3...0.0.4
https://gitlab.gnome.org/World/design/contrast/-/compare/1491dd15...0.0.4
https://gitlab.gnome.org/World/design/contrast/-/compare/0.0.4...0.0.5

Maybe...

- ... libhandy_0 is no longer needed after [ported to GTK4](https://gitlab.gnome.org/World/design/contrast/-/commit/78478151b07cac37f5cddf52f89c86c400842b5f).
- ... libsass is no longer needed after [this change](https://gitlab.gnome.org/World/design/contrast/-/commit/894f423d7f6c124940b3b9b1ef29b1eaeac48439).
- ... the license is gpl3Plus as mentioned [here](https://gitlab.gnome.org/World/design/contrast/-/blob/0.0.5/meson.build#L4).
- ... dbus is no longer need after [switched to zbus](https://gitlab.gnome.org/World/design/contrast/-/commit/33b28cc651ecea7f61be1a081107379c5511369a).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested picking a color from screen.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
