### PR TITLE
i3-swallow: init at unstable-2022-02-19

### DIFF
--- a/pkgs/applications/window-managers/i3/swallow.nix
+++ b/pkgs/applications/window-managers/i3/swallow.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonApplication
+, fetchFromGitHub
+, poetry-core
+, i3ipc
+, xlib
+, six
+}:
+
+buildPythonApplication rec {
+  pname = "i3-swallow";
+  version = "unstable-2022-02-19";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "jamesofarrell";
+    repo = "i3-swallow";
+    rev = "6fbc04645c483fe733de56b56743e453693d4c78";
+    sha256 = "1l3x8mixwq4n0lnyp0wz5vijgnypamq6lqjazcd2ywl2jv8d6fif";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    i3ipc
+    xlib
+    six
+  ];
+
+  # No tests available
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/jamesofarrell/i3-swallow";
+    description = "Swallow a terminal window in i3wm";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "swallow";
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26442,6 +26442,8 @@ with pkgs;
 
   i3-resurrect = python3Packages.callPackage ../applications/window-managers/i3/i3-resurrect.nix { };
 
+  i3-swallow = python3Packages.callPackage ../applications/window-managers/i3/swallow.nix { };
+
   i3blocks = callPackage ../applications/window-managers/i3/blocks.nix { };
 
   i3blocks-gaps = callPackage ../applications/window-managers/i3/blocks-gaps.nix { };


### PR DESCRIPTION
###### Motivation for this change
Really useful application to swallow windows using i3wm, very nice for stuff like `mpv`. Note that the pypi package uses a fork which only adds the ability to install it with pip.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
