### PR TITLE
hut: init at 0bcc6681

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hut/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hut/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, fetchFromSourcehut, lib, scdoc }:
+buildGoModule rec {
+  pname = "hut";
+  # No versions are listed upstream
+  version = "0bcc6681";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "hut";
+    # There are no tagged releases
+    rev = "0bcc6681048938e5bb4f5fc836523e9b9ef5d993";
+    sha256 = "sha256-hzXtFfrcgc0uKtSSHbE0cgFtpVtS/MjtGvAEdveIXZQ="; 
+  };
+
+  vendorSha256 = "sha256-zdQvk0M1a+Y90pnhqIpKxLJnlVJqMoSycewTep2Oux4=";
+
+  nativeBuildInputs = [ scdoc ];
+  
+  postBuild = ''
+    make doc/hut.1
+  '';
+
+  postInstall = ''
+    install -Dpm 0644 doc/hut.1 -t $out/share/man1/
+  '';
+  meta = with lib; {
+    description = "A CLI tool for sr.ht.";
+    homepage = "https://git.sr.ht/~emersion/hut";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ CodeLongAndProsper90 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6525,6 +6525,8 @@ with pkgs;
 
   humanfriendly = with python3Packages; toPythonApplication humanfriendly;
 
+  hut = callPackage ../applications/version-management/git-and-tools/hut { };
+
   hwinfo = callPackage ../tools/system/hwinfo { };
 
   hybridreverb2 = callPackage ../applications/audio/hybridreverb2 {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This adds the hut cli, an analog to the gh cli.
About the version and `rev = `: upstream hasn't made any tags or setup any versions, so I'm using the short commit id as the version and the latest commit to master as the rev-
if this isn't how it's supposed to be done, I'm open to suggestions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
