### PR TITLE
rustPlatform.bindgenHook: init

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -464,6 +464,8 @@ you of the correct hash.
   be disabled by setting `dontUseCargoParallelTests`.
 * `cargoInstallHook`: install binaries and static/shared libraries
   that were built using `cargoBuildHook`.
+* `bindgenHook`: for crates which use `bindgen` as a build dependency, lets
+  `bindgen` find `libclang` and `libclang` find the libraries in `buildInputs`.
 
 ### Examples {#examples}
 

--- a/pkgs/applications/audio/helvum/default.nix
+++ b/pkgs/applications/audio/helvum/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.cargo
     rustPlatform.rust.rustc
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
@@ -48,8 +49,6 @@ stdenv.mkDerivation rec {
     gtk4
     pipewire
   ];
-
-  LIBCLANG_PATH = "${libclang.lib}/lib";
 
   meta = with lib; {
     description = "A GTK patchbay for pipewire";

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -11,7 +11,7 @@
 , hunspell, libevent, libstartup_notification
 , libvpx
 , icu70, libpng, glib, pciutils
-, autoconf213, which, gnused, rustPackages
+, autoconf213, which, gnused, rustPackages, rustPlatform
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
 , gtk3, wrapGAppsHook
@@ -196,6 +196,7 @@ buildStdenv.mkDerivation ({
       which
       unzip
       wrapGAppsHook
+      rustPlatform.bindgenHook
     ]
     ++ lib.optionals buildStdenv.isDarwin [ xcbuild rsync ]
     ++ extraNativeBuildInputs;
@@ -210,28 +211,8 @@ buildStdenv.mkDerivation ({
     rm -f .mozconfig*
     # this will run autoconf213
     configureScript="$(realpath ./mach) configure"
-    export MOZCONFIG=$(pwd)/mozconfig
     export MOZBUILD_STATE_PATH=$(pwd)/mozbuild
 
-    # Set C flags for Rust's bindgen program. Unlike ordinary C
-    # compilation, bindgen does not invoke $CC directly. Instead it
-    # uses LLVM's libclang. To make sure all necessary flags are
-    # included we need to look in a few places.
-    # TODO: generalize this process for other use-cases.
-
-    BINDGEN_CFLAGS="$(< ${buildStdenv.cc}/nix-support/libc-crt1-cflags) \
-      $(< ${buildStdenv.cc}/nix-support/libc-cflags) \
-      $(< ${buildStdenv.cc}/nix-support/cc-cflags) \
-      $(< ${buildStdenv.cc}/nix-support/libcxx-cxxflags) \
-      ${lib.optionalString buildStdenv.cc.isClang "-idirafter ${buildStdenv.cc.cc.lib}/lib/clang/${lib.getVersion buildStdenv.cc.cc}/include"} \
-      ${lib.optionalString buildStdenv.cc.isGNU "-isystem ${lib.getDev buildStdenv.cc.cc}/include/c++/${lib.getVersion buildStdenv.cc.cc} -isystem ${buildStdenv.cc.cc}/include/c++/${lib.getVersion buildStdenv.cc.cc}/${buildStdenv.hostPlatform.config}"} \
-      $NIX_CFLAGS_COMPILE"
-    ${
-    # Bindgen doesn't like the flag added by `separateDebugInfo`.
-    lib.optionalString enableDebugSymbols ''
-      BINDGEN_CFLAGS="''${BINDGEN_CFLAGS/ -Wa,--compress-debug-sections/}"
-    ''}
-    echo "ac_add_options BINDGEN_CFLAGS='$BINDGEN_CFLAGS'" >> $MOZCONFIG
   '' + (lib.optionalString googleAPISupport ''
     # Google API key used by Chromium and Firefox.
     # Note: These are for NixOS/nixpkgs use ONLY. For your own distribution,

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -1,6 +1,7 @@
 { buildPackages
 , callPackage
 , cargo
+, clang
 , diffutils
 , lib
 , makeSetupHook
@@ -92,4 +93,13 @@ in {
           rustBuildPlatform rustTargetPlatform rustTargetPlatformSpec;
       };
     } ./maturin-build-hook.sh) {};
+
+    bindgenHook = callPackage ({}: makeSetupHook {
+      name = "rust-bindgen-hook";
+      substitutions = {
+        libclang = clang.cc.lib;
+        inherit clang;
+      };
+    }
+    ./rust-bindgen-hook.sh) {};
 }

--- a/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
+++ b/pkgs/build-support/rust/hooks/rust-bindgen-hook.sh
@@ -1,0 +1,13 @@
+# populates LIBCLANG_PATH and BINDGEN_EXTRA_CLANG_ARGS for rust projects that
+# depend on the bindgen crate
+
+# if you modify this, you probably also need to modify the wrapper for the cli
+# of bindgen in pkgs/development/tools/rust/bindgen/wrapper.sh
+
+populateBindgenEnv () {
+    export LIBCLANG_PATH=@libclang@/lib
+    BINDGEN_EXTRA_CLANG_ARGS="$(< @clang@/nix-support/cc-cflags) $(< @clang@/nix-support/libc-cflags) $(< @clang@/nix-support/libcxx-cxxflags) $NIX_CFLAGS_COMPILE"
+    export BINDGEN_EXTRA_CLANG_ARGS
+}
+
+postHook="${postHook:-}"$'\n'"populateBindgenEnv"$'\n'

--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -31,5 +31,5 @@ rec {
   # Hooks
   inherit (callPackage ../../../build-support/rust/hooks {
     inherit stdenv cargo rustc;
-  }) cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook maturinBuildHook;
+  }) cargoBuildHook cargoCheckHook cargoInstallHook cargoSetupHook maturinBuildHook bindgenHook;
 }

--- a/pkgs/development/tools/ashpd-demo/default.nix
+++ b/pkgs/development/tools/ashpd-demo/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
     rustPlatform.cargoSetupHook
     rustPlatform.rust.rustc
     wrapGAppsHook4
+    rustPlatform.bindgenHook
     desktop-file-utils
     glib # for glib-compile-schemas
   ];
@@ -62,11 +63,6 @@ stdenv.mkDerivation rec {
     wayland
     libshumate
   ];
-
-  # libspa-sys requires this for bindgen
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-  # <spa-0.2/spa/utils/defs.h> included by libspa-sys requires <stdbool.h>
-  BINDGEN_EXTRA_CLANG_ARGS = "-I${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include -I${glibc.dev}/include";
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/development/tools/rust/bindgen/default.nix
+++ b/pkgs/development/tools/rust/bindgen/default.nix
@@ -34,7 +34,9 @@ let
           touch $out
         '';
       };
-    } ''
+    }
+    # if you modify the logic to find the right clang flags, also modify rustPlatform.bindgenHook
+    ''
     mkdir -p $out/bin
     export cincludes="$(< ${clang}/nix-support/cc-cflags) $(< ${clang}/nix-support/libc-cflags)"
     export cxxincludes="$(< ${clang}/nix-support/libcxx-cxxflags)"

--- a/pkgs/servers/matrix-conduit/default.nix
+++ b/pkgs/servers/matrix-conduit/default.nix
@@ -14,20 +14,13 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-fpjzc2HiWP6nV8YZOwxsIOhy4ht/tQqcvCkcLMIFUaQ=";
 
   nativeBuildInputs = with pkgs; [
-    clang
-    llvmPackages.libclang
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = with pkgs; [
     pkg-config
-    clangStdenv
-    llvmPackages.libclang.lib
     rocksdb
   ];
-
-  preBuild = with pkgs; ''
-    export LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
-  '';
 
   cargoBuildFlags = "--bin conduit";
 

--- a/pkgs/tools/wayland/wluma/default.nix
+++ b/pkgs/tools/wayland/wluma/default.nix
@@ -24,24 +24,13 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [
     makeWrapper
     pkg-config
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
     udev
-    v4l-utils.lib
+    v4l-utils
   ];
-
-  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
-
-  # Works around the issue with rust-bindgen and the Nix gcc wrapper:
-  # https://hoverbear.org/blog/rust-bindgen-in-nix/
-  preBuild = ''
-    export BINDGEN_EXTRA_CLANG_ARGS="$(< ${stdenv.cc}/nix-support/libc-cflags) \
-    $(< ${stdenv.cc}/nix-support/cc-cflags) \
-    -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion llvmPackages.clang}/include \
-    -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include \
-    -idirafter ${v4l-utils.dev}/include"
-  '';
 
   postInstall = ''
     wrapProgram $out/bin/wluma \


### PR DESCRIPTION
###### Motivation for this change

I want to use this in nix-du

I only converted a few dependent packages to check that it works, I may do more of them in subsequent PRs

Without counting the doc, I'm removing lines ;)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
