### PR TITLE
separateDebugInfo: Use --strip-unneeded

### DIFF
--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -34,7 +34,7 @@ _separateDebugInfo() {
         # firmware blobs in QEMU.)
         (
             $OBJCOPY --only-keep-debug "$i" "$dst/${id:0:2}/${id:2}.debug"
-            $STRIP --strip-debug "$i"
+            $STRIP --strip-unneeded "$i"
 
             # Also a create a symlink <original-name>.debug.
             ln -sfn ".build-id/${id:0:2}/${id:2}.debug" "$dst/../$(basename "$i")"

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -3,6 +3,7 @@
 , autoreconfHook
 , docbook_xsl
 , docbook_xml_dtd_43
+, glibc
 , gtk-doc
 , lzip
 , libidn2
@@ -38,6 +39,7 @@ in stdenv.mkDerivation rec {
     python3
     libxslt
   ] ++ lib.optionals enableValgrindTests [
+    glibc.debug
     valgrind
   ];
 

--- a/pkgs/development/tools/analysis/valgrind/debug-info-from-env.patch
+++ b/pkgs/development/tools/analysis/valgrind/debug-info-from-env.patch
@@ -1,0 +1,31 @@
+diff --git a/coregrind/m_debuginfo/readelf.c b/coregrind/m_debuginfo/readelf.c
+index c586e3f33..e3bb1717f 100644
+--- a/coregrind/m_debuginfo/readelf.c
++++ b/coregrind/m_debuginfo/readelf.c
+@@ -1508,13 +1508,25 @@ DiImage* find_debug_file( struct _DebugInfo* di,
+    HChar*   debugpath = NULL; /* where we found it */
+ 
+    if (buildid != NULL) {
++      const HChar *dir = VG_(getenv)("NIX_DEBUG_INFO_DIRS");
+       debugpath = ML_(dinfo_zalloc)("di.fdf.1",
+-                                    VG_(strlen)(buildid) + 33);
++                                    VG_(strlen)(buildid) + 33 +
++                                    (dir ? VG_(strlen)(dir) : 0));
+ 
+       VG_(sprintf)(debugpath, "/usr/lib/debug/.build-id/%c%c/%s.debug",
+                    buildid[0], buildid[1], buildid + 2);
+ 
+       dimg = open_debug_file(debugpath, buildid, 0, rel_ok, NULL);
++
++      while (!dimg && dir) {
++         const HChar *sep = VG_(strchr)(dir, ':');
++         Int size = sep ? sep - dir : VG_(strlen)(dir);
++         VG_(sprintf)(debugpath, "%.*s/.build-id/%c%c/%s.debug",
++                      size, dir, buildid[0], buildid[1], buildid + 2);
++         dimg = open_debug_file(debugpath, buildid, 0, rel_ok, NULL);
++         dir = sep ? sep + 1 : NULL;
++      }
++
+       if (!dimg) {
+          ML_(dinfo_free)(debugpath);
+          debugpath = NULL;

--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, fetchpatch
 , autoreconfHook, perl
 , gdb, cctools, xnu, bootstrap_cmds
+, setupDebugInfoDirs
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +20,7 @@ stdenv.mkDerivation rec {
       url = "https://bugsfiles.kde.org/attachment.cgi?id=143535";
       sha256 = "036zyk30rixjvpylw3c7n171n4gpn6zcp7h6ya2dz4h5r478l9i6";
     })
+    ./debug-info-from-env.patch
   ];
 
   outputs = [ "out" "dev" "man" "doc" ];
@@ -31,6 +33,10 @@ stdenv.mkDerivation rec {
 
   # Perl is also a native build input.
   nativeBuildInputs = [ autoreconfHook perl ];
+
+  # Not propagatedNativeBuildInputs because of
+  # https://github.com/NixOS/nixpkgs/issues/64992.
+  propagatedBuildInputs = [ setupDebugInfoDirs ];
 
   enableParallelBuilding = true;
   separateDebugInfo = stdenv.isLinux;


### PR DESCRIPTION
###### Motivation for this change

According to https://stackoverflow.com/q/46197810/115030, `--only-keep-debug` preserves all the information stripped by `--strip-unneeded`. This reduces the size of the webkitgtk output by 22% (123 MB → 96 MB).

Inspired by #159612.

Not sure whether to target `staging` or `master`. I expect this to touch ~~a lot of packages~~ okay, just about every package (via python, which has `separateDebugInfo = true`), so I went with `staging` for now. But on the other hand `master` is currently blocked from feeding `nixos-unstable` due to the GNOME ISO size issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
