### PR TITLE
virt-viewer: 9.0 -> 11; libgovirt: init at 0.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -601,6 +601,12 @@
     githubId = 15623522;
     name = "Amar Paul";
   };
+  amarshall = {
+    email = "andrew@johnandrewmarshall.com";
+    github = "amarshall";
+    githubId = 153175;
+    name = "Andrew Marshall";
+  };
   ambroisie = {
     email = "bruno.nixpkgs@belanyi.fr";
     github = "ambroisie";

--- a/pkgs/applications/virtualization/libgovirt/default.nix
+++ b/pkgs/applications/virtualization/libgovirt/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, stdenv
+, fetchurl
+, glib
+, librest
+, libsoup
+, pkg-config
+}:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  pname = "libgovirt";
+  version = "0.3.8";
+
+  src = fetchurl {
+    url = "https://download.gnome.org/sources/libgovirt/0.3/${pname}-${version}.tar.xz";
+    sha256 = "sha256-HckYYikXa9+p8l/Y+oLAoFi2pgwcyAfHUH7IqTwPHfg=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  propagatedBuildInputs = [
+    librest
+    libsoup
+  ];
+
+  meta = {
+    homepage = "https://gitlab.gnome.org/GNOME/libgovirt";
+    description = "GObject wrapper for the oVirt REST API";
+    maintainers = [ maintainers.amarshall ];
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+  };
+}

--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, bash-completion
 , fetchurl
 , gdbm ? null
 , glib
@@ -8,10 +9,14 @@
 , gtk3
 , intltool
 , libcap ? null
+, libgovirt
 , libvirt
 , libvirt-glib
 , libxml2
+, meson
+, ninja
 , pkg-config
+, python3
 , shared-mime-info
 , spice-gtk ? null
 , spice-protocol ? null
@@ -31,27 +36,32 @@ with lib;
 
 stdenv.mkDerivation rec {
   baseName = "virt-viewer";
-  version = "9.0";
+  version = "11.0";
   name = "${baseName}-${version}";
 
   src = fetchurl {
-    url = "http://virt-manager.org/download/sources/${baseName}/${name}.tar.gz";
-    sha256 = "09a83mzyn3b4nd7wpa659g1zf1fjbzb79rk968bz6k5xl21k7d4i";
+    url = "http://virt-manager.org/download/sources/${baseName}/${name}.tar.xz";
+    sha256 = "sha256-pD+iMlxMHHelyMmAZaww7wURohrJjlkPIjQIabrZq9A=";
   };
 
   nativeBuildInputs = [
     glib
     intltool
+    meson
+    ninja
     pkg-config
+    python3
     shared-mime-info
     wrapGAppsHook
   ];
 
   buildInputs = [
+    bash-completion
     glib
     gsettings-desktop-schemas
     gtk-vnc
     gtk3
+    libgovirt
     libvirt
     libvirt-glib
     libxml2
@@ -67,7 +77,10 @@ stdenv.mkDerivation rec {
   propagatedUserEnvPkgs = optional spiceSupport spice-gtk;
 
   strictDeps = true;
-  enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs build-aux/post_install.py
+  '';
 
   meta = {
     description = "A viewer for remote virtual machines";

--- a/pkgs/applications/virtualization/virt-viewer/default.nix
+++ b/pkgs/applications/virtualization/virt-viewer/default.nix
@@ -1,11 +1,31 @@
-{ lib, stdenv, fetchurl, pkg-config, intltool, shared-mime-info, wrapGAppsHook
-, glib, gsettings-desktop-schemas, gtk-vnc, gtk3, libvirt, libvirt-glib, libxml2, vte
+{ lib
+, stdenv
+, fetchurl
+, gdbm ? null
+, glib
+, gsettings-desktop-schemas
+, gtk-vnc
+, gtk3
+, intltool
+, libcap ? null
+, libvirt
+, libvirt-glib
+, libxml2
+, pkg-config
+, shared-mime-info
+, spice-gtk ? null
+, spice-protocol ? null
 , spiceSupport ? true
-, spice-gtk ? null, spice-protocol ? null, libcap ? null, gdbm ? null
+, vte
+, wrapGAppsHook
 }:
 
-assert spiceSupport ->
-  spice-gtk != null && spice-protocol != null && libcap != null && gdbm != null;
+assert spiceSupport -> (
+  gdbm != null
+  && libcap != null
+  && spice-gtk != null
+  && spice-protocol != null
+);
 
 with lib;
 
@@ -19,11 +39,28 @@ stdenv.mkDerivation rec {
     sha256 = "09a83mzyn3b4nd7wpa659g1zf1fjbzb79rk968bz6k5xl21k7d4i";
   };
 
-  nativeBuildInputs = [ pkg-config intltool shared-mime-info wrapGAppsHook glib ];
+  nativeBuildInputs = [
+    glib
+    intltool
+    pkg-config
+    shared-mime-info
+    wrapGAppsHook
+  ];
+
   buildInputs = [
-    glib gsettings-desktop-schemas gtk-vnc gtk3 libvirt libvirt-glib libxml2 vte
+    glib
+    gsettings-desktop-schemas
+    gtk-vnc
+    gtk3
+    libvirt
+    libvirt-glib
+    libxml2
+    vte
   ] ++ optionals spiceSupport [
-    spice-gtk spice-protocol libcap gdbm
+    gdbm
+    libcap
+    spice-gtk
+    spice-protocol
   ];
 
   # Required for USB redirection PolicyKit rules file

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7052,6 +7052,8 @@ with pkgs;
 
   libcsptr = callPackage ../development/libraries/libcsptr { };
 
+  libgovirt = callPackage ../applications/virtualization/libgovirt { };
+
   libscrypt = callPackage ../development/libraries/libscrypt { };
 
   libcloudproviders = callPackage ../development/libraries/libcloudproviders { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update virt-viewer to latest, add missing package for dependency of said newer version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
