### PR TITLE
libgovirt: clean up

### DIFF
--- a/pkgs/applications/virtualization/libgovirt/default.nix
+++ b/pkgs/applications/virtualization/libgovirt/default.nix
@@ -2,38 +2,52 @@
 , stdenv
 , fetchurl
 , glib
+, gnome
 , librest
 , libsoup
 , pkg-config
+, gobject-introspection
 }:
-
-with lib;
 
 stdenv.mkDerivation rec {
   pname = "libgovirt";
   version = "0.3.8";
 
-  src = fetchurl {
-    url = "https://download.gnome.org/sources/libgovirt/0.3/${pname}-${version}.tar.xz";
-    sha256 = "sha256-HckYYikXa9+p8l/Y+oLAoFi2pgwcyAfHUH7IqTwPHfg=";
-  };
+  outputs = [ "out" "dev" ];
 
-  enableParallelBuilding = true;
+  src = fetchurl {
+    url = "mirror://gnome/sources/libgovirt/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "HckYYikXa9+p8l/Y+oLAoFi2pgwcyAfHUH7IqTwPHfg=";
+  };
 
   nativeBuildInputs = [
     pkg-config
+    gobject-introspection
   ];
 
-  propagatedBuildInputs = [
-    librest
+  buildInputs = [
     libsoup
   ];
 
-  meta = {
+  propagatedBuildInputs = [
+    glib
+    librest
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
+  };
+
+  meta = with lib; {
     homepage = "https://gitlab.gnome.org/GNOME/libgovirt";
     description = "GObject wrapper for the oVirt REST API";
     maintainers = [ maintainers.amarshall ];
     platforms = platforms.linux;
-    license = licenses.lgpl21;
+    license = licenses.lgpl21Plus;
   };
 }

--- a/pkgs/development/libraries/librest/default.nix
+++ b/pkgs/development/libraries/librest/default.nix
@@ -6,6 +6,9 @@
 , libsoup
 , libxml2
 , gobject-introspection
+, gtk-doc
+, docbook-xsl-nons
+, docbook_xml_dtd_412
 , gnome
 }:
 
@@ -13,7 +16,7 @@ stdenv.mkDerivation rec {
   pname = "rest";
   version = "0.8.1";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -23,6 +26,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     gobject-introspection
+    gtk-doc
+    docbook-xsl-nons
+    docbook_xml_dtd_412
   ];
 
   propagatedBuildInputs = [
@@ -32,6 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
+    "--enable-gtk-doc"
     # Remove when https://gitlab.gnome.org/GNOME/librest/merge_requests/2 is merged.
     "--with-ca-certificates=/etc/ssl/certs/ca-certificates.crt"
   ];

--- a/pkgs/development/libraries/librest/default.nix
+++ b/pkgs/development/libraries/librest/default.nix
@@ -4,6 +4,7 @@
 , pkg-config
 , glib
 , libsoup
+, libxml2
 , gobject-introspection
 , gnome
 }:
@@ -11,6 +12,8 @@
 stdenv.mkDerivation rec {
   pname = "rest";
   version = "0.8.1";
+
+  outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -22,9 +25,10 @@ stdenv.mkDerivation rec {
     gobject-introspection
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     glib
     libsoup
+    libxml2
   ];
 
   configureFlags = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- Split outputs to prevent closure contamination with propagated dependencies’ dev outputs.
- Use mirror URL.
- Add update script (also change source URL so it can be auto-updated).
- Correct dependencies:
  - Even though glib is propagated by other dependencies, let’s add it here as well for completeness.
  - libsoup should not need to be propagated.
- Add gobject-introspection.
- Use correct non-deprecated license.
- Reduce scope of lib.

Ideally, we would also switch to Meson but it currently specifies dependencies incorrectly:
https://gitlab.gnome.org/GNOME/libgovirt/-/merge_requests/15


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc @amarshall 