### PR TITLE
logrotate service enhancements

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -867,6 +867,13 @@
       </listitem>
       <listitem>
         <para>
+          <literal>services.logrotate.enable</literal> now defaults to
+          true if any rotate path has been defined, and some paths have
+          been added by default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>zrepl</literal> package has been updated from
           0.4.0 to 0.5:
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -294,6 +294,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 - `services.mattermost.plugins` has been added to allow the declarative installation of Mattermost plugins.
   Plugins are automatically repackaged using autoPatchelf.
 
+- `services.logrotate.enable` now defaults to true if any rotate path has
+  been defined, and some paths have been added by default.
+
 - The `zrepl` package has been updated from 0.4.0 to 0.5:
 
   - The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -4,7 +4,6 @@ with lib;
 
 let
   cfg = config.services.logrotate;
-  inherit (config.users) groups;
 
   pathOpts = { name, ... }:  {
     options = {
@@ -162,25 +161,6 @@ in
         '';
       }
     ) cfg.paths;
-
-    services.logrotate = {
-      paths = {
-        "/var/log/btmp" = {
-          frequency = mkDefault "monthly";
-          keep = mkDefault 1;
-          extraConfig = ''
-            create 0660 root ${groups.utmp.name}
-          '';
-        };
-        "/var/log/wtmp" = {
-          frequency = mkDefault "monthly";
-          keep = mkDefault 1;
-          extraConfig = ''
-            create 0664 root ${groups.utmp.name}
-          '';
-        };
-      };
-    };
 
     systemd.services.logrotate = {
       description = "Logrotate Service";

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -111,7 +111,10 @@ in
 
   options = {
     services.logrotate = {
-      enable = mkEnableOption "the logrotate systemd service";
+      enable = mkEnableOption "the logrotate systemd service" // {
+        default = foldr (n: a: a || n.enable) false (attrValues cfg.paths);
+        defaultText = literalExpression "cfg.paths != {}";
+      };
 
       paths = mkOption {
         type = with types; attrsOf (submodule pathOpts);

--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -84,10 +84,6 @@ let
     };
 
     config.name = name;
-    config.extraConfig = ''
-      missingok
-      notifempty
-    '';
   };
 
   mkConf = pathOpts: ''
@@ -101,7 +97,11 @@ let
   '';
 
   paths = sortProperties (attrValues (filterAttrs (_: pathOpts: pathOpts.enable) cfg.paths));
-  configFile = pkgs.writeText "logrotate.conf" (concatStringsSep "\n" ((map mkConf paths) ++ [ cfg.extraConfig ]));
+  configFile = pkgs.writeText "logrotate.conf" (
+    concatStringsSep "\n" (
+      [ "missingok" "notifempty" cfg.extraConfig ] ++ (map mkConf paths)
+    )
+  );
 
 in
 {

--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -988,5 +988,17 @@ in
       nginx.gid = config.ids.gids.nginx;
     };
 
+    services.logrotate.paths.nginx = mapAttrs (_: mkDefault) {
+      path = "/var/log/nginx/*.log";
+      frequency = "weekly";
+      keep = 26;
+      extraConfig = ''
+        compress
+        delaycompress
+        postrotate
+          [ ! -f /var/run/nginx/nginx.pid ] || kill -USR1 `cat /var/run/nginx/nginx.pid`
+        endscript
+      '';
+    };
   };
 }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1212,6 +1212,23 @@ in
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.is64bit (lib.mkDefault 4194304);
 
     boot.kernelParams = optional (!cfg.enableUnifiedCgroupHierarchy) "systemd.unified_cgroup_hierarchy=0";
+
+    services.logrotate.paths = {
+      "/var/log/btmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        keep = 1;
+        extraConfig = ''
+          create 0660 root ${config.users.groups.utmp.name}
+        '';
+      };
+      "/var/log/wtmp" = mapAttrs (_: mkDefault) {
+        frequency = "monthly";
+        keep = 1;
+        extraConfig = ''
+          create 0664 root ${config.users.groups.utmp.name}
+        '';
+      };
+    };
   };
 
   # FIXME: Remove these eventually.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -268,6 +268,7 @@ in
   litestream = handleTest ./litestream.nix {};
   locate = handleTest ./locate.nix {};
   login = handleTest ./login.nix {};
+  logrotate = handleTest ./logrotate.nix {};
   loki = handleTest ./loki.nix {};
   lxd = handleTest ./lxd.nix {};
   lxd-image = handleTest ./lxd-image.nix {};

--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -1,0 +1,35 @@
+# Test logrotate service works and is enabled by default
+
+import ./make-test-python.nix ({ pkgs, ...} : rec {
+  name = "logrotate";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ martinetd ];
+  };
+
+  # default machine
+  machine = { ... }: {
+  };
+
+  testScript =
+    ''
+      with subtest("whether logrotate works"):
+          machine.succeed(
+              # we must rotate once first to create logrotate stamp
+              "systemctl start --wait logrotate.service",
+
+              # wtmp is present in default config.
+              "rm -f /var/log/wtmp*",
+              "echo test > /var/log/wtmp",
+
+              # move into the future and rotate
+              "date -s 'now + 1 month + 1 day'",
+              # systemd will run logrotate from logrotate.timer automatically
+              # on date change, but if we want to wait for it to terminate
+              # it's easier to run again...
+              "systemctl start --wait logrotate.service",
+
+              # check rotate worked
+              "[ -e /var/log/wtmp.1 ]",
+          )
+    '';
+})

--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchFromGitHub, gzip, popt, autoreconfHook
 , mailutils ? null
 , aclSupport ? true, acl
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -24,6 +25,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ popt ] ++ lib.optionals aclSupport [ acl ];
+
+  passthru.tests = {
+    nixos-logrotate = nixosTests.logrotate;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/logrotate/logrotate";


### PR DESCRIPTION
###### Motivation for this change

There are quite a few independent changes here, if anything generates a lot of discussion I'll be happy to drop any single patch and split it into a different PR, but it's all related overall.

- #152223 added wtmp/btmp logrotate rules, but since the files belong with systemd the rule probably ought to be moved there.
- in #152223 we also talked about enabling logrotate by default: I think it makes sense, if some rules are enabled then we probably want the service to move. I've made the default value of logrotate.enable be true if any path is defined, so it's not needlessly enabled.
- while I'm at it I've copied the logrotate rule I use for nginx in services.nginx, that service creates logs and probably should take care of rotating them. Does this warrant a new option? it's always possible to disable the rule with `services.logrotate.paths."/var/log/nginx/*.log".enable = false` but that's more annoying to type than e.g. `services.nginx.rotateLogs = false` (if we add such a flag, I'd say we need to come up with a convention for other services to all use the same attribute, and also add it to systemd for wtmp/btmp -- I think it'd make sense and will be happy to gate this with a mkIf)
- I tried using `services.logrotate.extraConfig` but it appends lines, and global options only affect paths following them so options were ignored. I've moved extraConfig first, and ~made use of it instead of paths default extraConfig~ moved notifempty/missingok to be similar to it as I couldn't figure how to append lines by default (setting the default value would remove lines if set elsewhere, which isn't what the previous path extraConfig was doing).
- lastly I've added a simple test, mostly to make sure I didn't screw up the syntax of the enable statement and for manual testing, happy to remove it if it's not deemed useful. I know of `passthru.tests` for packages, is there an equivalent for nixos modules?

cc @ju1m @aanderse @ryantm who participated in previous logrotate PR
cc @Mic92 who last touched the nginx module

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
