### PR TITLE
nixos/binfmt: Add support for using statically-linked QEMU

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -213,6 +213,10 @@ rec {
           then selectEmulator pkgs
           else throw "Don't know how to run ${final.config} executables.";
 
+        staticEmulator = pkgs:
+          if builtins.elem final.system pkgs.qemu-user-static.passthru.qemuUserPlatforms then
+            "${pkgs.qemu-user-static}/bin/qemu-${final.qemuArch}"
+          else null;
     }) // mapAttrs (n: v: v final.parsed) inspect.predicates
       // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
       // args;

--- a/nixos/modules/system/boot/binfmt.nix
+++ b/nixos/modules/system/boot/binfmt.nix
@@ -34,6 +34,7 @@ let
 
   getEmulator = system: (lib.systems.elaborate { inherit system; }).emulator pkgs;
   getQemuArch = system: (lib.systems.elaborate { inherit system; }).qemuArch;
+  getStaticEmulator = system: (lib.systems.elaborate { inherit system; }).staticEmulator pkgs;
 
   # Mapping of systems to “magicOrExtension” and “mask”. Mostly taken from:
   # - https://github.com/cleverca22/nixos-configs/blob/master/qemu.nix
@@ -279,29 +280,54 @@ in {
         '';
         type = types.listOf types.str;
       };
+
+      preferStaticEmulators = mkOption {
+        default = false;
+        description = lib.mdDoc ''
+          Whether to use static emulators when available.
+
+          This enables the kernel to preload the emulator binaries when
+          the binfmt registrations are added, obviating the need to make
+          the emulator binaries available inside chroots and chroot-like
+          sandboxes.
+        '';
+        type = types.bool;
+      };
     };
   };
 
   config = {
+    assertions = lib.mapAttrsToList (name: reg: {
+      assertion = reg.fixBinary -> !reg.wrapInterpreterInShell;
+      message = "boot.binfmt.registrations.\"${name}\" cannot have fixBinary when the interpreter is invoked through a shell.";
+    }) cfg.registrations;
+
     boot.binfmt.registrations = builtins.listToAttrs (map (system: {
       name = system;
       value = { config, ... }: let
-        interpreter = getEmulator system;
+        staticEmulator = getStaticEmulator system;
+        interpreter =
+          if cfg.preferStaticEmulators && staticEmulator != null then staticEmulator
+          else getEmulator system;
         qemuArch = getQemuArch system;
 
-        preserveArgvZero = "qemu-${qemuArch}" == baseNameOf interpreter;
+        isQemu = "qemu-${qemuArch}" == baseNameOf interpreter;
+        isStaticEmulator = interpreter == staticEmulator;
+
         interpreterReg = let
           wrapperName = "qemu-${qemuArch}-binfmt-P";
           wrapper = pkgs.wrapQemuBinfmtP wrapperName interpreter;
         in
-          if preserveArgvZero then "${wrapper}/bin/${wrapperName}"
+          if isQemu && !isStaticEmulator then "${wrapper}/bin/${wrapperName}"
           else interpreter;
       in ({
-        preserveArgvZero = mkDefault preserveArgvZero;
+        preserveArgvZero = mkDefault isQemu;
 
         interpreter = mkDefault interpreterReg;
-        wrapInterpreterInShell = mkDefault (!config.preserveArgvZero);
-        interpreterSandboxPath = mkDefault (dirOf (dirOf config.interpreter));
+        fixBinary = mkDefault isStaticEmulator;
+        wrapInterpreterInShell = mkDefault (!config.preserveArgvZero && !config.fixBinary);
+        interpreterSandboxPath = mkDefault
+          (if config.fixBinary then null else dirOf (dirOf config.interpreter));
       } // (magics.${system} or (throw "Cannot create binfmt registration for system ${system}")));
     }) cfg.emulatedSystems);
     nix.settings = lib.mkIf (cfg.emulatedSystems != []) {
@@ -309,9 +335,12 @@ in {
       extra-sandbox-paths = let
         ruleFor = system: cfg.registrations.${system};
         hasWrappedRule = lib.any (system: (ruleFor system).wrapInterpreterInShell) cfg.emulatedSystems;
-      in [ "/run/binfmt" ]
+        hasNonFixedRule = lib.any (system: !(ruleFor system).fixBinary) cfg.emulatedSystems;
+      in [ ]
+        ++ lib.optional hasNonFixedRule "/run/binfmt"
         ++ lib.optional hasWrappedRule "${pkgs.bash}"
-        ++ (map (system: (ruleFor system).interpreterSandboxPath) cfg.emulatedSystems);
+        ++ (lib.filter (p: p != null)
+          (map (system: (ruleFor system).interpreterSandboxPath) cfg.emulatedSystems));
     };
 
     environment.etc."binfmt.d/nixos.conf".source = builtins.toFile "binfmt_nixos.conf"

--- a/nixos/tests/systemd-binfmt.nix
+++ b/nixos/tests/systemd-binfmt.nix
@@ -87,4 +87,27 @@ in {
       ).lower()
     '';
   };
+
+  chroot = makeTest {
+    name = "systemd-binfmt-chroot";
+    nodes.machine = { pkgs, ... }: {
+      boot.binfmt.emulatedSystems = [
+        "aarch64-linux"
+      ];
+      boot.binfmt.preferStaticEmulators = true;
+
+      environment.systemPackages = [
+        (pkgs.writeShellScriptBin "test-chroot" ''
+          set -euo pipefail
+          mkdir -p /tmp/chroot
+          cp ${pkgs.pkgsCross.aarch64-multiplatform.pkgsStatic.busybox}/bin/busybox /tmp/chroot/busybox
+          chroot /tmp/chroot /busybox uname -m | grep aarch64
+        '')
+      ];
+    };
+    testScript = ''
+      machine.start()
+      machine.succeed("test-chroot")
+    '';
+  };
 }

--- a/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
+++ b/pkgs/applications/virtualization/qemu/aio-find-static-library.patch
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+index 96de1a6ef9..908d841f6a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -420,8 +420,7 @@ zlib = dependency('zlib', required: true, kwargs: static_kwargs)
+ libaio = not_found
+ if not get_option('linux_aio').auto() or have_block
+   libaio = cc.find_library('aio', has_headers: ['libaio.h'],
+-                           required: get_option('linux_aio'),
+-                           kwargs: static_kwargs)
++                           required: get_option('linux_aio'))
+ endif
+ linux_io_uring = not_found
+ if not get_option('linux_io_uring').auto() or have_block

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -63,8 +63,9 @@ stdenv.mkDerivation rec {
     pkg-config flex bison meson ninja
 
     # Don't change this to python3 and python3.pkgs.*, breaks cross-compilation
-    python3Packages.python python3Packages.sphinx python3Packages.sphinx-rtd-theme
+    python3Packages.python
   ]
+    ++ lib.optionals enableDocs [ python3Packages.sphinx python3Packages.sphinx-rtd-theme ]
     ++ lib.optionals gtkSupport [ wrapGAppsHook ]
     ++ lib.optionals hexagonSupport [ glib ]
     ++ lib.optionals stdenv.isDarwin [ sigtool ];

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -247,7 +247,9 @@ stdenv.mkDerivation rec {
 
   # Add a ‘qemu-kvm’ wrapper for compatibility/convenience.
   postInstall = ''
-    ln -s $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} $out/bin/qemu-kvm
+    if [ -f $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} ]; then
+      ln -s $out/bin/qemu-system-${stdenv.hostPlatform.qemuArch} $out/bin/qemu-kvm
+    fi
   '';
 
   passthru = {

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -31,6 +31,7 @@
 , pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
 , enableTools ? true
+, enableBlobs ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if hostCpuOnly
                     then (lib.optional stdenv.isx86_64 "i386-softmmu"
@@ -182,7 +183,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional uringSupport "--enable-linux-io-uring"
     ++ lib.optional canokeySupport "--enable-canokey"
     ++ lib.optional capstoneSupport "--enable-capstone"
-    ++ lib.optional (!pluginsSupport) "--disable-plugins";
+    ++ lib.optional (!pluginsSupport) "--disable-plugins"
+    ++ lib.optional (!enableBlobs) "--disable-install-blobs";
 
   dontWrapGApps = true;
 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -30,6 +30,7 @@
 , capstoneSupport ? true, capstone
 , pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
+, enableTools ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if hostCpuOnly
                     then (lib.optional stdenv.isx86_64 "i386-softmmu"
@@ -153,7 +154,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--disable-strip" # We'll strip ourselves after separating debug info.
     (lib.enableFeature enableDocs "docs")
-    "--enable-tools"
+    (lib.enableFeature enableTools "tools")
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     # Always use our Meson, not the bundled version, which doesn't

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -28,6 +28,7 @@
 , uringSupport ? stdenv.isLinux, liburing
 , canokeySupport ? false, canokey-qemu
 , capstoneSupport ? true, capstone
+, pluginsSupport ? !stdenv.hostPlatform.isStatic
 , enableDocs ? true
 , hostCpuOnly ? false
 , hostCpuTargets ? (if hostCpuOnly
@@ -179,7 +180,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional smbdSupport "--smbd=${samba}/bin/smbd"
     ++ lib.optional uringSupport "--enable-linux-io-uring"
     ++ lib.optional canokeySupport "--enable-canokey"
-    ++ lib.optional capstoneSupport "--enable-capstone";
+    ++ lib.optional capstoneSupport "--enable-capstone"
+    ++ lib.optional (!pluginsSupport) "--disable-plugins";
 
   dontWrapGApps = true;
 

--- a/pkgs/applications/virtualization/qemu/user-static.nix
+++ b/pkgs/applications/virtualization/qemu/user-static.nix
@@ -1,0 +1,52 @@
+{ lib, pkgsStatic }:
+
+let
+  qemuUserPlatforms = [
+    "aarch64-linux"
+    "armv7l-linux"
+    "i386-linux"
+    "powerpc-linux"
+    "powerpc64-linux"
+    "powerpc64le-linux"
+    "riscv32-linux"
+    "riscv64-linux"
+    "x86_64-linux"
+  ];
+
+  qemuTargets = map (system: (lib.systems.elaborate { inherit system; }).qemuArch + "-linux-user") qemuUserPlatforms;
+
+  static = (pkgsStatic.qemu.override {
+    guestAgentSupport = false;
+    numaSupport = false;
+    seccompSupport = false;
+    alsaSupport = false;
+    pulseSupport = false;
+    sdlSupport = false;
+    jackSupport = false;
+    gtkSupport = false;
+    vncSupport = false;
+    smartcardSupport = false;
+    spiceSupport = false;
+    ncursesSupport = false;
+    libiscsiSupport = false;
+    smbdSupport = false;
+    tpmSupport = false;
+    uringSupport = false;
+    capstoneSupport = false;
+    enableDocs = false;
+    enableTools = false;
+    enableBlobs = false;
+    hostCpuTargets = qemuTargets;
+  }).overrideAttrs (old: {
+    # HACK: Otherwise the result will have the entire buildinput closure
+    # injected by the pkgsStatic stdenv
+    # <https://github.com/NixOS/nixpkgs/issues/83667>
+    postFixup = (old.postFixup or "") + ''
+      rm -f $out/nix-support/propagated-build-inputs
+    '';
+  });
+in static // {
+  passthru = (static.passthru or {}) // {
+    inherit qemuUserPlatforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33652,6 +33652,8 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
+  qemu-user-static = callPackage ../applications/virtualization/qemu/user-static.nix { };
+
   qemu-utils = callPackage ../applications/virtualization/qemu/utils.nix { };
 
   canokey-qemu = callPackage ../applications/virtualization/qemu/canokey-qemu.nix { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This PR adds support for using a statically-linked build of QEMU without any intermediate wrapper to the binfmt-misc integration in NixOS. It also enables the "F" (fix binary) flag, allowing chroot into a foreign root filesystem without first having to make the interpreter available inside the rootfs. This fixes #160300 so foreign chroots "just work."

To use the statically-linked QEMU, set `boot.binfmt.preferStaticEmulators = true;`.

Currently, `qemu-user-static` is built with musl and has a couple of hard-to-debug problems. When building `coreutils` for aarch64-linux on x86_64-linux with it (see #143060 for background), <s>all tests pass except for `test-free` where it segfaults</s> the tests become stuck. Other distros ship `qemu-user-static` with static glibc. To prevent introducing new breakages, this PR keeps the dynamically-linked QEMU as the default.

## How To Test

1. Run `nix-build -A nixosTests.systemd-binfmt`
	- The `chroot` test is added which makes use of the new `qemu-user-static`
2. Activate a config with this PR applied
3. Confirm that `nix-build --system aarch64-linux -A hello --check` works
4. Activate a config with `boot.binfmt.preferStaticEmulators = true;`
5. Open `/etc/nix/nix.conf` and observe that `extra-sandbox-paths` is now empty
	- Yay purity!
6. Confirm that `nix-build --system aarch64-linux -A hello --check` still works
	- Sadly `nix-build --system aarch64-linux -A coreutils --check` doesn't work now
7. Try chrooting into [ArchLinuxARM-aarch64-latest.tar.gz](http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
