### PR TITLE
Make fetchFromGitHub & friends overridable

### DIFF
--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -1,5 +1,6 @@
-{ fetchzip }:
+{ fetchzip, lib }:
 
+lib.makeOverridable (
 { owner, repo, rev, name ? "source"
 , ... # For hash agility
 }@args: fetchzip ({
@@ -7,3 +8,4 @@
   url = "https://bitbucket.org/${owner}/${repo}/get/${rev}.tar.gz";
   meta.homepage = "https://bitbucket.org/${owner}/${repo}/";
 } // removeAttrs args [ "owner" "repo" "rev" ]) // { inherit rev; }
+)

--- a/pkgs/build-support/fetchcvs/default.nix
+++ b/pkgs/build-support/fetchcvs/default.nix
@@ -3,8 +3,9 @@
 # tag="<tagname>" (get version by tag name)
 # If you don't specify neither one date="NOW" will be used (get latest)
 
-{stdenvNoCC, cvs, openssh}:
+{stdenvNoCC, cvs, openssh, lib}:
 
+lib.makeOverridable (
 {cvsRoot, module, tag ? null, date ? null, sha256}:
 
 stdenvNoCC.mkDerivation {
@@ -18,3 +19,4 @@ stdenvNoCC.mkDerivation {
 
   inherit cvsRoot module sha256 tag date;
 }
+)

--- a/pkgs/build-support/fetchdarcs/default.nix
+++ b/pkgs/build-support/fetchdarcs/default.nix
@@ -1,5 +1,6 @@
-{stdenvNoCC, darcs, cacert}:
+{stdenvNoCC, darcs, cacert, lib}:
 
+lib.makeOverridable (
 { url
 , rev ? null
 , context ? null
@@ -21,3 +22,4 @@ stdenvNoCC.mkDerivation {
 
   inherit url rev context name;
 }
+)

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -10,6 +10,7 @@
     appendShort = lib.optionalString ((builtins.match "[a-f0-9]*" rev) != null) "-${short}";
   in "${if matched == null then base else builtins.head matched}${appendShort}";
 in
+lib.makeOverridable (
 { url, rev ? "HEAD", md5 ? "", sha256 ? "", hash ? "", leaveDotGit ? deepClone
 , fetchSubmodules ? true, deepClone ? false
 , branchName ? null
@@ -107,3 +108,4 @@ stdenvNoCC.mkDerivation {
     gitRepoUrl = url;
   };
 }
+)

--- a/pkgs/build-support/fetchgitea/default.nix
+++ b/pkgs/build-support/fetchgitea/default.nix
@@ -2,6 +2,8 @@
 
 { lib, fetchFromGitHub }:
 
+lib.makeOverridable (
 { domain, ... }@args:
 
 fetchFromGitHub ((removeAttrs args [ "domain" ]) // { githubBase = domain; })
+)

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchgit, fetchzip }:
 
+lib.makeOverridable (
 { owner, repo, rev, name ? "source"
 , fetchSubmodules ? false, leaveDotGit ? null
 , deepClone ? false, private ? false, forceFetchGit ? false
@@ -60,3 +61,4 @@ let
 in
 
 fetcher fetcherArgs // { meta = newMeta; inherit rev owner repo; }
+)

--- a/pkgs/build-support/fetchgitiles/default.nix
+++ b/pkgs/build-support/fetchgitiles/default.nix
@@ -1,5 +1,6 @@
 { fetchzip, lib }:
 
+lib.makeOverridable (
 { url, rev, name ? "source", ... } @ args:
 
 fetchzip ({
@@ -8,3 +9,4 @@ fetchzip ({
   stripRoot = false;
   meta.homepage = url;
 } // removeAttrs args [ "url" "rev" ]) // { inherit rev; }
+)

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,5 +1,6 @@
 { fetchgit, fetchzip, lib }:
 
+lib.makeOverridable (
 # gitlab example
 { owner, repo, rev, protocol ? "https", domain ? "gitlab.com", name ? "source", group ? null
 , fetchSubmodules ? false, leaveDotGit ? false, deepClone ? false
@@ -30,3 +31,4 @@ let
 in
 
 fetcher fetcherArgs // { meta.homepage = "${protocol}://${domain}/${slug}/"; inherit rev; }
+)

--- a/pkgs/build-support/fetchgitlocal/default.nix
+++ b/pkgs/build-support/fetchgitlocal/default.nix
@@ -1,4 +1,7 @@
-{ runCommand, git }: src:
+{ runCommand, git, lib }:
+
+lib.makeOverridable (
+src:
 
 let
   srcStr = toString src;
@@ -38,3 +41,4 @@ let
     '';
 
 in nixPath
+)

--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -1,5 +1,6 @@
-{ fetchzip }:
+{ fetchzip, lib }:
 
+lib.makeOverridable (
 # cgit example, snapshot support is optional in cgit
 { repo, rev, name ? "source"
 , ... # For hash agility
@@ -8,3 +9,4 @@
   url = "https://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
   meta.homepage = "https://git.savannah.gnu.org/cgit/${repo}.git/";
 } // removeAttrs args [ "repo" "rev" ]) // { inherit rev; }
+)

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -1,5 +1,6 @@
 { fetchgit, fetchhg, fetchzip, lib }:
 
+lib.makeOverridable (
 { owner
 , repo, rev
 , domain ? "sr.ht"
@@ -48,3 +49,4 @@ in cases.${fetcher}.fetch cases.${fetcher}.arguments // {
   inherit rev;
   meta.homepage = "${baseUrl}";
 }
+)


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
