### PR TITLE
febio-studio: init at 1.6.1

### DIFF
--- a/pkgs/applications/science/biology/febio-studio/default.nix
+++ b/pkgs/applications/science/biology/febio-studio/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, fetchFromGitHub, cmake, zlib, libglvnd, libGLU, wrapQtAppsHook
+, sshSupport ? true, openssl, libssh
+, tetgenSupport ? true, tetgen
+, ffmpegSupport ? true, ffmpeg
+, dicomSupport  ? false, dcmtk
+, withModelRepo ? true
+, withCadFeatures ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "febio-studio";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "febiosoftware";
+    repo = "FEBioStudio";
+    rev = "v${version}";
+    sha256 = "0r6pg49i0q9idp7pjymj7mlxd63qjvmfvg0l7fmx87y1yd2hfw4h";
+  };
+
+  patches = [
+    ./febio-studio-cmake.patch # Fix Errors that appear with certain Cmake flags
+  ];
+
+  cmakeFlags = [
+    "-DQt_Ver=5"
+    "-DNOT_FIRST=On"
+    "-DOpenGL_GL_PREFERENCE=GLVND"
+  ]
+    ++ lib.optional sshSupport "-DUSE_SSH=On"
+    ++ lib.optional tetgenSupport "-DUSE_TETGEN=On"
+    ++ lib.optional ffmpegSupport "-DUSE_FFMPEG=On"
+    ++ lib.optional dicomSupport "-DUSE_DICOM=On"
+    ++ lib.optional withModelRepo "-DMODEL_REPO=On"
+    ++ lib.optional withCadFeatures "-DCAD_FEATURES=On"
+  ;
+
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/
+    cp -R bin $out/
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+  buildInputs = [ zlib libglvnd libGLU openssl libssh ]
+    ++ lib.optional sshSupport openssl
+    ++ lib.optional tetgenSupport tetgen
+    ++ lib.optional ffmpegSupport ffmpeg
+    ++ lib.optional dicomSupport dcmtk
+  ;
+
+  meta = with lib; {
+    description = "FEBio Suite Solver";
+    license = with licenses; [ mit ];
+    homepage = "https://febio.org/";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/applications/science/biology/febio-studio/febio-studio-cmake.patch
+++ b/pkgs/applications/science/biology/febio-studio/febio-studio-cmake.patch
@@ -1,0 +1,38 @@
+diff --git a/FEBioStudio/RepositoryPanel.cpp b/FEBioStudio/RepositoryPanel.cpp
+index 382db303..314cdc68 100644
+--- a/FEBioStudio/RepositoryPanel.cpp
++++ b/FEBioStudio/RepositoryPanel.cpp
+@@ -1364,10 +1364,10 @@ void CRepositoryPanel::loadingPageProgress(qint64 bytesSent, qint64 bytesTotal)
+ 
+ #else
+ 
+-CRepositoryPanel::CRepositoryPanel(CMainWindow* pwnd, QWidget* parent){}
++CRepositoryPanel::CRepositoryPanel(CMainWindow* pwnd, QDockWidget* parent){}
+ CRepositoryPanel::~CRepositoryPanel(){}
+ void CRepositoryPanel::OpenLink(const QString& link) {}
+-// void CRepositoryPanel::Raise() {}
++void CRepositoryPanel::Raise() {}
+ void CRepositoryPanel::SetModelList(){}
+ void CRepositoryPanel::ShowMessage(QString message) {}
+ void CRepositoryPanel::ShowWelcomeMessage(QByteArray messages) {}
+@@ -1396,6 +1396,7 @@ void CRepositoryPanel::on_actionSearch_triggered() {}
+ void CRepositoryPanel::on_actionClearSearch_triggered() {}
+ void CRepositoryPanel::on_actionDeleteRemote_triggered() {}
+ void CRepositoryPanel::on_actionModify_triggered() {}
++void CRepositoryPanel::on_actionCopyPermalink_triggered() {}
+ void CRepositoryPanel::on_treeWidget_itemSelectionChanged() {}
+ void CRepositoryPanel::on_treeWidget_customContextMenuRequested(const QPoint &pos) {}
+ void CRepositoryPanel::DownloadItem(CustomTreeWidgetItem *item) {}
+diff --git a/FEBioStudio/WzdUpload.cpp b/FEBioStudio/WzdUpload.cpp
+index 5ce74346..20062e06 100644
+--- a/FEBioStudio/WzdUpload.cpp
++++ b/FEBioStudio/WzdUpload.cpp
+@@ -1183,7 +1183,7 @@ void CWzdUpload::on_saveJson_triggered()
+ 		getProjectJson(&projectInfo);
+ 
+ 		QFile file(filedlg.selectedFiles()[0]);
+-		file.open(QIODeviceBase::WriteOnly);
++		file.open(QIODevice::WriteOnly);
+ 		file.write(projectInfo);
+ 		file.close();
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31853,6 +31853,8 @@ with pkgs;
 
   fastp = callPackage ../applications/science/biology/fastp { };
 
+  febio-studio = libsForQt5.callPackage ../applications/science/biology/febio-studio { };
+
   hisat2 = callPackage ../applications/science/biology/hisat2 { };
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
