### PR TITLE
python3Packages.databases: 0.5.4 -> 0.5.5, python3Packages.ormar: 0.10.23 -> 0.10.24

### DIFF
--- a/pkgs/development/python-modules/databases/default.nix
+++ b/pkgs/development/python-modules/databases/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "databases";
-  version = "0.5.4";
+  version = "0.5.5";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = version;
-    hash = "sha256-67ykx7HKGgRvJ+GRVEI/e2+x51kfHHFjh/iI4tY+6aE=";
+    hash = "sha256-NOXK1UCQzqvJRfzsgIfpihuD9oF52sMD+BxqUHWF8Rk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/ormar/default.nix
+++ b/pkgs/development/python-modules/ormar/default.nix
@@ -1,37 +1,39 @@
 { lib
-, buildPythonPackage
-, pythonOlder
-, fetchFromGitHub
-, poetry-core
-, databases
-, pydantic
-, sqlalchemy
-, asyncpg
-, psycopg2
 , aiomysql
-, aiosqlite
-, cryptography
-, orjson
-, typing-extensions
-, importlib-metadata
 , aiopg
-, mysqlclient
-, pymysql
-, pytestCheckHook
-, pytest-asyncio
+, aiosqlite
+, asyncpg
+, buildPythonPackage
+, cryptography
+, databases
 , fastapi
+, fetchFromGitHub
+, importlib-metadata
+, mysqlclient
+, orjson
+, poetry-core
+, psycopg2
+, pydantic
+, pymysql
+, pytest-asyncio
+, pytestCheckHook
+, pythonOlder
+, sqlalchemy
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "ormar";
-  version = "0.10.23";
+  version = "0.10.24";
   format = "pyproject";
+
   disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "collerek";
     repo = pname;
     rev = version;
-    sha256 = "sha256-ILJvJyd56lqlKq7+mUz26LvusYb5AOOfoA7OgNq2fT0=";
+    hash = "sha256-zKugeGDcYDI4VKspJPWeZCBubTqMxxfOVQCuF4pC49E=";
   };
 
   nativeBuildInputs = [
@@ -39,16 +41,15 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    databases
-    pydantic
-    sqlalchemy
-    asyncpg
-    psycopg2
     aiomysql
     aiosqlite
+    asyncpg
     cryptography
-
+    databases
     orjson
+    psycopg2
+    pydantic
+    sqlalchemy
   ] ++ lib.optionals (pythonOlder "3.8") [
     typing-extensions
     importlib-metadata
@@ -56,24 +57,35 @@ buildPythonPackage rec {
 
   checkInputs = [
     aiomysql
-    aiosqlite
     aiopg
+    aiosqlite
     asyncpg
-
-    psycopg2
-    mysqlclient
-    pymysql
-
-    pytestCheckHook
-    pytest-asyncio
     fastapi
+    mysqlclient
+    psycopg2
+    pymysql
+    pytest-asyncio
+    pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "ormar" ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'SQLAlchemy = ">=1.3.18,<=1.4.29"' 'SQLAlchemy = ">=1.3.18"' \
+      --replace 'databases = ">=0.3.2,!=0.5.0,!=0.5.1,!=0.5.2,!=0.5.3,<0.5.5"' 'databases = ">=0.5.5"'
+  '';
+
+  disabledTests = [
+    # TypeError: Object of type bytes is not JSON serializable
+    "test_bulk_operations_with_json"
+  ];
+
+  pythonImportsCheck = [
+    "ormar"
+  ];
 
   meta = with lib; {
     homepage = "https://github.com/collerek/ormar";
-    description = "A simple async ORM with fastapi in mind and pydantic validation.";
+    description = "Async ORM with fastapi in mind and pydantic validation";
     license = licenses.mit;
     maintainers = with maintainers; [ andreasfelix ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/collerek/ormar/releases/tag/0.10.24
https://github.com/encode/databases/releases/tag/0.5.5


Fix build (https://hydra.nixos.org/build/167071033)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
