### PR TITLE
mmdoc: init at 0.9.1

### DIFF
--- a/pkgs/tools/text/mmdoc/default.nix
+++ b/pkgs/tools/text/mmdoc/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmark-gfm
+, xxd
+, fastJson
+, libzip
+, ninja
+, meson
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mmdoc";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "ryantm";
+    repo = "mmdoc";
+    rev = version;
+    hash = "sha256-Lz2+vsXjz9BVOCI1vIrNTvZgh19OuvXEhnMw2QBZr1w=";
+  };
+
+  nativeBuildInputs = [ ninja meson pkg-config xxd ];
+
+  buildInputs = [ cmark-gfm fastJson libzip ];
+
+  doCheck = stdenv.isx86_64;
+
+  meta = with lib; {
+    description = "Minimal Markdown Documentation";
+    homepage = "https://github.com/ryantm/mmdoc";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ ryantm ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23681,6 +23681,8 @@ with pkgs;
 
   documentation-highlighter = callPackage ../misc/documentation-highlighter { };
 
+  mmdoc = callPackage ../tools/text/mmdoc { };
+
   documize-community = callPackage ../servers/documize-community { };
 
   doge = callPackage ../misc/doge { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a CommonMark to HTML renderer that I use for my personal website and maybe we'll use for Nixpkgs/NixOS manuals.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
