### PR TITLE
nixos/matrix-conduit: add turnserver settings

### DIFF
--- a/nixos/modules/services/misc/matrix-conduit.nix
+++ b/nixos/modules/services/misc/matrix-conduit.nix
@@ -95,6 +95,29 @@ in
                 instance will require manual migration of data.
               '';
             };
+            global.turn_uris = mkOption {
+              type = types.listOf types.str;
+              example = [ "turn:your.turn.url?transport=udp" "turn:your.turn.url?transport=tcp" ];
+              description = "`your.turn.url` has to match the REALM setting of your Coturn as well as `transport`.";
+            };
+            global.turn_secret = mkOption {
+              type = types.str;
+              description = "static-auth-secret of your turnserver.";
+            };
+            global.turn_username = mkOption {
+              type = types.str;
+              description = ''
+                If you have your TURN server configured to use a username and password, you can provide these instead of `turn_secret`.
+                Don't set `turn_secret` if you set this!
+              '';
+            };
+            global.turn_password = mkOption {
+              type = types.str;
+              description = ''
+                If you have your TURN server configured to use a username and password, you can provide these instead of `turn_secret`.
+                Don't set `turn_secret` if you set this!
+              '';
+            };
           };
         };
         default = {};


### PR DESCRIPTION
###### Motivation for this change

The turnserver settings of the conduit configuration are missing, see https://gitlab.com/famedly/conduit/-/blob/next/TURN.md.

This adds them.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
