### PR TITLE
guile_3_0: 3.0.7 -> 3.0.8

### DIFF
--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -83,9 +83,9 @@ builder rec {
   # Explicitly link against libgcc_s, to work around the infamous
   # "libgcc_s.so.1 must be installed for pthread_cancel to work".
 
-  # don't have "libgcc_s.so.1" on darwin
+  # don't have "libgcc_s.so.1" on clang
   LDFLAGS = lib.optionalString
-    (!stdenv.isDarwin && !stdenv.hostPlatform.isStatic) "-lgcc_s";
+    (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) "-lgcc_s";
 
   configureFlags = [
     "--with-libreadline-prefix=${lib.getDev readline}"

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -82,9 +82,9 @@ builder rec {
   # Explicitly link against libgcc_s, to work around the infamous
   # "libgcc_s.so.1 must be installed for pthread_cancel to work".
 
-  # don't have "libgcc_s.so.1" on darwin
+  # don't have "libgcc_s.so.1" on clang
   LDFLAGS = lib.optionalString
-    (!stdenv.isDarwin && !stdenv.hostPlatform.isStatic) "-lgcc_s";
+    (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) "-lgcc_s";
 
   configureFlags = [
     "--with-libreadline-prefix=${lib.getDev readline}"

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -14,6 +14,7 @@
 , pkg-config
 , pkgsBuildBuild
 , readline
+, writeScript
 }:
 
 let
@@ -24,11 +25,11 @@ let
 in
 builder rec {
   pname = "guile";
-  version = "3.0.7";
+  version = "3.0.8";
 
   src = fetchurl {
     url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-9X2GxwYgJxv863qb4MgXRKAz8IrcfOuoMsmRerPmkbc=";
+    sha256 = "sha256-2qcGClbygE6bdMjX5/6L7tErQ6qyeJo4WFGD/MF7ihM=";
   };
 
   outputs = [ "out" "dev" "info" ];
@@ -102,7 +103,10 @@ builder rec {
   ]
   # Disable JIT on Apple Silicon, as it is not yet supported
   # https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44505";
-  ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) "--enable-jit=no";
+  ++ lib.optional (stdenv.isDarwin && stdenv.isAarch64) "--enable-jit=no"
+  # At least on x86_64-darwin '-flto' autodetection is not correct:
+  #  https://github.com/NixOS/nixpkgs/pull/160051#issuecomment-1046193028
+  ++ lib.optional (stdenv.isDarwin) "--disable-lto";
 
   postInstall = ''
     wrapProgram $out/bin/guile-snarf --prefix PATH : "${gawk}/bin"
@@ -125,6 +129,20 @@ builder rec {
   doInstallCheck = doCheck;
 
   setupHook = ./setup-hook-3.0.sh;
+
+  passthru = {
+    updateScript = writeScript "update-guile-3" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl pcre common-updater-scripts
+
+      set -eu -o pipefail
+
+      # Expect the text in format of '"https://ftp.gnu.org/gnu/guile/guile-3.0.8.tar.gz"'
+      new_version="$(curl -s https://www.gnu.org/software/guile/download/ |
+          pcregrep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
+      update-source-version ${pname} "$new_version"
+    '';
+  };
 
   meta = with lib; {
     homepage = "https://www.gnu.org/software/guile/";


### PR DESCRIPTION
While at it added trivial updater script.

Changes: https://git.savannah.gnu.org/cgit/guile.git/tree/NEWS?h=v3.0.8#n8

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
