### PR TITLE
python3Packages.pylama: 8.3.6 -> 8.3.7

### DIFF
--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -10,12 +10,14 @@
 , pydocstyle
 , pyflakes
 , vulture
+, isort
+, pylint
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "pylama";
-  version = "8.3.6";
+  version = "8.3.7";
 
   format = "setuptools";
 
@@ -24,7 +26,7 @@ buildPythonPackage rec {
     owner = "klen";
     repo = "pylama";
     rev = version;
-    hash = "sha256-KU/G+2Fm4G/dUuNhhk8xM0Y8+7YOUUgREONM8CQGugw=";
+    hash = "sha256-//mrvZb4bT4aATURqa4g1DUagYe9SoP3o3OrwmiEJnI=";
   };
 
   patches = [
@@ -45,14 +47,22 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
+    # avoid infinite recursion pylint -> isort -> pylama
+    (pylint.override {
+      isort = isort.overridePythonAttrs (old: {
+        doCheck = false;
+      });
+    })
     pytestCheckHook
   ];
 
+  preCheck = ''
+    export HOME=$TEMP
+  '';
+
   disabledTests = [
-    "test_pylint" # infinite recursion
     "test_quotes" # FIXME package pylama-quotes
     "test_radon" # FIXME package radon
-    "test_sort"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
