### PR TITLE
coreboot-toolchain: Update to version 4.16

### DIFF
--- a/pkgs/development/tools/misc/coreboot-toolchain/default.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/default.nix
@@ -17,12 +17,12 @@ let
 
     stdenvNoCC.mkDerivation rec {
       pname = "coreboot-toolchain-${arch}";
-      version = "4.15";
+      version = "4.16";
 
       src = fetchgit {
         url = "https://review.coreboot.org/coreboot";
         rev = version;
-        sha256 = "1qsb2ca22h5f0iwc254qsfm7qcn8967ir8aybdxa1pakgmnfsyp9";
+        sha256 = "073n8yid3v0l9wgwnrdqrlgzaj9mnhs33a007dgr7xq3z0iw3i52";
         fetchSubmodules = false;
         leaveDotGit = true;
         postFetch = ''

--- a/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
+++ b/pkgs/development/tools/misc/coreboot-toolchain/stable.nix
@@ -35,10 +35,10 @@
     };
   }
   {
-    name = "acpica-unix2-20210331.tar.gz";
+    name = "acpica-unix2-20211217.tar.gz";
     archive = fetchurl {
-      sha256 = "1h98pvc9iy1c49cid0ppjwk5zsy2m1xbvfqb72pkwkrd4rn35arx";
-      url = "https://acpica.org/sites/acpica/files/acpica-unix2-20210331.tar.gz";
+      sha256 = "0521hmaw2zhi0mpgnaf2i83dykfgql4bx98cg7xqy8wmj649z194";
+      url = "https://acpica.org/sites/acpica/files/acpica-unix2-20211217.tar.gz";
     };
   }
   {

--- a/pkgs/development/tools/misc/coreboot-toolchain/update.sh
+++ b/pkgs/development/tools/misc/coreboot-toolchain/update.sh
@@ -8,7 +8,7 @@ fi
 
 pkg_dir="$(dirname "$0")"
 
-src="$(nix-build . --no-out-link -A coreboot-toolchain.src)"
+src="$(nix-build . --no-out-link -A coreboot-toolchain.i386.src)"
 urls=$($src/util/crossgcc/buildgcc -u)
 
 tmp=$(mktemp)


### PR DESCRIPTION
###### Motivation for this change

Update to version 4.16.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
