### PR TITLE
python3Packages.ffcv: init at 0.0.3

### DIFF
--- a/pkgs/development/python-modules/ffcv/default.nix
+++ b/pkgs/development/python-modules/ffcv/default.nix
@@ -1,0 +1,53 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, libjpeg
+, numba
+, opencv4
+, pandas
+, pkgconfig
+, pytorch-pfn-extras
+, terminaltables
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "ffcv";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "libffcv";
+    repo = pname;
+    # See https://github.com/libffcv/ffcv/issues/158.
+    rev = "131d56235eca3f1497bb84eeaec82c3434ef25d8";
+    sha256 = "0f7q2x48lknnf98mqaa35my05qwvdgv0h8l9lpagdw6yhx0a6p2x";
+  };
+
+  # See https://github.com/libffcv/ffcv/issues/159.
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'assertpy'," "" \
+      --replace "'fastargs'," "" \
+      --replace "'imgcat'," "" \
+      --replace "'matplotlib'," "" \
+      --replace "'psutil'," "" \
+      --replace "'sklearn'," "" \
+      --replace "'webdataset'," ""
+  '';
+
+  buildInputs = [ libjpeg pkgconfig ];
+  propagatedBuildInputs = [ opencv4 numba pandas pytorch-pfn-extras terminaltables tqdm ];
+
+  # `ffcv._libffcv*.so` cannot be loaded in the nix build environment for some
+  # reason. See https://github.com/NixOS/nixpkgs/pull/160441#issuecomment-1045204722.
+  doCheck = false;
+
+  pythonImportsCheck = [ "ffcv" ];
+
+  meta = with lib; {
+    description = "FFCV: Fast Forward Computer Vision";
+    homepage = "https://ffcv.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -1,0 +1,55 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, onnx
+, pytestCheckHook
+, pytorch
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "pytorch-pfn-extras";
+  version = "0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "pfnet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1ch4vhz3zjanj5advqsj51yy7idrp8yvydvcg4ymwa3wsfjrx58g";
+  };
+
+  propagatedBuildInputs = [ numpy pytorch typing-extensions ];
+
+  checkInputs = [ onnx pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytorch_pfn_extras" ];
+
+  disabledTestPaths = [
+    # Requires optuna which is currently (2022-02-16) marked as broken.
+    "tests/pytorch_pfn_extras_tests/test_config_types.py"
+
+    # Requires CUDA access which is not possible in the nix environment.
+    "tests/pytorch_pfn_extras_tests/cuda_tests/test_allocator.py"
+    "tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy_batchnorm.py"
+    "tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy_conv.py"
+    "tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy_linear.py"
+    "tests/pytorch_pfn_extras_tests/nn_tests/modules_tests/test_lazy.py"
+    "tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py"
+    "tests/pytorch_pfn_extras_tests/runtime_tests/test_to.py"
+    "tests/pytorch_pfn_extras_tests/test_handler.py"
+    "tests/pytorch_pfn_extras_tests/test_logic.py"
+    "tests/pytorch_pfn_extras_tests/test_reporter.py"
+    "tests/pytorch_pfn_extras_tests/training_tests/test_trainer.py"
+    "tests/pytorch_pfn_extras_tests/utils_tests/test_checkpoint.py"
+    "tests/pytorch_pfn_extras_tests/utils_tests/test_comparer.py"
+    "tests/pytorch_pfn_extras_tests/utils_tests/test_new_comparer.py"
+  ];
+
+  meta = with lib; {
+    description = "Supplementary components to accelerate research and development in PyTorch";
+    homepage = "https://github.com/pfnet/pytorch-pfn-extras";
+    license = licenses.mit;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2821,6 +2821,8 @@ in {
     hdf5 = pkgs.hdf5_1_10;
   };
 
+  ffcv = callPackage ../development/python-modules/ffcv { };
+
   ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
 
   ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8227,6 +8227,8 @@ in {
 
   pytorch-metric-learning = callPackage ../development/python-modules/pytorch-metric-learning { };
 
+  pytorch-pfn-extras = callPackage ../development/python-modules/pytorch-pfn-extras { };
+
   pytorchWithCuda = self.pytorch.override {
     cudaSupport = true;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Introduce `python3Packages.ffcv`. FFCV is an exciting new data loading library for computer vision applications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
