### PR TITLE
gnuradio related updates

### DIFF
--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -7,9 +7,9 @@
 , gtest
 , openssl
 , gflags
-, gnuradio3_8
+, gnuradio
 , thrift
-, libpcap
+, enableRawUdp ? true, libpcap
 , orc
 , pkg-config
 , blas, lapack
@@ -18,65 +18,86 @@
 , protobuf
 }:
 
-gnuradio3_8.pkgs.mkDerivation rec {
+gnuradio.pkgs.mkDerivation rec {
   pname = "gnss-sdr";
-  # There's an issue with cpufeatures on 0.0.15, see:
-  # https://github.com/NixOS/nixpkgs/pull/142557#issuecomment-950217925
-  version = "0.0.13";
+  version = "0.0.16";
 
   src = fetchFromGitHub {
     owner = "gnss-sdr";
     repo = "gnss-sdr";
     rev = "v${version}";
-    sha256 = "0a3k47fl5dizzhbqbrbmckl636lznyjby2d2nz6fz21637hvrnby";
+    sha256 = "sha256-ODe4k6PDGtDX11FrbggEbN3tc4UtATaItUIpCKl4JjM=";
   };
+
+  patches = [
+    # Use the relative install location for volk_gnsssdr_module and
+    # cpu_features which is bundled in the source. NOTE: Perhaps this patch
+    # should be sent upstream.
+    ./fix_libcpu_features_install_path.patch
+  ];
 
   nativeBuildInputs = [
     cmake
-    gnuradio3_8.unwrapped.python
-    gnuradio3_8.unwrapped.python.pkgs.Mako
-    gnuradio3_8.unwrapped.python.pkgs.six
+    pkg-config
+    gnuradio.unwrapped.python
+    gnuradio.unwrapped.python.pkgs.Mako
+    gnuradio.unwrapped.python.pkgs.six
+  ];
+  checkInputs = [
+    gtest
   ];
 
   buildInputs = [
     gmp
     armadillo
-    gnuradio3_8.unwrapped.boost
     glog
-    gtest
-    openssl
     gflags
+    openssl
     orc
-    # UHD support is optional, but gnuradio is built with it, so there's
-    # nothing to be gained by leaving it out.
-    gnuradio3_8.unwrapped.uhd
-    gnuradio3_8.unwrapped.log4cpp
     blas lapack
     matio
     pugixml
     protobuf
-    gnuradio3_8.pkgs.osmosdr
+    gnuradio.unwrapped.boost
+  ] ++ lib.optionals (gnuradio.hasFeature "gr-uhd") [
+    gnuradio.unwrapped.uhd
+  ] ++ (if (lib.versionAtLeast gnuradio.unwrapped.versionAttr.major "3.10") then [
+    gnuradio.unwrapped.spdlog
+  ] else [
+    gnuradio.unwrapped.log4cpp
+  ]) ++ lib.optionals (enableRawUdp) [
     libpcap
-  ] ++ lib.optionals (gnuradio3_8.hasFeature "gr-ctrlport") [
+  ] ++ lib.optionals (gnuradio.hasFeature "gr-ctrlport") [
     thrift
-    gnuradio3_8.unwrapped.python.pkgs.thrift
+    gnuradio.unwrapped.python.pkgs.thrift
+  ] ++ lib.optionals (gnuradio.hasFeature "gr-pdu" || gnuradio.hasFeature "gr-iio") [
+    gnuradio.unwrapped.libiio
+  ] ++ lib.optionals (gnuradio.hasFeature "gr-pdu") [
+    gnuradio.unwrapped.libad9361
   ];
 
   cmakeFlags = [
-    "-DGFlags_ROOT_DIR=${gflags}/lib"
+    "-DGFlags_INCLUDE_DIRS=${gflags}/include"
     "-DGLOG_INCLUDE_DIR=${glog}/include"
+    # Should use .dylib if darwin support is requested
+    "-DGFlags_LIBS=${gflags}/lib/libgflags.so"
+    "-DGLOG_LIBRARIES=${glog}/lib/libglog.so"
+    # Use our dependencies glog, gflags and armadillo dependencies
+    "-DENABLE_OWN_GLOG=OFF"
+    "-DENABLE_OWN_ARMADILLO=OFF"
+    "-DENABLE_ORC=ON"
+    "-DENABLE_LOG=ON"
+    "-DENABLE_RAW_UDP=${if enableRawUdp then "ON" else "OFF"}"
+    "-DENABLE_UHD=${if (gnuradio.hasFeature "gr-uhd") then "ON" else "OFF"}"
+    "-DENABLE_FMCOMMS2=${if (gnuradio.hasFeature "gr-iio" && gnuradio.hasFeature "gr-pdu") then "ON" else "OFF"}"
+    "-DENABLE_PLUTOSDR=${if (gnuradio.hasFeature "gr-iio") then "ON" else "OFF"}"
+    "-DENABLE_AD9361=${if (gnuradio.hasFeature "gr-pdu") then "ON" else "OFF"}"
     "-DENABLE_UNIT_TESTING=OFF"
 
     # gnss-sdr doesn't truly depend on BLAS or LAPACK, as long as
     # armadillo is built using both, so skip checking for them.
-    "-DBLAS=YES"
-    "-DLAPACK=YES"
     "-DBLAS_LIBRARIES=-lblas"
     "-DLAPACK_LIBRARIES=-llapack"
-
-    # Similarly, it doesn't actually use gfortran despite checking for
-    # its presence.
-    "-DGFORTRAN=YES"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -12,8 +12,6 @@
 , libpcap
 , orc
 , pkg-config
-, uhd
-, log4cpp
 , blas, lapack
 , matio
 , pugixml
@@ -52,7 +50,7 @@ gnuradio3_8.pkgs.mkDerivation rec {
     # UHD support is optional, but gnuradio is built with it, so there's
     # nothing to be gained by leaving it out.
     gnuradio3_8.unwrapped.uhd
-    log4cpp
+    gnuradio3_8.unwrapped.log4cpp
     blas lapack
     matio
     pugixml

--- a/pkgs/applications/radio/gnss-sdr/fix_libcpu_features_install_path.patch
+++ b/pkgs/applications/radio/gnss-sdr/fix_libcpu_features_install_path.patch
@@ -1,0 +1,47 @@
+--- a/CMakeLists.txt	1970-01-01 08:00:01.000000000 +0800
++++ b/CMakeLists.txt	2022-02-16 20:41:53.725290020 +0800
+@@ -1214,7 +1214,7 @@
+             BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
+             CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
+                 -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
+-                -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
++                -DCMAKE_INSTALL_LIBDIR=lib
+             DOWNLOAD_COMMAND ""
+             UPDATE_COMMAND ""
+             PATCH_COMMAND ""
+@@ -1247,7 +1247,7 @@
+                 )
+                 set(VOLK_GNSSSDR_BUILD_BYPRODUCTS
+                     ${VOLK_GNSSSDR_BUILD_BYPRODUCTS}
+-                    ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
++                    ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
+                 )
+             endif()
+             ExternalProject_Add(volk_gnsssdr_module
+@@ -1256,7 +1256,7 @@
+                 BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
+                 CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
+                     -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
+-                    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
++                    -DCMAKE_INSTALL_LIBDIR=lib
+                 DOWNLOAD_COMMAND ""
+                 UPDATE_COMMAND ""
+                 PATCH_COMMAND ""
+@@ -1271,7 +1271,7 @@
+                 BINARY_DIR ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/build
+                 CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
+                     -DCMAKE_BUILD_TYPE=$<$<CONFIG:None>:None>$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:NoOptWithASM>:NoOptWithASM>$<$<CONFIG:Coverage>:Coverage>$<$<CONFIG:O2WithASM>:O2WithASM>$<$<CONFIG:O3WithASM>:O3WithASM>$<$<CONFIG:ASAN>:ASAN>
+-                    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
++                    -DCMAKE_INSTALL_LIBDIR=lib
+                 DOWNLOAD_COMMAND ""
+                 UPDATE_COMMAND ""
+                 PATCH_COMMAND ""
+@@ -1310,7 +1310,7 @@
+         if(CMAKE_VERSION VERSION_GREATER 3.0 AND SUPPORTED_CPU_FEATURES_ARCH)
+             if(NOT CpuFeatures_FOUND)
+                 set_target_properties(Volkgnsssdr::volkgnsssdr PROPERTIES
+-                    INTERFACE_LINK_LIBRARIES ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/${CMAKE_INSTALL_LIBDIR}/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
++                    INTERFACE_LINK_LIBRARIES ${CMAKE_BINARY_DIR}/volk_gnsssdr_module/install/lib/${CMAKE_FIND_LIBRARY_PREFIXES}cpu_features${CMAKE_STATIC_LIBRARY_SUFFIX}
+                 )
+             endif()
+         endif()

--- a/pkgs/applications/radio/gnuradio/3.8.nix
+++ b/pkgs/applications/radio/gnuradio/3.8.nix
@@ -251,7 +251,11 @@ stdenv.mkDerivation rec {
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
-    inherit boost volk;
+    inherit
+      boost
+      volk
+      log4cpp
+    ;
   } // lib.optionalAttrs (hasFeature "gr-uhd") {
     inherit uhd;
   } // lib.optionalAttrs (hasFeature "gr-qtgui") {

--- a/pkgs/applications/radio/gnuradio/3.9.nix
+++ b/pkgs/applications/radio/gnuradio/3.9.nix
@@ -275,7 +275,11 @@ stdenv.mkDerivation rec {
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
-    inherit boost volk;
+    inherit
+      boost
+      volk
+      log4cpp
+    ;
   } // lib.optionalAttrs (hasFeature "gr-uhd") {
     inherit uhd;
   } // lib.optionalAttrs (hasFeature "gr-qtgui") {

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -49,12 +49,12 @@
 , versionAttr ? {
   major = "3.10";
   minor = "1";
-  patch = "0";
+  patch = "1";
 }
 }:
 
 let
-  sourceSha256 = "sha256-bU6z7H08G8QIToogAMI2P5tHBtVZezlBDqSbnEsqAjE=";
+  sourceSha256 = "sha256-vsAK+GQzcpA9Vsa6q4RFEzVpbF7/+yZkMsemKn6VhIg=";
   featuresInfo = {
     # Needed always
     basic = {

--- a/pkgs/applications/radio/gnuradio/default.nix
+++ b/pkgs/applications/radio/gnuradio/default.nix
@@ -293,9 +293,15 @@ stdenv.mkDerivation rec {
   ];
   passthru = shared.passthru // {
     # Deps that are potentially overriden and are used inside GR plugins - the same version must
-    inherit boost volk;
+    inherit
+      boost
+      volk
+      spdlog
+    ;
   } // lib.optionalAttrs (hasFeature "gr-uhd") {
     inherit uhd;
+  } // lib.optionalAttrs (hasFeature "gr-pdu") {
+    inherit libiio libad9361;
   } // lib.optionalAttrs (hasFeature "gr-qtgui") {
     inherit (libsForQt5) qwt;
   };

--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -5,7 +5,6 @@
 , qt5
 , gnuradio3_8Minimal
 , thrift
-, log4cpp
 , mpir
 , fftwFloat
 , alsa-lib
@@ -39,7 +38,7 @@ gnuradio3_8Minimal.pkgs.mkDerivation rec {
     qt5.wrapQtAppsHook
   ];
   buildInputs = [
-    log4cpp
+    gnuradio3_8Minimal.unwrapped.log4cpp
     mpir
     fftwFloat
     alsa-lib

--- a/pkgs/applications/radio/qradiolink/default.nix
+++ b/pkgs/applications/radio/qradiolink/default.nix
@@ -7,7 +7,6 @@
 , thrift
 # Not gnuradioPackages'
 , codec2
-, log4cpp
 , gmp
 , gsm
 , libopus
@@ -48,7 +47,7 @@ gnuradio3_8.pkgs.mkDerivation rec {
   buildInputs = [
     gnuradio3_8.unwrapped.boost
     codec2
-    log4cpp
+    gnuradio3_8.unwrapped.log4cpp
     gmp
     libpulseaudio
     libconfig

--- a/pkgs/development/libraries/volk/default.nix
+++ b/pkgs/development/libraries/volk/default.nix
@@ -10,6 +10,8 @@
 
 stdenv.mkDerivation rec {
   pname = "volk";
+  # Version 2.5.1 seems to cause a build issue for aarch64-darwin, see:
+  # https://github.com/NixOS/nixpkgs/pull/160152#issuecomment-1043380478A
   version = "2.5.0";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -14,16 +14,20 @@ let
   };
   mkDerivation = mkDerivationWith stdenv.mkDerivation;
 
-  callPackage = self.newScope {
+  callPackage = self.newScope ({
     inherit (gnuradio)
       # Packages that are potentially overriden and used as deps here.
       boost
-      uhd
       volk
     ;
     inherit mkDerivationWith mkDerivation;
-  };
-
+  } // lib.optionalAttrs (gnuradio.hasFeature "gr-uhd") {
+    inherit (gnuradio) uhd;
+  } // (if (lib.versionAtLeast gnuradio.versionAttr.major "3.10") then {
+    inherit (gnuradio) spdlog;
+  } else {
+    inherit (gnuradio) log4cpp;
+  }));
 in {
 
   inherit callPackage mkDerivation mkDerivationWith;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
