### PR TITLE
comixcursors: init at 0.9.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2903,6 +2903,12 @@
     githubId = 19733;
     name = "Moritz Heidkamp";
   };
+  DerickEddington = {
+    email = "derick.eddington@pm.me";
+    github = "DerickEddington";
+    githubId = 4731128;
+    name = "Derick Eddington";
+  };
   dermetfan = {
     email = "serverkorken@gmail.com";
     github = "dermetfan";

--- a/pkgs/data/icons/comixcursors/default.nix
+++ b/pkgs/data/icons/comixcursors/default.nix
@@ -1,0 +1,125 @@
+{ lib, stdenv, fetchFromGitLab, bc, librsvg, xcursorgen }:
+
+let
+  dimensions = {
+    color = [ "Black" "Blue" "Green" "Orange" "Red" "White" ];
+    opacity = [ "" "Opaque_" ];  # Translucent or opaque.
+    thickness = [ "" "Slim_" ];  # Thick or slim edges.
+    handedness = [ "" "LH_" ];   # Right- or left-handed.
+  };
+  product = lib.cartesianProductOfSets dimensions;
+  variantName =
+    { color, opacity, thickness, handedness }:
+    "${handedness}${opacity}${thickness}${color}";
+  variants =
+    # (The order of this list is already good looking enough to show in the
+    # meta.longDescription.)
+    map variantName product;
+in
+stdenv.mkDerivation rec {
+  pname = "comixcursors";
+  version = "0.9.2";
+
+  src = fetchFromGitLab {
+    owner = "limitland";
+    repo = "comixcursors";
+    # https://gitlab.com/limitland/comixcursors/-/issues/3
+    rev = "8c327c8514ab3a352583605c1ddcb7eb3d1d302b";
+    sha256 = "0bpxqw4izj7m0zb9lnxnmsjicfw60ppkdyv5nwrrz4x865wb296a";
+  };
+
+  nativeBuildInputs = [ bc librsvg xcursorgen ];
+
+  patches = [ ./makefile-shell-var.patch ];
+
+  postPatch = ''
+    patchShebangs ./install-all ./bin/
+  '';
+
+  # install-all is used instead of the directions in upstream's INSTALL file,
+  # because using its Makefile directly is broken.  Upstream itself seems to use
+  # its build-distribution script instead, which also uses install-all, but we
+  # do not use it because it does extra things for other distros.
+  #
+  # When not all of the variants, i.e. only a smaller subset of them, are
+  # desired (i.e. when a subset of outputs are chosen), install-all will still
+  # build all of them.  While upstream appears to provide old functionality for
+  # building only a subset, it is broken and we do not use it.  With prebuilt
+  # substitutions, installers of this package will get only the outputs they
+  # chose.
+  buildPhase = ''
+    ICONSDIR=$TMP/staged ./install-all
+  '';
+
+  installPhase = ''
+    for outputName in $outputs ; do
+      if [ $outputName != out ]; then
+        local outputDir=''${!outputName};
+        local iconsDir=$outputDir/share/icons
+        local cursorName=$(tr _ - <<<"$outputName")
+
+        mkdir -p $iconsDir
+        cp -r -d $TMP/staged/ComixCursors-$cursorName $iconsDir
+
+        unset outputDir iconsDir cursorName
+      fi
+    done
+
+    # Need this directory (empty) to prevent the builder scripts from breaking.
+    mkdir -p $out
+  '';
+
+  outputs = let
+    default = "Opaque_Black";
+  in
+    # Have the most-traditional variant be the default output (as the first).
+    # Even with outputsToInstall=[], the default/first still has an effect on
+    # some Nix tools (e.g. nix-build).
+    [ default ] ++ (lib.remove default variants)
+    # Need a dummy "out" output to prevent the builder scripts from breaking.
+    ++ [ "out" ];
+
+  # No default output (to the extent possible).  Instead, the outputs'
+  # attributes are used to choose which variant(s) to have.
+  outputsToInstall = [];
+
+  meta = with lib; {
+    description = "The Comix Cursors mouse themes";
+    longDescription = ''
+      There are many (${toString ((length outputs) - 1)}) variants of color,
+      opacity, edge thickness, and right- or left-handedness, for this cursor
+      theme.  This package's derivation has an output for each of these
+      variants, named following the upstream convention, and the attribute for
+      an output must be used to install a variant.  E.g.:
+      <programlisting language="nix">
+      environment.systemPackages = [
+        comixcursors.Blue
+        comixcursors.Opaque_Orange
+        comixcursors.Slim_Red
+        comixcursors.Opaque_Slim_White
+        comixcursors.LH_Green
+        comixcursors.LH_Opaque_Black
+        comixcursors.LH_Slim_Orange
+        comixcursors.LH_Opaque_Slim_Blue
+      ];
+      </programlisting>
+
+      Attempting to use just <literal>comixcursors</literal>, i.e. without an
+      output attribute, will not install any variants.  To install all the
+      variants, use <literal>comixcursors.all</literal> (which is a list), e.g.:
+      <programlisting language="nix">
+      environment.systemPackages = comixcursors.all ++ [...];
+      </programlisting>
+
+      The complete list of output attributes is:
+      <programlisting>
+      ${concatStringsSep "\n" variants}
+      </programlisting>
+    '';
+    homepage = "https://gitlab.com/limitland/comixcursors";
+    changelog = "https://gitlab.com/limitland/comixcursors/-/blob/HEAD/NEWS";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.DerickEddington ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/data/icons/comixcursors/makefile-shell-var.patch
+++ b/pkgs/data/icons/comixcursors/makefile-shell-var.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -22,8 +22,6 @@
+ 
+ # Makefile for ComixCursors project.
+ 
+-SHELL = /bin/bash
+-
+ CURSORSNAME = ComixCursors
+ PACKAGENAME ?= ${CURSORSNAME}
+ SUMMARY ?= The original Comix Cursors

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23444,6 +23444,8 @@ with pkgs;
 
   comic-relief = callPackage ../data/fonts/comic-relief {};
 
+  comixcursors = callPackage ../data/icons/comixcursors {};
+
   coreclr = callPackage ../development/compilers/coreclr { };
 
   corefonts = callPackage ../data/fonts/corefonts { };


### PR DESCRIPTION
###### Motivation for this change

To have the Comix Cursors mouse theme, since it was not in `nixpkgs`.  Other distros have provided it for a long time, and some people and I like to use it.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
- Tested, as applicable:
  - [X] `nix-build -K -A comixcursors.all` (and other output variants)
  - [X] `nixos-rebuild build -I nixpkgs=$MY/nixpkgs -I nixos-config=$MY/nixos-config/configuration.nix --fast`
  - [X] I've been [using a variety of the variants on NixOS](https://github.com/DerickEddington/nixos-config/blob/f28d88c1e63daa946e6d87c8ee7f4d7ed6b6aad3/configuration.nix#L148-L154) for some months.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] Release notes changes.  (Seems unnecessary for only adding this new simple package.)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

##### Notes

###### Many outputs: one per cursor variant

I designed this package to have a separate output for each variant (color * opacity * thickness * handedness) of the cursors, because there are so many variants (48) and installing them all is over 100 MiB, and some users (e.g. [myself](https://github.com/DerickEddington/nixos-config/blob/f28d88c1e63daa946e6d87c8ee7f4d7ed6b6aad3/configuration.nix#L162-L168)) will only want a smaller subset of them.  I also designed it to **not** install a default output, because there is not a variant that is the obvious default.  I documented these aspects in `meta.longDescription`, and I wrote comments in the package's source about them.

This design causes usage like `environment.systemPackages = [pkgs.comixcursors]` (i.e. no output attribute) to not install any variant.  It is required to instead use the output attributes like `pkgs.comixcursors.Blue`.  But usage like `nix-build -A comixcursors` (again, no output attribute) does use the first output as an assumed default (which I made be the basic black variant).

I think it makes sense to have these separate outputs of the single package, because building the upstream source builds all the variants together.  I figured this design is not an issue because NixOS's prebuilt binary substitutions system will be building them all anyway and users will get only the particular substitutions for the subset of outputs they choose to install.

###### All platforms

I defined `meta.platforms = lib.platforms.all` because this package installs only data files of cursors, which hypothetically could be of interest with non-unix platforms for some users, even though the cursors are intended for the X Window System (or maybe only for X.Org).  The set of installed files contains some symlinks (to other files within a same directory), and I don't know if that would be a problem for non-unix platforms as handled by Nix.