### PR TITLE
pythonPackages.fairseq: init at 0.10.2

### DIFF
--- a/pkgs/development/python-modules/fairseq/default.nix
+++ b/pkgs/development/python-modules/fairseq/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, pythonAtLeast
+, fetchFromGitHub
+
+# Native build inputs
+, cython
+, which
+
+# Build inputs
+, pybind11
+
+# Propagated build inputs
+, cffi
+, hydra
+, numpy
+, pytorch
+, regex
+, sacrebleu
+, tqdm
+, dataclasses
+
+# Check inputs
+, pytestCheckHook
+#, apex
+}:
+
+buildPythonPackage rec {
+  pname = "fairseq";
+  version = "0.10.2";
+
+  # Pypi source package doesn't contain tests
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "fairseq";
+    rev = "v${version}";
+    sha256 = "sha256:0k3lihngpy22mr6vgnvfmp7ngs91xijs24m64s7205lx3lyv7maq";
+  };
+
+  disabled = ! (pythonAtLeast "3.6");
+
+  nativeBuildInputs = [
+    cython
+    which
+  ];
+
+  buildInputs = [
+    pybind11
+  ];
+
+  propagatedBuildInputs = [
+    cffi
+    hydra
+    numpy
+    pytorch
+    regex
+    sacrebleu
+    tqdm
+  ] ++ lib.optional (pythonOlder "3.7") [
+    dataclasses
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    # apex
+  ];
+
+  pythonImportsCheck = [ "fairseq" ];
+
+  postPatch =
+    ''
+      substituteInPlace setup.py \
+        --replace '"dataclasses"' "'dataclasses; python_version<\"3.7\"'"
+    '';
+
+  disabledTestPaths = [
+    # FIXME: these megatron tests import the optional nvidia apex package
+    "fairseq/model_parallel/megatron/mpu/tests/test_cross_entropy.py"
+    "fairseq/model_parallel/megatron/mpu/tests/test_data.py"
+    "fairseq/model_parallel/megatron/mpu/tests/test_initialize.py"
+    "fairseq/model_parallel/megatron/mpu/tests/test_layers.py"
+    "fairseq/model_parallel/megatron/mpu/tests/test_random.py"
+  ];
+
+  meta = with lib; {
+    description = "Facebook AI Research Sequence-to-Sequence Toolkit";
+    homepage = "https://github.com/pytorch/fairseq";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
+    broken = true; # A large number of tests are still failing
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2737,6 +2737,8 @@ in {
 
   factory_boy = callPackage ../development/python-modules/factory_boy { };
 
+  fairseq = callPackage ../development/python-modules/fairseq { };
+
   fake_factory = callPackage ../development/python-modules/fake_factory { };
 
   fake-useragent = callPackage ../development/python-modules/fake-useragent { };


### PR DESCRIPTION
###### Motivation for this change

Facebook's Sequence-to-Sequence library for pytorch.

I'm leaving this as a draft PR because it probably needs a bit more work to be useful:

- [ ] Many tests fails, for reasons
- [ ] Optional dependencies/flags should probably be investigated
- [ ] Depends on #160205 and #160197


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
