### PR TITLE
tuntox: init at 0.0.10

### DIFF
--- a/pkgs/tools/networking/tuntox/default.nix
+++ b/pkgs/tools/networking/tuntox/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, stdenv
+, cscope
+, fetchFromGitHub
+, fetchpatch
+, git
+, libevent
+, libopus
+, libsodium
+, libtoxcore
+, libvpx
+, pkg-config
+, python3
+, python3Packages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tuntox";
+  version = "0.0.10";
+
+  src = fetchFromGitHub {
+    owner = "gjedeer";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "sha256-c/0OxUH8iw8nRuVg4Fszf6Z/JiEV+m0B2ofzy81uFu8=";
+  };
+
+  nativeBuildInputs = [ cscope git pkg-config ];
+
+  buildInputs = [ libopus libtoxcore libsodium libevent libvpx python3 ];
+
+  pythonBuildInputs = with python3Packages; [
+    jinja2
+    requests
+  ];
+
+  patches = [
+    # https://github.com/gjedeer/tuntox/pull/67
+    (fetchpatch {
+      url = "https://github.com/gjedeer/tuntox/compare/a646402f42e120c7148d4de29dbdf5b09027a80a..365d2e5cbc0e3655fb64c204db0515f5f4cdf5a4.patch";
+      sha256 = "sha256-P3uIRnV+pBi3s3agGYUMt2PZU4CRxx/DUR8QPVQ+UN8=";
+    })
+  ];
+
+  postPatch = ''
+      substituteInPlace gitversion.h --replace '7d45afdf7d00a95a8c3687175e2b1669fa1f7745' '365d2e5cbc0e3655fb64c204db0515f5f4cdf5a4'
+    '' + lib.optionalString stdenv.isLinux ''
+      substituteInPlace Makefile --replace ' -static ' ' '
+      substituteInPlace Makefile --replace 'CC=gcc' ' '
+    '' + lib.optionalString stdenv.isDarwin ''
+      substituteInPlace Makefile.mac --replace '.git/HEAD .git/index' ' '
+      substituteInPlace Makefile.mac --replace '/usr/local/lib/libtoxcore.a' '${libtoxcore}/lib/libtoxcore.a'
+      substituteInPlace Makefile.mac --replace '/usr/local/lib/libsodium.a' '${libsodium}/lib/libsodium.dylib'
+      substituteInPlace Makefile.mac --replace 'CC=gcc' ' '
+    '';
+
+  buildPhase = ''
+    '' + lib.optionalString stdenv.isLinux ''
+      make
+    '' + lib.optionalString stdenv.isDarwin ''
+      make -f Makefile.mac tuntox
+    '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv tuntox $out/bin/
+  '';
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tunnel TCP connections over the Tox protocol";
+    homepage = "https://github.com/gjedeer/tuntox";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [
+      willcohen
+    ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10511,6 +10511,8 @@ with pkgs;
 
   trytond = with python3Packages; toPythonApplication trytond;
 
+  tuntox = callPackage ../tools/networking/tuntox { };
+
   omapd = callPackage ../tools/security/omapd { };
 
   ttf2pt1 = callPackage ../tools/misc/ttf2pt1 { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Completes including package for #32823. Does not include adding a nixos service.
@fgaz 

While the upstream author builds binaries for linux, macOS is not included, nor does it appear on homebrew.

One specific use case for this package is to enable easier use of https://elpa.gnu.org/packages/crdt.html across the public internet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
