### PR TITLE
swift: 5.5.2 -> 5.5.3

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -52,7 +52,7 @@ let
   # - integration-tests
 
   versions = {
-    swift = "5.5.2";
+    swift = "5.5.3";
     yams = "4.0.2";
     argumentParser = "0.4.3";
     format = "swift-5.5-branch";
@@ -79,7 +79,7 @@ let
 
     swift = fetchSwiftRelease {
       repo = "swift";
-      sha256 = "1a9ja3r6ap4cappbvlk18krlvwi0q75z21j5yx5rhbnw4ihh7lda";
+      sha256 = "0ma96sfvwiv2f4qhzrvcwxi9igzd80930gnaw4r7ra4w190cnag7";
     };
     cmark = fetchSwiftRelease {
       repo = "swift-cmark";
@@ -99,7 +99,7 @@ let
     };
     swiftpm = fetchSwiftRelease {
       repo = "swift-package-manager";
-      sha256 = "0hdjvb2asfi6h3x9bjssxkc3bgjn3idlmyga3dl3lscfq88hjxr9";
+      sha256 = "0z90mg837jzwh516pypn48r3wsjf0lqymsyigdhgr7j2sgcckrr1";
     };
     syntax = fetchSwiftRelease {
       repo = "swift-syntax";
@@ -111,7 +111,7 @@ let
     };
     corelibsFoundation = fetchSwiftRelease {
       repo = "swift-corelibs-foundation";
-      sha256 = "1f7qcdx8597gwqa9pwl38d31w6w4d84c5hadj4ycj99msrm2f32x";
+      sha256 = "06gkdliihl1l86jx5khzwkjmjk45fq290x033rscramzcdxh7d1b";
     };
     corelibsLibdispatch = fetchSwiftRelease {
       repo = "swift-corelibs-libdispatch";
@@ -128,7 +128,7 @@ let
     };
     llvmProject = fetchSwiftRelease {
       repo = "llvm-project";
-      sha256 = "1gvqps5f9jh6lbhcjh1fyzp3bc0h9chbljzaspcrdi2qp878prlx";
+      sha256 = "18rn5xg5hpxxsacs0ygjmjpzpc8pq85898kknzc0s0z5m55h45z8";
     };
 
     # Projects that have their own versions during each release


### PR DESCRIPTION
###### Motivation for this change
5.5.3 is a patch release specific for Linux and Windows. I build the Nix expression locally to verify all tests from the toolchain passed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
