### PR TITLE
Hydras & Co. 0.6 release.

### DIFF
--- a/pkgs/development/coq-modules/LibHyps/default.nix
+++ b/pkgs/development/coq-modules/LibHyps/default.nix
@@ -1,0 +1,21 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+
+with lib;
+mkCoqDerivation {
+  pname = "LibHyps";
+  owner = "Matafou";
+  inherit version;
+  defaultVersion = if (versions.range "8.11" "8.15") coq.version then "2.0.4.1" else null;
+  release = {
+    "2.0.4.1".sha256 = "09p89701zhrfdmqlpxw3mziw8yylj1w1skb4b0xpbdwd1vsn4k3h";
+  };
+
+  configureScript = "./configure.sh";
+
+  releaseRev = (v: "libhyps-${v}");
+
+  meta = {
+    description = "Hypotheses manipulation library";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/coq-modules/addition-chains/default.nix
+++ b/pkgs/development/coq-modules/addition-chains/default.nix
@@ -8,11 +8,12 @@ mkCoqDerivation {
 
   release."0.4".sha256 = "1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
   release."0.5".sha256 = "121pcbn6v59l0c165ha9n00whbddpy11npx2y9cn7g879sfk2nqk";
+  release."0.6".sha256 = "1dri4sisa7mhclf8w4kw7ixs5zxm8xyjr034r1377p96rdk3jj0j";
   releaseRev = (v: "v${v}");
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.13" "8.14"; out = "0.5"; }
+    { case = range "8.13" "8.15"; out = "0.6"; }
     { case = range "8.11" "8.12"; out = "0.4"; }
   ] null;
 

--- a/pkgs/development/coq-modules/gaia-hydras/default.nix
+++ b/pkgs/development/coq-modules/gaia-hydras/default.nix
@@ -6,10 +6,12 @@ with lib; mkCoqDerivation rec {
   repo = "hydra-battles";
 
   release."0.5".sha256 = "121pcbn6v59l0c165ha9n00whbddpy11npx2y9cn7g879sfk2nqk";
+  release."0.6".sha256 = "1dri4sisa7mhclf8w4kw7ixs5zxm8xyjr034r1377p96rdk3jj0j";
   releaseRev = (v: "v${v}");
 
   inherit version;
   defaultVersion = with versions; switch [coq.coq-version mathcomp.version] [
+    { cases = [ (range "8.14" "8.15") (isGe "1.12.0") ]; out = "0.6"; }
     { cases = [ (range "8.13" "8.14") (isGe "1.12.0") ]; out = "0.5"; }
   ] null;
 

--- a/pkgs/development/coq-modules/hydra-battles/default.nix
+++ b/pkgs/development/coq-modules/hydra-battles/default.nix
@@ -1,21 +1,20 @@
-{ lib, mkCoqDerivation, coq, equations, version ? null }:
+{ lib, mkCoqDerivation, coq, equations, LibHyps, version ? null }:
 with lib;
 
-mkCoqDerivation {
+(mkCoqDerivation {
   pname = "hydra-battles";
   owner = "coq-community";
 
   release."0.4".sha256 = "1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
   release."0.5".sha256 = "121pcbn6v59l0c165ha9n00whbddpy11npx2y9cn7g879sfk2nqk";
+  release."0.6".sha256 = "1dri4sisa7mhclf8w4kw7ixs5zxm8xyjr034r1377p96rdk3jj0j";
   releaseRev = (v: "v${v}");
 
   inherit version;
   defaultVersion = with versions; switch coq.coq-version [
-    { case = range "8.13" "8.14"; out = "0.5"; }
+    { case = range "8.13" "8.15"; out = "0.6"; }
     { case = range "8.11" "8.12"; out = "0.4"; }
   ] null;
-
-  propagatedBuildInputs = [ equations ];
 
   useDune2 = true;
 
@@ -32,4 +31,7 @@ mkCoqDerivation {
     license = licenses.mit;
     platforms = platforms.unix;
   };
-}
+}).overrideAttrs(o:
+  let inherit (o) version; in {
+    propagatedBuildInputs = [ equations ] ++ optional (versions.isGe "0.6" version) LibHyps;
+  })

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -58,6 +58,7 @@ let
       iris = callPackage ../development/coq-modules/iris {};
       itauto = callPackage ../development/coq-modules/itauto { };
       ITree = callPackage ../development/coq-modules/ITree { };
+      LibHyps = callPackage ../development/coq-modules/LibHyps {};
       ltac2 = callPackage ../development/coq-modules/ltac2 {};
       math-classes = callPackage ../development/coq-modules/math-classes { };
       mathcomp = callPackage ../development/coq-modules/mathcomp {};


### PR DESCRIPTION
###### Motivation for this change

https://github.com/coq-community/hydra-battles/releases/tag/v0.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
