### PR TITLE
nixos/input-remapper: Fix missing [], add more options, add test

### DIFF
--- a/nixos/modules/services/misc/input-remapper.nix
+++ b/nixos/modules/services/misc/input-remapper.nix
@@ -7,23 +7,24 @@ let cfg = config.services.input-remapper; in
   options = {
     services.input-remapper = {
       enable = mkEnableOption "input-remapper, an easy to use tool to change the mapping of your input device buttons.";
-      package = mkOption {
-        type = types.package;
-        default = pkgs.input-remapper;
-        defaultText = literalExpression "pkgs.input-remapper";
-        description = ''
-          The input-remapper package to use.
-        '';
+      package = options.mkPackageOption pkgs "input-remapper" { };
+      enableUdevRules = mkEnableOption "udev rules added by input-remapper to handle hotplugged devices. Currently disabled by default due to https://github.com/sezanzeb/input-remapper/issues/140";
+      serviceWantedBy = mkOption {
+        default = [ "graphical.target" ];
+        example = [ "multi-user.target" ];
+        type = types.listOf types.str;
+        description = "Specifies the WantedBy setting for the input-remapper service.";
       };
     };
   };
 
   config = mkIf cfg.enable {
-    # FIXME: udev rule hangs sometimes when lots of devices connected, so let's not use it
-    # config.services.udev.packages = mapper-pkg;
-    services.dbus.packages = cfg.package;
-    systemd.packages = cfg.package;
-    environment.systemPackages = cfg.package;
+    services.udev.packages = mkIf cfg.enableUdevRules [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
     systemd.services.input-remapper.wantedBy = [ "graphical.target" ];
   };
+
+  meta.maintainers = with lib.maintainers; [ LunNova ];
 }

--- a/nixos/modules/services/misc/input-remapper.nix
+++ b/nixos/modules/services/misc/input-remapper.nix
@@ -23,7 +23,7 @@ let cfg = config.services.input-remapper; in
     services.dbus.packages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
     environment.systemPackages = [ cfg.package ];
-    systemd.services.input-remapper.wantedBy = [ "graphical.target" ];
+    systemd.services.input-remapper.wantedBy = cfg.serviceWantedBy;
   };
 
   meta.maintainers = with lib.maintainers; [ LunNova ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -224,6 +224,7 @@ in
   initrd-network-ssh = handleTest ./initrd-network-ssh {};
   initrdNetwork = handleTest ./initrd-network.nix {};
   initrd-secrets = handleTest ./initrd-secrets.nix {};
+  input-remapper = handleTest ./input-remapper.nix {};
   inspircd = handleTest ./inspircd.nix {};
   installer = handleTest ./installer.nix {};
   invoiceplane = handleTest ./invoiceplane.nix {};

--- a/nixos/tests/input-remapper.nix
+++ b/nixos/tests/input-remapper.nix
@@ -1,0 +1,45 @@
+import ./make-test-python.nix ({ pkgs, ... }:
+
+  {
+    name = "input-remapper";
+    meta = {
+      maintainers = with pkgs.lib.maintainers; [ LunNova ];
+    };
+
+    machine = { config, ... }:
+      let user = config.users.users.sybil; in
+      {
+        imports = [
+          ./common/user-account.nix
+          ./common/x11.nix
+        ];
+
+        services.xserver.enable = true;
+        services.input-remapper.enable = true;
+        users.users.sybil = { isNormalUser = true; group = "wheel"; };
+        test-support.displayManager.auto.user = user.name;
+        # passwordless pkexec bodge
+        security.sudo = { enable = true; wheelNeedsPassword = false; };
+        security.wrappers.pkexec = pkgs.lib.mkForce
+          {
+            setuid = true;
+            owner = "root";
+            group = "root";
+            source = "${pkgs.sudo}/bin/sudo";
+          };
+      };
+
+    enableOCR = true;
+
+    testScript = { nodes, ... }: ''
+      start_all()
+      machine.wait_for_x()
+
+      machine.succeed("systemctl status input-remapper.service")
+      machine.execute("su - sybil -c input-remapper-gtk >&2 &")
+
+      machine.wait_for_text("Input Remapper")
+      machine.wait_for_text("Preset")
+      machine.wait_for_text("Change Key")
+    '';
+  })

--- a/nixos/tests/input-remapper.nix
+++ b/nixos/tests/input-remapper.nix
@@ -18,7 +18,14 @@ import ./make-test-python.nix ({ pkgs, ... }:
         services.input-remapper.enable = true;
         users.users.sybil = { isNormalUser = true; group = "wheel"; };
         test-support.displayManager.auto.user = user.name;
-        # passwordless pkexec bodge
+        # workaround for pkexec not working in the test environment
+        # Error creating textual authentication agent:
+        #   Error opening current controlling terminal for the process (`/dev/tty'):
+        #   No such device or address
+        # passwordless pkexec with polkit module also doesn't work
+        # to allow the program to run, we replace pkexec with sudo
+        # and turn on passwordless sudo
+        # this is not correct in general but good enough for this test
         security.sudo = { enable = true; wheelNeedsPassword = false; };
         security.wrappers.pkexec = pkgs.lib.mkForce
           {

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -25,6 +25,10 @@
   # If you use Xmodmap to set keyboard mappings (or your DE does)
   # it is required to correctly map keys
 , withXmodmap ? true
+  # Some tests are flakey under high CPU load and could cause intermittent
+  # failures when building. Override this to true to run tests anyway
+  # See upstream issue: https://github.com/sezanzeb/input-remapper/issues/306
+, withDoCheck ? false
   # Version and rev and hash are package arguments to allow overriding
   # while ensuring the values in prePatch and src match
   # https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/7
@@ -66,7 +70,7 @@ buildPythonApplication {
     substituteInPlace inputremapper/logger.py --replace "logger.setLevel(logging.INFO)"  "logger.setLevel(logging.DEBUG)"
   '');
 
-  doCheck = true;
+  doCheck = withDoCheck;
   checkInputs = [
     psutil
   ];

--- a/pkgs/tools/inputmethods/input-remapper/default.nix
+++ b/pkgs/tools/inputmethods/input-remapper/default.nix
@@ -18,6 +18,7 @@
 , buildPythonApplication
 , procps
 , gtksourceview4
+, nixosTests
   # Change the default log level to debug for easier debugging of package issues
 , withDebugLogLevel ? false
   # Xmodmap is an optional dependency
@@ -145,6 +146,8 @@ buildPythonApplication {
     # Only install input-remapper prefixed binaries, we don't care about deprecated key-mapper ones
     install -m755 -D -t $out/bin/ bin/input-remapper*
   '';
+
+  passthru.tests = nixosTests.input-remapper;
 
   meta = with lib; {
     description = "An easy to use tool to change the mapping of your input device buttons";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes a bug, adds two new options for the service WantedBy target and the udev rules, and adds a test that the module works.

Disables python unit tests for the package due to flaky tests under high load. https://github.com/sezanzeb/input-remapper/issues/306

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
