### PR TITLE
oil-buku: init at 0.3.2

### DIFF
--- a/pkgs/applications/misc/oil/default.nix
+++ b/pkgs/applications/misc/oil/default.nix
@@ -1,0 +1,45 @@
+{ stdenvNoCC, lib, fetchFromGitHub, jq, gawk, peco, makeWrapper }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "oil-buku";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "AndreiUlmeyda";
+    repo = "oil";
+    rev = version;
+    sha256 = "12g0fd7h11hh94b2pyg3pqwbf8bc7gcnrnm1qqbf18s6z02b6ixr";
+  };
+
+  postPatch = ''
+    substituteInPlace src/oil --replace \
+      "LIBDIR=/usr/local/lib/oil" "LIBDIR=${placeholder "out"}/lib"
+
+    substituteInPlace Makefile --replace \
+      "LIBDIR ?= /usr/local/lib/oil" "LIBDIR ?= ${placeholder "out"}/lib" \
+
+    substituteInPlace Makefile --replace \
+      "BINDIR ?= /usr/local/bin" "BINDIR ?= ${placeholder "out"}/bin"
+
+    substituteInPlace src/json-to-line.jq --replace \
+      "/usr/bin/env -S jq" "${jq}/bin/jq"
+
+    substituteInPlace src/format-columns.awk --replace \
+      "/usr/bin/env -S awk" "${gawk}/bin/awk"
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postFixup = ''
+    wrapProgram $out/bin/oil \
+        --prefix PATH : ${lib.makeBinPath [ peco ]}
+  '';
+
+  meta = with lib; {
+    description = "Search-as-you-type cli frontend for the buku bookmarks manager using peco";
+    homepage = "https://github.com/AndreiUlmeyda/oil";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3580,6 +3580,8 @@ with pkgs;
 
   odafileconverter = libsForQt5.callPackage ../applications/graphics/odafileconverter {};
 
+  oil-buku = callPackage ../applications/misc/oil { };
+
   ossutil = callPackage ../tools/admin/ossutil {};
 
   pastel = callPackage ../applications/misc/pastel {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a search-as-you-type cli frontend for the buku bookmarks manager using peco. I kinda used it frequently on Arch linux, so I took some time to port it to nixpkgs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
