### PR TITLE
pythonPackages.torchtext: init at 0.11.2

### DIFF
--- a/pkgs/development/python-modules/torchtext/default.nix
+++ b/pkgs/development/python-modules/torchtext/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# Native build inputs
+, cmake
+, which
+
+# Build inputs
+, pybind11
+
+# Propogated build inputs
+, pytorch
+, requests
+, tqdm
+
+# Check inputs
+, pytestCheckHook
+}:
+
+
+buildPythonPackage rec {
+  version = "0.11.2";
+  pname = "torchtext";
+
+  # Pypi only contains platform specific wheels, fetching from github seems simpler
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "text";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256:06x0m6s7zpqqwhngrv4gqsij924knhsgw820dnvjc5alpfdjcaqk";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    which
+  ];
+
+  buildInputs =[
+    pybind11
+  ];
+
+  propagatedBuildInputs = [
+    pytorch
+    requests
+    tqdm
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "torchtext" ];
+
+  meta = {
+    homepage = https://pytorch.org;
+    description = "Data loaders and abstractions for text and NLP";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+    broken = true; # FIXME: tests can't find the torchtext._torchtext module generated via pybind11
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9915,6 +9915,8 @@ in {
 
   torchinfo = callPackage ../development/python-modules/torchinfo { };
 
+  torchtext = callPackage ../development/python-modules/torchtext { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix { };


### PR DESCRIPTION
###### Motivation for this change

The official pytorch text (natural language processing) library.

I'm leaving this as a draft PR because it probably needs a bit more work to be useful:

- [ ] The tests fail for reasons related to the extension built via `pybind11`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
