### PR TITLE
isabelle: Add option to install the linter

### DIFF
--- a/pkgs/applications/science/logic/isabelle/components/default.nix
+++ b/pkgs/applications/science/logic/isabelle/components/default.nix
@@ -1,0 +1,5 @@
+{ callPackage }:
+
+{
+  isabelle-linter = callPackage ./isabelle-linter.nix {};
+}

--- a/pkgs/applications/science/logic/isabelle/components/isabelle-linter.nix
+++ b/pkgs/applications/science/logic/isabelle/components/isabelle-linter.nix
@@ -1,0 +1,22 @@
+{ stdenv, lib, fetchFromGitHub, isabelle }:
+
+stdenv.mkDerivation rec {
+  pname = "isabelle-linter";
+  version = "Isabelle2021-1-v1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "isabelle-prover";
+    repo = "isabelle-linter";
+    rev = version;
+    sha256 = "0v6scc2rhj6bjv530gzz6i57czzcgpkw7a9iqnfdnm5gvs5qjk7a";
+  };
+
+  installPhase = import ./mkBuild.nix { inherit isabelle; path = "${pname}-${version}"; };
+
+  meta = with lib; {
+    description = "Linter component for Isabelle.";
+    homepage = "https://github.com/isabelle-prover/isabelle-linter";
+    maintainers = with maintainers; [ jvanbruegge ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/applications/science/logic/isabelle/components/mkBuild.nix
+++ b/pkgs/applications/science/logic/isabelle/components/mkBuild.nix
@@ -1,0 +1,36 @@
+{ isabelle, path }:
+
+let
+  dir = "$out/isabelle/${isabelle.dirname}";
+  iDir = "${isabelle}/${isabelle.dirname}";
+in ''
+  shopt -s extglob
+  mkdir -p ${dir}/lib/classes
+
+  cDir=$out/${isabelle.dirname}/contrib/${path}
+  mkdir -p $cDir
+  cp -r !(isabelle) $cDir
+
+  cd ${dir}
+  ln -s ${iDir}/!(lib|bin) ./
+  ln -s ${iDir}/lib/!(classes) lib/
+  ln -s ${iDir}/lib/classes/* lib/classes/
+
+  mkdir bin/
+  cp ${iDir}/bin/* bin/
+
+  export HOME=$TMP
+  bin/isabelle components -u $cDir
+  bin/isabelle scala_build
+
+  cd lib/classes
+  for f in ${iDir}/lib/classes/*; do
+    rm $(basename $f)
+  done
+
+  lDir=$out/${isabelle.dirname}/lib/classes/
+  mkdir -p $lDir
+  cp -r * $lDir
+  cd $out
+  rm -rf isabelle
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32646,6 +32646,7 @@ with pkgs;
     java = openjdk17;
     z3 = z3_4_4_0;
   };
+  isabelle-components = recurseIntoAttrs (callPackage ../applications/science/logic/isabelle/components { });
 
   iprover = callPackage ../applications/science/logic/iprover { };
 


### PR DESCRIPTION
###### Motivation for this change

Isabelle features an optional linter component. This PR adds an option to install it. This is waiting for #157843 and #157515 to be merged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
