### PR TITLE
mesa: 21.3.8 -> 22.0.1

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -6,7 +6,6 @@
 , libelf, libvdpau
 , libglvnd, libunwind
 , galliumDrivers ? ["auto"]
-, driDrivers ? ["auto"]
 , vulkanDrivers ? ["auto"]
 , eglPlatforms ? [ "x11" ] ++ lib.optionals stdenv.isLinux [ "wayland" ]
 , OpenGL, Xplugin
@@ -34,7 +33,7 @@ with lib;
 let
   # Release calendar: https://www.mesa3d.org/release-calendar.html
   # Release frequency: https://www.mesa3d.org/releasing.html#schedule
-  version = "21.3.8";
+  version = "22.0.1";
   branch  = versions.major version;
 
 self = stdenv.mkDerivation {
@@ -48,7 +47,7 @@ self = stdenv.mkDerivation {
       "ftp://ftp.freedesktop.org/pub/mesa/${version}/mesa-${version}.tar.xz"
       "ftp://ftp.freedesktop.org/pub/mesa/older-versions/${branch}.x/${version}/mesa-${version}.tar.xz"
     ];
-    sha256 = "19wx5plk6z0hhi0zdzxjx8ynl3lhlc5mbd8vhwqyk92kvhxjf3g7";
+    sha256 = "0vs20kyq9sxh52hd242yf7nz2wzw6di8jw7s19pb6q25qn19cpy0";
   };
 
   # TODO:
@@ -114,7 +113,6 @@ self = stdenv.mkDerivation {
     "-Ddri-search-path=${libglvnd.driverLink}/lib/dri"
 
     "-Dplatforms=${concatStringsSep "," eglPlatforms}"
-    "-Ddri-drivers=${concatStringsSep "," driDrivers}"
     "-Dgallium-drivers=${concatStringsSep "," galliumDrivers}"
     "-Dvulkan-drivers=${concatStringsSep "," vulkanDrivers}"
 


### PR DESCRIPTION
The DRI drivers were removed [0]:
> Mesa's main branch no longer has any "classic" drivers, use the
> "amber" branch instead.

Mesa 21.3 provided the following DRI drivers:
i915 i965 r100 r200 nouveau

For nouveau, there is a Gallium3D driver as well, and i965 can be
replaced with iris or crocus (iris was already the default for
generation 8+ Intel iGPUs and crocus is a new driver for older hardware
that supports generation 4 to 7 iGPUs [1]).
(See also [2] for some more information.)

[0]: https://gitlab.freedesktop.org/mesa/mesa/-/commit/cdde031ac2c8124721655532ee6f4149e20e9c61
[1]: https://airlied.blogspot.com/2021/04/crocus-gallium-for-gen4-7-generation.html
[2]: https://www.phoronix.com/scan.php?page=news_item&px=2021-Retire-Mesa-Classic-Main
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

TODO: Maybe link https://www.phoronix.com/scan.php?page=news_item&px=Mesa-Classic-Retired

~~Note: Doesn't build yet:~~
```
substituteStream(): WARNING: pattern '/nix/store/k00dkq3m5n2ccsqmyk8qv8hcp7ywckk1-mesa-22.0.0-rc2-drivers' doesn't match anything in file '/nix/store/b5yddns201xx8igq7absc7g75r4scfb6-mesa-22.0.0-rc2-dev/lib/pkgconfig/dri.pc'
error: cycle detected in build of '/nix/store/a2gs16c88ynld0cx7r59j2dqivsa1q6a-mesa-22.0.0-rc2.drv' in the references of output 'out' from output 'drivers'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
