### PR TITLE
Fix weasyprint on darwin (x86_64 and aarch64)

### DIFF
--- a/pkgs/development/python-modules/responses/default.nix
+++ b/pkgs/development/python-modules/responses/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage rec {
     "responses"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "Python module for mocking out the requests Python library";
     homepage = "https://github.com/getsentry/responses";

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -1,18 +1,16 @@
 { buildPythonPackage
 , fetchPypi
-, fetchpatch
 , pytestCheckHook
 , brotli
-, cairosvg
 , flit-core
 , fonttools
 , pydyf
 , pyphen
 , cffi
-, cssselect
-, lxml
+, cssselect2
+, pillow
 , html5lib
-, tinycss
+, tinycss2
 , zopfli
 , glib
 , harfbuzz
@@ -45,7 +43,6 @@ buildPythonPackage rec {
       pangoft2 = "${pango.out}/lib/libpangoft2-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       gobject = "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
-      pangocairo = "${pango.out}/lib/libpangocairo-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];
@@ -56,16 +53,15 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     brotli
-    cairosvg
     cffi
-    cssselect
+    cssselect2
+    pillow
     fonttools
     html5lib
-    lxml
     flit-core
     pydyf
     pyphen
-    tinycss
+    tinycss2
     zopfli
   ];
 
@@ -80,9 +76,12 @@ buildPythonPackage rec {
     # sensitive to sandbox environments
     "test_tab_size"
     "test_tabulation_character"
+    "test_http"
   ];
 
   FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  makeWrapperArgs = [ "--set FONTCONFIG_FILE ${fontconfig.out}/etc/fonts/fonts.conf" ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \


### PR DESCRIPTION
- add FONTCONFIG_FILE also for executable
- deactivate http_test due to permission denied in sandbox
- remove unused dependencies that caused build problems
- fix responses dependency by allowing local networking for tests

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
