### PR TITLE
liberation-circuit: 1.3 -> unstable-2022-01-02

### DIFF
--- a/pkgs/games/liberation-circuit/default.nix
+++ b/pkgs/games/liberation-circuit/default.nix
@@ -1,52 +1,23 @@
-{ stdenv, lib, fetchFromGitHub, fetchurl, cmake, git, makeWrapper, allegro5, libGL }:
+{ stdenv, lib, fetchFromGitHub, fetchurl, pkg-config, makeWrapper, allegro5, libGL }:
 
 stdenv.mkDerivation rec {
   pname = "liberation-circuit";
-  version = "1.3";
+  version = "unstable-2022-01-02";
 
   src = fetchFromGitHub {
     owner = "linleyh";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "BAv0wEJw4pK77jV+1bWPHeqyU/u0HtZLBF3ETUoQEAk=";
+    rev = "19e3363547793e931fd9419b61ebc2cd8e257714";
+    sha256 = "zIwjh4CBSmKz7pF7GM5af+VslWho5jHOLsulbW4C8TY=";
   };
 
-  patches = [
-    # Linux packaging assets
-    (fetchurl {
-      url = "https://github.com/linleyh/liberation-circuit/commit/72c1f6f4100bd227540aca14a535e7f4ebdeb851.patch";
-      sha256 = "0sad1z1lls0hanv88g1q6x5qr4s8f5p42s8j8v55bmwsdc0s5qys";
-    })
-  ];
-
-  # Hack to make binary diffs work
-  prePatch = ''
-    function patch {
-      git apply --whitespace=nowarn "$@"
-    }
-  '';
-
-  postPatch = ''
-    unset -f patch
-    substituteInPlace bin/launcher.sh --replace ./libcirc ./liberation-circuit
-  '';
-
-  nativeBuildInputs = [ cmake git makeWrapper ];
+  nativeBuildInputs = [ pkg-config makeWrapper ];
   buildInputs = [ allegro5 libGL ];
-
-  cmakeFlags = [
-    "-DALLEGRO_LIBRARY=${lib.getDev allegro5}"
-    "-DALLEGRO_INCLUDE_DIR=${lib.getDev allegro5}/include"
-  ];
-
-  NIX_CFLAGS_LINK = "-lallegro_image -lallegro_primitives -lallegro_color -lallegro_acodec -lallegro_audio -lallegro_dialog -lallegro_font -lallegro_main -lallegro -lm";
-  hardeningDisable = [ "format" ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/opt
-    cd ..
     cp -r bin $out/opt/liberation-circuit
     chmod +x $out/opt/liberation-circuit/launcher.sh
     makeWrapper $out/opt/liberation-circuit/launcher.sh $out/bin/liberation-circuit


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

While the project hasn't seen a new official release in a few years, development is still semi-active and has seen some important fixes and refactorings. Fixes #135942

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
