### PR TITLE
talosctl: 0.14.1 -> 0.14.2, install completion

### DIFF
--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,19 +1,24 @@
 { lib, buildGoModule, fetchFromGitHub, installShellFiles }:
-
+let
+  # look for GO_LDFLAGS getting set in the Makefile
+  version = "0.14.2";
+  sha256 = "sha256-sQtry94T5cDO+836D/p/8ptQi3WYKDBLr1QZyEXdLQI=";
+  vendorSha256 = "sha256-cd2iNMxWmkSWqqkPLYocUG+fCUXoeUXEuGQxjUWQnXk=";
+  pkgsVersion = "0.9.0-4-gc875fbe";
+  extrasVersion = "0.7.0-2-gb4c9d21";
+in
 buildGoModule rec {
   pname = "talosctl";
-  version = "0.14.1";
+  inherit version vendorSha256;
+  # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "talos-systems";
     repo = "talos";
     rev = "v${version}";
-    sha256 = "sha256-JeZ+Q6LTDJtoxfu4mJNc3wv3Y6OPcIUvgnozj9mWwLw=";
+    inherit sha256;
   };
 
-  vendorSha256 = "sha256-ujbEWvcNJJOUegVgAGEPwYF02TiqD1lZELvqc/Gmb4A=";
-
-  # look for GO_LDFLAGS getting set in the Makefile
   ldflags =
     let
       versionPkg = "github.com/talos-systems/talos/pkg/version"; # VERSION_PKG
@@ -24,8 +29,8 @@ buildGoModule rec {
       "-X ${versionPkg}.Name=Talos"
       "-X ${versionPkg}.SHA=${src.rev}" # should be the hash, but as we build from tags, this needs to do
       "-X ${versionPkg}.Tag=${src.rev}"
-      "-X ${versionPkg}.PkgsVersion=v0.9.0-2-g447ce75" # PKGS
-      "-X ${versionPkg}.ExtrasVersion=v0.7.0-1-gd6b73a7" # EXTRAS
+      "-X ${versionPkg}.PkgsVersion=v${pkgsVersion}" # PKGS
+      "-X ${versionPkg}.ExtrasVersion=v${extrasVersion}" # EXTRAS
       "-X ${imagesPkgs}.Username=talos-systems" # USERNAME
       "-X ${imagesPkgs}.Registry=ghcr.io" # REGISTRY
       "-X ${mgmtHelpersPkg}.ArtifactsPath=_out" # ARTIFACTS

--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "talosctl";
@@ -32,6 +32,15 @@ buildGoModule rec {
     ];
 
   subPackages = [ "cmd/talosctl" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd talosctl \
+      --bash <($out/bin/talosctl completion bash) \
+      --fish <($out/bin/talosctl completion fish) \
+      --zsh <($out/bin/talosctl completion zsh)
+  '';
 
   doCheck = false;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
