### PR TITLE
bingo: init at 0.5.2

### DIFF
--- a/pkgs/development/tools/bingo/default.nix
+++ b/pkgs/development/tools/bingo/default.nix
@@ -1,0 +1,41 @@
+{ lib, buildGoModule, fetchFromGitHub, testVersion, bingo }:
+
+buildGoModule rec {
+  pname = "bingo";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "bwplotka";
+    repo = "bingo";
+    rev = "v${version}";
+    sha256 = "sha256-4D8YaA/AH1gIp5iwD7WEAdBl73sqwHpfOe7bnxVcRcw=";
+  };
+
+  vendorSha256 = "sha256-xrz9FpwZd+FboVVTWSqGHRguGwrwE9cSFEEtulzbfDQ=";
+
+  patches = [
+    # Do not execute `go` command when invoking `bingo version`.
+    ./version_go.patch
+  ];
+
+  postPatch = ''
+    rm get_e2e_test.go get_e2e_utils_test.go
+  '';
+
+  CGO_ENABLED = 0;
+
+  ldflags = [ "-s" "-w" ];
+
+  passthru.tests.version = testVersion {
+    package = bingo;
+    command = "bingo version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Like `go get` but for Go tools! CI Automating versioning of Go binaries in a nested, isolated Go modules.";
+    homepage = "https://github.com/bwplotka/bingo";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aaronjheng ];
+  };
+}

--- a/pkgs/development/tools/bingo/version_go.patch
+++ b/pkgs/development/tools/bingo/version_go.patch
@@ -1,0 +1,17 @@
+diff --git a/main.go b/main.go
+index 5600f7e..662ed1b 100644
+--- a/main.go
++++ b/main.go
+@@ -201,10 +201,8 @@ func main() {
+ 			return pkgs.PrintTab(target, os.Stdout)
+ 		}
+ 	case "version":
+-		cmdFunc = func(ctx context.Context, r *runner.Runner) error {
+-			_, err := fmt.Fprintln(os.Stdout, version.Version)
+-			return err
+-		}
++		_, _ = fmt.Fprintln(os.Stdout, version.Version)
++		return
+ 	default:
+ 		exitOnUsageError(flags.Usage, "No such command", flags.Arg(0))
+ 	}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -216,6 +216,8 @@ with pkgs;
 
   beyond-identity = callPackage ../tools/security/beyond-identity {};
 
+  bingo = callPackage ../development/tools/bingo {};
+
   breakpad = callPackage ../development/misc/breakpad { };
 
   buf = callPackage ../development/tools/buf { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Like `go get` but for Go tools! CI Automating versioning of Go binaries in a nested, isolated Go modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
