### PR TITLE
python3.pkgs.osmpythontools: 0.3.3 -> 0.3.4

### DIFF
--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "osmpythontools";
-  version = "0.3.3";
+  version = "0.3.4";
 
   src = fetchFromGitHub {
     owner = "mocnik-science";
     repo = "osm-python-tools";
     rev = "v${version}";
-    sha256 = "sha256-335zo/kOX4OpUwHas2aaPibY6zNmDaaHJpolbTQWqKk=";
+    sha256 = "sha256-7r42b/B9h7cMgM+wFS0Fink/3WjUNvz+PwLn3C5hawc=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -54,6 +54,7 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/mocnik-science/osm-python-tools";
     license = licenses.gpl3Only;
+    changelog = "https://raw.githubusercontent.com/mocnik-science/osm-python-tools/v${version}/version-history.md";
     maintainers = with maintainers; [ das-g ];
   };
 }

--- a/pkgs/development/python-modules/osmpythontools/default.nix
+++ b/pkgs/development/python-modules/osmpythontools/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mocnik-science";
     repo = "osm-python-tools";
-    rev = "v.${version}";
+    rev = "v${version}";
     sha256 = "sha256-335zo/kOX4OpUwHas2aaPibY6zNmDaaHJpolbTQWqKk=";
   };
 


### PR DESCRIPTION
###### Motivation for this change

- Upstream replaced Git tag `v.0.3.3` (see #151028) with [`v0.3.3`](https://github.com/mocnik-science/osm-python-tools/releases/tag/v0.3.3).
- Upstream has a change log since 0.3.3
- Upstream release 0.3.4 ([PyPI](https://pypi.org/project/OSMPythonTools/0.3.4/), [Git tag `v0.3.4`](https://github.com/mocnik-science/osm-python-tools/releases/tag/v0.3.4))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
