### PR TITLE
certipy: unstable-2021-11-08 -> 2.0

### DIFF
--- a/pkgs/development/python-modules/dsinternals/default.nix
+++ b/pkgs/development/python-modules/dsinternals/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pycryptodomex
+, pyopenssl
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "dsinternals";
+  version = "1.2.4";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "p0dalirius";
+    repo = "pydsinternals";
+    rev = version;
+    hash = "sha256-C1ar9c4F4WI5ICX7PJe8FzVwK8bxZds+kMBpttEp9Ko=";
+  };
+
+  propagatedBuildInputs = [
+    pyopenssl
+    pycryptodomex
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "dsinternals"
+  ];
+
+  pytestFlagsArray = [
+    "tests/*.py"
+  ];
+
+  meta = with lib; {
+    description = "Module to interact with Windows Active Directory";
+    homepage = "https://github.com/p0dalirius/pydsinternals";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/tools/security/certipy/default.nix
+++ b/pkgs/tools/security/certipy/default.nix
@@ -5,22 +5,23 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "certipy";
-  version = "unstable-2021-11-08";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "ly4k";
     repo = "Certipy";
-    rev = "c2f5581505c54f3bf9fe4e6f07c17fa9ef501cab";
-    sha256 = "0m2n30prqd9d02kmryk8vry4cabcad1892qr8a02qfg6r98x8q3q";
+    rev = version;
+    hash = "sha256-xN0DrLrxWNCEy3HodA1pOJHYhDyA1sMRVIfefbXq45E=";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
     asn1crypto
-    pycryptodome
+    dnspython
+    dsinternals
     impacket
     ldap3
     pyasn1
-    dnspython
+    pycryptodome
   ];
 
   # Project has no tests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2462,6 +2462,8 @@ in {
 
   ds4drv = callPackage ../development/python-modules/ds4drv { };
 
+  dsinternals = callPackage ../development/python-modules/dsinternals { };
+
   dsmr-parser = callPackage ../development/python-modules/dsmr-parser { };
 
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/ly4k/Certipy/releases/tag/2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
