### PR TITLE
python3Packages.aio-georss-client: 0.8 -> 0.9

### DIFF
--- a/pkgs/development/python-modules/aio-geojson-geonetnz-volcano/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-geonetnz-volcano/default.nix
@@ -8,17 +8,21 @@
 , pytest-asyncio
 , pytestCheckHook
 , pytz
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aio-geojson-geonetnz-volcano";
-  version = "0.6";
+  version = "0.7";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-aio-geojson-geonetnz-volcano";
     rev = "v${version}";
-    sha256 = "0n97kij2fprzajh57sy1z57kaqiil7pd5y67lq2hqm2cnvkar5ci";
+    sha256 = "sha256-2iVUHMk4ydmGmmGS6lJV5pvxJHyP9bRSeh/dOXbquE0=";
   };
 
   propagatedBuildInputs = [
@@ -34,7 +38,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_geojson_geonetnz_volcano" ];
+  pythonImportsCheck = [
+    "aio_geojson_geonetnz_volcano"
+  ];
 
   meta = with lib; {
     description = "Python module for accessing the GeoNet NZ Volcanic GeoJSON feeds";

--- a/pkgs/development/python-modules/aio-geojson-nsw-rfs-incidents/default.nix
+++ b/pkgs/development/python-modules/aio-geojson-nsw-rfs-incidents/default.nix
@@ -8,17 +8,21 @@
 , pytest-asyncio
 , pytestCheckHook
 , pytz
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "aio-geojson-nsw-rfs-incidents";
-  version = "0.4";
+  version = "0.5";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-aio-geojson-nsw-rfs-incidents";
     rev = "v${version}";
-    sha256 = "sha256-o9tuoJ7VZ6bg0rYeRWClKxdbxxj6wPgkSF7ZdOfmJew=";
+    sha256 = "sha256-rWlt4MYnuY+CzszFVDniWBnqpQW3WldSEl00ns3ko3U=";
   };
 
   propagatedBuildInputs = [
@@ -34,7 +38,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_geojson_nsw_rfs_incidents" ];
+  pythonImportsCheck = [
+    "aio_geojson_nsw_rfs_incidents"
+  ];
 
   meta = with lib; {
     description = "Python module for accessing the NSW Rural Fire Service incidents feeds";

--- a/pkgs/development/python-modules/aio-georss-client/default.nix
+++ b/pkgs/development/python-modules/aio-georss-client/default.nix
@@ -15,14 +15,16 @@
 
 buildPythonPackage rec {
   pname = "aio-georss-client";
-  version = "0.8";
+  version = "0.9";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "exxamalte";
     repo = "python-aio-georss-client";
     rev = "v${version}";
-    sha256 = "0447scp5n906p8kfzy0lwdq06f6hkq71r2zala6g3vr6b3kla6h8";
+    sha256 = "sha256-cnOW9Ey6WdL2bAqPop5noETn12OeeKsMkWHKGmYCjJU=";
   };
 
   propagatedBuildInputs = [
@@ -40,7 +42,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_georss_client" ];
+  pythonImportsCheck = [
+    "aio_georss_client"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing GeoRSS feeds";

--- a/pkgs/development/python-modules/aio-georss-gdacs/default.nix
+++ b/pkgs/development/python-modules/aio-georss-gdacs/default.nix
@@ -12,6 +12,8 @@
 buildPythonPackage rec {
   pname = "aio-georss-gdacs";
   version = "0.5";
+  format = "setuptools";
+
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
@@ -32,7 +34,9 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [ "aio_georss_gdacs" ];
+  pythonImportsCheck = [
+    "aio_georss_gdacs"
+  ];
 
   meta = with lib; {
     description = "Python library for accessing GeoRSS feeds";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/exxamalte/python-aio-georss-client/releases/tag/v0.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
