### PR TITLE
element-{web,desktop}: 1.10.1 -> 1.10.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.10.1",
+  "version": "1.10.4",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.10.1",
-  "desktopSrcHash": "cA+yXVkfizVRbbykFRhNIbdaGLuEk2IuKFO8YJt78Q4=",
-  "desktopYarnHash": "0kz6vkfxxk4sbr9zpaig1lhsbwj4f57v4f4pr373xxsnk1wagkfn",
-  "webHash": "1g5hw39fr7adazmafpxivfxv28nzcv99r8sihga1j91avf6lxkim"
+  "version": "1.10.4",
+  "desktopSrcHash": "cuMo0wRMC6+un3BQK0+Ecnjvs6HugNk71yElNJarlyc=",
+  "desktopYarnHash": "0llnqwgiqggfcgjyaar2h2r1pyw8m14icfb1pcdphqxrah9gpsar",
+  "webHash": "0vf8npddbx4dmq9c1ghak97jn28b18ssblbrq5smdhlzsnxlpm3l"
 }


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
ChangeLogs (desktop):
* https://github.com/vector-im/element-desktop/releases/tag/v1.10.2
* https://github.com/vector-im/element-desktop/releases/tag/v1.10.3
* https://github.com/vector-im/element-desktop/releases/tag/v1.10.4

ChangeLogs (web):
* https://github.com/vector-im/element-web/releases/tag/v1.10.2
* https://github.com/vector-im/element-web/releases/tag/v1.10.3
* https://github.com/vector-im/element-web/releases/tag/v1.10.4


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
