### PR TITLE
apparmor: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, makeWrapper, autoreconfHook
+{ stdenv, lib, fetchFromGitLab, fetchpatch, makeWrapper, autoreconfHook
 , pkg-config, which
 , flex, bison
 , linuxHeaders ? stdenv.cc.libc.linuxHeaders
@@ -21,7 +21,7 @@
 }:
 
 let
-  apparmor-version = "3.0.3";
+  apparmor-version = "3.0.4";
 
   apparmor-meta = component: with lib; {
     homepage = "https://apparmor.net/";
@@ -31,9 +31,11 @@ let
     platforms = platforms.linux;
   };
 
-  apparmor-sources = fetchurl {
-    url = "https://launchpad.net/apparmor/${lib.versions.majorMinor apparmor-version}/${apparmor-version}/+download/apparmor-${apparmor-version}.tar.gz";
-    sha256 = "0nasq8pdmzkrf856yg1v8z5hcs0nn6gw2qr60ab0a7j9ixfv0g8m";
+  apparmor-sources = fetchFromGitLab {
+    owner = "apparmor";
+    repo = "apparmor";
+    rev = "v${apparmor-version}";
+    sha256 = "1a217j28rgfq4lsmpn0wv1xgmdr9ba8iysv9i6q477kj6z77zrb9";
   };
 
   aa-teardown = writeShellScript "aa-teardown" ''
@@ -48,8 +50,9 @@ let
     substituteInPlace ./common/Make.rules \
       --replace "/usr/bin/pod2man" "${buildPackages.perl}/bin/pod2man" \
       --replace "/usr/bin/pod2html" "${buildPackages.perl}/bin/pod2html" \
-      --replace "/usr/include/linux/capability.h" "${linuxHeaders}/include/linux/capability.h" \
       --replace "/usr/share/man" "share/man"
+    substituteInPlace ./utils/Makefile \
+      --replace "/usr/include/linux/capability.h" "${linuxHeaders}/include/linux/capability.h"
   '';
 
   patches = lib.optionals stdenv.hostPlatform.isMusl [
@@ -59,6 +62,8 @@ let
       sha256 = "0yyaqz8jlmn1bm37arggprqz0njb4lhjni2d9c8qfqj0kll0bam0";
     })
   ];
+
+  python = python3.withPackages (ps: with ps; [ setuptools ]);
 
   # Set to `true` after the next FIXME gets fixed or this gets some
   # common derivation infra. Too much copy-paste to fix one by one.
@@ -86,19 +91,16 @@ let
       ncurses
       which
       perl
-    ] ++ lib.optional withPython python3;
+    ] ++ lib.optional withPython python;
 
     buildInputs = lib.optional withPerl perl
-      ++ lib.optional withPython python3;
+      ++ lib.optional withPython python;
 
     # required to build apparmor-parser
     dontDisableStatic = true;
 
     prePatch = prePatchCommon + ''
       substituteInPlace ./libraries/libapparmor/swig/perl/Makefile.am --replace install_vendor install_site
-      substituteInPlace ./libraries/libapparmor/swig/perl/Makefile.in --replace install_vendor install_site
-      substituteInPlace ./libraries/libapparmor/src/Makefile.am --replace "/usr/include/netinet/in.h" "${lib.getDev stdenv.cc.libc}/include/netinet/in.h"
-      substituteInPlace ./libraries/libapparmor/src/Makefile.in --replace "/usr/include/netinet/in.h" "${lib.getDev stdenv.cc.libc}/include/netinet/in.h"
     '';
     inherit patches;
 
@@ -132,12 +134,12 @@ let
 
     strictDeps = true;
 
-    nativeBuildInputs = [ makeWrapper which python3 ];
+    nativeBuildInputs = [ makeWrapper which python ];
 
     buildInputs = [
       bash
       perl
-      python3
+      python
       libapparmor
       libapparmor.python
     ];
@@ -159,7 +161,7 @@ let
     postInstall = ''
       sed -i $out/bin/aa-unconfined -e "/my_env\['PATH'\]/d"
       for prog in aa-audit aa-autodep aa-cleanprof aa-complain aa-disable aa-enforce aa-genprof aa-logprof aa-mergeprof aa-unconfined ; do
-        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
+        wrapProgram $out/bin/$prog --prefix PYTHONPATH : "$out/lib/${python.libPrefix}/site-packages:$PYTHONPATH"
       done
 
       substituteInPlace $out/bin/aa-notify \


### PR DESCRIPTION
###### Motivation for this change


###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
