### PR TITLE
flatpak: 1.12.4 → 1.12.6

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -53,14 +53,14 @@
 
 stdenv.mkDerivation rec {
   pname = "flatpak";
-  version = "1.12.4";
+  version = "1.12.6";
 
   # TODO: split out lib once we figure out what to do with triggerdir
   outputs = [ "out" "dev" "man" "doc" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/flatpak/flatpak/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "792e6265f7f6d71b2a087028472a048287bed2587e43d2eec2c31d360c16211c"; # Taken from https://github.com/flatpak/flatpak/releases/
+    sha256 = "7wLLUFuRzOUXMJm1SFdo7vGJnrzznt+CfEJUFjqBFic="; # Taken from https://github.com/flatpak/flatpak/releases/
   };
 
   patches = [

--- a/pkgs/development/libraries/flatpak/unset-env-vars.patch
+++ b/pkgs/development/libraries/flatpak/unset-env-vars.patch
@@ -1,11 +1,11 @@
 diff --git a/common/flatpak-run.c b/common/flatpak-run.c
-index 8d52d3a5..81700183 100644
+index 146c4f87..bcdad2bc 100644
 --- a/common/flatpak-run.c
 +++ b/common/flatpak-run.c
-@@ -1232,6 +1232,7 @@ static const ExportData default_exports[] = {
-   {"PERLLIB", NULL},
-   {"PERL5LIB", NULL},
-   {"XCURSOR_PATH", NULL},
+@@ -1710,6 +1710,7 @@ static const ExportData default_exports[] = {
+   {"GST_PTP_HELPER", NULL},
+   {"GST_PTP_HELPER_1_0", NULL},
+   {"GST_INSTALL_PLUGINS_HELPER", NULL},
 +  {"GDK_PIXBUF_MODULE_FILE", NULL},
  };
  

--- a/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal-gtk/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , autoreconfHook
 , pkg-config
 , libxml2
@@ -16,27 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal-gtk";
-  version = "1.10.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "flatpak";
     repo = pname;
     rev = version;
-    sha256 = "7w+evZLtmTmDHVVsw25bJz99xtlSCE8qTFSxez9tlZk=";
+    sha256 = "I1ZoDqZQPfPwPr4Ybk+syz+YEkrK2ReflZaJJWD4Nsk=";
   };
-
-  patches = [
-    # Fix broken translation.
-    # https://github.com/flatpak/xdg-desktop-portal-gtk/issues/353
-    (fetchpatch {
-      url = "https://github.com/flatpak/xdg-desktop-portal-gtk/commit/e34f49ca8365801a7fcacccb46ab1e62aec17435.patch";
-      sha256 = "umMsSP0fuSQgxlHLaZlg25ln1aAL1mssWzPMIWAOUt4=";
-    })
-    (fetchpatch {
-      url = "https://github.com/flatpak/xdg-desktop-portal-gtk/commit/19c5385b9f5fe0f8dac8ae7cc4493bb08f802de6.patch";
-      sha256 = "nbmOb5er20zBOO4K2geYITafqBaNHbDpq1OOvIVD6hY=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -54,13 +40,18 @@ stdenv.mkDerivation rec {
     gnome.gnome-settings-daemon # schemas needed for settings api (mostly useless now that fonts were moved to g-d-s)
   ];
 
-  configureFlags = lib.optionals buildPortalsInGnome [
+  configureFlags = if buildPortalsInGnome then [
     "--enable-wallpaper"
     "--enable-screenshot"
     "--enable-screencast"
     "--enable-background"
     "--enable-settings"
     "--enable-appchooser"
+  ] else [
+    # These are now enabled by default, even though we do not need them for GNOME.
+    # https://github.com/flatpak/xdg-desktop-portal-gtk/issues/355
+    "--disable-settings"
+    "--disable-appchooser"
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , nixosTests
 , substituteAll
 , autoreconfHook
@@ -22,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal";
-  version = "1.10.1";
+  version = "1.12.1";
 
   outputs = [ "out" "installedTests" ];
 
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = pname;
     rev = version;
-    sha256 = "Q1ZP/ljdIxJHg+3JaTL/LIZV+3cK2+dognsTC95udVA=";
+    sha256 = "1fc3LXN6wp/zQw4HQ0Q99HUvBhynHrQi2p3s/08izuE=";
   };
 
   patches = [
@@ -38,12 +37,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit flatpak;
-    })
-    # Fixes the issue in https://github.com/flatpak/xdg-desktop-portal/issues/636
-    # Remove it when the next stable release arrives
-    (fetchpatch {
-      url = "https://github.com/flatpak/xdg-desktop-portal/commit/d7622e15ff8fef114a6759dde564826d04215a9f.patch";
-      sha256 = "sha256-vmfxK4ddG6Xon//rpiz6OiBsDLtT0VG5XyBJG3E4PPs=";
     })
   ];
 
@@ -84,7 +77,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Desktop integration portals for sandboxed apps";
-    license = licenses.lgpl21;
+    license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/misc/ostree/01-Drop-ostree-trivial-httpd-CLI-move-to-tests-director.patch
+++ b/pkgs/tools/misc/ostree/01-Drop-ostree-trivial-httpd-CLI-move-to-tests-director.patch
@@ -1,4 +1,4 @@
-From 977fdfad2ceba7232b4f78144b20640d7fd0aedb Mon Sep 17 00:00:00 2001
+From 196c2e1036ed990bca57c199f271c0359509e9f9 Mon Sep 17 00:00:00 2001
 From: Colin Walters <walters@verbum.org>
 Date: Tue, 19 Jun 2018 09:34:18 -0400
 Subject: [PATCH] Drop "ostree trivial-httpd" CLI, move to tests directory
@@ -14,19 +14,19 @@ Also at this point nothing should depend on `ostree trivial-httpd`.
  Makefile-ostree.am           |   7 ---
  Makefile-tests.am            |   7 +++
  configure.ac                 |   9 ---
- man/ostree-trivial-httpd.xml | 118 -----------------------------------
+ man/ostree-trivial-httpd.xml | 116 -----------------------------------
  src/ostree/main.c            |   5 --
  tests/libtest.sh             |  13 ++--
- 7 files changed, 12 insertions(+), 153 deletions(-)
+ 7 files changed, 12 insertions(+), 151 deletions(-)
  delete mode 100644 man/ostree-trivial-httpd.xml
 
 diff --git a/Makefile-man.am b/Makefile-man.am
-index bc58103b..bcfde285 100644
+index 78025fff..4aa668f6 100644
 --- a/Makefile-man.am
 +++ b/Makefile-man.am
-@@ -34,12 +34,6 @@ ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 \
+@@ -32,12 +32,6 @@ ostree-init.1 ostree-log.1 ostree-ls.1 ostree-prune.1 ostree-pull-local.1 \
  ostree-pull.1 ostree-refs.1 ostree-remote.1 ostree-reset.1 \
- ostree-rev-parse.1 ostree-show.1 ostree-summary.1 \
+ ostree-rev-parse.1 ostree-show.1 ostree-sign.1 ostree-summary.1 \
  ostree-static-delta.1
 -if USE_LIBSOUP
 -man1_files += ostree-trivial-httpd.1
@@ -38,10 +38,10 @@ index bc58103b..bcfde285 100644
  if BUILDOPT_FUSE
  man1_files += rofiles-fuse.1
 diff --git a/Makefile-ostree.am b/Makefile-ostree.am
-index f861afe4..497d99b0 100644
+index 82af1681..dabc7004 100644
 --- a/Makefile-ostree.am
 +++ b/Makefile-ostree.am
-@@ -144,13 +144,6 @@ ostree_SOURCES += src/ostree/ot-builtin-pull.c
+@@ -138,13 +138,6 @@ ostree_SOURCES += src/ostree/ot-builtin-pull.c
  endif
  
  if USE_LIBSOUP
@@ -56,10 +56,10 @@ index f861afe4..497d99b0 100644
  # This is necessary for the cookie jar bits
  ostree_CFLAGS += $(OT_INTERNAL_SOUP_CFLAGS)
 diff --git a/Makefile-tests.am b/Makefile-tests.am
-index fc2f2d91..7343b63f 100644
+index 6bae65cf..47b3ab20 100644
 --- a/Makefile-tests.am
 +++ b/Makefile-tests.am
-@@ -263,6 +263,13 @@ _installed_or_uninstalled_test_programs += \
+@@ -275,6 +275,13 @@ _installed_or_uninstalled_test_programs += \
  	$(NULL)
  endif
  
@@ -74,10 +74,10 @@ index fc2f2d91..7343b63f 100644
  test_programs += tests/test-repo-finder-avahi
  endif
 diff --git a/configure.ac b/configure.ac
-index 46a900f5..2f91cdec 100644
+index 93b98cb9..a588eea6 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -190,14 +190,6 @@ if test x$with_soup != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libsoup"; fi
+@@ -186,14 +186,6 @@ if test x$with_soup != xno; then OSTREE_FEATURES="$OSTREE_FEATURES libsoup"; fi
  AM_CONDITIONAL(USE_LIBSOUP, test x$with_soup != xno)
  AM_CONDITIONAL(HAVE_LIBSOUP_CLIENT_CERTS, test x$have_libsoup_client_certs = xyes)
  
@@ -92,20 +92,20 @@ index 46a900f5..2f91cdec 100644
  AS_IF([test x$with_curl = xyes && test x$with_soup = xno], [
    AC_MSG_WARN([Curl enabled, but libsoup is not; libsoup is needed for tests (make check, etc.)])
  ])
-@@ -617,7 +609,6 @@ echo "
-     Rust (internal oxidation):                    $rust_debug_release
+@@ -606,7 +598,6 @@ echo "
+     introspection:                                $found_introspection
      rofiles-fuse:                                 $enable_rofiles_fuse
      HTTP backend:                                 $fetcher_backend
 -    \"ostree trivial-httpd\":                       $enable_trivial_httpd_cmdline
      SELinux:                                      $with_selinux
+     fs-verity:                                    $ac_cv_header_linux_fsverity_h
      cryptographic checksums:                      $with_crypto
-     systemd:                                      $have_libsystemd
 diff --git a/man/ostree-trivial-httpd.xml b/man/ostree-trivial-httpd.xml
 deleted file mode 100644
-index d03c12be..00000000
+index 7ba1dae8..00000000
 --- a/man/ostree-trivial-httpd.xml
 +++ /dev/null
-@@ -1,118 +0,0 @@
+@@ -1,116 +0,0 @@
 -<?xml version='1.0'?> <!--*-nxml-*-->
 -<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
 -    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
@@ -126,9 +126,7 @@ index d03c12be..00000000
 -Lesser General Public License for more details.
 -
 -You should have received a copy of the GNU Lesser General Public
--License along with this library; if not, write to the
--Free Software Foundation, Inc., 59 Temple Place - Suite 330,
--Boston, MA 02111-1307, USA.
+-License along with this library. If not, see <https://www.gnu.org/licenses/>.
 --->
 -
 -<refentry id="ostree">
@@ -225,7 +223,7 @@ index d03c12be..00000000
 -    </refsect1>
 -</refentry>
 diff --git a/src/ostree/main.c b/src/ostree/main.c
-index a523ff9a..61ea742d 100644
+index 7d17080c..19d9b8b0 100644
 --- a/src/ostree/main.c
 +++ b/src/ostree/main.c
 @@ -118,11 +118,6 @@ static OstreeCommand commands[] = {
@@ -241,10 +239,10 @@ index a523ff9a..61ea742d 100644
  };
  
 diff --git a/tests/libtest.sh b/tests/libtest.sh
-index 3f5fd931..eacd96de 100755
+index 686f08dc..79f8bd1f 100755
 --- a/tests/libtest.sh
 +++ b/tests/libtest.sh
-@@ -160,15 +160,12 @@ fi
+@@ -174,15 +174,12 @@ fi
  if test -n "${OSTREE_UNINSTALLED:-}"; then
      OSTREE_HTTPD=${OSTREE_UNINSTALLED}/ostree-trivial-httpd
  else
@@ -266,5 +264,5 @@ index 3f5fd931..eacd96de 100755
  
  files_are_hardlinked() {
 -- 
-2.25.0
+2.35.1
 

--- a/pkgs/tools/misc/ostree/default.nix
+++ b/pkgs/tools/misc/ostree/default.nix
@@ -20,7 +20,7 @@
 , autoconf
 , automake
 , libtool
-, fuse
+, fuse3
 , util-linuxMinimal
 , libselinux
 , libsodium
@@ -41,13 +41,13 @@ let
   ]));
 in stdenv.mkDerivation rec {
   pname = "ostree";
-  version = "2021.6";
+  version = "2022.1";
 
   outputs = [ "out" "dev" "man" "installedTests" ];
 
   src = fetchurl {
     url = "https://github.com/ostreedev/ostree/releases/download/v${version}/libostree-${version}.tar.xz";
-    sha256 = "sha256-6AYxyxNj1HNP6dDJH2mmi+OEgWbW4EgdsZzkSpy09TE=";
+    sha256 = "sha256-Q6AOeFaEK4o09mFvws4c4jjvQyEMykH3DmtLDSqfytU=";
   };
 
   patches = [
@@ -90,7 +90,7 @@ in stdenv.mkDerivation rec {
     libsoup
     glib-networking
     gpgme
-    fuse
+    fuse3
     libselinux
     libsodium
     libcap

--- a/pkgs/tools/misc/ostree/fix-1592.patch
+++ b/pkgs/tools/misc/ostree/fix-1592.patch
@@ -1,8 +1,19 @@
+--- a/tests/basic-test.sh
++++ b/tests/basic-test.sh
+@@ -226,7 +226,7 @@ cd ${test_tmpdir}
+ if $OSTREE commit ${COMMIT_ARGS} -b test-bootable --bootable $test_tmpdir/checkout-test2-4 2>err.txt; then
+     fatal "committed non-bootable tree"
+ fi
+-assert_file_has_content err.txt "error: .*No such file or directory"
++assert_file_has_content err.txt "error:.*No such file or directory"
+ echo "ok commit fails bootable if no kernel"
+ 
+ cd ${test_tmpdir}
 diff --git a/tests/pull-test.sh b/tests/pull-test.sh
-index a8bc49a9..4a08ebb5 100644
+index f4084290..4af5ec6f 100644
 --- a/tests/pull-test.sh
 +++ b/tests/pull-test.sh
-@@ -275,7 +275,7 @@
+@@ -297,7 +297,7 @@ ostree_repo_init mirrorrepo-local --mode=archive
  if ${CMD_PREFIX} ostree --repo=mirrorrepo-local pull-local otherrepo 2>err.txt; then
      fatal "pull with mixed refs succeeded?"
  fi
@@ -11,7 +22,7 @@ index a8bc49a9..4a08ebb5 100644
  ${CMD_PREFIX} ostree --repo=mirrorrepo-local pull-local otherrepo localbranch
  ${CMD_PREFIX} ostree --repo=mirrorrepo-local rev-parse localbranch
  ${CMD_PREFIX} ostree --repo=mirrorrepo-local fsck
-@@ -286,7 +286,7 @@
+@@ -308,7 +308,7 @@ if ${CMD_PREFIX} ostree --repo=mirrorrepo-local pull-local otherrepo nosuchbranc
      fatal "pulled nonexistent branch"
  fi
  # So true
@@ -20,7 +31,7 @@ index a8bc49a9..4a08ebb5 100644
  echo "ok pull-local nonexistent branch"
  
  cd ${test_tmpdir}
-@@ -593,5 +593,5 @@
+@@ -687,5 +687,5 @@ rm ostree-srv/gnomerepo/summary
  if ${CMD_PREFIX} ostree --repo=repo pull origin main 2>err.txt; then
      fatal "pull of invalid ref succeeded"
  fi
@@ -28,10 +39,10 @@ index a8bc49a9..4a08ebb5 100644
 +assert_file_has_content_literal err.txt 'Fetching checksum for ref ((empty), main): Invalid rev lots of html here  lots of html here  lots of html here  lots of'
  echo "ok pull got HTML for a ref"
 diff --git a/tests/test-config.sh b/tests/test-config.sh
-index 7e913d32..69d1675d 100755
+index 2d9aaf53..f1e28614 100755
 --- a/tests/test-config.sh
 +++ b/tests/test-config.sh
-@@ -46,7 +46,7 @@
+@@ -44,7 +44,7 @@ assert_file_has_content list.txt "http://example\.com/ostree/repo/"
  if ${CMD_PREFIX} ostree config --repo=repo get --group=core lock-timeout-secs extra 2>err.txt; then
      assert_not_reached "ostree config get should error out if too many arguments are given"
  fi
@@ -40,7 +51,7 @@ index 7e913d32..69d1675d 100755
  echo "ok config get"
  
  ${CMD_PREFIX} ostree config --repo=repo set core.mode bare-user-only
-@@ -63,7 +63,7 @@
+@@ -61,7 +61,7 @@ assert_file_has_content repo/config "http://example\.com/ostree/"
  if ${CMD_PREFIX} ostree config --repo=repo set --group=core lock-timeout-secs 120 extra 2>err.txt; then
      assert_not_reached "ostree config set should error out if too many arguments are given"
  fi
@@ -48,8 +59,8 @@ index 7e913d32..69d1675d 100755
 +assert_file_has_content err.txt "Too many arguments given"
  echo "ok config set"
  
- # Check that "ostree config unset" works
-@@ -78,7 +78,7 @@
+ # Check that using `--` works and that "ostree config unset" works
+@@ -78,7 +78,7 @@ if ${CMD_PREFIX} ostree config --repo=repo get core.lock-timeout-secs 2>err.txt;
  fi
  # Check for any character where quotation marks would be as they appear differently in the Fedora and Debian
  # test suites (“” and '' respectively). See: https://github.com/ostreedev/ostree/pull/1839
@@ -58,7 +69,7 @@ index 7e913d32..69d1675d 100755
  
  # Check that it's idempotent
  ${CMD_PREFIX} ostree config --repo=repo unset core.lock-timeout-secs
-@@ -95,5 +95,5 @@
+@@ -95,5 +95,5 @@ ${CMD_PREFIX} ostree config --repo=repo unset --group='remote "aoeuhtns"' 'xa.ti
  if ${CMD_PREFIX} ostree config --repo=repo unset core.lock-timeout-secs extra 2>err.txt; then
      assert_not_reached "ostree config unset should error out if too many arguments are given"
  fi
@@ -66,10 +77,10 @@ index 7e913d32..69d1675d 100755
 +assert_file_has_content err.txt "Too many arguments given"
  echo "ok config unset"
 diff --git a/tests/test-fsck-collections.sh b/tests/test-fsck-collections.sh
-index dc6bcfeb..4a5eef55 100755
+index 3dbcdd23..d6359979 100755
 --- a/tests/test-fsck-collections.sh
 +++ b/tests/test-fsck-collections.sh
-@@ -100,7 +100,7 @@
+@@ -98,7 +98,7 @@ ${CMD_PREFIX} ostree fsck --repo=repo
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-bindings > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -78,7 +89,7 @@ index dc6bcfeb..4a5eef55 100755
  assert_file_has_content fsck "^Validating refs\.\.\.$"
  
  echo "ok 3 fsck detects missing ref bindings"
-@@ -113,7 +113,7 @@
+@@ -111,7 +111,7 @@ ${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collect
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-bindings > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -87,7 +98,7 @@ index dc6bcfeb..4a5eef55 100755
  assert_file_has_content fsck "^Validating refs\.\.\.$"
  assert_file_has_content fsck "^Validating refs in collections\.\.\.$"
  
-@@ -127,7 +127,7 @@
+@@ -125,7 +125,7 @@ ${CMD_PREFIX} ostree --repo=repo refs --collections --create=org.example.Collect
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-bindings > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -96,7 +107,7 @@ index dc6bcfeb..4a5eef55 100755
  assert_file_has_content fsck "^Validating refs\.\.\.$"
  assert_file_has_content fsck "^Validating refs in collections\.\.\.$"
  
-@@ -147,7 +147,7 @@
+@@ -145,7 +145,7 @@ echo "ok 6 fsck ignores unreferenced ref bindings"
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-back-refs > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -105,7 +116,7 @@ index dc6bcfeb..4a5eef55 100755
  assert_file_has_content fsck "^Validating refs\.\.\.$"
  assert_file_has_content fsck "^Validating refs in collections\.\.\.$"
  
-@@ -186,7 +186,7 @@
+@@ -184,7 +184,7 @@ ${CMD_PREFIX} ostree --repo=repo refs --create=new-ref $(cat ref3-checksum)
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-bindings > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -114,7 +125,7 @@ index dc6bcfeb..4a5eef55 100755
  assert_file_has_content fsck "^Validating refs\.\.\.$"
  
  echo "ok 9 fsck detects missing ref bindings"
-@@ -205,7 +205,7 @@
+@@ -203,7 +203,7 @@ echo "ok 10 fsck ignores unreferenced ref bindings"
  if ${CMD_PREFIX} ostree fsck --repo=repo --verify-back-refs > fsck 2> fsck-error; then
      assert_not_reached "fsck unexpectedly succeeded after adding unbound ref!"
  fi
@@ -124,10 +135,10 @@ index dc6bcfeb..4a5eef55 100755
  
  echo "ok 11 fsck ignores unreferenced ref bindings"
 diff --git a/tests/test-remote-add.sh b/tests/test-remote-add.sh
-index bb7eae89..62a3bcd7 100755
+index 2f5ea634..0f63853c 100755
 --- a/tests/test-remote-add.sh
 +++ b/tests/test-remote-add.sh
-@@ -83,7 +83,7 @@
+@@ -81,7 +81,7 @@ echo "ok remote delete"
  if $OSTREE remote delete nosuchremote 2>err.txt; then
      assert_not_reached "Deleting remote unexpectedly succeeded"
  fi


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Picked from https://github.com/NixOS/nixpkgs/pull/160343

Untested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
