### PR TITLE
pipewire: 0.3.45 -> 0.3.48

### DIFF
--- a/nixos/modules/services/desktops/pipewire/daemon/client-rt.conf.json
+++ b/nixos/modules/services/desktops/pipewire/daemon/client-rt.conf.json
@@ -8,7 +8,7 @@
   },
   "context.modules": [
     {
-      "name": "libpipewire-module-rtkit",
+      "name": "libpipewire-module-rt",
       "args": {},
       "flags": [
         "ifexists",

--- a/nixos/modules/services/desktops/pipewire/daemon/minimal.conf.json
+++ b/nixos/modules/services/desktops/pipewire/daemon/minimal.conf.json
@@ -3,7 +3,8 @@
     "link.max-buffers": 16,
     "core.daemon": true,
     "core.name": "pipewire-0",
-    "default.clock.min-quantum": 16,
+    "settings.check-quantum": true,
+    "settings.check-rate": true,
     "vm.overrides": {
       "default.clock.min-quantum": 1024
     }
@@ -11,11 +12,6 @@
   "context.spa-libs": {
     "audio.convert.*": "audioconvert/libspa-audioconvert",
     "api.alsa.*": "alsa/libspa-alsa",
-    "api.v4l2.*": "v4l2/libspa-v4l2",
-    "api.libcamera.*": "libcamera/libspa-libcamera",
-    "api.bluez5.*": "bluez5/libspa-bluez5",
-    "api.vulkan.*": "vulkan/libspa-vulkan",
-    "api.jack.*": "jack/libspa-jack",
     "support.*": "support/libspa-support"
   },
   "context.modules": [
@@ -39,23 +35,10 @@
       "name": "libpipewire-module-metadata"
     },
     {
-      "name": "libpipewire-module-spa-device-factory"
-    },
-    {
       "name": "libpipewire-module-spa-node-factory"
     },
     {
       "name": "libpipewire-module-client-node"
-    },
-    {
-      "name": "libpipewire-module-client-device"
-    },
-    {
-      "name": "libpipewire-module-portal",
-      "flags": [
-        "ifexists",
-        "nofail"
-      ]
     },
     {
       "name": "libpipewire-module-access",
@@ -66,12 +49,15 @@
     },
     {
       "name": "libpipewire-module-link-factory"
-    },
-    {
-      "name": "libpipewire-module-session-manager"
     }
   ],
   "context.objects": [
+    {
+      "factory": "metadata",
+      "args": {
+        "metadata.name": "default"
+      }
+    },
     {
       "factory": "spa-node-factory",
       "args": {
@@ -89,6 +75,42 @@
         "priority.driver": 19000,
         "node.group": "pipewire.freewheel",
         "node.freewheel": true
+      }
+    },
+    {
+      "factory": "adapter",
+      "args": {
+        "factory.name": "api.alsa.pcm.source",
+        "node.name": "system",
+        "node.description": "system",
+        "media.class": "Audio/Source",
+        "api.alsa.path": "hw:0",
+        "node.suspend-on-idle": true,
+        "resample.disable": true,
+        "channelmix.disable": true,
+        "adapter.auto-port-config": {
+          "mode": "dsp",
+          "monitor": false,
+          "position": "unknown"
+        }
+      }
+    },
+    {
+      "factory": "adapter",
+      "args": {
+        "factory.name": "api.alsa.pcm.sink",
+        "node.name": "system",
+        "node.description": "system",
+        "media.class": "Audio/Sink",
+        "api.alsa.path": "hw:0",
+        "node.suspend-on-idle": true,
+        "resample.disable": true,
+        "channelmix.disable": true,
+        "adapter.auto-port-config": {
+          "mode": "dsp",
+          "monitor": false,
+          "position": "unknown"
+        }
       }
     }
   ],

--- a/nixos/modules/services/desktops/pipewire/daemon/pipewire-pulse.conf.json
+++ b/nixos/modules/services/desktops/pipewire/daemon/pipewire-pulse.conf.json
@@ -6,8 +6,10 @@
   },
   "context.modules": [
     {
-      "name": "libpipewire-module-rtkit",
-      "args": {},
+      "name": "libpipewire-module-rt",
+      "args": {
+        "nice.level": -11
+      },
       "flags": [
         "ifexists",
         "nofail"
@@ -37,6 +39,61 @@
       }
     }
   ],
-  "context.exec": [],
-  "stream.properties": {}
+  "context.exec": [
+    {
+      "path": "pactl",
+      "args": "load-module module-always-sink"
+    }
+  ],
+  "stream.properties": {},
+  "pulse.rules": [
+    {
+      "matches": [
+        {}
+      ],
+      "actions": {
+        "update-props": {}
+      }
+    },
+    {
+      "matches": [
+        {
+          "application.process.binary": "teams"
+        },
+        {
+          "application.process.binary": "skypeforlinux"
+        }
+      ],
+      "actions": {
+        "quirks": [
+          "force-s16-info"
+        ]
+      }
+    },
+    {
+      "matches": [
+        {
+          "application.process.binary": "firefox"
+        }
+      ],
+      "actions": {
+        "quirks": [
+          "remove-capture-dont-move"
+        ]
+      }
+    },
+    {
+      "matches": [
+        {
+          "application.name": "~speech-dispatcher*"
+        }
+      ],
+      "actions": {
+        "update-props": {
+          "pulse.min.req": "1024/48000",
+          "pulse.min.quantum": "1024/48000"
+        }
+      }
+    }
+  ]
 }

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -25,15 +25,18 @@ let
     client = lib.importJSON ./daemon/client.conf.json;
     client-rt = lib.importJSON ./daemon/client-rt.conf.json;
     jack = lib.importJSON ./daemon/jack.conf.json;
+    minimal = lib.importJSON ./daemon/minimal.conf.json;
     pipewire = lib.importJSON ./daemon/pipewire.conf.json;
     pipewire-pulse = lib.importJSON ./daemon/pipewire-pulse.conf.json;
   };
+
+  useSessionManager = cfg.wireplumber.enable || cfg.media-session.enable;
 
   configs = {
     client = recursiveUpdate defaults.client cfg.config.client;
     client-rt = recursiveUpdate defaults.client-rt cfg.config.client-rt;
     jack = recursiveUpdate defaults.jack cfg.config.jack;
-    pipewire = recursiveUpdate defaults.pipewire cfg.config.pipewire;
+    pipewire = recursiveUpdate (if useSessionManager then defaults.pipewire else defaults.minimal) cfg.config.pipewire;
     pipewire-pulse = recursiveUpdate defaults.pipewire-pulse cfg.config.pipewire-pulse;
   };
 in {

--- a/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
+++ b/pkgs/development/libraries/pipewire/0070-installed-tests-path.patch
@@ -1,23 +1,23 @@
 diff --git a/meson.build b/meson.build
-index d4a4cda7..a27569bd 100644
+index 2107c19ec..20ccdfd9f 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -353,8 +353,8 @@ libinotify_dep = (build_machine.system() == 'freebsd'
- 
- alsa_dep = dependency('alsa', version : '>=1.1.7', required: get_option('pipewire-alsa'))
+@@ -380,8 +380,8 @@ lilv_lib = dependency('lilv-0', required: get_option('lv2'))
+ summary({'lilv (for lv2 plugins)': lilv_lib.found()}, bool_yn: true)
+ cdata.set('HAVE_LILV', lilv_lib.found())
  
 -installed_tests_metadir = pipewire_datadir / 'installed-tests' / pipewire_name
 -installed_tests_execdir = pipewire_libexecdir / 'installed-tests' / pipewire_name
 +installed_tests_metadir = get_option('installed_test_prefix') / 'share' / 'installed-tests' / pipewire_name
 +installed_tests_execdir = get_option('installed_test_prefix') / 'libexec' / 'installed-tests' / pipewire_name
- installed_tests_enabled = not get_option('installed_tests').disabled()
+ installed_tests_enabled = get_option('installed_tests').allowed()
  installed_tests_template = files('template.test.in')
  
 diff --git a/meson_options.txt b/meson_options.txt
-index 1b915ac3..85beb86a 100644
+index 961ae2a76..a36e9e45f 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -29,6 +29,9 @@ option('installed_tests',
+@@ -22,6 +22,9 @@ option('installed_tests',
         description: 'Install manual and automated test executables',
         type: 'feature',
         value: 'disabled')

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -69,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.45";
+    version = "0.3.46";
 
     outputs = [
       "out"
@@ -87,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-OnQd98qfOekAsVXLbciZLNPrM84KBX6fOx/f8y2BYI0=";
+      sha256 = "sha256-29p6nEaIDeOAAnRJXwJWEnMTCNzAGVi9f8856I1R+fg=";
     };
 
     patches = [
@@ -214,6 +214,7 @@ let
             "nix-support/client-rt.conf.json"
             "nix-support/client.conf.json"
             "nix-support/jack.conf.json"
+            "nix-support/minimal.conf.json"
             "nix-support/pipewire.conf.json"
             "nix-support/pipewire-pulse.conf.json"
           ];

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -69,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.46";
+    version = "0.3.47";
 
     outputs = [
       "out"
@@ -87,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-29p6nEaIDeOAAnRJXwJWEnMTCNzAGVi9f8856I1R+fg=";
+      sha256 = "sha256-RLdA6McMQd70Pz672S8W9nQhzj1zymqXWLLDZKT6vtQ=";
     };
 
     patches = [

--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -69,7 +69,7 @@ let
 
   self = stdenv.mkDerivation rec {
     pname = "pipewire";
-    version = "0.3.47";
+    version = "0.3.48";
 
     outputs = [
       "out"
@@ -87,7 +87,7 @@ let
       owner = "pipewire";
       repo = "pipewire";
       rev = version;
-      sha256 = "sha256-RLdA6McMQd70Pz672S8W9nQhzj1zymqXWLLDZKT6vtQ=";
+      sha256 = "sha256-+gk/MJ9YimHBwN2I42DRP+I2OqBFFtZ81Fd/l89HcSk=";
     };
 
     patches = [
@@ -139,7 +139,7 @@ let
     ++ lib.optional zeroconfSupport avahi
     ++ lib.optional raopSupport openssl
     ++ lib.optional rocSupport roc-toolkit
-    ++ lib.optionals x11Support [ libcanberra xorg.libxcb ];
+    ++ lib.optionals x11Support [ libcanberra xorg.libX11 xorg.libXfixes ];
 
     # Valgrind binary is required for running one optional test.
     checkInputs = lib.optional withValgrind valgrind;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.46
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.47
https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.48

Upstream is also shipping a minimal.conf for a couple of versions now, for use without a session manager. This updates the nixos module to use that minimal config as the config base when no session manger is enabled.

Changed from libxcb to libX11 as was found necessary in #136166 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
