### PR TITLE
libbfd: update build-components-separately.patch for 2.38

### DIFF
--- a/pkgs/development/tools/misc/binutils/build-components-separately.patch
+++ b/pkgs/development/tools/misc/binutils/build-components-separately.patch
@@ -57,10 +57,7 @@ index 0e04b4c05c4..848a02662e7 100644
  
  disassemble.lo: disassemble.c
  if am__fastdepCC
-@@ -324,12 +324,21 @@ libopcodes_la_SOURCES =  dis-buf.c disassemble.c dis-init.c
- # old version of libbfd, or to pick up libbfd for the wrong architecture
- # if host != build. So for building with shared libraries we use a
- # hardcoded path to libbfd.so instead of relying on the entries in libbfd.la.
+@@ -327,9 +327,18 @@ libopcodes_la_SOURCES =  dis-buf.c disassemble.c dis-init.c
 -libopcodes_la_DEPENDENCIES = $(OFILES) @SHARED_DEPENDENCIES@
 +libopcodes_la_DEPENDENCIES = $(OFILES) @SHARED_DEPENDENCIES@ libtool-soversion
  libopcodes_la_LIBADD = $(OFILES) @SHARED_LIBADD@
@@ -85,7 +82,7 @@ diff --git a/opcodes/configure.ac b/opcodes/configure.ac
 index e564f067334..5da62a3d58b 100644
 --- a/opcodes/configure.ac
 +++ b/opcodes/configure.ac
-@@ -96,6 +96,8 @@ BFD_CC_FOR_BUILD
+@@ -98,6 +98,8 @@ BFD_64_BIT
  AC_SUBST(HDEFINES)
  AC_PROG_INSTALL
  
@@ -94,7 +91,7 @@ index e564f067334..5da62a3d58b 100644
  AC_CHECK_DECLS([basename, stpcpy])
  
  # Check if sigsetjmp is available.  Using AC_CHECK_FUNCS won't do
-@@ -146,67 +148,31 @@ AC_CACHE_CHECK(linker --as-needed support, bfd_cv_ld_as_needed,
+@@ -148,44 +150,21 @@ AC_CACHE_CHECK(linker --as-needed support, bfd_cv_ld_as_needed,
  
  LT_LIB_M
  
@@ -139,29 +136,18 @@ index e564f067334..5da62a3d58b 100644
 -    SHARED_LIBADD="-L`pwd`/../libiberty/pic -liberty"
 -  fi
 -fi
--
+ 
  SHARED_LIBADD="$SHARED_LIBADD $LIBINTL"
  
- if test "$enable_shared" = "yes"; then
+@@ -193,11 +172,10 @@ if test "$enable_shared" = "yes"; then
    case "${host}" in
      *-*-cygwin*)
        SHARED_LDFLAGS="-no-undefined"
 -      SHARED_LIBADD="-L`pwd`/../bfd -lbfd -L`pwd`/../libiberty -liberty $SHARED_LIBADD"
 +      SHARED_LIBADD="-lbfd -liberty $SHARED_LIBADD"
        ;;
--   *-*-darwin*)
--     SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.dylib ${SHARED_LIBADD}"
--     SHARED_DEPENDENCIES="../bfd/libbfd.la"
--     ;;
      *)
--      case "$host_vendor" in
--        hp)
--          SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.sl ${SHARED_LIBADD}"
--	  ;;
--	*)
--          SHARED_LIBADD="-Wl,`pwd`/../bfd/.libs/libbfd.so ${SHARED_LIBADD}"
--	  ;;
--      esac
+-      SHARED_LIBADD="../bfd/libbfd.la ${SHARED_LIBADD}"
 -      SHARED_DEPENDENCIES="../bfd/libbfd.la"
 +      SHARED_LIBADD="-lbfd ${SHARED_LIBADD}"
        ;;


### PR DESCRIPTION
Otherwise the patch application fails as:

    applying patch /nix/store/y0l0144l12q7jpq4jv735shgxv8ygxwh-build-components-separately.patch
    1 out of 3 hunks FAILED -- saving rejects to file opcodes/Makefile.am.rej
    1 out of 2 hunks FAILED -- saving rejects to file opcodes/configure.ac.rej
1 out of 2 hunks FAILED -- saving rejects to file opcodes/configure.ac.rej

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
