### PR TITLE
nixos/mediatomb: make service use group

### DIFF
--- a/nixos/modules/services/misc/mediatomb.nix
+++ b/nixos/modules/services/misc/mediatomb.nix
@@ -366,6 +366,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       serviceConfig.ExecStart = "${binaryCommand} --port ${toString cfg.port} ${interfaceFlag} ${configFlag} --home ${cfg.dataDir}";
       serviceConfig.User = cfg.user;
+      serviceConfig.Group = cfg.group;
     };
 
     users.groups = optionalAttrs (cfg.group == "mediatomb") {


### PR DESCRIPTION
The systemd service for mediatomb did not use the group configuration setting in the service configuration, I added in the group specification

###### Motivation for this change

Specifying the group the mediatomb binary will be run as.

###### Things done

Untested, since this is a very simple change.