### PR TITLE
nixos: only run iso and boot tests on stable branch

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -48,18 +48,22 @@ in rec {
       constituents = pkgs.lib.concatLists [
         [ "nixos.channel" ]
         (onFullSupported "nixos.dummy")
-        (onAllSupported "nixos.iso_minimal")
-        (onSystems ["x86_64-linux" "aarch64-linux"] "nixos.amazonImage")
-        (onSystems ["x86_64-linux"] "nixos.iso_plasma5")
-        (onSystems ["x86_64-linux"] "nixos.iso_gnome")
+
+        (pkgs.lib.optionals stableBranch (pkgs.lib.concatLists [
+          (onAllSupported "nixos.iso_minimal")
+          (onSystems ["x86_64-linux" "aarch64-linux"] "nixos.amazonImage")
+          (onSystems ["x86_64-linux"] "nixos.iso_plasma5")
+          (onSystems ["x86_64-linux"] "nixos.iso_gnome")
+          (onSystems ["x86_64-linux"] "nixos.ova")
+          (onSystems ["aarch64-linux"] "nixos.sd_image")
+          (onSystems ["x86_64-linux"] "nixos.tests.boot.biosCdrom")
+          (onSystems ["x86_64-linux"] "nixos.tests.boot.biosUsb")
+          (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiCdrom")
+          (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiUsb")
+        ]))
+
         (onFullSupported "nixos.manual")
-        (onSystems ["x86_64-linux"] "nixos.ova")
-        (onSystems ["aarch64-linux"] "nixos.sd_image")
-        (onSystems ["x86_64-linux"] "nixos.tests.boot.biosCdrom")
-        (onSystems ["x86_64-linux"] "nixos.tests.boot.biosUsb")
         (onFullSupported "nixos.tests.boot-stage1")
-        (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiCdrom")
-        (onSystems ["x86_64-linux"] "nixos.tests.boot.uefiUsb")
         (onSystems ["x86_64-linux"] "nixos.tests.chromium")
         (onFullSupported "nixos.tests.containers-imperative")
         (onFullSupported "nixos.tests.containers-ip")


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Currently hydra runs a lot of tests for all of nixos/nixpkgs channels. If any of those tests are failing, the channel does not get updated. In addition, running some of these tests is quite heavy on resources.

Last week nixos-unstable was blocked by a gnome ISO test. The ISO doesn't get used on unstable, but still the channel did not get updated for a week until this problem was solved.

Several discussions have spawned as a result of this. One of which: https://discourse.nixos.org/t/considering-new-installation-approaches/17778. In this past such problems have arisen and @edolstra [suggested](https://github.com/NixOS/nixpkgs/pull/66640#issuecomment-522131320):

> Maybe ISO (and other image) generation should be moved out of the main jobsets into a jobset that runs at a lower frequency. After all, channel users don't really care whether the ISOs built correctly, so ISOs don't need to be a channel blocker.

I couldn't really figure out how to create new jobsets in Hydra that way, but it seemed like a step in that direction to avoid building ISOs for unstable channels, like nixos-unstable.

That is what this PR attempts to do. Only build ISOs, OVA, SD images and run boot tests on stable channels and avoid doing that on unstable ones.

Conveniently there already was an indication of `stableBranch` that gets passed to Nix in Hydra. This option's value can be found in the configuration tab of nixos jobsets, for example: https://hydra.nixos.org/jobset/nixos/trunk-combined#tabs-configuration.

Is this a step forwards? Let me know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
