### PR TITLE
python3Packages.python-socks: 2.0.2 -> 2.0.3

### DIFF
--- a/pkgs/development/python-modules/enlighten/default.nix
+++ b/pkgs/development/python-modules/enlighten/default.nix
@@ -5,28 +5,41 @@
 , blessed
 , prefixed
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "enlighten";
   version = "1.10.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7a5b83cd0f4d095e59d80c648ebb5f7ffca0cd8bcf7ae6639828ee1ad000632a";
+    hash = "sha256-eluDzQ9NCV5Z2Axkjrtff/ygzYvPeuZjmCjuGtAAYyo=";
   };
 
   propagatedBuildInputs = [
     blessed
     prefixed
   ];
-  checkInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "enlighten" ];
-  disabledTests =
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "enlighten"
+  ];
+
+  disabledTests = [
+    # AssertionError: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'> is not...
+    "test_init"
+  ] ++ lib.optional stdenv.isDarwin [
     # https://github.com/Rockhopper-Technologies/enlighten/issues/44
-    lib.optional stdenv.isDarwin "test_autorefresh"
-    ;
+    "test_autorefresh"
+  ];
 
   meta = with lib; {
     description = "Enlighten Progress Bar for Python Console Apps";

--- a/pkgs/development/python-modules/python-socks/default.nix
+++ b/pkgs/development/python-modules/python-socks/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "python-socks";
-  version = "2.0.2";
+  version = "2.0.3";
   format = "setuptools";
 
   disabled = pythonOlder "3.6.1";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "romis2012";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ixhi23x28bg45146p23z26y38rlz445xr0inwgx7avh0rs7vwfx";
+    sha256 = "sha256-tVoBon9HF9MTOK+dN9g58fQO706ElNlCeULx//7hPWA=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/romis2012/python-socks/releases/tag/v2.0.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
