### PR TITLE
wayback_machine_downloader: 2.2.1 -> 2.3.1

### DIFF
--- a/pkgs/applications/networking/wayback_machine_downloader/Gemfile
+++ b/pkgs/applications/networking/wayback_machine_downloader/Gemfile
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' do
-  gem 'wayback_machine_downloader'
-end
+source 'https://rubygems.org'
+gem 'wayback_machine_downloader'

--- a/pkgs/applications/networking/wayback_machine_downloader/Gemfile.lock
+++ b/pkgs/applications/networking/wayback_machine_downloader/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    wayback_machine_downloader (2.2.1)
+    wayback_machine_downloader (2.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  wayback_machine_downloader!
+  wayback_machine_downloader
 
 BUNDLED WITH
-   2.1.4
+   2.3.6

--- a/pkgs/applications/networking/wayback_machine_downloader/gemset.nix
+++ b/pkgs/applications/networking/wayback_machine_downloader/gemset.nix
@@ -4,9 +4,9 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12kb1qmvmmsaihqab1prn6cmynkn6cgb4vf41mgv22wkcgv5wgk2";
+      sha256 = "170426sashqc2k2angg8d0bhs7spi1x1isv6cyk2hif0l6xxm3cm";
       type = "gem";
     };
-    version = "2.2.1";
+    version = "2.3.1";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Version 2.2.1 fails with an error on nixos-unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
