### PR TITLE
polkadot: handle version without `leaveDotGit`

### DIFF
--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -15,34 +15,15 @@ rustPlatform.buildRustPackage rec {
     repo = "polkadot";
     rev = "v${version}";
     sha256 = "sha256-NXuYUmo80rrBZCcuISKon48SKyyJrkzCEhggxaJNfBM=";
-
-    # see the comment below on fakeGit for how this is used
-    leaveDotGit = true;
-    postFetch = ''
-      ( cd $out; git rev-parse --short HEAD > .git_commit )
-      rm -rf $out/.git
-    '';
   };
 
   cargoSha256 = "sha256-PIORMTzQbMdlrKwuF4MiGrLlg2nQpgLRsaHHeiCbqrg=";
 
   nativeBuildInputs =
     let
-      # the build process of polkadot requires a .git folder in order to determine
-      # the git commit hash that is being built and add it to the version string.
-      # since having a .git folder introduces reproducibility issues to the nix
-      # build, we check the git commit hash after fetching the source and save it
-      # into a .git_commit file, and then delete the .git folder. then we create a
-      # fake git command that will just return the contents of this file, which will
-      # be used when the polkadot build calls `git rev-parse` to fetch the commit
-      # hash.
+      # this mocks git to return the truncated SHA hash we get from Nix
       fakeGit = writeShellScriptBin "git" ''
-        if [[ $@ = "rev-parse --short HEAD" ]]; then
-          cat /build/source/.git_commit
-        else
-          >&2 echo "Unknown command: $@"
-          exit 1
-        fi
+        echo ${builtins.substring 0 6 version}
       '';
     in
     [ clang fakeGit ];


### PR DESCRIPTION
Leaving the `.git` directory around results in reproducibility
issues[0].

Kudos to @NobbZ for the hint.

[0]: https://github.com/NixOS/nixpkgs/issues/8567

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
