### PR TITLE
kchmviewer: init at 8.0

### DIFF
--- a/pkgs/applications/misc/kchmviewer/default.nix
+++ b/pkgs/applications/misc/kchmviewer/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, qmake, wrapQtAppsHook, chmlib, libzip, qtwebengine }:
+
+stdenv.mkDerivation rec {
+  pname = "kchmviewer";
+  version = "8.0";
+
+  src = fetchFromGitHub {
+    owner = "gyunaev";
+    repo = pname;
+    rev = "RELEASE_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "sha256-YNpiBf6AFBCRbAZRPODvqGbQQedJJJrZFQIQyzIeBlw=";
+  };
+
+  patches = [
+    # remove unused webkit
+    (fetchpatch {
+      url = "https://github.com/gyunaev/kchmviewer/commit/a4a3984465cb635822953350c571950ae726b539.patch";
+      sha256 = "sha256-nHW18a4SrTG4fETJmKS4ojHXwnX1d1uN1m4H0GIuI28=";
+    })
+    # QtWebengine fixes
+    (fetchpatch {
+      url = "https://github.com/gyunaev/kchmviewer/commit/9ac73e7ad15de08aab6b1198115be2eb44da7afe.patch";
+      sha256 = "sha256-qg2ytqA2On7jg19WZmHIOU7vLQI2hoyqItySLEA64SY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/gyunaev/kchmviewer/commit/99a6d94bdfce9c4578cce82707e71863a71d1453.patch";
+      sha256 = "sha256-o8JkaMmcJObmMt+o/6ooCAPCi+yRAWDAgxV+tR5eHfY=";
+    })
+  ];
+
+  buildInputs = [ chmlib libzip qtwebengine ];
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  postInstall = ''
+    install -Dm755 bin/kchmviewer -t $out/bin
+    install -Dm644 packages/kchmviewer.png -t $out/share/pixmaps
+    install -Dm644 packages/kchmviewer.desktop -t $out/share/applications
+  '';
+
+  meta = with lib; {
+    description = "CHM (Winhelp) files viewer";
+    homepage = "http://www.ulduzsoft.com/linux/kchmviewer/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26639,6 +26639,8 @@ with pkgs;
 
   kapow = libsForQt5.callPackage ../applications/misc/kapow { };
 
+  kchmviewer = libsForQt5.callPackage ../applications/misc/kchmviewer { };
+
   kappanhang = callPackage ../applications/radio/kappanhang { };
 
   okteta = libsForQt5.callPackage ../applications/editors/okteta { };


### PR DESCRIPTION
###### Motivation for this change
**[kchmviewer](https://github.com/gyunaev/kchmviewer)** is a CHM (Winhelp) files viewer written on Qt/KDE.
[![Packaging status](https://repology.org/badge/tiny-repos/kchmviewer.svg)](https://repology.org/project/kchmviewer/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
