### PR TITLE
gmid: 1.8 -> 1.8.1

### DIFF
--- a/pkgs/applications/networking/browsers/telescope/default.nix
+++ b/pkgs/applications/networking/browsers/telescope/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "telescope";
-  version = "0.7";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "omar-polo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-YF7pysKwEwtyERBDiF0AbnDfqK3S/ZS/y+/rd17dLDw=";
+    sha256 = "sha256-W42e1p70dMhF9C7BBPp1Yhp2PrRb8/Lu07yOGiUSmNg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/gemini/gmid/default.nix
+++ b/pkgs/servers/gemini/gmid/default.nix
@@ -2,22 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "gmid";
-  version = "1.7.5";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "omar-polo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-BBd0AL5jRRslxzDnxcTZRR+8J5D23NAQ7mp9K+leXAQ=";
+    sha256 = "sha256-LqFcwm6r4wF7kSnj8nOgaYTDOJVmB4jl1i5UmTI+skQ=";
   };
-
-  patches = [
-    # Fix cross-compilation
-    (fetchpatch {
-      url = "https://github.com/omar-polo/gmid/commit/eb77afa8d308a2f4f422df2ff19f023b5b2cc591.patch";
-      sha256 = "sha256-rTTZUpfXOg7X0Ad0Y9evyU7k+aVYpJ0t9SEkNA/sSdk=";
-    })
-  ];
 
   nativeBuildInputs = [ bison ];
 


### PR DESCRIPTION
###### Motivation for this change
Bugfix on landlock

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
