### PR TITLE
tarsnap: 1.0.39 -> 1.0.40

### DIFF
--- a/pkgs/tools/backup/tarsnap/default.nix
+++ b/pkgs/tools/backup/tarsnap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openssl, zlib, e2fsprogs }:
+{ lib, stdenv, fetchurl, openssl, zlib, e2fsprogs, getconf }:
 
 let
   zshCompletion = fetchurl {
@@ -8,15 +8,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "tarsnap";
-  version = "1.0.39";
+  version = "1.0.40";
 
   src = fetchurl {
     url = "https://www.tarsnap.com/download/tarsnap-autoconf-${version}.tgz";
-    sha256 = "10i0whbmb345l2ggnf4vs66qjcyf6hmlr8f4nqqcfq0h5a5j24sn";
+    sha256 = "vMrlOAwcHWviXcz7fC6qg2S6NAGq+u5h48VXQgPCf9U=";
   };
 
   preConfigure = ''
-    configureFlags="--with-bash-completion-dir=$out/share/bash-completion/completions"
+    configureFlags="--with-bash-completion-dir=$out/share/bash-completion/completions POSIX_SH=${stdenv.shell}"
   '';
 
   patchPhase = ''
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     install -m 444 -D ${zshCompletion} $out/share/zsh/site-functions/_tarsnap
   '';
 
-  buildInputs = [ openssl zlib ] ++ lib.optional stdenv.isLinux e2fsprogs ;
+  buildInputs = [ openssl zlib getconf ] ++ lib.optional stdenv.isLinux e2fsprogs ;
 
   meta = {
     description = "Online backups for the truly paranoid";


### PR DESCRIPTION
###### Motivation for this change

Upgrade tarsnap to the latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @thoughtpolice @roconnor 