### PR TITLE
stdenv/check-meta: remove onlyLicenses check

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -19,16 +19,9 @@ let
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [];
 
-  onlyLicenses = list:
-    lib.lists.all (license:
-      let l = lib.licenses.${license.shortName or "BROKEN"} or false; in
-      if license == l then true else
-        throw ''‘${showLicense license}’ is not an attribute of lib.licenses''
-    ) list;
-
   areLicenseListsValid =
     if lib.mutuallyExclusive allowlist blocklist then
-      assert onlyLicenses allowlist; assert onlyLicenses blocklist; true
+      true
     else
       throw "allowlistedLicenses and blocklistedLicenses are not mutually exclusive.";
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/154031. I could not find a reason for this check to exist and @wmertens has not replied. `meta.license` needs not be an attribute of `lib.licenses`, so allow/blocklists should not either.

cc @ony @roberth