### PR TITLE
coqPackages.VST: 2.8 → 2.9

### DIFF
--- a/pkgs/development/coq-modules/ITree/default.nix
+++ b/pkgs/development/coq-modules/ITree/default.nix
@@ -5,7 +5,7 @@ with lib; mkCoqDerivation rec {
   owner = "DeepSpec";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.10" "8.14";  out = "4.0.0"; }
+    { case = range "8.10" "8.15";  out = "4.0.0"; }
   ] null;
   release."4.0.0".sha256 = "0h5rhndl8syc24hxq1gch86kj7mpmgr89bxp2hmf28fd7028ijsm";
   releaseRev = v: "${v}";

--- a/pkgs/development/coq-modules/VST/default.nix
+++ b/pkgs/development/coq-modules/VST/default.nix
@@ -1,5 +1,7 @@
 { lib, mkCoqDerivation, coq, compcert, ITree, version ? null }:
 
+with lib;
+
 # A few modules that are not built and installed by default
 #  but that may be useful to some users.
 # They depend on ITree.
@@ -7,12 +9,15 @@ let extra_floyd_files = [
   "ASTsize.v"
   "io_events.v"
   "powerlater.v"
-  "printf.v"
+  ]
+  # floyd/printf.v is broken in VST 2.9
+  ++ optional (!versions.isGe "8.13" coq.coq-version) "printf.v"
+  ++ [
   "quickprogram.v"
   ];
 in
 
-with lib; mkCoqDerivation {
+mkCoqDerivation {
   pname = "coq${coq.coq-version}-VST";
   namePrefix = [];
   displayVersion = { coq = false; };
@@ -20,8 +25,10 @@ with lib; mkCoqDerivation {
   repo = "VST";
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.13" "8.15"; out = "2.9"; }
     { case = range "8.12" "8.13"; out = "2.8"; }
   ] null;
+  release."2.9".sha256 = "sha256:1adwzbl1pprrrwrm7cm493098fizxanxpv7nyfbvwdhgbhcnv6qf";
   release."2.8".sha256 = "sha256-cyK88uzorRfjapNQ6XgQEmlbWnDsiyLve5po1VG52q0=";
   releaseRev = v: "v${v}";
   extraBuildInputs = [ ITree ];

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -16,7 +16,8 @@ let compcert = mkCoqDerivation rec {
 
   defaultVersion =  with versions; switch coq.version [
       { case = range "8.8" "8.11"; out = "3.8"; }
-      { case = range "8.12" "8.14"; out = "3.10"; }
+      { case = isEq "8.12"       ; out = "3.9"; }
+      { case = range "8.12" "8.15"; out = "3.10"; }
     ] null;
 
   release = {
@@ -106,12 +107,17 @@ compcert.overrideAttrs (o:
           })
         ];
       }
-      { cases = [ (isEq "8.14") "3.10" ];
+      { cases = [ (range "8.14" "8.15") "3.10" ];
         out = [
           # Support for Coq 8.14.1
           (fetchpatch {
             url = "https://github.com/AbsInt/CompCert/commit/a79f0f99831aa0b0742bf7cce459cc9353bd7cd0.patch";
             sha256 = "sha256:0g20x8gfzvplpad9y9vr1p33k6qv6rsp691x6687v9ffvz7zsz94";
+          })
+          # Support for Coq 8.15.0
+          (fetchpatch {
+            url = "https://github.com/AbsInt/CompCert/commit/a882f78c069f7337dd9f4abff117d4df98ef38a6.patch";
+            sha256 = "sha256:16i87s608fj9ni7cvd5wrd7gicqniad7w78wi26pxdy0pacl7bjg";
           })
         ];
       }

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -96,9 +96,7 @@ let
       topology = callPackage ../development/coq-modules/topology {};
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
-      VST = callPackage ../development/coq-modules/VST {
-        compcert = self.compcert.override { version = "3.9"; };
-      };
+      VST = callPackage ../development/coq-modules/VST {};
       zorns-lemma = callPackage ../development/coq-modules/zorns-lemma {};
       filterPackages = doesFilter: if doesFilter then filterCoqPackages self else self;
     };


### PR DESCRIPTION
###### Motivation for this change

Support for Coq 8.15

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
