### PR TITLE
python3Packages.pyarrow: enable more dependencies

### DIFF
--- a/pkgs/development/libraries/arrow-cpp/default.nix
+++ b/pkgs/development/libraries/arrow-cpp/default.nix
@@ -162,6 +162,7 @@ stdenv.mkDerivation rec {
     "-DARROW_ENGINE=ON"
     "-DARROW_FILESYSTEM=ON"
     "-DARROW_FLIGHT_SQL=${if enableFlight then "ON" else "OFF"}"
+    "-DARROW_HDFS=ON"
     "-DARROW_IPC=ON"
     "-DARROW_JEMALLOC=${if enableJemalloc then "ON" else "OFF"}"
     "-DARROW_JSON=ON"

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -52,10 +52,6 @@ buildPythonPackage rec {
 
   PYARROW_CMAKE_OPTIONS = [
     "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"
-
-    # This doesn't use setup hook to call cmake so we need to workaround #54606
-    # ourselves
-    "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
   ];
 
   ARROW_HOME = _arrow-cpp;

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage rec {
   PYARROW_WITH_DATASET = zero_or_one true;
   PYARROW_WITH_FLIGHT = zero_or_one _arrow-cpp.enableFlight;
   PYARROW_WITH_PARQUET = zero_or_one true;
+  PYARROW_WITH_HDFS = zero_or_one true;
 
   PYARROW_CMAKE_OPTIONS = [
     "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -84,10 +84,8 @@ buildPythonPackage rec {
 
   dontUseSetuptoolsCheck = true;
   preCheck = ''
-    mv pyarrow/tests tests
-    rm -rf pyarrow
-    mkdir pyarrow
-    mv tests pyarrow/tests
+    shopt -s extglob
+    rm -r pyarrow/!(tests)
   '';
 
   pythonImportsCheck = map (module: "pyarrow.${module}") [

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -77,9 +77,6 @@ buildPythonPackage rec {
     # enabled in nixpkgs.
     # Upstream Issue: https://issues.apache.org/jira/browse/ARROW-11393
     "--deselect=pyarrow/tests/test_memory.py::test_env_var"
-    # Deselect a parquet dataset test because it erroneously fails to find the
-    # pyarrow._dataset module.
-    "--deselect=pyarrow/tests/parquet/test_dataset.py::test_parquet_dataset_deprecated_properties"
   ] ++ lib.optionals stdenv.isDarwin [
     # Requires loopback networking
     "--deselect=pyarrow/tests/test_ipc.py::test_socket_"

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -68,6 +68,17 @@ buildPythonPackage rec {
     mv tests pyarrow/tests
   '';
 
+  pythonImportsCheck = map (module: "pyarrow.${module}") [
+    "compute"
+    "csv"
+    "dataset"
+    "flight"
+    "fs"
+    "hdfs"
+    "json"
+    "parquet"
+  ];
+
   meta = with lib; {
     description = "A cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/";

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -1,4 +1,20 @@
-{ lib, stdenv, buildPythonPackage, python, isPy3k, arrow-cpp, cmake, cython, hypothesis, numpy, pandas, pytestCheckHook, pytest-lazy-fixture, pkg-config, setuptools-scm, six }:
+{ lib
+, stdenv
+, buildPythonPackage
+, python
+, isPy3k
+, arrow-cpp
+, cmake
+, cython
+, hypothesis
+, numpy
+, pandas
+, pytestCheckHook
+, pytest-lazy-fixture
+, pkg-config
+, setuptools-scm
+, six
+}:
 
 let
   zero_or_one = cond: if cond then 1 else 0;
@@ -16,7 +32,12 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake cython pkg-config setuptools-scm ];
   propagatedBuildInputs = [ numpy six ];
-  checkInputs = [ hypothesis pandas pytestCheckHook pytest-lazy-fixture ];
+  checkInputs = [
+    hypothesis
+    pandas
+    pytestCheckHook
+    pytest-lazy-fixture
+  ];
 
   PYARROW_BUILD_TYPE = "release";
 
@@ -87,3 +108,5 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ veprbl cpcloud ];
   };
 }
+
+

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -4,14 +4,18 @@
 , python
 , isPy3k
 , arrow-cpp
+, cffi
+, cloudpickle
 , cmake
 , cython
+, fsspec
 , hypothesis
 , numpy
 , pandas
 , pytestCheckHook
 , pytest-lazy-fixture
 , pkg-config
+, scipy
 , setuptools-scm
 , six
 }:
@@ -31,7 +35,7 @@ buildPythonPackage rec {
   sourceRoot = "apache-arrow-${version}/python";
 
   nativeBuildInputs = [ cmake cython pkg-config setuptools-scm ];
-  propagatedBuildInputs = [ numpy six ];
+  propagatedBuildInputs = [ numpy six cloudpickle scipy fsspec cffi ];
   checkInputs = [
     hypothesis
     pandas
@@ -108,5 +112,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ veprbl cpcloud ];
   };
 }
-
-


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR enables HDFS support for arrow-cpp as well as pyarrow, and adds more
dependencies to pyarrow to support serialization (`scipy`, `cloudpickle`) and C
FFI (`cffi`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
