### PR TITLE
libbpf: Fix src hash

### DIFF
--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     owner = "libbpf";
     repo = "libbpf";
     rev = "v${version}";
-    sha256 = "sha256-ieJ19igGCoPKGX6J0mQG+QD7QcXHX2SVzZUjMwxum/M=";
+    sha256 = "sha256-NFVJ8JquWVzu+QoaaOMzhnu6/IqdP1FPhtJFidXA4L4=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
The v0.7.0 tag seems to have been altered.

Follow-up: #159173

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->