### PR TITLE
python3Packages.pyquil: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -42,6 +42,8 @@ buildPythonPackage rec {
       --replace "pyjwt~=1.7.1" "pyjwt" \
       --replace "qcs-api-client~=0.8.0" "qcs-api-client" \
       --replace "iso8601~=0.1.14" "iso8601" \
+      --replace "rfc3986~=1.5.0" "rfc3986" \
+      --replace "pyquil~=3.0.0" "pyquil" \
       --replace "pydantic~=1.8.2" "pydantic"
     # Remove outdated test
     rm cirq_rigetti/service_test.py

--- a/pkgs/development/python-modules/pyquil/default.nix
+++ b/pkgs/development/python-modules/pyquil/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , importlib-metadata
 , ipython
 , lark
@@ -23,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "pyquil";
-  version = "3.0.1";
+  version = "3.1.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -32,16 +31,8 @@ buildPythonPackage rec {
     owner = "rigetti";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-OU7/LjcpCxvqlcfdlm5ll4f0DYXf0yxNprM8Muu2wyg=";
+    sha256 = "sha256-ejfzxCf2NucK/hfzswHu3h4DPPZQY8vkMAQ51XDRWKU=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "pyquil-pr-1404-unpin-qcs-api-client-version-pyproject.patch";
-      url = "https://github.com/rigetti/pyquil/commit/2e35a4fdf65262fdf39c5091aeddfa3f3564925a.patch";
-      sha256 = "sha256-KGDNU2wpzsuifQSbbkoMwaFXspHW6zyIJ5GRZbw+lUY=";
-    })
-  ];
 
   nativeBuildInputs = [
     poetry-core
@@ -97,7 +88,9 @@ buildPythonPackage rec {
     "test_classical"
   ];
 
-  pythonImportsCheck = [ "pyquil" ];
+  pythonImportsCheck = [
+    "pyquil"
+  ];
 
   meta = with lib; {
     description = "Python library for creating Quantum Instruction Language (Quil) programs";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/rigetti/pyquil/releases/tag/v3.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
