### PR TITLE
folly: 2021.10.25.00 -> 2022.02.07.00

### DIFF
--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -1,31 +1,33 @@
 { lib, stdenv
 , fetchFromGitHub
-, cmake
 , boost
-, libevent
+, cmake
 , double-conversion
-, glog
+, fetchpatch
+, fmt_8
 , gflags
+, glog
+, libevent
 , libiberty
+, libunwind
 , lz4
-, xz
-, zlib
-, jemalloc
 , openssl
 , pkg-config
-, libunwind
-, fmt
+, xz
+, zlib
+, zstd
+, follyMobile ? false
 }:
 
-stdenv.mkDerivation (rec {
+stdenv.mkDerivation rec {
   pname = "folly";
-  version = "2021.10.25.00";
+  version = "2022.02.07.00";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "folly";
     rev = "v${version}";
-    sha256 = "sha256-+di8Dzt5NRbqIydBR4sB6bUbQrZZ8URUosdP2JGQMec=";
+    sha256 = "sha256-C/PQBXhOELNxQFfQhgQeU+QmsdtFeBESyWerC+QZBEI=";
   };
 
   nativeBuildInputs = [
@@ -45,11 +47,12 @@ stdenv.mkDerivation (rec {
     lz4
     xz
     zlib
-    jemalloc
     libunwind
-    fmt
+    fmt_8
+    zstd
   ];
 
+  NIX_CFLAGS_COMPILE = [ "-DFOLLY_MOBILE=${if follyMobile then "1" else "0"}" ];
   cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
 
   meta = with lib; {
@@ -57,9 +60,7 @@ stdenv.mkDerivation (rec {
     homepage = "https://github.com/facebook/folly";
     license = licenses.asl20;
     # 32bit is not supported: https://github.com/facebook/folly/issues/103
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
     maintainers = with maintainers; [ abbradar pierreis ];
   };
-} // lib.optionalAttrs stdenv.isDarwin {
-  LDFLAGS = "-ljemalloc";
-})
+}


### PR DESCRIPTION
###### Motivation for this change
Add aarch64-darwin support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
