### PR TITLE
swaytools: init at 0.1.0

### DIFF
--- a/pkgs/tools/wayland/swaytools/default.nix
+++ b/pkgs/tools/wayland/swaytools/default.nix
@@ -1,0 +1,22 @@
+{ lib, python3Packages, slurp }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "swaytools";
+  version = "0.1.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1eb89259cbe027a0fa6bfc06ecf94e89b15e6f7b4965104e5b661c916ce7408c";
+  };
+
+  propagatedBuildInputs = [ slurp ];
+
+  passthru.updateScript = ./update.py;
+
+  meta = with lib; {
+    homepage = "https://github.com/tmccombs/swaytools";
+    description = "Collection of simple tools for sway (and i3)";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/tools/wayland/swaytools/update.py
+++ b/pkgs/tools/wayland/swaytools/update.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p python39Packages.requests python39Packages.pip python39Packages.packaging
+
+import requests
+import json
+import subprocess
+try:
+    from packaging.version import parse
+except ImportError:
+    from pip._vendor.packaging.version import parse
+
+
+URL_PATTERN = 'https://pypi.python.org/pypi/{package}/json'
+
+def findLine(key,derivation):
+    count = 0
+    lines = []
+    for line in derivation:
+        if key in line:
+            lines.append(count)
+        count += 1
+    return lines
+
+def get_version(package, url_pattern=URL_PATTERN):
+    """Return version of package on pypi.python.org using json."""
+    req = requests.get(url_pattern.format(package=package))
+    version = parse('0')
+    if req.status_code == requests.codes.ok:
+        j = json.loads(req.text.encode(req.encoding))
+        releases = j.get('releases', [])
+        for release in releases:
+            ver = parse(release)
+            if not ver.is_prerelease:
+                if ver > version:
+                    version = ver
+                    sha256  = j["releases"][release][-1]["digests"]["sha256"]
+    return version, sha256
+
+
+if __name__ == '__main__':
+
+    nixpkgs         = subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").strip('\n')
+    swaytoolsFolder = "/pkgs/tools/wayland/swaytools/"
+    with open(nixpkgs + swaytoolsFolder + "default.nix", 'r') as arq:
+        derivation = arq.readlines()
+
+    version, sha256 = get_version('swaytools')
+
+    key = "version = "
+    line = findLine(key,derivation)[0]
+    derivation[line] = f'  version = "{version}";\n'
+
+    key = "sha256 = "
+    line = findLine(key,derivation)[0]
+    derivation[line] = f'    sha256 = "{sha256}";\n'
+
+    with open(nixpkgs + swaytoolsFolder + "default.nix", 'w') as arq:
+        arq.writelines(derivation)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2642,6 +2642,8 @@ with pkgs;
 
   swayr = callPackage ../tools/wayland/swayr { };
 
+  swaytools = callPackage ../tools/wayland/swaytools { };
+
   wayland-utils = callPackage ../tools/wayland/wayland-utils { };
 
   wayland-proxy-virtwl = callPackage ../tools/wayland/wayland-proxy-virtwl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I use swaywm a lot, and sometimes I need to find out metadata relating to an open window, like app_id, pid of its process and things like that. Swaytools has a tool that does exactly that so I wrote a derivation to it so more people can also use it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
