### PR TITLE
plantuml-server: 1.2021.12 -> 1.2022.0

### DIFF
--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -1,20 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, maven, jdk8_headless }:
+{ lib, stdenv, fetchFromGitHub, maven, jdk17_headless }:
 
 let
-  version = "1.2021.12";
+  version = "1.2022.0";
 
   src = fetchFromGitHub {
     owner = "plantuml";
     repo = "plantuml-server";
     rev = "v${version}";
-    sha256 = "sha256:016mrs4djbaid1ma5922dvq372pphbzzmjzsjalj2dqp60538xll";
+    sha256 = "sha256:1dfiph2ryj6c0yaxdk3bd5gin6l6vf46d2v698hm9hkzsr9j1wma";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
   deps = stdenv.mkDerivation {
     name = "plantuml-server-${version}-deps";
     inherit src;
-    nativeBuildInputs = [ jdk8_headless maven ];
+    nativeBuildInputs = [ jdk17_headless maven ];
     buildPhase = ''
       runHook preBuild
 
@@ -28,7 +28,11 @@ let
     installPhase = ''find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete'';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256:12w1iw9c5j7y9hhaip07j3aszjiiakkww1v3zszlj15fj8jgqyf2";
+    outputHash = (
+      if stdenv.isDarwin
+      then "sha256:016ki4i7r865l38zv0ys3zbs6gb9r8jdyb32ncqzryhr4kanpz5s"
+      else "sha256:1pf77msvi99irhx2hhcs8cac8xn3vgcxcrjx6cpzv9kvmbfsdkaw"
+    );
   };
 in
 
@@ -37,7 +41,7 @@ stdenv.mkDerivation rec {
   inherit version;
   inherit src;
 
-  nativeBuildInputs = [ jdk8_headless maven ];
+  nativeBuildInputs = [ jdk17_headless maven ];
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://plantuml.com/changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
