### PR TITLE
terraform-providers.bitbucket: reintroduce

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -70,7 +70,6 @@ let
     in
     lib.optionalAttrs (config.allowAliases or false) {
       arukas = archived "2022/01";
-      bitbucket = archived "2022/01";
       chef = archived "2022/01";
       cherryservers = archived "2022/01";
       clc = archived "2022/01";

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -145,13 +145,13 @@
     "version": "1.12.2"
   },
   "bitbucket": {
-    "owner": "terraform-providers",
-    "provider-source-address": "registry.terraform.io/nixpkgs/bitbucket",
+    "owner": "DrFaust92",
+    "provider-source-address": "registry.terraform.io/DrFaust92/bitbucket",
     "repo": "terraform-provider-bitbucket",
-    "rev": "v1.2.0",
-    "sha256": "11n4wpvmaab164g6k077n9dbdbhd5lwl7pxpha5492ks468nd95b",
+    "rev": "v2.4.1",
+    "sha256": "07y0biab2g6plkyp8scqf7b12alijnxq2zqqr05lbm6wgrc22kvk",
     "vendorSha256": null,
-    "version": "1.2.0"
+    "version": "2.4.1"
   },
   "brightbox": {
     "owner": "brightbox",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -144,6 +144,15 @@
     "vendorSha256": null,
     "version": "1.12.2"
   },
+  "bitbucket": {
+    "owner": "terraform-providers",
+    "provider-source-address": "registry.terraform.io/nixpkgs/bitbucket",
+    "repo": "terraform-provider-bitbucket",
+    "rev": "v1.2.0",
+    "sha256": "11n4wpvmaab164g6k077n9dbdbhd5lwl7pxpha5492ks468nd95b",
+    "vendorSha256": null,
+    "version": "1.2.0"
+  },
   "brightbox": {
     "owner": "brightbox",
     "provider-source-address": "registry.terraform.io/brightbox/brightbox",


### PR DESCRIPTION
###### Motivation for this change

This provider was removed as part of #153015, but it's still useful!

I'm not sure if it counts as "blessed", but there's certainly [one obvious fork](https://github.com/DrFaust92/terraform-provider-bitbucket) that's being actively developed and maintained, so I've moved to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
