### PR TITLE
losslesscut-bin: 3.33.1 -> 3.43.0

### DIFF
--- a/pkgs/applications/video/losslesscut-bin/appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/appimage.nix
@@ -1,4 +1,4 @@
-{ appimageTools, lib, fetchurl, gtk3, gsettings-desktop-schemas, version }:
+{ appimageTools, lib, fetchurl, gtk3, gsettings-desktop-schemas, version, sha256 }:
 
 let
   pname = "losslesscut";
@@ -11,7 +11,7 @@ let
   src = fetchurl {
     url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
     name = nameSource;
-    sha256 = "0aqz5ijl5japfzzbcdcd2mmihkb8b2fc2hs9kkm3211yb37c5ygv";
+    inherit sha256;
   };
   extracted = appimageTools.extractType2 {
     inherit name src;

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -1,9 +1,9 @@
 { callPackage, stdenvNoCC, lib }:
 let
-  version = "3.33.1";
-  appimage = callPackage ./appimage.nix { inherit version; };
-  dmg = callPackage ./dmg.nix { inherit version; };
-  windows = callPackage ./windows.nix { inherit version; };
+  version = "3.43.0";
+  appimage = callPackage ./appimage.nix { inherit version; sha256 = "1xfr3i4gsi13wj374yr5idhgs0q71s4h33yxdr7b7xjdg2gb8lp1"; };
+  dmg = callPackage ./dmg.nix { inherit version; sha256 = "1axki47hrxx5m0hrmjpxcya091lahqfnh2pd3zhn5dd496slq8an"; };
+  windows = callPackage ./windows.nix { inherit version; sha256 = "1v00gym18hjxxm42dfqmw7vhwh8lgjz2jgv6fmg234npr3d43py5"; };
 in (
   if stdenvNoCC.isDarwin then dmg
   else if stdenvNoCC.isCygwin then windows
@@ -13,7 +13,7 @@ in (
   meta = with lib; {
     description = "The swiss army knife of lossless video/audio editing";
     homepage = "https://mifi.no/losslesscut/";
-    license = licenses.mit;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ ShamrockLee ];
   } // oldAttrs.meta // {
     platforms =

--- a/pkgs/applications/video/losslesscut-bin/dmg.nix
+++ b/pkgs/applications/video/losslesscut-bin/dmg.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, fetchurl, undmg, version }:
+{ stdenvNoCC, lib, fetchurl, undmg, version , sha256 }:
 
 let
   pname = "losslesscut";
@@ -10,7 +10,7 @@ let
   src = fetchurl {
     url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
     name = nameSource;
-    sha256 = "0xa1avbwar7x7kv5yn2ldca4vj3nwaz0dhjm3bcdy59q914xn3dj";
+    inherit sha256;
   };
 in stdenvNoCC.mkDerivation {
   inherit pname version src;

--- a/pkgs/applications/video/losslesscut-bin/windows.nix
+++ b/pkgs/applications/video/losslesscut-bin/windows.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , unzip
 , version
+, sha256
 , useMklink ? false
 , customSymlinkCommand ? null
 }:
@@ -18,12 +19,12 @@ let
     else if useMklink then (targetPath: linkPath: "mklink ${targetPath} ${linkPath}")
     else (targetPath: linkPath: "ln -s ${targetPath} ${linkPath}");
 in stdenvNoCC.mkDerivation {
-  inherit pname version;
+  inherit pname version sha256;
 
   src = fetchurl {
     name = nameSource;
     url = "https://github.com/${owner}/${nameRepo}/releases/download/v${version}/${nameSource}";
-    sha256 = "1rq9frab0jl9y1mgmjhzsm734jvz0a646zq2wi5xzzspn4wikhvb";
+    inherit sha256;
   };
 
   nativeBuildInputs = [ unzip ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
