### PR TITLE
rakudo: 2021.12 -> 2022.02

### DIFF
--- a/pkgs/development/interpreters/rakudo/default.nix
+++ b/pkgs/development/interpreters/rakudo/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "rakudo";
-  version = "2021.12";
+  version = "2022.02";
 
   src = fetchurl {
     url = "https://rakudo.org/dl/rakudo/rakudo-${version}.tar.gz";
-    sha256 = "sha256-f1PSxxONE6sBaS1b19vCjz8p7Ya9ltUoCFb1WhqwVAY=";
+    sha256 = "sha256-am6dvMbZoWEKNMbsZ+LT9pTXsz6eCg8iRUMIn6f3EzI=";
   };
 
   nativeBuildInputs = [ removeReferencesTo ];

--- a/pkgs/development/interpreters/rakudo/moarvm.nix
+++ b/pkgs/development/interpreters/rakudo/moarvm.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "moarvm";
-  version = "2021.12";
+  version = "2022.02";
 
   src = fetchurl {
     url = "https://moarvm.org/releases/MoarVM-${version}.tar.gz";
-    sha256 = "sha256-1Ju+sQ2WFsLYen+t0ca7elzhHBnHxEu7i+928ltQXE8=";
+    sha256 = "sha256-T5PNzmuKVloyKCuzjMlxzv63H10CLIUMM47oFFV07pY=";
   };
 
   postPatch = ''

--- a/pkgs/development/interpreters/rakudo/nqp.nix
+++ b/pkgs/development/interpreters/rakudo/nqp.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nqp";
-  version = "2021.12";
+  version = "2022.02";
 
   src = fetchurl {
     url = "https://github.com/raku/nqp/releases/download/${version}/nqp-${version}.tar.gz";
-    sha256 = "sha256-Dh1TT9HuYaTIByMJuvvARmDprnLYhhjaoOjxUCLw2RM=";
+    sha256 = "sha256-JdPJl0XNhPQEmpvZzya7XcgXklq6r+ccm9tohBzbGLE=";
   };
 
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

Updates `rakudo` and dependencies to 2022.02

- nqp: 2021.12 -> 2022.02
- moarvm: 2021.12 -> 2022.02

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
