### PR TITLE
gmid: 1.8 -> 1.8.1

### DIFF
--- a/pkgs/servers/gemini/gmid/default.nix
+++ b/pkgs/servers/gemini/gmid/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gmid";
-  version = "1.8";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "omar-polo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-CwJPaZefRDyn2fliOd9FnOLXq70HFu2RsUZhzWQdE3E";
+    sha256 = "sha256-LqFcwm6r4wF7kSnj8nOgaYTDOJVmB4jl1i5UmTI+skQ=";
   };
 
   nativeBuildInputs = [ bison ];

--- a/pkgs/servers/gemini/gmid/default.nix
+++ b/pkgs/servers/gemini/gmid/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, bison, libressl, libevent }:
+{ lib, stdenv, fetchFromGitHub, bison, which, libressl, libevent }:
 
 stdenv.mkDerivation rec {
   pname = "gmid";
@@ -8,18 +8,16 @@ stdenv.mkDerivation rec {
     owner = "omar-polo";
     repo = pname;
     rev = version;
-    sha256 = "sha256-LqFcwm6r4wF7kSnj8nOgaYTDOJVmB4jl1i5UmTI+skQ=";
+    hash = "sha256-XNif164C5b5sVsZW7sy0id4qM/mJzg3RhoHbwJuJqDk=";
   };
 
-  nativeBuildInputs = [ bison ];
+  nativeBuildInputs = [ bison which ];
 
   buildInputs = [ libressl libevent ];
 
-  configurePhase = ''
-    runHook preConfigure
-    ./configure PREFIX=$out
-    runHook postConfigure
-  '';
+  configureFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
 
   meta = with lib; {
     description = "Simple and secure Gemini server";


### PR DESCRIPTION
###### Motivation for this change
bugfix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
