### PR TITLE
ocamlPackages.gg: 0.9.1 → 1.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -1,31 +1,26 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, opaline }:
+{ lib, stdenv, fetchurl, ocaml, findlib, topkg, ocamlbuild }:
 
 let
-  inherit (lib) getVersion versionAtLeast;
-
-  pname = "gg";
-  version = "0.9.1";
-  webpage = "https://erratique.ch/software/${pname}";
+  homepage = "https://erratique.ch/software/gg";
+  version = "1.0.0";
 in
 
-assert versionAtLeast (getVersion ocaml) "4.01.0";
+lib.throwIfNot (lib.versionAtLeast ocaml.version "4.08")
+  "gg is not available for OCaml ${ocaml.version}"
 
 stdenv.mkDerivation {
 
-  name = "ocaml-${pname}-${version}";
+  pname = "ocaml${ocaml.version}-gg";
+  inherit version;
 
   src = fetchurl {
-    url = "${webpage}/releases/${pname}-${version}.tbz";
-    sha256 = "0czj41sr8jsivl3z8wyblf9k971j3kx2wc3s0c1nhzcc8allg9i2";
+    url = "${homepage}/releases/gg-${version}.tbz";
+    sha256 = "sha256:0j7bpj8k17csnz6v6frkz9aycywsb7xmznnb31g8rbfk3626f3ci";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opaline ];
+  buildInputs = [ ocaml findlib ocamlbuild topkg ];
 
-  createFindlibDestdir = true;
-
-  buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
-
-  installPhase = "opaline -libdir $OCAMLFIND_DESTDIR";
+  inherit (topkg) buildPhase installPhase;
 
   meta = with lib; {
     description = "Basic types for computer graphics in OCaml";
@@ -35,8 +30,8 @@ stdenv.mkDerivation {
       matrices, quaternions, axis aligned boxes, colors, color spaces, and
       raster data.
     '';
-    homepage = webpage;
-    platforms = ocaml.meta.platforms or [];
+    inherit homepage;
+    inherit (ocaml.meta) platforms;
     license = licenses.bsd3;
     maintainers = [ maintainers.jirkamarsik ];
   };


### PR DESCRIPTION
###### Motivation for this change

Improvements & future compatibility: https://github.com/dbuenzli/gg/blob/v1.0.0/CHANGES.md#v100-2022-02-15-la-forclaz-vs

cc maintainer @jirkamarsik

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
