### PR TITLE
Revert "[Backport release-21.11] types.singleLineStr: strings that don't contain '\n'"

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -300,19 +300,6 @@ rec {
       inherit (str) merge;
     };
 
-    # Allow a newline character at the end and trim it in the merge function.
-    singleLineStr =
-      let
-        inherit (strMatching "[^\n\r]*\n?") check merge;
-      in
-      mkOptionType {
-        name = "singleLineStr";
-        description = "(optionally newline-terminated) single-line string";
-        inherit check;
-        merge = loc: defs:
-          lib.removeSuffix "\n" (merge loc defs);
-      };
-
     strMatching = pattern: mkOptionType {
       name = "strMatching ${escapeNixString pattern}";
       description = "string matching the pattern ${pattern}";

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -30,7 +30,7 @@ let
 
     options.openssh.authorizedKeys = {
       keys = mkOption {
-        type = types.listOf types.singleLineStr;
+        type = types.listOf types.str;
         default = [];
         description = ''
           A list of verbatim OpenSSH public keys that should be added to the


### PR DESCRIPTION
Reverts NixOS/nixpkgs#156073

This is a fairly significant change to the expectations on this interface, and it is causing me quite a bit of heartache. I think the original change is significant enough to warrant release notes and holding until 22.11.

cc @Julow , and @NixOS/security in case there is significant justification for this restriction.