### PR TITLE
gnomeExtensions.dash-to-dock: Build from source again

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -21,7 +21,7 @@ let
     # By default we set url to src.url
     if [[ -z "$url" ]]; then
         url="$(${nix}/bin/nix-instantiate $systemArg --eval -E \
-                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url" \
+                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url or $UPDATE_NIX_ATTR_PATH.src.meta.homepage" \
             | tr -d '"')"
     fi
 

--- a/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome/extensions/dash-to-dock/default.nix
@@ -1,0 +1,48 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, glib
+, gettext
+, sassc
+, unstableGitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-dash-to-dock";
+  version = "71+date=2022-01-24";
+
+  # Temporarily switched to commit hash because stable version is buggy.
+  src = fetchFromGitHub {
+    owner = "micheleg";
+    repo = "dash-to-dock";
+    rev = "53114b4e000482a753e8b42dfa10d6057c08d1c6";
+    sha256 = "Gv78I/dxhc6FpjZWk10uHBfD24tHE4KdkpaAo8UZpwU=";
+  };
+
+  nativeBuildInputs = [
+    glib
+    gettext
+    sassc
+  ];
+
+  makeFlags = [
+    "INSTALLBASE=${placeholder "out"}/share/gnome-shell/extensions"
+  ];
+
+  passthru = {
+    extensionUuid = "dash-to-dock@micxgx.gmail.com";
+    extensionPortalSlug = "dash-to-dock";
+
+    updateScript = unstableGitUpdater {
+      stableVersion = true;
+      tagPrefix = "extensions.gnome.org-v";
+    };
+  };
+
+  meta = with lib; {
+    description = "A dock for the Gnome Shell";
+    homepage = "https://micheleg.github.io/dash-to-dock/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ eperuffo jtojnar rhoriguchi ];
+  };
+}

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -28,10 +28,6 @@ super: lib.trivial.pipe super [
     meta.maintainers = with lib.maintainers; [ eperuffo ];
   }))
 
-  (patchExtension "dash-to-dock@micxgx.gmail.com" (old: {
-    meta.maintainers = with lib.maintainers; [ eperuffo jtojnar rhoriguchi ];
-  }))
-
   (patchExtension "ddterm@amezin.github.com" (old: {
     # Requires gjs, zenity & vte via the typelib
     nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -2,6 +2,7 @@
 {
   "arcmenu@arcmenu.com" = callPackage ./arcmenu { };
   "clock-override@gnomeshell.kryogenix.org" = callPackage ./clock-override { };
+  "dash-to-dock@micxgx.gmail.com" = callPackage ./dash-to-dock { };
   "drop-down-terminal@gs-extensions.zzrough.org" = callPackage ./drop-down-terminal { };
   "EasyScreenCast@iacopodeenosee.gmail.com" = callPackage ./EasyScreenCast { };
   "emoji-selector@maestroschan.fr" = callPackage ./emoji-selector { };


### PR DESCRIPTION
###### Motivation for this change
The stable version has several usability bugs (e.g. https://github.com/micheleg/dash-to-dock/issues/1629) but patches do not apply cleanly to the zips from the extension portal. Let’s switch back to building from source to make it easier to update the extension. cc @piegamesde

This reverts commit 2bb795bab24f00d60b164ab40b504201a0cefa20, adds an update script and updates to latest git revision.

Additionally, I also modified `unstableGitUpdater` to support the version format from RFC 107, since extensions are often installed using `nix-env`. cc @romildo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
