### PR TITLE
midimonster: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6309,6 +6309,12 @@
     githubId = 37185887;
     name = "Calvin Kim";
   };
+  keldu = {
+    email = "mail@keldu.de";
+    github = "keldu";
+    githubId = 15373888;
+    name = "Claudius Holeksa";
+  };
   kennyballou = {
     email = "kb@devnulllabs.io";
     github = "kennyballou";

--- a/pkgs/tools/audio/midimonster/default.nix
+++ b/pkgs/tools/audio/midimonster/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, stdenv
+, fetchurl
+, zlib
+, fetchFromGitHub
+, gnumake
+, gcc
+, pkg-config
+, lua5_4
+, openssl
+, jack1
+, python3
+, alsa-lib
+, ncurses
+, libevdev
+}:
+
+stdenv.mkDerivation rec {
+  pname = "midimonster";
+  version = "0.6.0";
+
+  buildInputs = [pkg-config gnumake gcc lua5_4 openssl jack1 python3 alsa-lib ncurses libevdev];
+
+  src = fetchFromGitHub {
+    repo = "midimonster";
+    owner = "cbdevnet";
+    rev = "f16f7db86662fcdbf45b6373257c90c824b0b4b0";
+    sha256 = "131zs4j9asq9xl72cbyi463xpkj064ca1s7i77q5jrwqysgy52sp";
+};
+
+  doCheck = true;
+  enableParallelBuilding = true;
+
+  outputs = ["out" "man"];
+
+  buildPhase = ''
+    PLUGINS=$out/lib/midimonster make all
+  '';
+
+  installPhase = ''
+    PREFIX=$out make install
+
+    mkdir -p "$man/share/man/man1"
+    cp assets/midimonster.1 "$man/share/man/man1"
+
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    cp assets/MIDIMonster.svg "$out/share/icons/hicolor/scalable/apps/"
+  '';
+
+  meta = with lib; {
+    homepage = "https://midimonster.net";
+    description = "Multi-protocol translation tool";
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [keldu];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1058,6 +1058,8 @@ with pkgs;
 
   metapixel = callPackage ../tools/graphics/metapixel { };
 
+  midimonster = callPackage ../tools/audio/midimonster { };
+
   pferd = callPackage ../tools/misc/pferd {};
 
   qFlipper = libsForQt515.callPackage ../tools/misc/qflipper { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Midimonster is a powerful protocol translation tool which translates a multitude of lighting, audio and input protocols between each other with a simple config language. More complicated logic is available through the use of lua.
I am not the main developer, but I am associated with the project. I am quite new to NixOS, so I'm currently not completely familiar with every feature or process, but I tried to conform to every part I could find.  

###### Things done

The project doesn't have any unit/integration tests and I am not sure how I would test the config files.  

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)(Note: Tested with every provided example cfg. In ./result/share/midimonster)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


