### PR TITLE
boost159: fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/libraries/boost/1.59.nix
+++ b/pkgs/development/libraries/boost/1.59.nix
@@ -1,7 +1,20 @@
-{ callPackage, fetchurl, ... } @ args:
+{ callPackage, fetchurl, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
   version = "1.59.0";
+
+  boostBuildPatches = [
+    # Fixes a segfault on aarch64-darwin from an implicitly defined varargs function.
+    # https://github.com/boostorg/build/pull/238
+    (fetchpatch {
+      url = "https://github.com/boostorg/build/commit/48e9017139dd94446633480661e5447c7e0d8b1b.diff";
+      excludes = [
+        # Doesn't apply, isn't critical.
+        "src/engine/filesys.h"
+      ];
+      sha256 = "sha256-/HLOJKBcGqcK9yBYKSRCSMmTNhCH3sSpK1s3OzkIqx8";
+    })
+  ];
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2";

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -15,6 +15,7 @@
 , enableNumpy ? false
 , taggedLayout ? ((enableRelease && enableDebug) || (enableSingleThreaded && enableMultiThreaded) || (enableShared && enableStatic))
 , patches ? []
+, boostBuildPatches ? []
 , useMpi ? false
 , mpi
 , extraB2Args ? []
@@ -168,6 +169,10 @@ stdenv.mkDerivation {
       stdenv.hostPlatform.isMips64n32 ||
       # the patch above does not apply cleanly to pre-1.65 boost
       (stdenv.hostPlatform.isMips64n64 && (versionOlder version "1.65"));
+  };
+
+  passthru = {
+    inherit boostBuildPatches;
   };
 
   preConfigure = optionalString useMpi ''

--- a/pkgs/development/tools/boost-build/default.nix
+++ b/pkgs/development/tools/boost-build/default.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation {
     sourceRoot="$sourceRoot/tools/build"
   '';
 
+  patches = useBoost.boostBuildPatches or [];
+
   # Upstream defaults to gcc on darwin, but we use clang.
   postPatch = ''
     substituteInPlace src/build-system.jam \


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix build on aarch64-darwin (related: #136643).

The critical change is adding `#include "output.h"` to `make.c` so that the varargs function `out_printf` is not implicitly defined. I thought it best to backport an upstream fix than to include a local fix.

Requires #159990, so opening as a draft.

Getting a patch into `boost-build` was slightly interesting due to the structure here.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
