### PR TITLE
libarchive: add some reverse dependencies to passthru.tests

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -6,6 +6,9 @@
   # builds fine on windows, but libarchive has trouble linking windows
   # things it depends on for some reason.
   xarSupport ? stdenv.hostPlatform.isUnix,
+
+  # for passthru.tests
+  cmake, nix, samba
 }:
 
 assert xarSupport -> libxml2 != null;
@@ -48,6 +51,10 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  passthru.tests = {
+    inherit cmake nix samba;
+  };
 
   meta = {
     description = "Multi-format archive and compression library";


### PR DESCRIPTION
###### Motivation for this change
Packages that have a large reverse dependency set are hard to test because a full rebuild is infeasible. But on the other hand, it's tricky for reviewers to remember which reverse dependencies of a particular package are particularly important to ensure are working *or* are known to be particularly sensitive to changes in the depended package.

Therefore it makes sense to add a small selection of such packages to `passthru.tests`. Done here for `libarchive`.

See also  #157872 for a similar approach being applied there.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
