### PR TITLE
webkitgtk: revert "pull upstream fix for gcc-12"

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -1,7 +1,6 @@
 { lib, stdenv
 , runCommand
 , fetchurl
-, fetchpatch
 , perl
 , python3
 , ruby
@@ -83,30 +82,6 @@ stdenv.mkDerivation rec {
       inherit (addOpenGLRunpath) driverLink;
     })
     ./libglvnd-headers.patch
-
-    # Pull upstream patches for missing includes on gcc-12:
-    #  https://trac.webkit.org/changeset/288379/webkit
-    (fetchpatch {
-      name = "exchange-gcc-12.patch";
-      url  = "https://github.com/WebKit/WebKit/commit/198b392130b8dd625f4d5d36e652954eececb16b.patch";
-      excludes = [
-        "Source/JavaScriptCore/ChangeLog"
-        "Source/WTF/ChangeLog"
-        "Source/WebCore/ChangeLog"
-        "Tools/ChangeLog"
-
-        "Tools/ImageDiff/ImageDiff.cpp"
-      ];
-      sha256 = "sha256-D+wxfM8AEMBfvpghrwa5v9cYLyK5+Sab3J0RE/xVar8=";
-    })
-    (fetchpatch {
-      name = "string-gcc-12.patch";
-      url  = "https://github.com/WebKit/WebKit/commit/4e3fade6bd89347e041a1938d4ea85fee14e5534.patch";
-      excludes = [
-        "Source/WTF/ChangeLog"
-      ];
-      sha256 = "sha256-NPqZLfMUR6InQuqfVwNoZwuM3Jtbz5KAbm9SUBaprmc=";
-    })
   ];
 
   preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''


### PR DESCRIPTION
`nixpkgs/master` contains `2.34.5` version with patches applied.
Merge of `master` into `staging-next` causes `webkitgtk` to fail
to apply patches twice.

This reverts commit a74a1f32517b61107bd28f3b54cd49a6fc8db82c to
ease `master` merging.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
