### PR TITLE
python3Packages.aio-geojson-client: 0.15 -> 0.16

### DIFF
--- a/pkgs/development/python-modules/aio-geojson-client/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-client/default.nix
@@ -8,17 +8,21 @@
 , haversine
 , pytest-asyncio
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aio-geojson-client";
-  version = "0.15";
+  version = "0.16";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-aio-geojson-client";
     rev = "v${version}";
-    sha256 = "0sbzrzmny7x4bkbg6z0cjn4d10r50nxdyaq7g6lagwd8ijpkg8l3";
+    hash = "sha256-u3SwrSxeBJrBTHfqKY/mAb2p1jqW2AvRsHomKsI81gM=";
   };
 
   propagatedBuildInputs = [
@@ -34,7 +38,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_geojson_client" ];
+  pythonImportsCheck = [
+    "aio_geojson_client"
+  ];
 
   meta = with lib; {
     description = "Python module for accessing GeoJSON feeds";

--- a/pkgs/development/python-modules/aio-geojson-geonetnz-quakes/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-geonetnz-quakes/default.nix
@@ -7,17 +7,21 @@
 , pytest-asyncio
 , pytestCheckHook
 , pytz
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aio-geojson-geonetnz-quakes";
-  version = "0.13";
+  version = "0.14";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-aio-geojson-geonetnz-quakes";
     rev = "v${version}";
-    sha256 = "sha256-M1QleYVPqLFjxBmOlNJdydxDTk0JJf+GYVtOTC3YUTA=";
+    hash = "sha256-T3vQodb0/3YEjsyHLSI8DBKK75J8hvsaBqyQI7GkT3U=";
   };
 
   propagatedBuildInputs = [
@@ -32,7 +36,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_geojson_geonetnz_quakes" ];
+  pythonImportsCheck = [
+    "aio_geojson_geonetnz_quakes"
+  ];
 
   meta = with lib; {
     description = "Python module for accessing the GeoNet NZ Quakes GeoJSON feeds";

--- a/pkgs/development/python-modules/georss-ign-sismologia-client/default.nix
+++ b/pkgs/development/python-modules/georss-ign-sismologia-client/default.nix
@@ -8,14 +8,16 @@
 
 buildPythonPackage rec {
   pname = "georss-ign-sismologia-client";
-  version = "0.4";
+  version = "0.5";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-ign-sismologia-client";
     rev = "v${version}";
-    sha256 = "sha256-g7lZC5ZiJV8dNZJceLROqyBRZSuqaivGFhaQrKe4B7g=";
+    hash = "sha256-i3VdxntFwieCmB4ihHRSCV5YKDyYytl3XnU/G1LwLhg=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +28,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "georss_ign_sismologia_client" ];
+  pythonImportsCheck = [
+    "georss_ign_sismologia_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing the IGN Sismologia GeoRSS feed";

--- a/pkgs/development/python-modules/georss-nrcan-earthquakes-client/default.nix
+++ b/pkgs/development/python-modules/georss-nrcan-earthquakes-client/default.nix
@@ -8,14 +8,16 @@
 
 buildPythonPackage rec {
   pname = "georss-nrcan-earthquakes-client";
-  version = "0.3";
+  version = "0.4";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-nrcan-earthquakes-client";
     rev = "v${version}";
-    sha256 = "1brn6ycsw3d3znbqi2w2cxjw8hyfb44p2lra18rx2gyvgnkxg19l";
+    hash = "sha256-FFm37+dCkdoZXgvAjYhcHOYFf0oQ37bxJb7vzbWDTro=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +28,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "georss_nrcan_earthquakes_client" ];
+  pythonImportsCheck = [
+    "georss_nrcan_earthquakes_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing Natural Resources Canada Earthquakes feed";

--- a/pkgs/development/python-modules/georss-qld-bushfire-alert-client/default.nix
+++ b/pkgs/development/python-modules/georss-qld-bushfire-alert-client/default.nix
@@ -9,13 +9,15 @@
 buildPythonPackage rec {
   pname = "georss-qld-bushfire-alert-client";
   version = "0.5";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-qld-bushfire-alert-client";
     rev = "v${version}";
-    sha256 = "sha256-G7rIoG48MTWngtXCT5xzcjntzsYxtVWVhXflLsWY/dk=";
+    hash = "sha256-G7rIoG48MTWngtXCT5xzcjntzsYxtVWVhXflLsWY/dk=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +28,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "georss_qld_bushfire_alert_client" ];
+  pythonImportsCheck = [
+    "georss_qld_bushfire_alert_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing Queensland Bushfire Alert feed";

--- a/pkgs/development/python-modules/georss-tfs-incidents-client/default.nix
+++ b/pkgs/development/python-modules/georss-tfs-incidents-client/default.nix
@@ -9,13 +9,15 @@
 buildPythonPackage rec {
   pname = "georss-tfs-incidents-client";
   version = "0.3";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-tfs-incidents-client";
     rev = "v${version}";
-    sha256 = "11nvwrjzax4yy6aj971yym05yyizwfafy4ccsyy1qpwbs6dwbw7m";
+    hash = "sha256-9fDFm9GLXxy814wR75TjP3pfQPU+nCSV8Z509WXm24Y=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +28,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "georss_tfs_incidents_client" ];
+  pythonImportsCheck = [
+    "georss_tfs_incidents_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing Tasmania Fire Service Incidents feed";

--- a/pkgs/development/python-modules/georss-wa-dfes-client/default.nix
+++ b/pkgs/development/python-modules/georss-wa-dfes-client/default.nix
@@ -9,13 +9,15 @@
 buildPythonPackage rec {
   pname = "georss-wa-dfes-client";
   version = "0.3";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-georss-wa-dfes-client";
     rev = "v${version}";
-    sha256 = "01fk67kc6ww88yzsans8g81i6j7s0276gma5fk76la1c8vj2ifs7";
+     hash = "sha256-R7so5EYsKGrOdEXVZ44A+kgTA3pIW6W/R4hzw+Yx0wU=";
   };
 
   propagatedBuildInputs = [
@@ -26,7 +28,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "georss_wa_dfes_client" ];
+  pythonImportsCheck = [
+    "georss_wa_dfes_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing WA Department of Fire and Emergency Services (DFES) feed";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/exxamalte/python-aio-geojson-client/releases/tag/v0.16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
