### PR TITLE
python3Packages.furo: fix build

### DIFF
--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -9,18 +9,31 @@
 buildPythonPackage rec {
   pname = "furo";
   version = "2022.1.2";
-  format = "flit";
+  format = "wheel";
   disable = pythonOlder "3.6";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "b217f218cbcd423ffbfe69baa79389d4ecebf2d86f0d593c44ef31da7b5aed30";
+    inherit pname version format;
+    dist = "py3";
+    python = "py3";
+    sha256 = "sha256-lYAWv+E4fB6N31udcWlracTqpc2K/JSSq/sAirotMAw=";
   };
 
   propagatedBuildInputs = [
     sphinx
     beautifulsoup4
   ];
+
+  installCheckPhase = ''
+    # furo was built incorrectly if this directory is empty
+    # Ignore the hidden file .gitignore
+    cd "$out/lib/python"*
+    if [ "$(ls 'site-packages/furo/theme/furo/static/' | wc -l)" -le 0 ]; then
+      echo 'static directory must not be empty'
+      exit 1
+    fi
+    cd -
+  '';
 
   pythonImportsCheck = [ "furo" ];
 


### PR DESCRIPTION
###### Motivation for this change
furo requires webpack since version 2021.11.12 and was recently updated in 7b890d59335f78ff3a06b237b3d06d06c7fe0e78. Without this dependency, the built package is broken as it is missing some important files. This can be seen when trying to build kitty on Linux. webpack doesn't work correctly in nixpkgs, see https://github.com/NixOS/nixpkgs/issues/42275. I wasn't able to fix this.
To make furo build correctly again despite the broken webpack, I switched to fetching the wheel instead of the source from PyPI, which has the necessary files already generated.
I also added a small test to make sure that this directory won't be empty again in the future.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).