### PR TITLE
argo-rollouts: init at 1.1.1

### DIFF
--- a/pkgs/applications/networking/cluster/argo-rollouts/default.nix
+++ b/pkgs/applications/networking/cluster/argo-rollouts/default.nix
@@ -1,0 +1,27 @@
+{ buildGoModule, lib, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "argo-rollouts";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "argoproj";
+    repo = "argo-rollouts";
+    rev = "v${version}";
+    sha256 = "0qb1wbv3razwhqsv972ywfazaq73y83iw6f6qdjcbwwfwsybig21";
+  };
+
+  vendorSha256 = "00ic1nn3wgg495x2170ik1d1cha20b4w89j9jclq8p0b3nndv0c0";
+
+  # Disable tests since some test fail because of missing test data
+  doCheck = false;
+
+  subPackages = [ "cmd/rollouts-controller" "cmd/kubectl-argo-rollouts" ];
+
+  meta = with lib; {
+    description = "Kubernetes Progressive Delivery Controller";
+    homepage = "https://github.com/argoproj/argo-rollouts/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ psibi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24445,6 +24445,8 @@ with pkgs;
 
   argocd = callPackage ../applications/networking/cluster/argocd { };
 
+  argo-rollouts = callPackage ../applications/networking/cluster/argo-rollouts { };
+
   ario = callPackage ../applications/audio/ario { };
 
   arion = callPackage ../applications/virtualization/arion { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Includes Argo rollouts. This package is required for using the kubectl plugin for the rollouts (You can also use the controller, but I just use the kubectl plugin as of now). Eg:

```
❯ kubectl argo rollouts -n canary get rollout rollouts-demo
Name:            rollouts-demo
Namespace:       canary
Status:          ✔ Healthy
Strategy:        Canary
  Step:          4/4
  SetWeight:     100
  ActualWeight:  100
Images:          docker.io/argoproj/rollouts-demo:green (stable)
Replicas:
  Desired:       1
  Current:       1
  Updated:       1
  Ready:         1
  Available:     1

NAME                                       KIND         STATUS        AGE    INFO
⟳ rollouts-demo                            Rollout      ✔ Healthy     3d22h
├──# revision:2
│  ├──⧉ rollouts-demo-7457cfdf4f           ReplicaSet   ✔ Healthy     3d22h  stable
│  │  └──□ rollouts-demo-7457cfdf4f-cfzdj  Pod          ✔ Running     3d22h  ready:1/1
│  └──α rollouts-demo-7457cfdf4f-2         AnalysisRun  ✔ Successful  3d22h  ⚠ 1
└──# revision:1
   └──⧉ rollouts-demo-845cc87948           ReplicaSet   • ScaledDown  3d22h
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
