### PR TITLE
racket: support aarch64-darwin

### DIFF
--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -78,6 +78,13 @@ stdenv.mkDerivation rec {
     # fail to detect its variant at runtime.
     # See: https://github.com/NixOS/nixpkgs/issues/114993#issuecomment-812951247
     ./force-cs-variant.patch
+
+    # The entry point binary $out/bin/racket is codesigned at least once. The
+    # following error is triggered as a result.
+    # (error 'add-ad-hoc-signature "file already has a signature")
+    # We always remove the existing signature then call add-ad-hoc-signature to
+    # circumvent this error.
+    ./force-remove-codesign-then-add.patch
   ];
 
   preConfigure = ''
@@ -90,10 +97,34 @@ stdenv.mkDerivation rec {
         --replace /bin/rm ${coreutils}/bin/rm \
         --replace /bin/true ${coreutils}/bin/true
     done
+
+    # The configure script forces using `libtool -o` as AR on Darwin. But, the
+    # `-o` option is only available from Apple libtool. GNU ar works here.
+    substituteInPlace src/ChezScheme/zlib/configure \
+        --replace 'ARFLAGS="-o"' 'AR=ar; ARFLAGS="rc"'
+
     mkdir src/build
     cd src/build
 
-    gappsWrapperArgs+=("--prefix" "LD_LIBRARY_PATH" ":" ${LD_LIBRARY_PATH})
+  '' + lib.optionalString stdenv.isLinux ''
+    gappsWrapperArgs+=("--prefix"   "LD_LIBRARY_PATH" ":" ${libPath})
+  '' + lib.optionalString stdenv.isDarwin ''
+    gappsWrapperArgs+=("--prefix" "DYLD_LIBRARY_PATH" ":" ${libPath})
+  ''
+  ;
+
+  preBuild = lib.optionalString stdenv.isDarwin ''
+    # Cannot set DYLD_LIBRARY_PATH as an attr of this drv, becasue dynamic
+    # linker environment variables like this are purged.
+    # See: https://apple.stackexchange.com/a/212954/167199
+
+    # Make builders feed it to dlopen(...). Do not expose all of $libPath to
+    # DYLD_LIBRARY_PATH as the order of looking up symbols like
+    # `__cg_jpeg_resync_to_restart` will be messed up. Our libJPEG.dyllib
+    # expects it from our libTIFF.dylib, but instead it could not be found from
+    # the system `libTIFF.dylib`. DYLD_FALLBACK_LIBRARY_PATH has its own problem
+    # , too.
+    export DYLD_FALLBACK_LIBRARY_PATH="${libPath}"
   '';
 
   shared = if stdenv.isDarwin then "dylib" else "shared";
@@ -119,6 +150,6 @@ stdenv.mkDerivation rec {
     homepage = "https://racket-lang.org/";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ kkallio henrytill vrthra ];
-    platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
   };
 }

--- a/pkgs/development/interpreters/racket/force-remove-codesign-then-add.patch
+++ b/pkgs/development/interpreters/racket/force-remove-codesign-then-add.patch
@@ -1,0 +1,11 @@
+--- old/src/mac/codesign.rkt        2022-01-08 18:25:53.000000000 -0500
++++ new/src/mac/codesign.rkt        2022-02-15 15:49:51.000000000 -0500
+@@ -17,6 +17,5 @@
+    #:args (file)
+    file))
+
+-(if remove?
+-    (remove-signature file)
+-    (add-ad-hoc-signature file))
++(remove-signature file)
++(add-ad-hoc-signature file)

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -14,7 +14,7 @@ racket.overrideAttrs (oldAttrs: rec {
       as well as libraries that live in collections. In particular, raco
       and the pkg library are still bundled.
     '';
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     broken = false; # Minimal build does not require working FFI
   };
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
According to https://reviews.llvm.org/D96164, aarch64-darwin executables
require at least an ad hoc signature.

The build tool from the racket repo tries to sign $out/bin/racket but
errors out, because that binary already has a signature.

It is not clear yet at which stage the signature was introduced. This
patch removes the existing signature always before calling
add-ad-hoc-signature to circumvent that error.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
