### PR TITLE
cudatext: 1.155.0 → 1.156.2

### DIFF
--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -38,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "cudatext";
-  version = "1.155.0";
+  version = "1.156.2";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
     rev = version;
-    sha256 = "sha256-k6ALTbA2PhMZscinXKceM7MSzgr759Y6GxMrQAXMgwM=";
+    sha256 = "sha256-waVTNyK3OHpOvBJrXio+Xjn9q3WmUczbx3E26ChsuKo=";
   };
 
   postPatch = ''

--- a/pkgs/applications/editors/cudatext/deps.json
+++ b/pkgs/applications/editors/cudatext/deps.json
@@ -16,23 +16,23 @@
   },
   "ATSynEdit": {
     "owner": "Alexey-T",
-    "rev": "2022.01.20",
-    "sha256": "sha256-4UJ6t8j8uHB27jprqnlsGB8ytOMQLe4ZzSaYKiw4y70="
+    "rev": "2022.02.19",
+    "sha256": "sha256-cq2dirFNPaWRmZJu0F+CFA//+SuFOOpTH3Q5zL4oPQo="
   },
   "ATSynEdit_Cmp": {
     "owner": "Alexey-T",
-    "rev": "2021.12.28",
-    "sha256": "sha256-bXTjPdn0DIVTdoi30Ws5+M+UsC7F99IphMSTpI5ia/Q="
+    "rev": "2022.01.21",
+    "sha256": "sha256-el5YtzewnHV0fRPgVhApZUVP7huSQseqrO2ibvm6Ctg="
   },
   "EControl": {
     "owner": "Alexey-T",
-    "rev": "2022.01.07",
-    "sha256": "sha256-dgkyXrFs2hzuFjt9GW+WNyrLIp/i/AbRsM/MyMbatdA="
+    "rev": "2022.02.02",
+    "sha256": "sha256-T/6SQJHKzbv/PlObDyc9bcpC14krHgcLDQn0v2fNkLM="
   },
   "ATSynEdit_Ex": {
     "owner": "Alexey-T",
-    "rev": "2022.01.20",
-    "sha256": "sha256-CaGo38NV+mbwekzkgw0DxM4TZf2xwHtYFnC6RbWH+ts="
+    "rev": "2022.02.01",
+    "sha256": "sha256-FAcq6ixmFPQFBAGG2gqB4T+YGYT+Rh/OlKdGcH/iL3g="
   },
   "Python-for-Lazarus": {
     "owner": "Alexey-T",
@@ -41,8 +41,8 @@
   },
   "Emmet-Pascal": {
     "owner": "Alexey-T",
-    "rev": "2020.09.05",
-    "sha256": "0qfiirxnk5g3whx8y8hp54ch3h6gkkd01yf79m95bwar5qvdfybg"
+    "rev": "2022.01.17",
+    "sha256": "sha256-5yqxRW7xFJ4MwHjKnxYL8/HrCDLn30a1gyQRjGMx/qw="
   },
   "CudaText-lexers": {
     "owner": "Alexey-T",

--- a/pkgs/applications/editors/cudatext/update.sh
+++ b/pkgs/applications/editors/cudatext/update.sh
@@ -18,6 +18,6 @@ while IFS=$'\t' read repo owner rev; do
     url="https://github.com/${owner}/${repo}/archive/refs/tags/${latest}.tar.gz"
     hash=$(nix-prefetch-url --quiet --unpack --type sha256 $url)
     sriHash=$(nix hash to-sri --type sha256 $hash)
-    jq ".${repo}.rev = \"${latest}\" | .${repo}.sha256 = \"${sriHash}\"" deps.json | sponge deps.json
+    jq ".\"${repo}\".rev = \"${latest}\" | .\"${repo}\".sha256 = \"${sriHash}\"" deps.json | sponge deps.json
   fi
 done <<< $(jq -r 'to_entries[]|[.key,.value.owner,.value.rev]|@tsv' deps.json)


### PR DESCRIPTION
###### Motivation for this change
* [Changelog](https://cudatext.github.io/history.txt)
* Fix update script

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
