### PR TITLE
sourcehut: fix and update

### DIFF
--- a/nixos/tests/sourcehut.nix
+++ b/nixos/tests/sourcehut.nix
@@ -125,13 +125,18 @@ in
     virtualisation.memorySize = 2 * 1024;
     networking.domain = domain;
     networking.extraHosts = ''
-      ${config.networking.primaryIPAddress} meta.${domain}
       ${config.networking.primaryIPAddress} builds.${domain}
+      ${config.networking.primaryIPAddress} git.${domain}
+      ${config.networking.primaryIPAddress} meta.${domain}
     '';
 
     services.sourcehut = {
       enable = true;
-      services = [ "meta" "builds" ];
+      services = [
+        "builds"
+        "git"
+        "meta"
+      ];
       nginx.enable = true;
       nginx.virtualHost = {
         forceSSL = true;
@@ -148,6 +153,8 @@ in
         #enableWorker = true;
         inherit images;
       };
+      git.enable = true;
+
       settings."sr.ht" = {
         global-domain = config.networking.domain;
         service-key = pkgs.writeText "service-key" "8b327279b77e32a3620e2fc9aabce491cc46e7d821fd6713b2a2e650ce114d01";
@@ -156,6 +163,10 @@ in
       settings."builds.sr.ht" = {
         oauth-client-secret = pkgs.writeText "buildsrht-oauth-client-secret" "2260e9c4d9b8dcedcef642860e0504bc";
         oauth-client-id = "299db9f9c2013170";
+      };
+      settings."git.sr.ht" = {
+        oauth-client-secret = pkgs.writeText "gitsrht-oauth-client-secret" "3597288dc2c716e567db5384f493b09d";
+        oauth-client-id = "d07cb713d920702e";
       };
       settings.webhooks.private-key = pkgs.writeText "webhook-key" "Ra3IjxgFiwG9jxgp4WALQIZw/BMYt30xWiOsqD0J7EA=";
     };
@@ -193,5 +204,9 @@ in
     machine.wait_for_open_port(5002)
     machine.succeed("curl -sL http://localhost:5002 | grep builds.${domain}")
     #machine.wait_for_unit("buildsrht-worker.service")
+
+    # Testing gitsrht
+    machine.wait_for_unit("gitsrht.service")
+    machine.succeed("curl -sL http://git.${domain} | grep git.${domain}")
   '';
 })

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -11,13 +11,13 @@
 , python
 }:
 let
-  version = "0.74.17";
+  version = "0.75.2";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "builds.sr.ht";
     rev = version;
-    sha256 = "sha256-6Yc33lkhozpnx8e6yukUfo+/Qw5mwpJQQKuYbC7uqcU=";
+    sha256 = "sha256-SwyxMzmp9baRQ0vceuEn/OpfIv7z7jwq/l67hdOHXjM=";
   };
 
   buildWorker = src: buildGoModule {

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -29,12 +29,12 @@
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.68.13";
+  version = "0.68.14";
 
   src = fetchgit {
     url = "https://git.sr.ht/~sircmpwn/core.sr.ht";
     rev = version;
-    sha256 = "sha256-LPyEfpNlmod18Fj16xpihKOrsU/hQUfAeOmWMmUeVPQ=";
+    sha256 = "sha256-BY3W2rwrg0mhH3CltgUqg6Xv8Ve5VZNY/lI1cfbAjYM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -48,6 +48,11 @@ buildPythonPackage rec {
   inherit src version;
   pname = "gitsrht";
 
+  patches = [
+    # Revert change breaking Unix socket support for Redis
+    patches/redis-socket/git/0001-Revert-Add-webhook-queue-monitoring.patch
+  ];
+
   nativeBuildInputs = srht.nativeBuildInputs;
 
   propagatedBuildInputs = [

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -8,13 +8,13 @@
 , scmsrht
 }:
 let
-  version = "0.76.4";
+  version = "0.77.3";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "git.sr.ht";
     rev = version;
-    sha256 = "sha256-diUkQpB/ivg8JTaoTcSyKr9Q9LZiMo6qVInBDPceklc=";
+    sha256 = "sha256-eJvXCcmdiUzTK0EqNJkLEZsAfr6toD/378HObnMbOWM=";
   };
 
   buildShell = src: buildGoModule {

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "hgsrht";
-  version = "0.29.3";
+  version = "0.29.4";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~sircmpwn/hg.sr.ht";
     rev = version;
-    sha256 = "y8gKaamwD5lsYqO1SkxMcn3E2TWidHAo2slvEU+8ovg=";
+    sha256 = "Jn9M/R5tJK/GeJDWGo3LWCK2nwsfI9zh+/yo2M+X6Sk=";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
     sha256 = "sha256-iywZ6G5E4AJevg/Q1LoB7JMJxBcsAnbhiND++mFy/bw=";
   };
 
+  patches = [
+    # Revert change breaking Unix socket support for Redis
+    patches/redis-socket/lists/0001-Revert-Add-webhook-queue-monitoring.patch
+  ];
+
   nativeBuildInputs = srht.nativeBuildInputs;
 
   propagatedBuildInputs = [

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "listssrht";
-  version = "0.51.0";
+  version = "0.51.7";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "lists.sr.ht";
     rev = version;
-    sha256 = "sha256-iywZ6G5E4AJevg/Q1LoB7JMJxBcsAnbhiND++mFy/bw=";
+    sha256 = "sha256-oNY5A98oVoL2JKO0fU/8YVl8u7ywmHb/RHD8A6z9yIM=";
   };
 
   patches = [

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -8,13 +8,13 @@
 
 buildPythonPackage rec {
   pname = "mansrht";
-  version = "0.15.22";
+  version = "0.15.23";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "man.sr.ht";
     rev = version;
-    sha256 = "sha256-curouf+eNCKprDI23blGs4AzJMry6zlCLDt/+0j5c8A=";
+    sha256 = "sha256-xrBptXdwMee+YkPup/BYL/iXBhCzSUQ5htSHIw/1Ncc=";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -18,19 +18,19 @@
 , python
 }:
 let
-  version = "0.57.2";
+  version = "0.57.5";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "meta.sr.ht";
     rev = version;
-    sha256 = "sha256-+ksfAOuch/fLkFLYU52Ug0Hf0EoERy+oCwa9g+GKuAA=";
+    sha256 = "sha256-qsCwZaCiqvY445U053OCWD98jlIUi9NB2jWVP2oW3Vk=";
   };
 
   buildApi = src: buildGoModule {
     inherit src version;
     pname = "metasrht-api";
-    vendorSha256 = "sha256-vo+YbMyo/Eal7hbFxP9hwIW2cePJcGFszoDRCCzFYdM=";
+    vendorSha256 = "sha256-8Ubrr9qRlgW2wsLHrPHwulSWLz+gp4VPcTvOZpg8TYM=";
   };
 
 in

--- a/pkgs/applications/version-management/sourcehut/pages.nix
+++ b/pkgs/applications/version-management/sourcehut/pages.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "pagessrht";
-  version = "0.5.2";
+  version = "0.6.2";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "pages.sr.ht";
     rev = version;
-    sha256 = "sha256-yEM122uhF0MNkMlNXyvBSfkLogRQETeuBl2K66kivac=";
+    sha256 = "sha256-ob0+t9V2o8lhVC6fXbi1rNm0Mnbs+GoyAmhBqVZ13PA=";
   };
 
-  vendorSha256 = "sha256-udr+1y5ApQCSPhs3yQTTi9QfzRbz0A9COYuFMjQGa74=";
+  vendorSha256 = "sha256-b0sHSH0jkKoIVq045N96wszuLJDegkkj0v50nuDFleU=";
 
   postInstall = ''
     mkdir -p $out/share/sql/

--- a/pkgs/applications/version-management/sourcehut/patches/redis-socket/git/0001-Revert-Add-webhook-queue-monitoring.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/redis-socket/git/0001-Revert-Add-webhook-queue-monitoring.patch
@@ -1,0 +1,50 @@
+From 5ccb5386304c26f25b0a9eb10ce9edb6da32f91a Mon Sep 17 00:00:00 2001
+From: Julien Moutinho <julm+srht@sourcephile.fr>
+Date: Sat, 12 Feb 2022 00:11:59 +0100
+Subject: [PATCH git.sr.ht] Revert "Add webhook queue monitoring"
+
+This reverts commit 7ea630b776947ab82438d0ffa263b0f9d33ebff3.
+
+Which has broken Unix socket support for Redis.
+See https://lists.sr.ht/~sircmpwn/sr.ht-dev/%3C20211208082636.65665-1-me%40ignaskiela.eu%3E#%3C20211216033723.wefibfulfjhqnhem@sourcephile.fr%3E
+---
+ gitsrht/app.py      | 3 ---
+ gitsrht/webhooks.py | 5 +----
+ 2 files changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/gitsrht/app.py b/gitsrht/app.py
+index e9ccb56..4928851 100644
+--- a/gitsrht/app.py
++++ b/gitsrht/app.py
+@@ -48,9 +48,6 @@ class GitApp(ScmSrhtFlask):
+         self.add_template_filter(url_quote)
+         self.add_template_filter(commit_links)
+ 
+-        from gitsrht.webhooks import webhook_metrics_collector
+-        self.metrics_registry.register(webhook_metrics_collector)
+-
+         @self.context_processor
+         def inject():
+             notice = session.get("notice")
+diff --git a/gitsrht/webhooks.py b/gitsrht/webhooks.py
+index 8a203fe..6240d50 100644
+--- a/gitsrht/webhooks.py
++++ b/gitsrht/webhooks.py
+@@ -7,13 +7,10 @@ if not hasattr(db, "session"):
+     db.init()
+ from srht.webhook import Event
+ from srht.webhook.celery import CeleryWebhook, make_worker
+-from srht.metrics import RedisQueueCollector
+ from scmsrht.webhooks import UserWebhook
+ import sqlalchemy as sa
+ 
+-webhook_broker = cfg("git.sr.ht", "webhooks")
+-worker = make_worker(broker=webhook_broker)
+-webhook_metrics_collector = RedisQueueCollector(webhook_broker, "srht_webhooks", "Webhook queue length")
++worker = make_worker(broker=cfg("git.sr.ht", "webhooks"))
+ 
+ class RepoWebhook(CeleryWebhook):
+     events = [
+-- 
+2.34.1
+

--- a/pkgs/applications/version-management/sourcehut/patches/redis-socket/lists/0001-Revert-Add-webhook-queue-monitoring.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/redis-socket/lists/0001-Revert-Add-webhook-queue-monitoring.patch
@@ -1,0 +1,48 @@
+From 730e090f31b150d42be4b4722751f8e4610835b0 Mon Sep 17 00:00:00 2001
+From: Julien Moutinho <julm+srht@sourcephile.fr>
+Date: Sat, 12 Feb 2022 00:38:12 +0100
+Subject: [PATCH lists.sr.ht] Revert "Add webhook queue monitoring"
+
+This reverts commit e74e344808e8d523a9786cefcbf64c9a247d7a0e.
+
+Which has broken Unix socket support for Redis.
+See https://lists.sr.ht/~sircmpwn/sr.ht-dev/%3C20211208082636.65665-1-me%40ignaskiela.eu%3E#%3C20211216033723.wefibfulfjhqnhem@sourcephile.fr%3E
+---
+ listssrht/app.py      | 3 ---
+ listssrht/webhooks.py | 5 +----
+ 2 files changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/listssrht/app.py b/listssrht/app.py
+index aec59f3..83a355d 100644
+--- a/listssrht/app.py
++++ b/listssrht/app.py
+@@ -29,9 +29,6 @@ class ListsApp(SrhtFlask):
+         self.register_blueprint(user)
+         self.register_blueprint(gql_blueprint)
+ 
+-        from listssrht.webhooks import webhook_metrics_collector
+-        self.metrics_registry.register(webhook_metrics_collector)
+-
+         @self.context_processor
+         def inject():
+             from listssrht.types import ListAccess
+diff --git a/listssrht/webhooks.py b/listssrht/webhooks.py
+index ae5b1cb..86421ba 100644
+--- a/listssrht/webhooks.py
++++ b/listssrht/webhooks.py
+@@ -8,11 +8,8 @@ if not hasattr(db, "session"):
+     db.init()
+ from srht.webhook import Event
+ from srht.webhook.celery import CeleryWebhook, make_worker
+-from srht.metrics import RedisQueueCollector
+ 
+-webhook_broker = cfg("lists.sr.ht", "webhooks")
+-worker = make_worker(broker=webhook_broker)
+-webhook_metrics_collector = RedisQueueCollector(webhook_broker, "srht_webhooks", "Webhook queue length")
++worker = make_worker(broker=cfg("lists.sr.ht", "webhooks"))
+ 
+ class ListWebhook(CeleryWebhook):
+     events = [
+-- 
+2.34.1
+

--- a/pkgs/applications/version-management/sourcehut/patches/redis-socket/todo/0001-Revert-Add-webhook-queue-monitoring.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/redis-socket/todo/0001-Revert-Add-webhook-queue-monitoring.patch
@@ -1,0 +1,50 @@
+From 42a27ea60d8454552d54e1f51f1b976d1067fc32 Mon Sep 17 00:00:00 2001
+From: Julien Moutinho <julm+srht@sourcephile.fr>
+Date: Sat, 12 Feb 2022 00:30:29 +0100
+Subject: [PATCH todo.sr.ht] Revert "Add webhook queue monitoring"
+
+This reverts commit 320a5e8f7cd16ca43928c36f0320593f84d986fa.
+
+Which has broken Unix socket support for Redis.
+See https://lists.sr.ht/~sircmpwn/sr.ht-dev/%3C20211208082636.65665-1-me%40ignaskiela.eu%3E#%3C20211216033723.wefibfulfjhqnhem@sourcephile.fr%3E
+---
+ todosrht/flask.py    | 3 ---
+ todosrht/webhooks.py | 6 +-----
+ 2 files changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/todosrht/flask.py b/todosrht/flask.py
+index 5e8ac66..9d0fd27 100644
+--- a/todosrht/flask.py
++++ b/todosrht/flask.py
+@@ -43,9 +43,6 @@ class TodoApp(SrhtFlask):
+         self.add_template_filter(urls.tracker_url)
+         self.add_template_filter(urls.user_url)
+ 
+-        from todosrht.webhooks import webhook_metrics_collector
+-        self.metrics_registry.register(webhook_metrics_collector)
+-
+         @self.context_processor
+         def inject():
+             return {
+diff --git a/todosrht/webhooks.py b/todosrht/webhooks.py
+index eb8e08a..950047f 100644
+--- a/todosrht/webhooks.py
++++ b/todosrht/webhooks.py
+@@ -7,13 +7,9 @@ if not hasattr(db, "session"):
+     db.init()
+ from srht.webhook import Event
+ from srht.webhook.celery import CeleryWebhook, make_worker
+-from srht.metrics import RedisQueueCollector
+ import sqlalchemy as sa
+ 
+-
+-webhooks_broker = cfg("todo.sr.ht", "webhooks")
+-worker = make_worker(broker=webhooks_broker)
+-webhook_metrics_collector = RedisQueueCollector(webhooks_broker, "srht_webhooks", "Webhook queue length")
++worker = make_worker(broker=cfg("todo.sr.ht", "webhooks"))
+ 
+ import todosrht.tracker_import
+ 
+-- 
+2.34.1
+

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "scmsrht";
-  version = "0.22.16"; # Untagged version
+  version = "0.22.19"; # Untagged version
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "scm.sr.ht";
     rev = version;
-    sha256 = "sha256-A4Q7wUc4ag7KRWOkdYXCsbzuFHyJJsM15OjrCoVt9UQ=";
+    sha256 = "sha256-/QryPjWJ2S0Ov9DTdrwbM81HYucHiYcLh0oKacflywI=";
   };
 
   nativeBuildInputs = srht.nativeBuildInputs;

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
     sha256 = "sha256-P0xaQpK7O9zipGSIa5jL1O0L/fKt51EMNGt7XndYQ+g=";
   };
 
+  patches = [
+    # Revert change breaking Unix socket support for Redis
+    patches/redis-socket/todo/0001-Revert-Add-webhook-queue-monitoring.patch
+  ];
+
   nativeBuildInputs = srht.nativeBuildInputs;
 
   propagatedBuildInputs = [

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage rec {
   pname = "todosrht";
-  version = "0.66.1";
+  version = "0.67.2";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "todo.sr.ht";
     rev = version;
-    sha256 = "sha256-P0xaQpK7O9zipGSIa5jL1O0L/fKt51EMNGt7XndYQ+g=";
+    sha256 = "sha256-/QHsMlhzyah85ubZyx8j4GDUoITuWcLDJKosbZGeOZU=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Updating sourcehut and reverting forgotten upstream commits [breaking when using Redis via Unix sockets](https://lists.sr.ht/~sircmpwn/sr.ht-dev/%3C20211208082636.65665-1-me%40ignaskiela.eu%3E#%3C20211216033723.wefibfulfjhqnhem@sourcephile.fr%3E).

###### Things done
- [X] Revert upstream commits introducing webhook queue monitoring.
- [X] Run `pkgs/applications/version-management/sourcehut/update.sh`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
