### PR TITLE
vimix-icon-theme: allow selection of color variants

### DIFF
--- a/pkgs/data/icons/vimix-icon-theme/default.nix
+++ b/pkgs/data/icons/vimix-icon-theme/default.nix
@@ -1,7 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, gtk3, hicolor-icon-theme, jdupes }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk3
+, hicolor-icon-theme
+, jdupes
+, colorVariants ? [] # default: all
+}:
+
+let
+  pname = "vimix-icon-theme";
+
+in
+lib.checkListOfEnum "${pname}: color variants" [ "standard" "Amethyst" "Beryl" "Doder" "Ruby" "Black" "White" ] colorVariants
 
 stdenv.mkDerivation rec {
-  pname = "vimix-icon-theme";
+  inherit pname;
   version = "2021-11-09";
 
   src = fetchFromGitHub {
@@ -23,10 +36,16 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     patchShebangs install.sh
-    ./install.sh -a -d $out/share/icons
+
+    ./install.sh \
+      ${if colorVariants != [] then builtins.toString colorVariants else "-a"} \
+      -d $out/share/icons
+
     # replace duplicate files with symlinks
     jdupes -l -r $out/share/icons
+
     runHook postInstall
   '';
 

--- a/pkgs/data/icons/vimix-icon-theme/default.nix
+++ b/pkgs/data/icons/vimix-icon-theme/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       -d $out/share/icons
 
     # replace duplicate files with symlinks
-    jdupes -l -r $out/share/icons
+    jdupes -L -r $out/share/icons
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- vimix-icon-theme: allow selection of color variants
- vimix-icon-theme: use hard instead of symbolic links for duplicate files

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
