### PR TITLE
python3Packages.limits: 2.2.0 -> 2.3.3

### DIFF
--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -1,21 +1,28 @@
-{ lib, fetchPypi, buildPythonPackage, six }:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "limits";
-  version = "2.2.0";
+  version = "2.3.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "da6346f0dcf85f17f0f1cc709c3408a3058cf6fee68313c288127c287237b411";
+    sha256 = "sha256-1CcNKVkcxezqsZvgU0VaTmGbo5UGJQK94rVoGvfcG+g=";
   };
 
-  propagatedBuildInputs = [ six ];
+  propagatedBuildInputs = [
+    setuptools
+  ];
 
   doCheck = false; # ifilter
 
   meta = with lib; {
     description = "Rate limiting utilities";
-    license = licenses.mit;
     homepage = "https://limits.readthedocs.org/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/limits/default.nix
+++ b/pkgs/development/python-modules/limits/default.nix
@@ -1,23 +1,64 @@
 { lib
-, fetchPypi
 , buildPythonPackage
+, fetchFromGitHub
+, hiro
+, pymemcache
+, pymongo
+, pytest-asyncio
+, pytest-lazy-fixture
+, pytestCheckHook
+, pythonOlder
+, redis
 , setuptools
 }:
 
 buildPythonPackage rec {
   pname = "limits";
   version = "2.3.3";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-1CcNKVkcxezqsZvgU0VaTmGbo5UGJQK94rVoGvfcG+g=";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "alisaifee";
+    repo = pname;
+    rev = version;
+    hash = "sha256-ndENV9QBmOecyxFA9rikQ5+5la9k0OfRSTAOLg0aULU=";
   };
 
   propagatedBuildInputs = [
     setuptools
+    redis
+    pymemcache
+    pymongo
   ];
 
-  doCheck = false; # ifilter
+  checkInputs = [
+    hiro
+    pytest-asyncio
+    pytest-lazy-fixture
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pytest.ini \
+      --replace "--cov=limits" "" \
+      --replace "-K" ""
+    # redis-py-cluster doesn't support redis > 4
+    substituteInPlace tests/conftest.py \
+      --replace "import rediscluster" ""
+  '';
+
+  pythonImportsCheck = [
+    "limits"
+  ];
+
+  pytestFlagsArray = [
+    # All other tests require a running Docker instance
+    "tests/test_limits.py"
+    "tests/test_ratelimit_parser.py"
+    "tests/test_limit_granularities.py"
+  ];
 
   meta = with lib; {
     description = "Rate limiting utilities";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/alisaifee/limits/blob/master/HISTORY.rst

Enable basic tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
