### PR TITLE
brave: 1.35.101 -> 1.35.103

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,11 +91,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.35.101";
+  version = "1.35.103";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "q5GL6R87b3iYLiM9oJQgCOVeXzyNFY6x8fQ9KsDN7gk=";
+    sha256 = "UgperKruN2quKdFTf/iTa+dd2GB57nt+mu6KBe4VvYk=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#135103

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).