### PR TITLE
libguestfs: 1.44.1 → 1.46.2

### DIFF
--- a/pkgs/development/libraries/libguestfs/default.nix
+++ b/pkgs/development/libraries/libguestfs/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, autoreconfHook, makeWrapper
-, ncurses, cpio, gperf, cdrkit, flex, bison, qemu, pcre, augeas, libxml2
+{ lib, stdenv, fetchurl, pkg-config, autoreconfHook, makeWrapper
+, ncurses, cpio, gperf, cdrkit, flex, bison, qemu, pcre2, augeas, libxml2
 , acl, libcap, libcap_ng, libconfig, systemd, fuse, yajl, libvirt, hivex, db
 , gmp, readline, file, numactl, libapparmor, jansson
 , getopt, perlPackages, ocamlPackages
@@ -12,11 +12,11 @@ assert javaSupport -> jdk != null;
 
 stdenv.mkDerivation rec {
   pname = "libguestfs";
-  version = "1.44.1";
+  version = "1.46.2";
 
   src = fetchurl {
     url = "https://libguestfs.org/download/${lib.versions.majorMinor version}-stable/${pname}-${version}.tar.gz";
-    sha256 = "09dhmlbfdwirlmkasa28x69vqs5xndq0lnng6b4if76s6bfxrdvj";
+    sha256 = "0sq092irlj2jf64m7hjx23hn5k4iypqxmlyn9g2z0q0xab56ksp6";
   };
 
   strictDeps = true;
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     ++ (with ocamlPackages; [ ocaml findlib ]);
   buildInputs = [
     ncurses jansson
-    pcre augeas libxml2 acl libcap libcap_ng libconfig
+    pcre2 augeas libxml2 acl libcap libcap_ng libconfig
     systemd fuse yajl libvirt gmp readline file hivex db
     numactl libapparmor perlPackages.ModuleBuild
     libtirpc
@@ -53,13 +53,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (!javaSupport) [ "--without-java" ];
   patches = [
     ./libguestfs-syms.patch
-    # Set HAVE_RPM, HAVE_DPKG, HAVE_PACMAN
-    (fetchpatch {
-      url = "https://github.com/libguestfs/libguestfs/commit/210959cc344d6a4a1e3afa26d276b130651def74.patch";
-      sha256 = "121l58mk2mwhhqc3rcisdw3di7y729b30hyffc8a50mq5k7fvsdb";
-     })
   ];
-  NIX_CFLAGS_COMPILE="-I${libxml2.dev}/include/libxml2/";
   installFlags = [ "REALLY_INSTALL=yes" ];
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.13

cc maintainer @offlinehacker

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
