### PR TITLE
python3Packages.dask: 2022.01.0 -> 2022.02.0, python3Packages.distributed: 2021.12.0 -> 2022.2.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "dask";
-  version = "2022.01.0";
+  version = "2022.02.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -32,8 +32,7 @@ buildPythonPackage rec {
     owner = "dask";
     repo = pname;
     rev = version;
-    sha256 = "sha256-HlVvnhEDzefzv9xchlXl9d4KCumoAqoYUWmIiCXLJyM=
-";
+    hash = "sha256-tDqpIS8j6a16YbJak+P1GkCEZvJyheWV5vkUrkhScRY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -19,19 +19,16 @@
 
 buildPythonPackage rec {
   pname = "distributed";
-  version = "2021.12.0";
-  disabled = pythonOlder "3.6";
+  version = "2022.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   # get full repository need conftest.py to run tests
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c6119a2cf1fb2d8ac60337915bb9a790af6530afcb5d7a809a3308323b874714";
+    hash = "sha256-Gi9u7JczpnAEg53E7N5tXBfAeWZaLBVzRU3SpbU3bZU=";
   };
-
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace "dask == 2021.11.2" "dask"
-  '';
 
   propagatedBuildInputs = [
     bokeh
@@ -49,10 +46,17 @@ buildPythonPackage rec {
     zict
   ];
 
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "dask == 2022.02.0" "dask"
+  '';
+
   # when tested random tests would fail and not repeatably
   doCheck = false;
 
-  pythonImportsCheck = [ "distributed" ];
+  pythonImportsCheck = [
+    "distributed"
+  ];
 
   meta = with lib; {
     description = "Distributed computation in Python";

--- a/pkgs/development/python-modules/fsspec/default.nix
+++ b/pkgs/development/python-modules/fsspec/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "fsspec";
-  version = "2021.10.1";
+  version = "2022.01.0";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "intake";
     repo = "filesystem_spec";
     rev = version;
-    sha256 = "sha256-LgrOHBXKs2bEgtgrdHb1OEhOeQ5Rbgr6X5YtgiqiCH0=";
+    sha256 = "sha256-iPe2q9hY3ZRIKQGpxrHda3t9G0AtbtohVcWdnAzlzCo=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/gcsfs/default.nix
+++ b/pkgs/development/python-modules/gcsfs/default.nix
@@ -18,15 +18,16 @@
 
 buildPythonPackage rec {
   pname = "gcsfs";
-  version = "2021.10.1";
+  version = "2022.01.0";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "fsspec";
     repo = pname;
     rev = version;
-    sha256 = "sha256-cpV+HKE39Yct1yu5xW9HZftx2Wy9ydFL2YLvPD3YM2M=";
+    hash = "sha256-wNeK1GdjK9GKaaECcFeBLjFf/h3MbLI5e4MX0UNoTqE=";
   };
 
   propagatedBuildInputs = [
@@ -47,10 +48,14 @@ buildPythonPackage rec {
     vcrpy
   ];
 
-  disabledTests = [
-    # Tests wants to communicate with the Link-local address
-    "test_GoogleCredentials_None"
+  disabledTestPaths = [
+    # Tests require a running Docker instance
+    "gcsfs/tests/test_core.py"
+    "gcsfs/tests/test_mapping.py"
+    "gcsfs/tests/test_retry.py"
   ];
+
+  pytestFlagsArray = [ "-x" ];
 
   pythonImportsCheck = [
     "gcsfs"

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "tifffile";
-  version = "2021.11.2";
+  version = "2022.2.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-FT4x+h2JL0gvq7KunyVh+kKe5C0BpvZ+WM7hNjfZKFs=";
+    hash = "sha256-ftp0EXZDaBuyyqaVtI854iQ7SIf3z5kdWt/9gT5cg3M=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/167244566)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
