### PR TITLE
drone-cli: add darwin aarch64 support

### DIFF
--- a/pkgs/development/tools/continuous-integration/drone-cli/0001-use-different-upstream-for-gomod.patch
+++ b/pkgs/development/tools/continuous-integration/drone-cli/0001-use-different-upstream-for-gomod.patch
@@ -1,0 +1,23 @@
+diff --git a/go.mod b/go.mod
+index 99f9b37..ebbdb54 100644
+--- a/go.mod
++++ b/go.mod
+@@ -28,3 +28,5 @@ require (
+ 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+ 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+ )
++
++replace github.com/jackspirou/syscerts => github.com/akhenakh/syscerts v0.0.0-20201230132944-1f7ee1de1ba3
+diff --git a/go.sum b/go.sum
+index 8c379ed..283ba39 100644
+--- a/go.sum
++++ b/go.sum
+@@ -64,6 +64,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
+ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
++github.com/akhenakh/syscerts v0.0.0-20201230132944-1f7ee1de1ba3 h1:2d14fzBv1dj4PimhBxXDlaltfNU6rGmA4NyYa3aB5xQ=
++github.com/akhenakh/syscerts v0.0.0-20201230132944-1f7ee1de1ba3/go.mod h1:ijVDlqqT/Ok/B2v7GaiSj4gfCl7uipB8/8jwgJvrTSk=
+ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/pkgs/development/tools/continuous-integration/drone-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/drone-cli/default.nix
@@ -5,16 +5,18 @@ buildGoModule rec {
   pname = "drone-cli";
   revision = "v${version}";
 
-  vendorSha256 = "sha256-bYjEVmQ7lPd+Gn5cJwlzBQkMkLAXA1iSa1DXz/IM1Ss=";
+  vendorSha256 = "0hh079qvxs4bcf0yy42y6sb303wxxam5h2mz56irdl0q2vqkk0f0";
 
   doCheck = false;
+
+  patches = [ ./0001-use-different-upstream-for-gomod.patch ];
 
   ldflags = [
     "-X main.version=${version}"
   ];
 
   src = fetchFromGitHub {
-    owner = "drone";
+    owner = "harness";
     repo = "drone-cli";
     rev = revision;
     sha256 = "sha256-TFIGKTVrAMSOFEmu3afdDKBgyEwF2KIv3rt1fS6rCxw=";
@@ -22,7 +24,7 @@ buildGoModule rec {
 
   meta = with lib; {
     mainProgram = "drone";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ techknowlogick ];
     license = licenses.asl20;
     description = "Command line client for the Drone continuous integration server";
   };


### PR DESCRIPTION
###### Motivation for this change
Drone-CLI fails to build for darwin/aarch64 otherwise due to outdated library in gomod, this adds a patch to swap upstream library used

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
