### PR TITLE
python3Packages.ibis-framework: install with poetry

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -80,8 +80,7 @@ buildPythonPackage rec {
     sqlalchemy
     tables
     toolz
-  ] ++ lib.optionals (pythonOlder "3.8") [
-    # TODO: remove when ibis 3.0.0 is released
+  ] ++ lib.optionals (pythonOlder "3.8" && lib.versionOlder version "3.0.0") [
     importlib-metadata
   ];
 
@@ -144,8 +143,7 @@ buildPythonPackage rec {
     done
 
     wait
-
-    # TODO: remove when 3.0.0 is released
+  '' + lib.optionalString (lib.versionOlder version "3.0.0") ''
     export PYTEST_BACKENDS="${backendsString}"
   '';
 

--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -14,6 +14,7 @@
 , numpy
 , pandas
 , parsy
+, poetry-core
 , pyarrow
 , pytest
 , pytest-mock
@@ -49,7 +50,7 @@ in
 buildPythonPackage rec {
   pname = "ibis-framework";
   version = "2.1.1";
-  format = "setuptools";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -59,6 +60,8 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "sha256-n3fR6wvcSfIo7760seB+5SxtoYSqQmqkzZ9VlNQF200=";
   };
+
+  nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [
     atpublic
@@ -78,6 +81,7 @@ buildPythonPackage rec {
     tables
     toolz
   ] ++ lib.optionals (pythonOlder "3.8") [
+    # TODO: remove when ibis 3.0.0 is released
     importlib-metadata
   ];
 
@@ -90,8 +94,13 @@ buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "atpublic>=2.3,<3" "atpublic>=2.3"
+    substituteInPlace pyproject.toml \
+      --replace 'atpublic = ">=2.3,<3"' 'atpublic = ">=2.3"'
+  '';
+
+  preBuild = ''
+    # setup.py exists only for developer convenience and is automatically generated
+    rm setup.py
   '';
 
   disabledTests = [
@@ -136,6 +145,7 @@ buildPythonPackage rec {
 
     wait
 
+    # TODO: remove when 3.0.0 is released
     export PYTEST_BACKENDS="${backendsString}"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Use poetry instead of setuptools to install `python3Packages.ibis-framework`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
