### PR TITLE
matomo: 4.5.0 -> 4.7.1, module improvements

### DIFF
--- a/nixos/modules/services/web-apps/matomo-doc.xml
+++ b/nixos/modules/services/web-apps/matomo-doc.xml
@@ -6,46 +6,13 @@
  <title>Matomo</title>
  <para>
   Matomo is a real-time web analytics application. This module configures
-  php-fpm as backend for Matomo, optionally configuring an nginx vhost as well.
+  php-fpm as backend for Matomo, optionally configuring MariaDB database and an
+  nginx vhost as well.
  </para>
  <para>
   An automatic setup is not suported by Matomo, so you need to configure Matomo
   itself in the browser-based Matomo setup.
  </para>
- <section xml:id="module-services-matomo-database-setup">
-  <title>Database Setup</title>
-
-  <para>
-   You also need to configure a MariaDB or MySQL database and -user for Matomo
-   yourself, and enter those credentials in your browser. You can use
-   passwordless database authentication via the UNIX_SOCKET authentication
-   plugin with the following SQL commands:
-<programlisting>
-# For MariaDB
-INSTALL PLUGIN unix_socket SONAME 'auth_socket';
-CREATE DATABASE matomo;
-CREATE USER 'matomo'@'localhost' IDENTIFIED WITH unix_socket;
-GRANT ALL PRIVILEGES ON matomo.* TO 'matomo'@'localhost';
-
-# For MySQL
-INSTALL PLUGIN auth_socket SONAME 'auth_socket.so';
-CREATE DATABASE matomo;
-CREATE USER 'matomo'@'localhost' IDENTIFIED WITH auth_socket;
-GRANT ALL PRIVILEGES ON matomo.* TO 'matomo'@'localhost';
-</programlisting>
-   Then fill in <literal>matomo</literal> as database user and database name,
-   and leave the password field blank. This authentication works by allowing
-   only the <literal>matomo</literal> unix user to authenticate as the
-   <literal>matomo</literal> database user (without needing a password), but no
-   other users. For more information on passwordless login, see
-   <link xlink:href="https://mariadb.com/kb/en/mariadb/unix_socket-authentication-plugin/" />.
-  </para>
-
-  <para>
-   Of course, you can use password based authentication as well, e.g. when the
-   database is not on the same host.
-  </para>
- </section>
  <section xml:id="module-services-matomo-archive-processing">
   <title>Archive Processing</title>
 

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -122,6 +122,23 @@ in {
           If this is set to null (the default), no nginx virtualHost will be configured.
         '';
       };
+
+      database.createLocally = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Create local MariaDB database for Matomo.
+        '';
+      };
+
+      database.name = mkOption {
+        type = types.str;
+        default = "matomo";
+        description = ''
+          MariaDB database name for Matomo.
+        '';
+      };
     };
   };
 
@@ -325,6 +342,16 @@ in {
           expires 1M;
         '';
       }];
+    };
+
+    services.mysql = mkIf cfg.database.createLocally {
+      enable = true;
+      package = mkDefault pkgs.mariadb;
+      settings.mysqld.max_allowed_packet = mkDefault "64M";
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        { name = user; ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; }; }
+      ];
     };
   };
 

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -208,7 +208,7 @@ in {
         # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
         # Copy config folder
         chmod g+s "${dataDir}"
-        cp -r "${cfg.package}/share/config" "${dataDir}/"
+        cp -r "${cfg.package}/share/matomo/config" "${dataDir}/"
         mkdir -p "${dataDir}/misc"
         chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
@@ -295,7 +295,7 @@ in {
       "${cfg.hostname}" = mkMerge [ cfg.nginx {
         # don't allow to override the root easily, as it will almost certainly break Matomo.
         # disadvantage: not shown as default in docs.
-        root = mkForce "${cfg.package}/share";
+        root = mkForce "${cfg.package}/share/matomo";
 
         # define locations here instead of as the submodule option's default
         # so that they can easily be extended with additional locations if required

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -165,7 +165,7 @@ in {
       requiredBy = [ "${phpExecutionUnit}.service" ];
       before = [ "${phpExecutionUnit}.service" ];
       # the update part of the script can only work if the database is already up and running
-      requires = [ databaseService ];
+      wants = [ databaseService ];
       after = [ databaseService ];
       path = [ cfg.package ];
       environment.PIWIK_USER_PATH = dataDir;

--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -113,13 +113,13 @@ in {
           }
         '';
         description = ''
-            With this option, you can customize an nginx virtualHost which already has sensible defaults for Matomo.
-            Either this option or the webServerUser option is mandatory.
-            Set this to {} to just enable the virtualHost if you don't need any customization.
-            If enabled, then by default, the <option>serverName</option> is
-            <literal>''${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
-            SSL is active, and certificates are acquired via ACME.
-            If this is set to null (the default), no nginx virtualHost will be configured.
+          With this option, you can customize an nginx virtualHost which already has sensible defaults for Matomo.
+          Either this option or the webServerUser option is mandatory.
+          Set this to {} to just enable the virtualHost if you don't need any customization.
+          If enabled, then by default, the <option>serverName</option> is
+          <literal>''${user}.''${config.networking.hostName}.''${config.networking.domain}</literal>,
+          SSL is active, and certificates are acquired via ACME.
+          If this is set to null (the default), no nginx virtualHost will be configured.
         '';
       };
     };
@@ -186,20 +186,20 @@ in {
           rm -rf ${dataDir}/tmp
         fi
         ln -sfT ${cfg.package} ${dataDir}/current-package
-        '';
+      '';
       script = ''
-            # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
-            # Copy config folder
-            chmod g+s "${dataDir}"
-            cp -r "${cfg.package}/share/config" "${dataDir}/"
-            mkdir -p "${dataDir}/misc"
-            chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
+        # Use User-Private Group scheme to protect Matomo data, but allow administration / backup via 'matomo' group
+        # Copy config folder
+        chmod g+s "${dataDir}"
+        cp -r "${cfg.package}/share/config" "${dataDir}/"
+        mkdir -p "${dataDir}/misc"
+        chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
-            # check whether user setup has already been done
-            if test -f "${dataDir}/config/config.ini.php"; then
-              # then execute possibly pending database upgrade
-              matomo-console core:update --yes
-            fi
+        # check whether user setup has already been done
+        if test -f "${dataDir}/config/config.ini.php"; then
+          # then execute possibly pending database upgrade
+          matomo-console core:update --yes
+        fi
       '';
     };
 

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -15,10 +15,7 @@ let
           forceSSL = false;
           enableACME = false;
         };
-      };
-      services.mysql = {
-        enable = true;
-        package = pkgs.mariadb;
+        mariaDB = true;
       };
       services.nginx.enable = true;
     };

--- a/pkgs/servers/web-apps/matomo/default.nix
+++ b/pkgs/servers/web-apps/matomo/default.nix
@@ -61,22 +61,22 @@ let
         '';
 
         # TODO: future versions might rename the PIWIK_… variables to MATOMO_…
-        # TODO: Move more unnecessary files from share/, especially using PIWIK_INCLUDE_PATH.
+        # TODO: Move more unnecessary files from share/matomo, especially using PIWIK_INCLUDE_PATH.
         #       See https://forum.matomo.org/t/bootstrap-php/5926/10 and
         #       https://github.com/matomo-org/matomo/issues/11654#issuecomment-297730843
         installPhase = ''
           runHook preInstall
 
-          # copy everything to share/, used as webroot folder, and then remove what's known to be not needed
-          mkdir -p $out/share
-          cp -ra * $out/share/
+          # copy everything to share/matomo, used as webroot folder, and then remove what's known to be not needed
+          mkdir -p $out/share/matomo
+          cp -ra * $out/share/matomo
           # tmp/ is created by matomo in PIWIK_USER_PATH
-          rmdir $out/share/tmp
+          rmdir $out/share/matomo/tmp
           # config/ needs to be accessed by PIWIK_USER_PATH anyway
-          ln -s $out/share/config $out/
+          ln -s $out/share/matomo/config $out/
 
           makeWrapper ${php}/bin/php $out/bin/matomo-console \
-            --add-flags "$out/share/console"
+            --add-flags "$out/share/matomo/console"
 
           runHook postInstall
         '';
@@ -96,7 +96,7 @@ let
         # The filesToFix list may contain files that are exclusive to only one of the versions we build
         # make sure to test for existence to avoid erroring on an incompatible version and failing
         postFixup = ''
-          pushd $out/share > /dev/null
+          pushd $out/share/matomo > /dev/null
           for f in $filesToFix; do
             if [ -f "$f" ]; then
               length="$(wc -c "$f" | cut -d' ' -f1)"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update Matomo and add more automatic setup, like MariaDB database.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by running the service and checking that both setup and system check pass more tests.

Depends on https://github.com/NixOS/nixpkgs/pull/100617.