### PR TITLE
python3Packages.gigalixir: disable failing test

### DIFF
--- a/pkgs/development/python-modules/gigalixir/default.nix
+++ b/pkgs/development/python-modules/gigalixir/default.nix
@@ -1,9 +1,9 @@
-{ buildPythonApplication
+{ lib
+, buildPythonApplication
 , click
 , fetchPypi
 , git
 , httpretty
-, lib
 , qrcode
 , pygments
 , pyopenssl
@@ -11,17 +11,38 @@
 , requests
 , rollbar
 , stripe
+, pythonOlder
 , sure
 }:
 
 buildPythonApplication rec {
   pname = "gigalixir";
   version = "1.2.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-P70xsI/zwsoSgK1XCPzJSI5NQ58M431kmgo5gHXbaNw=";
+    hash = "sha256-P70xsI/zwsoSgK1XCPzJSI5NQ58M431kmgo5gHXbaNw=";
   };
+
+  propagatedBuildInputs = [
+    click
+    pygments
+    pyopenssl
+    qrcode
+    requests
+    rollbar
+    stripe
+  ];
+
+  checkInputs = [
+    git
+    httpretty
+    pytestCheckHook
+    sure
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \
@@ -29,24 +50,14 @@ buildPythonApplication rec {
       --replace "cryptography==" "cryptography>="
   '';
 
-  propagatedBuildInputs = [
-    click
-    requests
-    stripe
-    rollbar
-    pygments
-    qrcode
-    pyopenssl
+  disabledTests = [
+    # Test requires network access
+    "test_rollback_without_version"
   ];
 
-  checkInputs = [
-    httpretty
-    sure
-    pytestCheckHook
-    git
+  pythonImportsCheck = [
+    "gigalixir"
   ];
-
-  pythonImportsCheck = [ "gigalixir" ];
 
   meta = with lib; {
     description = "Gigalixir Command-Line Interface";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Test requires network access


Found while running `nix-review` of #160422.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
