### PR TITLE
pythonPackages.expecttest: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/expecttest/default.nix
+++ b/pkgs/development/python-modules/expecttest/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# Native build inputs
+, poetry-core
+
+# Check inputs
+, pytestCheckHook
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "expecttest";
+  version = "0.1.3";
+  format = "pyproject";
+
+  # Pypi doesn't contain the test, so fetch from GitHub
+  src = fetchFromGitHub {
+    owner = "ezyang";
+    repo = "expecttest";
+    rev = "1450e7fc26d5a55a2efb8cca93b0f193a259d8e1";
+    sha256 = "sha256:07dgbkjiwxi0jvmrgglyrfxk3jqvmnv66fmd05f72zwvaiafjag4";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  checkInputs = [
+    pytestCheckHook
+    hypothesis
+  ];
+
+  pytestFlagsArray = [
+    "test_expecttest.py"
+  ];
+
+  pythonImportsCheck = [ "expecttest" ];
+
+  meta = with lib; {
+    description = "Module which implements expect tests";
+    homepage = "https://github.com/ezyang/expecttest";
+    license = licenses.mit;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2689,6 +2689,8 @@ in {
 
   expects = callPackage ../development/python-modules/expects { };
 
+  expecttest = callPackage ../development/python-modules/expecttest { };
+
   expiringdict = callPackage ../development/python-modules/expiringdict { };
 
   explorerscript = callPackage ../development/python-modules/explorerscript { };


### PR DESCRIPTION
###### Motivation for this change
Adds expecttest which is a check input for several currently unpackaged pytorch packages (torchdata, torchtext, torchaudio).

###### TODO

- [ ] Needs a maintainer

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
