### PR TITLE
cloudflared: 2021.11 -> 2022.2

### DIFF
--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "cloudflared";
-  version = "2021.11.0";
+  version = "2022.2.0";
 
   src = fetchFromGitHub {
     owner  = "cloudflare";
     repo   = "cloudflared";
     rev    = version;
-    sha256 = "sha256-amwzMSPMaXbIj95RhSVnl0kwHnEluKj4L7q4Zu2HPgE=";
+    sha256 = "sha256-yo4Tu9wSxGdUAr2436lAlaP2U+5m/J4+oNQd/UQk3a0=";
   };
 
   vendorSha256 = null;
@@ -18,8 +18,8 @@ buildGoModule rec {
   ldflags = [ "-X main.Version=${version}" ];
 
   meta = with lib; {
-    description = "CloudFlare Argo Tunnel daemon (and DNS-over-HTTPS client)";
-    homepage    = "https://www.cloudflare.com/products/argo-tunnel";
+    description = "CloudFlare Tunnel daemon (and DNS-over-HTTPS client)";
+    homepage    = "https://www.cloudflare.com/products/tunnel";
     license     = licenses.unfree;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ bbigras enorris thoughtpolice ];


### PR DESCRIPTION
Note that the product was renamed from "Argo Tunnel" to "Tunnel", evidenced by https://github.com/cloudflare/cloudflared/commit/cbdf88ea285886bf32104fbdb367a81bffa25b72