### PR TITLE
s6-man-pages, s6-networking-man-pages, execline-man-pages: update to latest releases

### DIFF
--- a/pkgs/data/documentation/execline-man-pages/default.nix
+++ b/pkgs/data/documentation/execline-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "execline-man-pages";
-  version = "2.8.1.0.3";
-  sha256 = "1n7c75lmyrjzzcbwjl6fxhfs4k29qlr66r1q35799h942cn4li7v";
+  version = "2.8.1.0.4";
+  sha256 = "1cxi09dlzvjbilmzgmr3xvwvx0l3s1874k3gr85kbjnvp1c1r6cd";
   description = "Port of the documentation for the execline suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];
 }

--- a/pkgs/data/documentation/s6-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-man-pages/default.nix
@@ -2,7 +2,7 @@
 
 buildManPages {
   pname = "s6-man-pages";
-  version = "2.11.0.0.5";
+  version = "2.11.0.1.1";
   sha256 = "03gl0vvdaqfb5hs0dfdbs9djxiyq3abcx9vwgkfw22b1rm2fa0r6";
   description = "Port of the documentation for the s6 supervision suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];

--- a/pkgs/data/documentation/s6-networking-man-pages/default.nix
+++ b/pkgs/data/documentation/s6-networking-man-pages/default.nix
@@ -2,8 +2,8 @@
 
 buildManPages {
   pname = "s6-networking-man-pages";
-  version = "2.5.0.0.2";
-  sha256 = "1ix8qrivp9prw0m401d7s9vkxhw16a4sxfhrs7abf9qqhs2zkd1r";
+  version = "2.5.1.0.1";
+  sha256 = "1h87s3wixsms8ys7gvm1s9d8pzn73q5j4sgybpi3gmr55d4cwra4";
   description = "Port of the documentation for the s6-networking suite to mdoc";
   maintainers = [ lib.maintainers.sternenseemann ];
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
