### PR TITLE
n8n: 0.163.0 -> 0.163.1

### DIFF
--- a/pkgs/applications/networking/n8n/node-packages.nix
+++ b/pkgs/applications/networking/n8n/node-packages.nix
@@ -7015,13 +7015,13 @@ let
         sha1 = "021e4d9c7705f21bbf37d03ceb58767402774c64";
       };
     };
-    "url-parse-1.5.5" = {
+    "url-parse-1.5.6" = {
       name = "url-parse";
       packageName = "url-parse";
-      version = "1.5.5";
+      version = "1.5.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/url-parse/-/url-parse-1.5.5.tgz";
-        sha512 = "LYNZ15yZDI+HPHUji/yJpj+MnWvQuPZIOJ+gDtHM6gJq33bbmXLfgODIic6SE8tLLes5KWPjZnI3dWlPG6JiTg==";
+        url = "https://registry.npmjs.org/url-parse/-/url-parse-1.5.6.tgz";
+        sha512 = "xj3QdUJ1DttD1LeSfvJlU1eiF1RvBSBfUu8GplFGdUzSO28y5yUtEl7wb//PI4Af6qh0o/K8545vUmucRrfWsw==";
       };
     };
     "utf7-1.0.2" = {
@@ -7462,10 +7462,10 @@ in
   n8n = nodeEnv.buildNodePackage {
     name = "n8n";
     packageName = "n8n";
-    version = "0.163.0";
+    version = "0.163.1";
     src = fetchurl {
-      url = "https://registry.npmjs.org/n8n/-/n8n-0.163.0.tgz";
-      sha512 = "7znPwaONZgCGJKfkjkHP/zTsPiSf7+Wun6TjQ9j/NmyMiPku99EiwDtH3lW5GFCcy+Doo4GUVMqXpEM8GOcNVw==";
+      url = "https://registry.npmjs.org/n8n/-/n8n-0.163.1.tgz";
+      sha512 = "lhup+qIy3cG0oWvBuOWi57Tn3F2k5NBD00KJ3ilKgnk4VsY+LmAca2xvyZNKvlRPa9i++3ukG6XioPTDuXylgw==";
     };
     dependencies = [
       (sources."@azure/abort-controller-1.0.5" // {
@@ -8627,7 +8627,7 @@ in
           sources."punycode-1.3.2"
         ];
       })
-      sources."url-parse-1.5.5"
+      sources."url-parse-1.5.6"
       (sources."utf7-1.0.2" // {
         dependencies = [
           sources."semver-5.3.0"


### PR DESCRIPTION
###### Motivation for this change
Emergency upstream hotfix for broken OAuth logins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
