### PR TITLE
[21.11] nats-server: add patch for CVE-2022-24450

### DIFF
--- a/pkgs/servers/nats-server/2.6.0-CVE-2022-24450.patch
+++ b/pkgs/servers/nats-server/2.6.0-CVE-2022-24450.patch
@@ -1,0 +1,156 @@
+Based on upstream https://github.com/nats-io/nats-server/commit/a0a2e32185e62e3f4176e5391c71d4b6f4d1301f
+with minor adaptations to apply to 2.6.0 and test changes omitted
+as we don't currently run them
+
+diff --git a/server/client.go b/server/client.go
+index 57f0d589..f13de9a8 100644
+--- a/server/client.go
++++ b/server/client.go
+@@ -1,4 +1,4 @@
+-// Copyright 2012-2021 The NATS Authors
++// Copyright 2012-2022 The NATS Authors
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+ // You may obtain a copy of the License at
+@@ -1777,35 +1777,15 @@ func (c *client) processConnect(arg []byte) error {
+ 			return ErrAuthentication
+ 		}
+ 
+-		// Check for Account designation, this section should be only used when there is not a jwt.
+-		if account != _EMPTY_ {
+-			var acc *Account
+-			var wasNew bool
+-			var err error
+-			if !srv.NewAccountsAllowed() {
+-				acc, err = srv.LookupAccount(account)
+-				if err != nil {
+-					c.Errorf(err.Error())
+-					c.sendErr(ErrMissingAccount.Error())
+-					return err
+-				} else if accountNew && acc != nil {
+-					c.sendErrAndErr(ErrAccountExists.Error())
+-					return ErrAccountExists
+-				}
+-			} else {
+-				// We can create this one on the fly.
+-				acc, wasNew = srv.LookupOrRegisterAccount(account)
+-				if accountNew && !wasNew {
+-					c.sendErrAndErr(ErrAccountExists.Error())
+-					return ErrAccountExists
+-				}
+-			}
+-			// If we are here we can register ourselves with the new account.
+-			if err := c.registerWithAccount(acc); err != nil {
+-				c.reportErrRegisterAccount(acc, err)
+-				return ErrBadAccount
+-			}
+-		} else if c.acc == nil {
++		// Check for Account designation, we used to have this as an optional feature for dynamic
++		// sandbox environments. Now its considered an error.
++		if accountNew || account != _EMPTY_ {
++			c.authViolation()
++			return ErrAuthentication
++		}
++
++		// If no account designation.
++		if c.acc == nil {
+ 			// By default register with the global account.
+ 			c.registerWithAccount(srv.globalAccount())
+ 		}
+diff --git a/server/events.go b/server/events.go
+index 980e20ee..33498821 100644
+--- a/server/events.go
++++ b/server/events.go
+@@ -1550,7 +1550,7 @@ func (s *Server) sendLeafNodeConnect(a *Account) {
+ func (s *Server) sendLeafNodeConnectMsg(accName string) {
+ 	subj := fmt.Sprintf(leafNodeConnectEventSubj, accName)
+ 	m := accNumConnsReq{Account: accName}
+-	s.sendInternalMsg(subj, "", &m.Server, &m)
++	s.sendInternalMsg(subj, _EMPTY_, &m.Server, &m)
+ }
+ 
+ // sendAccConnsUpdate is called to send out our information on the
+diff --git a/server/jwt.go b/server/jwt.go
+index e7a5babb..5ab89791 100644
+--- a/server/jwt.go
++++ b/server/jwt.go
+@@ -1,4 +1,4 @@
+-// Copyright 2018-2019 The NATS Authors
++// Copyright 2018-2022 The NATS Authors
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+ // You may obtain a copy of the License at
+@@ -70,9 +70,6 @@ func validateTrustedOperators(o *Options) error {
+ 	if len(o.TrustedOperators) == 0 {
+ 		return nil
+ 	}
+-	if o.AllowNewAccounts {
+-		return fmt.Errorf("operators do not allow dynamic creation of new accounts")
+-	}
+ 	if o.AccountResolver == nil {
+ 		return fmt.Errorf("operators require an account resolver to be configured")
+ 	}
+diff --git a/server/opts.go b/server/opts.go
+index 4b0d701f..78fdf307 100644
+--- a/server/opts.go
++++ b/server/opts.go
+@@ -202,7 +202,6 @@ type Options struct {
+ 	NoAuthUser            string        `json:"-"`
+ 	SystemAccount         string        `json:"-"`
+ 	NoSystemAccount       bool          `json:"-"`
+-	AllowNewAccounts      bool          `json:"-"`
+ 	Username              string        `json:"-"`
+ 	Password              string        `json:"-"`
+ 	Authorization         string        `json:"-"`
+diff --git a/server/route.go b/server/route.go
+index a3b76ea2..0cc8762a 100644
+--- a/server/route.go
++++ b/server/route.go
+@@ -1035,20 +1035,17 @@ func (c *client) processRemoteSub(argo []byte, hasOrigin bool) (err error) {
+ 		acc = v.(*Account)
+ 	}
+ 	if acc == nil {
+-		expire := false
+ 		isNew := false
+-		if !srv.NewAccountsAllowed() {
+-			// if the option of retrieving accounts later exists, create an expired one.
+-			// When a client comes along, expiration will prevent it from being used,
+-			// cause a fetch and update the account to what is should be.
+-			if staticResolver {
+-				c.Errorf("Unknown account %q for remote subject %q", accountName, sub.subject)
+-				return
+-			}
+-			c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
+-			expire = true
++		// if the option of retrieving accounts later exists, create an expired one.
++		// When a client comes along, expiration will prevent it from being used,
++		// cause a fetch and update the account to what is should be.
++		if staticResolver {
++			c.Errorf("Unknown account %q for remote subject %q", accountName, sub.subject)
++			return
+ 		}
+-		if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew && expire {
++		c.Debugf("Unknown account %q for remote subject %q", accountName, sub.subject)
++
++		if acc, isNew = srv.LookupOrRegisterAccount(accountName); isNew {
+ 			acc.mu.Lock()
+ 			acc.expired = true
+ 			acc.incomplete = true
+diff --git a/server/server.go b/server/server.go
+index 51df6842..a79e494f 100644
+--- a/server/server.go
++++ b/server/server.go
+@@ -1022,13 +1022,6 @@ func (s *Server) logPid() error {
+ 	return ioutil.WriteFile(s.getOpts().PidFile, []byte(pidStr), 0660)
+ }
+ 
+-// NewAccountsAllowed returns whether or not new accounts can be created on the fly.
+-func (s *Server) NewAccountsAllowed() bool {
+-	s.mu.Lock()
+-	defer s.mu.Unlock()
+-	return s.opts.AllowNewAccounts
+-}
+-
+ // numReservedAccounts will return the number of reserved accounts configured in the server.
+ // Currently this is 1, one for the global default account.
+ func (s *Server) numReservedAccounts() int {

--- a/pkgs/servers/nats-server/default.nix
+++ b/pkgs/servers/nats-server/default.nix
@@ -15,6 +15,10 @@ buildGoPackage rec {
     sha256 = "sha256-DggzXYPyu0dQ40L98VzxgN9S/35vLJJow9UjDtMz9rY=";
   };
 
+  patches = [
+    ./2.6.0-CVE-2022-24450.patch
+  ];
+
   meta = {
     description = "High-Performance server for NATS";
     license = licenses.asl20;


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-24450
https://advisories.nats.io/CVE/CVE-2022-24450.txt

See #158847 for master.

Needed minor (whitespace) modifications to patch to apply cleanly. Omitted extensive test changes from patch to reduce size - we don't currently have the tests working anyway. Seeing as this is actually a minor feature removal we could possibly have got away with simply adding a couple of lines somewhere simply saying "Nope" if the feature was ever used :shrug: 

cc @derekcollison 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
