### PR TITLE
python3Packages.treeo: 0.4.0 -> 0.0.9

### DIFF
--- a/pkgs/development/python-modules/treeo/default.nix
+++ b/pkgs/development/python-modules/treeo/default.nix
@@ -4,24 +4,20 @@
 , jaxlib
 , lib
 , poetry-core
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "treeo";
-  version = "0.4.0";
+  version = "0.0.9";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "cgarciae";
     repo = pname;
     rev = version;
-    sha256 = "176r1kgsdlylvdrxmhnzni81p8m9cfnsn4wwn6fnmsgam2qbp76j";
+    hash = "sha256-Yk4KNE5BncYoEHWZSEeSgoNb0TLMRbs8kSovUEKR2Ek=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'typing-extensions = "^3.10.0"' 'typing-extensions = "*"'
-  '';
 
   nativeBuildInputs = [
     poetry-core
@@ -30,15 +26,19 @@ buildPythonPackage rec {
   # jax is not declared in the dependencies, but is necessary.
   propagatedBuildInputs = [
     jax
+    jaxlib
   ];
 
-  checkInputs = [ jaxlib ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
   pythonImportsCheck = [
     "treeo"
   ];
 
   meta = with lib; {
-    description = "A small library for creating and manipulating custom JAX Pytree classes.";
+    description = "A small library for creating and manipulating custom JAX Pytree classes";
     homepage = "https://github.com/cgarciae/treeo";
     license = licenses.mit;
     maintainers = with maintainers; [ ndl ];

--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -39,8 +39,6 @@ buildPythonPackage rec {
     poetry-core
   ];
 
-  buildInputs = [ jaxlib ];
-
   propagatedBuildInputs = [
     einops
     flax


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/159455

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
