### PR TITLE
vimPlugins.todo-nvim: init at 2022-02-19

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -6808,6 +6808,18 @@ final: prev:
     meta.homepage = "https://github.com/folke/todo-comments.nvim/";
   };
 
+  todo-nvim = buildVimPluginFrom2Nix {
+    pname = "todo.nvim";
+    version = "2022-02-19";
+    src = fetchFromGitHub {
+      owner = "AmeerTaweel";
+      repo = "todo.nvim";
+      rev = "b252b4116812352161acfa73cdce6a15ffbde2eb";
+      sha256 = "+m3jy0ue0rAzRQ4hJDFPVVjNaOGNImkZjhIqI/AGTeY=";
+    };
+    meta.homepage = "https://github.com/AmeerTaweel/todo.nvim";
+  };
+
   todo-txt-vim = buildVimPluginFrom2Nix {
     pname = "todo.txt-vim";
     version = "2021-03-20";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -18,6 +18,7 @@ alvan/vim-closetag
 alvarosevilla95/luatab.nvim
 alx741/vim-hindent
 alx741/vim-stylishask
+AmeerTaweel/todo.nvim
 amiorin/ctrlp-z
 andersevenrud/cmp-tmux
 andersevenrud/nordic.nvim


### PR DESCRIPTION
###### Motivation for this change

Neovim plugin to highlight, list and search TODO comments. It also integrates with [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
