### PR TITLE
python3Packages.decopatch: 1.4.8 -> 1.4.9

### DIFF
--- a/pkgs/development/python-modules/decopatch/default.nix
+++ b/pkgs/development/python-modules/decopatch/default.nix
@@ -3,30 +3,41 @@
 , fetchPypi
 , makefun
 , setuptools-scm
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "decopatch";
-  version = "1.4.8";
+  version = "1.4.9";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0i6i811s2j1z0cl6y177dwsbfxib8dvb5c2jpgklvc2xy4ahhsy6";
+    hash = "sha256-tYgsjPDVsB0hi04E9nYtB7ModCDqUJcG9Zlxw9b+xW8=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
-  propagatedBuildInputs = [ makefun ];
+  propagatedBuildInputs = [
+    makefun
+  ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace "'pytest-runner', " ""
+    substituteInPlace setup.cfg \
+      --replace "pytest-runner" ""
   '';
+
+  pythonImportsCheck = [
+    "decopatch"
+  ];
 
   # Tests would introduce multiple cirucular dependencies
   # Affected: makefun, pytest-cases
   doCheck = false;
-
-  pythonImportsCheck = [ "decopatch" ];
 
   meta = with lib; {
     description = "Python helper for decorators";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/smarie/python-decopatch/releases/tag/1.4.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
