### PR TITLE
python3Packages.pikepdf: 4.4.1 -> 4.5.0

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "pikepdf";
-  version = "4.4.1";
+  version = "4.5.0";
   disabled = ! isPy3k;
 
   src = fetchFromGitHub {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     extraPostFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-8yYqyXz4ZqZxsk2Ka8S0rDsHaqO4l6cZTyNuVQuHkew=";
+    hash = "sha256-0yW52SV3jn1FctszlnGG6T73Fd8ThJWR6c/8qAxGjjw=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/pikepdf/paths.patch
+++ b/pkgs/development/python-modules/pikepdf/paths.patch
@@ -1,5 +1,5 @@
 diff --git a/src/pikepdf/_methods.py b/src/pikepdf/_methods.py
-index 9db6b49..4020bcf 100644
+index 87e99fe..253a701 100644
 --- a/src/pikepdf/_methods.py
 +++ b/src/pikepdf/_methods.py
 @@ -204,7 +204,7 @@ def _mudraw(buffer, fmt) -> bytes:
@@ -12,15 +12,33 @@ index 9db6b49..4020bcf 100644
              check=True,
          )
 diff --git a/src/pikepdf/jbig2.py b/src/pikepdf/jbig2.py
-index 80cc910..64f6d31 100644
+index 04c762d..924727c 100644
 --- a/src/pikepdf/jbig2.py
 +++ b/src/pikepdf/jbig2.py
-@@ -25,7 +25,7 @@ def extract_jbig2(
-         global_path = Path(tmpdir) / "global"
+@@ -26,7 +26,7 @@ def extract_jbig2(
          output_path = Path(tmpdir) / "outfile"
  
--        args = ["jbig2dec", "-e", "-o", os.fspath(output_path)]
-+        args = ["@jbig2dec@", "-e", "-o", os.fspath(output_path)]
+         args = [
+-            "jbig2dec",
++            "@jbig2dec@",
+             "--embedded",
+             "--format",
+             "png",
+@@ -59,7 +59,7 @@ def extract_jbig2_bytes(jbig2: bytes, jbig2_globals: bytes) -> bytes:
+         output_path = Path(tmpdir) / "outfile"
  
-         # Get the raw stream, because we can't decode im_obj - that is why we are here
-         # (Strictly speaking we should remove any non-JBIG2 filters if double encoded)
+         args = [
+-            "jbig2dec",
++            "@jbig2dec@",
+             "--embedded",
+             "--format",
+             "png",
+@@ -84,7 +84,7 @@ def extract_jbig2_bytes(jbig2: bytes, jbig2_globals: bytes) -> bytes:
+ 
+ def jbig2dec_available() -> bool:
+     try:
+-        proc = run(['jbig2dec', '--version'], stdout=PIPE, check=True, encoding='ascii')
++        proc = run(['@jbig2dec@', '--version'], stdout=PIPE, check=True, encoding='ascii')
+     except (CalledProcessError, FileNotFoundError):
+         return False
+     else:


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pikepdf/pikepdf/blob/v4.5.0/docs/release_notes.rst


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
