### PR TITLE
rtabmap: init at unstable-2022-02-07

### DIFF
--- a/pkgs/applications/video/rtabmap/0001-remove-printer-support.patch
+++ b/pkgs/applications/video/rtabmap/0001-remove-printer-support.patch
@@ -1,0 +1,139 @@
+From c04ce502d29f7769efbff730d1f9060b8c24629a Mon Sep 17 00:00:00 2001
+From: ckie <git-525ff67@ckie.dev>
+Date: Tue, 8 Feb 2022 19:18:49 +0200
+Subject: [PATCH] remove printer support
+
+---
+ app/src/CMakeLists.txt       |  4 ++--
+ guilib/src/CMakeLists.txt    |  4 ++--
+ guilib/src/GraphViewer.cpp   | 12 +-----------
+ guilib/src/ImageView.cpp     | 16 ----------------
+ guilib/src/utilite/UPlot.cpp |  9 ---------
+ 5 files changed, 5 insertions(+), 40 deletions(-)
+
+diff --git a/app/src/CMakeLists.txt b/app/src/CMakeLists.txt
+index b20a07d4..2cad8c1e 100644
+--- a/app/src/CMakeLists.txt
++++ b/app/src/CMakeLists.txt
+@@ -63,9 +63,9 @@ ENDIF()
+ TARGET_LINK_LIBRARIES(rtabmap rtabmap_core rtabmap_gui rtabmap_utilite ${LIBRARIES})
+ IF(Qt5_FOUND)
+     IF(Qt5Svg_FOUND)
+-        QT5_USE_MODULES(rtabmap Widgets Core Gui Svg PrintSupport)
++        QT5_USE_MODULES(rtabmap Widgets Core Gui Svg)
+     ELSE()
+-        QT5_USE_MODULES(rtabmap Widgets Core Gui PrintSupport)
++        QT5_USE_MODULES(rtabmap Widgets Core Gui)
+     ENDIF()
+ ENDIF(Qt5_FOUND)
+ 
+diff --git a/guilib/src/CMakeLists.txt b/guilib/src/CMakeLists.txt
+index 3711205b..a393aa25 100644
+--- a/guilib/src/CMakeLists.txt
++++ b/guilib/src/CMakeLists.txt
+@@ -208,9 +208,9 @@ ADD_LIBRARY(rtabmap_gui ${SRC_FILES})
+ TARGET_LINK_LIBRARIES(rtabmap_gui rtabmap_core rtabmap_utilite ${LIBRARIES})
+ IF(Qt5_FOUND)
+     IF(Qt5Svg_FOUND)
+-        QT5_USE_MODULES(rtabmap_gui Widgets Core Gui Svg PrintSupport)
++        QT5_USE_MODULES(rtabmap_gui Widgets Core Gui Svg)
+     ELSE()
+-        QT5_USE_MODULES(rtabmap_gui Widgets Core Gui PrintSupport)
++        QT5_USE_MODULES(rtabmap_gui Widgets Core Gui)
+     ENDIF()
+ ENDIF(Qt5_FOUND)
+ 
+diff --git a/guilib/src/GraphViewer.cpp b/guilib/src/GraphViewer.cpp
+index 58907c34..7b41061f 100644
+--- a/guilib/src/GraphViewer.cpp
++++ b/guilib/src/GraphViewer.cpp
+@@ -38,7 +38,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <QtGui/QDesktopServices>
+ #include <QtGui/QContextMenuEvent>
+ #include <QColorDialog>
+-#include <QPrinter>
+ #include <QFileDialog>
+ #ifdef QT_SVG_LIB
+ #include <QtSvg/QSvgGenerator>
+@@ -2011,16 +2010,7 @@ void GraphViewer::contextMenuEvent(QContextMenuEvent * event)
+ 				this->scene()->setSceneRect(this->scene()->itemsBoundingRect());  // Re-shrink the scene to it's bounding contents
+ 				QSize sceneSize = this->scene()->sceneRect().size().toSize();
+ 
+-				if(QFileInfo(filePath).suffix().compare("pdf") == 0)
+-				{
+-					QPrinter printer(QPrinter::HighResolution);
+-					printer.setOrientation(QPrinter::Portrait);
+-					printer.setOutputFileName( filePath );
+-					QPainter p(&printer);
+-					scene()->render(&p);
+-					p.end();
+-				}
+-				else if(QFileInfo(filePath).suffix().compare("svg") == 0)
++				if(QFileInfo(filePath).suffix().compare("svg") == 0)
+ 				{
+ #ifdef QT_SVG_LIB
+ 					QSvgGenerator svgGen;
+diff --git a/guilib/src/ImageView.cpp b/guilib/src/ImageView.cpp
+index 714f2d36..887e7bdc 100644
+--- a/guilib/src/ImageView.cpp
++++ b/guilib/src/ImageView.cpp
+@@ -37,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <QInputDialog>
+ #include <QVBoxLayout>
+ #include <QColorDialog>
+-#include <QPrinter>
+ #include <QGraphicsRectItem>
+ #include "rtabmap/utilite/ULogger.h"
+ #include "rtabmap/gui/KeypointItem.h"
+@@ -843,21 +842,6 @@ void ImageView::contextMenuEvent(QContextMenuEvent * e)
+ 				}
+ 
+ 				_savedFileName = text;
+-				if(QFileInfo(text).suffix().compare("pdf") == 0)
+-				{
+-					QPrinter printer(QPrinter::HighResolution);
+-					printer.setOrientation(QPrinter::Portrait);
+-					printer.setOutputFileName( text );
+-					QPainter p(&printer);
+-					p.begin(&printer);
+-					double xscale = printer.pageRect().width()/double(_graphicsView->sceneRect().width());
+-					double yscale = printer.pageRect().height()/double(_graphicsView->sceneRect().height());
+-					double scale = qMin(xscale, yscale);
+-					p.scale(scale, scale);
+-					_graphicsView->scene()->render(&p, _graphicsView->sceneRect(), _graphicsView->sceneRect());
+-					p.end();
+-				}
+-				else
+ 				{
+ 					QImage img(_graphicsView->sceneRect().width(), _graphicsView->sceneRect().height(), QImage::Format_ARGB32_Premultiplied);
+ 					QPainter p(&img);
+diff --git a/guilib/src/utilite/UPlot.cpp b/guilib/src/utilite/UPlot.cpp
+index 1b11c65e..8bf94841 100644
+--- a/guilib/src/utilite/UPlot.cpp
++++ b/guilib/src/utilite/UPlot.cpp
+@@ -42,7 +42,6 @@
+ #include <QFileDialog>
+ #include <QtGui/QClipboard>
+ #include <QApplication>
+-#include <QPrinter>
+ #include <QColorDialog>
+ #include <QToolTip>
+ #ifdef QT_SVG_LIB
+@@ -2849,14 +2848,6 @@ void UPlot::contextMenuEvent(QContextMenuEvent * event)
+ 			else
+ 			{
+ #endif
+-				if(QFileInfo(text).suffix().compare("pdf") == 0)
+-				{
+-					QPrinter printer;
+-					printer.setOutputFormat(QPrinter::PdfFormat);
+-					printer.setOutputFileName(text);
+-					this->render(&printer);
+-				}
+-				else
+ 				{
+ 					QPixmap figure = QPixmap::grabWidget(this);
+ 					figure.save(text);
+-- 
+2.34.1
+

--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -1,0 +1,59 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, opencv, pcl, libusb1, eigen
+, wrapQtAppsHook, qtbase, g2o, ceres-solver, libpointmatcher, octomap, freenect
+, libdc1394, librealsense, libGL, libGLU, vtkWithQt5, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "rtabmap";
+  version = "unstable-2022-02-07";
+
+  src = fetchFromGitHub {
+    owner = "introlab";
+    repo = "rtabmap";
+    rev = "f584f42ea423c44138aa0668b5c8eb18f2978fe2";
+    sha256 = "sha256-xotOcaz5XrmzwEKuVEQZoeq6fEVbACK7PSUW9kULH40=";
+  };
+
+  patches = [
+    # Our Qt5 seems to be missing PrintSupport.. I think?
+    ./0001-remove-printer-support.patch
+  ];
+
+  nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook wrapGAppsHook ];
+  buildInputs = [
+    ## Required
+    opencv
+    pcl
+    ## Optional
+    libusb1
+    eigen
+    g2o
+    ceres-solver
+    # libpointmatcher - ABI mismatch
+    octomap
+    freenect
+    libdc1394
+    # librealsense - missing includedir
+    qtbase
+    libGL
+    libGLU
+    vtkWithQt5
+  ];
+
+  # Disable warnings that are irrelevant to us as packagers
+  cmakeFlags = "-Wno-dev";
+
+  # We run one of the executables we build while the build is
+  # still running (and patchelf hasn't been invoked) which means
+  # the RPATH is not set correctly. This hacks around that error:
+  #
+  # build/bin/rtabmap-res_tool: error while loading shared libraries: librtabmap_utilite.so.0.20: cannot open shared object file: No such file or directory
+  LD_LIBRARY_PATH = "/build/source/build/bin";
+
+  meta = with lib; {
+    description = "Real-Time Appearance-Based 3D Mapping";
+    homepage = "https://introlab.github.io/rtabmap/";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ckie ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -94,6 +94,10 @@ in stdenv.mkDerivation rec {
     for lib in $out/lib/libvtk*.so; do
       ln -s $lib $out/lib/"$(basename "$lib" | sed -e 's/-[[:digit:]]*.[[:digit:]]*//g')"
     done
+
+    mv $out/include/vtk-${majorVersion}/* $out/include
+    rmdir $out/include/vtk-${majorVersion}
+    ln -s $out/include $out/include/vtk-${majorVersion}
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -90,6 +90,12 @@ in stdenv.mkDerivation rec {
     sed -i 's/fprintf(output, shift)/fprintf(output, "%s", shift)/g' ./ThirdParty/libxml2/vtklibxml2/xpath.c
   '';
 
+  preFixup = ''
+    for lib in $out/lib/libvtk*.so; do
+      ln -s $lib $out/lib/"$(basename "$lib" | sed -e 's/-[[:digit:]]*.[[:digit:]]*//g')"
+    done
+  '';
+
   meta = with lib; {
     description = "Open source libraries for 3D computer graphics, image processing and visualization";
     homepage = "https://www.vtk.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9033,6 +9033,8 @@ with pkgs;
 
   rocket = libsForQt5.callPackage ../tools/graphics/rocket { };
 
+  rtabmap = libsForQt5.callPackage ../applications/video/rtabmap/default.nix { };
+
   rtaudio = callPackage ../development/libraries/audio/rtaudio {
     jack = libjack2;
     inherit (darwin.apple_sdk.frameworks) CoreAudio;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I was running this in an Ubuntu VM but performance was 💩. Native is better~! 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
