### PR TITLE
libusb1: 1.0.24 -> 1.0.25

### DIFF
--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -12,23 +12,16 @@
 
 stdenv.mkDerivation rec {
   pname = "libusb";
-  version = "1.0.24";
+  version = "1.0.25";
 
   src = fetchFromGitHub {
     owner = "libusb";
     repo = "libusb";
     rev = "v${version}";
-    sha256 = "18ri8ky422hw64zry7bpbarb1m0hiljyf64a0a9y093y7aad38i7";
+    sha256 = "sha256-9ha22rlHFCrWYvcYKYAUlMC4aWMElDAgUPMxKePzPJA=";
   };
 
   outputs = [ "out" "dev" ];
-
-  patches = [ (fetchpatch {
-    # https://bugs.archlinux.org/task/69121
-    url = "https://github.com/libusb/libusb/commit/f6d2cb561402c3b6d3627c0eb89e009b503d9067.patch";
-    sha256 = "1dbahikcbwkjhyvks7wbp7fy2bf7nca48vg5z0zqvqzjb9y595cq";
-    excludes = [ "libusb/version_nano.h" ];
-  }) ];
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];
   propagatedBuildInputs =


### PR DESCRIPTION
###### Motivation for this change

Closes https://github.com/NixOS/nixpkgs/issues/135678.

Some testing would be nice, I only built it for now.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`) -> no result/bin folder
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
