### PR TITLE
python3Packages.warlock: enable tests

### DIFF
--- a/pkgs/development/python-modules/warlock/default.nix
+++ b/pkgs/development/python-modules/warlock/default.nix
@@ -1,27 +1,51 @@
 { lib
 , buildPythonPackage
-, fetchPypi
-, six
+, fetchFromGitHub
+, pythonOlder
 , jsonpatch
 , jsonschema
-, jsonpointer
+, six
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "warlock";
   version = "1.3.3";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "a093c4d04b42b7907f69086e476a766b7639dca50d95edc83aef6aeab9db2090";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bcwaldon";
+    repo = pname;
+    rev = version;
+    hash = "sha256-59V4KOwjs/vhA3F3E0j3p5L4JnKPgcExN+mgSWs0Cn0=";
   };
 
-  propagatedBuildInputs = [ six jsonpatch jsonschema jsonpointer ];
+  propagatedBuildInputs = [
+    jsonpatch
+    jsonschema
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "jsonschema>=0.7,<4" "jsonschema"
+    sed -i "/--cov/d" pytest.ini
+  '';
+
+  pythonImportsCheck = [
+    "warlock"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/bcwaldon/warlock";
     description = "Python object model built on JSON schema and JSON patch";
+    homepage = "https://github.com/bcwaldon/warlock";
     license = licenses.asl20;
+    maintainers = with maintainers; [ ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Enable tests and relax `jsonschema` constraint.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
