### PR TITLE
kalendar: 0.4.0 -> 1.0.0

### DIFF
--- a/pkgs/applications/office/kalendar/default.nix
+++ b/pkgs/applications/office/kalendar/default.nix
@@ -10,6 +10,7 @@
 , qtsvg
 , qtlocation
 , qtdeclarative
+, qqc2-desktop-style
 
 , kirigami2
 , kdbusaddons
@@ -38,14 +39,14 @@
 
 mkDerivation rec {
   pname = "kalendar";
-  version = "0.4.0";
+  version = "1.0.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "pim";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-j383I40lChsI/VOgceaHYGhE61p3SpvInUrkUV5HnHY=";
+    sha256 = "sha256-kjtLVU+8wbIa7R6J1XOjuvS3AnJNngxNBCx24Dy1QzM=";
   };
 
   nativeBuildInputs = [
@@ -60,6 +61,7 @@ mkDerivation rec {
     qtsvg
     qtlocation
     qtdeclarative
+    qqc2-desktop-style
 
     kirigami2
     kdbusaddons


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Version bump

~Currently, it builds and runs on master however, it doesnt build on nixos-unstable. So, I'm unable to run it along with the rest of my system. I believe it should work, however im not too sure. (I would like to wait till nixos-unstable advances so that it hopefully builds on unstable)~ It works (I was using an older version of unstable)

Also, as with the previous update (https://github.com/NixOS/nixpkgs/pull/153084), clearing ~/.cache/KDE/kalendar is necessary if you ran a previous version.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
