### PR TITLE
iterm2: fix build

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11565,6 +11565,17 @@
       githubId = 55607356;
       name = "Stephan Heßelmann";
   };
+  steinybot = {
+    name = "Jason Pickens";
+    email = "jasonpickensnz@gmail.com";
+    matrix = "@steinybot:matrix.org";
+    github = "steinybot";
+    githubId = 4659562;
+    keys = [{
+      longkeyid = "ed25519/0x21DE1CAE59762A0F";
+      fingerprint = "2709 1DEC CC42 4635 4299  569C 21DE 1CAE 5976 2A0F";
+    }];
+  };
   stelcodes = {
     email = "stel@stel.codes";
     github = "stelcodes";

--- a/pkgs/applications/terminal-emulators/iterm2/default.nix
+++ b/pkgs/applications/terminal-emulators/iterm2/default.nix
@@ -1,48 +1,42 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ fetchzip, lib, stdenvNoCC }:
 
  /*
- This derivation is impure: it relies on an Xcode toolchain being installed
- and available in the expected place. The values of sandboxProfile
- are copied pretty directly from the MacVim derivation, which
- is also impure. In order to build you at least need the `sandbox`
- option set to `relaxed` or `false`.
+ This cannot be built from source as it requires entitlements and
+ for that it needs to be code signed. Automatic updates will have
+ to be disabled via preferences instead of at build time. To do
+ that edit $HOME/Library/Preferences/com.googlecode.iterm2.plist
+ and add:
+ SUEnableAutomaticChecks = 0;
  */
 
 stdenvNoCC.mkDerivation rec {
   pname = "iterm2";
-  version = "3.4.14";
+  version = "3.4.15";
 
-  src = fetchFromGitHub {
-    owner = "gnachman";
-    repo = "iTerm2";
-    rev = "v${version}";
-    sha256 = "sha256-sDCnBO7xDpecu2cSjpHwync2DVsj9EKUmgpqEVLtxRM=";
+  src = fetchzip {
+    url = "https://iterm2.com/downloads/stable/iTerm2-${lib.replaceStrings ["."] ["_"] version}.zip";
+    sha256 = "sha256-ZE/uYBKB2popdIdZWA8AvyJiwMzt32u6u/H/AyNcoVo=";
   };
 
-  patches = [ ./disable_updates.patch ];
-  postPatch = ''
-    sed -i -e 's/CODE_SIGN_IDENTITY = "Developer ID Application"/CODE_SIGN_IDENTITY = ""/g' ./iTerm2.xcodeproj/project.pbxproj
-  '';
-
-  preConfigure = "LD=$CC";
-  makeFlagsArray = ["Nix"];
   installPhase = ''
-    mkdir -p $out/Applications
-    mv Build/Products/Deployment/iTerm2.app $out/Applications/iTerm.app
-  '';
-
-  sandboxProfile = ''
-     (allow file-read* file-write* process-exec mach-lookup)
-     ; block homebrew dependencies
-     (deny file-read* file-write* process-exec mach-lookup (subpath "/usr/local") (with no-log))
+    runHook preInstall
+    APP_DIR="$out/Applications/iTerm2.app"
+    mkdir -p "$APP_DIR"
+    cp -r . "$APP_DIR"
+    mkdir -p "$out/bin"
+    cat << EOF > "$out/bin/iterm2"
+    #!${stdenvNoCC.shell}
+    open -na "$APP_DIR" --args "$@"
+    EOF
+    chmod +x "$out/bin/iterm2"
+    runHook postInstall
   '';
 
   meta = with lib; {
     description = "A replacement for Terminal and the successor to iTerm";
     homepage = "https://www.iterm2.com/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ tricktron ];
-    platforms = platforms.darwin;
-    hydraPlatforms = [];
+    maintainers = with maintainers; [ steinybot tricktron ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `Nix` target for the iTerm2 build no longer works and has been removed. See https://gitlab.com/gnachman/iterm2/-/issues/9868.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
