### PR TITLE
python3Packages.flake8-bugbear: init at 22.1.11

### DIFF
--- a/pkgs/development/python-modules/flake8-bugbear/default.nix
+++ b/pkgs/development/python-modules/flake8-bugbear/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, attrs
+, flake8
+, pytestCheckHook
+, hypothesis
+, hypothesmith
+}:
+
+buildPythonPackage rec {
+  pname = "flake8-bugbear";
+  version = "22.1.11";
+
+  src = fetchFromGitHub {
+    owner = "PyCQA";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-sTg69Hgvi77wtLWEH4JtcIAMFk7exr5CBXmyS0nE5Vc=";
+  };
+
+  propagatedBuildInputs = [
+    attrs
+    flake8
+  ];
+
+  checkInputs = [
+    flake8
+    pytestCheckHook
+    hypothesis
+    hypothesmith
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PyCQA/flake8-bugbear";
+    changelog = "https://github.com/PyCQA/flake8-bugbear/blob/${version}/README.rst#change-log";
+    description = ''
+      A plugin for flake8 finding likely bugs and design problems in your
+      program.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ newam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2861,6 +2861,8 @@ in {
 
   flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };
 
+  flake8-bugbear = callPackage ../development/python-modules/flake8-bugbear { };
+
   flake8 = callPackage ../development/python-modules/flake8 { };
 
   flake8-length = callPackage ../development/python-modules/flake8-length { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear);  a plugin for flake8 finding likely bugs and design problems in your program.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
