### PR TITLE
python3Packages.reolink: 0053 -> 0.60

### DIFF
--- a/pkgs/development/python-modules/ffmpeg-python/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-python/default.nix
@@ -1,24 +1,37 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, substituteAll
-, pytestCheckHook
 , ffmpeg
 , future
-, pytest-runner
 , pytest-mock
+, pytestCheckHook
+, pythonAtLeast
+, pythonOlder
+, substituteAll
 }:
 
 buildPythonPackage rec {
   pname = "ffmpeg-python";
   version = "0.2.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "kkroening";
     repo = "ffmpeg-python";
     rev = version;
-    sha256 = "0mmydmfz3yiclbgi4lqrv9fh2nalafg4bkm92y2qi50mwqgffk8f";
+    hash = "sha256-Dk3nHuYVlIiFF6nORZ5TVFkBXdoZUxLfoiz68V1tvlY=";
   };
+
+  propagatedBuildInputs = [
+    future
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
 
   patches = [
     (substituteAll {
@@ -27,14 +40,23 @@ buildPythonPackage rec {
     })
   ];
 
-  buildInputs = [ pytest-runner ];
-  propagatedBuildInputs = [ future ];
-  checkInputs = [ pytestCheckHook pytest-mock ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "'pytest-runner'" ""
+  '';
+
+  pythonImportsCheck = [
+    "ffmpeg"
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.10") [
+    "test__output__video_size"
+  ];
 
   meta = with lib; {
     description = "Python bindings for FFmpeg - with complex filtering support";
     homepage = "https://github.com/kkroening/ffmpeg-python";
     license = licenses.asl20;
-    maintainers = [ maintainers.AluisioASG ];
+    maintainers = with maintainers; [ AluisioASG ];
   };
 }

--- a/pkgs/development/python-modules/reolink/default.nix
+++ b/pkgs/development/python-modules/reolink/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "reolink";
-  version = "0053";
+  version = "0.60";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "fwestenberg";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0qjp7n2qa9n9fdhfcgfgw89hy19z5144cxhkhmhv1xnfdiz175qd";
+    sha256 = "sha256-4yk05obra0icWHPXaJ+Wj+xxDRkVYg/VsrXTQUdHJIc=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/fwestenberg/reolink/releases/tag/v0.60

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
