### PR TITLE
xrootd: init at 5.4.0

### DIFF
--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, callPackage
+, fetchFromGitHub
+, cmake
+, cppunit
+, curl
+, fuse
+, libkrb5
+, libuuid
+, libxml2
+, openssl
+, pkg-config
+, readline
+, systemd
+, zlib
+, enableTests ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xrootd";
+  version = "5.4.0";
+
+  src = fetchFromGitHub {
+    owner = "xrootd";
+    repo = "xrootd";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "A2yUz2KhuRBoo5lMpZwPLNCJlYQXqsZSBR+Knj+gWAk=";
+  };
+
+  outputs = [ "bin" "out" "dev" "man" ];
+
+  passthru.tests = lib.optionalAttrs enableTests {
+    test-runner = callPackage ./test-runner.nix { };
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    libkrb5
+    libuuid
+    libxml2
+    openssl
+    readline
+    zlib
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    fuse
+    systemd
+  ]
+  ++ lib.optionals enableTests [
+    cppunit
+  ];
+
+  preConfigure = ''
+    patchShebangs genversion.sh
+
+    # Manually apply part of
+    # https://github.com/xrootd/xrootd/pull/1619
+    # Remove after the above PR is merged.
+    sed -i 's/set\((\s*CMAKE_INSTALL_[A-Z_]\+DIR\s\+"[^"]\+"\s*)\)/define_default\1/g' cmake/XRootDOSDefs.cmake
+  '';
+
+  cmakeFlags = lib.optionals enableTests [
+    "-DENABLE_TESTS=TRUE"
+  ];
+
+  meta = with lib; {
+    description = "High performance, scalable fault tolerant data access";
+    homepage = "https://xrootd.slac.stanford.edu";
+    license = licenses.lgpl3Plus;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/tools/networking/xrootd/test-runner.nix
+++ b/pkgs/tools/networking/xrootd/test-runner.nix
@@ -1,0 +1,27 @@
+{ lib
+, runCommand
+, xrootd
+}:
+
+# These tests are specified in the test procedure of the upstream CD:
+# https://github.com/xrootd/xrootd/blob/master/.github/workflows/build.yml#L90-L98
+runCommand "${xrootd.pname}-run-tests-${xrootd.version}" {
+  testRunnerPath = "${xrootd}/bin/test-runner";
+  testLibraries = [ "XrdClTests" ];
+  XrdClTestsSuites = [ "UtilsTest" "SocketTest" "PollerTest" ];
+  pname = "${xrootd.pname}-run-tests";
+  inherit (xrootd) version;
+  meta.mainProgram = "test-runner";
+} ''
+  for testLibrary in $testLibraries; do
+    echo "Testing $testLibrary"
+    testLibraryPath="${xrootd.out}/lib/lib''${testLibrary}.so"
+    testsuiteVarname="''${testLibrary}Suites"
+    for testsuite in ''${!testsuiteVarname}; do
+      echo "Doing test $testsuite"
+      "$testRunnerPath" "$testLibraryPath" "All Tests/$testsuite/"
+    done
+  done
+  mkdir -p "$out/bin"
+  ln -s "$testRunnerPath" "$out/bin/test-runner"
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1083,6 +1083,8 @@ with pkgs;
 
   xcd = callPackage ../tools/misc/xcd { };
 
+  xrootd = callPackage ../tools/networking/xrootd { };
+
   xtrt = callPackage ../tools/archivers/xtrt { };
 
   yabridge = callPackage ../tools/audio/yabridge {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
XRootD is a commonly-used data protocol for the high-energy physics, and a missing dependency for ROOT, gfal2, etc..

Cc: @veprbl 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
