### PR TITLE
Minor fixes for `emptyValue`s

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -284,6 +284,15 @@ checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-var
 checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
 checkConfigOutput '^"a b c"$' config.resultFooFoo ./declare-variants.nix ./define-variant.nix
 
+## emptyValue's
+checkConfigOutput "[ ]" config.list.a ./emptyValues.nix
+checkConfigOutput "{ }" config.attrs.a ./emptyValues.nix
+checkConfigOutput "null" config.null.a ./emptyValues.nix
+checkConfigOutput "{ }" config.submodule.a ./emptyValues.nix
+# These types don't have empty values
+checkConfigError 'The option .int.a. is used but not defined' config.int.a ./emptyValues.nix
+checkConfigError 'The option .nonEmptyList.a. is used but not defined' config.nonEmptyList.a ./emptyValues.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/emptyValues.nix
+++ b/lib/tests/modules/emptyValues.nix
@@ -1,0 +1,36 @@
+{ lib, ... }:
+let
+  inherit (lib) types;
+in {
+
+  options = {
+    int = lib.mkOption {
+      type = types.lazyAttrsOf types.int;
+    };
+    list = lib.mkOption {
+      type = types.lazyAttrsOf (types.listOf types.int);
+    };
+    nonEmptyList = lib.mkOption {
+      type = types.lazyAttrsOf (types.nonEmptyListOf types.int);
+    };
+    attrs = lib.mkOption {
+      type = types.lazyAttrsOf (types.attrsOf types.int);
+    };
+    null = lib.mkOption {
+      type = types.lazyAttrsOf (types.nullOr types.int);
+    };
+    submodule = lib.mkOption {
+      type = types.lazyAttrsOf (types.submodule {});
+    };
+  };
+
+  config = {
+    int.a = lib.mkIf false null;
+    list.a = lib.mkIf false null;
+    nonEmptyList.a = lib.mkIf false null;
+    attrs.a = lib.mkIf false null;
+    null.a = lib.mkIf false null;
+    submodule.a = lib.mkIf false null;
+  };
+
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -390,7 +390,7 @@ rec {
             ).optionalValue
           ) def.value
         ) defs)));
-      emptyValue = { value = {}; };
+      emptyValue = { value = []; };
       getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["*"]);
       getSubModules = elemType.getSubModules;
       substSubModules = m: listOf (elemType.substSubModules m);
@@ -402,7 +402,7 @@ rec {
       let list = addCheck (types.listOf elemType) (l: l != []);
       in list // {
         description = "non-empty " + list.description;
-        # Note: emptyValue is left as is, because another module may define an element.
+        emptyValue = { }; # no .value attr, meaning unset
       };
 
     attrsOf = elemType: mkOptionType rec {


### PR DESCRIPTION
###### Motivation for this change
Split off from https://github.com/NixOS/nixpkgs/pull/132448 since it's mostly separate change.

This fixes two `emptyValue` values and adds some test cases for `emptyValue`s.

Originally I also wanted to use these `emptyValue`'s as defaults when no `default` is specified for an option, but I think that might not be a great idea.

###### Things done

- [x] Wrote and ran lib tests successfully with `lib/tests/modules.sh`