### PR TITLE
python3Packages.semantic-version: 2.8.5 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/semantic-version/default.nix
+++ b/pkgs/development/python-modules/semantic-version/default.nix
@@ -2,6 +2,7 @@
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -17,12 +18,13 @@ buildPythonPackage rec {
     sha256 = "sha256-q/VIc1U+Xgem/U1fZTt4H1rkEpekk2ZrWdzyFABqErI=";
   };
 
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [
     "semantic_version"
   ];
-
-  # ModuleNotFoundError: No module named 'tests'
-  doCheck = false;
 
   meta = with lib; {
     description = "A library implementing the 'SemVer' scheme";

--- a/pkgs/development/python-modules/semantic-version/default.nix
+++ b/pkgs/development/python-modules/semantic-version/default.nix
@@ -1,20 +1,33 @@
-{ lib, fetchPypi, buildPythonPackage }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+}:
 
 buildPythonPackage rec {
-  pname = "semantic_version";
-  version = "2.8.5";
+  pname = "semantic-version";
+  version = "2.9.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54";
+    pname = "semantic_version";
+    inherit version;
+    sha256 = "sha256-q/VIc1U+Xgem/U1fZTt4H1rkEpekk2ZrWdzyFABqErI=";
   };
+
+  pythonImportsCheck = [
+    "semantic_version"
+  ];
 
   # ModuleNotFoundError: No module named 'tests'
   doCheck = false;
 
   meta = with lib; {
     description = "A library implementing the 'SemVer' scheme";
-    license = licenses.bsdOriginal;
+    homepage = "https://github.com/rbarrois/python-semanticversion/";
+    license = licenses.bsd2;
     maintainers = with maintainers; [ layus makefu ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/rbarrois/python-semanticversion/blob/master/ChangeLog#290-2022-02-06

Enable tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
