### PR TITLE
fishnet: 2.4.0 -> 2.5.1

### DIFF
--- a/pkgs/servers/fishnet/Cargo.lock.patch
+++ b/pkgs/servers/fishnet/Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 963e40e..fb76d78 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -230,7 +230,7 @@ dependencies = [
+
+ [[package]]
+ name = "fishnet"
+-version = "2.5.1-dev"
++version = "2.5.1"
+ dependencies = [
+  "arrayvec",
+  "atty",

--- a/pkgs/servers/fishnet/default.nix
+++ b/pkgs/servers/fishnet/default.nix
@@ -6,21 +6,21 @@
 }:
 
 let
-  nnueFile = "nn-6762d36ad265.nnue";
+  nnueFile = "nn-13406b1dcbe0.nnue";
   nnue = fetchurl {
     url = "https://tests.stockfishchess.org/api/nn/${nnueFile}";
-    sha256 = "0727dsxfpns9fkyir95fybibqmigk5h45k154b2c5rk5s9md6qk7";
+    sha256 = "sha256-E0BrHcvgo238XgfaUdjbOLekXX2kMHjsJadiTCuDI28=";
   };
 in
 rustPlatform.buildRustPackage rec {
   pname = "fishnet";
-  version = "2.4.0";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "niklasf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-1Gl2vJFn9yVYH62yBJefAOBX/jJaFAdSZj2Lj3imcps=";
+    sha256 = "sha256-nVRG60sSpTqfqhCclvWoeyHR0+oO1Jn1PgftigDGq5c=";
     fetchSubmodules = true;
   };
 
@@ -29,7 +29,13 @@ rustPlatform.buildRustPackage rec {
     cp -v '${nnue}' 'Fairy-Stockfish/src/${nnueFile}'
   '';
 
-  cargoSha256 = "sha256-/s7Yyi2FUh+EDvgaHLgZ/FA6kk2FQrZr3L3B76fqTuc=";
+  cargoSha256 = "sha256-BJK7M/pjHRj74xoeciavhkK2YRpeogkELIuXetX73so=";
+
+  # TODO: Cargo.lock is out of date, so fix it. Likely not necessary anymore in
+  # the next update.
+  cargoPatches = [
+    ./Cargo.lock.patch
+  ];
 
   meta = with lib; {
     description = "Distributed Stockfish analysis for lichess.org";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update fishnet from 2.4.0 to 2.5.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
