### PR TITLE
rustdesk: init at 1.1.8

### DIFF
--- a/pkgs/applications/networking/remote/rustdesk/cargo.patch
+++ b/pkgs/applications/networking/remote/rustdesk/cargo.patch
@@ -1,0 +1,50 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index c3e139e..b77d8bd 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1761,11 +1761,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "magnum-opus"
+-version = "0.3.4-2"
+-source = "git+https://github.com/open-trade/magnum-opus#ad0836164abf4a4df69009b1ee08eabe3a13b33f"
++version = "0.4.0"
++source = "git+https://github.com/TheRadioGuy/magnum-opus#171e1d021004626f7444d1e39b98f50bc3cb2604"
+ dependencies = [
+- "bindgen 0.59.1",
+- "target_build_utils",
++ "libc",
++ "opusic-sys",
+ ]
+ 
+ [[package]]
+@@ -2188,6 +2188,16 @@ version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+ 
++[[package]]
++name = "opusic-sys"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5eace752ce07a037241dba8f02c654799f051e431b27028056bcb480e83b54f5"
++dependencies = [
++ "cmake",
++ "libc",
++]
++
+ [[package]]
+ name = "parity-tokio-ipc"
+ version = "0.7.2"
+diff --git a/Cargo.toml b/Cargo.toml
+index 75504a0..43e1624 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -32,7 +32,7 @@ libc = "0.2"
+ parity-tokio-ipc = { git = "https://github.com/open-trade/parity-tokio-ipc" }
+ flexi_logger = "0.17"
+ runas = "0.2"
+-magnum-opus = { git = "https://github.com/open-trade/magnum-opus" }
++magnum-opus = { git = "https://github.com/TheRadioGuy/magnum-opus" }
+ dasp = { version = "0.11", features = ["signal", "interpolate-linear", "interpolate"], optional = true }
+ rubato = { version = "0.8", optional = true }
+ samplerate = { version = "0.2", optional = true }

--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -1,0 +1,104 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, makeWrapper
+, rustPlatform
+, cmake
+, yasm
+, nasm
+, zip
+, pkg-config
+, clang
+, gtk3
+, xdotool
+, libxcb
+, libXfixes
+, alsa-lib
+, pulseaudio
+, libXtst
+, libvpx
+, libyuv
+, libopus
+, libsciter
+, llvmPackages
+, wrapGAppsHook
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rustdesk";
+  version = "1.1.8";
+
+  src = fetchFromGitHub {
+    owner = "rustdesk";
+    repo = "rustdesk";
+    rev = "0325500ebf331b66220cec6e9078afb83b0e98a7";
+    sha256 = "sha256-xglyyoiAjJx3y8+A2OYHZffjqjDkcTjIluPA/J42VVg=";
+  };
+
+  cargoSha256 = "sha256-4MQKa54f3X7IHGd29H6RY7v2toeHvTHInIpgXjdotjw=";
+
+  LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";
+
+  # Change magnus-opus version to upstream so that it does not use
+  # vcpkg for libopus since it does not work.
+  cargoPatches = [
+    ./cargo.patch
+  ];
+
+  # Manually simulate a vcpkg installation so that it can link the libaries
+  # properly.
+  postUnpack = let
+    vcpkg_target = "x64-linux";
+  in ''
+    export VCPKG_ROOT="$TMP/vcpkg";
+
+    mkdir -p $VCPKG_ROOT/installed/${vcpkg_target}/lib
+
+    ln -s ${libvpx.out}/lib/* $VCPKG_ROOT/installed/${vcpkg_target}/lib/
+    ln -s ${libyuv.out}/lib/* $VCPKG_ROOT/installed/${vcpkg_target}/lib/
+  '';
+
+  nativeBuildInputs = [ pkg-config cmake makeWrapper copyDesktopItems yasm nasm clang wrapGAppsHook ];
+  buildInputs = [ alsa-lib pulseaudio libXfixes libxcb xdotool gtk3 libvpx libopus libXtst libyuv ];
+
+  # Checks require an active X display.
+  doCheck = false;
+
+  desktopItems = [ (makeDesktopItem {
+    name = "rustdesk";
+    exec = meta.mainProgram;
+    icon = "rustdesk";
+    desktopName = "RustDesk";
+    comment = meta.description;
+    genericName = "Remote Desktop";
+    categories = ["Network"];
+  }) ];
+
+  # Add static ui resources and libsciter to same folder as binary so that it
+  # can find them.
+  postInstall = ''
+    mkdir -p $out/{share/src,lib/rustdesk}
+
+    # so needs to be next to the executable
+    mv $out/bin/rustdesk $out/lib/rustdesk
+    ln -s ${libsciter}/lib/libsciter-gtk.so $out/lib/rustdesk
+
+    makeWrapper $out/lib/rustdesk/rustdesk $out/bin/rustdesk \
+      --run "cd $out/share"
+
+    cp -a $src/src/ui $out/share/src
+
+    install -Dm0644 $src/logo.svg $out/share/icons/hicolor/scalable/apps/rustdesk.svg
+  '';
+
+  meta = with lib; {
+    description = "Yet another remote desktop software";
+    homepage = "https://rustdesk.com";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ leixb ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "rustdesk";
+  };
+}

--- a/pkgs/development/libraries/libsciter/default.nix
+++ b/pkgs/development/libraries/libsciter/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, glib
+, cairo
+, libuuid
+, pango
+, gdk-pixbuf
+, gtk3
+, stdenv
+, fetchurl
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libsciter";
+  version = "4.4.8.23-bis"; # Version specified in GitHub commit title
+
+  src = fetchurl {
+    url = "https://github.com/c-smile/sciter-sdk/raw/9f1724a45f5a53c4d513b02ed01cdbdab08fa0e5/bin.lnx/x64/libsciter-gtk.so";
+    sha256 = "a1682fbf55e004f1862d6ace31b5220121d20906bdbf308d0a9237b451e4db86";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [ glib cairo libuuid pango gtk3 ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D $src $out/lib/libsciter-gtk.so
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://sciter.com";
+    description = "Embeddable HTML/CSS/JavaScript engine for modern UI development";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ leixb ];
+    license = licenses.unfree;
+  };
+}

--- a/pkgs/development/libraries/libyuv/default.nix
+++ b/pkgs/development/libraries/libyuv/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchgit
+, cmake
+, libjpeg
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libyuv";
+  version = "1787"; # Defined in: include/libyuv/version.h
+
+  src = fetchgit {
+    url = "https://chromium.googlesource.com/libyuv/libyuv.git";
+    rev = "eb6e7bb63738e29efd82ea3cf2a115238a89fa51"; # refs/heads/stable
+    sha256 = "sha256-DtRYoaAXb9ZD2OLiKbzKzH5vzuu+Lzu4eHaDgPB9hjU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  # NEON does not work on aarch64, we disable it
+  cmakeFlags = lib.optionals stdenv.isAarch64 ["-DCMAKE_CXX_FLAGS=-DLIBYUV_DISABLE_NEON"];
+
+  buildInputs = [ libjpeg ];
+
+  meta = with lib; {
+    homepage = "https://chromium.googlesource.com/libyuv/libyuv";
+    description = "Open source project that includes YUV scaling and conversion functionality";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ leixb ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9542,6 +9542,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  rustdesk = callPackage ../applications/networking/remote/rustdesk { };
+
   rustscan = callPackage ../tools/security/rustscan {
     inherit (darwin.apple_sdk.frameworks) Security;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18924,6 +18924,8 @@ with pkgs;
 
   libyubikey = callPackage ../development/libraries/libyubikey { };
 
+  libyuv = callPackage ../development/libraries/libyuv { };
+
   libzapojit = callPackage ../development/libraries/libzapojit { };
 
   libzen = callPackage ../development/libraries/libzen { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18595,6 +18595,8 @@ with pkgs;
 
   libschrift = callPackage ../development/libraries/libschrift { };
 
+  libsciter = callPackage ../development/libraries/libsciter { };
+
   libsearpc = callPackage ../development/libraries/libsearpc { };
 
   libsigcxx = callPackage ../development/libraries/libsigcxx { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

closes #143067

Also adds `libsciter` and `libyuv` which are required to run.

- `rustdesk` should be able to be build for `darwin` but I am not sure how to package `libsciter.dylib` nor do I have a way to test it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


[aur]: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rustdesk