### PR TITLE
[21.11] libspf2: Switch to a more supported upstream

### DIFF
--- a/pkgs/development/libraries/libspf2/default.nix
+++ b/pkgs/development/libraries/libspf2/default.nix
@@ -1,28 +1,17 @@
-{ lib, stdenv, fetchurl, autoreconfHook }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
 
 with lib;
 
 stdenv.mkDerivation rec {
   pname = "libspf2";
-  version = "1.2.10";
+  version = "2.2.12";
 
-  src = fetchurl {
-    url = "https://www.libspf2.org/spf/libspf2-${version}.tar.gz";
-    sha256 = "1j91p0qiipzf89qxq4m1wqhdf01hpn1h5xj4djbs51z23bl3s7nr";
+  src = fetchFromGitHub {
+    owner = "helsinki-systems";
+    repo = "libspf2";
+    rev = "v${version}";
+    sha256 = "03iiaafdcwh220pqignk407h6klrakwz0zkb8iwk6nkwipkwvhsx";
   };
-
-  patches = [
-    (fetchurl {
-      name = "0001-gcc-variadic-macros.patch";
-      url = "https://github.com/shevek/libspf2/commit/5852828582f556e73751076ad092f72acf7fc8b6.patch";
-      sha256 = "1v6ashqzpr0xidxq0vpkjd8wd66cj8df01kyzj678ljzcrax35hk";
-    })
-    (fetchurl {
-      name = "0002-CVE-2021-20314.patch";
-      url = "https://github.com/shevek/libspf2/commit/c37b7c13c30e225183899364b9f2efdfa85552ef.patch";
-      sha256 = "190nnh7mlz6328829ba6jajad16s3md8kraspn81qnvhwh0nkiak";
-    })
-  ];
 
   postPatch = ''
     # disable static bins compilation
@@ -39,10 +28,11 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    description = "Implementation of the Sender Policy Framework for SMTP authorization";
-    homepage = "https://www.libspf2.org";
+    description = "Implementation of the Sender Policy Framework for SMTP " +
+                  "authorization (Helsinki Systems fork)";
+    homepage = "https://github.com/helsinki-systems/libspf2";
     license = with licenses; [ lgpl21Plus bsd2 ];
-    maintainers = with maintainers; [ pacien ];
+    maintainers = with maintainers; [ pacien ajs124 das_j ];
     platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

__Depends on: https://github.com/NixOS/nixpkgs/pull/160939__

This includes fixes for:
- CVE-2021-33912
- CVE-2021-33913
- other buffer/use-after-free fixes

GitHub: security issue NixOS#160671
GitHub: master PR NixOS#149589

(cherry picked from commit 24c6b28)
(cherry picked from commit 49135f9)


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
