### PR TITLE
updatecli: init at 0.20.0

### DIFF
--- a/pkgs/development/tools/updatecli/default.nix
+++ b/pkgs/development/tools/updatecli/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+
+buildGoModule rec {
+  pname = "updatecli";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "updatecli";
+    repo = "updatecli";
+    rev = "v${version}";
+    sha256 = "sha256-NdjGwrR4ZNdT/h0TPf/PZL12SJhWHvfzDNd1pyh+dtM=";
+  };
+
+  vendorSha256 = "sha256-e2HHoH6uSPmuELimXwlvDBwffj1mzAIj1kJ/27QNgXc=";
+
+  doCheck = false;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    for shell in bash fish zsh; do
+      $out/bin/updatecli completion $shell > updatecli.$shell
+      installShellCompletion updatecli.$shell
+    done
+  '';
+
+  meta = with lib; {
+    description =
+      "Automatically open a PR on your GitOps repository when a third party service publishes an update";
+    homepage = "https://updatecli.io/";
+    license = [ licenses.mit ];
+    maintainers = [ maintainers.koozz ];
+    mainProgram = "updatecli";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33883,6 +33883,8 @@ with pkgs;
 
   unityhub = callPackage ../development/tools/unityhub { };
 
+  updatecli = callPackage ../development/tools/updatecli { };
+
   urbit = callPackage ../misc/urbit { };
 
   usb-reset = callPackage ../applications/misc/usb-reset { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[Updatecli](https://updatecli.io) is a commandline tool to automatically open a PR on your GitOps repository when a third party service publishes an update.

###### Things done
Basic Go application [installation from GitHub](https://github.com/updatecli/updatecli).
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
