### PR TITLE
[RFH] lens: build from source instead of appimage

### DIFF
--- a/pkgs/applications/networking/cluster/lens/default.nix
+++ b/pkgs/applications/networking/cluster/lens/default.nix
@@ -1,53 +1,36 @@
 { lib
-, fetchurl
-, appimageTools
-, wrapGAppsHook
-, gsettings-desktop-schemas
-, gtk3
+, fetchFromGitHub
+, yarn2nix-moretea
+, nodejs-14_x
+, yarn
+, fetchYarnDeps
 }:
-
 let
+  yarn2nix = yarn2nix-moretea.override { nodejs = nodejs-14_x; };
+in
+yarn2nix.mkYarnPackage rec {
   pname = "lens";
   version = "5.3.4";
-  build = "${version}-latest.20220120.1";
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://api.k8slens.dev/binaries/Lens-${build}.x86_64.AppImage";
-    sha256 = "sha256-9vRLQFSocVkHAfgwdKSPhSAO4G/v/ANd0WQmilcZiVw=";
-    name = "${pname}.AppImage";
+  src = fetchFromGitHub {
+    owner = "lensapp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-dVanSi6VkLVUoEK0r8vqkJztCjD9ulx8LeNsMnikh7Q=";
   };
 
-  appimageContents = appimageTools.extractType2 {
-    inherit name src;
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    sha256 = "sha256-KryL1Q3Sar14FHJq1cnH/WgnqZCWryrjnB3wvOCslAE=";
   };
 
-in
-appimageTools.wrapType2 {
-  inherit name src;
-
-  profile = ''
-    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
-  '';
-
-  extraInstallCommands =
-    ''
-      mv $out/bin/${name} $out/bin/${pname}
-
-      install -m 444 -D ${appimageContents}/lens.desktop $out/share/applications/${pname}.desktop
-      install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/lens.png \
-         $out/share/icons/hicolor/512x512/apps/${pname}.png
-
-      substituteInPlace $out/share/applications/${pname}.desktop \
-        --replace 'Icon=lens' 'Icon=${pname}' \
-        --replace 'Exec=AppRun' 'Exec=${pname}'
-    '';
+  distPhase = ":"; # disable useless $out/tarballs directory
 
   meta = with lib; {
     description = "The Kubernetes IDE";
     homepage = "https://k8slens.dev/";
     license = licenses.mit;
-    maintainers = with maintainers; [ dbirks ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ dbirks otavio ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/networking/cluster/lens/default.nix
+++ b/pkgs/applications/networking/cluster/lens/default.nix
@@ -1,4 +1,10 @@
-{ lib, fetchurl, appimageTools, wrapGAppsHook, gsettings-desktop-schemas, gtk3 }:
+{ lib
+, fetchurl
+, appimageTools
+, wrapGAppsHook
+, gsettings-desktop-schemas
+, gtk3
+}:
 
 let
   pname = "lens";


### PR DESCRIPTION
I'd like to convert from AppImage to build from source to check if it solves the permission error or not. I am facing a problem as I couldn't figure out how to make the derivation install the binary, it doesn't seem to generate it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
