### PR TITLE
octave-symbolic: 2.9.0 -> unstable-2021-10-16

### DIFF
--- a/pkgs/development/octave-modules/symbolic/default.nix
+++ b/pkgs/development/octave-modules/symbolic/default.nix
@@ -1,38 +1,27 @@
 { buildOctavePackage
 , lib
-, fetchurl
+, fetchFromGitHub
 # Octave's Python (Python 3)
 , python
-# Needed only to get the correct version of sympy needed
-, python2Packages
 }:
 
 let
-  # Need to use sympy 1.5.1 for https://github.com/cbm755/octsympy/issues/1023
-  # It has been addressed, but not merged yet.
-  # In the meantime, we create a Python environment with Python 3, its mpmath
-  # version and sympy 1.5 from python2Packages.
-  pythonEnv = (let
-      overridenPython = let
-        packageOverrides = self: super: {
-          sympy = super.sympy.overridePythonAttrs (old: rec {
-            version = python2Packages.sympy.version;
-            src = python2Packages.sympy.src;
-          });
-        };
-      in python.override {inherit packageOverrides; self = overridenPython; };
-    in overridenPython.withPackages (ps: [
+  pythonEnv = python.withPackages (ps: [
       ps.sympy
       ps.mpmath
-    ]));
+    ]);
 
 in buildOctavePackage rec {
   pname = "symbolic";
-  version = "2.9.0";
+  version = "unstable-2021-10-16";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "1jr3kg9q6r4r4h3hiwq9fli6wsns73rqfzkrg25plha9195c97h8";
+  # https://github.com/cbm755/octsympy/issues/1023 has been resolved, however
+  # a new release has not been made
+  src = fetchFromGitHub {
+    owner = "cbm755";
+    repo = "octsympy";
+    rev = "5b58530f4ada78c759829ae703a0e5d9832c32d4";
+    sha256 = "sha256-n6P1Swjl4RfgxfLY0ZuN3pcL8PcoknA6yxbnw96OZ2k=";
   };
 
   propagatedBuildInputs = [ pythonEnv ];


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/160381

https://github.com/cbm755/octsympy/issues/1023 previously prevented us from using sympy 1.6+.
This issue has since been resolved however, no new tag nor release has been made.

To test run
```
nix-shell -E 'with import ./. { }; runCommand "shell" { buildInputs = [(octave.withPackages(opkgs: with opkgs; [symbolic]))];} ""'
```
in a checked out version of this branch. Then, enter octave and 
```
pkg load symbolic
syms x
```

Also, https://github.com/NixOS/nixpkgs/issues/148779

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
