### PR TITLE
liquidfun: refactor

### DIFF
--- a/pkgs/development/libraries/liquidfun/default.nix
+++ b/pkgs/development/libraries/liquidfun/default.nix
@@ -1,21 +1,15 @@
 { lib, stdenv, requireFile, cmake, libGLU, libGL, libX11, libXi }:
 
-let
-  sourceInfo = rec {
-    version="1.1.0";
-    name="liquidfun-${version}";
-    url="https://github.com/google/liquidfun/releases/download/v${version}/${name}";
-    hash="5011a000eacd6202a47317c489e44aa753a833fb562d970e7b8c0da9de01df86";
-  };
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
+  pname = "liquidfun";
+  version = "1.1.0";
+
   src = requireFile {
-    url = sourceInfo.url;
-    sha256 = sourceInfo.hash;
-    name = sourceInfo.name + ".tar.gz";
+    url = "https://github.com/google/liquidfun/releases/download/v${version}/liquidfun-${version}";
+    sha256 = "5011a000eacd6202a47317c489e44aa753a833fb562d970e7b8c0da9de01df86";
+    name = "liquidfun-${version}.tar.gz";
   };
 
-  inherit (sourceInfo) name version;
   nativeBuildInputs = [ cmake ];
   buildInputs = [ libGLU libGL libX11 libXi ];
 
@@ -34,15 +28,12 @@ stdenv.mkDerivation {
     cmake -DBOX2D_INSTALL=ON -DBOX2D_BUILD_SHARED=ON -DCMAKE_INSTALL_PREFIX=$out ..
   '';
 
-  meta = {
+  meta = with lib; {
     description = "2D physics engine based on Box2D";
-    maintainers = with lib.maintainers;
-    [
-      qknight
-    ];
-    platforms = lib.platforms.linux;
-    hydraPlatforms = [];
-    license = lib.licenses.bsd2;
+    maintainers = with maintainers; [ qknight ];
+    platforms = platforms.linux;
+    hydraPlatforms = [ ];
+    license = licenses.bsd2;
     homepage = "https://google.github.io/liquidfun/";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
make the package more readable

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
