### PR TITLE
checkov: 2.0.853 -> 2.0.859

### DIFF
--- a/pkgs/development/python-modules/bc-python-hcl2/default.nix
+++ b/pkgs/development/python-modules/bc-python-hcl2/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , nose
+, pythonOlder
 }:
 
 let
@@ -19,11 +20,14 @@ let
 in
 buildPythonPackage rec {
   pname = "bc-python-hcl2";
-  version = "0.3.24";
+  version = "0.3.30";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-YsiMkTPRSKR4511csJOv9/Jf1b3TVUM7N2lInejdNrQ=";
+    hash = "sha256-wfcTIPKbMPa7xpXzkFtxnxG2ZRFzTw35EP7f4zwHxcs=";
   };
 
   # Nose is required during build process, so can not use `checkInputs`.

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -32,13 +32,13 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "checkov";
-  version = "2.0.853";
+  version = "2.0.859";
 
   src = fetchFromGitHub {
     owner = "bridgecrewio";
     repo = pname;
     rev = version;
-    hash = "sha256-qD6P3ppxckqiCB6wiypdVQtY+b3PN3dhuAQP5REDq3U=";
+    hash = "sha256-uvuAMD/upr8mvK/YCvvlPGIZBMZ0SHxXMdv18NIsOYM=";
   };
 
   nativeBuildInputs = with py.pkgs; [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/bridgecrewio/checkov/releases/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
