### PR TITLE
lucky: 0.26.0 -> 0.29.0

### DIFF
--- a/pkgs/development/web/lucky-cli/default.nix
+++ b/pkgs/development/web/lucky-cli/default.nix
@@ -35,6 +35,7 @@ crystal.buildCrystalPackage rec {
   meta = with lib; {
     description =
       "A Crystal library for creating and running tasks. Also generates Lucky projects";
+    homepage = "https://luckyframework.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.unix;

--- a/pkgs/development/web/lucky-cli/default.nix
+++ b/pkgs/development/web/lucky-cli/default.nix
@@ -2,13 +2,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "lucky-cli";
-  version = "0.26.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "luckyframework";
     repo = "lucky_cli";
     rev = "v${version}";
-    sha256 = "sha256-bZWyAZrAYG45fqmEQYXsk8YLKurpppaahOkALAQXGhY=";
+    sha256 = "sha256-OmvKd35jR003qQnA/NBI4MjGRw044bYUYa59RKbz+lI=";
   };
 
   # the integration tests will try to clone a remote repos

--- a/pkgs/development/web/lucky-cli/shard.lock
+++ b/pkgs/development/web/lucky-cli/shard.lock
@@ -2,13 +2,13 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.2
+    version: 0.14.3
 
-  future:
-    git: https://github.com/crystal-community/future.cr.git
-    version: 0.1.0
+  lucky_task:
+    git: https://github.com/luckyframework/lucky_task.git
+    version: 0.1.1
 
   teeplate:
     git: https://github.com/luckyframework/teeplate.git
-    version: 0.8.2
+    version: 0.8.5
 

--- a/pkgs/development/web/lucky-cli/shards.nix
+++ b/pkgs/development/web/lucky-cli/shards.nix
@@ -2,19 +2,19 @@
   ameba = {
     owner = "crystal-ameba";
     repo = "ameba";
-    rev = "v0.14.2";
-    sha256 = "1l1q1icpzg1zvhfj8948w36j7ikaj7w816677zi29vi6y2d1dmf2";
+    rev = "v0.14.3";
+    sha256 = "1cfr95xi6hsyxw1wlrh571hc775xhwmssk3k14i8b7dgbwfmm5x1";
   };
-  future = {
-    owner = "crystal-community";
-    repo = "future.cr";
-    rev = "v0.1.0";
-    sha256 = "1p88mfn1ab5hz4r81vjfm1vn9rww0lbbii8lyzfx9pkxanh9rp98";
+  lucky_task = {
+    owner = "luckyframework";
+    repo = "lucky_task";
+    rev = "v0.1.1";
+    sha256 = "0w0rnf22pvj3lp5z8c4sshzwhqgwpbjpm7nry9mf0iz3fa0v48f7";
   };
   teeplate = {
     owner = "luckyframework";
     repo = "teeplate";
-    rev = "v0.8.2";
-    sha256 = "1v7njslcpir52nnyd30mfnxvqmb7ycqnlq80qnx6myw20iy9dcww";
+    rev = "v0.8.5";
+    sha256 = "1kr05qrp674rph1324wry57gzvgvcvlz0w27brlvdgd3gi4s8sdj";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Regular upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
