### PR TITLE
k3sup: init at 0.11.3

### DIFF
--- a/pkgs/applications/networking/cluster/k3sup/default.nix
+++ b/pkgs/applications/networking/cluster/k3sup/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, makeWrapper
+, bash
+, openssh
+}:
+
+buildGoModule rec {
+  pname = "k3sup";
+  version = "0.11.3";
+
+  src = fetchFromGitHub {
+    owner = "alexellis";
+    repo = "k3sup";
+    rev = version;
+    sha256 = "sha256-6WYUmC2uVHFGLsfkA2EUOWmmo1dSKJzI4MEdRnlLgYY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  vendorSha256 = "sha256-Pd+BgPWoxf1AhP0o5SgFSvy4LyUQB7peKWJk0BMy7ds=";
+
+  postConfigure = ''
+    substituteInPlace vendor/github.com/alexellis/go-execute/pkg/v1/exec.go \
+      --replace "/bin/bash" "${bash}/bin/bash"
+  '';
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/alexellis/k3sup/cmd.GitCommit=ref/tags/${version}"
+    "-X github.com/alexellis/k3sup/cmd.Version=${version}"
+  ];
+
+  postInstall = ''
+    wrapProgram "$out/bin/k3sup" \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alexellis/k3sup";
+    description = "Bootstrap Kubernetes with k3s over SSH";
+    license = licenses.mit;
+    maintainers = with maintainers; [ welteki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26643,6 +26643,8 @@ with pkgs;
 
   k3s = callPackage ../applications/networking/cluster/k3s { };
 
+  k3sup = callPackage ../applications/networking/cluster/k3sup {};
+
   kconf = callPackage ../applications/networking/cluster/kconf { };
 
   kail = callPackage ../tools/networking/kail {  };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
[k3sup](https://github.com/alexellis/k3sup) is a light-weight utility to get from zero to KUBECONFIG with [k3s](https://k3s.io/) on any local or remote VM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
