### PR TITLE
arkade, krane: remove kubectl wrapper

### DIFF
--- a/pkgs/applications/networking/cluster/arkade/default.nix
+++ b/pkgs/applications/networking/cluster/arkade/default.nix
@@ -2,8 +2,6 @@
 , stdenv
 , buildGoModule
 , fetchFromGitHub
-, makeWrapper
-, kubectl
 }:
 
 buildGoModule rec {
@@ -39,13 +37,6 @@ buildGoModule rec {
     "-X github.com/alexellis/arkade/cmd.GitCommit=ref/tags/${version}"
     "-X github.com/alexellis/arkade/cmd.Version=${version}"
   ];
-
-  buildInputs = [ makeWrapper ];
-
-  postInstall = ''
-    wrapProgram "$out/bin/arkade" \
-      --prefix PATH : ${lib.makeBinPath [ kubectl ]}
-  '';
 
   meta = with lib; {
     homepage = "https://github.com/alexellis/arkade";

--- a/pkgs/applications/networking/cluster/krane/default.nix
+++ b/pkgs/applications/networking/cluster/krane/default.nix
@@ -1,7 +1,5 @@
 { lib
 , bundlerApp
-, makeWrapper
-, kubectl
 , bundlerUpdateScript
 }:
 
@@ -9,13 +7,6 @@ bundlerApp {
   pname = "krane";
   gemdir = ./.;
   exes = [ "krane" ];
-
-  buildInputs = [ makeWrapper ];
-
-  postBuild = ''
-    wrapProgram "$out/bin/krane" \
-      --prefix PATH : ${lib.makeBinPath [ kubectl ]}
-  '';
 
   passthru.updateScript = bundlerUpdateScript "krane";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Wrapping `kubectl` may cause problems for users if they want to use another `kubectl`, e.g from the host system or because of version compatibility, etc. 

Similar issues occur with trying to wrap with `docker` and `podman`, we avoid doing that and defer to the user.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
