### PR TITLE
yelp: Use webkit2gtk-4.0 ABI

### DIFF
--- a/pkgs/desktops/gnome/core/yelp/default.nix
+++ b/pkgs/desktops/gnome/core/yelp/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , gettext
 , fetchurl
-, webkitgtk_4_1
+, webkitgtk
 , pkg-config
 , gtk3
 , glib
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     glib
-    webkitgtk_4_1
+    webkitgtk
     sqlite
     libxml2
     libxslt
@@ -43,6 +43,10 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
   ];
+
+  # To reduce the GNOME ISO closure size.  Remove when other packages
+  # are using webkit2gtk_4_1.
+  configureFlags = ["--with-webkit2gtk-4-0"];
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
###### Motivation for this change

yelp was our only package using the webkit2gtk-4.1 ABI, which inflated the NixOS GNOME ISO with an extra flavor of webkit2gtk.

Fixes part of #159612.

This shrinks the GNOME ISO by 26 MB after compression (2,291,744,768 → 2,266,103,808 bytes).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
