### PR TITLE
droidmote: init at 3.0.6

### DIFF
--- a/pkgs/tools/inputmethods/droidmote/default.nix
+++ b/pkgs/tools/inputmethods/droidmote/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, fetchurl, autoPatchelfHook }:
+
+let
+  srcs = {
+    x86_64-linux = fetchurl {
+      urls = [
+        "https://videomap.it/script/dms-ubuntu-x64"
+        "https://archive.org/download/videomap/dms-ubuntu-x64"
+      ];
+      sha256 = "1x7pp6k27lr206a8j2pn0wf4wjb0zi28s0g1g3rb08jmr8fh1jnh";
+    };
+    i686-linux = fetchurl {
+      urls = [
+        "https://videomap.it/script/dms-ubuntu-x32"
+        "https://archive.org/download/videomap/dms-ubuntu-x32"
+      ];
+      sha256 = "1d62d7jz50wzk5rqqm3xab66jdzi9i1j6mwxf7r7nsgm6j5zz8r4";
+    };
+    aarch64-linux = fetchurl {
+      urls = [
+        "https://videomap.it/script/dms-ubuntu-arm64"
+        "https://archive.org/download/videomap/dms-ubuntu-arm64"
+      ];
+      sha256 = "1l1x7iqbxn6zsh3d37yb5x15qsxlwy3cz8g2g8vnzkgaafw9vva0";
+    };
+    armv7l-linux = fetchurl {
+      urls = [
+        "https://videomap.it/script/dms-ubuntu-arm"
+        "https://archive.org/download/videomap/dms-ubuntu-arm"
+      ];
+      sha256 = "1i7q9mylzvbsfydv4xf83nyqkh0nh01612jrqm93q1w6d0k2zvcd";
+    };
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "droidmote";
+  version = "3.0.6";
+
+  src = srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D $src $out/bin/droidmote
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Control your computer from your couch";
+    homepage = "https://www.videomap.it/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ atila ];
+    platforms = lib.attrNames srcs;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1738,6 +1738,8 @@ with pkgs;
 
   droidcam = callPackage ../applications/video/droidcam { };
 
+  droidmote = callPackage ../tools/inputmethods/droidmote { };
+
   ecdsautils = callPackage ../tools/security/ecdsautils { };
 
   echidna = haskell.lib.compose.justStaticExecutables (haskellPackages.callPackage (../tools/security/echidna) { });


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This is a very nice app for controlling your pc from the couch. This derivation installs the server binary, which has to be paired with an Android app. I hope it can help more people.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
