### PR TITLE
README: replace codetriage with normal GH contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.codetriage.com/nixos/nixpkgs"><img src="https://www.codetriage.com/nixos/nixpkgs/badges/users.svg" alt="Code Triagers badge" /></a>
+  <a href="https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md"><img src="https://img.shields.io/github/contributors-anon/NixOS/nixpkgs" alt="Contributors badge" /></a>
   <a href="https://opencollective.com/nixos"><img src="https://opencollective.com/nixos/tiers/supporter/badge.svg?label=Supporter&color=brightgreen" alt="Open Collective supporters" /></a>
 </p>
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Replaced code triage badge with GH contributers badge and a link to CONTRIBUTING.md

I don't think many contributors use code triage anymore since it was added to the README 6 years ago
LMK if I'm mistaken

---

There is another type of contributor badge that shields.io has called contributors_anon which is as follows:

| type | badge |
|-|-|
| contributors | ![](https://img.shields.io/github/contributors/NixOS/nixpkgs) |
| contributors_anon | ![](https://img.shields.io/github/contributors-anon/NixOS/nixpkgs) |

Here are some details on them:

https://github.com/badges/shields/issues/5969
https://stackoverflow.com/questions/36410357/github-v3-api-list-contributors/36462386#36462386

