### PR TITLE
release-python.nix: add test job sets

### DIFF
--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -26,4 +26,22 @@ let
         []);
     in if res.success then res.value else []
     );
-in (mapTestOn (packagePython pkgs))
+
+  jobs = {
+    lib-tests = import ../../lib/tests/release.nix { inherit pkgs; };
+    pkgs-lib-tests = import ../pkgs-lib/tests { inherit pkgs; };
+
+    tested = pkgs.releaseTools.aggregate {
+      name = "python-tested";
+      meta.description = "Release-critical packages from the python package sets";
+      constituents = [
+        jobs.remarshal.x86_64-linux                 # Used in pkgs.formats helper
+        jobs.python39Packages.colorama.x86_64-linux  # Used in nixos test-driver
+        jobs.python39Packages.ptpython.x86_64-linux  # Used in nixos test-driver
+        jobs.python39Packages.requests.x86_64-linux  # Almost ubiquous package
+        jobs.python39Packages.sphinx.x86_64-linux    # Document creation for many packages
+      ];
+    };
+
+  } // (mapTestOn (packagePython pkgs));
+in jobs


### PR DESCRIPTION
###### Motivation for this change
Avoid packages which have small downstream dependencies being skipped while doing large updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
