### PR TITLE
grcov: init at 0.8.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2975,6 +2975,12 @@
     githubId = 8404455;
     name = "Diego Lelis";
   };
+  DieracDelta = {
+    email = "justin@restivo.me";
+    github = "DieracDelta";
+    githubId = 13730968;
+    name = "Justin Restivo";
+  };
   diffumist = {
     email = "git@diffumist.me";
     github = "diffumist";

--- a/pkgs/development/tools/misc/grcov/default.nix
+++ b/pkgs/development/tools/misc/grcov/default.nix
@@ -1,0 +1,38 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "grcov";
+  version = "0.8.7";
+
+  src = fetchFromGitHub {
+    owner = "mozilla";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-4McF9tLIjDCftyGI29pm/LnTUBVWG+pY5z+mGFKySQM=";
+  };
+
+  cargoSha256 = "sha256-/filuQ4AWsKVIsXbDX7S1yhCArLNTZpOMEn3ID6WuMo=";
+
+  # tests do not find grcov path correctly
+  checkFlags = let
+    skipList = [
+      "test_coveralls_service_job_id_is_not_sufficient"
+      "test_coveralls_service_name_is_not_sufficient"
+      "test_coveralls_works_with_just_service_name_and_job_id_args"
+      "test_coveralls_works_with_just_token_arg"
+      "test_integration"
+      "test_integration_guess_single_file"
+      "test_integration_zip_dir"
+      "test_integration_zip_zip"
+    ];
+    skipFlag = test: "--skip " + test;
+  in builtins.concatStringsSep " " (builtins.map skipFlag skipList);
+
+  meta = with lib; {
+    description =
+      "Rust tool to collect and aggregate code coverage data for multiple source files";
+    homepage = "https://github.com/mozilla/grcov";
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ DieracDelta ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14955,6 +14955,8 @@ with pkgs;
   gradle_7 = callPackage gradle-packages.gradle_7 { };
   gradle = gradle_7;
 
+  grcov = callPackage ../development/tools/misc/grcov { };
+
   gperf = callPackage ../development/tools/misc/gperf { };
   # 3.1 changed some parameters from int to size_t, leading to mismatches.
   gperf_3_0 = callPackage ../development/tools/misc/gperf/3.0.x.nix { };


### PR DESCRIPTION
###### Motivation for this change

Add [grcov](https://github.com/mozilla/grcov) to nixpkgs.

###### Things done

I tested this by generating grcov coverage reports. Seems to work fine. There are a couple failing integration tests which I've disabled. These tests are looking for `grcov` in the `target/(debug|release)/grcov` and not finding them. The application itself seems to work.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
