### PR TITLE
python3Packages.aiohttp: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -92,7 +92,10 @@ buildPythonPackage rec {
   # Probably because we run `python -m pytest` instead of `pytest` in the hook.
   preCheck = ''
     cd tests
-  '';
+  '' + lib.optionalString stdenv.isDarwin ''
+    # Work around "OSError: AF_UNIX path too long"
+    export TMPDIR="/tmp"
+   '';
 
   meta = with lib; {
     description = "Asynchronous HTTP Client/Server for Python and asyncio";


### PR DESCRIPTION
###### Motivation for this change

Fixes failures during tests on Darwin. Similar to https://github.com/NixOS/nixpkgs/pull/126642, https://github.com/NixOS/nixpkgs/pull/145276, and https://github.com/NixOS/nixpkgs/pull/149128. Upstream does not seem interested in fixing this.

```
=================================== FAILURES ===================================
_________________________ test_unix_connector[pyloop] __________________________

unix_server = <function unix_server.<locals>.go at 0x105fc28b0>
unix_sockname = '/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-python3.9-aiohttp-3.8.1.drv-0/tmpcljw3ph_/socket.sock'

    @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="requires UNIX sockets")
    async def test_unix_connector(unix_server, unix_sockname) -> None:
        async def handler(request):
            return web.Response()

        app = web.Application()
        app.router.add_get("/", handler)
>       await unix_server(app)

app        = <Application 0x105d1f970>
handler    = <function test_unix_connector.<locals>.handler at 0x10577c9d0>
unix_server = <function unix_server.<locals>.go at 0x105fc28b0>
unix_sockname = '/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-python3.9-aiohttp-3.8.1.drv-0/tmpcljw3ph_/socket.sock'

test_connector.py:2096:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_connector.py:61: in go
    await site.start()
        app        = <Application 0x105d1f970>
        runner     = <aiohttp.web_runner.AppRunner object at 0x105c3b900>
        runners    = [<aiohttp.web_runner.AppRunner object at 0x105c3b900>]
        site       = <aiohttp.web_runner.UnixSite object at 0x105c3b5e0>
        unix_sockname = '/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-python3.9-aiohttp-3.8.1.drv-0/tmpcljw3ph_/socket.sock'
/nix/store/17kr2wf77nz9iq7z3ww3apdrahcvjsr2-python3.9-aiohttp-3.8.1/lib/python3.9/site-packages/aiohttp/web_runner.py:162: in start
    self._server = await loop.create_unix_server(
        __class__  = <class 'aiohttp.web_runner.UnixSite'>
        loop       = <_UnixSelectorEventLoop running=False closed=False debug=False>
        self       = <aiohttp.web_runner.UnixSite object at 0x105c3b5e0>
        server     = <aiohttp.web_server.Server object at 0x1060da6d0>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
protocol_factory = <aiohttp.web_server.Server object at 0x1060da6d0>
path = '/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-python3.9-aiohttp-3.8.1.drv-0/tmpcljw3ph_/socket.sock'

    async def create_unix_server(
            self, protocol_factory, path=None, *,
            sock=None, backlog=100, ssl=None,
            ssl_handshake_timeout=None,
            start_serving=True):
        if isinstance(ssl, bool):
            raise TypeError('ssl argument must be an SSLContext or None')

        if ssl_handshake_timeout is not None and not ssl:
            raise ValueError(
                'ssl_handshake_timeout is only meaningful with ssl')

        if path is not None:
            if sock is not None:
                raise ValueError(
                    'path and sock can not be specified at the same time')

            path = os.fspath(path)
            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

            # Check for abstract socket. `str` and `bytes` paths are supported.
            if path[0] not in (0, '\x00'):
                try:
                    if stat.S_ISSOCK(os.stat(path).st_mode):
                        os.remove(path)
                except FileNotFoundError:
                    pass
                except OSError as err:
                    # Directory may have permissions only to create socket.
                    logger.error('Unable to check or remove stale UNIX socket '
                                 '%r: %r', path, err)

            try:
>               sock.bind(path)
E               OSError: AF_UNIX path too long

backlog    = 128
path       = '/private/var/folders/1s/gpt7p1x559sb7qjb_4bhq7zc75yv8y/T/nix-build-python3.9-aiohttp-3.8.1.drv-0/tmpcljw3ph_/socket.sock'
protocol_factory = <aiohttp.web_server.Server object at 0x1060da6d0>
self       = <_UnixSelectorEventLoop running=False closed=False debug=False>
sock       = <socket.socket [closed] fd=-1, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
ssl        = None
ssl_handshake_timeout = None
start_serving = True

/nix/store/z740mapbgfi953b61jx72c0jy3phfcy8-python3-3.9.10/lib/python3.9/asyncio/unix_events.py:296: OSError
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).