### PR TITLE
nixos/*: cleanup

### DIFF
--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -655,7 +655,7 @@ in
       long_polling_interval = null;
     };
 
-    services.redis.enable = lib.mkDefault (cfg.redis.host == "localhost");
+    services.redis.servers.discourse.enable = lib.mkDefault (cfg.redis.host == "localhost");
 
     services.postgresql = lib.mkIf databaseActuallyCreateLocally {
       enable = true;

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
   nodes = {
     webserver = { pkgs, lib, ... }: {
       services.caddy.enable = true;
-      services.caddy.config = ''
+      services.caddy.extraConfig = ''
         http://localhost {
           encode gzip
 
@@ -22,7 +22,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       '';
 
       specialisation.etag.configuration = {
-        services.caddy.config = lib.mkForce ''
+        services.caddy.extraConfig = lib.mkForce ''
           http://localhost {
             encode gzip
 
@@ -38,7 +38,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       };
 
       specialisation.config-reload.configuration = {
-        services.caddy.config = ''
+        services.caddy.extraConfig = ''
           http://localhost:8080 {
           }
         '';

--- a/nixos/tests/jibri.nix
+++ b/nixos/tests/jibri.nix
@@ -22,9 +22,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         forceSSL = true;
       };
 
-      security.acme.email = "me@example.org";
+      security.acme.defaults.email = "me@example.org";
       security.acme.acceptTerms = true;
-      security.acme.server = "https://example.com"; # self-signed only
+      security.acme.defaults.server = "https://example.com"; # self-signed only
     };
 
   testScript = ''

--- a/nixos/tests/jitsi-meet.nix
+++ b/nixos/tests/jitsi-meet.nix
@@ -21,9 +21,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
         forceSSL = true;
       };
 
-      security.acme.email = "me@example.org";
+      security.acme.defaults.email = "me@example.org";
       security.acme.acceptTerms = true;
-      security.acme.server = "https://example.com"; # self-signed only
+      security.acme.defaults.server = "https://example.com"; # self-signed only
     };
   };
 

--- a/nixos/tests/step-ca.nix
+++ b/nixos/tests/step-ca.nix
@@ -9,6 +9,7 @@ import ./make-test-python.nix ({ pkgs, ... }:
     '';
   in
   {
+    name = "step-ca";
     nodes =
       {
         caserver =
@@ -42,8 +43,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
         caclient =
           { config, pkgs, ... }: {
-            security.acme.server = "https://caserver:8443/acme/acme/directory";
-            security.acme.email = "root@example.org";
+            security.acme.defaults.server = "https://caserver:8443/acme/acme/directory";
+            security.acme.defaults.email = "root@example.org";
             security.acme.acceptTerms = true;
 
             security.pki.certificateFiles = [ "${test-certificates}/root_ca.crt" ];

--- a/nixos/tests/web-apps/peertube.nix
+++ b/nixos/tests/web-apps/peertube.nix
@@ -30,10 +30,11 @@ import ../make-test-python.nix ({pkgs, ...}:
         '';
       };
 
-      services.redis = {
+      services.redis.servers.peertube = {
         enable = true;
         bind = "0.0.0.0";
         requirePass = "turrQfaQwnanGbcsdhxy";
+        port = 6379;
       };
     };
 
@@ -109,7 +110,7 @@ import ../make-test-python.nix ({pkgs, ...}:
     start_all()
 
     database.wait_for_unit("postgresql.service")
-    database.wait_for_unit("redis.service")
+    database.wait_for_unit("redis-peertube.service")
 
     database.wait_for_open_port(5432)
     database.wait_for_open_port(6379)


### PR DESCRIPTION
###### Motivation for this change
Trying to find out why nixos-unstable fails to evaluate. But found some other eval traces.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
