### PR TITLE
prosody: fixes

### DIFF
--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -72,17 +72,17 @@ stdenv.mkDerivation rec {
         cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
       '') (lib.lists.unique(nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules))}
       wrapProgram $out/bin/prosody \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
+        --set LUA_PATH "$luaEnvPath" \
+        --set LUA_CPATH "$luaEnvCPath"
       wrapProgram $out/bin/prosodyctl \
         --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
+        --set LUA_PATH "$luaEnvPath" \
+        --set LUA_CPATH "$luaEnvCPath"
 
       make -C tools/migration install
       wrapProgram $out/bin/prosody-migrator \
-        --prefix LUA_PATH ';' "$luaEnvPath" \
-        --prefix LUA_CPATH ';' "$luaEnvCPath"
+        --set LUA_PATH "$luaEnvPath" \
+        --set LUA_CPATH "$luaEnvCPath"
     '';
 
   passthru = {

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -5,6 +5,7 @@
 , withDBI ? true
 # use withExtraLibs to add additional dependencies of community modules
 , withExtraLibs ? [ ]
+, withExtraLuaPackages ? _: [ ]
 , withOnlyInstalledCommunityModules ? [ ]
 , withCommunityModules ? [ ] }:
 
@@ -17,6 +18,7 @@ let
     ]
     ++ lib.optional withLibevent p.luaevent
     ++ lib.optional withDBI p.luadbi
+    ++ withExtraLuaPackages p
   );
 in
 stdenv.mkDerivation rec {

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -63,23 +63,26 @@ stdenv.mkDerivation rec {
     make -C tools/migration
   '';
 
+  luaEnvPath = lua.pkgs.lib.genLuaPathAbsStr luaEnv;
+  luaEnvCPath = lua.pkgs.lib.genLuaCPathAbsStr luaEnv;
+
   # the wrapping should go away once lua hook is fixed
   postInstall = ''
       ${concatMapStringsSep "\n" (module: ''
         cp -r $communityModules/mod_${module} $out/lib/prosody/modules/
       '') (lib.lists.unique(nixosModuleDeps ++ withCommunityModules ++ withOnlyInstalledCommunityModules))}
       wrapProgram $out/bin/prosody \
-        --prefix LUA_PATH ';' "$LUA_PATH" \
-        --prefix LUA_CPATH ';' "$LUA_CPATH"
+        --prefix LUA_PATH ';' "$luaEnvPath" \
+        --prefix LUA_CPATH ';' "$luaEnvCPath"
       wrapProgram $out/bin/prosodyctl \
         --add-flags '--config "/etc/prosody/prosody.cfg.lua"' \
-        --prefix LUA_PATH ';' "$LUA_PATH" \
-        --prefix LUA_CPATH ';' "$LUA_CPATH"
+        --prefix LUA_PATH ';' "$luaEnvPath" \
+        --prefix LUA_CPATH ';' "$luaEnvCPath"
 
       make -C tools/migration install
       wrapProgram $out/bin/prosody-migrator \
-        --prefix LUA_PATH ';' "$LUA_PATH" \
-        --prefix LUA_CPATH ';' "$LUA_CPATH"
+        --prefix LUA_PATH ';' "$luaEnvPath" \
+        --prefix LUA_CPATH ';' "$luaEnvCPath"
     '';
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21047,6 +21047,7 @@ with pkgs;
     # _compat can probably be removed on next minor version after 0.10.0
     lua = lua5_2_compat;
     withExtraLibs = [];
+    withExtraLuaPackages = _: [];
   };
 
   prosody-filer = callPackage ../servers/xmpp/prosody-filer { };


### PR DESCRIPTION
###### Motivation for this change

Either I'm crazy or no one uses lua/prosody :(

Each of these changes were necessary to get it to run again on my system. I'm open to suggestions on how to name/approach the luaEnv extension problem, or otherwise utilize setuphooks to make the old way work again. To summarize the problems I ran into:

- `LUA_PATH`/`LUA_CPATH` are now empty variables, and generating them from `luaEnv` appears to be the recommended way to replace them (cc @teto who can confirm this or offer suggestions?)
- `makeWrapper` cannot handle prefixing values that contain special wildcard characters such as the `?` placeholder used by lua paths
  this commit is separate because it can be reverted later once the bug affecting `makeWrapper` is identified/fixed
- using `luaEnv` as the sole source for `LUA_PATH`/`LUA_CPATH` means that `withExtraLibs` can't be used to add lua packages to the closure/wrapper (like it could in the past)
  the new extension function approach might be "better" anyway because it's guaranteed to use the correct luaPackages package set (and there's precedent in nixpkgs for other similar wrappers for python/etc that do this afair), but it isn't as obvious/discoverable to use.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
