### PR TITLE
microsoft-edge init at 98.0.1108.56

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13953,4 +13953,10 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  zanculmarktum = {
+    name = "Azure Zanculmarktum";
+    email = "zanculmarktum@gmail.com";
+    github = "zanculmarktum";
+    githubId = 16958511;
+  };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13959,4 +13959,10 @@
     github = "zanculmarktum";
     githubId = 16958511;
   };
+  kuwii = {
+    name = "kuwii";
+    email = "kuwii.someone@gmail.com";
+    github = "kuwii";
+    githubId = 10705175;
+  };
 }

--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -1,0 +1,191 @@
+{ channel, version, revision, sha256 }:
+
+{ stdenv
+, fetchurl
+, lib
+
+, binutils-unwrapped
+, xz
+, gnutar
+, file
+
+, glibc
+, glib
+, nss
+, nspr
+, atk
+, at-spi2-atk
+, xorg
+, cups
+, dbus
+, expat
+, libdrm
+, libxkbcommon
+, gtk3
+, pango
+, cairo
+, gdk-pixbuf
+, mesa
+, alsa-lib
+, at-spi2-core
+, libuuid
+, systemd
+}:
+
+let
+
+  baseName = "microsoft-edge";
+
+  shortName = if channel == "stable"
+              then "msedge"
+              else "msedge-" + channel;
+
+  longName = if channel == "stable"
+             then baseName
+             else baseName + "-" + channel;
+
+  iconSuffix = if channel == "stable"
+               then ""
+               else "_${channel}";
+
+  desktopSuffix = if channel == "stable"
+                  then ""
+                  else "-${channel}";
+in
+
+stdenv.mkDerivation rec {
+  name="${baseName}-${channel}-${version}";
+
+  src = fetchurl {
+    url = "https://packages.microsoft.com/repos/edge/pool/main/m/${baseName}-${channel}/${baseName}-${channel}_${version}-${revision}_amd64.deb";
+    inherit sha256;
+  };
+
+  unpackCmd = "${binutils-unwrapped}/bin/ar p $src data.tar.xz | ${xz}/bin/xz -dc | ${gnutar}/bin/tar -xf -";
+  sourceRoot = ".";
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontPatchELF = true;
+
+  buildPhase = let
+    libPath = {
+      msedge = lib.makeLibraryPath [
+        glibc glib nss nspr atk at-spi2-atk xorg.libX11
+        xorg.libxcb cups.lib dbus.lib expat libdrm
+        xorg.libXcomposite xorg.libXdamage xorg.libXext
+        xorg.libXfixes xorg.libXrandr libxkbcommon
+        gtk3 pango cairo gdk-pixbuf mesa
+        alsa-lib at-spi2-core xorg.libxshmfence systemd
+      ];
+      naclHelper = lib.makeLibraryPath [
+        glib nspr atk libdrm xorg.libxcb mesa xorg.libX11
+        xorg.libXext dbus.lib libxkbcommon
+      ];
+      libwidevinecdm = lib.makeLibraryPath [
+        glib nss nspr
+      ];
+      libGLESv2 = lib.makeLibraryPath [
+        xorg.libX11 xorg.libXext xorg.libxcb
+      ];
+      libsmartscreen = lib.makeLibraryPath [
+        libuuid stdenv.cc.cc.lib
+      ];
+      libsmartscreenn = lib.makeLibraryPath [
+        libuuid
+      ];
+      liboneauth = lib.makeLibraryPath [
+        libuuid xorg.libX11
+      ];
+    };
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath.msedge}" \
+      opt/microsoft/${shortName}/msedge
+
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      opt/microsoft/${shortName}/msedge-sandbox
+
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      opt/microsoft/${shortName}/msedge_crashpad_handler
+
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath.naclHelper}" \
+      opt/microsoft/${shortName}/nacl_helper
+
+    patchelf \
+      --set-rpath "${libPath.libwidevinecdm}" \
+      opt/microsoft/${shortName}/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
+
+    patchelf \
+      --set-rpath "${libPath.libGLESv2}" \
+      opt/microsoft/${shortName}/libGLESv2.so
+
+    patchelf \
+      --set-rpath "${libPath.libsmartscreen}" \
+      opt/microsoft/${shortName}/libsmartscreen.so
+
+    patchelf \
+      --set-rpath "${libPath.libsmartscreenn}" \
+      opt/microsoft/${shortName}/libsmartscreenn.so
+
+    patchelf \
+      --set-rpath "${libPath.liboneauth}" \
+      opt/microsoft/${shortName}/liboneauth.so
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R opt usr/bin usr/share $out
+
+    ${if channel == "stable"
+      then ""
+      else "ln -sf $out/opt/microsoft/${shortName}/${baseName}-${channel} $out/opt/microsoft/${shortName}/${baseName}"}
+
+    ln -sf $out/opt/microsoft/${shortName}/${longName} $out/bin/${longName}
+
+    rm -rf $out/share/doc
+    rm -rf $out/opt/microsoft/${shortName}/cron
+
+    for icon in '16' '24' '32' '48' '64' '128' '256'
+    do
+      ${ "icon_source=$out/opt/microsoft/${shortName}/product_logo_\${icon}${iconSuffix}.png" }
+      ${ "icon_target=$out/share/icons/hicolor/\${icon}x\${icon}/apps" }
+      mkdir -p $icon_target
+      cp $icon_source $icon_target/microsoft-edge${desktopSuffix}.png
+    done
+
+    substituteInPlace $out/share/applications/${longName}.desktop \
+      --replace /usr/bin/${baseName}-${channel} $out/bin/${longName}
+
+    substituteInPlace $out/share/gnome-control-center/default-apps/${longName}.xml \
+      --replace /opt/microsoft/${shortName} $out/opt/microsoft/${shortName}
+
+    substituteInPlace $out/share/menu/${longName}.menu \
+      --replace /opt/microsoft/${shortName} $out/opt/microsoft/${shortName}
+
+    substituteInPlace $out/opt/microsoft/${shortName}/xdg-mime \
+      --replace "''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" "''${XDG_DATA_DIRS:-/run/current-system/sw/share}" \
+      --replace "xdg_system_dirs=/usr/local/share/:/usr/share/" "xdg_system_dirs=/run/current-system/sw/share/" \
+      --replace /usr/bin/file ${file}/bin/file
+
+    substituteInPlace $out/opt/microsoft/${shortName}/default-app-block \
+      --replace /opt/microsoft/${shortName} $out/opt/microsoft/${shortName}
+
+    substituteInPlace $out/opt/microsoft/${shortName}/xdg-settings \
+      --replace "''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" "''${XDG_DATA_DIRS:-/run/current-system/sw/share}" \
+      --replace "''${XDG_CONFIG_DIRS:-/etc/xdg}" "''${XDG_CONFIG_DIRS:-/run/current-system/sw/etc/xdg}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.microsoft.com/en-us/edge";
+    description = "The web browser from Microsoft";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ zanculmarktum kuwii ];
+  };
+}

--- a/pkgs/applications/networking/browsers/microsoft-edge/default.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/default.nix
@@ -1,0 +1,20 @@
+{
+  beta = import ./browser.nix {
+    channel = "beta";
+    version = "99.0.1150.16";
+    revision = "1";
+    sha256 = "sha256:0qsgs889d6qwxz9qf42psmjqfhmrqgp07srq5r38npl5pncr137h";
+  };
+  dev = import ./browser.nix {
+    channel = "dev";
+    version = "100.0.1163.1";
+    revision = "1";
+    sha256 = "sha256:153faqxyw5f5b6cqnvd71dl7941znkzci8dwbcgaxway0b6882jq";
+  };
+  stable = import ./browser.nix {
+    channel = "stable";
+    version = "98.0.1108.56";
+    revision = "1";
+    sha256 = "sha256:03jbj2s2fs60fzfgsmyb284q7nckji87qgb86mvl5g0hbl19aza7";
+  };
+}

--- a/pkgs/applications/networking/browsers/microsoft-edge/update.sh
+++ b/pkgs/applications/networking/browsers/microsoft-edge/update.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl gzip
+
+# To update: ./update.sh > default.nix
+
+index_file=$(curl -sL https://packages.microsoft.com/repos/edge/dists/stable/main/binary-amd64/Packages.gz | gzip -dc)
+
+echo "{"
+
+packages=()
+echo "$index_file" | while read -r line; do
+    if [[ "$line" =~ ^Package:[[:space:]]*(.*) ]]; then
+        Package="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$line" =~ ^Version:[[:space:]]*(.*)-([a-zA-Z0-9+.~]*) ]]; then
+        Version="${BASH_REMATCH[1]}"
+        Revision="${BASH_REMATCH[2]}"
+    fi
+    if [[ "$line" =~ ^SHA256:[[:space:]]*(.*) ]]; then
+        SHA256="${BASH_REMATCH[1]}"
+    fi
+
+    if ! [[ "$line" ]]; then
+        found=0
+        for i in "${packages[@]}"; do
+            if [[ "$i" == "$Package" ]]; then
+                found=1
+            fi
+        done
+
+        if (( ! $found )); then
+            channel="${Package##*-}"
+            name="${Package%-${channel}}"
+            cat <<EOF
+  ${channel} = import ./browser.nix {
+    channel = "${channel}";
+    version = "${Version}";
+    revision = "${Revision}";
+    sha256 = "sha256:$(nix-hash --type sha256 --to-base32 ${SHA256})";
+  };
+EOF
+        fi
+
+        packages+=($Package)
+        Package=""
+        Version=""
+    fi
+done
+
+echo "}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18996,6 +18996,10 @@ with pkgs;
 
   microsoft_gsl = callPackage ../development/libraries/microsoft_gsl { };
 
+  microsoft-edge = callPackage (import ../applications/networking/browsers/microsoft-edge).stable { };
+  microsoft-edge-beta = callPackage (import ../applications/networking/browsers/microsoft-edge).beta { };
+  microsoft-edge-dev = callPackage (import ../applications/networking/browsers/microsoft-edge).dev { };
+
   micronucleus = callPackage ../development/tools/misc/micronucleus { };
 
   markdown-anki-decks = callPackage ../tools/misc/markdown-anki-decks { };


### PR DESCRIPTION
###### Motivation for this change

Add Microsoft Edge browser package to NixOS based on [Azure Zanculmarktum/overlays](https://gitlab.com/zanc/overlays/-/tree/master/edge) authored by @zanculmarktum .

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
