### PR TITLE
sasutils: init at 0.3.12

### DIFF
--- a/pkgs/os-specific/linux/sasutils/default.nix
+++ b/pkgs/os-specific/linux/sasutils/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages, fetchFromGitHub, sg3_utils }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sasutils";
+  version = "0.3.12";
+
+  src = fetchFromGitHub {
+    owner = "stanford-rc";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0kh5pcc2shdmrvqqi2y1zamzsfvk56pqgwqgqhjfz4r6yfpm04wl";
+  };
+
+  propagatedBuildInputs = [ sg3_utils ];
+
+  meta = with lib; {
+    homepage = "https://github.com/stanford-rc/sasutils";
+    description = "A set of command-line tools to ease the administration of Serial Attached SCSI (SAS) fabrics";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aij ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22968,6 +22968,8 @@ with pkgs;
 
   s3ql = callPackage ../tools/backup/s3ql { };
 
+  sasutils = callPackage ../os-specific/linux/sasutils { };
+
   sass = callPackage ../development/tools/sass { };
 
   sassc = callPackage ../development/tools/sassc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I wanted to see more information about my SAS disks than what `lsblk` or `lsscsi` can show.

For example `sas_discover` shows how many drives are in each enclosure

```
[nix-shell:~/nixpkgs]$ sas_discover                                                                                                                                                  
m5
|--host7 
|  |--3x--expander-7:1  
|  |  |-- 16 x end_device -- disk
|  |  `--  1 x end_device -- enclosure  
|  `--4x--expander-7:0  
|     |-- 16 x end_device -- disk
|     `--  1 x end_device -- enclosure  
|--host5 
|  `--  4 x end_device -- disk
|--host1 
|  `--  4 x end_device -- disk
`--host6 
   `--  4 x end_device -- disk
```

and with extra `-v` flags it shows more details on individual drives.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
