### PR TITLE
keybase-gui: add Apple Intel support

### DIFF
--- a/pkgs/tools/security/keybase/darwin.nix
+++ b/pkgs/tools/security/keybase/darwin.nix
@@ -1,0 +1,44 @@
+{
+  fetchurl,
+  lib,
+  stdenvNoCC,
+  undmg
+}:
+
+{
+  meta,
+  pname
+}:
+
+with lib;
+
+let
+  # Check these places for new versions:
+  # https://prerelease.keybase.io/index.html
+  version = "5.9.2";
+  versionSuffix = "20220131223535%2Ba25f15e42b";
+  fileName = "Keybase-${version}-${versionSuffix}.dmg";
+in
+  stdenvNoCC.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      # Workaround for https://github.com/NixOS/nix/issues/6116.
+      name = builtins.replaceStrings ["%2B"] ["+"] fileName;
+      url = "https://s3.amazonaws.com/prerelease.keybase.io/darwin/${fileName}";
+      sha256 = "15a20d62a860d21c8c5397b6e3b36dcada6029a39649444753de59c0c9c547dd";
+    };
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ undmg ];
+
+    installPhase = ''
+      mkdir -p "$out/Applications"
+      cp -r "Keybase.app" "$out/Applications"
+    '';
+
+    meta = meta // {
+      platforms = [ "x86_64-darwin" ];
+      maintainers = with maintainers; [ steinybot ];
+    };
+  }

--- a/pkgs/tools/security/keybase/gui.nix
+++ b/pkgs/tools/security/keybase/gui.nix
@@ -1,116 +1,19 @@
-{ stdenv, lib, fetchurl, alsa-lib, atk, cairo, cups, udev, libdrm, mesa
-, dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libappindicator-gtk3
-, libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook
-, runtimeShell, gsettings-desktop-schemas }:
+{
+  lib,
+  pkgs,
+  stdenv
+}:
 
 let
-  versionSuffix = "20220216215910.c82d65a685";
+  package = if stdenv.isLinux then ./linux.nix else ./darwin.nix;
+  mkKeybaseGui = pkgs.callPackage package {};
 in
 
-stdenv.mkDerivation rec {
+mkKeybaseGui {
   pname = "keybase-gui";
-  version = "5.9.3"; # Find latest version from https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
-
-  src = fetchurl {
-    url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version + "-" + versionSuffix}_amd64.deb";
-    hash = "sha256-JY2DaqApv6K02y3B+JIXpV4SvvMQpBhw9eqr/5Sn0cg=";
-  };
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    wrapGAppsHook
-  ];
-
-  buildInputs = [
-    alsa-lib
-    atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gsettings-desktop-schemas
-    gtk3
-    libappindicator-gtk3
-    libnotify
-    nspr
-    nss
-    pango
-    systemd
-    xorg.libX11
-    xorg.libXScrnSaver
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXtst
-    xorg.libxcb
-    libdrm
-    mesa.out
-  ];
-
-  runtimeDependencies = [
-    (lib.getLib udev)
-    libappindicator-gtk3
-  ];
-
-  dontBuild = true;
-  dontConfigure = true;
-  dontPatchELF = true;
-
-  unpackPhase = ''
-    ar xf $src
-    tar xf data.tar.xz
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mv usr/share $out/share
-    mv opt/keybase $out/share/
-
-    cat > $out/bin/keybase-gui <<EOF
-    #!${runtimeShell}
-
-    checkFailed() {
-      if [ "\$NIX_SKIP_KEYBASE_CHECKS" = "1" ]; then
-        return
-      fi
-      echo "Set NIX_SKIP_KEYBASE_CHECKS=1 if you want to skip this check." >&2
-      exit 1
-    }
-
-    if [ ! -S "\$XDG_RUNTIME_DIR/keybase/keybased.sock" ]; then
-      echo "Keybase service doesn't seem to be running." >&2
-      echo "You might need to run: keybase service" >&2
-      checkFailed
-    fi
-
-    if [ -z "\$(keybase status | grep kbfsfuse)" ]; then
-      echo "Could not find kbfsfuse client in keybase status." >&2
-      echo "You might need to run: kbfsfuse" >&2
-      checkFailed
-    fi
-
-    exec $out/share/keybase/Keybase "\$@"
-    EOF
-    chmod +x $out/bin/keybase-gui
-
-    substituteInPlace $out/share/applications/keybase.desktop \
-      --replace run_keybase $out/bin/keybase-gui
-  '';
-
-  meta = with lib; {
+  meta = {
     homepage = "https://www.keybase.io/";
     description = "The Keybase official GUI";
-    platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ avaq rvolosatovs puffnfresh np Br1ght0ne shofius ];
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/tools/security/keybase/linux.nix
+++ b/pkgs/tools/security/keybase/linux.nix
@@ -1,0 +1,121 @@
+{ stdenv, lib, fetchurl, alsa-lib, atk, cairo, cups, udev, libdrm, mesa
+, dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, gtk3, libappindicator-gtk3
+, libnotify, nspr, nss, pango, systemd, xorg, autoPatchelfHook, wrapGAppsHook
+, runtimeShell, gsettings-desktop-schemas }:
+
+args@{
+  meta,
+  pname
+}:
+
+with lib;
+
+stdenv.mkDerivation rec {
+  inherit pname;
+
+  # Check these places for new versions:
+  # https://prerelease.keybase.io/index.html
+  # https://prerelease.keybase.io/deb/dists/stable/main/binary-amd64/Packages
+  version = "5.9.3";
+  versionSuffix = "20220216215910.c82d65a685";
+
+  src = fetchurl {
+    url = "https://s3.amazonaws.com/prerelease.keybase.io/linux_binaries/deb/keybase_${version}-${versionSuffix}_amd64.deb";
+    sha256 = "sha256-JY2DaqApv6K02y3B+JIXpV4SvvMQpBhw9eqr/5Sn0cg=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gsettings-desktop-schemas
+    gtk3
+    libappindicator-gtk3
+    libnotify
+    nspr
+    nss
+    pango
+    systemd
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxcb
+    libdrm
+    mesa.out
+  ];
+
+  runtimeDependencies = [
+    (lib.getLib udev)
+    libappindicator-gtk3
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+
+  unpackPhase = ''
+    ar xf $src
+    tar xf data.tar.xz
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv usr/share $out/share
+    mv opt/keybase $out/share/
+
+    cat > $out/bin/keybase-gui <<EOF
+    #!${runtimeShell}
+
+    checkFailed() {
+      if [ "\$NIX_SKIP_KEYBASE_CHECKS" = "1" ]; then
+        return
+      fi
+      echo "Set NIX_SKIP_KEYBASE_CHECKS=1 if you want to skip this check." >&2
+      exit 1
+    }
+
+    if [ ! -S "\$XDG_RUNTIME_DIR/keybase/keybased.sock" ]; then
+      echo "Keybase service doesn't seem to be running." >&2
+      echo "You might need to run: keybase service" >&2
+      checkFailed
+    fi
+
+    if [ -z "\$(keybase status | grep kbfsfuse)" ]; then
+      echo "Could not find kbfsfuse client in keybase status." >&2
+      echo "You might need to run: kbfsfuse" >&2
+      checkFailed
+    fi
+
+    exec $out/share/keybase/Keybase "\$@"
+    EOF
+    chmod +x $out/bin/keybase-gui
+
+    substituteInPlace $out/share/applications/keybase.desktop \
+      --replace run_keybase $out/bin/keybase-gui
+  '';
+
+  meta = args.meta // {
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ avaq rvolosatovs puffnfresh np Br1ght0ne shofius ];
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Installing Keybase GUI on a MacBook.

Sadly no aarch64 support so I will have to figure out how to run under Rosetta.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
