### PR TITLE
dupeguru: 4.0.4 -> 4.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8910,9 +8910,9 @@
     githubId = 2946283;
     name = "Brian Cohen";
   };
-  novoxudonoser = {
+  novoxd = {
     email = "radnovox@gmail.com";
-    github = "novoxudonoser";
+    github = "novoxd";
     githubId = 6052922;
     name = "Kirill Struokov";
   };

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -1,8 +1,8 @@
-{lib, python3Packages, fetchpatch, gettext, qt5, fetchFromGitHub}:
+{lib, python3Packages, gettext, qt5, fetchFromGitHub}:
 
 python3Packages.buildPythonApplication rec {
   pname = "dupeguru";
-  version = "4.0.4";
+  version = "4.1.1";
 
   format = "other";
 
@@ -10,18 +10,9 @@ python3Packages.buildPythonApplication rec {
     owner = "arsenetar";
     repo = "dupeguru";
     rev = version;
-    sha256 = "0ma4f1c6vmpz8gi4sdy43x1ik7wh42wayvk1iq520d3i714kfcpy";
+    sha256 = "sha256-0lJocrNQHTrpslbPE6xjZDWhzza8cAt2js35LvicZKg=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # already merged to master, remove next version bump
-    (fetchpatch {
-      name = "remove-m-from-so-var.patch";
-      url = "https://github.com/arsenetar/dupeguru/commit/bd0f53bcbe463c48fe141b73af13542da36d82ba.patch";
-      sha256 = "07iisz8kcr7v8lb21inzj1avlpfhh9k8wcivbd33w49cr3mmnr26";
-    })
-  ];
 
   nativeBuildInputs = [
     gettext
@@ -31,6 +22,7 @@ python3Packages.buildPythonApplication rec {
 
   pythonPath = with python3Packages; [
     pyqt5
+    pyqt5.pyqt5_sip
     send2trash
     sphinx
     polib
@@ -42,9 +34,12 @@ python3Packages.buildPythonApplication rec {
     "NO_VENV=1"
   ];
 
-  # TODO: package pytest-monkeyplus for running tests
-  # https://github.com/NixOS/nixpkgs/pull/75054/files#r357690123
-  doCheck = false;
+  checkInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
 
   # Avoid double wrapping Python programs.
   dontWrapQtApps = true;

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -61,6 +61,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/arsenetar/dupeguru";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = [ maintainers.novoxudonoser ];
+    maintainers = [ maintainers.novoxd ];
   };
 }

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -88,7 +88,7 @@ in buildPythonPackage rec {
   ];
 
   passthru = {
-    inherit sip;
+    inherit sip pyqt5_sip;
     multimediaEnabled = withMultimedia;
     webKitEnabled = withWebKit;
     WebSocketsEnabled = withWebSockets;


### PR DESCRIPTION
###### Motivation for this change

Fix #120203 . cc @dschrempf .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
