### PR TITLE
pyqt5_sip: init at 12.9.1

### DIFF
--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
 
   pythonPath = with python3Packages; [
     pyqt5
-    pyqt5.pyqt5_sip
+    pyqt5_sip
     send2trash
     sphinx
     polib

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -7,6 +7,7 @@
 , lndir
 , dbus-python
 , sip
+, pyqt5_sip
 , pyqt-builder
 , libsForQt5
 , withConnectivity ? false
@@ -16,21 +17,7 @@
 , withLocation ? false
 }:
 
-let
-  pyqt5_sip = buildPythonPackage rec {
-    pname = "PyQt5_sip";
-    version = "12.9.0";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "0cmfxb7igahxy74qkq199l6zdxrr75bnxris42fww3ibgjflir6k";
-    };
-
-    # There is no test code and the check phase fails with:
-    # > error: could not create 'PyQt5/sip.cpython-38-x86_64-linux-gnu.so': No such file or directory
-    doCheck = false;
-  };
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "PyQt5";
   version = "5.15.4";
   format = "pyproject";

--- a/pkgs/development/python-modules/pyqt/sip.nix
+++ b/pkgs/development/python-modules/pyqt/sip.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pyqt5-sip";
+  version = "12.9.1";
+
+  src = fetchPypi {
+    pname = "PyQt5_sip";
+    inherit version;
+    sha256 = "LyTymbRMURwjeWqvu7WBv96/eNCQVle3zuIUG0mCAw4=";
+  };
+
+  # There is no test code and the check phase fails with:
+  # > error: could not create 'PyQt5/sip.cpython-38-x86_64-linux-gnu.so': No such file or directory
+  doCheck = false;
+  pythonImportsCheck = ["PyQt5.sip"];
+
+  meta = with lib; {
+    description = "Python bindings for Qt5";
+    homepage    = "https://www.riverbankcomputing.com/software/sip/";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ sander ];
+  };
+}

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -83,6 +83,7 @@ python3Packages.buildPythonApplication {
     dbus-python
   ] ++ lib.optionals withQt5 [
     pyqt5
+    pyqt5_sip
     enum-compat
   ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7359,6 +7359,8 @@ in {
 
   pyqt5 = callPackage ../development/python-modules/pyqt/5.x.nix { };
 
+  pyqt5_sip = callPackage ../development/python-modules/pyqt/sip.nix { };
+
   pyqt5_with_qtmultimedia = self.pyqt5.override {
     withMultimedia = true;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

I hope it's OK I put @SuperSandro2000 as a maintainer of this new package, since it's a dependency of `pyqt5` which you are listed as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
