### PR TITLE
pythonPackages.sacrebleu: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/sacrebleu/default.nix
+++ b/pkgs/development/python-modules/sacrebleu/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+# Propagated build inputs
+, portalocker
+, regex
+, tabulate
+, numpy
+, colorama
+
+# Check inputs
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sacrebleu";
+  version = "1.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256:0jxq311kkszpqm58bl043rcczdxjfqwwxyw313pxfpf45q6ly678";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "portalocker==" "portalocker>="
+  '';
+
+  propagatedBuildInputs = [
+    portalocker
+    regex
+    tabulate
+    numpy
+    colorama
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # all api tests require network access
+    "test/test_api.py"
+  ];
+
+  pythonImportsCheck = [ "sacrebleu" ];
+
+  meta = with lib; {
+    description = "Hassle-free computation of shareable, comparable, and reproducible BLEU, chrF, and TER scores";
+    homepage = "https://github.com/mjpost/sacrebleu";
+    changelog = "https://github.com/mjpost/sacrebleu/blob/v{version}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8813,6 +8813,8 @@ in {
 
   sacremoses = callPackage ../development/python-modules/sacremoses { };
 
+  sacrebleu = callPackage ../development/python-modules/sacrebleu { };
+
   safe = callPackage ../development/python-modules/safe { };
 
   safety = callPackage ../development/python-modules/safety { };


### PR DESCRIPTION
###### Motivation for this change

A python data science library for computing BLEU scores.

I haven't used it directly, but packaged it a test dependency for some other pytorch related packages.

###### TODO

I'll probably leave this as a draft PR since I don't have any interest in using this package for anything other than a check input.

- [ ] Needs a maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
