### PR TITLE
pridecat: init at unstable-2020-06-19

### DIFF
--- a/pkgs/tools/misc/pridecat/default.nix
+++ b/pkgs/tools/misc/pridecat/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "pridecat";
+  version = "unstable-2020-06-19";
+
+  src = fetchFromGitHub {
+    owner = "lunasorcery";
+    repo = "pridecat";
+    rev = "92396b11459e7a4b5e8ff511e99d18d7a1589c96";
+    sha256 = "sha256-PyGLbbsh9lFXhzB1Xn8VQ9zilivycGFEIc7i8KXOxj8=";
+  };
+
+  # fixes the install path in the Makefile
+  patches = [ ./fix_install.patch ];
+
+  meta = with lib; {
+    description = "Like cat, but more colorful";
+    homepage = "https://github.com/lunasorcery/pridecat";
+    license = licenses.cc-by-nc-sa-40;
+    maintainers = with maintainers; [ lunarequest ];
+  };
+}

--- a/pkgs/tools/misc/pridecat/fix_install.patch
+++ b/pkgs/tools/misc/pridecat/fix_install.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile b/Makefile
+index 815c27e..1556807 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,5 @@
+ CXX ?= clang
++out ?= /usr/local
+ 
+ all: pridecat
+ 
+@@ -6,7 +7,8 @@ pridecat: main.cpp
+ 	$(CXX) main.cpp -o pridecat -std=c++11 -lstdc++ -Wall -Wextra -O3
+ 
+ install: pridecat
+-	cp pridecat /usr/local/bin/pridecat
++	mkdir -p ${out}/bin	
++	cp pridecat ${out}/bin/pridecat
+ 
+ uninstall:
+ 	rm -f /usr/local/bin/pridecat

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -361,9 +361,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  pridecat = callPackage ../tools/misc/pridecat { };
+
   proto-contrib = callPackage ../development/tools/proto-contrib { };
 
-  protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc {};
+  protoc-gen-doc = callPackage ../development/tools/protoc-gen-doc { };
 
   protoc-gen-go = callPackage ../development/tools/protoc-gen-go { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
