### PR TITLE
lib/types: Introduce types.unconditional

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -284,6 +284,16 @@ checkConfigOutput '^"a b"$' config.resultFoo ./declare-variants.nix ./define-var
 checkConfigOutput '^"a y z"$' config.resultFooBar ./declare-variants.nix ./define-variant.nix
 checkConfigOutput '^"a b c"$' config.resultFooFoo ./declare-variants.nix ./define-variant.nix
 
+## types.unconditional
+checkConfigOutput "10" config.ifTrue ./unconditional.nix
+checkConfigError "The option .ifFalse. is used but not defined." config.ifFalse ./unconditional.nix
+checkConfigOutput "10" config.attrsIfTrue.foo ./unconditional.nix
+checkConfigError "The option .attrsIfFalse.foo. is used but not defined." config.attrsIfFalse.foo ./unconditional.nix
+checkConfigOutput "[ \"foo\" ]" config.attrKeys ./unconditional.nix
+checkConfigOutput "10" config.listIfTrue.0 ./unconditional.nix
+checkConfigError "The option .listIfFalse.\[definition 1-entry 1\]. is used but not defined." config.listIfFalse.0 ./unconditional.nix
+checkConfigOutput "1" config.listLength ./unconditional.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/unconditional.nix
+++ b/lib/tests/modules/unconditional.nix
@@ -1,0 +1,39 @@
+{ lib, config, ... }: {
+
+  options = {
+    ifTrue = lib.mkOption {
+      type = lib.types.unconditional lib.types.int;
+    };
+    ifFalse = lib.mkOption {
+      type = lib.types.unconditional lib.types.int;
+    };
+    attrsIfTrue = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.unconditional lib.types.int);
+    };
+    attrsIfFalse = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.unconditional lib.types.int);
+    };
+    attrKeys = lib.mkOption {
+      default = lib.attrNames config.attrsIfFalse;
+    };
+    listIfTrue = lib.mkOption {
+      type = lib.types.listOf (lib.types.unconditional lib.types.int);
+    };
+    listIfFalse = lib.mkOption {
+      type = lib.types.listOf (lib.types.unconditional lib.types.int);
+    };
+    listLength = lib.mkOption {
+      default = lib.length config.listIfFalse;
+    };
+  };
+
+  config = {
+    ifTrue = lib.mkIf true 10;
+    ifFalse = lib.mkIf false 10;
+    attrsIfTrue.foo = lib.mkIf true 10;
+    attrsIfFalse.foo = lib.mkIf false 10;
+    listIfTrue = [ (lib.mkIf true 10) ];
+    listIfFalse = [ (lib.mkIf false 10) ];
+  };
+
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -151,9 +151,12 @@ rec {
       # issue deprecation warnings recursively. Can also be used to reuse
       # nested types
       nestedTypes ? {}
+      # Whether `mkIf` assignments can cause the definiton to be optional in
+      # the parent option. If `processed` is false, this is implicitly false too
+    , conditional ? true
     }:
     { _type = "option-type";
-      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor deprecationMessage nestedTypes;
+      inherit name check merge emptyValue getSubOptions getSubModules substSubModules typeMerge functor deprecationMessage nestedTypes conditional;
       description = if description == null then name else description;
     };
 
@@ -161,6 +164,10 @@ rec {
   # When adding new types don't forget to document them in
   # nixos/doc/manual/development/option-types.xml!
   types = rec {
+
+    unconditional = elemType: elemType // {
+      conditional = false;
+    };
 
     anything = mkOptionType {
       name = "anything";
@@ -423,30 +430,7 @@ rec {
       nestedTypes.elemType = elemType;
     };
 
-    # A version of attrsOf that's lazy in its values at the expense of
-    # conditional definitions not working properly. E.g. defining a value with
-    # `foo.attr = mkIf false 10`, then `foo ? attr == true`, whereas with
-    # attrsOf it would correctly be `false`. Accessing `foo.attr` would throw an
-    # error that it's not defined. Use only if conditional definitions don't make sense.
-    lazyAttrsOf = elemType: mkOptionType rec {
-      name = "lazyAttrsOf";
-      description = "lazy attribute set of ${elemType.description}s";
-      check = isAttrs;
-      merge = loc: defs:
-        zipAttrsWith (name: defs:
-          let merged = mergeDefinitions (loc ++ [name]) elemType defs;
-          # mergedValue will trigger an appropriate error when accessed
-          in merged.optionalValue.value or elemType.emptyValue.value or merged.mergedValue
-        )
-        # Push down position info.
-        (map (def: mapAttrs (n: v: { inherit (def) file; value = v; }) def.value) defs);
-      emptyValue = { value = {}; };
-      getSubOptions = prefix: elemType.getSubOptions (prefix ++ ["<name>"]);
-      getSubModules = elemType.getSubModules;
-      substSubModules = m: lazyAttrsOf (elemType.substSubModules m);
-      functor = (defaultFunctor name) // { wrapped = elemType; };
-      nestedTypes.elemType = elemType;
-    };
+    lazyAttrsOf = elemType: attrsOf (unconditional elemType);
 
     # TODO: drop this in the future:
     loaOf = elemType: types.attrsOf elemType // {

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -201,6 +201,19 @@ Value types are types that take a value parameter.
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
 
+`types.unconditional` *`t`*
+
+:   The same as *`t`*, but without full support for conditional definitions
+    using `lib.mkIf <cond>`. This has the advantage that when used as the
+    element type in `types.attrsOf` and `types.listOf`, the attribute keys and
+    the list length respectively can be known without evaluating each
+    individual attribute/list value, keeping these structures lazy.
+    For instance, this prevents a case of infinite recursion by allowing elements
+    in an attribute set to reference other elements of the same attribute set
+    via the `config` module argument.
+    If `lib.mkIf <cond>` is used on such a type, the value is assumed to exist,
+    but an error is thrown when evaluated and the condition is false.
+
 ## Composed Types {#sec-option-types-composed}
 
 Composed types are types that take a type as parameter. `listOf

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -392,6 +392,31 @@
           </itemizedlist>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term>
+          <literal>types.unconditional</literal>
+          <emphasis><literal>t</literal></emphasis>
+        </term>
+        <listitem>
+          <para>
+            The same as <emphasis><literal>t</literal></emphasis>, but
+            without full support for conditional definitions using
+            <literal>lib.mkIf &lt;cond&gt;</literal>. This has the
+            advantage that when used as the element type in
+            <literal>types.attrsOf</literal> and
+            <literal>types.listOf</literal>, the attribute keys and the
+            list length respectively can be known without evaluating
+            each individual attribute/list value, keeping these
+            structures lazy. For instance, this prevents a case of
+            infinite recursion by allowing elements in an attribute set
+            to reference other elements of the same attribute set via
+            the <literal>config</literal> module argument. If
+            <literal>lib.mkIf &lt;cond&gt;</literal> is used on such a
+            type, the value is assumed to exist, but an error is thrown
+            when evaluated and the condition is false.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </section>
   <section xml:id="sec-option-types-composed">


### PR DESCRIPTION
###### Motivation for this change
Introduce `types.unconditional <elemType>` as a type, which when used as e.g. `attrsOf (unconditional str)` can replace `lazyAttrsOf str`. This type ensures that conditional `mkIf` definitions can't influence whether the option is defined or not, and therefore make the attribute set values be evaluated lazily. This notably also works with `listOf (unconditional str)`, making the list elements evaluated lazily, which was not possible before.
 
Split off from https://github.com/NixOS/nixpkgs/pull/132448

###### Things done

- [x] Write and run tests
- [x] Write docs