### PR TITLE
lv2: reduce closure

### DIFF
--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   pname = "lv2";
   version = "1.18.2";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "https://lv2plug.in/spec/${pname}-${version}.tar.bz2";
     sha256 = "sha256-TokfvHRMBYVb6136gugisUkX3Wbpj4K4Iw29HHqy4F4=";
@@ -27,7 +29,10 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  wafConfigureFlags = lib.optionals stdenv.isDarwin [
+  wafConfigureFlags = [
+    "--includedir=${placeholder "dev"}/include"
+    "--bindir=${placeholder "dev"}/bin"
+  ] ++ lib.optionals stdenv.isDarwin [
     "--lv2dir=${placeholder "out"}/lib/lv2"
   ];
 

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -5,6 +5,7 @@
 , pkg-config
 , python3
 , wafHook
+, pipewire
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +30,10 @@ stdenv.mkDerivation rec {
   wafConfigureFlags = lib.optionals stdenv.isDarwin [
     "--lv2dir=${placeholder "out"}/lib/lv2"
   ];
+
+  passthru.tests = {
+    inherit pipewire;
+  };
 
   meta = with lib; {
     homepage = "https://lv2plug.in";

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, fetchurl, gtk2, libsndfile, pkg-config, python3, wafHook }:
+{ stdenv
+, lib
+, fetchurl
+, gtk2
+, libsndfile
+, pkg-config
+, python3
+, wafHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "lv2";
@@ -9,16 +17,26 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-TokfvHRMBYVb6136gugisUkX3Wbpj4K4Iw29HHqy4F4=";
   };
 
-  nativeBuildInputs = [ pkg-config wafHook ];
-  buildInputs = [ gtk2 libsndfile python3 ];
+  nativeBuildInputs = [
+    pkg-config
+    wafHook
+  ];
 
-  wafConfigureFlags = lib.optionals stdenv.isDarwin [ "--lv2dir=${placeholder "out"}/lib/lv2" ];
+  buildInputs = [
+    gtk2
+    libsndfile
+    python3
+  ];
+
+  wafConfigureFlags = lib.optionals stdenv.isDarwin [
+    "--lv2dir=${placeholder "out"}/lib/lv2"
+  ];
 
   meta = with lib; {
     homepage = "https://lv2plug.in";
     description = "A plugin standard for audio systems";
     license = licenses.mit;
-    maintainers = [ maintainers.goibhniu ];
+    maintainers = with maintainers; [ goibhniu ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/audio/lv2/default.nix
+++ b/pkgs/development/libraries/audio/lv2/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, gtk2
 , libsndfile
 , pkg-config
 , python3
@@ -23,7 +22,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk2
     libsndfile
     python3
   ];


### PR DESCRIPTION
###### Motivation for this change
gtk2 is optional

Before:
```
$ nix path-info -Sh ./result
/nix/store/ysdp0p56qpnx9kd6lyyx6rgbwnz97wq6-lv2-1.18.2	 327.1M
```
After:
```
$ nix path-info -Sh ./result
/nix/store/q1rcs1dkj4zrrd0nd3qk3dnn5akh1b9g-lv2-1.18.2	 141.5M
```

related: https://github.com/NixOS/nixpkgs/issues/159612

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
