### PR TITLE
notejot: drop needed comment, remove teams.pantheon.members from maintainers

### DIFF
--- a/pkgs/applications/misc/notejot/default.nix
+++ b/pkgs/applications/misc/notejot/default.nix
@@ -17,24 +17,12 @@
 
 stdenv.mkDerivation rec {
   pname = "notejot";
-  version = "3.4.9"; # make sure to recheck src.rev
+  version = "3.4.9";
 
   src = fetchFromGitHub {
     owner = "lainsce";
     repo = pname;
-    # Note from Fedora spec file:
-    # https://src.fedoraproject.org/rpms/notejot/blob/bbe621cef4d5a2c27eed029063b8e8cfd7c8d400/f/notejot.spec
-    # Upstream confusingly made several bugfix post-releases of version 3.4.9,
-    # tagged as 3.4.x, but with prominent notices like "This is still 3.4.9". We
-    # respect upstream’s wishes (and the version numbers inside the source tarball)
-    # by packaging these releases as 3.4.9 with appropriate snapshot info.
-    # https://github.com/lainsce/notejot/releases/tag/3.4.9
-    #
-    # Note that sometimes upstream don't update their version in meson.build
-    # (https://github.com/lainsce/notejot/issues/236), always follow the version
-    # from Fedora Rawhide.
-    # https://github.com/lainsce/notejot/blob/3.4.9/meson.build#L1
-    rev = "3.4.9";
+    rev = version;
     hash = "sha256-42k9CAnXAb7Ic580SIa95MDCkCWtso1F+0eD69HX8WI=";
   };
 
@@ -66,9 +54,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/lainsce/notejot";
-    description = "Stupidly-simple sticky notes applet";
+    description = "Stupidly-simple notes app";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ AndersonTorres ] ++ teams.pantheon.members;
+    maintainers = with maintainers; [ AndersonTorres ];
     platforms = platforms.linux;
     mainProgram = "io.github.lainsce.Notejot";
   };


### PR DESCRIPTION
###### Motivation for this change

The comment are broke by https://github.com/NixOS/nixpkgs/pull/159585

No longer an AppCenter application and has other active maintainers.
The app used to be `Stupidly simple sticky notes applet` in 1.x release, but it is no longer the case.

###### Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
