### PR TITLE
super-productivity: update electron to version 13, as 11 is EOL

### DIFF
--- a/pkgs/applications/office/super-productivity/default.nix
+++ b/pkgs/applications/office/super-productivity/default.nix
@@ -1,7 +1,7 @@
-{ stdenv , lib , fetchurl , appimageTools , makeWrapper , electron_11 }:
+{ stdenv , lib , fetchurl , appimageTools , makeWrapper , electron_13 }:
 
 let
-  electron = electron_11;
+  electron = electron_13;
 in
 stdenv.mkDerivation rec {
   pname = "super-productivity";


### PR DESCRIPTION
This is more or less a backport of https://github.com/NixOS/nixpkgs/pull/148162/commits/61d5e58435cca65f085217600c730fdd4110ecaf , but keeping the changes minimal as we're on a release branch.

Built and tested on NixOS 21.11