### PR TITLE
python3Packages.aesara: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/aesara/default.nix
+++ b/pkgs/development/python-modules/aesara/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     sha256 = "sha256-933bM15BZi4sTjnIOGAg5dc5tXVWQ9lFzktOtzj5DNQ=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     cython
   ];
 

--- a/pkgs/development/python-modules/aesara/default.nix
+++ b/pkgs/development/python-modules/aesara/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, numpy
+, scipy
+, filelock
+, etuples
+, logical-unification
+, minikanren
+, cons
+, numba
+, numba-scipy
+, libgpuarray
+, sympy
+, cython
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "aesara";
+  version = "2.4.0";
+
+  src = fetchFromGitHub {
+    owner = "aesara-devs";
+    repo = "aesara";
+    rev = "38d7a813646c1e350170c46bafade0e7d0e2427c";
+    sha256 = "sha256-933bM15BZi4sTjnIOGAg5dc5tXVWQ9lFzktOtzj5DNQ=";
+  };
+
+  buildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    filelock
+    etuples
+    logical-unification
+    minikanren
+    cons
+    numba
+    numba-scipy
+    libgpuarray
+    sympy
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pythonImportsCheck = [ "aesara" ];
+
+  meta = with lib; {
+    description = "Python library to define, optimize, and efficiently evaluate mathematical expressions involving multi-dimensional arrays";
+    homepage = "https://github.com/aesara-devs/aesara";
+    changelog = "https://github.com/aesara-devs/aesara/releases";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/development/python-modules/cons/default.nix
+++ b/pkgs/development/python-modules/cons/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, logical-unification
+, pytestCheckHook
+, pytest-html
+}:
+
+buildPythonPackage rec {
+  pname = "cons";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "pythological";
+    repo = "python-cons";
+    rev = "fbeedfc8a3d1bff4ba179d492155cdd55538365e";
+    sha256 = "sha256-ivHFep9iYPvyiBIZKMAzqrLGnQkeuxd0meYMZwZFFH0=";
+  };
+
+  propagatedBuildInputs = [
+    logical-unification
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-html
+  ];
+
+  pytestFlagsArray = [
+    "--html=testing-report.html"
+    "--self-contained-html"
+  ];
+
+  pythonImportsCheck = [ "cons" ];
+
+  meta = with lib; {
+    description = "An implementation of Lisp/Scheme-like cons in Python";
+    homepage = "https://github.com/pythological/python-cons";
+    changelog = "https://github.com/pythological/python-cons/releases";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/development/python-modules/etuples/default.nix
+++ b/pkgs/development/python-modules/etuples/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, cons
+, multipledispatch
+, pytestCheckHook
+, pytest-html
+}:
+
+buildPythonPackage rec {
+  pname = "etuples";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "pythological";
+    repo = "etuples";
+    rev = "35d760ceb64ec318f302a6e4d3a4a80feda97a9e";
+    sha256 = "sha256-CXD8MhsdWYAcG5WDVTT/A2HDtiO1xfQbrwlYVnxXpBU=";
+  };
+
+  propagatedBuildInputs = [
+    cons
+    multipledispatch
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-html
+  ];
+
+  pytestFlagsArray = [
+    "--html=testing-report.html"
+    "--self-contained-html"
+  ];
+
+  pythonImportsCheck = [ "etuples" ];
+
+  meta = with lib; {
+    description = "Python S-expression emulation using tuple-like objects";
+    homepage = "https://github.com/pythological/etuples";
+    changelog = "https://github.com/pythological/etuples/releases";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/development/python-modules/logical-unification/default.nix
+++ b/pkgs/development/python-modules/logical-unification/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, toolz
+, multipledispatch
+, pytestCheckHook
+, pytest-html
+, pytest-benchmark
+}:
+
+buildPythonPackage rec {
+  pname = "logical-unification";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "pythological";
+    repo = "unification";
+    rev = "707cf4a39e27a4a8bf06b7e7dce7223085574e65";
+    sha256 = "sha256-3wqO0pWWFRQeoGNvbSDdLNYFyjNnv+O++F7+vTBUJoI=";
+  };
+
+  propagatedBuildInputs = [
+    toolz
+    multipledispatch
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-html
+    pytest-benchmark  # Needed for the `--benchmark-skip` flag
+  ];
+
+  pytestFlagsArray = [
+    "--benchmark-skip"
+    "--html=testing-report.html"
+    "--self-contained-html"
+  ];
+
+  pythonImportsCheck = [ "unification" ];
+
+  meta = with lib; {
+    description = "Straightforward unification in Python that's extensible via generic functions";
+    homepage = "https://github.com/pythological/unification";
+    changelog = "https://github.com/pythological/unification/releases";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/development/python-modules/minikanren/default.nix
+++ b/pkgs/development/python-modules/minikanren/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, toolz
+, cons
+, multipledispatch
+, etuples
+, logical-unification
+, pytestCheckHook
+, pytest-html
+}:
+
+buildPythonPackage rec {
+  pname = "minikanren";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "pythological";
+    repo = "kanren";
+    rev = "5aa9b1734cbb3fe072a7c72b46e1b72a174d28ac";
+    sha256 = "sha256-daAtREgm91634Q0mc0/WZivDiyZHC7TIRoGRo8hMnGE=";
+  };
+
+  propagatedBuildInputs = [
+    toolz
+    cons
+    multipledispatch
+    etuples
+    logical-unification
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-html
+  ];
+
+  pytestFlagsArray = [
+    "--html=testing-report.html"
+    "--self-contained-html"
+  ];
+
+  pythonImportsCheck = [ "kanren" ];
+
+  meta = with lib; {
+    description = "Relational programming in Python";
+    homepage = "https://github.com/pythological/kanren";
+    changelog = "https://github.com/pythological/kanren/releases";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/development/python-modules/numba-scipy/default.nix
+++ b/pkgs/development/python-modules/numba-scipy/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, scipy
+, numba
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "numba-scipy";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-qJeoWiG1LdtFB9cME1d8xVaC0BXGDJEYjCOEdHvSkmQ=";
+  };
+
+  propagatedBuildInputs = [
+    scipy
+    numba
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "scipy>=0.16,<=1.6.2" "scipy>=0.16,<=1.7.3"
+  '';
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "numba" ];
+
+  meta = with lib; {
+    description = "Extends Numba to make it aware of SciPy";
+    homepage = "https://github.com/numba/numba-scipy";
+    changelog = "https://github.com/numba/numba-scipy/blob/master/CHANGE_LOG";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ Etjean ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2655,6 +2655,8 @@ in {
 
   eth-utils = callPackage ../development/python-modules/eth-utils { };
 
+  etuples = callPackage ../development/python-modules/etuples { };
+
   et_xmlfile = callPackage ../development/python-modules/et_xmlfile { };
 
   ev3dev2 = callPackage ../development/python-modules/ev3dev2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5554,6 +5554,8 @@ in {
 
   numba = callPackage ../development/python-modules/numba { };
 
+  numba-scipy = callPackage ../development/python-modules/numba-scipy { };
+
   numcodecs = callPackage ../development/python-modules/numcodecs { };
 
   numericalunits = callPackage ../development/python-modules/numericalunits { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5060,6 +5060,8 @@ in {
 
   minidump = callPackage ../development/python-modules/minidump { };
 
+  minikanren = callPackage ../development/python-modules/minikanren { };
+
   minikerberos = callPackage ../development/python-modules/minikerberos { };
 
   minimock = callPackage ../development/python-modules/minimock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1807,6 +1807,8 @@ in {
 
   connexion = callPackage ../development/python-modules/connexion { };
 
+  cons = callPackage ../development/python-modules/cons { };
+
   consonance = callPackage ../development/python-modules/consonance { };
 
   constantly = callPackage ../development/python-modules/constantly { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4759,6 +4759,8 @@ in {
 
   logfury = callPackage ../development/python-modules/logfury { };
 
+  logical-unification = callPackage ../development/python-modules/logical-unification { };
+
   logilab_astng = callPackage ../development/python-modules/logilab_astng { };
 
   logilab_common = callPackage ../development/python-modules/logilab/common.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -222,6 +222,8 @@ in {
 
   aenum = callPackage ../development/python-modules/aenum { };
 
+  aesara = callPackage ../development/python-modules/aesara { };
+
   afdko = callPackage ../development/python-modules/afdko { };
 
   affine = callPackage ../development/python-modules/affine { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Addition of [Aesara](https://github.com/aesara-devs/aesara), successor to Theano for array computations in Python.
Also, addition of the following packages that were needed as dependencies:
- [logical-unification](https://github.com/pythological/unification/)
- [cons](https://github.com/pythological/python-cons)
- [etuples](https://github.com/pythological/etuples)
- [miniKanren](https://github.com/pythological/kanren)
- [numba-scipy](https://github.com/numba/numba-scipy)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
    **=> Tested unit tests from Aesara source code**
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
