### PR TITLE
wireshark: 3.6.1 -> 3.6.2

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -11,7 +11,7 @@ assert withQt  -> qt5  != null;
 with lib;
 
 let
-  version = "3.6.1";
+  version = "3.6.2";
   variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "sha256-BDTtqPtr+I4rQqZ+tdHeJUpn1QW+w7tR/unXyteSWjg=";
+    sha256 = "sha256-XZAaVXKu+VPwStwlPtKgaZ1MYnedMkkCHh6FQaAkww4=";
   };
 
   cmakeFlags = [


### PR DESCRIPTION
###### Motivation for this change
https://www.wireshark.org/docs/relnotes/wireshark-3.6.2.html

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).