### PR TITLE
duckdb: enable extensions

### DIFF
--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , fetchFromGitHub
 , cmake
+, ninja
 }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-F5YOqDeY3rgcnuu5SNqOfUxhsaXgqvdJZTnD1unI0tc=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ninja ];
 
   meta = with lib; {
     homepage = "https://github.com/duckdb/duckdb";

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -15,7 +15,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-F5YOqDeY3rgcnuu5SNqOfUxhsaXgqvdJZTnD1unI0tc=";
   };
 
+  cmakeFlags = [
+    "-DBUILD_FTS_EXTENSION=1"
+    "-DBUILD_HTTPFS_EXTENSION=1"
+    "-DBUILD_ICU_EXTENSION=1"
+    "-DBUILD_REST_EXTENSION=1"
+    "-DBUILD_TPCDS_EXTENSION=1"
+    "-DBUILD_TPCH_EXTENSION=1"
+    "-DBUILD_VISUALIZER_EXTENSION=1"
+  ];
   nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ openssl ];
 
   meta = with lib; {
     homepage = "https://github.com/duckdb/duckdb";

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "Embeddable SQL OLAP Database Management System";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ costrouc ];
+    maintainers = with maintainers; [ costrouc cpcloud ];
   };
 }

--- a/pkgs/development/libraries/duckdb/version.patch
+++ b/pkgs/development/libraries/duckdb/version.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 92c097228..5f51929f6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -157,45 +157,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+   set(SUN TRUE)
+ endif()
+ 
+-execute_process(
+-        COMMAND git log -1 --format=%h
+-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        RESULT_VARIABLE GIT_RESULT
+-        OUTPUT_VARIABLE GIT_COMMIT_HASH
+-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+-execute_process(
+-        COMMAND git describe --tags --abbrev=0
+-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        OUTPUT_VARIABLE GIT_LAST_TAG
+-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+-execute_process(
+-        COMMAND git describe --tags --long
+-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-        OUTPUT_VARIABLE GIT_ITERATION
+-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+-
+-if(GIT_RESULT EQUAL "0")
+-  string(REGEX REPLACE "v([0-9]+).[0-9]+.[0-9]+" "\\1" DUCKDB_MAJOR_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE "v[0-9]+.([0-9]+).[0-9]+" "\\1" DUCKDB_MINOR_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE "v[0-9]+.[0-9]+.([0-9]+)" "\\1" DUCKDB_PATCH_VERSION "${GIT_LAST_TAG}")
+-  string(REGEX REPLACE ".*-([0-9]+)-.*" "\\1" DUCKDB_DEV_ITERATION "${GIT_ITERATION}")
+-
+-  if(DUCKDB_DEV_ITERATION EQUAL 0)
+-    # on a tag; directly use the version
+-    set(DUCKDB_VERSION "${GIT_LAST_TAG}")
+-  else()
+-    # not on a tag, increment the patch version by one and add a -devX suffix
+-    math(EXPR DUCKDB_PATCH_VERSION "${DUCKDB_PATCH_VERSION}+1")
+-    set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
+-  endif()
+-else()
+-  # fallback for when building from tarball
+-  set(DUCKDB_MAJOR_VERSION 0)
+-  set(DUCKDB_MINOR_VERSION 0)
+-  set(DUCKDB_PATCH_VERSION 1)
+-  set(DUCKDB_DEV_ITERATION 0)
+-  set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
+-endif()
++set(DUCKDB_VERSION "@DUCKDB_VERSION@")
+ 
+ option(AMALGAMATION_BUILD
+        "Build from the amalgamation files, rather than from the normal sources."


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump duckdb from 0.3.1 to 0.3.2 and enable extensions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
