### PR TITLE
nerd-font-patcher: use upstream repo with `sparseCheckout`

### DIFF
--- a/pkgs/applications/misc/nerd-font-patcher/default.nix
+++ b/pkgs/applications/misc/nerd-font-patcher/default.nix
@@ -4,15 +4,16 @@ python3Packages.buildPythonApplication rec {
   pname = "nerd-font-patcher";
   version = "2.1.0";
 
-  # The size of the nerd fonts repository is bigger than 2GB, because it
-  # contains a lot of fonts and the patcher.
-  # until https://github.com/ryanoasis/nerd-fonts/issues/484 is not fixed,
-  # we download the patcher from an alternative repository
+  # This uses a sparse checkout because the repo is >2GB without it
   src = fetchFromGitHub {
-    owner = "betaboon";
-    repo = "nerd-fonts-patcher";
-    rev = "180684d7a190f75fd2fea7ca1b26c6540db8d3c0";
-    sha256 = "sha256-FAbdLf0XiUXGltAgmq33Wqv6PFo/5qCv62UxXnj3SgI=";
+    owner = "ryanoasis";
+    repo = "nerd-fonts";
+    rev = "v${version}";
+    sparseCheckout = ''
+      font-patcher
+      /src/glyphs
+    '';
+    sha256 = "sha256-ePBlEVjzAJ7g6iAGIqPfgZ8bwtNILmyEVm0zD+xNN6k=";
   };
 
   propagatedBuildInputs = with python3Packages; [ fontforge ];


### PR DESCRIPTION
###### Motivation for this change
Since #135881 was merged, we can use `sparseCheckout` with the Nerd Fonts repo to get the patcher without incurring a 2 GB download. With this patch, only about 1.6 MiB is downloaded. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
