### PR TITLE
 vimPlugins.select-and-search: init at 2014-08-04, vimPlugins.indent-detector-vim: init at 2015-07-06

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -41,12 +41,12 @@ final: prev:
 
   aerial-nvim = buildVimPluginFrom2Nix {
     pname = "aerial.nvim";
-    version = "2022-02-04";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "stevearc";
       repo = "aerial.nvim";
-      rev = "91350456c176fe5ef72e342dd3a75f726805454d";
-      sha256 = "18kj8rb6zdqaw255zi767si84jk5lbr3k1vhqjfi265399iwgii7";
+      rev = "ee369de02aebc52e7d34506298556e15030c52dc";
+      sha256 = "0d31lkaiqn5f8rg1asinp72hlngmfbih7rffb4q4zm5hwayyqi3p";
     };
     meta.homepage = "https://github.com/stevearc/aerial.nvim/";
   };
@@ -77,12 +77,12 @@ final: prev:
 
   ale = buildVimPluginFrom2Nix {
     pname = "ale";
-    version = "2022-02-06";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "dense-analysis";
       repo = "ale";
-      rev = "6d9399d863e6e921c87c1a95795109b872bd3925";
-      sha256 = "0rdrdli1fqqasp3jl508ikv0g6qp5y8fzrn8sq9x7fkmg4sazqg3";
+      rev = "47470eddc277e0a141e6e36a1e2a19045e051d1c";
+      sha256 = "1wrhi9gwr5wjl7jdvqvldrl4480qcx6ry9gkl41dhiz643g28pvk";
     };
     meta.homepage = "https://github.com/dense-analysis/ale/";
   };
@@ -413,12 +413,12 @@ final: prev:
 
   bufexplorer = buildVimPluginFrom2Nix {
     pname = "bufexplorer";
-    version = "2022-01-28";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "jlanzarotta";
       repo = "bufexplorer";
-      rev = "b3a24722bea9029b4c37eb0547b87152d514c66f";
-      sha256 = "14114786fkqjzpl3aqsk2lmfnlhxzdkkanv6ls6q0cwvpqdng6wc";
+      rev = "4b1d3adca7e968ebc619cf2f6f3e197ef78c8342";
+      sha256 = "0imyzav898hzx4d669rxx7qyac6b8csp04am2j85rr31rywylpn0";
     };
     meta.homepage = "https://github.com/jlanzarotta/bufexplorer/";
   };
@@ -473,12 +473,12 @@ final: prev:
 
   catppuccin-nvim = buildVimPluginFrom2Nix {
     pname = "catppuccin-nvim";
-    version = "2022-02-04";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "catppuccin";
       repo = "nvim";
-      rev = "d48d3926b10ac1f9ef77cbcac35a4c7160cff6bf";
-      sha256 = "1vvn4qh849rdswvz4cnqci3ahp0z6jppqzg6rlavh8aayppw89lk";
+      rev = "406fdf2f2d2372df52d503e9f7bef96d89901c9f";
+      sha256 = "17b07krgc9pzqhmwls2d50xbiqs4fgzmdi61qrz1v5n0bgs011mr";
     };
     meta.homepage = "https://github.com/catppuccin/nvim/";
   };
@@ -497,12 +497,12 @@ final: prev:
 
   chadtree = buildVimPluginFrom2Nix {
     pname = "chadtree";
-    version = "2022-02-07";
+    version = "2022-02-10";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "chadtree";
-      rev = "7287befe22ee7fac9b83c3b3499571f6fc8143ae";
-      sha256 = "16rfwpmrz7y8d0s8xn8fx90q9b3gnnmnrm9ls7ss83ay7mfvsriy";
+      rev = "c1298eeb39f7429d09009d3ff0a639774e5b6bde";
+      sha256 = "156rafw6f1157szmmaa7gy5ccnrgmsprcsbwh83l0dkvis7ml1fl";
     };
     meta.homepage = "https://github.com/ms-jpq/chadtree/";
   };
@@ -881,12 +881,12 @@ final: prev:
 
   coc-lua = buildVimPluginFrom2Nix {
     pname = "coc-lua";
-    version = "2022-01-26";
+    version = "2022-02-10";
     src = fetchFromGitHub {
       owner = "josa42";
       repo = "coc-lua";
-      rev = "80a1100866354d2e057fb5a7ef979978b5990ecc";
-      sha256 = "1jqx2195c01im5gnp5knqwgrb9fkxsasb9m54s8c2vhqg7i7j7pg";
+      rev = "5855e8aac30d29166499137857b26a911a9c0bd0";
+      sha256 = "0hj4bn5lhfb50xjr3gyn7pdz5vdhia953349b547q2w972jv1z3d";
     };
     meta.homepage = "https://github.com/josa42/coc-lua/";
   };
@@ -917,12 +917,12 @@ final: prev:
 
   coc-nvim = buildVimPluginFrom2Nix {
     pname = "coc.nvim";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "neoclide";
       repo = "coc.nvim";
-      rev = "86fa3b18144aaeaa06bf5a7150c8d676ef1acca3";
-      sha256 = "0ppjxkh8nqhrypl46rfs4bgfmci9idbc589js6i2waqxzha7a9jf";
+      rev = "6116a010e18b7adcca024d95891da9af4e0dcd27";
+      sha256 = "06sc3rr4dxk1j6glb6vyxkw8k9m90g7gd1zdgsj5pw7mxfk9xbik";
     };
     meta.homepage = "https://github.com/neoclide/coc.nvim/";
   };
@@ -1182,12 +1182,12 @@ final: prev:
 
   coq_nvim = buildVimPluginFrom2Nix {
     pname = "coq_nvim";
-    version = "2022-02-07";
+    version = "2022-02-10";
     src = fetchFromGitHub {
       owner = "ms-jpq";
       repo = "coq_nvim";
-      rev = "98bc8a70b66c4ac05f6e648c43a278a6ff46b7a4";
-      sha256 = "15p77qk7a6p9viczl0ym5izdvfbq2d67pgv597zcy7cxmxf5vgcs";
+      rev = "37540cf653d9faae1cb2808d2625bdec11d76cf6";
+      sha256 = "1kp4wgyi9wywpnx7fmnfc44m09dkbjdj7xx95dmrxn55zcgda0h8";
     };
     meta.homepage = "https://github.com/ms-jpq/coq_nvim/";
   };
@@ -1302,12 +1302,12 @@ final: prev:
 
   ctrlp-vim = buildVimPluginFrom2Nix {
     pname = "ctrlp.vim";
-    version = "2022-01-14";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "ctrlpvim";
       repo = "ctrlp.vim";
-      rev = "ed04d2ec91c78748f0d8ddf69df2f6e5cffa7bb8";
-      sha256 = "1336bk2w4ll1vq6vwd0pq77021i13hcrm3mqzynznvhxwwxrk4dy";
+      rev = "d5b092036bc651912474f64277913be8502f8f09";
+      sha256 = "12nmcam301h69181hznsh19p9sl42srp98dfa56ghy4iyrcg2d34";
     };
     meta.homepage = "https://github.com/ctrlpvim/ctrlp.vim/";
   };
@@ -1784,12 +1784,12 @@ final: prev:
 
   edge = buildVimPluginFrom2Nix {
     pname = "edge";
-    version = "2022-02-04";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "edge";
-      rev = "4078d2bb859fbb907880dca5f2bcb4815b30351d";
-      sha256 = "036lnw87dw2rrx2r2nb4yplwrhy5dhdi44crbmfrpq34iqw97yzr";
+      rev = "40ea50a854175d65f4ce9ea84fff39ba572e3f67";
+      sha256 = "0wwp0hdvlri3kbq2b6glckyrbs4dbqynh25hgj3j77pc4zkjmjla";
     };
     meta.homepage = "https://github.com/sainnhe/edge/";
   };
@@ -1954,12 +1954,12 @@ final: prev:
 
   fern-vim = buildVimPluginFrom2Nix {
     pname = "fern.vim";
-    version = "2022-01-11";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "lambdalisue";
       repo = "fern.vim";
-      rev = "b6204ec4e04732d7b4ba73a3e4af48cba3576d67";
-      sha256 = "0ndddww8ciwil7bpn77yahb7fcn5i59sq91syqy3qr0wwmfc7mwc";
+      rev = "d415fcee2634b6c9bb4fad223c4e909498c6dcb8";
+      sha256 = "0vs8nhhmpnp5jnqkmn5dz3mkhp894hyhv0v32j9qqsvdrllzsyjz";
     };
     meta.homepage = "https://github.com/lambdalisue/fern.vim/";
   };
@@ -1978,12 +1978,12 @@ final: prev:
 
   fidget-nvim = buildVimPluginFrom2Nix {
     pname = "fidget.nvim";
-    version = "2022-02-06";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "j-hui";
       repo = "fidget.nvim";
-      rev = "a4ff3c978c6b4740143223bf090a7acf7444e2f8";
-      sha256 = "0v8vnr10hvxg4izniaaj3awf8c30qbcjs4wzrd25lbx6didvmx56";
+      rev = "2a69ee6d17cd264eb10b33170df4cfce4cc4f4f3";
+      sha256 = "0l7ir0fky6czmjkkhd13di4x39jhy70i0s0wjiiyqn9cdfm0xw14";
     };
     meta.homepage = "https://github.com/j-hui/fidget.nvim/";
   };
@@ -2063,12 +2063,12 @@ final: prev:
 
   formatter-nvim = buildVimPluginFrom2Nix {
     pname = "formatter.nvim";
-    version = "2021-11-03";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "mhartington";
       repo = "formatter.nvim";
-      rev = "0cdce2da8762ee01ee7d8df047b6e569d58c1ba3";
-      sha256 = "1169xj5k04l7gfhxqa4afq9khf6yv5bcihir21sgzpym4z69axh7";
+      rev = "80a14fae599dfd200c805c345a7515266abf3438";
+      sha256 = "1d42mbxhry3scycykxh381xdykm225sg5v02f9lfv9r2r3ay81jf";
     };
     meta.homepage = "https://github.com/mhartington/formatter.nvim/";
   };
@@ -2327,12 +2327,12 @@ final: prev:
 
   gitsigns-nvim = buildVimPluginFrom2Nix {
     pname = "gitsigns.nvim";
-    version = "2022-02-07";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "lewis6991";
       repo = "gitsigns.nvim";
-      rev = "11425117a9dcd533e5d42e083248ee0caea88b04";
-      sha256 = "0lsd4c446q8f6ylf5g5vyi0gb81v59a4zlcwasvxw29giwxz3grv";
+      rev = "e2b2730254df7648c79794555978f10fceb4b163";
+      sha256 = "1kmbhfphf128psrxps7iyb1kb2s1lbc63qkxwla1cl3ywnl7f8gl";
     };
     meta.homepage = "https://github.com/lewis6991/gitsigns.nvim/";
   };
@@ -2471,24 +2471,24 @@ final: prev:
 
   gruvbox-material = buildVimPluginFrom2Nix {
     pname = "gruvbox-material";
-    version = "2022-02-04";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "gruvbox-material";
-      rev = "2a4f998b65fe39f6a762a7d261249a93c848dac9";
-      sha256 = "09q7dh46dbajdd5hfc88jdfwxsv7c8zm1hmm3wjfjfwb5bln06dq";
+      rev = "591ca7fa71449b0e6ffe27f4525c3ceecc0b5684";
+      sha256 = "1i5yq5lj4ws8j3v4pc459ls69fgcgfh8a4fr98gnj4z650nprkpg";
     };
     meta.homepage = "https://github.com/sainnhe/gruvbox-material/";
   };
 
   gruvbox-nvim = buildVimPluginFrom2Nix {
     pname = "gruvbox.nvim";
-    version = "2022-01-27";
+    version = "2022-02-10";
     src = fetchFromGitHub {
       owner = "ellisonleao";
       repo = "gruvbox.nvim";
-      rev = "d4d0c6e66c1f4d5bdc0cb216c882d88d223a4187";
-      sha256 = "0s12sxhpk59r8a12df0zbhbmj6djffqmh1pw2fhw392zrb1549m8";
+      rev = "2cde593c25dfba0bdc73b67d81ce2876eae96762";
+      sha256 = "0yizw7bnsxdz3snj149nwfw8xxr9jknxlalvsdyvx9n8jhz6j4rv";
     };
     meta.homepage = "https://github.com/ellisonleao/gruvbox.nvim/";
   };
@@ -2904,12 +2904,12 @@ final: prev:
 
   julia-vim = buildVimPluginFrom2Nix {
     pname = "julia-vim";
-    version = "2021-12-08";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "JuliaEditorSupport";
       repo = "julia-vim";
-      rev = "e4972997fb5aee1c180e9840586a09553865cc20";
-      sha256 = "11v9fhd7i9si5psnsrvdgrih64rgjjy7ypjlfz9ys74rcryfyy5x";
+      rev = "a630e12de13db03313b88d6983cbbb81398eadcd";
+      sha256 = "08rlj48cw7c9cslrkpiw63fic5yw8vvls7ifcw48m1bhpibxfmnh";
     };
     meta.homepage = "https://github.com/JuliaEditorSupport/julia-vim/";
   };
@@ -3180,12 +3180,12 @@ final: prev:
 
   lightspeed-nvim = buildVimPluginFrom2Nix {
     pname = "lightspeed.nvim";
-    version = "2022-02-07";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "ggandor";
       repo = "lightspeed.nvim";
-      rev = "0c01dc2e2cad214614352d372ed9d7438240488f";
-      sha256 = "05ybrag1gkhapr1yvs7zz2qfqibnpf2h4lg3x6f0ag9g0khhh96c";
+      rev = "b04fc4e129512ce5ccd15acfe8388a898daa0a2a";
+      sha256 = "0a7bz8v0lh8myj39vk553gkglmk83smqc3nylfabqyxkij1gmdqx";
     };
     meta.homepage = "https://github.com/ggandor/lightspeed.nvim/";
   };
@@ -3240,12 +3240,12 @@ final: prev:
 
   litee-calltree-nvim = buildVimPluginFrom2Nix {
     pname = "litee-calltree.nvim";
-    version = "2022-01-20";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "ldelossa";
       repo = "litee-calltree.nvim";
-      rev = "be1c8d67ef80dc4cdfc164d3a95a45d8d551b3eb";
-      sha256 = "0qqyws79a4d4kn1vgb7p8iw7vlx2flb3ra2y2xvjilyvzz4ppqrq";
+      rev = "ba1a0f49e71849863b4212ca0ac1974aeb7c7032";
+      sha256 = "1y55p429rd7z8jph30ils2g35vmqam4qk1ii9s88jwfl545g7qga";
     };
     meta.homepage = "https://github.com/ldelossa/litee-calltree.nvim/";
   };
@@ -3264,12 +3264,12 @@ final: prev:
 
   litee-symboltree-nvim = buildVimPluginFrom2Nix {
     pname = "litee-symboltree.nvim";
-    version = "2022-01-13";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "ldelossa";
       repo = "litee-symboltree.nvim";
-      rev = "9baa027c79abdadc0a63bdd14d248241a1333b99";
-      sha256 = "0lr203px4ydakqnqavymd2f08gj5mid1nhb63rww72i7i959hz7v";
+      rev = "07545e1c5bd5c081c7e28540591275cbb46b7d02";
+      sha256 = "0pld9i7db4w4wqwc1nnmymfgr7miia60l1rj0pakfkgyf1g5w61s";
     };
     meta.homepage = "https://github.com/ldelossa/litee-symboltree.nvim/";
   };
@@ -3347,12 +3347,12 @@ final: prev:
 
   lsp_signature-nvim = buildVimPluginFrom2Nix {
     pname = "lsp_signature.nvim";
-    version = "2022-01-30";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "ray-x";
       repo = "lsp_signature.nvim";
-      rev = "30c7cf023782f50cfa8f65d0508163d6ebfd2442";
-      sha256 = "1qnzy258giqxkhmbvfv8fph5k3f2r313mj0rqsans2v8bq6ay6g0";
+      rev = "42eb06b5903dc212acb03f276e6e3fd24f92593c";
+      sha256 = "0mh2glx9fmf56znpnxn8y8n185pdl8hxiy00pymc5r2g2q8gjrlb";
     };
     meta.homepage = "https://github.com/ray-x/lsp_signature.nvim/";
   };
@@ -3371,12 +3371,12 @@ final: prev:
 
   lspsaga-nvim = buildVimPluginFrom2Nix {
     pname = "lspsaga.nvim";
-    version = "2022-02-02";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "tami5";
       repo = "lspsaga.nvim";
-      rev = "ca8bc243e6ae36fa3eeab53191f302ca84660a3c";
-      sha256 = "1967vi3an7f5gp6hdwbkrd5nm71nb1i82jh3ygy1k7i2y4fa6apr";
+      rev = "d8073a0e4d19d71da900fb77dcc5f23d72bb8707";
+      sha256 = "0f5qzi9kk02z6siqzwz2zak687zb4q2nkg66x3pnnqvhfqazjb5q";
     };
     meta.homepage = "https://github.com/tami5/lspsaga.nvim/";
   };
@@ -3419,12 +3419,12 @@ final: prev:
 
   luasnip = buildVimPluginFrom2Nix {
     pname = "luasnip";
-    version = "2022-02-06";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "l3mon4d3";
       repo = "luasnip";
-      rev = "0997bc216a136f2847343d96040c9b0c90b661c9";
-      sha256 = "1iyjbk6l7y35f72cpffddsj97j140vgg0kk5iyaq6mg8rcsq49lq";
+      rev = "b993af2bd38a60c815768c6ddb250010ed8a1a4f";
+      sha256 = "0bwmink8j8pgnxs2csskcbry46h5hl5iaqcdmm6c01ds6dcj1wql";
     };
     meta.homepage = "https://github.com/l3mon4d3/luasnip/";
   };
@@ -3551,12 +3551,12 @@ final: prev:
 
   mini-nvim = buildVimPluginFrom2Nix {
     pname = "mini.nvim";
-    version = "2022-02-05";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "echasnovski";
       repo = "mini.nvim";
-      rev = "6cb7cdb1cd7f111784d5d971fa41a655e11df4b3";
-      sha256 = "1jsn2vf8gn61qzzibxngsf29cm4xhr2nidzsjg02l6ayhd7rlhgl";
+      rev = "f2ccb9339c979968b19db48b5f8b31c6f0ee7481";
+      sha256 = "0f7yw2mjdimmi70liya75wnbbrk37xi2sncpsg0awh15sibynq05";
     };
     meta.homepage = "https://github.com/echasnovski/mini.nvim/";
   };
@@ -3983,12 +3983,12 @@ final: prev:
 
   neorg = buildVimPluginFrom2Nix {
     pname = "neorg";
-    version = "2022-02-07";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "nvim-neorg";
       repo = "neorg";
-      rev = "27578af8581ca109ac51f0f5d215d12bf6933be1";
-      sha256 = "1bc0s8c9lbdzyycncz2cqkspb353h72hnqcd5v0vb19zbxvnhsqp";
+      rev = "d3473a9bfdebbd042428d895c84545bc85124159";
+      sha256 = "0ahijwjp21v79svgx44dlx5x69g6nh0qv9xi0x9markxj86660yz";
     };
     meta.homepage = "https://github.com/nvim-neorg/neorg/";
   };
@@ -4295,12 +4295,12 @@ final: prev:
 
   null-ls-nvim = buildVimPluginFrom2Nix {
     pname = "null-ls.nvim";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "jose-elias-alvarez";
       repo = "null-ls.nvim";
-      rev = "e8a666829a3d803844f24daa4932e4f5fe76cbeb";
-      sha256 = "0inl9dizwq2j3r2z7jsxdqmrq5iyq7b123x2n23dfzsvvv5s3279";
+      rev = "f8f3932fb2abaa22e2536b5ac6ef1253a76647c7";
+      sha256 = "0h5q16i2n1rssml9ws5rvkmg9gslsdfw69asdq6rmr11w5kihyf9";
     };
     meta.homepage = "https://github.com/jose-elias-alvarez/null-ls.nvim/";
   };
@@ -4367,12 +4367,12 @@ final: prev:
 
   nvim-bqf = buildVimPluginFrom2Nix {
     pname = "nvim-bqf";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "kevinhwang91";
       repo = "nvim-bqf";
-      rev = "3cace9658fa504e2090b668f6652cf86ba4e81ab";
-      sha256 = "1ly17jywj4idwq52x471imj7b1xm7q0j8xak3khr5jc8n7mnwydg";
+      rev = "aaa160d4423c6c0029f91af85a7e1f092b1aa966";
+      sha256 = "07n78gwj8q7mnw6rnzsmnl6cl51g5harrzn2g3fz6rhpr2f1hlwz";
     };
     meta.homepage = "https://github.com/kevinhwang91/nvim-bqf/";
   };
@@ -4571,12 +4571,12 @@ final: prev:
 
   nvim-gps = buildVimPluginFrom2Nix {
     pname = "nvim-gps";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "smiteshp";
       repo = "nvim-gps";
-      rev = "6d6e936db0ad936039ef1a503c4b0bd0fe6286de";
-      sha256 = "020ln7aq3h0rh5aslrgbdvjlbyvpyjxz9fa9lvsxx9bwcx6f1ci5";
+      rev = "6afd8f7a69e7008dabe048d4fb1ee8e467a72fdf";
+      sha256 = "13pgq09sxhfxxmrrqzc1f8b119f6d7yyx30lzbgr2vx59bh69ph2";
     };
     meta.homepage = "https://github.com/smiteshp/nvim-gps/";
   };
@@ -4667,12 +4667,12 @@ final: prev:
 
   nvim-lsp-ts-utils = buildVimPluginFrom2Nix {
     pname = "nvim-lsp-ts-utils";
-    version = "2022-01-26";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "jose-elias-alvarez";
       repo = "nvim-lsp-ts-utils";
-      rev = "64d233a8859e27139c55472248147114e0be1652";
-      sha256 = "1isnz4pys9wdf7w4qfiyjl4a2h66b0iwnxlbs88pn0r7hc8kgr74";
+      rev = "337e4fa31d88e5553edeb05ac572bacd4a24d867";
+      sha256 = "1xa2zxyqfgzp4zjccrjnj9djdb4f4i9gr2m4gxa6cqz01b21xwmq";
     };
     meta.homepage = "https://github.com/jose-elias-alvarez/nvim-lsp-ts-utils/";
   };
@@ -4715,12 +4715,12 @@ final: prev:
 
   nvim-neoclip-lua = buildVimPluginFrom2Nix {
     pname = "nvim-neoclip.lua";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "AckslD";
       repo = "nvim-neoclip.lua";
-      rev = "80d363113355e431016bd0a477b3bd56c7d82d95";
-      sha256 = "1jgg0zkwfbxyfqlq5xd4vhzklmgs5p3xi8amn9vmga7zkx33cy63";
+      rev = "841021836ee00e7da6dbad819508e384f4e2362a";
+      sha256 = "1qjwyicpvbp8396lby62jd9fj8yh2dak5kk1vf64ppjvdf038hpd";
     };
     meta.homepage = "https://github.com/AckslD/nvim-neoclip.lua/";
   };
@@ -4739,12 +4739,12 @@ final: prev:
 
   nvim-notify = buildVimPluginFrom2Nix {
     pname = "nvim-notify";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "rcarriga";
       repo = "nvim-notify";
-      rev = "2edf33d0eb3c358716d4474d6081d361c80f7aa3";
-      sha256 = "07hc9v9whyxxmnsf95a5fmmdxaw800ppaj0d588lnbnx1hs3dmpm";
+      rev = "27f3176b950dc803b61c29bd007e140c232544e5";
+      sha256 = "1b4s7vcr1d2d6jnkbsnybc55fmwgk52cdfqsm8x5m37fbwn4k6dq";
     };
     meta.homepage = "https://github.com/rcarriga/nvim-notify/";
   };
@@ -4787,12 +4787,12 @@ final: prev:
 
   nvim-spectre = buildVimPluginFrom2Nix {
     pname = "nvim-spectre";
-    version = "2022-01-30";
+    version = "2022-02-10";
     src = fetchFromGitHub {
       owner = "nvim-pack";
       repo = "nvim-spectre";
-      rev = "9842b5fe987fb2c5a4ec4d42f8dbcdd04a047d4d";
-      sha256 = "12ww1yqxsk6qm6cimgr0ljgc98n831dpm711q4xqg9c6wm0pyzg7";
+      rev = "208d983e9bab4d0eb98b4642636e1b4f41c5280a";
+      sha256 = "0yq7whrlzrwiyk6xzakvrf9drrr21gy2s5318rnn9r01mp27z6in";
     };
     meta.homepage = "https://github.com/nvim-pack/nvim-spectre/";
   };
@@ -4811,24 +4811,24 @@ final: prev:
 
   nvim-tree-lua = buildVimPluginFrom2Nix {
     pname = "nvim-tree.lua";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "kyazdani42";
       repo = "nvim-tree.lua";
-      rev = "e42a4337d0d9de4de5c0d4ab960f2101ef33f273";
-      sha256 = "125j1ng5xr12wpqg9wymxlxgzw9v2alqb9fmpwg0mbf9aybip27k";
+      rev = "b54de4b48a2e0481da8fc502e6e2a5cf5e4b0ba2";
+      sha256 = "0svlmm58w8c6mcqlx8gb47j6sn0z2i4rx9fpgihhhkk7pvjhinwc";
     };
     meta.homepage = "https://github.com/kyazdani42/nvim-tree.lua/";
   };
 
   nvim-treesitter = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter";
-      rev = "d6e6581a256061449a8a039c792a93a4b4e86b85";
-      sha256 = "1m1cm1lynaa8wslpy01hkxdp5kxnwxx570wpj2wy5x1xjl5pglgz";
+      rev = "4990db79a87f49e56a3a1bb8507926ebd52ec4cc";
+      sha256 = "0c2wpk1bc3ga1m54s4kjmlskv3l2rkgf83xj1alm1rfgzwhl38vv";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter/";
   };
@@ -4871,24 +4871,24 @@ final: prev:
 
   nvim-treesitter-textobjects = buildVimPluginFrom2Nix {
     pname = "nvim-treesitter-textobjects";
-    version = "2022-02-04";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "nvim-treesitter";
       repo = "nvim-treesitter-textobjects";
-      rev = "438d2cfa3922a58ef828803d6ca9c944b4b4c996";
-      sha256 = "0lycnr6q304z1n146phcyjsv4z2rr02yxpq9aj2gvybqljb16m18";
+      rev = "fea609aa58b3390a09e8df0e96902fd4b094d8b7";
+      sha256 = "0221ax71334ghsr8xznp9jk2iv9r0bin47ch8r7hsfh4r0wgc5w7";
     };
     meta.homepage = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/";
   };
 
   nvim-ts-autotag = buildVimPluginFrom2Nix {
     pname = "nvim-ts-autotag";
-    version = "2022-02-06";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "windwp";
       repo = "nvim-ts-autotag";
-      rev = "5bbdfdaa303c698f060035f37a91eaad8d2f8e27";
-      sha256 = "1gw1r3w9largx945lblbfacr3kc6pgx4qf1lhsgvp11i5v7qj1z5";
+      rev = "5149f0c6557fa4a492d82895a564f4cd4a9c7715";
+      sha256 = "0zyx4qkm6gq2lw75f2b1k974dv3bz12gd4f6j76dr805b8kq6l5m";
     };
     meta.homepage = "https://github.com/windwp/nvim-ts-autotag/";
   };
@@ -4907,12 +4907,12 @@ final: prev:
 
   nvim-ts-rainbow = buildVimPluginFrom2Nix {
     pname = "nvim-ts-rainbow";
-    version = "2022-02-03";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "p00f";
       repo = "nvim-ts-rainbow";
-      rev = "ece7deac8f4dfa643f17f3ed5bd85359e2e05f78";
-      sha256 = "1625rcsyvailnrflvbrcizj8llqd47frynj4a1s3pdxg4m6d113q";
+      rev = "c6c26c4def0e9cd82f371ba677d6fc9baa0038af";
+      sha256 = "0q0awc93l6cafbvb3wghrmvsn0qqg8hgkhfy5r86bvr0prwbvxga";
     };
     meta.homepage = "https://github.com/p00f/nvim-ts-rainbow/";
   };
@@ -5003,12 +5003,12 @@ final: prev:
 
   octo-nvim = buildVimPluginFrom2Nix {
     pname = "octo.nvim";
-    version = "2022-02-02";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "pwntester";
       repo = "octo.nvim";
-      rev = "d21c5cc8e2a28c58a28eee353dbab81c74e76382";
-      sha256 = "13lzq4py15szsr3ii3nq8xdy7vcqa0fkzsz18c84yvyy0k38q7d1";
+      rev = "9b7902d28c6d50c481e5b46209ef0ebe5b78990f";
+      sha256 = "1gqrr9kc7l3ibdwacmfwqz7vb80wdrxzsv73g59l8vhp3q6m7q7a";
     };
     meta.homepage = "https://github.com/pwntester/octo.nvim/";
   };
@@ -5051,12 +5051,12 @@ final: prev:
 
   onedarkpro-nvim = buildVimPluginFrom2Nix {
     pname = "onedarkpro.nvim";
-    version = "2022-01-16";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "olimorris";
       repo = "onedarkpro.nvim";
-      rev = "55846471df3c6257cc2b4c7ad6001a55d52e2c34";
-      sha256 = "179wwb7b65yyh345a5hnhdc10kxchddzicdlpiqkvy77rbrxc65a";
+      rev = "579f0a552154677ebe5a2f4a7e97f551967da998";
+      sha256 = "1g9zbylx8dvall19yxlymrqqp6bk24h5xs3z5a5i0dkwjvnaxx8v";
     };
     meta.homepage = "https://github.com/olimorris/onedarkpro.nvim/";
   };
@@ -5123,12 +5123,12 @@ final: prev:
 
   packer-nvim = buildVimPluginFrom2Nix {
     pname = "packer.nvim";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "wbthomason";
       repo = "packer.nvim";
-      rev = "e5c8c01374350b4fcfd56da2afc87434c51b3972";
-      sha256 = "07ai0kwh5i6ka4kxfzz25rgi2f13s7cb24wk7swpasfxllsjypqp";
+      rev = "8551feef9030edf364188c26a6db797f827cda77";
+      sha256 = "060wjn7l518fhg35jqvx0m526qkvhrvc9n778hb3blnm19fj7p55";
     };
     meta.homepage = "https://github.com/wbthomason/packer.nvim/";
   };
@@ -5292,12 +5292,12 @@ final: prev:
 
   presence-nvim = buildVimPluginFrom2Nix {
     pname = "presence.nvim";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "andweeb";
       repo = "presence.nvim";
-      rev = "9aeb8e0cf3df82090955d609c9d64d74bf6b9afd";
-      sha256 = "0qha4byqx0g048n2k9l1p066w0cps17nd77ij9mj79pdl9az1ylg";
+      rev = "ebdf23b9b180c7f162e3afb4a250c313ca2b7271";
+      sha256 = "0wygl17k2adbsy3pjyyb6amsrx14r11ldbqj21kmkjq289n58f6n";
     };
     meta.homepage = "https://github.com/andweeb/presence.nvim/";
   };
@@ -5545,12 +5545,12 @@ final: prev:
 
   refactoring-nvim = buildVimPluginFrom2Nix {
     pname = "refactoring.nvim";
-    version = "2022-02-04";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "theprimeagen";
       repo = "refactoring.nvim";
-      rev = "23340bf6b19ab50504165462676f87a3e1bd4870";
-      sha256 = "04kgaf2fay2gi82fwpl6nhjk7r2zw4nkv2dkm71gd7l6b3idx8k3";
+      rev = "1c77bd656b4802d890ec3382e438e45109e2b862";
+      sha256 = "0s1zhrnrkzb1xc3mb95930w31kad0vwff78z8ag2liawq10s2yhb";
     };
     meta.homepage = "https://github.com/theprimeagen/refactoring.nvim/";
   };
@@ -5725,12 +5725,12 @@ final: prev:
 
   SchemaStore-nvim = buildVimPluginFrom2Nix {
     pname = "SchemaStore.nvim";
-    version = "2022-02-01";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "b0o";
       repo = "SchemaStore.nvim";
-      rev = "058575f0bd94b115604bef9c4c48c5d02e21ffef";
-      sha256 = "1mh2lf6lr6js9p8mqxs7pr97nczk8skxric3sw2z0vd9sf3pj2kk";
+      rev = "73c15bf820f1a94b3f1e52484ff102667bc1f987";
+      sha256 = "0n2q41k69ljca5vj2kapgwffrxk478lgd7l2yg8rsd54jsav5w7q";
     };
     meta.homepage = "https://github.com/b0o/SchemaStore.nvim/";
   };
@@ -5942,12 +5942,12 @@ final: prev:
 
   sonokai = buildVimPluginFrom2Nix {
     pname = "sonokai";
-    version = "2022-02-04";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "sainnhe";
       repo = "sonokai";
-      rev = "8cd458541338cb7c71707cf9189ed9a27cfcdc15";
-      sha256 = "16xldhfgpx0jjcsqpszjdq8mp4jqb3vwxcyh9wp3mpadbylyb8vv";
+      rev = "73622eaf3764237d32395b2b589fa9231eb44b83";
+      sha256 = "0xd6kzc043bmf27bs653d8q8vkdlr33ja0k63vmikz9vk91w3czb";
     };
     meta.homepage = "https://github.com/sainnhe/sonokai/";
   };
@@ -6268,12 +6268,12 @@ final: prev:
 
   tabnine-vim = buildVimPluginFrom2Nix {
     pname = "tabnine-vim";
-    version = "2022-01-20";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "codota";
       repo = "tabnine-vim";
-      rev = "251ab5f24cc376daf488b68e2d46a219854dcf5f";
-      sha256 = "0v7jdrsyx754y13zwc6cjwqmwc4ic63ala55sxpa0bvsyx63cvdh";
+      rev = "bcb474cafade81a7fc1ecab4bd2ceda6fe359e66";
+      sha256 = "0mpawhqhnva3xqpxq27amd6hr0nls3zsxxwzb7bsrkzk4lc2p1kj";
       fetchSubmodules = true;
     };
     meta.homepage = "https://github.com/codota/tabnine-vim/";
@@ -6401,12 +6401,12 @@ final: prev:
 
   telescope-coc-nvim = buildVimPluginFrom2Nix {
     pname = "telescope-coc.nvim";
-    version = "2022-02-07";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "fannheyward";
       repo = "telescope-coc.nvim";
-      rev = "b6e2f29a9af35c141bf95a751e1cf628333efcb2";
-      sha256 = "1mrbrnb8r0am34wbpkanka47aanw87yan6ykzs97mym5w101krpj";
+      rev = "0481789b0ba59d0b13f32a33f6b1b844f829f412";
+      sha256 = "0mnxy4fvk2n5qqvqhblnflyqzjd6z8w9ifnajfilzzrdfbny87jf";
     };
     meta.homepage = "https://github.com/fannheyward/telescope-coc.nvim/";
   };
@@ -7267,12 +7267,12 @@ final: prev:
 
   vim-android = buildVimPluginFrom2Nix {
     pname = "vim-android";
-    version = "2022-02-05";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "hsanson";
       repo = "vim-android";
-      rev = "12468bc4271a6e3373662e9b9f9d59b30e4ccdea";
-      sha256 = "04ilkr2gl96471hp6cxcqhqn3mm25hkaw0vgbzi1izpi6fqkps00";
+      rev = "e9d03b12378b173b39d416df6469ca417b9cac9d";
+      sha256 = "1r7jcd8q41v1v0syy097qd34ydx0bczgad9ihsmsz83bdbx51dbl";
     };
     meta.homepage = "https://github.com/hsanson/vim-android/";
   };
@@ -7315,12 +7315,12 @@ final: prev:
 
   vim-argwrap = buildVimPluginFrom2Nix {
     pname = "vim-argwrap";
-    version = "2022-02-06";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "FooSoft";
       repo = "vim-argwrap";
-      rev = "0c03483702ca3ded88653c1762ba3b25ab8a6393";
-      sha256 = "0bl5aiycch25jq9vkv6j3xrz56adlb7jhvzz82hc9h0fiwzshjzn";
+      rev = "0faba07179f96cae2ab49cf2cc22ebeb922c1532";
+      sha256 = "1lb1rjp1q25gqpzbjix9anjxvx7cqw1qlacvc693f59gl8s8nbf4";
     };
     meta.homepage = "https://github.com/FooSoft/vim-argwrap/";
   };
@@ -7567,12 +7567,12 @@ final: prev:
 
   vim-clap = buildVimPluginFrom2Nix {
     pname = "vim-clap";
-    version = "2022-02-05";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "liuchengxu";
       repo = "vim-clap";
-      rev = "40a748c201d44d1b910159f201754adfd88b52c2";
-      sha256 = "098hf2b0p7csr4b4fwfn2772xpj1m2c0zg9zf8ysgrf20lqw31a2";
+      rev = "936edac04920196b331edf3a056c42e5b926c0aa";
+      sha256 = "153503q7rfb58ga3hislhbn98hh7gcycwmdmdq22dagxd16zrr31";
     };
     meta.homepage = "https://github.com/liuchengxu/vim-clap/";
   };
@@ -7603,12 +7603,12 @@ final: prev:
 
   vim-closer = buildVimPluginFrom2Nix {
     pname = "vim-closer";
-    version = "2021-03-28";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "rstacruz";
       repo = "vim-closer";
-      rev = "26bba80f4d987f12141da522d69aa1fa4aff4436";
-      sha256 = "1pyi5akzvvkdngm577m1c1210r0yypdwsvp1y7ag6gdfnls75xws";
+      rev = "43acc7c59fca861cb92cc47f01f184d9d342a73b";
+      sha256 = "1q03kz5ffyz8ifxdn7bgf3r7jlqa8vya13pnjyqda15wly1fl0k8";
     };
     meta.homepage = "https://github.com/rstacruz/vim-closer/";
   };
@@ -7639,12 +7639,12 @@ final: prev:
 
   vim-codefmt = buildVimPluginFrom2Nix {
     pname = "vim-codefmt";
-    version = "2021-12-24";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "google";
       repo = "vim-codefmt";
-      rev = "605dc002cabfec67eded553298aba21ab392ea78";
-      sha256 = "1zlmibs23nyxkaj95h7z2m2p8xizvdr0i3477zs4y3lm6g0rqs23";
+      rev = "27e5ac299a0714025cc46fc1da11694a8662b058";
+      sha256 = "06zp45w1mxq075lrw1x2p87l4gdc5fijgag4mj7j61jd2x92xsx7";
     };
     meta.homepage = "https://github.com/google/vim-codefmt/";
   };
@@ -8299,12 +8299,12 @@ final: prev:
 
   vim-floaterm = buildVimPluginFrom2Nix {
     pname = "vim-floaterm";
-    version = "2022-02-07";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "voldikss";
       repo = "vim-floaterm";
-      rev = "d38f75fdc237ed8ff2864b9e481ce2ec5b5504a0";
-      sha256 = "1h3am33r40ssih8j1n3l939qmqgh7f7awwrqdpkvgj1wisiq2v21";
+      rev = "237787fe2206f8ebec1293aa5730eef71b04c69b";
+      sha256 = "1qr9cf8yk6kjm3q7pgcp2pkbli31x94vgxxzd4xx7f4ssfv8l0bl";
     };
     meta.homepage = "https://github.com/voldikss/vim-floaterm/";
   };
@@ -8515,12 +8515,12 @@ final: prev:
 
   vim-go = buildVimPluginFrom2Nix {
     pname = "vim-go";
-    version = "2022-02-06";
+    version = "2022-02-08";
     src = fetchFromGitHub {
       owner = "fatih";
       repo = "vim-go";
-      rev = "d1e3a60213fba8ca4a6050ca3c71410960a77591";
-      sha256 = "1igik71zcl70mi6fqsf55pk4g0sc891zfp0pnk086cy5klf6854v";
+      rev = "f7a4509fc1d1434daf922894f0aee140c9fa3f1a";
+      sha256 = "1g0v9miazm9z9nbi3s8k5imh75kp4d1mz5q95y2aqm12bi5a7890";
     };
     meta.homepage = "https://github.com/fatih/vim-go/";
   };
@@ -8539,12 +8539,12 @@ final: prev:
 
   vim-graphql = buildVimPluginFrom2Nix {
     pname = "vim-graphql";
-    version = "2022-01-31";
+    version = "2022-02-07";
     src = fetchFromGitHub {
       owner = "jparise";
       repo = "vim-graphql";
-      rev = "5ce866172da4b90f77b8371423dc031fe2f4ece7";
-      sha256 = "07rl7il0aqirmrg720c3k96v0rfwj4njmx2pnql3wd8nbl2w5czb";
+      rev = "15c5937688490af8dde09e90c9a5585c840ba81c";
+      sha256 = "07j704ysc2klqfjk3918b1kjq16pw1yb1fykdsi2a0lamndn9l04";
     };
     meta.homepage = "https://github.com/jparise/vim-graphql/";
   };
@@ -9309,12 +9309,12 @@ final: prev:
 
   vim-markdown = buildVimPluginFrom2Nix {
     pname = "vim-markdown";
-    version = "2022-01-29";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "preservim";
       repo = "vim-markdown";
-      rev = "50d42082819cfa91745b6eff6e28ad5cbc8b27fa";
-      sha256 = "1582y2cyqywbgf4pg8m5m2s0nd6wwgnm1nxy5kmrfcn1119hn639";
+      rev = "b4dc23e2b0c4ce1ed77eb630bf04238ee2871e2e";
+      sha256 = "1b4dz229a5qlfdigc4h0chrdb368bkskq11g6a6mc0fhnzm20j1i";
     };
     meta.homepage = "https://github.com/preservim/vim-markdown/";
   };
@@ -9622,12 +9622,12 @@ final: prev:
 
   vim-ocaml = buildVimPluginFrom2Nix {
     pname = "vim-ocaml";
-    version = "2022-01-24";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "ocaml";
       repo = "vim-ocaml";
-      rev = "9485f5aa3aa8e3d8505fce9a70efecc38dfee329";
-      sha256 = "13lwc63iavqpwr25knrzs5f5mn7yrq8lhmm8p1d99vd5j7ngyy5x";
+      rev = "335ebc6e433afb972aa797be0587895a11dddab5";
+      sha256 = "079pfc897zz36mb36as7vq38b9njy42phjvmgarqlyqrwgjc0win";
     };
     meta.homepage = "https://github.com/ocaml/vim-ocaml/";
   };
@@ -11460,12 +11460,12 @@ final: prev:
 
   vimtex = buildVimPluginFrom2Nix {
     pname = "vimtex";
-    version = "2022-02-06";
+    version = "2022-02-09";
     src = fetchFromGitHub {
       owner = "lervag";
       repo = "vimtex";
-      rev = "becbae7acad2fd80eeeb266ddb29f4cb1cc7846a";
-      sha256 = "0ckf7ypq6cdzpcs1cknqccdx3vx3cydq19jsh83znmc1qs6zr4ab";
+      rev = "950f9e5ea26cf7f63cd9f0bf71bbae87e70c2158";
+      sha256 = "0gc7zh1h60mnds2xgsliblxg951swcnafxxla1w74yjjsn9cmsbd";
     };
     meta.homepage = "https://github.com/lervag/vimtex/";
   };

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -5771,6 +5771,18 @@ final: prev:
     meta.homepage = "https://github.com/RobertAudi/securemodelines/";
   };
 
+  select-and-search = buildVimPluginFrom2Nix {
+    pname = "select-and-search";
+    version = "2014-08-04";
+    src = fetchFromGitHub {
+      owner = "luochen1990";
+      repo = "select-and-search";
+      rev = "6d599c6d64201c0a15a57b650bfa1ec90c1e4052";
+      sha256 = "1wd3q8qi8dmjv99x6xlj819gbqj3yh7yn5fa5iid72nylwfh4il0";
+    };
+    meta.homepage = "https://github.com/luochen1990/select-and-search/";
+  };
+
   self = buildVimPluginFrom2Nix {
     pname = "self";
     version = "2014-05-28";

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -2733,6 +2733,18 @@ final: prev:
     meta.homepage = "https://github.com/lukas-reineke/indent-blankline.nvim/";
   };
 
+  indent-detector-vim = buildVimPluginFrom2Nix {
+    pname = "indent-detector.vim";
+    version = "2015-07-06";
+    src = fetchFromGitHub {
+      owner = "luochen1990";
+      repo = "indent-detector.vim";
+      rev = "a0a66b836cef8f89b8f36b33881fa22d7b9a5816";
+      sha256 = "1l455myr9p621liqd1iyv850ksbrzc7vagn9nq5n0v9i87albmhp";
+    };
+    meta.homepage = "https://github.com/luochen1990/indent-detector.vim/";
+  };
+
   indentLine = buildVimPluginFrom2Nix {
     pname = "indentLine";
     version = "2021-01-28";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -431,6 +431,7 @@ lukaszkorecki/workflowish
 lumiliet/vim-twig
 luochen1990/indent-detector.vim
 luochen1990/rainbow
+luochen1990/select-and-search
 luukvbaal/stabilize.nvim
 lyokha/vim-xkbswitch
 machakann/vim-highlightedyank

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -429,6 +429,7 @@ lukas-reineke/cmp-under-comparator
 lukas-reineke/indent-blankline.nvim
 lukaszkorecki/workflowish
 lumiliet/vim-twig
+luochen1990/indent-detector.vim
 luochen1990/rainbow
 luukvbaal/stabilize.nvim
 lyokha/vim-xkbswitch


### PR DESCRIPTION
###### Motivation for this change
closes: #158492

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
