### PR TITLE
ganttproject-bin: 2.8.10 -> 3.1.31

### DIFF
--- a/pkgs/applications/misc/ganttproject-bin/default.nix
+++ b/pkgs/applications/misc/ganttproject-bin/default.nix
@@ -1,19 +1,22 @@
-{ lib, stdenv, fetchzip, makeDesktopItem, makeWrapper
-, jre
+{ lib
+, stdenv
+, fetchzip
+, makeDesktopItem
+, makeWrapper
+, openjdk11
 }:
 
 stdenv.mkDerivation rec {
   pname = "ganttproject-bin";
-  version = "2.8.10";
+  version = "3.1.3100";
 
-  src = let build = "r2364"; in fetchzip {
-    sha256 = "0cclgyqv4f9pjsdlh93cqvgbzrp8ajvrpc2xszs03sknqz2kdh7r";
-    url = "https://dl.ganttproject.biz/ganttproject-${version}/"
-        + "ganttproject-${version}-${build}.zip";
+  src = fetchzip {
+    sha256 = "sha256-hw2paak0P670/kemiuqYHIaN0uUtkVKy+AX2X7OdnJ4=";
+    url = "https://dl.ganttproject.biz/ganttproject-${version}/ganttproject-${version}.zip";
   };
 
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ jre ];
+  buildInputs = [ openjdk11 ];
 
   installPhase = let
 
@@ -27,9 +30,7 @@ stdenv.mkDerivation rec {
       categories = "Office;";
     };
 
-    javaOptions = [
-      "-Dawt.useSystemAAFontSettings=on"
-    ];
+    javaOptions = [ "-Dawt.useSystemAAFontSettings=on" ];
 
   in ''
     mkdir -pv "$out/share/ganttproject"
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
 
     mkdir -pv "$out/bin"
     wrapProgram "$out/share/ganttproject/ganttproject" \
-      --set JAVA_HOME "${jre}" \
+      --set JAVA_HOME "${openjdk11}" \
       --set _JAVA_OPTIONS "${builtins.toString javaOptions}"
 
     mv -v "$out/share/ganttproject/ganttproject" "$out/bin"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
