### PR TITLE
pythonPackages.torchdata: init at 0.3.0a1-e86cedc

### DIFF
--- a/pkgs/development/python-modules/torchdata/default.nix
+++ b/pkgs/development/python-modules/torchdata/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# Propogated build inputs
+, pytorch
+, requests
+
+# Check inputs
+, pytestCheckHook
+, expecttest
+, fsspec
+, numpy
+, rarfile
+, torchaudio
+, torchtext
+# , iopath
+}:
+
+
+buildPythonPackage rec {
+  pname = "torchdata";
+  version = "0.3.0a1-e86cedc";
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "data";
+    # rev = "v${version}";
+    rev = "e86cedc5ffd024ea293f541fc77e8a3b4856c8c9"; # git branch release/0.3.0
+    sha256 = "sha256:06gk7pqk2dbkxmaskycvvwyzhapbl5dr2r1v2vswdi6yx5iqzcwa";
+  };
+
+  propagatedBuildInputs = [
+    pytorch # FIXME: relies on an unstable version of pytorch for now
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    expecttest
+    fsspec
+    numpy
+    rarfile
+    torchaudio
+    torchtext
+    # iopath
+  ];
+
+  disabledTests = [
+    # Tests that require network access
+    "test_gdrive_iterdatapipe"
+    "test_online_iterdatapipe"
+    "test_http_reader_iterdatapipe"
+    "test_on_disk_cache_holder_iterdatapipe"
+  ];
+
+  disabledTestPaths = [
+    # FIXME: This test relies on a newer (unstable) version of torchtext
+    "test/test_text_examples.py"
+  ];
+
+  pythonImportsCheck = [ "torchdata" ];
+
+  meta = with lib; {
+    description = "A PyTorch repo for data loading and utilities to be shared by the PyTorch domain libraries.";
+    homepage = "github.com/pytorch/data";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9911,6 +9911,8 @@ in {
 
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
+  torchdata = callPackage ../development/python-modules/torchdata { };
+
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };
 
   torchinfo = callPackage ../development/python-modules/torchinfo { };


### PR DESCRIPTION
###### Motivation for this change

Unstable version of the new composable pytorch data loading library. 

###### TODO

I intend to use this at work, however it's not ready to merge. I'm leaving it as a draft PR for the time being:

- [ ] Unstable version of torchdata that depends on unstable pytorch. Needs to be updated to a stable package once released.
- [ ] Depends on #160197 for tests
- [ ] Tests also depend on #160210, #160207 (though these could be disabled)
- [ ] Needs a maintainer

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
