### PR TITLE
spruce: Update to use go117

### DIFF
--- a/pkgs/development/tools/misc/spruce/default.nix
+++ b/pkgs/development/tools/misc/spruce/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule rec {
   pname = "spruce";
-  version = "unstable-20220210";
+  version = "unstable-2022-02-10";
 
   src = fetchFromGitHub {
     owner = "geofffranks";

--- a/pkgs/development/tools/misc/spruce/default.nix
+++ b/pkgs/development/tools/misc/spruce/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "spruce";
-  version = "1.29.0";
+  version = "unstable-20220210";
 
   src = fetchFromGitHub {
     owner = "geofffranks";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-HjJWiBYd1YFDZ+XOFcU2Df6bmKFBwVQ6YbiZv1IVN3A=";
+    rev = "473931f33fceae90b3f5cfb7616c296343a9559b";
+    sha256 = "sha256-TFyWkoAKmj3KH2pqhVKMtP6QKTtu0s7H5gNP+fotUzg=";
   };
 
   deleteVendor = true;
-  vendorSha256 = "sha256-67PGSW3wV8i3mAt3rCuWbFmeOe+QhHXn2rTUmeN6YMA=";
+  vendorSha256 = "sha256-VeC5c/BgcxK3Qawb2QOhqtfTIgbQbrQj546zX6yPD+s=";
 
   meta = with lib; {
     description = "A BOSH template merge tool";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15544,9 +15544,7 @@ with pkgs;
 
   spooles = callPackage ../development/libraries/science/math/spooles {};
 
-  spruce = callPackage ../development/tools/misc/spruce {
-    buildGoModule = buildGo116Module;
-  };
+  spruce = callPackage ../development/tools/misc/spruce {};
 
   sqlcheck = callPackage ../development/tools/database/sqlcheck { };
 


### PR DESCRIPTION
Had to upstream some fixes to the main repo (and the vendor folder still
didn't work - a little confused).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
