### PR TITLE
pacman: 5.2.2 -> 6.0.1

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -1,40 +1,83 @@
-{ stdenv, lib, fetchurl, pkg-config, m4, perl, libarchive, openssl, zlib, bzip2,
-xz, curl, runtimeShell }:
+{ lib
+, stdenv
+, fetchurl
+, asciidoc
+, bzip2
+, coreutils
+, curl
+, gpgme
+, installShellFiles
+, libarchive
+, meson
+, ninja
+, openssl
+, perl
+, pkg-config
+, python3
+, runtimeShell
+, xz
+, zlib
+}:
 
 stdenv.mkDerivation rec {
   pname = "pacman";
-  version = "5.2.2";
+  version = "6.0.1";
 
   src = fetchurl {
-    url = "https://sources.archlinux.org/other/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "1829jcc300fxidr3cahx5kpnxkpg500daqgn2782hg5m5ygil85v";
+    url = "https://sources.archlinux.org/other/${pname}/${pname}-${version}.tar.xz";
+    hash = "sha256-DbYUVuVqpJ4mDokcCwJb4hAxnmKxVSHynT6TsA079zE=";
   };
 
-  enableParallelBuilding = true;
-
-  configureFlags = [
-    # trying to build docs fails with a2x errors, unable to fix through asciidoc
-    "--disable-doc"
-
-    "--sysconfdir=/etc"
-    "--localstatedir=/var"
-    "--with-scriptlet-shell=${runtimeShell}"
+  nativeBuildInputs = [
+    asciidoc
+    coreutils
+    installShellFiles
+    meson
+    ninja
+    pkg-config
+    python3
   ];
 
-  installFlags = [ "sysconfdir=${placeholder "out"}/etc" ];
+  buildInputs = [
+    bzip2
+    curl
+    gpgme
+    libarchive
+    openssl
+    perl
+    xz
+    zlib
+  ];
 
-  nativeBuildInputs = [ pkg-config m4 ];
-  buildInputs = [ curl perl libarchive openssl zlib bzip2 xz ];
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "install_dir : SYSCONFDIR" "install_dir : '${placeholder "out"}/etc'" \
+      --replace "join_paths(LOCALSTATEDIR, 'lib/pacman/')," "'${placeholder "out"}/var/lib/pacman/'," \
+      --replace "join_paths(LOCALSTATEDIR, 'cache/pacman/pkg/')," "'${placeholder "out"}/var/cache/pacman/pkg/',"
 
-  postFixup = ''
-    substituteInPlace $out/bin/repo-add \
+    substituteInPlace doc/meson.build \
+      --replace "/bin/true" "${coreutils}/bin/true"
+
+    substituteInPlace scripts/repo-add.sh.in \
       --replace bsdtar "${libarchive}/bin/bsdtar"
+  '';
+
+  mesonFlags = [
+    "--sysconfdir=/etc"
+    "--localstatedir=/var"
+    "-Dmakepkg-template-dir=${placeholder "out"}/share/makepkg-template"
+    "-Dscriptlet-shell=${runtimeShell}"
+  ];
+
+  postInstall = ''
+    installShellCompletion --bash scripts/pacman --zsh scripts/_pacman
   '';
 
   meta = with lib; {
     description = "A simple library-based package manager";
-    homepage = "https://www.archlinux.org/pacman/";
-    license = licenses.gpl2;
+    homepage = "https://archlinux.org/pacman/";
+    changelog = "https://gitlab.archlinux.org/pacman/pacman/-/raw/v${version}/NEWS";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ mt-caret ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Package update.

It takes some patching of `meson.build` to have the same behaviour as pacman 5.x : configure the tools to use /etc and /var by default but install files under $out/etc and $out/var.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
