### PR TITLE
jrnl: 2.8.3 -> 2.8.4

### DIFF
--- a/pkgs/applications/misc/jrnl/default.nix
+++ b/pkgs/applications/misc/jrnl/default.nix
@@ -1,25 +1,19 @@
 { lib
 , fetchFromGitHub
-, fetchpatch
 , python3
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "jrnl";
-  version = "2.8.3";
+  version = "2.8.4";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "jrnl-org";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-+kPr7ndY6u1HMw6m0UZJ5jxVIPNjlTfQt7OYEdZkHBE=";
+    sha256 = "sha256-Edu+GW/D+R5r0R750Z1f8YUVPMYbm9PK4D73sTDzDEc=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'tzlocal = ">2.0, <3.0"' 'tzlocal = ">2.0, !=3.0"'
-  '';
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
@@ -45,14 +39,10 @@ python3.pkgs.buildPythonApplication rec {
     toml
   ];
 
-  patches = [
-    # Switch to poetry-core, https://github.com/jrnl-org/jrnl/pull/1359
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/jrnl-org/jrnl/commit/a55a240eff7a167af5974a03e9de6f7b818eafd9.patch";
-      sha256 = "1w3gb4vasvh51nggf89fsqsm4862m0g7hr36qz22n4vg9dds175m";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'tzlocal = ">2.0, <3.0"' 'tzlocal = ">2.0, !=3.0"'
+  '';
 
   preCheck = ''
     export HOME=$(mktemp -d);


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/jrnl-org/jrnl/blob/v2.8.4/CHANGELOG.md

Fix build (https://hydra.nixos.org/build/167042471)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
