### PR TITLE
Cardinal: init at 22.02

### DIFF
--- a/pkgs/applications/audio/cardinal/default.nix
+++ b/pkgs/applications/audio/cardinal/default.nix
@@ -1,0 +1,76 @@
+{
+  stdenv
+, fetchFromGitHub
+, fetchpatch
+, fetchurl
+, fetchzip
+, freetype
+, jansson
+, lib
+, libGL
+, libX11
+, libXcursor
+, libXext
+, libXrandr
+, libarchive
+, liblo
+, libsamplerate
+, mesa
+, pkg-config
+, python3
+, speexdsp
+}:
+
+stdenv.mkDerivation rec {
+  name = "cardinal-${version}";
+  version = "22.02";
+
+  src = fetchurl {
+    url =
+      "https://github.com/DISTRHO/Cardinal/releases/download/${version}/cardinal-${version}.tar.xz";
+    sha256 = "sha256-IVlAROFGFffTEU00NCmv74w1DRb7dNMp20FeBVoDrdM=";
+  };
+
+  patches = [
+    # see https://github.com/DISTRHO/Cardinal/issues/151#issuecomment-1041886260
+    (fetchpatch {
+      url =
+        "https://github.com/DISTRHO/Cardinal/commit/13e9ef37c5dd35d77a54b1cb006767be7a72ac69.patch";
+      sha256 = "sha256-NYUYLbLeBX1WEzjPi0s/T1N+EXQKyi0ifbPxgBYDjRs=";
+    })
+  ];
+
+  prePatch = ''
+    patchShebangs ./dpf/utils/generate-ttl.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    freetype
+    jansson
+    libGL
+    libX11
+    libXcursor
+    libXext
+    libXrandr
+    libXrandr
+    libarchive
+    liblo
+    libsamplerate
+    mesa
+    python3
+    speexdsp
+  ];
+
+  makeFlags = [ "SYSDEPS=true" "PREFIX=$(out)" ];
+
+  meta = {
+    description = "Plugin wrapper around VCV Rack";
+    homepage = "https://github.com/DISTRHO/cardinal";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.magnetophon ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24745,6 +24745,8 @@ with pkgs;
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
+  cardinal = callPackage ../applications/audio/cardinal { };
+
   carla = libsForQt5.callPackage ../applications/audio/carla { };
 
   castor = callPackage ../applications/networking/browsers/castor { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
