### PR TITLE
nimlsp: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/development/nim-packages/jsonschema/default.nix
+++ b/pkgs/development/nim-packages/jsonschema/default.nix
@@ -1,8 +1,22 @@
-{ fetchFromGitHub }:
+{ lib, buildNimPackage, fetchFromGitHub, astpatternmatching }:
 
-fetchFromGitHub {
-  owner = "PMunch";
-  repo = "jsonschema";
-  rev = "7b41c03e3e1a487d5a8f6b940ca8e764dc2cbabf";
-  sha256 = "1js64jqd854yjladxvnylij4rsz7212k31ks541pqrdzm6hpblbz";
+buildNimPackage rec {
+  pname = "jsonschema";
+  version = "unstable-2019-09-12";
+
+  src = fetchFromGitHub {
+    owner = "PMunch";
+    repo = "jsonschema";
+    rev = "7b41c03e3e1a487d5a8f6b940ca8e764dc2cbabf";
+    sha256 = "1js64jqd854yjladxvnylij4rsz7212k31ks541pqrdzm6hpblbz";
+  };
+
+  propagatedBuildInputs = [ astpatternmatching ];
+
+  meta = with lib; {
+    homepage = "https://github.com/PMunch/jsonschema";
+    description = "Schema validation of JSON for Nim";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
 }

--- a/pkgs/development/tools/misc/nimlsp/default.nix
+++ b/pkgs/development/tools/misc/nimlsp/default.nix
@@ -2,17 +2,17 @@
 
 nimPackages.buildNimPackage rec {
   pname = "nimlsp";
-  version = "0.3.2";
+  version = "0.4.0";
   nimBinOnly = true;
 
   src = fetchFromGitHub {
     owner = "PMunch";
     repo = "nimlsp";
     rev = "v${version}";
-    sha256 = "1lm823nvpp3bj9527jd8n1jxh6y8p8ngkfkj91p94m7ffai6jazq";
+    sha256 = "sha256-eih8JmofLFXkidanRocjtA6wv84HkA1bi0M4dxkiDr4=";
   };
 
-  buildInputs = with nimPackages; [ astpatternmatching jsonschema ];
+  buildInputs = with nimPackages; [ jsonschema ];
 
   nimFlags = [
     "--threads:on"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
