### PR TITLE
boost: use clang 7 for versions older than 1.6.9

### DIFF
--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -1,10 +1,18 @@
 { lib
+, stdenv
+, llvmPackages_7
 , callPackage
 , boost-build
 , fetchurl
 }:
 
 let
+  # Older boost versions (< 1.6.9) require clang < 8
+  compatibleStdenv =
+    if stdenv.cc.isClang && !(lib.versionOlder stdenv.cc.version "8.0.0")
+    then llvmPackages_7.stdenv
+    else stdenv;
+
   # for boost 1.55 we need to use 1.56's b2
   # since 1.55's build system is not working
   # with our derivation
@@ -16,9 +24,9 @@ let
     };
   };
 
-  makeBoost = file:
+  makeBoost = file: args:
     lib.fix (self:
-      callPackage file {
+      callPackage file (args // {
         boost-build = boost-build.override {
           # useBoost allows us passing in src and version from
           # the derivation we are building to get a matching b2 version.
@@ -27,22 +35,22 @@ let
             then self
             else useBoost156; # see above
         };
-      }
+      })
     );
 in {
-  boost155 = makeBoost ./1.55.nix;
-  boost159 = makeBoost ./1.59.nix;
-  boost160 = makeBoost ./1.60.nix;
-  boost165 = makeBoost ./1.65.nix;
-  boost166 = makeBoost ./1.66.nix;
-  boost167 = makeBoost ./1.67.nix;
-  boost168 = makeBoost ./1.68.nix;
-  boost169 = makeBoost ./1.69.nix;
-  boost170 = makeBoost ./1.70.nix;
-  boost171 = makeBoost ./1.71.nix;
-  boost172 = makeBoost ./1.72.nix;
-  boost173 = makeBoost ./1.73.nix;
-  boost174 = makeBoost ./1.74.nix;
-  boost175 = makeBoost ./1.75.nix;
-  boost177 = makeBoost ./1.77.nix;
+  boost155 = makeBoost ./1.55.nix { stdenv = compatibleStdenv; };
+  boost159 = makeBoost ./1.59.nix { stdenv = compatibleStdenv; };
+  boost160 = makeBoost ./1.60.nix { stdenv = compatibleStdenv; };
+  boost165 = makeBoost ./1.65.nix { stdenv = compatibleStdenv; };
+  boost166 = makeBoost ./1.66.nix { stdenv = compatibleStdenv; };
+  boost167 = makeBoost ./1.67.nix { stdenv = compatibleStdenv; };
+  boost168 = makeBoost ./1.68.nix { stdenv = compatibleStdenv; };
+  boost169 = makeBoost ./1.69.nix {};
+  boost170 = makeBoost ./1.70.nix {};
+  boost171 = makeBoost ./1.71.nix {};
+  boost172 = makeBoost ./1.72.nix {};
+  boost173 = makeBoost ./1.73.nix {};
+  boost174 = makeBoost ./1.74.nix {};
+  boost175 = makeBoost ./1.75.nix {};
+  boost177 = makeBoost ./1.77.nix {};
 }


### PR DESCRIPTION
Older versions of boost don't build with newer versions of clang
(see #85156), and the default clang version on x86_64-darwin is now
new enough that these older versions of boost no longer build.

###### Motivation for this change

Unfortunately I have to deal with software that relies on `boost159`. I tried overriding locally, but IIUC it is not possible with the current structure of the boost packages.

```
❯ nix-build -E 'let pkgs = import ./. { system = "x86_64-darwin"; }; in pkgs.boost159.override { stdenv = pkgs.clang7Stdenv; }'
error: assertion '(with lib; (((toolset == "clang") && (! (versionOlder (stdenv).cc.version "8.0.0"))) -> (! (versionOlder version "1.69"))))' failed
```

This change provides a stdenv that allows the package to build, and allows the stdenv to be overridden.

There's possibly a trade-off here. If someone's using these old versions of boost, they will benefit from being cached on hydra. However, it might come as a surprise to consumers that the compiler version of boost is not the same as the default compiler version and I don't know if it's safe to mix and match C++ compilers like this. The other way I can think of to work around the assertion preventing overriding is to use `meta.broken` instead, which would also prevent hydra builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (via rosetta)
    - [ ] boost155 - not supported
    - [x] boost159
    - [x] boost160
    - [x] boost165
    - [ ] boost166 - failed
    - [ ] boost168 - failed
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
