### PR TITLE
enpass: remove trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -81,9 +81,6 @@ trim_trailing_whitespace = unset
 [pkgs/tools/misc/timidity/timidity.cfg]
 trim_trailing_whitespace = unset
 
-[pkgs/tools/security/enpass/data.json]
-insert_final_newline = unset
-trim_trailing_whitespace = unset
 
 [pkgs/top-level/emscripten-packages.nix]
 trim_trailing_whitespace = unset

--- a/pkgs/tools/security/enpass/data.json
+++ b/pkgs/tools/security/enpass/data.json
@@ -5,8 +5,8 @@
     "version": "6.6.1.809"
   },
   "i386": {
-    "path": "pool/main/e/enpass/enpass_5.6.9_i386.deb", 
-    "sha256": "3f699ac3e2ecfd4afee1505d8d364d4f6b6b94c55ba989d0a80bd678ff66cb2c", 
+    "path": "pool/main/e/enpass/enpass_5.6.9_i386.deb",
+    "sha256": "3f699ac3e2ecfd4afee1505d8d364d4f6b6b94c55ba989d0a80bd678ff66cb2c",
     "version": "5.6.9"
   }
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
