### PR TITLE
qFlipper: re-init at 0.8.2

### DIFF
--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -1,31 +1,116 @@
-{ lib, fetchurl, appimageTools }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, zlib
+, libusb1
+, libGL
+, qmake
+, wrapQtAppsHook
+, mkDerivation
 
+, qttools
+, qtbase
+, qt3d
+, qtsvg
+, qtserialport
+, qtdeclarative
+, qtquickcontrols
+, qtquickcontrols2
+, qtgraphicaleffects
+, qtwayland
+}:
 let
-  pname = "qflipper";
-  version = "0.5.3";
-  name = "${pname}-${version}";
-  src = fetchurl {
-    url = "https://update.flipperzero.one/builds/qFlipper/${version}/qFlipper-x86_64-${version}.AppImage";
-    sha256 = "sha256-UFGFl1zb0t1y7FBd5EX1YS3npWM5slL/wLiTOF/CLNM=";
+  version = "0.8.2";
+  timestamp = "99999999999";
+  commit = "nix-${version}";
+  hash = "sha256-BaqKlF2SZueykFhtj91McP39oXYAx+lz8eXhn5eouqg=";
+
+  udev_rules = ''
+    #Flipper Zero serial port
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ATTRS{manufacturer}=="Flipper Devices Inc.", TAG+="uaccess"
+    #Flipper Zero DFU
+    SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ATTRS{manufacturer}=="STMicroelectronics", TAG+="uaccess"
+  '';
+
+in
+mkDerivation {
+  pname = "qFlipper";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "flipperdevices";
+    repo = "qFlipper";
+    rev = version;
+    inherit hash;
+    fetchSubmodules = true;
   };
-  appimageContents = appimageTools.extractType2 { inherit name src; };
 
-in appimageTools.wrapType2 {
-  inherit name src;
+  nativeBuildInputs = [
+    pkg-config
+    qmake
+    qttools
+  ];
 
-  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsecret ];
+  buildInputs = [
+    zlib
+    libusb1
+    libGL
+    wrapQtAppsHook
 
-  extraInstallCommands = ''
-    mv $out/bin/${name} $out/bin/qFlipper
-    install -m 444 -D ${appimageContents}/qFlipper.desktop -t $out/share/applications
-    cp -r ${appimageContents}/usr/share/icons $out/share
+    qtbase
+    qt3d
+    qtsvg
+    qtserialport
+    qtdeclarative
+    qtquickcontrols
+    qtquickcontrols2
+    qtgraphicaleffects
+  ] ++ lib.optionals (stdenv.isLinux) [
+    qtwayland
+  ];
+
+  preBuild = ''
+    substituteInPlace qflipper_common.pri \
+        --replace 'GIT_VERSION = unknown' 'GIT_VERSION = "${version}"' \
+        --replace 'GIT_TIMESTAMP = 0' 'GIT_TIMESTAMP = ${timestamp}' \
+        --replace 'GIT_COMMIT = unknown' 'GIT_COMMIT = "${commit}"'
+    cat qflipper_common.pri
+
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ${lib.optionalString stdenv.isLinux ''
+      install -Dm755 qFlipper $out/bin/qFlipper
+    ''}
+    ${lib.optionalString stdenv.isDarwin ''
+      install -Dm755 qFlipper.app/Contents/MacOS/qFlipper $out/bin/qFlipper
+    ''}
+    cp qFlipperTool $out/bin
+
+    mkdir -p $out/share/applications
+    cp installer-assets/appimage/qFlipper.desktop $out/share/applications
+
+    mkdir -p $out/share/icons
+    cp application/assets/icons/qFlipper.png $out/share/icons
+
+    mkdir -p $out/etc/udev/rules.d
+    tee $out/etc/udev/rules.d/42-flipperzero.rules << EOF
+    ${udev_rules}
+    EOF
+
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "Cross-platform desktop tool to manage your flipper device";
     homepage = "https://flipperzero.one/";
-    license = licenses.unfree;
-    maintainers = with maintainers; [ wolfangaukang ];
-    platforms = [ "x86_64-linux" ];
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ cab404 ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ]; # qtbase doesn't build yet on aarch64-darwin
   };
+
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -982,6 +982,7 @@ mapAliases ({
   QmidiNet = qmidinet; # Added 2016-05-22
   qca-qt5 = libsForQt5.qca-qt5; # Added 2015-12-19
   qcsxcad = libsForQt5.qcsxcad; # Added 2020-11-05
+  qflipper = qFlipper; # Added 2022-02-11
   qmk_firmware = throw "qmk_firmware has been removed because it was broken"; # Added 2021-04-02
   qr-filetransfer = throw ''"qr-filetransfer" has been renamed to "qrcp"''; # Added 2020-12-02
   qt-3 = throw "qt-3 has been removed from nixpkgs, as it's unmaintained and insecure"; # Added 2021-02-15

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1043,7 +1043,7 @@ with pkgs;
 
   pferd = callPackage ../tools/misc/pferd {};
 
-  qflipper = callPackage ../tools/misc/qflipper { };
+  qFlipper = libsForQt515.callPackage ../tools/misc/qflipper { };
 
   quich = callPackage ../tools/misc/quich { } ;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

qFlipper in nixpkgs is super-old, and is based on appimage. This fixes both problems (adding aarch64-linux and x86_64-darwin as well)
@WolfangAukang if you are still interested in maintaining an updated version, please let me know

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
