### PR TITLE
xone: init package and module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10246,6 +10246,13 @@
     githubId = 6047658;
     name = "Ryan Horiguchi";
   };
+  rhysmdnz = {
+    email = "rhys@memes.nz";
+    matrix = "@rhys:memes.nz";
+    github = "rhysmdnz";
+    githubId = 2162021;
+    name = "Rhys Davies";
+  };
   ribose-jeffreylau = {
     name = "Jeffrey Lau";
     email = "jeffrey.lau@ribose.com";

--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -83,6 +83,7 @@ in {
         b43Firmware_5_1_138
         b43Firmware_6_30_163_46
         b43FirmwareCutter
+        xow_dongle-firmware
       ] ++ optional pkgs.stdenv.hostPlatform.isx86 facetimehd-firmware;
     })
     (mkIf cfg.wirelessRegulatoryDatabase {

--- a/nixos/modules/hardware/xone.nix
+++ b/nixos/modules/hardware/xone.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.xone;
+in
+{
+  options.hardware.xone = {
+    enable = mkEnableOption "the xone driver for Xbox One and Xbobx Series X|S accessories";
+  };
+
+  config = mkIf cfg.enable {
+    boot = {
+      blacklistedKernelModules = [ "xpad" "mt76x2u" ];
+      extraModulePackages = with config.boot.kernelPackages; [ xone ];
+    };
+    hardware.firmware = [ pkgs.xow_dongle-firmware ];
+  };
+
+  meta = {
+    maintainers = with maintainers; [ rhysmdnz ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -91,6 +91,7 @@
   ./hardware/video/switcheroo-control.nix
   ./hardware/video/uvcvideo/default.nix
   ./hardware/video/webcam/facetimehd.nix
+  ./hardware/xone.nix
   ./hardware/xpadneo.nix
   ./i18n/input-method/default.nix
   ./i18n/input-method/fcitx.nix

--- a/pkgs/os-specific/linux/firmware/xow_dongle-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/xow_dongle-firmware/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchurl, cabextract }:
+
+stdenv.mkDerivation rec {
+  pname = "xow_dongle-firmware";
+  version = "2017-07";
+
+  dontUnpack = true;
+  dontInstall = true;
+
+  src = fetchurl {
+    url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
+    sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
+  };
+
+  nativeBuildInputs = [ cabextract ];
+
+  buildPhase = ''
+    cabextract -F FW_ACC_00U.bin ${src}
+    mkdir -p $out/lib/firmware
+    cp -a FW_ACC_00U.bin $out/lib/firmware/xow_dongle.bin
+  '';
+
+  meta = with lib; {
+    description = "Xbox One wireless dongle firmware";
+    homepage = "https://www.xbox.com/en-NZ/accessories/adapters/wireless-adapter-windows";
+    license = licenses.unfree;
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+    platforms = platforms.linux;
+  };
+}
+
+

--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, lib, fetchFromGitHub, kernel, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "xone-${version}-${kernel.version}";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "medusalix";
+    repo = "xone";
+    rev = "v${version}";
+    sha256 = "sha256-m4305Xl5w4nyAVqubjwWsiyPDVtfGykjlSW2eKEytVk=";
+  };
+
+  setSourceRoot = ''
+    export sourceRoot=$(pwd)/source
+  '';
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)"
+    "VERSION=${version}"
+  ];
+
+  buildFlags = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  meta = with lib; {
+    description = "Linux kernel driver for Xbox One and Xbox Series X|S accessories";
+    homepage = "https://github.com/medusalix/xone";
+    license = licenses.gpl2;
+    maintainers = with lib.maintainers; [ rhysmdnz ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34115,6 +34115,8 @@ with pkgs;
 
   xosview2 = callPackage ../tools/X11/xosview2 { };
 
+  xow_dongle-firmware = callPackage ../os-specific/linux/firmware/xow_dongle-firmware { };
+
   xpad = callPackage ../applications/misc/xpad { };
 
   xsane = callPackage ../applications/graphics/sane/xsane.nix {

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -460,6 +460,8 @@ in {
 
     xmm7360-pci = callPackage ../os-specific/linux/xmm7360-pci { };
 
+    xone = callPackage ../os-specific/linux/xone { };
+
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 
     zenpower = callPackage ../os-specific/linux/zenpower { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -460,7 +460,7 @@ in {
 
     xmm7360-pci = callPackage ../os-specific/linux/xmm7360-pci { };
 
-    xone = callPackage ../os-specific/linux/xone { };
+    xone = if lib.versionAtLeast kernel.version "5.4" then callPackage ../os-specific/linux/xone { } else null;
 
     xpadneo = callPackage ../os-specific/linux/xpadneo { };
 


### PR DESCRIPTION
###### Motivation for this change
This adds a package and a module for [xone](https://github.com/medusalix/xone), a kernel driver for Xbox One and Xbox Series X|S accessories.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
