### PR TITLE
obsidian: 0.13.23 -> 0.13.30

### DIFF
--- a/pkgs/applications/misc/obsidian/default.nix
+++ b/pkgs/applications/misc/obsidian/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, lib, makeWrapper, electron_13, makeDesktopItem, graphicsmagick
+{ stdenv, fetchurl, lib, makeWrapper, electron_16, makeDesktopItem, graphicsmagick
 , writeScript }:
 
 let
-  electron = electron_13;
+  electron = electron_16;
   icon = fetchurl {
     url =
       "https://forum.obsidian.md/uploads/default/original/1X/bf119bd48f748f4fd2d65f2d1bb05d3c806883b5.png";
@@ -31,11 +31,11 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "obsidian";
-  version = "0.13.23";
+  version = "0.13.30";
 
   src = fetchurl {
     url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/obsidian-${version}.tar.gz";
-    sha256 = "1chxf6vrybjvc64k66a3l5xvv6iv6w8b03pdcrc0pr0nnlwkcf8c";
+    sha256 = "ymdqdDD7WWfol/jLBsz8tEzcN7Ed1HSIrkuA51cvKKw=";
   };
 
   nativeBuildInputs = [ makeWrapper graphicsmagick ];
@@ -68,6 +68,7 @@ in stdenv.mkDerivation rec {
     description =
       "A powerful knowledge base that works on top of a local folder of plain text Markdown files";
     homepage = "https://obsidian.md";
+    downloadPage = "https://github.com/obsidianmd/obsidian-releases/releases";
     license = licenses.obsidian;
     maintainers = with maintainers; [ conradmearns zaninime ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
###### Motivation for this change
`obsidian: 0.13.23 -> 0.13.30`
~Despite, this is pre-release version, current version is broken and with 0.13.24 everything works fine for me...~
https://github.com/NixOS/nixpkgs/issues/158956

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
