### PR TITLE
dpcmd: Init package

### DIFF
--- a/pkgs/tools/misc/dpcmd/default.nix
+++ b/pkgs/tools/misc/dpcmd/default.nix
@@ -1,0 +1,38 @@
+{ fetchFromGitHub
+, lib
+, libusb1
+, pkg-config
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dpcmd";
+  version = "1.2";
+
+  src = fetchFromGitHub {
+    rev = "f5646a6fa966f2c2d0e3d7b2d234454fb9d4229a";
+    owner = "DediProgSW";
+    repo = "SF100Linux";
+    sha256 = "0ljqqlzxsp74aci3h0ll59pifjkqskl4vp2898k79b6knb13xhil";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libusb1 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./dpcmd $out/bin/dpcmd
+    install -Dm644 ChipInfoDb.dedicfg $out/share/DediProg/ChipInfoDb.dedicfg
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/DediProgSW/SF100Linux";
+    description = "Linux software for SF100/SF600";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ felixsinger ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5403,6 +5403,8 @@ with pkgs;
 
   flamerobin = callPackage ../applications/misc/flamerobin { };
 
+  dpcmd = callPackage ../tools/misc/dpcmd { };
+
   flashrom = callPackage ../tools/misc/flashrom { };
 
   flent = python3Packages.callPackage ../applications/networking/flent { };


### PR DESCRIPTION
###### Motivation for this change

Init package. WIP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
