### PR TITLE
perlPackages: restore meta.position

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,46 +1,60 @@
 { lib, stdenv, perl, buildPerl, toPerlModule }:
 
-{ buildInputs ? [], nativeBuildInputs ? [], ... } @ attrs:
+{ buildInputs ? []
+, nativeBuildInputs ? []
+, outputs ? [ "out" "devdoc" ]
+, src ? null
+
+, doCheck ? true
+, checkTarget ? "test"
+
+# Prevent CPAN downloads.
+, PERL_AUTOINSTALL ? "--skipdeps"
+
+# From http://wiki.cpantesters.org/wiki/CPANAuthorNotes: "allows
+# authors to skip certain tests (or include certain tests) when
+# the results are not being monitored by a human being."
+, AUTOMATED_TESTING ? true
+
+# current directory (".") is removed from @INC in Perl 5.26 but many old libs rely on it
+# https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
+, PERL_USE_UNSAFE_INC ? "1"
+
+, ...
+}@attrs:
 
 assert attrs?pname -> attrs?version;
 assert attrs?pname -> !(attrs?name);
 
 lib.warnIf (attrs ? name) "builtPerlPackage: `name' (\"${attrs.name}\") is deprecated, use `pname' and `version' instead"
 
-toPerlModule(stdenv.mkDerivation (
-  (
-  lib.recursiveUpdate
-  {
-    outputs = [ "out" "devdoc" ];
+(let
+  defaultMeta = {
+    homepage = "https://metacpan.org/release/${lib.getName attrs}"; # TODO: phase-out `attrs.name`
+    platforms = perl.meta.platforms;
+  };
 
-    doCheck = true;
+  cleanedAttrs = builtins.removeAttrs attrs [
+    "meta" "builder" "version" "pname" "fullperl"
+    "buildInputs" "nativeBuildInputs" "buildInputs"
+    "PERL_AUTOINSTALL" "AUTOMATED_TESTING" "PERL_USE_UNSAFE_INC"
+    ];
 
-    checkTarget = "test";
-
-    # Prevent CPAN downloads.
-    PERL_AUTOINSTALL = "--skipdeps";
-
-    # From http://wiki.cpantesters.org/wiki/CPANAuthorNotes: "allows
-    # authors to skip certain tests (or include certain tests) when
-    # the results are not being monitored by a human being."
-    AUTOMATED_TESTING = true;
-
-    # current directory (".") is removed from @INC in Perl 5.26 but many old libs rely on it
-    # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
-    PERL_USE_UNSAFE_INC = "1";
-
-    meta.homepage = "https://metacpan.org/release/${lib.getName attrs}"; # TODO: phase-out `attrs.name`
-    meta.platforms = perl.meta.platforms;
-  }
-  attrs
-  )
-  //
-  {
+  package = stdenv.mkDerivation ({
     pname = "perl${perl.version}-${lib.getName attrs}"; # TODO: phase-out `attrs.name`
     version = lib.getVersion attrs;                     # TODO: phase-out `attrs.name`
+
     builder = ./builder.sh;
+
     buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.mini or perl) ];
+
     fullperl = buildPerl;
-  }
-))
+
+    inherit outputs src doCheck checkTarget;
+    inherit PERL_AUTOINSTALL AUTOMATED_TESTING PERL_USE_UNSAFE_INC;
+
+    meta = defaultMeta // (attrs.meta or { });
+  } // cleanedAttrs);
+
+in toPerlModule package)


### PR DESCRIPTION
###### Motivation for this change
Remove `lib.recursiveUpdate { ... } attrs // { ... }` logic, so that nix can determine where a derivation originates.

This should hopefully be 0 rebuilds

Before:
```
# nix 2.5
$ nix eval .#perlPackages.ModuleBuild.meta.position
"/nix/store/giwp1862ymjgq8blinx79wng0r7f15fv-source/lib/attrsets.nix:369"

# nix 2.7
$ nix eval .#perlPackages.ModuleBuild.meta.position
error: flake 'git+file:///home/jon/projects/nixpkgs' does not provide attribute 'packages.x86_64-linux.perlPackages.ModuleBuild.meta.position', 'legacyPackages.x86_64-linux.perlPackages.ModuleBuild.meta.position' or 'perlPackages.ModuleBuild.meta.position'
```

After:
```
# nix 2.5
$ nix eval .#perlPackages.ModuleBuild.meta.position
"/nix/store/lxnj1c2xdsy28f8g867waypzn1b1lzsv-source/pkgs/top-level/perl-packages.nix:13938"

# nix 2.7
$ nix eval .#perlPackages.ModuleBuild.meta.position
"/nix/store/lxnj1c2xdsy28f8g867waypzn1b1lzsv-source/pkgs/top-level/perl-packages.nix:13938"
```

Related:
- https://github.com/NixOS/nixpkgs/pull/158548#issuecomment-1033877175
- https://github.com/repology/repology-updater/pull/1225
- https://github.com/NixOS/nixpkgs/pull/158850

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
