### PR TITLE
freedv: extend platform support

### DIFF
--- a/pkgs/applications/radio/freedv/default.nix
+++ b/pkgs/applications/radio/freedv/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     description = "Digital voice for HF radio";
     license = licenses.lgpl21;
     maintainers = with maintainers; [ mvs ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/radio/freedv/default.nix
+++ b/pkgs/applications/radio/freedv/default.nix
@@ -1,16 +1,18 @@
-{ lib
+{ config
+, lib
 , stdenv
 , fetchFromGitHub
 , cmake
 , codec2
+, libpulseaudio
 , libsamplerate
 , libsndfile
 , lpcnetfreedv
 , portaudio
-, pulseaudio
 , speexdsp
 , hamlib
 , wxGTK31-gtk3
+, pulseSupport ? config.pulseaudio or stdenv.isLinux
 }:
 
 stdenv.mkDerivation rec {
@@ -33,12 +35,12 @@ stdenv.mkDerivation rec {
     speexdsp
     hamlib
     wxGTK31-gtk3
-  ] ++ (if stdenv.isLinux then [ pulseaudio ] else [ portaudio ]);
+  ] ++ (if pulseSupport then [ libpulseaudio ] else [ portaudio ]);
 
   cmakeFlags = [
     "-DUSE_INTERNAL_CODEC2:BOOL=FALSE"
     "-DUSE_STATIC_DEPS:BOOL=FALSE"
-  ] ++ lib.optionals stdenv.isLinux [ "-DUSE_PULSEAUDIO:BOOL=TRUE" ];
+  ] ++ lib.optionals pulseSupport [ "-DUSE_PULSEAUDIO:BOOL=TRUE" ];
 
   meta = with lib; {
     homepage = "https://freedv.org/";

--- a/pkgs/development/libraries/lpcnetfreedv/default.nix
+++ b/pkgs/development/libraries/lpcnetfreedv/default.nix
@@ -30,5 +30,6 @@ in stdenv.mkDerivation rec {
     description = "Experimental Neural Net speech coding for FreeDV";
     license = licenses.bsd3;
     maintainers = with maintainers; [ mvs ];
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

FreeDV is a cross‐platform application. Upstream explicitly supports Windows, Linux and Mac OS X, but it should run on all unixoid systems. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- ~[ ] Tested, as applicable:~
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
