### PR TITLE
mas: 1.8.2 -> 1.8.6

### DIFF
--- a/pkgs/os-specific/darwin/mas/default.nix
+++ b/pkgs/os-specific/darwin/mas/default.nix
@@ -1,38 +1,41 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchurl
-, libarchive
-, p7zip
+, installShellFiles
+, testVersion
+, mas
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "mas";
-  version = "1.8.2";
+  version = "1.8.6";
 
   src = fetchurl {
-    url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas.pkg";
-    sha256 = "HlLQKBVIYKanS6kjkbYdabBi1T0irxE6fNd2H6mDKe4=";
+    # Use the tarball until https://github.com/mas-cli/mas/issues/452 is fixed.
+    # Even though it looks like an OS/arch specific build it is actually a universal binary.
+    url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas-${version}.monterey.bottle.tar.gz";
+    sha256 = "0q4skdhymgn5xrwafyisfshx327faia682yv83mf68r61m2jl10d";
   };
 
-  nativeBuildInputs = [ libarchive p7zip ];
-
-  unpackPhase = ''
-    7z x $src
-    bsdtar -xf Payload~
-  '';
-
-  dontBuild = true;
+  nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
-    mkdir -p $out
-    cp -r ./usr/local/bin $out
+    install -D './${version}/bin/mas' "$out/bin/mas"
+    installShellCompletion --cmd mas --bash './${version}/etc/bash_completion.d/mas'
   '';
+
+  passthru.tests = {
+    version = testVersion {
+      package = mas;
+      command = "mas version";
+    };
+  };
 
   meta = with lib; {
     description = "Mac App Store command line interface";
     homepage = "https://github.com/mas-cli/mas";
     license = licenses.mit;
-    maintainers = with maintainers; [ zachcoyle ];
-    platforms = platforms.darwin;
+    maintainers = with maintainers; [ steinybot zachcoyle ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to the latest version for better macOS Monterey support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
