### PR TITLE
plasma-theme-switcher: init at 0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6332,6 +6332,12 @@
     githubId = 209729;
     name = "Kevin Griffin";
   };
+  kevink = {
+    email = "kevin@kevink.dev";
+    github = "Unkn0wnCat";
+    githubId = 8211181;
+    name = "Kevin Kandlbinder";
+  };
   kfollesdal = {
     email = "kfollesdal@gmail.com";
     github = "kfollesdal";

--- a/pkgs/applications/misc/plasma-theme-switcher/default.nix
+++ b/pkgs/applications/misc/plasma-theme-switcher/default.nix
@@ -1,0 +1,42 @@
+{
+  stdenv, lib, cmake, extra-cmake-modules, fetchFromGitHub, qtbase, kdeFrameworks
+}:
+
+stdenv.mkDerivation rec {
+  pname = "plasma-theme-switcher";
+  version = "0.1";
+  dontWrapQtApps = true;
+
+  src = fetchFromGitHub {
+    owner = "maldoinc";
+    repo = "plasma-theme-switcher";
+    rev = "v${version}";
+    sha256 = "sdcJ6K5QmglJEDIEl4sd8x7DuCPCqMHRxdYbcToM46Q=";
+  };
+
+  buildInputs = [
+    qtbase
+    kdeFrameworks.plasma-framework
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp plasma-theme $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/maldoinc/plasma-theme-switcher/";
+    description = "A KDE Plasma theme switcher";
+    license = with licenses; [ gpl2Only ];
+    maintainers = with maintainers; [ kevink ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31654,6 +31654,8 @@ with pkgs;
 
   plasma-applet-volumewin7mixer = libsForQt5.callPackage ../applications/misc/plasma-applet-volumewin7mixer { };
 
+  plasma-theme-switcher = libsForQt5.callPackage ../applications/misc/plasma-theme-switcher {};
+
   plasma-pass = libsForQt5.callPackage ../tools/security/plasma-pass { };
 
   inherit (callPackages ../applications/misc/redshift {


### PR DESCRIPTION
###### Motivation for this change

The package "plasma-theme-switcher" allows for easily modifying the Plasma desktop theme. This is useful for use with NixOS as color schemes or themes can be set from scripts in the global configuration.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] ~~Tested, as applicable:~~ Not testable w/o full Plasma environment.
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [x] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~ Nothing depends on this.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
