### PR TITLE
nodePackages.spectral-cli: init at 6.2.1

### DIFF
--- a/pkgs/applications/networking/browsers/decentr/default.nix
+++ b/pkgs/applications/networking/browsers/decentr/default.nix
@@ -1,0 +1,165 @@
+{ stdenv
+, lib
+, fetchurl
+, unzip
+, dpkg
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gnome2
+, gnome
+, gsettings-desktop-schemas
+, gtk3
+, libpulseaudio
+, libuuid
+, libdrm
+, libX11
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libxkbcommon
+, libXrandr
+, libXrender
+, libXScrnSaver
+, libxshmfence
+, libXtst
+, mesa
+, nspr
+, nss
+, pango
+, udev
+, xorg
+, zlib
+, xdg-utils
+, wrapGAppsHook
+}:
+
+let
+  rpath = lib.makeLibraryPath [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gnome2.GConf
+    gtk3
+    libdrm
+    libpulseaudio
+    libX11
+    libxkbcommon
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libxshmfence
+    libXtst
+    libuuid
+    mesa
+    nspr
+    nss
+    pango
+    udev
+    xdg-utils
+    xorg.libxcb
+    zlib
+  ];
+
+in
+
+stdenv.mkDerivation rec {
+  pname = "decentr";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "https://decentr.net/files/Ubuntu_X64_Decentr_${version}.zip";
+    sha256 = "sha256-Nl0/ML1taJQhjP4ldAYuB9Jv5zuVBX0blYAYkw0/vCA=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  doInstallCheck = true;
+
+  nativeBuildInputs = [ unzip dpkg wrapGAppsHook ];
+
+  buildInputs = [ glib gsettings-desktop-schemas gnome.adwaita-icon-theme ];
+
+  unpackPhase = ''
+    unzip -qq $src
+    dpkg-deb --fsys-tarfile *.deb | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out $out/bin
+    cp -R usr/share $out
+    cp -R opt/ $out/opt
+    export BINARYWRAPPER=$out/opt/decentr.org/decentr-unstable/decentr-browser-unstable
+    # Fix path to bash in $BINARYWRAPPER
+    substituteInPlace $BINARYWRAPPER \
+        --replace /bin/bash ${stdenv.shell}
+    ln -sf $BINARYWRAPPER $out/bin/decentr
+    for exe in $out/opt/decentr.org/decentr-unstable/{decentr,chrome_crashpad_handler}; do
+    patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${rpath}" $exe
+    done
+    # Fix paths
+    substituteInPlace $out/share/applications/decentr-browser-unstable.desktop \
+        --replace /usr/bin/decentr-browser-unstable $out/bin/decentr
+    substituteInPlace $out/share/gnome-control-center/default-apps/decentr-browser-unstable.xml \
+        --replace /opt/decentr.org $out/opt/decentr.org
+    substituteInPlace $out/share/menu/decentr-browser-unstable.menu \
+        --replace /opt/decentr.org $out/opt/decentr.org
+    substituteInPlace $out/opt/decentr.org/decentr-unstable/default-app-block \
+        --replace /opt/decentr.org $out/opt/decentr.org
+    # Correct icons location
+    icon_sizes=("16" "22" "24" "32" "48" "64" "128" "256")
+    for icon in ''${icon_sizes[*]}
+    do
+        mkdir -p $out/share/icons/hicolor/$icon\x$icon/apps
+        ln -s $out/opt/decentr.org/decentr-unstable/product_logo_$icon.png $out/share/icons/hicolor/$icon\x$icon/apps/decentr-browser.png
+    done
+    # Replace xdg-settings and xdg-mime
+    ln -sf ${xdg-utils}/bin/xdg-settings $out/opt/decentr.org/decentr-unstable/xdg-settings
+    ln -sf ${xdg-utils}/bin/xdg-mime $out/opt/decentr.org/decentr-unstable/xdg-mime
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    # Bypass upstream wrapper which suppresses errors
+    $out/opt/decentr.org/decentr-unstable/decentr --version
+  '';
+
+  meta = with lib; {
+    homepage = "https://decentr.org/";
+    #  TODO: Refactor everything below. I copied this from Brave Browser's.
+    description = "Browse to earn";
+    maintainers = with maintainers; [ diogox ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -475,6 +475,10 @@ let
       ];
     };
 
+    spectral-cli = super.spectral-cli.override {
+      buildInputs = [ self.node-gyp-build ];
+    };
+
     thelounge = super.thelounge.override {
       buildInputs = [ self.node-pre-gyp ];
       postInstall = ''

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -264,6 +264,7 @@
 , "smartdc"
 , "snyk"
 , "socket.io"
+, "spectral-cli"
 , "speed-test"
 , "sql-formatter"
 , "ssb-server"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24988,6 +24988,8 @@ with pkgs;
     plugins = [];
   };
 
+  decentr = callPackage ../applications/networking/browsers/decentr { };
+
   dfasma = libsForQt5.callPackage ../applications/audio/dfasma { };
 
   dfilemanager = libsForQt5.callPackage ../applications/misc/dfilemanager { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
