### PR TITLE
haskell.packages.ghc9xx.aeson-diff: Fix build by jailbreaking

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -48,6 +48,11 @@ self: super: {
   });
 
   # Jailbreaks & Version Updates
+
+  # This `doJailbreak` can be removed once the following PR is released to Hackage:
+  # https://github.com/thsutton/aeson-diff/pull/58
+  aeson-diff = doJailbreak super.aeson-diff;
+
   async = doJailbreak super.async;
   data-fix = doJailbreak super.data-fix;
   dec = doJailbreak super.dec;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -81,6 +81,11 @@ self: super: {
   extra = dontCheck super.extra;
 
   # Jailbreaks & Version Updates
+
+  # This `doJailbreak` can be removed once the following PR is released to Hackage:
+  # https://github.com/thsutton/aeson-diff/pull/58
+  aeson-diff = doJailbreak super.aeson-diff;
+
   assoc = doJailbreak super.assoc;
   async = doJailbreak super.async;
   attoparsec = super.attoparsec_0_14_4;


### PR DESCRIPTION
###### Motivation for this change
`aeson-diff` has an upper bound on `base < 4.15`, causing the builds on GHC 9.x.x fail. This has been addressed with the upstream commit https://github.com/thsutton/aeson-diff/commit/1d247f4f4a20f528be3ac75982b5927bc779082e but it is yet to be published on Hackage.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
