### PR TITLE
thunderbird-bin: 91.5.1 -> 91.6.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.5.1";
+  version = "91.6.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/af/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/af/thunderbird-91.6.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "90a7b62161c8e4bd0dfcb0c69995e80b1733b86513d5786559eefd0ee19ca6ec";
+      sha256 = "5782b92cb688c475352e81e4e245cb409ea8e9749bdadbae46459aa60e10dd72";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ar/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ar/thunderbird-91.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "f7167cdff08c42f0a067e8631f8ae85ea12f301a7d49ba8919fa90cdf5ac1aaf";
+      sha256 = "1192a35bfbfe355d2263f927a52034942cc7976ca87dc775c45fab3553f8ec28";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ast/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ast/thunderbird-91.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "74ffcdac8a170ba700d2c58066c66143129a7f21f8123c174dfd598240f2271d";
+      sha256 = "6eac6f3a3bbb77b79aa78b18dbd5806fa892c51cc96186fc6a816ab0f1d23d04";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/be/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/be/thunderbird-91.6.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "aabe3dce7ddcfcaad6212549f7ce709c6832c01aa7cfaa15fad82d75259fa8ee";
+      sha256 = "71f1de0952e25aa66fafb6fd59fb649f812fb87ce6959c68e6b88e4289d67e2f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/bg/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/bg/thunderbird-91.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "f0fa8e63643e1a44ab6997caf148812e749004a450825b0b77f1ac0cc52c6ec3";
+      sha256 = "948380888ca8b699af5aa68fa697cbfaca6c19a836ea45309b4c990196876682";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/br/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/br/thunderbird-91.6.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "8391eb495214140878bba1f658cb1dbab4a93187f32bb99e65613b09db70269c";
+      sha256 = "0eb4c53d80b176c70cda74b941f67f96bf6485b53ec59ef62edbee9a559e55e0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ca/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ca/thunderbird-91.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "82b1498ee1745b087b58f44ca57f1d355b61aa42ec2787302e6a59dfb5391a3e";
+      sha256 = "bd12886d0c9d14680c5fef47b4813439b426637ecc4580ec4adb0dab3e4fbbf7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/cak/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/cak/thunderbird-91.6.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "52761eec2ef3327ea5f435bfcb73dd4a5c378e78d57f9849283460ed39318af8";
+      sha256 = "824c358bf84a112088558298ffedf689ef549a76534a31eb20cb5bc0f7b05f57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/cs/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/cs/thunderbird-91.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "406bff52470379be7d6b8315909067e1a1f7623a7d4415a23b6f53ea4f896064";
+      sha256 = "4ffc14a50d23cf03e2f63e353cbc46a4bda969eb5282918e72a64204d855051f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/cy/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/cy/thunderbird-91.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "4fa869d8592709da2ddba8657424475377aea9617ad411abb25c8ae8e55612fe";
+      sha256 = "982edd269cb143dc3c75d65a1a5f0edcece633636b26f90bfba40bef3e8ce89c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/da/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/da/thunderbird-91.6.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "1ed471dab670fe7ba58ccb4fe39bec2f3ee6625a6713c3b1f3fe9703e0a703cf";
+      sha256 = "a400209beba894224c72c5099ea36b1d684bba5a722ef7aaf0ab4aaa923678d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/de/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/de/thunderbird-91.6.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "16b6e291489f37699587b62cafb3caa3e09ae21b160c9739afb35ae450dcffbc";
+      sha256 = "bdd8a89902f98bf989b3deb0e228da21120c9ba323b3b64d61c607df5c622a69";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/dsb/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/dsb/thunderbird-91.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "3872f1263a7ba9f6a31f1fcd26440ab3ec231efca678cd75459bd71a4b0637f9";
+      sha256 = "9ee57285fc96ab5a5ae45a3916bbc1d82a6796d5b1bb8c89e76b3a923e39d5cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/el/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/el/thunderbird-91.6.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "aaab178dc1f6d9f1818f63b98091113546bdf36e823efc0c252979b570406ef0";
+      sha256 = "2aafdba1b7eaf6cb5df1e75a82de4523be19c8632408be2598d0dbecc580af9a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/en-CA/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/en-CA/thunderbird-91.6.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "d2e98a42a5de6793f34725f989b645a0531dfca95e014e58bcb951fd5a4f9681";
+      sha256 = "beb44c477f907ef19d75ed0fe9fab24cb83e8f65c7806c05a9034c5dd0a0eafb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/en-GB/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/en-GB/thunderbird-91.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "4459fb379c2299be6915a5a54ad6963dbd80dd5a9838baf1d2edcf63ef0354bd";
+      sha256 = "ed2923b03fce5ac782751d972da1384131ceefab46d730453c7847d9fdc73da1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/en-US/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/en-US/thunderbird-91.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "a88c57cb36623d18a53c1940ccfa5874c222b6a2e44aab7760ccd6c70518f748";
+      sha256 = "d3860a48ac7064cf30f075a4a8ac7503125489eb8ecedb4a122165bbbb14bb35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/es-AR/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/es-AR/thunderbird-91.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "979514cb958a4626d07379099c3fc77ed4208cecd3b0af9c059a04064e60df43";
+      sha256 = "ebf79dd944da523f7ab9d3a9cbd91c795682146c21da1da79854bf6efcdcc635";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/es-ES/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/es-ES/thunderbird-91.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "745d0865606c238512e01e414305f83664b1395ff9d02b36f9df37b1bcca0e2f";
+      sha256 = "5befd338d085a1ffa65dcf9f201036bc63011b653f0d3c557df19be2c22c30f6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/et/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/et/thunderbird-91.6.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "1a009c0ec4ad94819de0eb006c6f0919080271e8d5c6c5b324c6624657ef8440";
+      sha256 = "ec5d18f9666078b7a89baead60482e82e0ffa8dc69fcd90a4145218172233b1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/eu/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/eu/thunderbird-91.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3beab0dd08c2089dabf99d246d9a06bb0339b88945e012fadc53a9420b105eb7";
+      sha256 = "2b01f42ac561a4c20275cc5a00b1bbaa1d30d6a8f9b7dd4ed577bd3c9bc0c9dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/fi/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/fi/thunderbird-91.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "d0006d6b5a2fdeb69171452c9eee4f7e54d18cf0a42bbccc056144af127109c8";
+      sha256 = "f8dbaf54fe79d30e224d3cc7eb26fe127f61362de501bfb235285cca9f08aba6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/fr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/fr/thunderbird-91.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "4345711b2199bd5f0cc89e34cd7a65bb22290268c872c990fb32ee49c174d58e";
+      sha256 = "164c5ee22564d05d21df5a9ae78dbce25dfde692407894dba1b99113d496a00a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/fy-NL/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/fy-NL/thunderbird-91.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "7f90afe3e04e1a7db5236d12d2133c3552e0d6744262f5107522dc1b88b9d26d";
+      sha256 = "dbd6d00cbdec84657bf692abc1b3f9a85a975e4ec6f8dff65031c76a16d81314";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ga-IE/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ga-IE/thunderbird-91.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "ecf987ec7a479fcd1aeec4a680fe7b785f3273914be7bc5ea34a1160024bca30";
+      sha256 = "708d40fce28188b0f53678fd3fc5e920fcf31288c92d91bcba3e3d7912891d19";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/gd/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/gd/thunderbird-91.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "e688777e2ca5a0964bdb295c17de71f0b3e7ce8ed3a81a027cb58d65f0b13843";
+      sha256 = "9189273e5afe68d766aee5ab4a9472d183dfb5134ebc4789eb5471d17af5fd87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/gl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/gl/thunderbird-91.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "b7e37320a6f29312851d814713522c0edaf3ad10bb6096e08e60ad9d6eae3c34";
+      sha256 = "2db559b48a178fdc337d79ea6dda580ec2b2d9dff420d18a4818dfb584cd7707";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/he/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/he/thunderbird-91.6.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "9e317e22ca0e8e6d809437efee263fb3e0b6418696282f8670b7f8f92ec6c56a";
+      sha256 = "bd6cba45422ef915882224cc2b34c67fd9f922232aac4668216af9b0e0ab35d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/hr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/hr/thunderbird-91.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "51f6eec36a08b766bc9567ae7dbac5b015890c0792dd4a37f9654345bd34f9be";
+      sha256 = "717701849d73b9fb925e9356f9b967ebe10c428bebf476fde83281cd485d1721";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/hsb/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/hsb/thunderbird-91.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "1f91258f84978b313d2ced008ef0e760e5e425dde3116d1e6adfd7d87895a043";
+      sha256 = "e17fec2f93fef53c3fc8dc03cacb5fa5db43aa245550c639d77c8b18cf9e89fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/hu/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/hu/thunderbird-91.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "d5665c6b1415493f18085c1606b12e4ff52f02ac9d932f5e14c6794685b7c68e";
+      sha256 = "4b1401754efb86b9f32e38d16d82514a4d8cc49fba1715b27d567b3b206828e5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/hy-AM/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/hy-AM/thunderbird-91.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "2100b04070066d8ce65d7bb3bf25d4f3dcdec4c14dce3f9c5455923de84e6c84";
+      sha256 = "fb843515f0a997deb773e3531e54472d582bccabc272a7905ab34f37012c535d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/id/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/id/thunderbird-91.6.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "7e9e2f1d5ee6db5f72a46a5345c6d4bd4e6cfa76c2637609dab0e415b93e1975";
+      sha256 = "f0d859da6c2fa4fc128c5ff5a72933326d29d50b7487b7f75398dcd5ba679cbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/is/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/is/thunderbird-91.6.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "089acd20ab3894dc04ecec3cb85317d40ff9f86a2fef381429f06a70b92f4785";
+      sha256 = "68730084ae59729516a95d5055f5ef2cffa78cb21d5dfda746302ab9a9695cbf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/it/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/it/thunderbird-91.6.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "22efeb3bdf740d1b0dfe1850589403758fea11b443ad6099c630e7cab866fbe8";
+      sha256 = "7b27316ebfea7b504ce59bb9ba4a92f7e9654944079318ce81d4fb503800003d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ja/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ja/thunderbird-91.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "5e950fb7dae9573d877b783eb12f36cb801f0299fe360e2538aab9a86ffb5911";
+      sha256 = "5640fb8720a29804d0c6c2fcb021c7d76e236aad4fbcaadb6158678163691566";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ka/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ka/thunderbird-91.6.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "24cb7fb080728903c118a31e56a7d1e02e554b2a03ca272ee0e8f14d58e1b1cd";
+      sha256 = "d6ef38fe6807c204acb4e9a29a36c1b5cf488978262fc61b76b4e741c401c431";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/kab/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/kab/thunderbird-91.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "0bfd4b98c2659b7541cdaf2fe4be33f71463d6eaeb14b5722f2916abe82411d0";
+      sha256 = "59b1b5218ccd5fe35e1019fa21e462c0f3b38f499af2afa575d460fa02462f73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/kk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/kk/thunderbird-91.6.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "62d530819b0bc304416db7e470a8856afb8d41813165a8b3ebc417957d5447fd";
+      sha256 = "1aa240a0465c0c00e34a8e20f240c29c049395e2ddd6df9650b91cc4934a4236";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ko/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ko/thunderbird-91.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "f081bbe2756b4ea78dbbe1a18377eb64ac729329a5bf2c97489dfb03ab1c2949";
+      sha256 = "8fdd1174cd08cb9f59ae2392c183a43dcf727d2298a06e14a8d3564326e8c0f1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/lt/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/lt/thunderbird-91.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "26f2cca527fee03e4b7747dceaa0ce1ee0c3f6efb2adc670ec6c1f19d2118d3b";
+      sha256 = "5185ca2c5905a67231cf0190da9ed7d91efe31a0c7b60eeda115f0420b48c8f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/lv/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/lv/thunderbird-91.6.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "f39fb8ddd6e246643750c5f23fa1d5993437c78f4062acc4c3db22d8b1dc3b56";
+      sha256 = "22f7d535fed6f1a3876119835d066685867eba39eb0bdf42fb1e791ea6777648";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ms/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ms/thunderbird-91.6.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "07835a7669f3595f20d7d41db4e799c968d30166f0db764d47b2fb1a8d8e6f0a";
+      sha256 = "8bdf9d970643986a7186bd8fd9442bc34f3ceb72b5a7bcfec7087987f7d04d9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/nb-NO/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/nb-NO/thunderbird-91.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "2dda693d9dcd5602cdde27d54871cf5b2b06afceaa0133a77632637a81a4bd69";
+      sha256 = "1a728cff35cadb029da9d8297f07292f0f22858d5666aafc812d78cb01038b75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/nl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/nl/thunderbird-91.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "05a884da304dd5c8692ced6b5d974f14e1b0007ae683f3511285b7432828b71c";
+      sha256 = "227dd7607fc9ed43f73b32b34949064d505e4b8ea634be118c708aea5fec85d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/nn-NO/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/nn-NO/thunderbird-91.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "8250f8d18feb596ed758b07933d590d7f3de016c5ce08eedb6024a4d116acb63";
+      sha256 = "e642373912d36997fcf573257f6874291f891abea26cf0ff537361c2f923b142";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/pa-IN/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/pa-IN/thunderbird-91.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "5a510109f30fed267a61d8586714e2554b74866de8b1948c80a39ad7db42e460";
+      sha256 = "0a979e7b32aa864c0e26be76557c1e1702f875d7912bc2e8cdcb0509acc94bd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/pl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/pl/thunderbird-91.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "d3fad496d1aac376fe9557ba039a916a7527a1a120e102724fd35c469adeb8eb";
+      sha256 = "3b36d87c51c3e700f815dc873d89f99b8f8e2dd6c06a92ea0b57ef156b18b58f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/pt-BR/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/pt-BR/thunderbird-91.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "bfd0685dae994a75a284220358b1ebf4d0a71d151b2b674215b5d1c4566784de";
+      sha256 = "598906f8677ff8ec20c9070991981a3dd5963245ad72b8fb6e2e68d354f24c46";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/pt-PT/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/pt-PT/thunderbird-91.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "d4cded9e8e065c312573931b4e60a5a62a154763fdf859a5fc53d120209520f9";
+      sha256 = "f6868810f5a367f3072cb1fef7754afd8ed4aa3c6746ed3bc51796e6c8e31211";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/rm/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/rm/thunderbird-91.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "5761e7778adc41e69351c49db232792096a3d69994f79ce556cd4dbb1a356530";
+      sha256 = "6ca880ad69c8e3b822ee7576b1ed95d5da58c5c23530ce90c366c5f39f0030d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ro/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ro/thunderbird-91.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "63bd9a8c5035d8964e609159d301ca52e68fef0f136ad378a8016fd1dc7a1ea4";
+      sha256 = "05c4632c8e57ed9ccfc5fc43f6ddae8d87955f7d74f2e8002ff1e0d44b093a8e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/ru/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/ru/thunderbird-91.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "a0d3731c3a6f207e8549d3d5e2e143c0b4620eda6902e9636d8c37558a78d09e";
+      sha256 = "e292c40d765b6df4daffd0f3ada667ff66404ed287dc617ae9c83d0b596c7975";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/sk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/sk/thunderbird-91.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "22635dd9abad4690c52932afd8b9b8cdad03270ef87c18ae3061308c62932064";
+      sha256 = "2e31a6befce117a1d6cfbc9fb300aba8ea954098d13c480c4afb993f941d9be8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/sl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/sl/thunderbird-91.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "e2c395a8483115801b34c8de7a34bea1ce219e1cd0012c7d27af4b11e11577f8";
+      sha256 = "a181ac2911d643febf1e53a39c5009b44ee35445a2d9004d8a5f2f6527fc7c7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/sq/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/sq/thunderbird-91.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "aeb72ddfb97fa6fad9f4295f00bd01eccc78f919c34b899925383d7877d10454";
+      sha256 = "55b769dc2bd92869934d08b3e7983847c59a595ca1b0e30c9402c08bbd822854";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/sr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/sr/thunderbird-91.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "ce9b6671b7d138bbad4ccb4a2dd660d8f2ba452f5f331dc8b630005e4a64ff91";
+      sha256 = "e0052a2e6fb4cc77132cc4f584837c62aa0ef265f0e065576f26ad2899824eb9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/sv-SE/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/sv-SE/thunderbird-91.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "59bdd6acf2aecdddb2f31a0e6305ac5eb59d8d8c3ffd6fbaded92d97a8deff4f";
+      sha256 = "5b9aa774f2e5a09e5339fabc578e06a2839e34ef81b1afc977e2142cd90bb4ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/th/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/th/thunderbird-91.6.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "62c76e4291580ec271f36737cb6dd621c6e30ddf02a070b008d312afed0cc727";
+      sha256 = "cfcac3e81aba6a8ff621145131107bbd8ce8b3a8a95c8932848c2189874abc77";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/tr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/tr/thunderbird-91.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "4c59cb186ea76ee79b123d29e3cc8a9c75e58a5f8c46e3b71a7a0b1937d99e42";
+      sha256 = "bf5259d1b504917f46cc012a7294feade5be3007840d22b7dbe2062bb2f50964";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/uk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/uk/thunderbird-91.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "19df95c2001aee2a6ed00df011caaa5be03062a559619971897640511848856f";
+      sha256 = "ebcc2733f8ae242d917ed58c8be42dd50110982bf959470804cc3b0c34894e4d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/uz/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/uz/thunderbird-91.6.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d773684ed49309e642436b40012b52980286fd07c508d8a9ee92c6210063fa13";
+      sha256 = "63072b21e035676e5f433a62d0e5b1706d7ee3f06a60e93c059814d9042aa72d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/vi/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/vi/thunderbird-91.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "8bda4d3c6a9ceda51fcccfeadb9942c595acffb8a14823a59523468871332651";
+      sha256 = "c3128bc20f69f9f11c2158cb7761e3af42f3b04b50e79b887e5720a2f5f708b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/zh-CN/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/zh-CN/thunderbird-91.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "4ffa3da9d6c9f45fa90527621af47e67e1c76f09c325a1176be2f14f52ea9362";
+      sha256 = "f1a854c83e86f3f94373184ea5a753d1954cb1530132afa2094712023b03cf47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-x86_64/zh-TW/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-x86_64/zh-TW/thunderbird-91.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "e3c053b3835566481e1207cc1da3922ce4949c0215553bc2dce5a62715a7a919";
+      sha256 = "d6ad381788be5b6f9336e58599c3ce6a387c42681ffdfecbef3de479d2feed52";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/af/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/af/thunderbird-91.6.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "f131f7266ae90708a4f5a544d5b6b656488e676e79e91e998ac4dacd969effe4";
+      sha256 = "66e46f5fde9513400f457625375b92331e36f44defbeb033ecab5fa8fa7ea13f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ar/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ar/thunderbird-91.6.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "8dbb28b438d1f72d314b32ad8b884829a9bda3bb3a8d4a677e3abcb0f7edc005";
+      sha256 = "ccf1517b16a352b82ab8bc2e0d79df1747a5e4fb2077db50d6bb69ce5734d4ff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ast/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ast/thunderbird-91.6.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "0c1dfbb7b8d001e28ba6fb5648af5d993b3a89e19381cb9bdee898ea7134ec64";
+      sha256 = "32a1eb80ae667d8e425117496532839c1fa5640a38feb18e744d49bd75c3181e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/be/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/be/thunderbird-91.6.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "dc4888c238652ff13e66ada3d21e129f3bc01f663dec38bed1f200426c5ec8af";
+      sha256 = "03d7d9525714abe1da415901d228769b360447357d0d3510900703194cae1c4a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/bg/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/bg/thunderbird-91.6.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "77c370a1f1e9e0683baf5a6a6abe937f198be08cf6ed3a6f29c59c3be64080ff";
+      sha256 = "63acec6b15b323dff5461f3eb50049b6df4b8007959971f281eb5f84e253a7d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/br/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/br/thunderbird-91.6.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "bce47698480a1c38d5b0d397c3e69c3c5ac99a0937885abbd633284614daea6a";
+      sha256 = "9486e8ab4bd8e48f68162557137be10bd027cb8b2768cf495e6ee77af171b628";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ca/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ca/thunderbird-91.6.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "bf288be4f977ebaffcd2e16c691a3223924fec7f39ec3e7368fb9b88f9c1156b";
+      sha256 = "9d0ac31c526a5b66f58fc7088ed688a341dcfe4b1cbc81a198cf37be0d2aa091";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/cak/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/cak/thunderbird-91.6.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "fcfb6268df5aba758dcefae6e6c0469648d56663789d32175a8e52068d48aaf8";
+      sha256 = "a21ca84079a3e50b7920a748997e13f708c405007d46da81c4c75c985c0ff1c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/cs/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/cs/thunderbird-91.6.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "529b31c7cd03b0c199a8acab13dfb684db5c2bd9fa10f96e8da748bcaa5e0a04";
+      sha256 = "021ea567bc605334ad109d093fd4d51d578625fbc67bccd083b3eb7a0dcc8113";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/cy/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/cy/thunderbird-91.6.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c4b22b81608421ff5c6ce74ea7b145a6ad09ae506ae25af9ad93ac0434ad1734";
+      sha256 = "d4998981e545c1fa84af594ec8c40c64ee1e6cd126a7cf78fbab22fd32878fc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/da/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/da/thunderbird-91.6.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "cf28d1a77ac2acf26fc314628fe21e5c9ddfcbe85a76d28070d15d78a6b73360";
+      sha256 = "ba8ae9a7c00279ba3b571cbc9cd8a329974946532390bc798f753732f1264625";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/de/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/de/thunderbird-91.6.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "a752cd04414a80ed92e42bf95b6460714b500e1d466d5663a64c9dcc7a678e66";
+      sha256 = "6d5465e75b1040e7f841bf450f0d04d40576a01e00838688d1b018e0278903ac";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/dsb/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/dsb/thunderbird-91.6.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "31ef88cc4cc2892fd501df71a751aa3c3ee8acc61fdb437897172de8e75de9c2";
+      sha256 = "baba359620cfed4f3b4f6e923fe83471ec6adad3a4957e4cfd0de2eeb8bc3662";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/el/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/el/thunderbird-91.6.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "5edf4e1008b3d8d19d623a8f3cf2d8fb1f7a1030de9db686bfb8c09c61e740d2";
+      sha256 = "c42bb117623a693d8a16b481323f5355efb8206d7a8a68574017b3e83efa9f9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/en-CA/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/en-CA/thunderbird-91.6.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "60e91f33b0b5e75e4a18f1fac688e4c249be77874103d1a44ad2cbd1188afc6d";
+      sha256 = "c90cf897f067e96af1cea4b81c7a1050651d0a27b37157cc8f42bf6ae4ca48a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/en-GB/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/en-GB/thunderbird-91.6.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "b08d2650702304409b19967d5ff6883881d37577c8e3ed0d545e36e81306cc96";
+      sha256 = "4b4ae3851412f63bd8dd8eafb3e4f631e96e6aba0236a567dce1d51d6cc49fdc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/en-US/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/en-US/thunderbird-91.6.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "347dfd3d8bf993e2fdc7c844c8b1a94925ab637acad9e07a1616f8657e8574b3";
+      sha256 = "e8507bff022b9b9e7e06b0a0594e9be5ef1c83154abf3d9ed98aaa3a8e81c620";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/es-AR/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/es-AR/thunderbird-91.6.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "e2c23ea75312f53201e02079063c946ae76fd11acb75cafed8d643ad49e5d484";
+      sha256 = "18390aeb2835e80b7fee76427938a0a725e1dd5e9653ba0f73a405316f363de3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/es-ES/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/es-ES/thunderbird-91.6.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "205d541dc22a3961b1aaaafd617743d1a25b52ee5bdf8b9add6ca56fbcd6861e";
+      sha256 = "139a20f325d92092d53956792e6eea86392a17f873c2a4c8802f809893856aff";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/et/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/et/thunderbird-91.6.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "4967717f2b6c21d9868e4fdb812e999f3002bb197b3a111a479d97fabc70d2c2";
+      sha256 = "79048b92cb01a727975d1f9c58d718f65f1c65063bce21a4a195fca72a9613b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/eu/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/eu/thunderbird-91.6.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "ea5ad491a38b4fd3b78f0741b7545ea7a9d11c3cd82f992fe7b6f38acd4f1a36";
+      sha256 = "e2e2bd2236ab197c319f0ff63c9c8250d6903ede82230f8d7232aa8c02b39ad6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/fi/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/fi/thunderbird-91.6.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "45884d2b6d7af2a2f9f4195d5ddc9eadbd34a0d6cae039193b4eba4da49e3909";
+      sha256 = "8b328babaaa59efc603655fbe6b1039e08fc3213adb25000d21dafe3ab018b73";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/fr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/fr/thunderbird-91.6.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "1d2153eb9e903a37e03596e11d2bc0a869260421ac07b3787d05a163c9c5b32d";
+      sha256 = "1779d72de20dd8f128938a5fbff868055a1d4162dd067f1f3710b5628876a80b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/fy-NL/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/fy-NL/thunderbird-91.6.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6ad87450cbb8a98fbd55d7399ef73f5668c1f8e288cb6d36b426fc8c373837bd";
+      sha256 = "28e5dad6fd3467fbd3b84b7024d85d0c943e58ec0c1e720eb73e1df09dd291b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ga-IE/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ga-IE/thunderbird-91.6.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "4b268107debcde5a45fc69c5ce4881b0bc8b9809a2cfcf877fe655339ec5890d";
+      sha256 = "2f3deff2145de0646160a33be75c08ed805b913a5dd7ce2b75b923774a7b613b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/gd/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/gd/thunderbird-91.6.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "3a6f0b431d5301a9cdf1499b186580bfbf468aad4e7123175a9defa04e68e6ac";
+      sha256 = "b5df962b040afa9f6c86e7a65b188da5e02578d37313b4f615f9ca4ccf3cd54b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/gl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/gl/thunderbird-91.6.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "e79001ca8b96cc9c5cb1a9ada3362e5365b68c05b4324ff2d36e1421faee691a";
+      sha256 = "7c8e98e151a19ae205ee925fe9ac88f150f3bbb49199a72a81d48390336103b9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/he/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/he/thunderbird-91.6.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d246a1b5a9d03e656392df6fdd4a6dda9e035551d0498519fbf53d44ec033a34";
+      sha256 = "a00d6306ccb64abbcf558f565bae5bd0516cc6c04e59ee67f530ba93051255a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/hr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/hr/thunderbird-91.6.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "f3d4604bea32362a4ee9ca41d3ef98e910ff448b32e37d0c59dc33d92366ab1f";
+      sha256 = "21d0c8c6383a9e5cb735b1cd1c5bee447a1eb53d3eb077ed563e401458bbc00a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/hsb/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/hsb/thunderbird-91.6.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "8ca969121ab8fc69dc598415a7d5ece9fd86e51c3b90f48f9c51d01157a3a14e";
+      sha256 = "715744c899a4e2bf6632ab9b597b3b5379e6ff1e4eddacca1fbef508475696f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/hu/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/hu/thunderbird-91.6.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8b76452c8aa27409237d592fa386f8fa257bf44151e77f5cbf990b1c7580689f";
+      sha256 = "e196e42dffd57bbd8ac7e2e499de7fad4a2f90c81a6addf271e4ed7545914e21";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/hy-AM/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/hy-AM/thunderbird-91.6.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "7855e8b013d16365fcbf883646ac83f8c094b3efc4ab9c6ada1eccf211c53d2e";
+      sha256 = "eb472ae72f80cce6fa521693fc04bd4e16da1c630652e753b5c4d57a507bee0e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/id/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/id/thunderbird-91.6.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "b41b74af5f85a56e0ffe6345f78f39190b22a867110ef043f24300f68e845324";
+      sha256 = "5029b35413fb2946264f360543c52d9b51579abcd8c8d2ad88c0fdd2b9add150";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/is/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/is/thunderbird-91.6.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "963c23e640536d88fc486b654e69584587cdc39d2acff9f64372faf7fd73f8db";
+      sha256 = "3f3be192f528838237418dfc33fecdbc36049f2ce3df39f53476267faa8c0517";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/it/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/it/thunderbird-91.6.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "4835f22538eaf2da8913d79ae575c7401fcc7fb3b7c0d21d386906c055ed7912";
+      sha256 = "7c0d85b807d8f6daea7b4a1539cfe5b3dbb44ec49088a1ea035870bc40d53034";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ja/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ja/thunderbird-91.6.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "edd3a047d63172f5f42fa31b4b89a8d07c6d9eccb3d53d19f4f7ad8cc1cea539";
+      sha256 = "7a3ae0c9134026ac73e2b8008365361329d73d3801d77baf2130df06e6d9757b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ka/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ka/thunderbird-91.6.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "06b55cb6215cece0d95827eeb196bd5f1255d348a7d906a0515667a71050ef85";
+      sha256 = "e383fff63bc20eec7654fed27b41b790332e4d49982e17b726185198da2a5288";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/kab/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/kab/thunderbird-91.6.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "36de72132e0311c4428182c5795249e37042f1eb05d1c05aeff9f1e46b602656";
+      sha256 = "8785975221c35230cdb14b1ff787107497d56dbd7e325593e459355476cf7529";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/kk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/kk/thunderbird-91.6.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "e3462a463f867b4645bc77739e275deae77bf64068a6ddd1522ac281cfbfbd3d";
+      sha256 = "e081b71c81a6bab16e504c3840813aff324a31588900e2eba9ff5dc9e055e508";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ko/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ko/thunderbird-91.6.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "e90f011e920958ea853dd426f57a1e5cb0593ce117d5a9e19a90c6df69d729c9";
+      sha256 = "80f6b03a7dbae0f8c18d4c71e8a12a0097ef7da46f5a76ab2b8b841b7b52c17e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/lt/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/lt/thunderbird-91.6.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "4e3eaffa505b5f8a37b0534a754ab89c2f7b4dc65ead78ca266d4fa8cb5aa841";
+      sha256 = "c95bb6b0e39c96c3375d2286bbad61c8cbcd464e938f2673075e6087cbcfe9c8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/lv/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/lv/thunderbird-91.6.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "0dd8c818bd60cd6e67df751933c0aeb89bf10fa64235edc639955c86a0e51168";
+      sha256 = "c2aaaf69ac6daf76519dc68294fd5e62f5f32ab5b3a241d7b43790481ed53c6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ms/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ms/thunderbird-91.6.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "b0b9f303014a1b90a52ec39f36f2e2029562ef70fcc9b77c0f7048558f1ad7bf";
+      sha256 = "432df1ec154d7d215c2b0d0cc76bb035f2b1a6dc36332cd588b9e930be5aedce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/nb-NO/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/nb-NO/thunderbird-91.6.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "89f787643d5d2451a0f7095f69805d4c0d0e05c62fbe0468c78b6bcc9dfc0dcd";
+      sha256 = "23135385afb41a6f9996b97f3211c6f8e929eaba6837cb49f23f657232f54018";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/nl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/nl/thunderbird-91.6.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "9ebf8a5cd8df953078dc634ac17325c8e0fdd01cce3dbb8561fb29e8b8a4e6cd";
+      sha256 = "86ee6735e5438d73c9a1a5c5885825ff9bca4fa8165de409454b9ca1084d13ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/nn-NO/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/nn-NO/thunderbird-91.6.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "ec702407e9dfd14de776a5409413b8ddf3c32cf6aa17e8a37ba349e8fa7ba1db";
+      sha256 = "43b2c30b54814c5db19d00104766fa227c527c994200f8227d3d2259da5e98d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/pa-IN/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/pa-IN/thunderbird-91.6.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "f26de0a71646669f07ba23c8e181700b1569ce41049f62215c19ca746a4ca38d";
+      sha256 = "f5a4e9bafe29c29bc6ed790fb3d54921b5e1e04eb3c03911715c2b11745e2aa9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/pl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/pl/thunderbird-91.6.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "d497057a71cfe867f53a5dadf3b1b8fdf30db8470cbfedd416b39acef3d61163";
+      sha256 = "41c39f38d4423b73ec8c5ce7226af2ce8517f66f5cbaac3ce1d83491ef131b58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/pt-BR/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/pt-BR/thunderbird-91.6.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "90367905fe8dd83f9c6acb093e9ba6583124171037755ef2f3a6771c94e1cb44";
+      sha256 = "861520e2034b2d666c8cd13a9b92600b95970aae5a91028e3821719096ad712c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/pt-PT/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/pt-PT/thunderbird-91.6.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "b611af59f7f88efa10aef43f8ac464b5c514412b534cff39eb2844ae1ca18077";
+      sha256 = "7d4a2d50a7cef14ef4dde20b1f24c9e64705024de1100ee216883d766d54403e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/rm/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/rm/thunderbird-91.6.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "5d75ac9e6c0c27b0faf436d69305f206e09867c306264a4de30cd3b1f879c1d0";
+      sha256 = "d6236d8c39d09c41db122398badd336c507043968c5b2a430f665de0b1aa9668";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ro/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ro/thunderbird-91.6.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "aa64e96ad2d1a361c8cd96b5b0e88cdd51eba2c3c036ac453ff9225320d08f6a";
+      sha256 = "983c7bb9bea566f8f28ec80b8f153d017379f51b5269cc1c50a0bc072ea91833";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/ru/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/ru/thunderbird-91.6.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "6d293d0ee9eebd01c6e36e085333c4da15f0ce2ece73dc99015545255a435538";
+      sha256 = "6f8a2de51d780bb6ee81880263b723bc3e8d6ecf8b0b2e4d6cb7a83e49221b8a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/sk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/sk/thunderbird-91.6.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "37436cda08659abd49108f7e9a8ee5645d2ee1ed0086a7b4158279342d0cbdfb";
+      sha256 = "4c5456a74ae74b28f39cf611160c9480612a6421e1596e00e11d3a2e812b17bf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/sl/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/sl/thunderbird-91.6.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "fc8e6fed968e6312f69545479b5b3230390d41490a2a5b6385f046a2a3709018";
+      sha256 = "ea9fe0115971df32c0c7d83c780d2e7af93820f1771faca166f14fb9714061cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/sq/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/sq/thunderbird-91.6.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "ce68e8f855d6d366b1490cc3b7e044a84fba63bcfa11453afc4b98ec665450c6";
+      sha256 = "e71b2450b25a1fcc4163d0ad7e89818effa795e9d84542fb9f4682fddea3a6c6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/sr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/sr/thunderbird-91.6.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "128843650ddfa57493c8691e7c591685cca4b1ab6c118949ef1580318954f110";
+      sha256 = "a8fc9120f4776eb5a536f8ba3cd347c7fdeee60964efb624f7a935184d73fb0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/sv-SE/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/sv-SE/thunderbird-91.6.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "7180055d5184c38f3fb893538b0c270d3d125da4434debe6fffdcd3288d8ea53";
+      sha256 = "82288275a7eb2d9a5d1146213a7a52d4a44a9f48e0687fc27f3724547b5fdf23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/th/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/th/thunderbird-91.6.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "4b964b7517b941622f18328f73813aca740a4da1799805a0a267b510704308e7";
+      sha256 = "4f397341d446143b7a1586d445f11503fc631a282a54e47af630e79910a27187";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/tr/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/tr/thunderbird-91.6.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "71d551988a6ff2bd96900bf4ce72e05ac47bcb36af9a25af4e3b76d16da37d50";
+      sha256 = "49749bb2174b550ea58382279b9cee9a768caf25d123a8e0e7ce39630d2b7632";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/uk/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/uk/thunderbird-91.6.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "e62b6fce0bb1175c9c6acb37ff9454509766d4953fb0d4494023143fd70650a9";
+      sha256 = "48cd510c9be791e09ebcef75ade05a11bc1acbac22d8a9a7c55ea24972675862";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/uz/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/uz/thunderbird-91.6.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "c5c9e10e82ab793d9a82d95bcb20eb288395e32c27dcf5ca2a91fc937e479aba";
+      sha256 = "8f4294412062714faf063e20f09668747fde5dc367c9c68e4a4c3d747d319ffb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/vi/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/vi/thunderbird-91.6.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "081895dc1684360c0859d5084ece871c7539e91b858392dbaa3ddf8ee0f38ea9";
+      sha256 = "4d5996253f9ecd84a456ea042b00a9a8e67f1e8e62be2f70b0a17fcfefc17431";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/zh-CN/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/zh-CN/thunderbird-91.6.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "b5fadde23bd94f3ab2fbe6b8070040d9e89a506a399d9c1348b80a8639b8220b";
+      sha256 = "ebcb70d6483302543e169284c1ce2eabf015b4627ed5ee10f64a3997a36f41cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.5.1/linux-i686/zh-TW/thunderbird-91.5.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.0/linux-i686/zh-TW/thunderbird-91.6.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4d31d6a8d4f94486e4ebec3c98d2d535fd5485b3b73dfa0a52760300608c7eac";
+      sha256 = "256ae0b8e783434f49e757db502b9536506e4256362ce8eaa3311899c0dee779";
     }
     ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Bug fixes
- Thunderbird will now offer to send large forwarded attachments via FileLink
- The release note contains “various security fixes” but the Security Advisories is not updated yet.

https://www.thunderbird.net/en-US/thunderbird/91.6.0/releasenotes/
https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird91.6

Related: #158763

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
