### PR TITLE
Revert "Merge pull request #158822 from helsinki-systems/upd/mariadb"

### DIFF
--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -10,7 +10,6 @@
 , bzip2, lz4, lzo, snappy, xz, zlib, zstd
 , cracklib, judy, libevent, libxml2
 , linux-pam, numactl, pmdk
-, fmt_8
 , withStorageMroonga ? true, kytea, libsodium, msgpack, zeromq
 , withStorageRocks ? true
 }:
@@ -174,8 +173,7 @@ in stdenv.mkDerivation (common // {
     ++ lib.optionals stdenv.hostPlatform.isLinux [ linux-pam ]
     ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) pmdk.dev
     ++ lib.optional (!stdenv.hostPlatform.isDarwin) mytopEnv
-    ++ lib.optionals withStorageMroonga [ kytea libsodium msgpack zeromq ]
-    ++ lib.optionals (lib.versionAtLeast common.version "10.7") [ fmt_8 ];
+    ++ lib.optionals withStorageMroonga [ kytea libsodium msgpack zeromq ];
 
   patches = common.patches;
 
@@ -237,27 +235,17 @@ in stdenv.mkDerivation (common // {
 in {
   mariadb_104 = mariadbPackage {
     # Supported until 2024-06-18
-    version = "10.4.23";
-    sha256 = "1wlhjd1xvk6p2lb93v8kfjk1scyjz882fx0i0sjyyk047mh2i852";
+    version = "10.4.22";
+    sha256 = "000ca1hdnj2jg051cjgdd2ralgwgh2p8nwb1x6b85202xdpc7ga4";
   };
   mariadb_105 = mariadbPackage {
     # Supported until 2025-06-24
-    version = "10.5.14";
-    sha256 = "02y292mfvr6ils4m61lh9vy74z3w2xkz6xinpgg9wl5h7q29gzaf";
+    version = "10.5.13";
+    sha256 = "0n0w1pyypv6wsknaqyykj3lc9zv6smji4q5jcf90w4rid330iw0n";
   };
   mariadb_106 = mariadbPackage {
     # Supported until 2026-07
-    version = "10.6.6";
-    sha256 = "1hz1iwkgrlhhrn5ypxszfp5ngfmfakjxl3ihzsm4845xhzn1fr77";
-  };
-  mariadb_107 = mariadbPackage {
-    # Supported until 2023-02
-    version = "10.7.2";
-    sha256 = "1cx5s8vq7s3r4w1drmp549kl2nyijzq6ds2mcjyzc7bk9ylipx6p";
-  };
-  mariadb_108 = mariadbPackage {
-    # Supported until 2023-05
-    version = "10.8.1";
-    sha256 = "0ns0z8w3374jrfdrmq7ncag089xwmf7wkr5aq3p9shk1b5mln9z2";
+    version = "10.6.5";
+    sha256 = "13qaqb2h6kysfdi3h1l9zbb2qlpjgxb1n8mxnj5jm96r50209gp0";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21516,8 +21516,6 @@ with pkgs;
     mariadb_104
     mariadb_105
     mariadb_106
-    mariadb_107
-    mariadb_108
   ;
   mariadb = mariadb_106;
 


### PR DESCRIPTION
This reverts commit ce1346ad83e03c401b62fe2d9872bbf349dec472, reversing
changes made to b506de1d77bc7ce2ab0a3ea14d149de4128d5fa7.

###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/158822#issuecomment-1035933840

upstream unpublished the tarballs and will either re-release them with this version or release new versions

###### Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
