### PR TITLE
desktopToDarwinBundle: fix squircle icons

### DIFF
--- a/pkgs/build-support/make-darwin-bundle/write-darwin-bundle.nix
+++ b/pkgs/build-support/make-darwin-bundle/write-darwin-bundle.nix
@@ -4,32 +4,33 @@ let
   pListText = lib.generators.toPlist { } {
     CFBundleDevelopmentRegion = "English";
     CFBundleExecutable = "$name";
-    CFBundleIconFiles = [ "$iconPlistArray" ];
+    CFBundleIconFile = "$icon";
     CFBundleIdentifier = "org.nixos.$name";
     CFBundleInfoDictionaryVersion = "6.0";
     CFBundleName = "$name";
     CFBundlePackageType = "APPL";
     CFBundleSignature = "???";
   };
-
-# The generation of the CFBundleIconFiles array is a bit of a hack, since we
-# will always end up with an empty first element (<string></string>) but macOS
-# appears to ignore this which allows us to use the nix PList generator.
 in writeScriptBin "write-darwin-bundle" ''
     shopt -s nullglob
 
-    readonly prefix="$1"
-    readonly name="$2"
-    readonly exec="$3"
-    iconPlistArray=""
+    readonly prefix=$1
+    readonly name=$2
+    readonly exec=$3
+    readonly icon=$4.icns
+    readonly squircle=''${5:-1}
+    readonly plist=$prefix/Applications/$name.app/Contents/Info.plist
 
-    for icon in "$prefix/Applications/$name.app/Contents/Resources"/*; do
-        iconPlistArray="$iconPlistArray</string><string>"$(basename "$icon")""
-    done
-
-    cat > "$prefix/Applications/$name.app/Contents/Info.plist" <<EOF
+    cat > "$plist" <<EOF
 ${pListText}
 EOF
+
+  if [[ $squircle != 0 && $squircle != "false" ]]; then
+    sed  "
+      s|CFBundleIconFile|CFBundleIconFiles|;
+      s|<string>$icon</string>|<array><string>$icon</string></array>|
+    " -i "$plist"
+  fi
 
     cat > "$prefix/Applications/$name.app/Contents/MacOS/$name" <<EOF
 #!/bin/bash

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -40,10 +40,10 @@ convertIconTheme() {
 
         local -a validSizes=(
             ${exactSize}
-            $(expr $iconSize + 1)x$(expr $iconSize + 1)${scaleSuffix}
-            $(expr $iconSize + 2)x$(expr $iconSize + 2)${scaleSuffix}
-            $(expr $iconSize - 1)x$(expr $iconSize - 1)${scaleSuffix}
-            $(expr $iconSize - 2)x$(expr $iconSize - 2)${scaleSuffix}
+            $((iconSize + 1))x$((iconSize + 1))${scaleSuffix}
+            $((iconSize + 2))x$((iconSize + 2))${scaleSuffix}
+            $((iconSize - 1))x$((iconSize - 1))${scaleSuffix}
+            $((iconSize - 2))x$((iconSize - 2))${scaleSuffix}
         )
 
         for iconIndex in "${!candidateIcons[@]}"; do
@@ -68,8 +68,8 @@ convertIconTheme() {
         local -r iconSize=$3
         local -r scale=$4
 
-        local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
-        local dim=$(expr $iconSize \* $scale)
+        local density=$((72 * scale))x$((72 * scale))
+        local dim=$((iconSize * scale))
 
         magick convert -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
     }
@@ -81,8 +81,8 @@ convertIconTheme() {
         local -r scale=$4
 
         if [[ $in != '-' ]]; then
-            local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
-            local dim=$(expr $iconSize \* $scale)
+            local density=$((72 * scale))x$((72 * scale))
+            local dim=$((iconSize * scale))
             rsvg-convert --keep-aspect-ratio --width "$dim" --height "$dim" "$in" --output "$out"
             magick convert -density "$density" -units PixelsPerInch "$out" "$out"
         else
@@ -115,7 +115,7 @@ convertIconTheme() {
                 local result=${resultdir}/${iconSize}x${iconSize}${scales[$scale]}${scaleSuffix:+x}.png
                 case $type in
                     fixed)
-                        local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
+                        local density=$((72 * scale))x$((72 * scale))
                         magick convert -density "$density" -units PixelsPerInch "$icon" "$result"
                         ;;
                     threshold)

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -10,31 +10,147 @@ getDesktopParam() {
     awk -F "=" "/${pattern}/ {print \$2}" "${file}"
 }
 
+# Convert a freedesktop.org icon theme for a given app to a .icns file. When possible, missing
+# icons are synthesized from SVG or rescaled from existing ones (when within the size threshold).
+convertIconTheme() {
+    local -r out=$1
+    local -r sharePath=$2
+    local -r iconName=$3
+    local -r theme=${4:-hicolor}
+
+    local -ra iconSizes=(16 32 128 256 512)
+    local -ra scales=([1]="" [2]="@2")
+
+    # Based loosely on the algorithm at:
+    # https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup
+    # Assumes threshold = 2 for ease of implementation.
+    function findIcon() {
+        local -r iconSize=$1
+        local -r scale=$2
+
+        local scaleSuffix=${scales[$scale]}
+        local exactSize=${iconSize}x${iconSize}${scaleSuffix}
+
+        local -a validSizes=(
+            ${exactSize}
+            $(expr $iconSize + 1)x$(expr $iconSize + 1)${scaleSuffix}
+            $(expr $iconSize + 2)x$(expr $iconSize + 2)${scaleSuffix}
+            $(expr $iconSize - 1)x$(expr $iconSize - 1)${scaleSuffix}
+            $(expr $iconSize - 2)x$(expr $iconSize - 2)${scaleSuffix}
+        )
+
+        for iconIndex in "${!candidateIcons[@]}"; do
+            for maybeSize in "${validSizes[@]}"; do
+                icon=${candidateIcons[$iconIndex]}
+                if [[ $icon = */$maybeSize/* ]]; then
+                    if [[ $maybeSize = $exactSize ]]; then
+                        echo "fixed $icon"
+                    else
+                        echo "threshold $icon"
+                    fi
+                    return 0
+                fi
+            done
+        done
+        echo "scalable"
+    }
+
+    function resizeIcon() {
+        local -r in=$1
+        local -r out=$2
+        local -r iconSize=$3
+        local -r scale=$4
+
+        local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
+        local dim=$(expr $iconSize \* $scale)
+
+        magick convert -scale "${dim}x${dim}" -density "$density" -units PixelsPerInch "$in" "$out"
+    }
+
+    function synthesizeIcon() {
+        local -r in=$1
+        local -r out=$2
+        local -r iconSize=$3
+        local -r scale=$4
+
+        if [[ $in != '-' ]]; then
+            local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
+            local dim=$(expr $iconSize \* $scale)
+            rsvg-convert --keep-aspect-ratio --width "$dim" --height "$dim" "$in" --output "$out"
+            magick convert -density "$density" -units PixelsPerInch "$out" "$out"
+        else
+            return 1
+        fi
+    }
+
+    function getIcons() {
+        local -r sharePath=$1
+        local -r iconname=$2
+        local -r theme=$3
+        local -r resultdir=$(mktemp -d)
+
+        local -ar candidateIcons=(
+            "${sharePath}/icons/${theme}/"*"/${iconname}.png"
+            "${sharePath}/icons/${theme}/"*"/${iconname}.xpm"
+        )
+
+        local -a scalableIcon=("${sharePath}/icons/${theme}/scalable/${iconname}.svg"*)
+        if [[ ${#scalableIcon[@]} = 0 ]]; then
+            scalableIcon=('-')
+        fi
+
+        for iconSize in "${iconSizes[@]}"; do
+            for scale in "${!scales[@]}"; do
+                local iconResult=$(findIcon $iconSize $scale)
+                local type=${iconResult%% *}
+                local icon=${iconResult#* }
+                local scaleSuffix=${scales[$scale]}
+                local result=${resultdir}/${iconSize}x${iconSize}${scales[$scale]}${scaleSuffix:+x}.png
+                case $type in
+                    fixed)
+                        local density=$(expr 72 \* $scale)x$(expr 72 \* $scale)
+                        magick convert -density "$density" -units PixelsPerInch "$icon" "$result"
+                        ;;
+                    threshold)
+                        # Synthesize an icon of the exact size if a scalable icon is available
+                        # instead of scaling one and ending up with a fuzzy icon.
+                        if ! synthesizeIcon "${scalableIcon[0]}" "$result" "$iconSize" "$scale"; then
+                            resizeIcon "$icon" "$result" "$iconSize" "$scale"
+                        fi
+                        ;;
+                    scalable)
+                        synthesizeIcon "${scalableIcon[0]}" "$result" "$iconSize" "$scale" || true
+                        ;;
+                esac
+            done
+        done
+        echo "$resultdir"
+    }
+
+    iconsdir=$(getIcons "$sharePath" "apps/${iconName}" "$theme")
+    if [[ ! -z "$(ls -1 "$iconsdir/"*)" ]]; then
+        icnsutil compose "$out/${iconName}.icns" "$iconsdir/"*
+    else
+        echo "Warning: no icons were found. Creating an empty icon for ${iconName}.icns."
+        touch "$out/${iconName}.icns"
+    fi
+}
+
 # For a given .desktop file, generate a darwin '.app' bundle for it.
 convertDesktopFile() {
-    local -r file="$1"
+    local -r file=$1
+    local -r sharePath=$(dirname "$(dirname "$file")")
     local -r name=$(getDesktopParam "${file}" "^Name")
     local -r exec=$(getDesktopParam "${file}" "Exec")
-    local -r iconName=$(getDesktopParam "${file}" "Icon")
-    local -r iconFiles=$(find "$out/share/icons/" -name "${iconName}.*" 2>/dev/null);
-    local -r pixMaps=$(find "$out/share/pixmaps/" -name "${iconName}.xpm" 2>/dev/null);
+    local -r iconName=$(getDesktopParam "${file}" "^Icon")
+    local -r squircle=$(getDesktopParam "${file}" "X-macOS-SquircleIcon")
 
     mkdir -p "$out/Applications/${name}.app/Contents/MacOS"
     mkdir -p "$out/Applications/${name}.app/Contents/Resources"
 
-    local i=0;
-    for icon in $iconFiles; do
-      ln -s "$icon" "$out/Applications/${name}.app/Contents/Resources/$i-$(basename "$icon")"
-      (( i +=1 ));
-    done
+    convertIconTheme "$out/Applications/${name}.app/Contents/Resources" "$sharePath" "$iconName"
 
-    for pixmap in $pixMaps; do
-      local newIconName="$i-$(basename "$pixmap")";
-      convert "$pixmap" "$out/Applications/${name}.app/Contents/Resources/${newIconName%.xpm}.png"
-      (( i +=1 ));
-    done
-
-    write-darwin-bundle "$out" "$name" "$exec"
+    write-darwin-bundle "$out" "$name" "$exec" "$iconName" "$squircle"
 }
 
 convertDesktopFiles() {

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -18,7 +18,7 @@ convertIconTheme() {
     local -r iconName=$3
     local -r theme=${4:-hicolor}
 
-    local -ra iconSizes=(16 32 128 256 512)
+    local -ra iconSizes=(16 32 48 128 256 512)
     local -ra scales=([1]="" [2]="@2")
 
     # Based loosely on the algorithm at:
@@ -30,6 +30,13 @@ convertIconTheme() {
 
         local scaleSuffix=${scales[$scale]}
         local exactSize=${iconSize}x${iconSize}${scaleSuffix}
+
+        if [[ $exactSize = '48x48@2' ]]; then
+            # macOS does not support a 2x scale variant of 48x48 icons
+            # See: https://en.wikipedia.org/wiki/Apple_Icon_Image_format#Icon_types
+            echo "unsupported"
+            return 0
+        fi
 
         local -a validSizes=(
             ${exactSize}
@@ -120,6 +127,8 @@ convertIconTheme() {
                         ;;
                     scalable)
                         synthesizeIcon "${scalableIcon[0]}" "$result" "$iconSize" "$scale" || true
+                        ;;
+                    *)
                         ;;
                 esac
             done

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -17,8 +17,8 @@ python3Packages.buildPythonPackage rec {
   doCheck = true;
 
   checkPhase = ''
-    ${python3Packages.python}/bin/python3 tests/test_icnsutil.py
-    ${python3Packages.python}/bin/python3 tests/test_cli.py
+    ${python3.interpreter} tests/test_icnsutil.py
+    ${python3.interpreter} tests/test_cli.py
   '';
 
   meta = {

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -1,9 +1,9 @@
 { lib
-, python3Packages
+, python3
 , fetchFromGitHub
 }:
 
-python3Packages.buildPythonPackage rec {
+python3.pkgs.buildPythonPackage rec {
   pname = "icnsutil";
   version = "1.0.1";
 

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -1,9 +1,10 @@
 { lib
-, python3
+, python
 , fetchFromGitHub
+, buildPythonPackage
 }:
 
-python3.pkgs.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "icnsutil";
   version = "1.0.1";
 
@@ -17,8 +18,8 @@ python3.pkgs.buildPythonPackage rec {
   doCheck = true;
 
   checkPhase = ''
-    ${python3.interpreter} tests/test_icnsutil.py
-    ${python3.interpreter} tests/test_cli.py
+    ${python.interpreter} tests/test_icnsutil.py
+    ${python.interpreter} tests/test_cli.py
   '';
 
   meta = {

--- a/pkgs/development/python-modules/icnsutil/default.nix
+++ b/pkgs/development/python-modules/icnsutil/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "icnsutil";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "relikd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-TfQvAbP7iCpRQg2G+ejl245NCYo9DpYwMgiwY2BuJnY=";
+  };
+
+  doCheck = true;
+
+  checkPhase = ''
+    ${python3Packages.python}/bin/python3 tests/test_icnsutil.py
+    ${python3Packages.python}/bin/python3 tests/test_cli.py
+  '';
+
+  meta = {
+    homepage = "https://github.com/relikd/icnsutil";
+    description = "Create and extract .icns files.";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.reckenrode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -821,8 +821,9 @@ with pkgs;
 
   writeDarwinBundle = callPackage ../build-support/make-darwin-bundle/write-darwin-bundle.nix { };
 
-  desktopToDarwinBundle = makeSetupHook { deps = [ writeDarwinBundle imagemagick ]; }
-    ../build-support/setup-hooks/desktop-to-darwin-bundle.sh;
+  desktopToDarwinBundle = makeSetupHook {
+    deps = [ writeDarwinBundle librsvg imagemagick python3Packages.icnsutil ];
+  } ../build-support/setup-hooks/desktop-to-darwin-bundle.sh;
 
   keepBuildTree = makeSetupHook { } ../build-support/setup-hooks/keep-build-tree.sh;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3916,6 +3916,8 @@ in {
 
   icmplib = callPackage ../development/python-modules/icmplib { };
 
+  icnsutil = callPackage ../development/python-modules/icnsutil { };
+
   ics = callPackage ../development/python-modules/ics { };
 
   idasen = callPackage ../development/python-modules/idasen { };


### PR DESCRIPTION
###### Motivation for this change

I’m working on a deriviation for Final Fantasy XIV. It’s running under Wine, and having an app launcher would be really handy. Fortunately, @hexagonal-sun is awesome, and #131891 does exactly what I want. Unfortunately, macOS 12 (and possibly 11, but I haven’t tested it) automatically makes the icon into a squircle, which makes it look kind of bad. See below.

<img width="250" alt="squircle" src="https://user-images.githubusercontent.com/7413633/154828684-6570115b-fe99-4ed9-b37f-e61e3fc8c93d.png">

The right icon is the app’s normal icon, and the left one is the squirclified icon. Since element-desktop seems to be the only other thing using this right now (though I couldn’t get it to produce an app bundle when I built it with `nix build`), I’m not sure what the intended behavior is.

I am assuming that automatically turning icons into squircles is not the intended behavior, so I have tried to keep the changes minimal by just turning the icons into a single icns file and using `CFBundleIconName` instead of `CFBundleIconNames`. There’s a `UIPrerenderedIcon` key that sounds like it should do what I want, but it’s only supported on iOS.

If my assumption is wrong, I’d be happy to rework this accordingly (though I’d still need a way to override with the upstream icon).

For reference the derivation I’m working on is available [here](https://github.com/reckenrode/nixpkgs/blob/ffxiv/pkgs/games/ffxiv/default.nix).

###### Things done

The comparison icon was generated with the changes before (left) and after (right).

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
