### PR TITLE
Flutter fixup

### DIFF
--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -2,6 +2,8 @@
 , fetchFromGitLab
 , flutter
 , olm
+, imagemagick
+, makeDesktopItem
 }:
 
 flutter.mkFlutterApp rec {
@@ -17,8 +19,21 @@ flutter.mkFlutterApp rec {
     hash = "sha256-PJH3jMQc6u9R6Snn+9rNN8t+8kt6l3Xt7zKPbpqj13E=";
   };
 
+  desktopItem = makeDesktopItem {
+    name = "Fluffychat";
+    exec = "@out@/bin/fluffychat";
+    icon = "fluffychat";
+    desktopName = "Fluffychat";
+    genericName = "Chat with your friends (matrix client)";
+    categories = "Chat;Network;InstantMessaging;";
+  };
+
   buildInputs = [
     olm
+  ];
+
+  nativeBuildInputs = [
+    imagemagick
   ];
 
   flutterExtraFetchCommands = ''
@@ -30,6 +45,24 @@ flutter.mkFlutterApp rec {
     pushd $M
     bash scripts/prepare.sh
     popd
+  '';
+
+  postInstall = ''
+    FAV=$out/app/data/flutter_assets/assets/favicon.png
+    ICO=$out/share/icons
+
+    install -D $FAV $ICO/fluffychat.png
+    mkdir $out/share/applications
+    cp $desktopItem/share/applications/*.desktop $out/share/applications
+
+    for s in 24 32 42 64 128 256 512; do
+      D=$ICO/hicolor/''${s}x''${s}/apps
+      mkdir -p $D
+      convert $FAV -resize ''${s}x''${s} $D/fluffychat.png
+    done
+
+    substituteInPlace $out/share/applications/*.desktop \
+      --subst-var out
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -8,7 +8,7 @@ flutter.mkFlutterApp rec {
   pname = "fluffychat";
   version = "1.2.0";
 
-  vendorHash = "sha256-Qg0IlajbIl8e3BkKgn4O+mbZGvhfqr7XwllBLJQAA/I=";
+  vendorHash = "sha256-slQeCECItZirEVf3agB8mqhTg6/JLsErFV2yDj4M3k0=";
 
   src = fetchFromGitLab {
     owner = "famedly";
@@ -20,6 +20,17 @@ flutter.mkFlutterApp rec {
   buildInputs = [
     olm
   ];
+
+  flutterExtraFetchCommands = ''
+    M=$(echo $TMP/.pub-cache/hosted/pub.dartlang.org/matrix-*)
+    sed -i $M/scripts/prepare.sh \
+      -e "s|/usr/lib/x86_64-linux-gnu/libolm.so.3|${olm}/lib/libolm.so.3|g"  \
+      -e "s|if which flutter >/dev/null; then|exit; if which flutter >/dev/null; then|g"
+
+    pushd $M
+    bash scripts/prepare.sh
+    popd
+  '';
 
   meta = with lib; {
     description = "Chat with your friends (matrix client)";

--- a/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fluffychat/default.nix
@@ -10,7 +10,7 @@ flutter.mkFlutterApp rec {
   pname = "fluffychat";
   version = "1.2.0";
 
-  vendorHash = "sha256-slQeCECItZirEVf3agB8mqhTg6/JLsErFV2yDj4M3k0=";
+  vendorHash = "sha256-j5opwEFifa+DMG7Uziv4SWEPVokD6OSq8mSIr0AdDL0=";
 
   src = fetchFromGitLab {
     owner = "famedly";
@@ -39,12 +39,18 @@ flutter.mkFlutterApp rec {
   flutterExtraFetchCommands = ''
     M=$(echo $TMP/.pub-cache/hosted/pub.dartlang.org/matrix-*)
     sed -i $M/scripts/prepare.sh \
-      -e "s|/usr/lib/x86_64-linux-gnu/libolm.so.3|${olm}/lib/libolm.so.3|g"  \
+      -e "s|/usr/lib/x86_64-linux-gnu/libolm.so.3|/bin/sh|g"  \
       -e "s|if which flutter >/dev/null; then|exit; if which flutter >/dev/null; then|g"
 
     pushd $M
     bash scripts/prepare.sh
     popd
+  '';
+
+  # replace olm dummy path
+  postConfigure = ''
+    M=$(echo $TMP/.pub-cache/hosted/pub.dartlang.org/matrix-*)
+    ln -sf ${olm}/lib/libolm.so.3 $M/ffi/olm/libolm.so
   '';
 
   postInstall = ''

--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -254,9 +254,10 @@ let
     mkdir -p $out/bin
     mv $built $out/app
 
-    for f in $built/data/flutter_assets/assets/*.desktop; do
+    for f in $(find $out/app -iname "*.desktop" -type f); do
       install -D $f $out/share/applications/$(basename $f)
     done
+
     for f in $(find $out/app -maxdepth 1 -type f); do
       ln -s $f $out/bin/$(basename $f)
     done

--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -63,6 +63,9 @@ let
       nukeReferences
     ];
 
+    # avoid pub phase
+    dontBuild = true;
+
     installPhase = ''
       . ${../fetchgit/deterministic-git}
 
@@ -207,6 +210,7 @@ let
 
     # ensure we're using a lockfile for the right package version
     if [ -e pubspec.lock ]; then
+      # FIXME: currently this is broken. in theory this should not break, but flutter has it's own way of doing things.
       # diff -u pubspec.lock $depsFolder/pubspec.lock
       true
     else

--- a/pkgs/build-support/flutter/default.nix
+++ b/pkgs/build-support/flutter/default.nix
@@ -79,6 +79,7 @@ let
       flutter config --enable-linux-desktop
       flutter packages get
       flutter build linux || true # so it downloads tools
+      ${lib.optionalString (args ? flutterExtraFetchCommands) args.flutterExtraFetchCommands}
 
       RES="$TMP"
 
@@ -130,6 +131,7 @@ let
     '';
 
     GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
       "GIT_PROXY_COMMAND" "NIX_GIT_SSL_CAINFO" "SOCKS_SERVER"

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -4,20 +4,20 @@ let
   getPatches = dir:
     let files = builtins.attrNames (builtins.readDir dir);
     in map (f: dir + ("/" + f)) files;
-  version = "2.10.0";
+  version = "2.10.1";
   channel = "stable";
   filename = "flutter_linux_${version}-${channel}.tar.xz";
 
   # Decouples flutter derivation from dart derivation,
   # use specific dart version to not need to bump dart derivation when bumping flutter.
-  dartVersion = "2.16.0";
+  dartVersion = "2.16.1";
   dartSourceBase = "https://storage.googleapis.com/dart-archive/channels";
   dartForFlutter = dart.override {
     version = dartVersion;
     sources = {
       "${dartVersion}-x86_64-linux" = fetchurl {
         url = "${dartSourceBase}/stable/release/${dartVersion}/sdk/dartsdk-linux-x64-release.zip";
-        sha256 = "sha256-n+hr3iMt5S0iEeR/X9zBQ86TbjCajaG0RyE+Ij1/aNM=";
+        sha256 = "sha256-PMY6DCFQC8XrlnFzOEPcwgBAs5/cAvNd78969Z+I1Fk=";
       };
     };
   };
@@ -29,7 +29,7 @@ in {
     pname = "flutter";
     src = fetchurl {
       url = "https://storage.googleapis.com/flutter_infra_release/releases/${channel}/linux/${filename}";
-      sha256 = "sha256-4ZEpZPGVnisnK9QT1o4G2G6CiflYElh+e3+X8odnx1U=";
+      sha256 = "sha256-rSfwcglDV2rvJl10j7FByAWmghd2FYxrlkgYnvRO54Y=";
     };
     patches = getPatches ./patches;
   };

--- a/pkgs/development/tools/rust/duckscript/default.nix
+++ b/pkgs/development/tools/rust/duckscript/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchurl
+, runCommand
+, fetchCrate
+, rustPlatform
+, Security
+, openssl
+, pkg-config
+, SystemConfiguration
+, libiconv
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "duckscript_cli";
+  version = "0.8.10";
+
+  src = fetchCrate {
+    inherit pname version;
+    sha256 = "sha256-cMvcCX8ViCcUFMuxAPo3/wxXvg5swAcBrLx1x7lSwvM=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ]
+    ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration libiconv ];
+
+  cargoSha256 = "sha256-8ywMLXFmdq119K/hl1hpsVhzG+nrdO4eux3lAqUjB+A=";
+
+  meta = with lib; {
+    description = "Simple, extendable and embeddable scripting language.";
+    homepage = "https://github.com/sagiegurari/duckscript";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
@@ -20,7 +20,7 @@ flutter.mkFlutterApp {
   meta = with lib; {
     description = "Firmware Updater for Linux";
     homepage = "https://github.com/canonical/firmware-updater";
-    license = licenses.free;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ mkg20001 ];
     platforms = platforms.linux;
   };

--- a/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
+++ b/pkgs/os-specific/linux/firmware/firmware-updater/default.nix
@@ -7,7 +7,7 @@ flutter.mkFlutterApp {
   pname = "firmware-updater";
   version = "unstable";
 
-  vendorHash = "sha256-QgeRCFbd3AcFekJunFTwu2nDOQpAOMJUxZhgY4stJJc=";
+  vendorHash = "sha256-L8am4vTx4KlMHUdIhrUsCxGc27vkolawS/9DyFCPOJQ=";
 
   src = fetchFromGitHub {
     owner = "canonical";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13606,6 +13606,10 @@ with pkgs;
 
   duktape = callPackage ../development/interpreters/duktape { };
 
+  duckscript = callPackage ../development/tools/rust/duckscript {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+  };
+
   evcxr = callPackage ../development/interpreters/evcxr {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Packaging some more things for flutter to check and smooth out the raw edges of mkFlutterApp

If yov've got any comments regarding #147107 this is the place to comment

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
