### PR TITLE
deja-dup: 42.8 → 43.2

### DIFF
--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -8,12 +8,12 @@
 , gettext
 , itstool
 , glib
-, gtk3
+, gtk4
 , coreutils
-, libsoup
+, libsoup_3
 , libsecret
-, libhandy
-, wrapGAppsHook
+, libadwaita
+, wrapGAppsHook4
 , libgpg-error
 , json-glib
 , duplicity
@@ -21,14 +21,14 @@
 
 stdenv.mkDerivation rec {
   pname = "deja-dup";
-  version = "42.8";
+  version = "43.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = pname;
     rev = version;
-    sha256 = "sha256-DkRqZAj47wzt4lDvhAbO0PYcRA7oHEo2k69IMLOD3Ps=";
+    sha256 = "sha256-iFrPx/m/nTdm7xVVd1SZh5QNpSqI+TCbMfx0/jLgc1c=";
   };
 
   patches = [
@@ -45,15 +45,15 @@ stdenv.mkDerivation rec {
     vala
     gettext
     itstool
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    libsoup
+    libsoup_3
     glib
-    gtk3
+    gtk4
     libsecret
-    libhandy
+    libadwaita
     libgpg-error
     json-glib
   ];

--- a/pkgs/applications/backup/deja-dup/fix-paths.patch
+++ b/pkgs/applications/backup/deja-dup/fix-paths.patch
@@ -1,6 +1,6 @@
---- a/libdeja/tools/duplicity/DuplicityInstance.vala
-+++ b/libdeja/tools/duplicity/DuplicityInstance.vala
-@@ -159,7 +159,7 @@
+--- a/libdeja/duplicity/DuplicityInstance.vala
++++ b/libdeja/duplicity/DuplicityInstance.vala
+@@ -114,7 +114,7 @@ internal class DuplicityInstance : Object
      // We already are pretty sure we don't have other duplicities in our
      // archive directories, because we use our own and we ensure we only have
      // one deja-dup running at a time via DBus.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Now follows GNOME version scheme (though not the schedule).
Ported to GTK 4 and libsoup 3.

https://gitlab.gnome.org/World/deja-dup/-/tags/43.alpha
https://gitlab.gnome.org/World/deja-dup/-/tags/43.beta
https://gitlab.gnome.org/World/deja-dup/-/tags/43.0
https://gitlab.gnome.org/World/deja-dup/-/tags/43.1
https://gitlab.gnome.org/World/deja-dup/-/tags/43.2



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
