### PR TITLE
nixos/mastodon: allow webDomain option

### DIFF
--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -24,6 +24,7 @@ let
     DB_PORT = toString(cfg.database.port);
     DB_NAME = cfg.database.name;
     LOCAL_DOMAIN = cfg.localDomain;
+    WEB_DOMAIN = cfg.webDomain;
     SMTP_SERVER = cfg.smtp.host;
     SMTP_PORT = toString(cfg.smtp.port);
     SMTP_FROM_ADDRESS = cfg.smtp.fromAddress;
@@ -212,6 +213,25 @@ in {
       localDomain = lib.mkOption {
         description = "The domain serving your Mastodon instance.";
         example = "social.example.org";
+        type = lib.types.str;
+      };
+
+      webDomain = lib.mkOption {
+        description = ''
+          You can use this option if you want the Mastodon username domain part to
+          be different from the domain you host Mastodon on.
+
+          For example, you can set <option>localDomain</option> to <code>example.org</code>
+          and <option>webDomain</option> to <code>social.example.org</code>.
+          Then you will be able to use Mastodon on the <code>social.example.org</code> domain,
+          but your username will look like <code>@me@example.org</code>.
+
+          This does require you to setup a <code>/.well-known/webfinger</code> location on
+          your <code>example.org</code> webserver, see: <link xlink:href="https://docs.joinmastodon.org/admin/config/#web-domain">https://docs.joinmastodon.org/admin/config/#web-domain</link>
+        '';
+        example = "social.example.org";
+        default = cfg.localDomain;
+        defaultText = lib.literalExpression "config.services.mastodon.localDomain";
         type = lib.types.str;
       };
 
@@ -576,7 +596,7 @@ in {
     services.nginx = lib.mkIf cfg.configureNginx {
       enable = true;
       recommendedProxySettings = true; # required for redirections to work
-      virtualHosts."${cfg.localDomain}" = {
+      virtualHosts."${cfg.webDomain}" = {
         root = "${cfg.package}/public/";
         forceSSL = true; # mastodon only supports https
         enableACME = true;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

This allows for easy configuration of a seperate web domain and username domain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
