### PR TITLE
python3Packages.qiskit: 0.34.1 -> 0.34.2

### DIFF
--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -30,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "qiskit-aer";
-  version = "0.10.2";
+  version = "0.10.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     owner = "Qiskit";
     repo = "qiskit-aer";
     rev = version;
-    sha256 = "0icdsiwpvjwiakg94i562wpgnj1qd7l8pkcjnvfwksq4w3pd9xjg";
+    sha256 = "sha256-COvJCj18qRNQJUXKrtlYJQGLjna44IgtNZeNVJJaIHg=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -54,7 +54,7 @@ in
 
 buildPythonPackage rec {
   pname = "qiskit-terra";
-  version = "0.19.1";
+  version = "0.19.2";
 
   disabled = pythonOlder "3.6";
 
@@ -62,7 +62,7 @@ buildPythonPackage rec {
     owner = "qiskit";
     repo = pname;
     rev = version;
-    sha256 = "16d8dghjn81v6hxfg4bpj3cl2csy2rkc279qvijnwp2i9x4y8iyq";
+    sha256 = "sha256-P2QTdt1H9I5T/ONNoo7XEVnoHweOdq3p2NH3l3/yAn4=";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -28,7 +28,7 @@ in
 buildPythonPackage rec {
   pname = "qiskit";
   # NOTE: This version denotes a specific set of subpackages. See https://qiskit.org/documentation/release_notes.html#version-history
-  version = "0.34.1";
+  version = "0.34.2";
 
   disabled = pythonOlder "3.6";
 
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "qiskit";
     repo = "qiskit";
     rev = version;
-    sha256 = "08hfd5ny206x2d9r700wgcmqvh0vcisp4kbv6n3grdizwbvh0ny0";
+    sha256 = "sha256-weL65IQs6vbjJiPJdaizU0ST6u9qDYb0LhTwC6yAdhY=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
﻿Beaten to the punch by @r-ryantm. Closes #159477. Closes #159524.

- python3Packages.qiskit-terra: 0.19.1 -> 0.19.2
- python3Packages.qiskit-aer: 0.10.2 -> 0.10.3
- python3Packages.qiskit: 0.34.1 -> 0.34.2



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
