### PR TITLE
weylus: build from source and fix desktop shortcut

### DIFF
--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -1,64 +1,79 @@
 { lib
-, dbus
 , stdenv
+, rustPlatform
+, fetchFromGitHub
+, dbus
+, ffmpeg
+, x264
+, libva
 , gst_all_1
 , xorg
 , libdrm
-, libva
-, fetchzip
-, copyDesktopItems
-, fontconfig
-, libpng
-, pipewire
-, makeWrapper
-, autoPatchelfHook
+, pkg-config
+, pango
+, cmake
+, autoconf
+, libtool
+, nodePackages
+, ApplicationServices
+, Carbon
+, Cocoa
+, VideoToolbox
 }:
 
-stdenv.mkDerivation rec {
+rustPlatform.buildRustPackage rec {
   pname = "weylus";
   version = "0.11.4";
 
-  src = fetchzip {
-    url = "https://github.com/H-M-H/Weylus/releases/download/v${version}/linux.zip";
-    sha256 = "sha256-EW3TdI4F4d4X/BeSqI05QtS77ym1U5jdswFfNtSFyFk=";
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "H-M-H";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0gq2czxvahww97j4i3k18np29zl6wx85f8253wn3ibqrpfnklz6l";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 ./weylus $out/bin/weylus
-    copyDesktopItems ./weylus.desktop
-
-    runHook postInstall
-  '';
-
   buildInputs = [
-    libpng
+    ffmpeg
+    x264
+  ] ++ lib.optionals stdenv.isDarwin [
+    ApplicationServices
+    Carbon
+    Cocoa
+  ] ++ lib.optionals stdenv.isLinux [
     dbus
-    libdrm
-    fontconfig
     libva
     gst_all_1.gst-plugins-base
-    pipewire
-    # autoPatchelfHook complains if these are missing, even on wayland
+    xorg.libXext
     xorg.libXft
     xorg.libXinerama
     xorg.libXcursor
+    xorg.libXrender
+    xorg.libXfixes
+    xorg.libXtst
     xorg.libXrandr
     xorg.libXcomposite
-    xorg.libXtst
+    xorg.libXi
+    xorg.libXv
+    pango
+    libdrm
   ];
 
-  nativeBuildInputs = [ copyDesktopItems autoPatchelfHook makeWrapper ];
+  nativeBuildInputs = [
+    cmake
+    nodePackages.typescript
+  ] ++ lib.optionals stdenv.isLinux [
+    pkg-config
+    autoconf
+    libtool
+  ];
 
-  postFixup = let
-    GST_PLUGIN_PATH = lib.makeSearchPathOutput  "lib" "lib/gstreamer-1.0" [
-      gst_all_1.gst-plugins-base
-      pipewire
-    ];
-  in ''
-    wrapProgram $out/bin/weylus --prefix GST_PLUGIN_PATH : ${GST_PLUGIN_PATH}
+  cargoSha256 = "1pigmch0sy9ipsafd83b8q54xwqjxdaif363n1q8n46arq4v81j0";
+
+  cargoBuildFlags = [ "--features=ffmpeg-system" ];
+  cargoTestFlags = [ "--features=ffmpeg-system" ];
+
+  postInstall = ''
+    install -vDm755 weylus.desktop $out/share/applications/weylus.desktop
   '';
 
   meta = with lib; {
@@ -66,6 +81,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/H-M-H/Weylus";
     license = with licenses; [ agpl3Only ];
     maintainers = with maintainers; [ lom ];
-    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/graphics/weylus/default.nix
+++ b/pkgs/applications/graphics/weylus/default.nix
@@ -39,6 +39,7 @@ rustPlatform.buildRustPackage rec {
     ApplicationServices
     Carbon
     Cocoa
+    VideoToolbox
   ] ++ lib.optionals stdenv.isLinux [
     dbus
     libva

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1032,7 +1032,9 @@ with pkgs;
 
   weidu = callPackage ../tools/games/weidu { };
 
-  weylus = callPackage ../applications/graphics/weylus { };
+  weylus = callPackage ../applications/graphics/weylus  {
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa VideoToolbox;
+  };
 
   gfshare = callPackage ../tools/security/gfshare { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I'm using weylus. I want to build it from source. The desktop icon is missing. I fix it.

###### Things done

1. build weylus from source
2. fix desktop icon
3. I thought it works for Mac since it's built from souce. But I don't have a Mac.
4. I haven't test it with pipewire. @noneucat Could you please help test it?

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@legendofmiracles