### PR TITLE
python3Packages.asyncwhois: 0.4.1 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/asyncwhois/default.nix
+++ b/pkgs/development/python-modules/asyncwhois/default.nix
@@ -1,9 +1,9 @@
 { lib
-, aiodns
 , asynctest
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
+, python-socks
 , pythonOlder
 , tldextract
 , whodap
@@ -11,7 +11,8 @@
 
 buildPythonPackage rec {
   pname = "asyncwhois";
-  version = "0.4.1";
+  version = "1.0.0";
+  format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
@@ -19,11 +20,11 @@ buildPythonPackage rec {
     owner = "pogzyb";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-mKKN2IuveOE+3mZGS5LFa15lJPA9y7KgLd0FoRuEMH0=";
+    hash = "sha256-9tSGfF/Ezuya4pEyr1XolWXvSO/F/UrobRVlyHITNTU=";
   };
 
   propagatedBuildInputs = [
-    aiodns
+    python-socks
     tldextract
     whodap
   ];
@@ -33,8 +34,13 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  # Disable tests that require network access
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "python-socks[asyncio]" "python-socks"
+  '';
+
   disabledTests = [
+    # Tests require network access
     "test_pywhois_aio_get_hostname_from_ip"
     "test_pywhois_get_hostname_from_ip"
     "test_pywhois_aio_lookup_ipv4"
@@ -44,9 +50,13 @@ buildPythonPackage rec {
     "test_from_whois_cmd"
     "test_get_hostname_from_ip"
     "test_whois_query_run"
+    "test_whois_query_create_connection"
+    "test_whois_query_send_and_recv"
   ];
 
-  pythonImportsCheck = [ "asyncwhois" ];
+  pythonImportsCheck = [
+    "asyncwhois"
+  ];
 
   meta = with lib; {
     description = "Python module for retrieving WHOIS information";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/pogzyb/asyncwhois/releases/tag/v1.0.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
