### PR TITLE
flake/nixosSystem: pass the final lib to eval-config.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         nixos = import ./nixos/lib { lib = final; };
 
         nixosSystem = args:
-          import ./nixos/lib/eval-config.nix (args // {
+          import ./nixos/lib/eval-config.nix ({ lib = final; } // args // {
             modules = args.modules ++ [ {
               system.nixos.versionSuffix =
                 ".${final.substring 0 8 (self.lastModifiedDate or self.lastModified or "19700101")}.${self.shortRev or "dirty"}";

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -107,7 +107,10 @@ rec {
   # Same as `makeExtensible` but the name of the extending attribute is
   # customized.
   makeExtensibleWithCustomName = extenderName: rattrs:
-    fix' rattrs // {
-      ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
-   };
+    let
+      self = rattrs self // {
+        ${extenderName} = f: makeExtensibleWithCustomName extenderName (extends f rattrs);
+        __unfix__ = rattrs; # TODO: remove this?
+      };
+    in self;
 }


### PR DESCRIPTION
Extracted from https://github.com/NixOS/nixpkgs/pull/157056. The `makeExtensible` fix isn't strictly necessary for this but seems reasonable regardless.