### PR TITLE
libxml2: 2.9.12 → 2.9.13

### DIFF
--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -14,7 +14,7 @@
 , libiconv
 , pythonSupport ? enableShared && stdenv.buildPlatform == stdenv.hostPlatform
 , icuSupport ? false
-, icu ? null
+, icu
 , enableShared ? stdenv.hostPlatform.libc != "msvcrt" && !stdenv.hostPlatform.isStatic
 , enableStatic ? !enableShared
 , gnome
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
   ];
 
   installFlags = lib.optionals pythonSupport [
-    "pythondir=\"${placeholder "py"}/lib/${python.libPrefix}/site-packages\""
+    "pythondir=\"${placeholder "py"}/${python.sitePackages}\""
   ];
 
   enableParallelBuilding = true;
@@ -109,8 +109,9 @@ stdenv.mkDerivation rec {
     MACOSX_DEPLOYMENT_TARGET=10.16
   '';
 
-  preInstall = lib.optionalString pythonSupport
-    ''substituteInPlace python/libxml2mod.la --replace "${python}" "$py"'';
+  preInstall = lib.optionalString pythonSupport ''
+    substituteInPlace python/libxml2mod.la --replace "${python}" "$py"
+  '';
 
   postFixup = ''
     moveToOutput bin/xml2-config "$dev"

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    "--exec_prefix=$dev"
+    "--exec-prefix=${placeholder "dev"}"
     (lib.enableFeature enableStatic "static")
     (lib.enableFeature enableShared "shared")
     (lib.withFeature icuSupport "icu")

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -102,12 +102,6 @@ stdenv.mkDerivation rec {
     MACOSX_DEPLOYMENT_TARGET=10.16
   '';
 
-  # disable test that's problematic with newer pythons: see
-  # https://mail.gnome.org/archives/xml/2017-August/msg00014.html
-  preCheck = lib.optionalString (pythonSupport && !(python?pythonOlder && python.pythonOlder "3.5")) ''
-    echo "" > python/tests/tstLastError.py
-  '';
-
   preInstall = lib.optionalString pythonSupport
     ''substituteInPlace python/libxml2mod.la --replace "${python}" "$py"'';
 

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -134,6 +134,6 @@ stdenv.mkDerivation rec {
     description = "XML parsing library for C";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ eelco ];
+    maintainers = with maintainers; [ eelco jtojnar ];
   };
 }

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , zlib
 , pkg-config
 , autoreconfHook
@@ -22,7 +21,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libxml2";
-  version = "2.9.12";
+  version = "2.9.13";
 
   outputs = [ "bin" "dev" "out" "man" "doc" ]
     ++ lib.optional pythonSupport "py"
@@ -30,7 +29,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "KKkvarHzEaz15HhWTEkIjvCsdwkNnHGbvF1Rjx/mLrk=";
+    sha256 = "J2EwYC0S/khOzANEfuXnWdBGVVj7yda9FE43RTBuvw4=";
   };
 
   patches = [
@@ -46,13 +45,6 @@ stdenv.mkDerivation rec {
     #   https://github.com/NixOS/nixpkgs/pull/63174
     #   https://github.com/NixOS/nixpkgs/pull/72342
     ./utf8-xmlErrorFuncHandler.patch
-
-    # Work around lxml API misuse.
-    # https://gitlab.gnome.org/GNOME/libxml2/issues/255
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/libxml2/commit/85b1792e37b131e7a51af98a37f92472e8de5f3f.patch";
-      sha256 = "epqlNs2S0Zczox3KyCB6R2aJKh87lXydlZ0x6tLHweE=";
-    })
   ];
 
   strictDeps = true;
@@ -110,7 +102,7 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = lib.optionalString pythonSupport ''
-    substituteInPlace python/libxml2mod.la --replace "${python}" "$py"
+    substituteInPlace python/libxml2mod.la --replace "$dev/${python.sitePackages}" "$py/${python.sitePackages}"
   '';
 
   postFixup = ''

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -15,6 +15,7 @@
 , icu ? null
 , enableShared ? stdenv.hostPlatform.libc != "msvcrt" && !stdenv.hostPlatform.isStatic
 , enableStatic ? !enableShared
+, gnome
 }:
 
 stdenv.mkDerivation rec {
@@ -26,8 +27,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional (enableStatic && enableShared) "static";
 
   src = fetchurl {
-    url = "http://xmlsoft.org/sources/${pname}-${version}.tar.gz";
-    sha256 = "14hxwzmf5xqppx77z7i0ni9lpzg1a84dqpf8j8l1fvy570g6imn8";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "KKkvarHzEaz15HhWTEkIjvCsdwkNnHGbvF1Rjx/mLrk=";
   };
 
   patches = [
@@ -121,6 +122,11 @@ stdenv.mkDerivation rec {
   passthru = {
     inherit version;
     pythonSupport = pythonSupport;
+
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -3,6 +3,8 @@
 , fetchurl
 , fetchpatch
 , zlib
+, pkg-config
+, autoreconfHook
 , xz
 , libintl
 , python
@@ -54,6 +56,11 @@ stdenv.mkDerivation rec {
   ];
 
   strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
 
   buildInputs = lib.optionals pythonSupport [
     python

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,6 +1,13 @@
-{ lib, stdenv, fetchurl, fetchpatch
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
 , pkg-config
-, libxml2, findXMLCatalogs, gettext, python, libgcrypt
+, libxml2
+, findXMLCatalogs
+, gettext
+, python
+, libgcrypt
 , cryptoSupport ? false
 , pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform
 }:
@@ -8,6 +15,8 @@
 stdenv.mkDerivation rec {
   pname = "libxslt";
   version = "1.1.34";
+
+  outputs = [ "bin" "dev" "out" "man" "doc" ] ++ lib.optional pythonSupport "py";
 
   src = fetchurl {
     url = "http://xmlsoft.org/sources/${pname}-${version}.tar.gz";
@@ -23,25 +32,34 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  outputs = [ "bin" "dev" "out" "man" "doc" ] ++ lib.optional pythonSupport "py";
-
   nativeBuildInputs = [
     pkg-config
   ];
 
-  buildInputs = [ libxml2.dev ]
-    ++ lib.optional stdenv.isDarwin gettext
-    ++ lib.optionals pythonSupport [ libxml2.py python ]
-    ++ lib.optionals cryptoSupport [ libgcrypt ];
+  buildInputs = [
+    libxml2.dev
+  ] ++ lib.optional stdenv.isDarwin [
+    gettext
+  ] ++ lib.optionals pythonSupport [
+    libxml2.py
+    python
+  ] ++ lib.optionals cryptoSupport [
+    libgcrypt
+  ];
 
-  propagatedBuildInputs = [ findXMLCatalogs ];
+  propagatedBuildInputs = [
+    findXMLCatalogs
+  ];
 
   configureFlags = [
     "--without-debug"
     "--without-mem-debug"
     "--without-debugger"
-  ] ++ lib.optional pythonSupport "--with-python=${python}"
-    ++ lib.optional (!cryptoSupport) "--without-crypto";
+  ] ++ lib.optionals pythonSupport [
+    "--with-python=${python}"
+  ] ++ lib.optionals (!cryptoSupport) [
+    "--without-crypto"
+  ];
 
   postFixup = ''
     moveToOutput bin/xslt-config "$dev"
@@ -62,7 +80,7 @@ stdenv.mkDerivation rec {
     description = "A C library and tools to do XSL transformations";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ maintainers.eelco ];
-    broken = !(pythonSupport -> libxml2.pythonSupport); # see #73102 for why this is not an assert
+    maintainers = with maintainers; [ eelco ];
+    broken = pythonSupport && !libxml2.pythonSupport; # see #73102 for why this is not an assert
   };
 }

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -10,6 +10,7 @@
 , libgcrypt
 , cryptoSupport ? false
 , pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform
+, gnome
 }:
 
 stdenv.mkDerivation rec {
@@ -19,8 +20,8 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "man" "doc" ] ++ lib.optional pythonSupport "py";
 
   src = fetchurl {
-    url = "http://xmlsoft.org/sources/${pname}-${version}.tar.gz";
-    sha256 = "0zrzz6kjdyavspzik6fbkpvfpbd25r2qg6py5nnjaabrsr3bvccq";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "KMR9szq02u+mIy8xzLPGUmDIJRUeyG7EYTVSR/P1aCQ=";
   };
 
   patches = [
@@ -73,6 +74,11 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit pythonSupport;
+
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     description = "A C library and tools to do XSL transformations";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ eelco ];
+    maintainers = with maintainers; [ eelco jtojnar ];
     broken = pythonSupport && !libxml2.pythonSupport; # see #73102 for why this is not an assert
   };
 }

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchurl
 , pkg-config
+, autoreconfHook
 , libxml2
 , findXMLCatalogs
 , gettext
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+    autoreconfHook
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -1,12 +1,12 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , pkg-config
 , libxml2
 , findXMLCatalogs
 , gettext
 , python
+, ncurses
 , libgcrypt
 , cryptoSupport ? false
 , pythonSupport ? stdenv.buildPlatform == stdenv.hostPlatform
@@ -15,23 +15,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libxslt";
-  version = "1.1.34";
+  version = "1.1.35";
 
   outputs = [ "bin" "dev" "out" "man" "doc" ] ++ lib.optional pythonSupport "py";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "KMR9szq02u+mIy8xzLPGUmDIJRUeyG7EYTVSR/P1aCQ=";
+    sha256 = "gkfzPpqHLGrIWapFAYvExNALl+L+rJ7rwQyTzh803Xk=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Fixes use-after-free in xsltApplyTemplates
-      name = "CVE-2021-30560.patch";
-      url = "https://gitlab.gnome.org/GNOME/libxslt/-/commit/50f9c9cd3b7dfe9b3c8c795247752d1fdcadcac8.patch";
-      hash = "sha256-XJD9SBo8xzztQQ6g13h4IzID7HV7u3xWSQdb2rVCJBQ=";
-    })
-  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -44,6 +35,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals pythonSupport [
     libxml2.py
     python
+    ncurses
   ] ++ lib.optionals cryptoSupport [
     libgcrypt
   ];


### PR DESCRIPTION
###### Motivation for this change

Fix CVE-2022-23308

https://mail.gnome.org/archives/xml/2022-February/msg00009.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
