### PR TITLE
makeWrapper: Don't glob in prefix/suffix

### DIFF
--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -51,7 +51,19 @@ makeWrapper() {
         local varName="$2"    # name of list variable to add to
         local separator="$3"  # character used to separate elements of list
         local value="$4"      # one value, or multiple values separated by `separator`, to add to list
-        if test -n "$value"; then
+
+        # Disable file globbing, since bash will otherwise try to find
+        # filenames matching the the value to be prefixed/suffixed if
+        # it contains characters considered wildcards, such as `?` and
+        # `*`. We want the value as is, except we also want to split
+        # it on on the separator; hence we can't quote it.
+        local reenableGlob=0
+        if [[ ! -o noglob ]]; then
+            reenableGlob=1
+        fi
+        set -o noglob
+
+        if [[ -n "$value" ]]; then
             local old_ifs=$IFS
             IFS=$separator
 
@@ -85,6 +97,10 @@ makeWrapper() {
                 } >> "$wrapper"
             done
             IFS=$old_ifs
+        fi
+
+        if (( reenableGlob )); then
+            set +o noglob
         fi
     }
 

--- a/pkgs/test/make-wrapper/default.nix
+++ b/pkgs/test/make-wrapper/default.nix
@@ -64,6 +64,7 @@ runCommand "make-wrapper-test"
     (mkWrapperBinary { name = "test-run-and-set"; args = [ "--run" "export VAR=foo" "--set" "VAR" "bar" ]; })
     (mkWrapperBinary { name = "test-args"; args = [ "--add-flags" "abc" ]; wrapped = wrappedBinaryArgs; })
     (mkWrapperBinary { name = "test-prefix"; args = [ "--prefix" "VAR" ":" "abc" ]; })
+    (mkWrapperBinary { name = "test-prefix-noglob"; args = [ "--prefix" "VAR" ":" "./*" ]; })
     (mkWrapperBinary { name = "test-suffix"; args = [ "--suffix" "VAR" ":" "abc" ]; })
     (mkWrapperBinary { name = "test-prefix-and-suffix"; args = [ "--prefix" "VAR" ":" "foo" "--suffix" "VAR" ":" "bar" ]; })
     (mkWrapperBinary { name = "test-prefix-multi"; args = [ "--prefix" "VAR" ":" "abc:foo:foo" ]; })
@@ -112,6 +113,8 @@ runCommand "make-wrapper-test"
     # Only append the value once when given multiple times in a parameter
     # to makeWrapper
     + mkTest "test-prefix" "VAR=abc"
+    # --prefix doesn't expand globs
+    + mkTest "VAR=f?oo test-prefix-noglob" "VAR=./*:f?oo"
 
 
     # --suffix works


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Disable file globbing in `--prefix` / `--suffix`, since bash will otherwise try to find filenames matching the the value to be prefixed / suffixed if it contains characters considered wildcards, such as `?` and `*`.

Fixes the bug reported in #159366 and #128503.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
