### PR TITLE
sage: don't test for Cython source code in tracebacks (temporarily)

### DIFF
--- a/pkgs/applications/science/math/sage/patches/no-cython-sources-in-tracebacks-on-ipython8.patch
+++ b/pkgs/applications/science/math/sage/patches/no-cython-sources-in-tracebacks-on-ipython8.patch
@@ -1,0 +1,52 @@
+diff --git a/src/sage/repl/interface_magic.py b/src/sage/repl/interface_magic.py
+index 8a455b69b0..a93e1c9e04 100644
+--- a/src/sage/repl/interface_magic.py
++++ b/src/sage/repl/interface_magic.py
+@@ -260,7 +260,7 @@ class InterfaceMagic(object):
+             2
+             120
+             sage: shell.run_cell('%%gap foo\n1+1;\n')
+-            ...File "<string>", line unknown
++            ...File...<string>...
+             SyntaxError: Interface magics have no options, got "foo"
+             <BLANKLINE>
+             sage: shell.run_cell('%%gap?')
+diff --git a/src/sage/repl/interpreter.py b/src/sage/repl/interpreter.py
+index 71dbe429fd..36b1d986d6 100644
+--- a/src/sage/repl/interpreter.py
++++ b/src/sage/repl/interpreter.py
+@@ -70,25 +70,6 @@ that shell.  The bulk of this functionality is provided through
+ 
+ TESTS:
+ 
+-Check that Cython source code appears in tracebacks::
+-
+-    sage: from sage.repl.interpreter import get_test_shell
+-    sage: shell = get_test_shell()
+-    sage: print("dummy line"); shell.run_cell('1/0') # see #25320 for the reason of the `...` and the dummy line in this test
+-    dummy line
+-    ...
+-    ZeroDivisionError...Traceback (most recent call last)
+-    <ipython-input-...> in <module>...
+-    ----> 1 Integer(1)/Integer(0)
+-    .../sage/rings/integer.pyx in sage.rings.integer.Integer...div...
+-    ...
+-    -> ...                  raise ZeroDivisionError("rational division by zero")
+-       ....:            x = <Rational> Rational.__new__(Rational)
+-       ....:            mpq_div_zz(x.value, ....value, (<Integer>right).value)
+-    <BLANKLINE>
+-    ZeroDivisionError: rational division by zero
+-    sage: shell.quit()
+-
+ Test prompt transformer::
+ 
+     sage: from sage.repl.interpreter import SagePromptTransformer
+@@ -423,7 +404,7 @@ def SagePreparseTransformer(lines):
+         sage: from sage.repl.interpreter import get_test_shell
+         sage: shell = get_test_shell()
+         sage: shell.run_cell(bad_syntax)
+-          File "<string>", line unknown
++          File...<string>...
+         SyntaxError: Mismatched ']'
+         <BLANKLINE>
+         sage: shell.quit()

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -119,6 +119,16 @@ stdenv.mkDerivation rec {
     # https://trac.sagemath.org/ticket/32959
     ./patches/linbox-1.7-upgrade.patch
 
+    # To emit better tracebacks, IPython 8 parses Python files using the ast
+    # module (via the stack_data package). Since Cython is a superset of Python,
+    # this results in no Cython code being printed in tracebacks. Fixing this
+    # properly is tracked in https://github.com/alexmojaki/stack_data/issues/21,
+    # but for now we just disable the corresponding test. An alternative would
+    # be to revert IPython's IPython/core/ultratb.py, but this would need to be
+    # Sage-specific (since it would worsen tracebacks for pure Python code).
+    # Sage tracks this at https://trac.sagemath.org/ticket/33170
+    ./patches/no-cython-sources-in-tracebacks-on-ipython8.patch
+
     # https://trac.sagemath.org/ticket/32968
     (fetchSageDiff {
       base = "9.5";


### PR DESCRIPTION
###### Motivation for this change

To emit better tracebacks, IPython 8 (#154969) parses Python files using the `ast` module (via the `stack_data` package). Since Cython is a superset of Python, this results in no Cython code being printed in tracebacks. Fixing this properly is tracked in https://github.com/alexmojaki/stack_data/issues/21, but for now we just disable the corresponding test. An alternative would be to revert IPython's [IPython/core/ultratb.py](https://github.com/ipython/ipython/commit/221eb78a8e09cea6c1634ae71fdc8621a2fe05df), but this would need to be Sage-specific (since it would worsen tracebacks for pure Python code).

Sage tracks the IPython 8 upgrade at https://trac.sagemath.org/ticket/33170, a ticket which also includes two minor test changes. I added those to this PR as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
