### PR TITLE
packagekit: 1.2.5pre -> 1.2.5.1pre

### DIFF
--- a/pkgs/tools/package-management/packagekit/default.nix
+++ b/pkgs/tools/package-management/packagekit/default.nix
@@ -11,6 +11,7 @@
 , vala
 , gtk-doc
 , nix
+, nlohmann_json ? null
 , boost
 , meson
 , ninja
@@ -26,18 +27,24 @@
 , enableSystemd ? stdenv.isLinux
 , systemd
 }:
+let
+  nix_version = lib.removeSuffix nix.VERSION_SUFFIX nix.version;
+  useNlohmann = lib.versionAtLeast "2.7" nix_version;
+in
+
+assert useNlohmann -> nlohmann_json != null;
 
 stdenv.mkDerivation rec {
   pname = "packagekit";
-  version = "1.2.5pre";
+  version = "1.2.5.1pre";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchFromGitHub {
     owner = "PackageKit";
     repo = "PackageKit";
-    rev = "9c2ef9cddf39ebde587907561f8e7ac99ed6be1a";
-    sha256 = "05z1ds240kcmigygkbgjasr4spn7vd7cbpsbfrghhgnmszx9bjgl";
+    rev = "33b847c49b4a42499e3c0f10fef62830c874e086";
+    sha256 = "UDpMswf0EBwcoHTqoWiztXnIAwM69nM+S9MPsR24amw=";
   };
 
   buildInputs = [
@@ -52,6 +59,7 @@ stdenv.mkDerivation rec {
     nix
     boost
   ] ++ lib.optional enableSystemd systemd
+  ++ lib.optional useNlohmann nlohmann_json
   ++ lib.optional enableBashCompletion bash-completion;
   nativeBuildInputs = [
     vala


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Should resolve : https://github.com/NixOS/nix/issues/6096 ( PackageKit build fails using Nix 2.7-pre ).

Current builds of `packagekit` fail on Nix 2.7-pre, since `forceValue` function no longer provides default argument, and dependency on `nlohmann_json` is now required with certain `nix` headers.

NOTE: `nlohmann_json` dependency is handled conditionally, since it is only required by Nix 2.7-pre; but really this should be handled as a `propagatedBuildInputs` by Nix itself - the issue being that non-flake ( `nix-build` style ) builds won't necessarily have this defined for their internal `nix` derivation. For example if you were to use `nix` v2.6.0 + `nixpkgs-unstable` with an overlay of `nix = prev.nixUnstable;` - build fail over missing `nlohmann_json` headers ( yes I know the patches should handle this gracefully, but they don't; a separate issue ). I did not add any conditional logic to `top-level.nix` for passing of `nlohmann_json` - but because it is excluded from `buildInputs` it does not appear in `nix-store --query --tree ...;` which I'm calling "good enough"; feel free to add/move conditionals if you really care about the closure.

Also note that the `1.2.5.1pre` version I used here is "made up" - Since this was already a pre-release by PackageKit, my goal was just to make a version string which is distinct from the existing one. If this seems problematic or ill advised, feel free to modify it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
