### PR TITLE
survex: 1.2.44 -> 1.4.1

### DIFF
--- a/pkgs/applications/misc/survex/default.nix
+++ b/pkgs/applications/misc/survex/default.nix
@@ -1,67 +1,60 @@
 { lib
 , stdenv
-, fetchgit
-, autoreconfHook
-, pkg-config
-, wxGTK30-gtk3
-, wxmac
-, ffmpeg
-, proj_7
-, perl532
-, unscii
-, python2
-, libGL
-, libGLU
-, xlibsWrapper
-, docbook2x
-, docbook5
+, fetchurl
 , Carbon
 , Cocoa
+, ffmpeg
+, glib
+, libGLU
+, mesa
+, perl
+, pkg-config
+, proj
+, python3
+, wrapGAppsHook
+, wxGTK30-gtk3
+, wxmac
+, xlibsWrapper
 }:
 
-let
-  perlenv = perl532.withPackages (perlPackages: with perlPackages; [ LocalePO ] );
-in
 stdenv.mkDerivation rec {
   pname = "survex";
-  version = "1.2.44";
+  version = "1.4.1";
 
-  nativeBuildInputs = [ docbook5 docbook2x autoreconfHook pkg-config perlenv python2 ];
-
-  buildInputs = [
-    libGL libGLU ffmpeg proj_7
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    wxmac Carbon Cocoa
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    wxGTK30-gtk3 xlibsWrapper
+  nativeBuildInputs = [
+    perl
+    pkg-config
+    python3
+    wrapGAppsHook
   ];
 
-  src = fetchgit {
-    url = "git://git.survex.com/survex";
-    rev = version;
-    sha256 = "11gaqmabrf3av665jy3mr0m8hg76fmvnd0g3rghzmyh8d8v6xk34";
+  buildInputs = [
+    ffmpeg
+    glib
+    libGLU
+    mesa
+    proj
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Carbon
+    Cocoa
+    wxmac
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wxGTK30-gtk3
+    xlibsWrapper
+  ];
+
+  src = fetchurl {
+    url = "https://survex.com/software/${version}/${pname}-${version}.tar.gz";
+    hash = "sha256-69X1jGjBTQIQzkD1mTZTzE8L/GXnnf5SI52l7eIiLz4=";
   };
-
-  enableParallelBuilding = true;
-
-  # Docs rely on sgmltools-lite, a package that would be quite complex to
-  # provide as it is quite old. So this preConfigure hook effectively disables
-  # the doc generation. An example of packaging sgmltools-lite from Gentoo can
-  # be found here:
-  # https://gitweb.gentoo.org/repo/gentoo.git/tree/app-text/sgmltools-lite/sgmltools-lite-3.0.3-r15.ebuild?id=0b8b716331049599ea3299981e3a9ea6e258c5e0
 
   postPatch = ''
     patchShebangs .
-    echo "" > doc/Makefile.am
-    # substituteInPlace doc/Makefile --replace "docbook2man" "docbook2man --sgml" # Will be needed once sgmltools-lite is packaged.
-    for perltool in './extract-msgs.pl' './gettexttomsg.pl' '$(srcdir)/gdtconvert' '$(srcdir)/gen_img2aven'; do
-      substituteInPlace src/Makefile.am \
-        --replace "$perltool" "${perlenv}/bin/perl $perltool"
-    done
-    substituteInPlace lib/Makefile.am \
-      --replace '$(srcdir)/make-pixel-font' '${perlenv}/bin/perl $(srcdir)/make-pixel-font'
-    substituteInPlace lib/make-pixel-font --replace /usr/share/unifont/unifont.hex ${unscii.extra}/share/fonts/misc/unifont.hex
   '';
+
+  enableParallelBuilding = true;
+  doCheck = true;
+  enableParallelChecking = false;
 
   meta = with lib; {
     description = "Free Software/Open Source software package for mapping caves";
@@ -71,7 +64,7 @@ stdenv.mkDerivation rec {
       variety of platforms, including Linux/Unix, macOS, and Microsoft Windows.
     '';
     homepage = "https://survex.com/";
-    changelog = "https://github.com/ojwb/survex/blob/${version}/NEWS";
+    changelog = "https://github.com/ojwb/survex/raw/v${version}/NEWS";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.matthewcroughan ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/survex/default.nix
+++ b/pkgs/applications/misc/survex/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
-  doCheck = true;
+  doCheck = (!stdenv.isDarwin); # times out
   enableParallelChecking = false;
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
One less user of Python 2.x -> #148779

Use source tarball to get man pages out of the box
Depend on `proj` 8.x and `python3`
Need GApps wrapping or it crashes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
