### PR TITLE
[DRAFT] nixos/orjail: Add module for orjail

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -389,6 +389,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://orjail.github.io/">orjail</link>,
+          wrapper for tunneling applications through the Tor online
+          anonymity network. Available as
+          <link xlink:href="options.html#opt-programs.orjail.enable">programs.orjail</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://nbd.sourceforge.io/">nbd</link>, a
           Network Block Device server. Available as
           <link xlink:href="options.html#opt-services.nbd.server.enable">services.nbd</link>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -117,6 +117,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 - [ethercalc](https://github.com/audreyt/ethercalc), an online collaborative
   spreadsheet. Available as [services.ethercalc](options.html#opt-services.ethercalc.enable).
 
+- [orjail](https://orjail.github.io/), wrapper for tunneling applications through the Tor online anonymity network. Available as [programs.orjail](options.html#opt-programs.orjail.enable).
+
 - [nbd](https://nbd.sourceforge.io/), a Network Block Device server. Available as [services.nbd](options.html#opt-services.nbd.server.enable).
 
 - [nix-ld](https://github.com/Mic92/nix-ld), Run unpatched dynamic binaries on NixOS. Available as [programs.nix-ld](options.html#opt-programs.nix-ld.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -193,6 +193,7 @@
   ./programs/npm.nix
   ./programs/noisetorch.nix
   ./programs/oblogout.nix
+  ./programs/orjail/orjail.nix
   ./programs/pantheon-tweaks.nix
   ./programs/partition-manager.nix
   ./programs/plotinus.nix

--- a/nixos/modules/programs/orjail/orjail.nix
+++ b/nixos/modules/programs/orjail/orjail.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.orjail;
+
+  wrappedBins = pkgs.runCommand "orjail-wrapped-binaries"
+    { preferLocalBuild = true;
+      allowSubstitutes = false;
+    }
+    ''
+      mkdir -p $out/bin
+      ${lib.concatStringsSep "\n" (lib.mapAttrsToList (command: value:
+      let
+        opts = if builtins.isAttrs value
+        then value
+        else { executable = value; extraArgs = []; };
+        args = lib.escapeShellArgs ( opts.extraArgs );
+      in
+      ''
+        cat <<_EOF >$out/bin/${command}
+        #! ${pkgs.runtimeShell}
+        exec ${pkgs.orjailWrapper}/bin/orjail ${args} ${toString opts.executable} "\$@"
+        _EOF
+        chmod 0755 $out/bin/${command}
+      '') cfg.wrappedBinaries)}
+    '';
+
+in {
+  options.programs.orjail = {
+    enable = mkEnableOption "orjail";
+
+    wrappedBinaries = mkOption {
+      type = types.attrsOf (types.either types.path (types.submodule {
+        options = {
+          executable = mkOption {
+            type = types.path;
+            description = "Executable to run through Tor";
+            example = literalExpression ''"''${lib.getBin pkgs.firefox}/bin/firefox"'';
+          };
+          extraArgs = mkOption {
+            type = types.listOf types.str;
+            default = [];
+            description = "Extra arguments to pass to orjail";
+            example = [ "-f" ];
+          };
+        };
+      }));
+      default = {};
+      example = literalExpression ''
+        {
+          firefox = {
+            executable = "''${lib.getBin pkgs.firefox}/bin/firefox";
+          };
+          mpv = {
+            executable = "''${lib.getBin pkgs.mpv}/bin/mpv";
+          };
+        }
+      '';
+      description = ''
+        Wrap the binaries in orjail and place them in the global path.
+        </para>
+        <para>
+        You will get file collisions if you put the actual application binary in
+        the global environment (such as by adding the application package to
+        <code>environment.systemPackages</code>), and applications started via
+        .desktop files are not wrapped if they specify the absolute path to the
+        binary.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    programs.firejail.enable = true;
+
+    nixpkgs.overlays = [
+      (self: super: {
+        orjailWrapper = super.orjail.overrideAttrs (old: {
+	  patches = (old.patches or []) ++ [
+  	    ./orjail_wrapper.patch
+          ];
+        });
+      })
+    ];
+
+    environment.systemPackages = [ pkgs.orjail ] ++ [ wrappedBins ];
+
+    systemd = {
+      services.orjail = {
+        wantedBy = [ "multi-user.target" ];
+        description = "Orjail Service";
+        after = [ "network.target" ];
+        serviceConfig = {
+	  Type = "oneshot";
+	  ExecStart = "${pkgs.orjailWrapper}/bin/orjail -v -f -k :";
+	};
+      };
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ onny ];
+}

--- a/nixos/modules/programs/orjail/orjail_wrapper.patch
+++ b/nixos/modules/programs/orjail/orjail_wrapper.patch
@@ -1,0 +1,32 @@
+diff --git a/usr/sbin/orjail b/usr/sbin/orjail
+index ee0e58a..7167105 100755
+--- a/usr/sbin/orjail
++++ b/usr/sbin/orjail
+@@ -404,13 +404,10 @@ while [[ $# -gt 0 ]]; do
+   shift
+ done
+ 
+-if [[ $EUID -ne 0 ]]; then
+-   die "$DEFAULTNAME must be run as root."
+-fi
+-
+ TORBIN=$(command -v tor)
++tor
+ if ! [ -x "$TORBIN" ]; then
+-  die "Can't locate tor executable.";
++  die "Can't locate $TORBIN tor executable.";
+ fi
+ 
+ # No arguments, no party
+@@ -436,9 +433,9 @@ for cmd in ip iptables bc mkdir chown grep $FIREJAILBIN ${SUDOBIN:-su}; do
+ done
+ ! [ 0 = $err ] && exit $err
+ 
+-FIREJAILBIN=
++FIREJAILBIN=/run/wrappers/bin/firejail
+ if [ $USEFIREJAIL = y ]; then
+-  firejail_version=$(firejail --version | grep -io "9.[0-9]\\{2\\}")
++  firejail_version=$($FIREJAILBIN --version | grep -io "9.[0-9]\\{2\\}")
+   if [[ $(echo "$firejail_version>9.44" | bc) -eq 0 ]]; then
+ 	  die "orjail requires at least firejail 0.9.44.10 to run."
+   fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds an extra option to enable the program `orjail` and wrap applications to run through it. `orjail` is a sandbox based on `firejail` which will also tunnel internet traffic through the Tor network.
Usage would be similar to [programs.firejail](https://search.nixos.org/options?channel=21.11&show=programs.firejail.wrappedBinaries&from=0&size=50&sort=relevance&type=packages&query=firejail) like this:
``` 
programs.orjail.wrappedBinaries = {
  firefox = {
    executable = "${lib.getBin pkgs.firefox}/bin/firefox";
  };
  mpv = {
    executable = "${lib.getBin pkgs.mpv}/bin/mpv";
  };
}
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
