### PR TITLE
flake: add Nixpkgs default arguments as input

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -14,6 +14,8 @@ Note that all this is checked during evaluation already, and the check includes 
 
 Each of these criteria can be altered in the nixpkgs configuration.
 
+## Configure Nixpkgs for NixOS {#sec-configure-nixpkgs-for-nixos}
+
 The nixpkgs configuration for a NixOS system is set in the `configuration.nix`, as in the following example:
 
 ```nix
@@ -23,6 +25,8 @@ The nixpkgs configuration for a NixOS system is set in the `configuration.nix`, 
   };
 }
 ```
+
+## Configure user-invoked Nixpkgs {#sec-configure-nixpkgs-for-user}
 
 However, this does not allow unfree software for individual users. Their configurations are managed separately.
 

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -19,7 +19,7 @@ The nixpkgs configuration for a NixOS system is set in the `configuration.nix`, 
 ```nix
 {
   nixpkgs.config = {
-    allowUnfree = true;
+    allowBroken = true;
   };
 }
 ```
@@ -30,11 +30,9 @@ A user's nixpkgs configuration is stored in a user-specific configuration file l
 
 ```nix
 {
-  allowUnfree = true;
+  allowBroken = true;
 }
 ```
-
-Note that we are not able to test or build unfree software on Hydra due to policy. Most unfree licenses prohibit us from either executing or distributing the software.
 
 ## Installing broken packages {#sec-allow-broken}
 
@@ -77,12 +75,22 @@ The difference between a package being unsupported on some system and being brok
 
 ## Installing unfree packages {#sec-allow-unfree}
 
+Note that we are not able to test or build unfree software on Hydra due to policy. Most unfree licenses prohibit us from either executing or distributing the software.
+
 There are several ways to tweak how Nix handles a package which has been marked as unfree.
 
 -   To temporarily allow all unfree packages, you can use an environment variable for a single invocation of the nix tools:
 
     ```ShellSession
     $ export NIXPKGS_ALLOW_UNFREE=1
+    ```
+
+-   To allow all unfree software to be used, add to the Nixpkgs configuration:
+
+     ```nix
+    {
+      allowUnfree = true;
+    }
     ```
 
 -   It is possible to permanently allow individual unfree packages, while still blocking unfree packages by default using the `allowUnfreePredicate` configuration option in the user configuration file.

--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -38,6 +38,43 @@ A user's nixpkgs configuration is stored in a user-specific configuration file l
 }
 ```
 
+## Configure with Flakes {#sec-configure-with-flakes}
+
+Users of the experimental Flakes feature, can set arguments using the `parameters` input. This is an input to the `nixpkgs` flake, which must provide the attribute `lib.pkgsParameters`.
+
+First, create a subflake; a flake in a subdirectory.
+
+```nix
+# ./nixpkgs-parameters/flake.nix
+{
+  description = "Parameters for Nixpkgs";
+  outputs = { self }: {
+    lib.pkgsParameters = {
+      overlays = [ ];
+      buildSystem = null; # same as host system
+      config = {
+        allowBroken = true;
+      };
+    };
+  };
+}
+```
+
+Then, inject it into nixpkgs with `follows`.
+
+```nix
+# ./flake.nix (section)
+{
+  inputs.nixpkgs.inputs.parameters.follows = "parameters";
+  inputs.parameters.url = "./nixpkgs-parameters";
+
+  outputs = { nixpkgs, ... }:
+    {
+      # ...
+    };
+}
+```
+
 ## Installing broken packages {#sec-allow-broken}
 
 There are two ways to try compiling a package which has been marked as broken.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "parameters": {
+      "locked": {
+        "lastModified": 1644876547,
+        "narHash": "sha256-dpWwv62R4LEBMc5VjYY5MN+wVsjLZ9O66y0CvRQ/IjQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2a1aaaa410c07b8e195e30c457cc20b83f0c60a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "default-parameters",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "parameters": "parameters"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Actually solve the problem of `nixpkgs.config` in a flake, and more.

Flakes are just functional programming with default arguments. The fact that everything has a default might throw you off, but it's still functional programming, where `follows` is apply. Enjoy!

Here's a flake producing `skype` from `legacyPackages` without the unfree error:

`flake.nix`
```nix
{
  description = "A very basic flake";

  inputs.nixpkgs.url = "github:hercules-ci/nixpkgs/add-flake-default-arguments-as-input";
  inputs.nixpkgs.inputs.parameters.follows = "parameters";
  inputs.parameters.url = "./parameters";

  outputs = { self, nixpkgs, ... }: {

    packages.x86_64-linux.skype = nixpkgs.legacyPackages.x86_64-linux.skype;

    defaultPackage.x86_64-linux = self.packages.x86_64-linux.skype;

  };
}
```

`parameters/flake.nix`
```nix
{
  outputs = { self }: {
    lib.pkgsParameters = {
      overlays = [ ];
      buildSystem = null; # same as host system
      config = {
        allowUnfree = true;
      };
    };
  };
}
```

Refs

- https://github.com/NixOS/nixpkgs/issues/158740
- https://github.com/NixOS/nixpkgs/issues/109421
- https://github.com/NixOS/nixpkgs/pull/117842
- https://github.com/NixOS/nixpkgs/issues/101101
- https://github.com/NixOS/nixpkgs/pull/101367

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
