### PR TITLE
Introduce `types.raw`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -138,7 +138,7 @@ rec {
             # support for that, in turn it's lazy in its values. This means e.g.
             # a `_module.args.pkgs = import (fetchTarball { ... }) {}` won't
             # start a download when `pkgs` wasn't evaluated.
-            type = types.lazyAttrsOf types.unspecified;
+            type = types.lazyAttrsOf types.raw;
             internal = true;
             description = "Arguments passed to each module.";
           };

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -293,6 +293,12 @@ checkConfigOutput "{ }" config.submodule.a ./emptyValues.nix
 checkConfigError 'The option .int.a. is used but not defined' config.int.a ./emptyValues.nix
 checkConfigError 'The option .nonEmptyList.a. is used but not defined' config.nonEmptyList.a ./emptyValues.nix
 
+## types.raw
+checkConfigOutput "{ foo = <CODE>; }" config.unprocessedNesting ./raw.nix
+checkConfigOutput "10" config.processedToplevel ./raw.nix
+checkConfigError "The option .multiple. is defined multiple times" config.multiple ./raw.nix
+checkConfigOutput "bar" config.priorities ./raw.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/raw.nix
+++ b/lib/tests/modules/raw.nix
@@ -1,0 +1,30 @@
+{ lib, ... }: {
+
+  options = {
+    processedToplevel = lib.mkOption {
+      type = lib.types.raw;
+    };
+    unprocessedNesting = lib.mkOption {
+      type = lib.types.raw;
+    };
+    multiple = lib.mkOption {
+      type = lib.types.raw;
+    };
+    priorities = lib.mkOption {
+      type = lib.types.raw;
+    };
+  };
+
+  config = {
+    processedToplevel = lib.mkIf true 10;
+    unprocessedNesting.foo = throw "foo";
+    multiple = lib.mkMerge [
+      "foo"
+      "foo"
+    ];
+    priorities = lib.mkMerge [
+      "foo"
+      (lib.mkForce "bar")
+    ];
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -162,6 +162,13 @@ rec {
   # nixos/doc/manual/development/option-types.xml!
   types = rec {
 
+    raw = mkOptionType rec {
+      name = "raw";
+      description = "raw value";
+      check = value: true;
+      merge = mergeOneOption;
+    };
+
     anything = mkOptionType {
       name = "anything";
       description = "anything";

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -63,6 +63,17 @@ merging is handled.
     ```
     :::
 
+`types.raw`
+
+:   A type which doesn't do any checking, merging or nested evaluation. It
+    accepts a single arbitrary value that is not recursed into, making it
+    useful for values coming from outside the module system, such as package
+    sets or arbitrary data. Options of this type are still evaluated according
+    to priorities and conditionals, so `mkForce`, `mkIf` and co. still work on
+    the option value itself, but not for any value nested within it. This type
+    should only be used when checking, merging and nested evaluation are not
+    desirable.
+
 `types.attrs`
 
 :   A free-form attribute set.

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -94,6 +94,25 @@
       </varlistentry>
       <varlistentry>
         <term>
+          <literal>types.raw</literal>
+        </term>
+        <listitem>
+          <para>
+            A type which doesn’t do any checking, merging or nested
+            evaluation. It accepts a single arbitrary value that is not
+            recursed into, making it useful for values coming from
+            outside the module system, such as package sets or arbitrary
+            data. Options of this type are still evaluated according to
+            priorities and conditionals, so <literal>mkForce</literal>,
+            <literal>mkIf</literal> and co. still work on the option
+            value itself, but not for any value nested within it. This
+            type should only be used when checking, merging and nested
+            evaluation are not desirable.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <literal>types.attrs</literal>
         </term>
         <listitem>


### PR DESCRIPTION
###### Motivation for this change
- Introduce `types.raw` as a type that doesn't do any nested processing for `mkIf`, `mkForce`, etc. on its values. This is useful when this processing would throw errors or where it would be too expensive (such as with package sets like nixpkgs).
- Use `types.raw` for `_module.args`'s type. This finally fixes https://github.com/NixOS/nixpkgs/issues/53458

This is split off from https://github.com/NixOS/nixpkgs/pull/132448. This is also motivated by wanting to deprecate `types.attrs` and `types.unspecified`, for which `types.attrsOf types.raw` and `types.raw` (or `types.anything`) is an adequate general replacement.

###### Things done

- [x] Wrote and ran tests
- [x] Wrote docs