### PR TITLE
cryptomator: 1.5.15 -> 1.6.7

### DIFF
--- a/pkgs/development/libraries/java/jffi/default.nix
+++ b/pkgs/development/libraries/java/jffi/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitHub, jdk, jre, ant, libffi, texinfo, pkg-config }:
+
+stdenv.mkDerivation rec {
+  pname = "jffi";
+  version = "1.3.9";
+
+  src = fetchFromGitHub {
+    owner = "jnr";
+    repo = "jffi";
+    rev = "jffi-${version}";
+    sha256 = "sha256-VjZYhMbad+AesANG06umRzqMWj+Ebzu59TYK7Tm/bFo=";
+  };
+
+  nativeBuildInputs = [ jdk ant texinfo pkg-config ];
+  buildInputs = [ libffi ] ;
+
+  buildPhase = ''
+    # The pkg-config script in the build.xml doesn't work propery
+    # set the lib path manually to work around this.
+    export LIBFFI_LIBS="${libffi}/lib/libffi.so"
+
+    ant -Duse.system.libffi=1 jar
+    ant -Duse.system.libffi=1 archive-platform-jar
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/java
+    cp -r dist/* $out/share/java
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    # The pkg-config script in the build.xml doesn't work propery
+    # set the lib path manually to work around this.
+    export LIBFFI_LIBS="${libffi}/lib/libffi.so"
+
+    ant -Duse.system.libffi=1 test
+  '';
+
+  meta = with lib; {
+    description = "Java Foreign Function Interface ";
+    homepage = "https://github.com/jnr/jffi";
+    platforms = platforms.unix;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bachp ];
+  };
+}

--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "cryptomator";
-  version = "1.6.5";
+  version = "1.6.7";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     rev = version;
-    sha256 = "sha256-6Z1GwrOsjjG546ZS+v/q4WL4tHgYPvMga8x4DY+unJs=";
+    sha256 = "sha256-hOILOdVYBnS9XuEXaIJcf2bPF72Lcr7IBX4CFCIsC8k=";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central (120MB)
@@ -24,7 +24,7 @@ let
     buildInputs = [ jre ];
 
     buildPhase = ''
-      while mvn -Plinux package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+      while mvn -Plinux package -Dmaven.test.skip=true -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
         echo "timeout, restart maven to continue downloading"
       done
     '';
@@ -37,14 +37,16 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-4yHN5hYLjatni8seLOHyuEVnxOdNVia6rY3oPewR+20=";
+    outputHash = "sha256-XFqXjNjPN2vwA3jay7TS79S4FHksjjrODdD/p4oTvpg=";
+
+    doCheck = false;
   };
 
 in stdenv.mkDerivation rec {
   inherit pname version src;
 
   buildPhase = ''
-    mvn -Plinux package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+    mvn -Plinux package --offline -Dmaven.test.skip=true -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
   '';
 
   installPhase = ''

--- a/pkgs/tools/security/cryptomator/default.nix
+++ b/pkgs/tools/security/cryptomator/default.nix
@@ -1,25 +1,18 @@
 { lib, stdenv, fetchFromGitHub
 , autoPatchelfHook
-, fuse, packer
+, fuse, jffi
 , maven, jdk, jre, makeWrapper, glib, wrapGAppsHook
 }:
 
 let
   pname = "cryptomator";
-  version = "1.5.15";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     rev = version;
-    sha256 = "06n7wda7gfalvsg1rlcm51ss73nlbhh95z6zq18yvn040clkzkij";
-  };
-
-  icons = fetchFromGitHub {
-    owner = "cryptomator";
-    repo = "cryptomator-linux";
-    rev = version;
-    sha256 = "1sqbx858zglv0xkpjya0cpbkxf2hkj1xvxhnir3176y2xyjv6aib";
+    sha256 = "sha256-6Z1GwrOsjjG546ZS+v/q4WL4tHgYPvMga8x4DY+unJs=";
   };
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central (120MB)
@@ -28,10 +21,10 @@ let
     inherit src;
 
     nativeBuildInputs = [ jdk maven ];
+    buildInputs = [ jre ];
 
     buildPhase = ''
-      cd main
-      while mvn -Prelease package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+      while mvn -Plinux package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
         echo "timeout, restart maven to continue downloading"
       done
     '';
@@ -44,42 +37,50 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "195ysv9l861y9d1lvmvi7wmk172ynlba9n233blpaigq88cjn208";
+    outputHash = "sha256-4yHN5hYLjatni8seLOHyuEVnxOdNVia6rY3oPewR+20=";
   };
 
 in stdenv.mkDerivation rec {
   inherit pname version src;
 
   buildPhase = ''
-    cd main
-    mvn -Prelease package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
+    mvn -Plinux package --offline -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
   '';
 
   installPhase = ''
-    mkdir -p $out/bin/ $out/usr/share/cryptomator/libs/
+    mkdir -p $out/bin/ $out/share/cryptomator/libs/ $out/share/cryptomator/mods/
 
-    cp buildkit/target/libs/* buildkit/target/linux-libs/* $out/usr/share/cryptomator/libs/
+    cp target/libs/* $out/share/cryptomator/libs/
+    cp target/mods/* target/cryptomator-*.jar $out/share/cryptomator/mods/
+
+    # The bundeled jffi.so dosn't work on nixos and causes a segmentation fault
+    # we thus replace it with a version build by nixos
+    rm $out/share/cryptomator/libs/jff*.jar
+    cp -f ${jffi}/share/java/jffi-complete.jar $out/share/cryptomator/libs/
 
     makeWrapper ${jre}/bin/java $out/bin/cryptomator \
-      --add-flags "-classpath '$out/usr/share/cryptomator/libs/*'" \
+      --add-flags "--class-path '$out/share/cryptomator/libs/*'" \
+      --add-flags "--module-path '$out/share/cryptomator/mods'" \
       --add-flags "-Dcryptomator.settingsPath='~/.config/Cryptomator/settings.json'" \
-      --add-flags "-Dcryptomator.ipcPortPath='~/.config/Cryptomator/ipcPort.bin'" \
+      --add-flags "-Dcryptomator.ipcSocketPath='~/.config/Cryptomator/ipc.socket'" \
       --add-flags "-Dcryptomator.logDir='~/.local/share/Cryptomator/logs'" \
       --add-flags "-Dcryptomator.mountPointsDir='~/.local/share/Cryptomator/mnt'" \
       --add-flags "-Djdk.gtk.version=3" \
       --add-flags "-Xss20m" \
       --add-flags "-Xmx512m" \
-      --add-flags "org.cryptomator.launcher.Cryptomator" \
-      --prefix PATH : "$out/usr/share/cryptomator/libs/:${lib.makeBinPath [ jre glib ]}" \
+      --add-flags "-Djavafx.embed.singleThread=true " \
+      --add-flags "-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "--module org.cryptomator.desktop/org.cryptomator.launcher.Cryptomator" \
+      --prefix PATH : "$out/share/cryptomator/libs/:${lib.makeBinPath [ jre glib ]}" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ fuse ]}" \
       --set JAVA_HOME "${jre.home}"
 
     # install desktop entry and icons
-    cp -r ${icons}/resources/appimage/AppDir/usr/* $out/
+    cp -r ${src}/dist/linux/appimage/resources/AppDir/usr/* $out/
   '';
 
   nativeBuildInputs = [ autoPatchelfHook maven makeWrapper wrapGAppsHook jdk ];
-  buildInputs = [ fuse packer jre glib ];
+  buildInputs = [ fuse jre glib jffi ];
 
   meta = with lib; {
     description = "Free client-side encryption for your cloud files";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20950,6 +20950,8 @@ with pkgs;
 
   jdom = callPackage ../development/libraries/java/jdom { };
 
+  jffi = callPackage ../development/libraries/java/jffi { };
+
   jflex = callPackage ../development/libraries/java/jflex { };
 
   lombok = callPackage ../development/libraries/java/lombok { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update to latest version and fix segault when trying to mount a tresor.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
