### PR TITLE
fetchFromGitHub: fix meta

### DIFF
--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -10,8 +10,18 @@
 }@args:
 
 let
+
+  position = (if args.meta.description or null != null
+    then builtins.unsafeGetAttrPos "description" args.meta
+    else builtins.unsafeGetAttrPos "rev" args
+  );
   baseUrl = "https://${githubBase}/${owner}/${repo}";
-  newMeta = meta // { homepage = meta.homepage or baseUrl; };
+  newMeta = meta // {
+    homepage = meta.homepage or baseUrl;
+
+    # to indicate where derivation originates, similar to make-derivation.nix's mkDerivation
+    position = "${position.file}:${toString position.line}";
+  };
   passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
   varBase = "NIX${if varPrefix == null then "" else "_${varPrefix}"}_GITHUB_PRIVATE_";
   useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || (sparseCheckout != "");

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -5,10 +5,13 @@
 , deepClone ? false, private ? false, forceFetchGit ? false
 , sparseCheckout ? ""
 , githubBase ? "github.com", varPrefix ? null
+, meta ? { }
 , ... # For hash agility
 }@args:
+
 let
   baseUrl = "https://${githubBase}/${owner}/${repo}";
+  newMeta = meta // { homepage = meta.homepage or baseUrl; };
   passthruAttrs = removeAttrs args [ "owner" "repo" "rev" "fetchSubmodules" "forceFetchGit" "private" "githubBase" "varPrefix" ];
   varBase = "NIX${if varPrefix == null then "" else "_${varPrefix}"}_GITHUB_PRIVATE_";
   useFetchGit = fetchSubmodules || (leaveDotGit == true) || deepClone || forceFetchGit || (sparseCheckout != "");
@@ -37,4 +40,4 @@ let
   ) // privateAttrs // passthruAttrs // { inherit name; };
 in
 
-fetcher fetcherArgs // { meta.homepage = baseUrl; inherit rev; }
+fetcher fetcherArgs // { meta = newMeta; inherit rev; }


### PR DESCRIPTION
###### Motivation for this change
Useful for packages which are just the fetcher. (e.g. cabin, fonts)

related:
- https://github.com/repology/repology-updater/pull/1225
- https://github.com/NixOS/nixpkgs/pull/158548#issuecomment-1033877175

Also, to reduce noise in: https://repology.org/log/10558694

before:
```
$ nix eval .#cabin.meta
{ homepage = "https://github.com/impallari/Cabin"; }
```

after:
```
nix-repl> cabin.meta
{ description = "A humanist sans with 4 weights and true italics"; homepage = "http://www.impallari.com/cabin"; license = { ... }; longDescription = "The Cabin font family is a humanist sans with 4 weights and true italics,\ninspired by Edward Johnston’s and Eric Gill’s typefaces, with a touch of\nmodernism. Cabin incorporates modern proportions, optical adjustments, and\nsome elements of the geometric sans. It remains true to its roots, but has\nits own personality.\n\nThe weight distribution is almost monotone, although top and bottom curves\nare slightly thin. Counters of the b, g, p and q are rounded and optically\nadjusted. The curved stem endings have a 10 degree angle. E and F have\nshorter center arms. M is splashed.\n"; maintainers = [ ... ]; platforms = [ ... ]; position = "/home/jon/projects/nixpkgs/pkgs/data/fonts/cabin/default.nix:19"; }
```

tangentially related: #158850

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
