### PR TITLE
git-machete: updates to 3.7.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -3,7 +3,6 @@
 , fetchFromGitHub
 , installShellFiles
 , git
-, pytest
 , nix-update-script
 , testVersion
 , git-machete
@@ -22,29 +21,7 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  checkInputs = [ git pytest ];
-
-  ### Maybe not needed at all? since `python setup.py test` is executed anyway?
-  /*
-  Executing setuptoolsCheckPhase
-  running test
-  WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
-  running egg_info
-  writing git_machete.egg-info/PKG-INFO
-  writing dependency_links to git_machete.egg-info/dependency_links.txt
-  writing top-level names to git_machete.egg-info/top_level.txt
-  reading manifest file 'git_machete.egg-info/SOURCES.txt'
-  reading manifest template 'MANIFEST.in'
-  adding license file 'LICENSE'
-  writing manifest file 'git_machete.egg-info/SOURCES.txt'
-  running build_ext
-  test_add (git_machete.tests.functional.test_machete.MacheteTester)
-  Verify behaviour of a 'git machete add' command. ... ok
-  ....
-  */
-  postCheck = ''
-    pytest
-  '';
+  checkInputs = [ git ];
 
   postInstall = ''
     installShellCompletion --bash --name git-machete completion/git-machete.completion.bash

--- a/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-machete/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , installShellFiles
 , git
-, stestr
+, pytest
 , nix-update-script
 , testVersion
 , git-machete
@@ -22,19 +22,37 @@ buildPythonApplication rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  checkInputs = [ git stestr ];
+  checkInputs = [ git pytest ];
 
+  ### Maybe not needed at all? since `python setup.py test` is executed anyway?
+  /*
+  Executing setuptoolsCheckPhase
+  running test
+  WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
+  running egg_info
+  writing git_machete.egg-info/PKG-INFO
+  writing dependency_links to git_machete.egg-info/dependency_links.txt
+  writing top-level names to git_machete.egg-info/top_level.txt
+  reading manifest file 'git_machete.egg-info/SOURCES.txt'
+  reading manifest template 'MANIFEST.in'
+  adding license file 'LICENSE'
+  writing manifest file 'git_machete.egg-info/SOURCES.txt'
+  running build_ext
+  test_add (git_machete.tests.functional.test_machete.MacheteTester)
+  Verify behaviour of a 'git machete add' command. ... ok
+  ....
+  */
   postCheck = ''
-    stestr run
+    pytest
   '';
 
   postInstall = ''
     installShellCompletion --bash --name git-machete completion/git-machete.completion.bash
     installShellCompletion --zsh --name _git-machete completion/git-machete.completion.zsh
+    installShellCompletion --fish completion/git-machete.fish
   '';
 
   postInstallCheck = ''
-    git init
     test "$($out/bin/git-machete version)" = "git-machete version ${version}"
   '';
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Just minor updates to git-machete package, further explained in the inline comments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
