### PR TITLE
nixos/mysql: harden default configuration

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -27,7 +27,7 @@
       </listitem>
       <listitem>
         <para>
-          PHP 8.1 is now available
+          PHP 8.1 is now available.
         </para>
       </listitem>
       <listitem>

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -245,6 +245,33 @@
     <itemizedlist>
       <listitem>
         <para>
+          MySQL now listens only on loopback interface by default. This
+          change increases security, but may impact users who have MySQL
+          servers on separate machines or in containers. To get old
+          behaviour, set
+          <literal>services.mysql.settings.mysqld.bind-address = &quot;*&quot;</literal>.
+        </para>
+        <para>
+          MySQL module now also removes <literal>test</literal> database
+          and anonymous users by default on initial database setup. This
+          change doesn’t impact existing databases. To disable this
+          behaviour, refer to
+          <literal>services.mysql.dropInitialTestDatabase</literal> and
+          <literal>services.mysql.dropInitialAnonymousUsers</literal>
+          options.
+        </para>
+        <para>
+          To secure an existing database, run these commands:
+        </para>
+        <programlisting language="SQL">
+  DROP DATABASE test;
+  DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+  DELETE FROM mysql.user WHERE User='';
+  FLUSH PRIVILEGES;
+</programlisting>
+      </listitem>
+      <listitem>
+        <para>
           <literal>pkgs.ghc</literal> now refers to
           <literal>pkgs.targetPackages.haskellPackages.ghc</literal>.
           This <emphasis>only</emphasis> makes a difference if you are

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -11,7 +11,7 @@ In addition to numerous new and upgraded packages, this release has the followin
   the option to use DNS-01 validation when using `enableACME` on
   web server virtual hosts (e.g. `services.nginx.virtualHosts.*.enableACME`).
 
-- PHP 8.1 is now available
+- PHP 8.1 is now available.
 
 - Mattermost has been updated to extended support release 6.3, as the previously packaged extended support release 5.37 is [reaching its end of life](https://docs.mattermost.com/upgrade/extended-support-release.html).
   Migrations may take a while, see the [changelog](https://docs.mattermost.com/install/self-managed-changelog.html#release-v6-3-extended-support-release)

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -75,6 +75,24 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## Backward Incompatibilities {#sec-release-22.05-incompatibilities}
 
+- MySQL now listens only on loopback interface by default. This change
+  increases security, but may impact users who have MySQL servers on
+  separate machines or in containers. To get old behaviour, set
+  `services.mysql.settings.mysqld.bind-address = "*"`.
+
+  MySQL module now also removes `test` database and anonymous users by default
+  on initial database setup. This change doesn't impact existing databases.
+  To disable this behaviour, refer to `services.mysql.dropInitialTestDatabase`
+  and `services.mysql.dropInitialAnonymousUsers` options.
+
+  To secure an existing database, run these commands:
+  ```SQL
+    DROP DATABASE test;
+    DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+    DELETE FROM mysql.user WHERE User='';
+    FLUSH PRIVILEGES;
+  ```
+
 - `pkgs.ghc` now refers to `pkgs.targetPackages.haskellPackages.ghc`.
   This _only_ makes a difference if you are cross-compiling and will
   ensure that `pkgs.ghc` always runs on the host platform and compiles

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -406,10 +406,10 @@ in
               # Create initial databases
               if ! test -e "${cfg.dataDir}/${database.name}"; then
                   echo "Creating initial database: ${database.name}"
-                  ( echo 'create database `${database.name}`;'
+                  ( echo 'CREATE DATABASE `${database.name}`;'
 
                     ${optionalString (database.schema != null) ''
-                    echo 'use `${database.name}`;'
+                    echo 'USE `${database.name}`;'
 
                     # TODO: this silently falls through if database.schema does not exist,
                     # we should catch this somehow and exit, but can't do it here because we're in a subshell.
@@ -429,7 +429,7 @@ in
               ''
                 # Set up the replication master
 
-                ( echo "use mysql;"
+                ( echo "USE mysql;"
                   echo "CREATE USER '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' IDENTIFIED WITH mysql_native_password;"
                   echo "SET PASSWORD FOR '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}' = PASSWORD('${cfg.replication.masterPassword}');"
                   echo "GRANT REPLICATION SLAVE ON *.* TO '${cfg.replication.masterUser}'@'${cfg.replication.slaveHost}';"
@@ -440,9 +440,9 @@ in
               ''
                 # Set up the replication slave
 
-                ( echo "stop slave;"
-                  echo "change master to master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
-                  echo "start slave;"
+                ( echo "STOP SLAVE;"
+                  echo "CHANGE MASTER TO master_host='${cfg.replication.masterHost}', master_user='${cfg.replication.masterUser}', master_password='${cfg.replication.masterPassword}';"
+                  echo "START SLAVE;"
                 ) | ${cfg.package}/bin/mysql -u ${superUser} -N
               ''}
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -305,6 +305,7 @@ in
       {
         datadir = cfg.dataDir;
         port = mkDefault 3306;
+        bind-address = mkDefault "localhost";
       }
       (mkIf (cfg.replication.role == "master" || cfg.replication.role == "slave") {
         log-bin = "mysql-bin-${toString cfg.replication.serverId}";


### PR DESCRIPTION
###### Motivation for this change

Make several changes to increase MySQL default security:

* Bind to localhost, not to all interfaces. This brings it closer to PostgreSQL, where default is also to bind to localhost. Someone also mentioned to me that CentOS configures MySQL that way, though I didn't find any immediate confirmation to that;
* Remove anonymous users and default `test` database. This is what [`mysql_secure_installation`](https://dev.mysql.com/doc/refman/8.0/en/mysql-secure-installation.html) does. We only perform this on initial database setup, so this doesn't affect existing databases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested by building and running a machine and checking that MySQL now binds to 127.0.0.1 and ::1, `test` database doesn't exist and I can't connect to database as any user except `mysql` and `root`.

I would also like to run tests, but for some reason e.g. `tests.mysql.mariadb_106.x86_64-linux` doesn't exist, and `tests.mysql.mariadb_106` tries to run a test for aarch64, which leads to "Exec format error". MySQL tests also [fail on Hydra](https://hydra.nixos.org/eval/1743296?filter=tests.mysql&compare=1743278&full=).

I placed a release notes entry on top of current release notes, because it can potentially affect production deployments. I also considered making interface binding change dependent on `system.stateVersion`, but decided against it because this is not a state change, but a configuration change.