### PR TITLE
python3Packages.shap: fix broken package

### DIFF
--- a/pkgs/development/python-modules/shap/default.nix
+++ b/pkgs/development/python-modules/shap/default.nix
@@ -9,9 +9,12 @@
 , pandas
 , tqdm
 , slicer
+, cloudpickle
 , numba
 , matplotlib
 , nose
+, pytest-mpl
+, pytest-cov
 , ipython
 }:
 
@@ -35,6 +38,7 @@ buildPythonPackage rec {
     tqdm
     slicer
     numba
+    cloudpickle
   ];
 
   preCheck = ''
@@ -42,22 +46,41 @@ buildPythonPackage rec {
     # when importing the local copy the extension is not found
     rm -r shap
   '';
-  checkInputs = [ pytestCheckHook matplotlib nose ipython ];
+  checkInputs = [
+    pytestCheckHook
+    matplotlib
+    nose
+    ipython
+    pytest-mpl
+    pytest-cov
+  ];
   # Those tests access the network
-  disabledTests = [
-    "test_kernel_shap_with_a1a_sparse_zero_background"
-    "test_kernel_shap_with_a1a_sparse_nonzero_background"
-    "test_kernel_shap_with_high_dim_sparse"
-    "test_sklearn_random_forest_newsgroups"
-    "test_sum_match_random_forest"
-    "test_sum_match_extra_trees"
-    "test_single_row_random_forest"
-    "test_sum_match_gradient_boosting_classifier"
-    "test_single_row_gradient_boosting_classifier"
-    "test_HistGradientBoostingClassifier_proba"
-    "test_HistGradientBoostingClassifier_multidim"
-    "test_sum_match_gradient_boosting_regressor"
-    "test_single_row_gradient_boosting_regressor"
+  pytestFlagsArray = [
+    "--deselect" "tests/explainers/test_kernel.py::test_kernel_shap_with_a1a_sparse_zero_background"
+    "--deselect" "tests/explainers/test_kernel.py::test_kernel_shap_with_a1a_sparse_nonzero_background"
+    "--deselect" "tests/explainers/test_kernel.py::test_kernel_shap_with_high_dim_sparse"
+    "--deselect" "tests/explainers/test_tree.py::test_sum_match_random_forest"
+    "--deselect" "tests/explainers/test_tree.py::test_sum_match_extra_trees"
+    "--deselect" "tests/explainers/test_tree.py::test_single_row_random_forest"
+    "--deselect" "tests/explainers/test_tree.py::test_sum_match_gradient_boosting_classifier"
+    "--deselect" "tests/explainers/test_tree.py::test_single_row_gradient_boosting_classifier"
+    "--deselect" "tests/explainers/test_tree.py::test_HistGradientBoostingClassifier_proba"
+    "--deselect" "tests/explainers/test_tree.py::test_HistGradientBoostingClassifier_multidim"
+    "--deselect" "tests/explainers/test_tree.py::test_sum_match_gradient_boosting_regressor"
+    "--deselect" "tests/explainers/test_tree.py::test_single_row_gradient_boosting_regressor"
+    "--deselect" "tests/explainers/test_tree.py::test_sklearn_random_forest_newsgroups"
+    "--deselect" "tests/plots/test_dependence_string_features.py::test_dependence_one_string_feature"
+    "--deselect" "tests/plots/test_dependence_string_features.py::test_dependence_two_string_features"
+    "--deselect" "tests/plots/test_dependence_string_features.py::test_dependence_one_string_feature_no_interaction"
+    "--deselect" "tests/plots/test_dependence_string_features.py::test_dependence_one_string_feature_auto_interaction"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_with_data"
+    "--deselect" "tests/plots/test_summary.py::test_random_multi_class_summary"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_bar_with_data"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_dot_with_data"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_violin_with_data"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_layered_violin_with_data"
+    "--deselect" "tests/plots/test_summary.py::test_random_summary_with_log_scale"
   ];
 
   meta = with lib; {
@@ -66,7 +89,5 @@ buildPythonPackage rec {
     license = licenses.mit;
     maintainers = with maintainers; [ evax ];
     platforms = platforms.unix;
-    # ModuleNotFoundError: No module named 'sklearn.ensemble.iforest'
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The package was marked as broken some time ago, then updated.

###### Things done

I reviewed the test suite and disabled the tests accessing the network
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
