### PR TITLE
super-productivity: switch to electron 17

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26303,7 +26303,7 @@ with pkgs;
   srain = callPackage ../applications/networking/irc/srain { };
 
   super-productivity = callPackage ../applications/office/super-productivity {
-    electron = electron_13;
+    electron = electron_17;
   };
 
   wlroots = wlroots_0_15;


### PR DESCRIPTION
Electron 13 is EOL, and thus marked insecure.

Built and tested as an outlier package on NixOS 21.11, everything seems to work fine