### PR TITLE
vengi-tools: 0.0.17 -> 0.0.18

### DIFF
--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -87,9 +87,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
-    # There used to be a roundtrip test here, but it started failing on 0.0.17
-    # Relevant upstream ticket:
-    # https://github.com/mgerhardy/vengi/issues/113
+    voxconvert-roundtrip = callPackage ./test-voxconvert-roundtrip.nix {};
     voxconvert-all-formats = callPackage ./test-voxconvert-all-formats.nix {};
     run-voxedit = nixosTests.vengi-tools;
   };

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -29,32 +29,14 @@
 
 stdenv.mkDerivation rec {
   pname = "vengi-tools";
-  version = "0.0.17";
+  version = "0.0.18";
 
   src = fetchFromGitHub {
     owner = "mgerhardy";
     repo = "vengi";
     rev = "v${version}";
-    sha256 = "sha256-h+R9L0BBD3NSFWUh43g4V2LBcNyqVInBeJiOLY03nRk=";
+    sha256 = "sha256-Ur1X5FhOa87jbjWBXievBfCHW+qP/8bqLiyKAC8+KU4=";
   };
-
-  # Patch from the project's author for fixing an issue with AnimationShaders.h
-  # not being included when turning off some components
-  patches = [(writeText "vengi-tools-fix-build.patch" ''
-    diff --git a/src/modules/voxelworldrender/CMakeLists.txt b/src/modules/voxelworldrender/CMakeLists.txt
-    index aebe5f97b..903e62b37 100644
-    --- a/src/modules/voxelworldrender/CMakeLists.txt
-    +++ b/src/modules/voxelworldrender/CMakeLists.txt
-    @@ -27,7 +27,7 @@ set(FILES
-            voxel/models/plants/3.qb
-            voxel/models/plants/4.qb
-     )
-    -engine_add_module(TARGET ''${LIB} SRCS ''${SRCS} ''${SRCS_SHADERS} FILES ''${FILES} DEPENDENCIES frontend voxelrender)
-    +engine_add_module(TARGET ''${LIB} SRCS ''${SRCS} ''${SRCS_SHADERS} FILES ''${FILES} DEPENDENCIES animation frontend voxelrender)
-     generate_shaders(''${LIB} world water postprocess)
-
-     set(TEST_SRCS
-  '')];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
+++ b/pkgs/applications/graphics/vengi-tools/test-voxconvert-roundtrip.nix
@@ -1,0 +1,15 @@
+{ stdenv
+, vengi-tools
+}:
+
+stdenv.mkDerivation {
+  name = "vengi-tools-test-voxconvert-roundtrip";
+  meta.timeout = 10;
+  buildCommand = ''
+    ${vengi-tools}/bin/vengi-voxconvert --input ${vengi-tools}/share/vengi-voxedit/chr_knight.qb --output chr_knight.vox
+    ${vengi-tools}/bin/vengi-voxconvert --input chr_knight.vox --output chr_knight.qb
+    ${vengi-tools}/bin/vengi-voxconvert --input chr_knight.qb --output chr_knight1.vox
+    diff chr_knight.vox chr_knight1.vox
+    touch $out
+  '';
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Please also take a look at https://github.com/NixOS/nixpkgs/pull/158116