### PR TITLE
dwarf2json: init at unstable-2021-04-15

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -850,6 +850,11 @@ in mkLicense lset) ({
     free = false;
   };
 
+  vol-sl = {
+    fullName = "Volatility Software License, Version 1.0";
+    url = "https://www.volatilityfoundation.org/license/vsl-v1.0";
+  };
+
   vsl10 = {
     spdxId = "VSL-1.0";
     fullName = "Vovida Software License v1.0";

--- a/pkgs/tools/misc/dwarf2json/default.nix
+++ b/pkgs/tools/misc/dwarf2json/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, buildGoModule }:
+
+buildGoModule rec {
+  pname = "dwarf2json";
+  version = "unstable-2021-04-15";
+
+  src = fetchFromGitHub {
+    owner = "volatilityfoundation";
+    repo = "dwarf2json";
+    rev = "e8a1ce85dc33bf2039adc7f8a5f47f3016153720";
+    sha256 = "sha256-hnS00glAcj78mZp5as63CsEn+dcr+GNEkz8iC3KM0h0=";
+  };
+
+  vendorSha256 = "sha256-tgs0l+sYdAxMHwVTew++keNpDyrHmevpmOBVIiuL+34=";
+
+  meta = with lib; {
+    homepage = "https://github.com/volatilityfoundation/dwarf2json";
+    description = "Convert ELF/DWARF symbol and type information into vol3's intermediate JSON";
+    license = licenses.vol-sl;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ arkivm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -479,6 +479,8 @@ with pkgs;
 
   dump1090 = callPackage ../applications/radio/dump1090 { };
 
+  dwarf2json = callPackage ../tools/misc/dwarf2json { };
+
   ebook2cw = callPackage ../applications/radio/ebook2cw { };
 
   edwin = callPackage ../data/fonts/edwin { };


### PR DESCRIPTION
###### Motivation for this change

* Add Volatility Software License
* dwarf2json is a utility to convert dwarf symbols and type information into a volatility's JSON format

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
