### PR TITLE
[21.11] pythonPackages.cchardet: fix build on non-x86_64

### DIFF
--- a/pkgs/development/python-modules/cchardet/default.nix
+++ b/pkgs/development/python-modules/cchardet/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , fetchPypi
 , python
@@ -14,9 +15,32 @@ buildPythonPackage rec {
     sha256 = "c428b6336545053c2589f6caf24ea32276c6664cb86db817e03a94c60afa0eaf";
   };
 
+  pythonImportsCheck = [
+    "cchardet"
+  ];
+
   checkInputs = [ nose ];
+
+  # on non x86-64 some charsets are identified as their superset, so we skip these tests (last checked with version 2.1.7)
+  preCheck = ''
+    cp -R src/tests $TMPDIR
+    pushd $TMPDIR
+  '' + lib.optionalString (stdenv.hostPlatform.system != "x86_64-linux") ''
+    rm $TMPDIR/tests/testdata/th/tis-620.txt  # identified as iso-8859-11, which is fine for all practical purposes
+    rm $TMPDIR/tests/testdata/ga/iso-8859-1.txt  # identified as windows-1252, which is fine for all practical purposes
+    rm $TMPDIR/tests/testdata/fi/iso-8859-1.txt  # identified as windows-1252, which is fine for all practical purposes
+  '';
+
   checkPhase = ''
-    ${python.interpreter} setup.py nosetests
+    runHook preCheck
+
+    nosetests
+
+    runHook postCheck
+  '';
+
+  postCheck = ''
+    popd
   '';
 
   meta = {


### PR DESCRIPTION
(cherry picked from commit 34afacfd7833cf7ab2dc7f7213d4fc73d0bc23d8)
plus: align python test invocation with master

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Manual backport was required by https://github.com/NixOS/nixpkgs/pull/158349#issuecomment-1032439787

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
