### PR TITLE
various packages: remove gconf dependency

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -12,7 +12,6 @@
 , freetype
 , gdk-pixbuf
 , glib
-, gnome2
 , gnome
 , gsettings-desktop-schemas
 , gtk3
@@ -60,7 +59,6 @@ rpath = lib.makeLibraryPath [
   freetype
   gdk-pixbuf
   glib
-  gnome2.GConf
   gtk3
   libdrm
   libpulseaudio

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, patchelf, makeWrapper
 
 # Linked dynamic libraries.
-, glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, gconf, nss, nspr
+, glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, nss, nspr
 , libXcursor, libXext, libXfixes, libXrender, libXScrnSaver, libXcomposite, libxcb
 , alsa-lib, libXdamage, libXtst, libXrandr, libxshmfence, expat, cups
 , dbus, gtk3, gdk-pixbuf, gcc-unwrapped, at-spi2-atk, at-spi2-core
@@ -57,7 +57,7 @@ let
   version = chromium.upstream-info.version;
 
   deps = [
-    glib fontconfig freetype pango cairo libX11 libXi atk gconf nss nspr
+    glib fontconfig freetype pango cairo libX11 libXi atk nss nspr
     libXcursor libXext libXfixes libXrender libXScrnSaver libXcomposite libxcb
     alsa-lib libXdamage libXtst libXrandr libxshmfence expat cups
     dbus gdk-pixbuf gcc-unwrapped.lib

--- a/pkgs/applications/networking/browsers/icecat-bin/default.nix
+++ b/pkgs/applications/networking/browsers/icecat-bin/default.nix
@@ -3,7 +3,6 @@
 , fetchzip
 , autoPatchelfHook
 , wrapGAppsHook
-, gnome2
 , gtk2
 , nss
 , xdg-utils
@@ -14,6 +13,7 @@
 , cups
 , curl
 , dbus
+, dbus-glib
 , expat
 , fontconfig
 , freetype
@@ -72,12 +72,12 @@ stdenv.mkDerivation rec {
     cups
     curl
     dbus
+    dbus-glib
     expat
     fontconfig.lib
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     gtk2
     gtk3
     libX11

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -11,7 +11,6 @@
 , freetype
 , gdk-pixbuf
 , glib
-, gnome2
 , gtk3
 , gtk4
 , lib
@@ -79,7 +78,6 @@ in stdenv.mkDerivation rec {
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     gtk3
     libX11
     libXScrnSaver

--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -4,7 +4,7 @@
 , freetype, fontconfig, libXft, libXrender, libxcb, expat
 , libuuid
 , libxml2
-, glib, gtk3, pango, gdk-pixbuf, cairo, atk, at-spi2-atk, at-spi2-core, gnome2
+, glib, gtk3, pango, gdk-pixbuf, cairo, atk, at-spi2-atk, at-spi2-core
 , libdrm, mesa
 , nss, nspr
 , patchelf, makeWrapper
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     libXi libXft libXcursor libXfixes libXScrnSaver libXcomposite libXdamage libXtst libXrandr
     atk at-spi2-atk at-spi2-core alsa-lib dbus cups gtk3 gdk-pixbuf libexif ffmpeg systemd libva
     freetype fontconfig libXrender libuuid expat glib nss nspr
-    libxml2 pango cairo gnome2.GConf
+    libxml2 pango cairo
     libdrm mesa
   ] ++ lib.optional proprietaryCodecs vivaldi-ffmpeg-codecs;
 

--- a/pkgs/applications/networking/instant-messengers/franz/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/franz/generic.nix
@@ -13,7 +13,6 @@
 , freetype
 , fontconfig
 , gtk3
-, gnome2
 , dbus
 , nss
 , nspr
@@ -61,7 +60,6 @@ stdenv.mkDerivation rec {
     freetype
     fontconfig
     dbus
-    gnome2.GConf
     nss
     nspr
     alsa-lib

--- a/pkgs/applications/networking/instant-messengers/gitter/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gitter/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, alsa-lib, atk, at-spi2-core, cairo, cups, dbus, dpkg, expat, fetchurl
-, fontconfig, freetype, gdk-pixbuf, glib, gnome2, gtk3,  libdrm, libX11
+, fontconfig, freetype, gdk-pixbuf, glib, gtk3,  libdrm, libX11
 , libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext, libXfixes
 , libXi, libXrandr, libXrender, libXtst, libappindicator-gtk3, libcxx
 , libnotify, libpulseaudio, libxcb, makeDesktopItem, makeWrapper, mesa, nspr, nss
@@ -18,7 +18,6 @@ let gitterDirectorySuffix = "opt/gitter";
      freetype
      gdk-pixbuf
      glib
-     gnome2.GConf
      gtk3
      libX11
      libXScrnSaver

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, autoPatchelfHook, dpkg, wrapGAppsHook, nixosTests
-, gnome2, gtk3, atk, at-spi2-atk, cairo, pango, gdk-pixbuf, glib, freetype, fontconfig
+, gtk3, atk, at-spi2-atk, cairo, pango, gdk-pixbuf, glib, freetype, fontconfig
 , dbus, libX11, xorg, libXi, libXcursor, libXdamage, libXrandr, libXcomposite
 , libXext, libXfixes, libXrender, libXtst, libXScrnSaver, nss, nspr, alsa-lib
 , cups, expat, libuuid, at-spi2-core, libappindicator-gtk3, mesa
@@ -56,7 +56,6 @@ in stdenv.mkDerivation rec {
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     gtk3
     libX11
     libXScrnSaver

--- a/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/skypeforlinux/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, dpkg
-, alsa-lib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, glibc, gnome2, gnome
+, alsa-lib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, glibc, gnome
 , gtk3, libappindicator-gtk3, libnotify, libpulseaudio, libsecret, libv4l, nspr, nss, pango, systemd, wrapGAppsHook, xorg
 , at-spi2-atk, libuuid, at-spi2-core, libdrm, mesa, libxkbcommon, libxshmfence }:
 
@@ -26,7 +26,6 @@ let
     libsecret
     libuuid
 
-    gnome2.GConf
     gdk-pixbuf
     gtk3
     libappindicator-gtk3

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -18,7 +18,6 @@
 , freetype
 , gdk-pixbuf
 , glib
-, gnome2
 , gtk3
 , libGL
 , libappindicator-gtk3
@@ -105,7 +104,6 @@ let
       freetype
       gdk-pixbuf
       glib
-      gnome2.GConf
       gtk3
       libGL
       libappindicator-gtk3

--- a/pkgs/applications/networking/mullvad-vpn/default.nix
+++ b/pkgs/applications/networking/mullvad-vpn/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, dpkg
 , alsa-lib, atk, cairo, cups, dbus, expat, fontconfig, freetype
-, gdk-pixbuf, glib, gnome2, pango, nspr, nss, gtk3, mesa
+, gdk-pixbuf, glib, pango, nspr, nss, gtk3, mesa
 , xorg, autoPatchelfHook, systemd, libnotify, libappindicator
 , makeWrapper
 }:
@@ -16,7 +16,6 @@ let deps = [
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     pango
     gtk3
     libappindicator

--- a/pkgs/development/tools/nwjs/default.nix
+++ b/pkgs/development/tools/nwjs/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, buildEnv, makeWrapper
 
 , xorg, alsa-lib, at-spi2-core, dbus, glib, gtk3, atk, pango, freetype
-, fontconfig , gdk-pixbuf, cairo, mesa, nss, nspr, gconf, expat, systemd
+, fontconfig , gdk-pixbuf, cairo, mesa, nss, nspr, expat, systemd
 , libcap, libdrm, libxkbcommon
 , libnotify
 , ffmpeg, libxcb, cups
@@ -18,7 +18,7 @@ let
     paths = [
       xorg.libX11 xorg.libXrender glib gtk3 atk at-spi2-core pango cairo gdk-pixbuf
       freetype fontconfig xorg.libXcomposite alsa-lib xorg.libXdamage
-      xorg.libXext xorg.libXfixes mesa nss nspr gconf expat dbus
+      xorg.libXext xorg.libXfixes mesa nss nspr expat dbus
       xorg.libXtst xorg.libXi xorg.libXcursor xorg.libXrandr
       xorg.libXScrnSaver xorg.libxshmfence cups
       libcap libdrm libnotify

--- a/pkgs/development/tools/selenium/chromedriver/default.nix
+++ b/pkgs/development/tools/selenium/chromedriver/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, unzip, makeWrapper
 , cairo, fontconfig, freetype, gdk-pixbuf, glib
-, glibc, gtk2, libX11, nspr, nss, pango, gconf
+, glibc, gtk2, libX11, nspr, nss, pango
 , libxcb, libXi, libXrender, libXext, dbus
 , testVersion, chromedriver
 }:
@@ -30,9 +30,9 @@ let
   libs = lib.makeLibraryPath [
     stdenv.cc.cc.lib
     cairo fontconfig freetype
-    gdk-pixbuf glib gtk2 gconf
+    gdk-pixbuf glib gtk2
     libX11 nspr nss pango libXrender
-    gconf libxcb libXext libXi
+    libxcb libXext libXi
     dbus
   ];
 

--- a/pkgs/development/tools/unityhub/default.nix
+++ b/pkgs/development/tools/unityhub/default.nix
@@ -12,7 +12,7 @@ in appimageTools.wrapType2 rec {
   inherit name src;
 
   extraPkgs = (pkgs: with pkgs; with xorg; [ gtk2 gdk-pixbuf glib libGL libGLU nss nspr
-    alsa-lib cups gnome2.GConf libcap fontconfig freetype pango
+    alsa-lib cups libcap fontconfig freetype pango
     cairo dbus dbus-glib libdbusmenu libdbusmenu-gtk2 expat zlib libpng12 udev tbb
     libpqxx gtk3 libsecret lsb-release openssl nodejs ncurses5
 

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -2,7 +2,6 @@
 , autoPatchelfHook
 , callPackage
 , fetchzip
-, gnome2
 , gtk2
 , gtk3
 , lib
@@ -38,7 +37,6 @@ stdenv.mkDerivation rec {
     nss
     gtk2
     alsa-lib
-    gnome2.GConf
     gtk3
     mesa # for libgbm
   ];

--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, makeWrapper, fetchurl, dpkg, alsa-lib, atk, cairo, cups, dbus, expat
-, fontconfig, freetype, gdk-pixbuf, glib, gnome2, pango, mesa, nspr, nss, gtk3
+, fontconfig, freetype, gdk-pixbuf, glib, pango, mesa, nspr, nss, gtk3
 , at-spi2-atk, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
@@ -38,7 +38,6 @@ in stdenv.mkDerivation rec {
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     pango
     gtk3
     gsettings-desktop-schemas

--- a/pkgs/tools/misc/mongodb-compass/default.nix
+++ b/pkgs/tools/misc/mongodb-compass/default.nix
@@ -14,7 +14,6 @@ fontconfig,
 freetype,
 gdk-pixbuf,
 glib,
-gnome2,
 gtk3,
 lib,
 libdrm,
@@ -50,7 +49,6 @@ let
     freetype
     gdk-pixbuf
     glib
-    gnome2.GConf
     gtk3
     libdrm
     libnotify

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14494,7 +14494,7 @@ with pkgs;
 
   checkstyle = callPackage ../development/tools/analysis/checkstyle { };
 
-  chromedriver = callPackage ../development/tools/selenium/chromedriver { gconf = gnome2.GConf; };
+  chromedriver = callPackage ../development/tools/selenium/chromedriver { };
 
   chromium-xorg-conf = callPackage ../os-specific/linux/chromium-xorg-conf { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26050,7 +26050,7 @@ with pkgs;
 
   googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
+  google-chrome = callPackage ../applications/networking/browsers/google-chrome { };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15227,12 +15227,9 @@ with pkgs;
     jre_headless = jre8_headless;
   };
 
-  nwjs = callPackage ../development/tools/nwjs {
-    gconf = gnome2.GConf;
-  };
+  nwjs = callPackage ../development/tools/nwjs { };
 
   nwjs-sdk = callPackage ../development/tools/nwjs {
-    gconf = gnome2.GConf;
     sdk = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
Part of #39976. Electron-based applications no longer require gconf: https://github.com/electron/electron/issues/2727 https://github.com/electron/electron/pull/19498

###### Things done
Checked that each program still launches successfully.
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

nixpkgs-review:
```
27 packages built:
betaflight-configurator brave chromedriver cypress emuflight-configurator ferdi franz gitter google-chrome google-chrome-beta google-chrome-dev icecat-bin inav-configurator insomnia mongodb-compass mullvad-vpn nwjs nwjs-sdk onlykey opera selendroid selenium-server-standalone signal-desktop skypeforlinux slack unityhub vivaldi
```