### PR TITLE
python3Packages.requests_oauthlib: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/applications/networking/seahub/default.nix
+++ b/pkgs/applications/networking/seahub/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchFromGitHub, python3, makeWrapper }:
+{ lib
+, fetchFromGitHub
+, python3
+, makeWrapper
+}:
 let
   # Seahub 8.x.x does not support django-webpack-loader >=1.x.x
   python = python3.override {
@@ -25,9 +29,12 @@ python.pkgs.buildPythonApplication rec {
   };
 
   dontBuild = true;
+
   doCheck = false; # disabled because it requires a ccnet environment
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   propagatedBuildInputs = with python.pkgs; [
     django
@@ -44,7 +51,7 @@ python.pkgs.buildPythonApplication rec {
     djangorestframework
     openpyxl
     requests
-    requests_oauthlib
+    requests-oauthlib
     pyjwt
     pycryptodome
     qrcode
@@ -65,10 +72,10 @@ python.pkgs.buildPythonApplication rec {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/haiwen/seahub";
     description = "The web end of seafile server";
+    homepage = "https://github.com/haiwen/seahub";
     license = licenses.asl20;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ greizgh schmittlauch ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/apprise/default.nix
+++ b/pkgs/development/python-modules/apprise/default.nix
@@ -13,7 +13,7 @@
 , pythonOlder
 , pyyaml
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , six
 , slixmpp
 }:
@@ -41,7 +41,7 @@ buildPythonPackage rec {
     markdown
     pyyaml
     requests
-    requests_oauthlib
+    requests-oauthlib
     six
   ];
 

--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -1,37 +1,47 @@
-{ buildPythonPackage, pythonAtLeast, pytest, requests, requests_oauthlib, six
-, fetchFromGitHub, responses, lib
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-oauthlib
+, responses
+, six
 }:
 
 buildPythonPackage rec {
   pname = "asana";
-  version = "0.10.3";
+  version = "0.10.9";
+  format = "setuptools";
 
-  # upstream reportedly doesn't support 3.7 yet, blocked on
-  # https://bugs.python.org/issue34226
-  disabled = pythonAtLeast "3.7";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "asana";
     repo = "python-asana";
     rev = "v${version}";
-    sha256 = "11nsfygcfpc2qb2gy4npi9w00cqfh88g7k3rsfq7xambz1zjdz1n";
+    sha256 = "sha256-9gOkCMY15ChdhiFdzS0TjvWpVTKKEGt7XIcK6EhkSK8=";
   };
 
-  checkInputs = [ pytest responses ];
-  propagatedBuildInputs = [ requests requests_oauthlib six ];
+  propagatedBuildInputs = [
+    requests
+    requests-oauthlib
+    six
+  ];
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "requests_oauthlib >= 0.8.0, == 0.8.*" "requests_oauthlib>=0.8.0<2.0"
-  '';
+  checkInputs = [
+    pytestCheckHook
+    responses
+  ];
 
-  checkPhase = ''
-    py.test tests
-  '';
+  pythonImportsCheck = [
+    "asana"
+  ];
 
   meta = with lib; {
     description = "Python client library for Asana";
     homepage = "https://github.com/asana/python-asana";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/atlassian-python-api/default.nix
+++ b/pkgs/development/python-modules/atlassian-python-api/default.nix
@@ -4,7 +4,7 @@
 , deprecated
 , oauthlib
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , six
 , pytestCheckHook
 , pythonOlder
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     deprecated
     oauthlib
     requests
-    requests_oauthlib
+    requests-oauthlib
     six
   ];
 

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -1,31 +1,45 @@
-{ lib, buildPythonPackage, fetchFromGitHub, requests, requests_oauthlib
-, django, python3-openid, mock, coverage }:
+{ lib
+, buildPythonPackage
+, django
+, fetchFromGitHub
+, python3-openid
+, pythonOlder
+, requests
+, requests-oauthlib
+}:
 
 buildPythonPackage rec {
   pname = "django-allauth";
   version = "0.47.0";
+  format = "setuptools";
 
-  # no tests on PyPI
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "pennersr";
     repo = pname;
     rev = version;
-    sha256 = "sha256-wKrsute6TCl331UrxNEBf/zTtGnyGHsOZQwdiicbg2o=";
+    hash = "sha256-wKrsute6TCl331UrxNEBf/zTtGnyGHsOZQwdiicbg2o=";
   };
 
-  propagatedBuildInputs = [ requests requests_oauthlib django python3-openid ];
+  propagatedBuildInputs = [
+    requests
+    requests-oauthlib
+    django
+    python3-openid
+  ];
 
-  checkInputs = [ coverage mock ];
-
+  # Tests requires a Django instance
   doCheck = false;
-  checkPhase = ''
-    cd $NIX_BUILD_TOP/$sourceRoot
-    coverage run manage.py test allauth
-  '';
+
+  pythonImportsCheck = [
+    "allauth"
+  ];
 
   meta = with lib; {
     description = "Integrated set of Django applications addressing authentication, registration, account management as well as 3rd party (social) account authentication";
     homepage = "https://www.intenct.nl/projects/django-allauth";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/exchangelib/default.nix
+++ b/pkgs/development/python-modules/exchangelib/default.nix
@@ -17,7 +17,7 @@
 , pyyaml
 , requests
 , requests_ntlm
-, requests_oauthlib
+, requests-oauthlib
 , requests-kerberos
 , requests-mock
 , tzdata
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "ecederstrand";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-fdYc+fJEePgCzAkUWz7pmL/CI/O9zm5G9xh1f4bhrH4=";
+    hash = "sha256-fdYc+fJEePgCzAkUWz7pmL/CI/O9zm5G9xh1f4bhrH4=";
   };
 
   propagatedBuildInputs = [
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     pygments
     requests
     requests_ntlm
-    requests_oauthlib
+    requests-oauthlib
     requests-kerberos
     tzdata
     tzlocal

--- a/pkgs/development/python-modules/fitbit/default.nix
+++ b/pkgs/development/python-modules/fitbit/default.nix
@@ -1,41 +1,49 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, coverage
-, python-dateutil
 , freezegun
 , mock
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
 , requests-mock
-, requests_oauthlib
-, sphinx
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "fitbit";
   version = "0.3.1";
+  format = "setuptools";
 
-  checkInputs = [ coverage freezegun mock requests-mock sphinx ];
-  propagatedBuildInputs = [ python-dateutil requests_oauthlib ];
+  disabled = pythonOlder "3.7";
 
-  # The source package on PyPi is missing files required for unit testing.
-  # https://github.com/orcasgit/python-fitbit/issues/148
   src = fetchFromGitHub {
-    rev = version;
     owner = "orcasgit";
     repo = "python-fitbit";
-    sha256 = "1w2lpgf6bs5nbnmslppaf4lbhr9cj6grg0a525xv41jip7iy3vfn";
+    rev = version;
+    hash = "sha256-1u3h47lRBrJ7EUWBl5+RLGW4KHHqXqqrXbboZdy7VPA=";
   };
 
-  postPatch = ''
-    substituteInPlace requirements/test.txt \
-      --replace 'Sphinx>=1.2,<1.4' 'Sphinx' \
-      --replace 'coverage>=3.7,<4.0' 'coverage'
-  '';
+  propagatedBuildInputs = [
+    python-dateutil
+    requests-oauthlib
+  ];
+
+  checkInputs = [
+    freezegun
+    mock
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "fitbit"
+  ];
 
   meta = with lib; {
     description = "Fitbit API Python Client Implementation";
-    license = licenses.asl20;
     homepage = "https://github.com/orcasgit/python-fitbit";
+    license = licenses.asl20;
     maintainers = with maintainers; [ delroth ];
   };
 }

--- a/pkgs/development/python-modules/flickrapi/default.nix
+++ b/pkgs/development/python-modules/flickrapi/default.nix
@@ -1,35 +1,66 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , requests
 , requests-toolbelt
-, requests_oauthlib
-, pytest
-, pytest-runner
-, pytest-cov
+, requests-oauthlib
+, pytestCheckHook
 , responses
+, pythonOlder
 }:
 
 buildPythonPackage rec {
-  pname   = "flickrapi";
-  version = "2.4.0";
+  pname = "flickrapi";
+  version = "2.4";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "03g2z21k6nhxgwysjrgnxj9m1yg25mnnkr10gpyfhfkd9w77pcpz";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "sybrenstuvel";
+    repo = pname;
+    rev = "version-${version}";
+    hash = "sha256-vRZrlXKI0UDdmDevh3XUngH4X8G3VlOCSP0z/rxhIgw=";
   };
 
-  propagatedBuildInputs = [ requests requests-toolbelt requests_oauthlib ];
+  propagatedBuildInputs = [
+    requests
+    requests-toolbelt
+    requests-oauthlib
+  ];
 
-  checkInputs = [ pytest pytest-runner pytest-cov responses ];
-  doCheck = false; # Otherwise:
-  # ========================= no tests ran in 0.01 seconds =========================
-  # builder for '/nix/store/c8a58v6aa18zci08q2l53s12ywn8jqhq-python3.6-flickrapi-2.4.0.drv' failed with exit code 5
+  checkInputs = [
+    pytestCheckHook
+    responses
+  ];
 
-  meta = {
+  preCheck = ''
+    export HOME=$(mktemp -d);
+  '';
+
+  disabledTests = [
+    # Tests require network access
+    "test_default_format"
+    "test_etree_default_format"
+    "test_etree_format_error"
+    "test_etree_format_happy"
+    "test_explicit_format"
+    "test_json_callback_format"
+    "test_json_format"
+    "test_parsed_json_format"
+    "test_walk"
+    "test_xmlnode_format"
+    "test_xmlnode_format_error"
+  ];
+
+  pythonImportsCheck = [
+    "flickrapi"
+  ];
+
+  meta = with lib; {
     description = "A Python interface to the Flickr API";
-    homepage    = "https://stuvel.eu/flickrapi";
-    license     = lib.licenses.psfl;
-    maintainers = with lib.maintainers; [ obadz ];
+    homepage = "https://stuvel.eu/flickrapi";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ obadz ];
   };
 }

--- a/pkgs/development/python-modules/google-auth-oauthlib/default.nix
+++ b/pkgs/development/python-modules/google-auth-oauthlib/default.nix
@@ -6,12 +6,16 @@
 , mock
 , pytestCheckHook
 , google-auth
-, requests_oauthlib
+, requests-oauthlib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "google-auth-oauthlib";
   version = "0.5.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
@@ -20,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     google-auth
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [
@@ -29,7 +33,13 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = lib.optionals stdenv.isDarwin [ "test_run_local_server" ];
+  disabledTests = lib.optionals stdenv.isDarwin [
+    "test_run_local_server"
+  ];
+
+  pythonImportsCheck = [
+    "google_auth_oauthlib"
+  ];
 
   meta = with lib; {
     description = "Google Authentication Library: oauthlib integration";

--- a/pkgs/development/python-modules/google-auth-oauthlib/default.nix
+++ b/pkgs/development/python-modules/google-auth-oauthlib/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-BsTOs6sqk7hbiXa76Gy7gq4dHALS3tPP0IR6i2lVJjs=";
+    hash = "sha256-BsTOs6sqk7hbiXa76Gy7gq4dHALS3tPP0IR6i2lVJjs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/google-nest-sdm/default.nix
+++ b/pkgs/development/python-modules/google-nest-sdm/default.nix
@@ -11,7 +11,7 @@
 , pytest-asyncio
 , pytestCheckHook
 , pythonOlder
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     google-auth
     google-auth-oauthlib
     google-cloud-pubsub
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/homeconnect/default.nix
+++ b/pkgs/development/python-modules/homeconnect/default.nix
@@ -2,26 +2,33 @@
 , buildPythonPackage
 , fetchPypi
 , requests
-, requests_oauthlib
+, requests-oauthlib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "homeconnect";
   version = "0.7.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-/h0dEVmP0R9tVt56mvu72Ksrvnuox1FA7BgrZMOhV6Q=";
+    hash = "sha256-/h0dEVmP0R9tVt56mvu72Ksrvnuox1FA7BgrZMOhV6Q=";
   };
 
   propagatedBuildInputs = [
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Project has no tests
   doCheck = false;
-  pythonImportsCheck = [ "homeconnect" ];
+
+  pythonImportsCheck = [
+    "homeconnect"
+  ];
 
   meta = with lib; {
     description = "Python client for the BSH Home Connect REST API";

--- a/pkgs/development/python-modules/jira/default.nix
+++ b/pkgs/development/python-modules/jira/default.nix
@@ -5,37 +5,39 @@
 , flaky
 , keyring
 , requests-mock
-, requests_oauthlib
+, requests-oauthlib
 , requests-toolbelt
 , setuptools-scm
 , setuptools-scm-git-archive
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jira";
   version = "3.1.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "pycontribs";
     repo = pname;
     rev = version;
-    sha256 = "04s2zgwxip54g894hps2cm081cp07mbi7qipmsv4dvailhsg43nn";
+    hash = "sha256-1g7yNKRR7Ua2rjfiE1c94LKAQGVCX0gSeqTc2Pn7QhM=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace "--cov-report=xml --cov jira" ""
-  '';
-
-  nativeBuildInputs = [ setuptools-scm setuptools-scm-git-archive ];
+  nativeBuildInputs = [
+    setuptools-scm
+    setuptools-scm-git-archive
+  ];
 
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
     defusedxml
     keyring
-    requests_oauthlib
+    requests-oauthlib
     requests-toolbelt
   ];
 
@@ -45,11 +47,20 @@ buildPythonPackage rec {
     requests-mock
   ];
 
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace "--cov-report=xml --cov jira" ""
+  '';
+
+  pythonImportsCheck = [
+    "jira"
+  ];
+
   # impure tests because of connectivity attempts to jira servers
   doCheck = false;
 
   meta = with lib; {
-    description = "This library eases the use of the JIRA REST API from Python.";
+    description = "Library to interact with the JIRA REST API";
     homepage = "https://github.com/pycontribs/jira";
     license = licenses.bsd2;
     maintainers = with maintainers; [ globin ];

--- a/pkgs/development/python-modules/kubernetes/default.nix
+++ b/pkgs/development/python-modules/kubernetes/default.nix
@@ -11,7 +11,7 @@
 , python-dateutil
 , pyyaml
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , urllib3
 , websocket-client
 
@@ -24,6 +24,7 @@ buildPythonPackage rec {
   pname = "kubernetes";
   version = "20.13.0";
   format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -41,7 +42,7 @@ buildPythonPackage rec {
     python-dateutil
     pyyaml
     requests
-    requests_oauthlib
+    requests-oauthlib
     urllib3
     websocket-client
   ];
@@ -61,7 +62,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Kubernetes python client";
+    description = "Kubernetes Python client";
     homepage = "https://github.com/kubernetes-client/python";
     license = licenses.asl20;
     maintainers = with maintainers; [ lsix ];

--- a/pkgs/development/python-modules/lmnotify/default.nix
+++ b/pkgs/development/python-modules/lmnotify/default.nix
@@ -3,28 +3,39 @@
 , fetchPypi
 , oauthlib
 , requests
-, requests_oauthlib
+, requests-oauthlib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "lmnotify";
   version = "0.0.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-cCP7BU2f7QJe9gAI298cvkp3OGijvBv8G1RN7qfZ5PE=";
+    hash = "sha256-cCP7BU2f7QJe9gAI298cvkp3OGijvBv8G1RN7qfZ5PE=";
   };
 
-  propagatedBuildInputs = [ oauthlib requests requests_oauthlib ];
+  propagatedBuildInputs = [
+    oauthlib
+    requests
+    requests-oauthlib
+  ];
 
-  doCheck = false; # no tests exist
+  # Module has no tests
+  doCheck = false;
 
-  pythonImportsCheck = [ "lmnotify" ];
+  pythonImportsCheck = [
+    "lmnotify"
+  ];
 
   meta = with lib; {
     description = "Python package for sending notifications to LaMetric Time";
     homepage = "https://github.com/keans/lmnotify";
-    maintainers = with maintainers; [ rhoriguchi ];
     license = licenses.mit;
+    maintainers = with maintainers; [ rhoriguchi ];
   };
 }

--- a/pkgs/development/python-modules/mezzanine/default.nix
+++ b/pkgs/development/python-modules/mezzanine/default.nix
@@ -1,38 +1,56 @@
 { lib
-
+, beautifulsoup4
+, bleach
 , buildPythonPackage
-, fetchPypi
-, isPyPy
-, pyflakes
-, pep8
+, chardet
 , django
 , django_contrib_comments
+, fetchPypi
 , filebrowser_safe
-, grappelli_safe
-, bleach
-, tzlocal
-, beautifulsoup4
-, requests
-, requests_oauthlib
 , future
+, grappelli_safe
+, isPyPy
+, pep8
 , pillow
-, chardet
+, pyflakes
+, pythonOlder
+, requests
+, requests-oauthlib
+, tzlocal
 }:
 
 buildPythonPackage rec {
+  pname = "mezzanine";
   version = "5.1.3";
-  pname = "Mezzanine";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6" || isPyPy;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-G/Oj5g70tFUhnbSVElVk0s9Ka+MEuPsEgj6blcFBOoY=";
+    pname = "Mezzanine";
+    inherit version;
+    hash = "sha256-G/Oj5g70tFUhnbSVElVk0s9Ka+MEuPsEgj6blcFBOoY=";
   };
 
-  disabled = isPyPy || lib.versionOlder django.version "1.11"
-    || lib.versionAtLeast django.version "2.0";
+  buildInputs = [
+    pyflakes
+    pep8
+  ];
 
-  buildInputs = [ pyflakes pep8 ];
-  propagatedBuildInputs = [ django django_contrib_comments filebrowser_safe grappelli_safe bleach tzlocal beautifulsoup4 requests requests_oauthlib future pillow chardet ];
+  propagatedBuildInputs = [
+    beautifulsoup4
+    bleach
+    chardet
+    django
+    django_contrib_comments
+    filebrowser_safe
+    future
+    grappelli_safe
+    pillow
+    requests
+    requests-oauthlib
+    tzlocal
+  ];
 
   # Tests Fail Due to Syntax Warning, Fixed for v3.1.11+
   doCheck = false;
@@ -41,12 +59,10 @@ buildPythonPackage rec {
     sed -i 's/==/>=/' setup.py
   '';
 
-  LC_ALL="en_US.UTF-8";
+  LC_ALL = "en_US.UTF-8";
 
   meta = with lib; {
-    description = ''
-      A content management platform built using the Django framework
-    '';
+    description = "Content management platform built using the Django framework";
     longDescription = ''
       Mezzanine is a powerful, consistent, and flexible content
       management platform. Built using the Django framework, Mezzanine
@@ -64,11 +80,9 @@ buildPythonPackage rec {
     '';
     homepage = "http://mezzanine.jupo.org/";
     downloadPage = "https://github.com/stephenmcd/mezzanine/releases";
-    license = licenses.free;
+    license = licenses.bsd2;
     maintainers = with maintainers; [ prikhi ];
     platforms = platforms.unix;
-    # mezzanine requires django-1.11. Consider overriding python package set to use django_1_11"
-    broken = versionOlder django.version "1.11" || versionAtLeast django.version "2.0";
   };
-
 }
+

--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -1,51 +1,66 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, isPy3k
-, requests
-, requests_oauthlib
-, isodate
-, certifi
-, enum34 ? null
-, typing
-, aiohttp
 , aiodns
-, pytest
+, aiohttp
+, buildPythonPackage
+, certifi
+, fetchFromGitHub
 , httpretty
-, mock
-, futures ? null
+, isodate
+, pytest-aiohttp
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-oauthlib
 , trio
 }:
 
 buildPythonPackage rec {
-  version = "0.6.21";
   pname = "msrest";
+  version = "0.6.21";
+  format = "setuptools";
 
-  # no tests in PyPI tarball
-  # see https://github.com/Azure/msrest-for-python/pull/152
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "Azure";
     repo = "msrest-for-python";
     rev = "v${version}";
-    sha256 = "sha256-IlBwlVQ/v+vJmCWNbFZKGL6a9K09z4AYrPm3kwaA/nI=";
+    hash = "sha256-IlBwlVQ/v+vJmCWNbFZKGL6a9K09z4AYrPm3kwaA/nI=";
   };
 
   propagatedBuildInputs = [
-    requests requests_oauthlib isodate certifi
-  ] ++ lib.optionals (!isPy3k) [ enum34 typing ]
-    ++ lib.optionals isPy3k [ aiohttp aiodns ];
+    aiodns
+    aiohttp
+    certifi
+    isodate
+    requests
+    requests-oauthlib
+  ];
 
-  checkInputs = [ pytest httpretty ]
-    ++ lib.optionals (!isPy3k) [ mock futures ]
-    ++ lib.optional isPy3k trio;
+  checkInputs = [
+    httpretty
+    pytest-aiohttp
+    pytestCheckHook
+    trio
+  ];
 
-  # Deselected tests require network access
-  checkPhase = ''
-    pytest tests/ -k "not test_conf_async_trio_requests"
-  '';
+  disabledTests = [
+    # Test require network access
+    "test_basic_aiohttp"
+    "test_basic_aiohttp"
+    "test_basic_async_requests"
+    "test_basic_async_requests"
+    "test_conf_async_requests"
+    "test_conf_async_requests"
+    "test_conf_async_trio_requests"
+  ];
+
+  pythonImportsCheck = [
+    "msrest"
+  ];
 
   meta = with lib; {
-    description = "The runtime library 'msrest' for AutoRest generated Python clients.";
+    description = "The runtime library for AutoRest generated Python clients";
     homepage = "https://github.com/Azure/msrest-for-python";
     license = licenses.mit;
     maintainers = with maintainers; [ bendlas jonringer maxwilson ];

--- a/pkgs/development/python-modules/mwclient/default.nix
+++ b/pkgs/development/python-modules/mwclient/default.nix
@@ -1,11 +1,21 @@
-{ lib, buildPythonPackage, fetchFromGitHub
-, requests, requests_oauthlib, six
-, pytest, pytestcache, pytest-cov, responses, mock
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-oauthlib
+, responses
+, six
 }:
 
 buildPythonPackage rec {
   version = "0.10.1";
   pname = "mwclient";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "mwclient";
@@ -14,17 +24,31 @@ buildPythonPackage rec {
     sha256 = "120snnsh9n5svfwkyj1w9jrxf99jnqm0jk282yypd3lpyca1l9hj";
   };
 
-  checkInputs = [ pytest pytestcache pytest-cov responses mock ];
+  propagatedBuildInputs = [
+    requests
+    requests-oauthlib
+    six
+  ];
 
-  propagatedBuildInputs = [ requests requests_oauthlib six ];
+  checkInputs = [
+    mock
+    pytestCheckHook
+    responses
+  ];
 
-  checkPhase = ''
-    py.test
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace " --cov mwclient test" ""
   '';
+
+  pythonImportsCheck = [
+    "mwclient"
+  ];
 
   meta = with lib; {
     description = "Python client library to the MediaWiki API";
     license = licenses.mit;
     homepage = "https://github.com/mwclient/mwclient";
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/mwoauth/default.nix
+++ b/pkgs/development/python-modules/mwoauth/default.nix
@@ -1,40 +1,47 @@
 { lib
 , buildPythonPackage
-, six
-, pyjwt
-, requests
-, oauthlib
-, requests_oauthlib
 , fetchPypi
+, oauthlib
+, pyjwt
+, pythonOlder
+, requests
+, requests-oauthlib
+, six
 }:
 
 buildPythonPackage rec {
   pname = "mwoauth";
   version = "0.3.7";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "9e0d70a1fa6f452584de1cb853ae6c11f41233549f7839cfb879f99410f6ad46";
+    hash = "sha256-ng1wofpvRSWE3hy4U65sEfQSM1SfeDnPuHn5lBD2rUY=";
   };
 
   propagatedBuildInputs = [
     oauthlib
     pyjwt
     requests
-    requests_oauthlib
+    requests-oauthlib
     six
   ];
 
   postPatch = ''
     # https://github.com/mediawiki-utilities/python-mwoauth/pull/43
-    substituteInPlace setup.py --replace "PyJWT>=1.0.1,<2.0.0" "PyJWT>=1.0.1"
+    substituteInPlace setup.py \
+      --replace "PyJWT>=1.0.1,<2.0.0" "PyJWT>=1.0.1"
   '';
 
   # PyPI source has no tests included
   # https://github.com/mediawiki-utilities/python-mwoauth/issues/44
   doCheck = false;
 
-  pythonImportsCheck = [ "mwoauth" ];
+  pythonImportsCheck = [
+    "mwoauth"
+  ];
 
   meta = with lib; {
     description = "Python library to perform OAuth handshakes with a MediaWiki installation";

--- a/pkgs/development/python-modules/ondilo/default.nix
+++ b/pkgs/development/python-modules/ondilo/default.nix
@@ -4,30 +4,35 @@
 , oauthlib
 , pythonOlder
 , requests
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "ondilo";
   version = "0.3.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "JeromeHXP";
     repo = pname;
     rev = version;
-    sha256 = "sha256-MI6K+41I/IVi+GRBdmRIHbljULDFLAwpo3W8tdxCOBM=";
+    hash = "sha256-MI6K+41I/IVi+GRBdmRIHbljULDFLAwpo3W8tdxCOBM=";
   };
 
   propagatedBuildInputs = [
     oauthlib
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Project has no tests
   doCheck = false;
-  pythonImportsCheck = [ "ondilo" ];
+
+  pythonImportsCheck = [
+    "ondilo"
+  ];
 
   meta = with lib; {
     description = "Python package to access Ondilo ICO APIs";

--- a/pkgs/development/python-modules/pleroma-bot/default.nix
+++ b/pkgs/development/python-modules/pleroma-bot/default.nix
@@ -4,30 +4,45 @@
 , pytestCheckHook
 , requests-mock
 , oauthlib
-, requests_oauthlib
+, requests-oauthlib
 , requests
 , pyaml
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pleroma-bot";
   version = "0.8.6";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "robertoszek";
-    repo = "pleroma-bot";
+    repo = pname;
     rev = version;
-    sha256 = "1q0xhgqq41zbqiawpd4kbdx41zhwxxp5ipn1c2rc8d7pjyb5p75w";
+    hash = "sha256-vJxblpf3NMSyYMHeWG7vHP5AeluTtMtVxOsHgvGDHeA=";
   };
 
-  propagatedBuildInputs = [ pyaml requests requests_oauthlib oauthlib ];
-  checkInputs = [ pytestCheckHook requests-mock ];
+  propagatedBuildInputs = [
+    pyaml
+    requests
+    requests-oauthlib
+    oauthlib
+  ];
 
-  pythonImportsCheck = [ "pleroma_bot" ];
+  checkInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [
+    "pleroma_bot"
+  ];
 
   meta = with lib; {
-    homepage = "https://robertoszek.github.io/pleroma-bot/";
     description = "Bot for mirroring one or multiple Twitter accounts in Pleroma/Mastodon";
+    homepage = "https://robertoszek.github.io/pleroma-bot/";
     license = licenses.mit;
     maintainers = with maintainers; [ robertoszek ];
   };

--- a/pkgs/development/python-modules/pyatmo/default.nix
+++ b/pkgs/development/python-modules/pyatmo/default.nix
@@ -9,7 +9,7 @@
 , pytestCheckHook
 , pythonOlder
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , requests-mock
 , setuptools-scm
 }:
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     aiohttp
     oauthlib
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pybotvac/default.nix
+++ b/pkgs/development/python-modules/pybotvac/default.nix
@@ -2,29 +2,35 @@
 , buildPythonPackage
 , fetchPypi
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , voluptuous
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pybotvac";
   version = "0.0.23";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "54b4fe565c10000c54d5644d081e2de1f850daefbac39cea74cea649b47bfb12";
+    hash = "sha256-VLT+VlwQAAxU1WRNCB4t4fhQ2u+6w5zqdM6mSbR7+xI=";
   };
 
   propagatedBuildInputs = [
     requests
-    requests_oauthlib
+    requests-oauthlib
     voluptuous
   ];
 
   # no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "pybotvac" ];
+  pythonImportsCheck = [
+    "pybotvac"
+  ];
 
   meta = with lib; {
     description = "Python module for interacting with Neato Botvac Connected vacuum robots";

--- a/pkgs/development/python-modules/pymfy/default.nix
+++ b/pkgs/development/python-modules/pymfy/default.nix
@@ -6,13 +6,14 @@
 , pytestCheckHook
 , pythonOlder
 , requests
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "pymfy";
   version = "0.11.0";
   format = "pyproject";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
@@ -22,11 +23,13 @@ buildPythonPackage rec {
     sha256 = "0wpjwjmywfyqgwvfa5kwcjpaljc32qa088kk88nl9nqdvc31mzhv";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  nativeBuildInputs = [
+    poetry-core
+  ];
 
   propagatedBuildInputs = [
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [
@@ -34,7 +37,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "pymfy" ];
+  pythonImportsCheck = [
+    "pymfy"
+  ];
 
   meta = with lib; {
     description = "Python client for the Somfy Open API";

--- a/pkgs/development/python-modules/pynello/default.nix
+++ b/pkgs/development/python-modules/pynello/default.nix
@@ -4,7 +4,7 @@
 , python-dateutil
 , pythonOlder
 , requests
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
@@ -18,19 +18,21 @@ buildPythonPackage rec {
     owner = "pschmitt";
     repo = pname;
     rev = version;
-    sha256 = "015rlccsn2vff9if82rjj2fza3bjbmawqhamc22wq40gq7pbfk5i";
+    hash = "sha256-sUy37sEPEMyFYFVBzFVdcg31nZAyC+Ricm4LqxmjuQQ=";
   };
 
   propagatedBuildInputs = [
     python-dateutil
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "pynello" ];
+  pythonImportsCheck = [
+    "pynello"
+  ];
 
   meta = with lib; {
     description = "Python library for nello.io intercoms";

--- a/pkgs/development/python-modules/pysmappee/default.nix
+++ b/pkgs/development/python-modules/pysmappee/default.nix
@@ -1,25 +1,27 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
 , cachetools
+, fetchFromGitHub
 , paho-mqtt
+, pythonOlder
 , pytz
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , schedule
-, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pysmappee";
   version = "0.2.29";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "smappee";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Ffi55FZsZUKDcS4qV46NpRK3VP6axzrL2BO+hYW7J9E=";
+    hash = "sha256-Ffi55FZsZUKDcS4qV46NpRK3VP6axzrL2BO+hYW7J9E=";
   };
 
   propagatedBuildInputs = [
@@ -27,14 +29,16 @@ buildPythonPackage rec {
     paho-mqtt
     pytz
     requests
-    requests_oauthlib
+    requests-oauthlib
     schedule
   ];
 
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "pysmappee" ];
+  pythonImportsCheck = [
+    "pysmappee"
+  ];
 
   meta = with lib; {
     description = "Python Library for the Smappee dev API";

--- a/pkgs/development/python-modules/pysnow/default.nix
+++ b/pkgs/development/python-modules/pysnow/default.nix
@@ -1,28 +1,55 @@
 { lib
+, brotli
 , buildPythonPackage
 , fetchFromGitHub
-, poetry
-, brotli
-, ijson
-, nose
+, fetchpatch
 , httpretty
-, requests_oauthlib
+, ijson
+, poetry-core
 , python_magic
 , pytz
+, pytestCheckHook
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "pysnow";
   version = "0.7.16";
+  format = "pyproject";
 
-  # tests not included in pypi tarball
+
   src = fetchFromGitHub {
     owner = "rbw";
     repo = pname;
     rev = version;
-    sha256 = "0dj90w742klfcjnx7yhp0nzki2mzafqzzr0rk2dp6vxn8h58z8ww";
+    hash = "sha256-nKOPCkS2b3ObmBnk/7FTv4o4vwUX+tOtZI5OQQ4HSTY=";
   };
-  format = "pyproject";
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    brotli
+    ijson
+    python_magic
+    pytz
+    requests-oauthlib
+  ];
+
+  checkInputs = [
+    httpretty
+    pytestCheckHook
+  ];
+
+  patches = [
+    # Switch to peotry-core, https://github.com/rbw/pysnow/pull/183
+    (fetchpatch {
+      name = "switch-to-poetry-core.patch";
+      url = "https://github.com/rbw/pysnow/commit/f214a203432b329df5317f3a25b2c0d9b55a9029.patch";
+      sha256 = "sha256-ViRR+9WStlaQwyrLGk/tMOUAcEMY+kB61ZEKGMQJ30o=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -31,26 +58,15 @@ buildPythonPackage rec {
       --replace 'oauthlib = "^3.1.0"' 'oauthlib = "*"'
   '';
 
-  nativeBuildInputs = [ poetry ];
-  propagatedBuildInputs = [
-    brotli
-    ijson
-    python_magic
-    pytz
-    requests_oauthlib
+  pythonImportsCheck = [
+    "pysnow"
   ];
-
-  checkInputs = [ nose httpretty ];
-  checkPhase = ''
-    nosetests --cover-package=pysnow --with-coverage --cover-erase
-  '';
-  pythonImportsCheck = [ "pysnow" ];
 
   meta = with lib; {
     description = "ServiceNow HTTP client library written in Python";
     homepage = "https://github.com/rbw/pysnow";
     license = licenses.mit;
-    maintainers = [ maintainers.almac ];
+    maintainers = with maintainers; [ almac ];
   };
 
 }

--- a/pkgs/development/python-modules/python-google-nest/default.nix
+++ b/pkgs/development/python-modules/python-google-nest/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
@@ -14,11 +14,11 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "y3BOhorVkJ3rFPifNOopLMqk6y1fHX5vxHGiqWvWHhE=";
+    hash = "sha256-y3BOhorVkJ3rFPifNOopLMqk6y1fHX5vxHGiqWvWHhE=";
   };
 
   propagatedBuildInputs = [
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Project has no tests

--- a/pkgs/development/python-modules/python-twitter/default.nix
+++ b/pkgs/development/python-modules/python-twitter/default.nix
@@ -2,20 +2,23 @@
 , buildPythonPackage
 , fetchFromGitHub
 , fetchpatch
-, pytest-runner
+, filetype
 , future
-, requests
-, responses
-, requests_oauthlib
-, pytest
 , hypothesis
+, pytestCheckHook
+, pythonOlder
+, requests
+, requests-oauthlib
+, responses
 }:
 
 buildPythonPackage rec {
   pname = "python-twitter";
   version = "3.5";
+  format = "setuptools";
 
-  # No tests in PyPi Tarball
+  disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "bear";
     repo = pname;
@@ -31,12 +34,30 @@ buildPythonPackage rec {
     })
   ];
 
-  nativeBuildInputs = [ pytest-runner ];
-  propagatedBuildInputs = [ future requests requests_oauthlib ];
-  checkInputs = [ pytest responses hypothesis ];
+  propagatedBuildInputs = [
+    filetype
+    future
+    requests
+    requests-oauthlib
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    responses
+    hypothesis
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
+  pythonImportsCheck = [
+    "twitter"
+  ];
 
   meta = with lib; {
-    description = "A Python wrapper around the Twitter API";
+    description = "Python wrapper around the Twitter API";
     homepage = "https://github.com/bear/python-twitter";
     license = licenses.asl20;
     maintainers = [ maintainers.marsam ];

--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -1,11 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pythonOlder
-, requests_oauthlib
-, simplejson
 , pkce
 , pytestCheckHook
+, pythonOlder
+, requests-oauthlib
+, simplejson
 }:
 
 buildPythonPackage rec {
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   propagatedBuildInputs = [
-    requests_oauthlib
+    requests-oauthlib
     simplejson
     pkce
   ];

--- a/pkgs/development/python-modules/ring-doorbell/default.nix
+++ b/pkgs/development/python-modules/ring-doorbell/default.nix
@@ -1,31 +1,33 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy3k
 , oauthlib
 , pytestCheckHook
+, pythonOlder
 , pytz
 , requests
 , requests-mock
-, requests_oauthlib
+, requests-oauthlib
 }:
 
 buildPythonPackage rec {
   pname = "ring-doorbell";
   version = "0.7.2";
-  disabled = !isPy3k;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "ring_doorbell";
     inherit version;
-    sha256 = "0a7e82abf27086843eb39c0279f5dfccea6751ff848560e67154ca6fbfa4ef2b";
+    hash = "sha256-Cn6Cq/JwhoQ+s5wCefXfzOpnUf+EhWDmcVTKb7+k7ys=";
   };
 
   propagatedBuildInputs = [
     oauthlib
     pytz
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [
@@ -33,11 +35,13 @@ buildPythonPackage rec {
     requests-mock
   ];
 
-  pythonImportsCheck = [ "ring_doorbell" ];
+  pythonImportsCheck = [
+    "ring_doorbell"
+  ];
 
   meta = with lib; {
+    description = "Python library to communicate with Ring Door Bell";
     homepage = "https://github.com/tchellomello/python-ring-doorbell";
-    description = "A Python library to communicate with Ring Door Bell (https://ring.com/)";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ graham33 ];
   };

--- a/pkgs/development/python-modules/tellduslive/default.nix
+++ b/pkgs/development/python-modules/tellduslive/default.nix
@@ -3,12 +3,16 @@
 , docopt
 , fetchFromGitHub
 , requests
-, requests_oauthlib
+, requests-oauthlib
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "tellduslive";
   version = "0.10.11";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "molobrakos";
@@ -20,12 +24,15 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     docopt
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Project has no tests
   doCheck = false;
-  pythonImportsCheck = [ "tellduslive" ];
+
+  pythonImportsCheck = [
+    "tellduslive"
+  ];
 
   meta = with lib; {
     description = "Python module to communicate with Telldus Live";

--- a/pkgs/development/python-modules/tweepy/default.nix
+++ b/pkgs/development/python-modules/tweepy/default.nix
@@ -3,11 +3,11 @@
 , buildPythonPackage
 , fetchFromGitHub
 , oauthlib
-, requests
-, pythonOlder
-, vcrpy
 , pytestCheckHook
-, requests_oauthlib
+, pythonOlder
+, requests
+, requests-oauthlib
+, vcrpy
 }:
 
 buildPythonPackage rec {
@@ -21,14 +21,14 @@ buildPythonPackage rec {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7ogsocRTMTO5yegyY7BADu9NrHK7zMMbihBu8oF4UlQ=";
+    hash = "sha256-GUo8uvShyIOWWcO5T1JvV7DMC1W70YILx/hvHIGQg0o=";
   };
 
   propagatedBuildInputs = [
     aiohttp
     oauthlib
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/twitterapi/default.nix
+++ b/pkgs/development/python-modules/twitterapi/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , requests
-, requests_oauthlib
+, requests-oauthlib
 , pythonOlder
 }:
 
@@ -17,12 +17,12 @@ buildPythonPackage rec {
     owner = "geduldig";
     repo = "TwitterAPI";
     rev = "v${version}";
-    sha256 = "sha256-WqeoIZt2OGDXKPAbjm3cHI1kgiCEJC6+ROXXx4TR4b4=";
+    hash = "sha256-WqeoIZt2OGDXKPAbjm3cHI1kgiCEJC6+ROXXx4TR4b4=";
   };
 
   propagatedBuildInputs = [
     requests
-    requests_oauthlib
+    requests-oauthlib
   ];
 
   # Tests are interacting with the Twitter API

--- a/pkgs/development/python-modules/vdirsyncer/default.nix
+++ b/pkgs/development/python-modules/vdirsyncer/default.nix
@@ -7,7 +7,7 @@
 , click-threading
 , requests-toolbelt
 , requests
-, requests_oauthlib # required for google oauth sync
+, requests-oauthlib
 , atomicwrites
 , hypothesis
 , pytestCheckHook
@@ -17,13 +17,15 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.18.0";
   pname = "vdirsyncer";
+  version = "0.18.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-J7w+1R93STX7ujkpFcjI1M9jmuUaRLZ0aGtJoQJfwgE=";
+    hash = "sha256-J7w+1R93STX7ujkpFcjI1M9jmuUaRLZ0aGtJoQJfwgE=";
   };
 
   propagatedBuildInputs = [
@@ -32,7 +34,7 @@ buildPythonPackage rec {
     click-log
     click-threading
     requests
-    requests_oauthlib # required for google oauth sync
+    requests-oauthlib
     requests-toolbelt
   ];
 

--- a/pkgs/development/python-modules/weconnect-mqtt/default.nix
+++ b/pkgs/development/python-modules/weconnect-mqtt/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect-mqtt";
-  version = "0.30.2";
+  version = "0.32.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-mqtt";
     rev = "v${version}";
-    sha256 = "sha256-e8dDdtabEHQKNx3c63Ou3T3ygsj4763C9Pd8usFrSCE=";
+    sha256 = "sha256-XuWiWL3cszC8aM+CJcAk359VaBCZNUOu4mAfmbdpoGg=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/weconnect/default.nix
+++ b/pkgs/development/python-modules/weconnect/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "weconnect";
-  version = "0.37.2";
+  version = "0.38.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "tillsteinbach";
     repo = "WeConnect-python";
     rev = "v${version}";
-    sha256 = "sha256-54T4L1MzF2rkKM0AXz+bPBdVL7Izdho6c3AVSXBho2E=";
+    sha256 = "sha256-n9MqJ+npdHYpQJ8m6V8Oop+VuQ3EOCRrfIlU5qAc/Y8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -129,7 +129,7 @@ in pythonPackages.buildPythonApplication rec {
     gobject-introspection
   ] ++ lib.optional enableAbsubmit         essentia-extractor
     ++ lib.optional enableAcoustid         pythonPackages.pyacoustid
-    ++ lib.optional enableBeatport         pythonPackages.requests_oauthlib
+    ++ lib.optional enableBeatport         pythonPackages.requests-oauthlib
     ++ lib.optional enableConvert          ffmpeg
     ++ lib.optional enableDiscogs          pythonPackages.discogs-client
     ++ lib.optional (enableFetchart

--- a/pkgs/tools/backup/gphotos-sync/default.nix
+++ b/pkgs/tools/backup/gphotos-sync/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchFromGitHub, python3Packages, ffmpeg }:
+{ lib
+, fetchFromGitHub
+, python3Packages
+, ffmpeg
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "gphotos-sync";
@@ -17,10 +21,12 @@ python3Packages.buildPythonApplication rec {
     exif
     psutil
     pyyaml
-    requests_oauthlib
+    requests-oauthlib
   ];
 
-  buildInputs = [ ffmpeg ];
+  buildInputs = [
+    ffmpeg
+  ];
 
   checkInputs = with python3Packages; [
     pytestCheckHook
@@ -41,8 +47,8 @@ python3Packages.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Google Photos and Albums backup with Google Photos Library API";
-    homepage    = "https://github.com/gilesknap/gphotos-sync";
-    license     = licenses.mit;
+    homepage = "https://github.com/gilesknap/gphotos-sync";
+    license = licenses.mit;
     maintainers = with maintainers; [ dnr ];
   };
 }

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -108,6 +108,7 @@ mapAliases ({
   qiskit-aqua = throw "qiskit-aqua has been removed due to deprecation, with its functionality moved to different qiskit packages";
   rdflib-jsonld = throw "rdflib-jsonld is not compatible with rdflib 6"; # added 2021-11-05
   repeated_test = throw "repeated_test is no longer maintained"; # added 2022-01-11
+  requests_oauthlib = requests-oauthlib; # added 2022-02-12
   requests_toolbelt = requests-toolbelt; # added 2017-09-26
   roboschool = throw "roboschool is deprecated in favor of PyBullet and has been removed"; # added 2022-01-15
   rotate-backups = throw "rotate-backups was removed in favor of the top-level rotate-backups"; # added 2021-07-01

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8745,7 +8745,7 @@ in {
 
   requests_ntlm = callPackage ../development/python-modules/requests_ntlm { };
 
-  requests_oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
+  requests-oauthlib = callPackage ../development/python-modules/requests-oauthlib { };
 
   requests-pkcs12 = callPackage ../development/python-modules/requests-pkcs12 { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/requests/requests-oauthlib/releases/tag/v1.3.1

The renaming will affect around 25 packages. I will wait with it till the next `python-unstable` run and include it there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
