### PR TITLE
gitUpdater: init

### DIFF
--- a/pkgs/applications/audio/r128gain/default.nix
+++ b/pkgs/applications/audio/r128gain/default.nix
@@ -1,8 +1,7 @@
 { lib
 , fetchFromGitHub
-, genericUpdater
+, gitUpdater
 , substituteAll
-, common-updater-scripts
 , ffmpeg
 , python3Packages
 , sox
@@ -33,12 +32,7 @@ python3Packages.buildPythonApplication rec {
   # sandbox to be disabled.
   doCheck = false;
 
-  passthru = {
-    updateScript = genericUpdater {
-      inherit pname version;
-      versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
-    };
-  };
+  passthru.updateScript = gitUpdater { inherit pname version; };
 
   meta = with lib; {
     description = "Fast audio loudness scanner & tagger (ReplayGain v2 / R128)";

--- a/pkgs/applications/blockchains/nbxplorer/util/update-common.sh
+++ b/pkgs/applications/blockchains/nbxplorer/util/update-common.sh
@@ -26,7 +26,7 @@ getRepo() {
 }
 
 getLatestVersionTag() {
-  "$nixpkgs"/pkgs/common-updater/scripts/list-git-tags https://github.com/$(getRepo) 2>/dev/null \
+  "$nixpkgs"/pkgs/common-updater/scripts/list-git-tags --url=https://github.com/$(getRepo) 2>/dev/null \
     | sort -V | tail -1 | sed 's|^v||'
 }
 

--- a/pkgs/applications/networking/shellhub-agent/default.nix
+++ b/pkgs/applications/networking/shellhub-agent/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 , makeWrapper
 , openssh
 }:
@@ -25,9 +24,8 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X main.AgentVersion=v${version}" ];
 
   passthru = {
-    updateScript = genericUpdater {
+    updateScript = gitUpdater {
       inherit pname version;
-      versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
       rev-prefix = "v";
       ignoredVersions = ".(rc|beta).*";
     };

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -4,8 +4,7 @@
 , pbr
 , requests
 , setuptools
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 }:
 
 buildPythonApplication rec {
@@ -42,10 +41,7 @@ buildPythonApplication rec {
 
   pythonImportsCheck = [ "git_review" ];
 
-  passthru.updateScript = genericUpdater {
-    inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
-  };
+  passthru.updateScript = gitUpdater { inherit pname version; };
 
   meta = with lib; {
     description = "Tool to submit code to Gerrit";

--- a/pkgs/applications/video/epgstation/update.nix
+++ b/pkgs/applications/video/epgstation/update.nix
@@ -13,7 +13,7 @@ let
     inherit pname version;
     attrPath = lib.toLower pname;
     rev-prefix = "v";
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${homepage}";
+    versionLister = "${common-updater-scripts}/bin/list-git-tags --url=${homepage}";
   };
   updateScript = builtins.elemAt updater 0;
   updateArgs = map (lib.escapeShellArg) (builtins.tail updater);

--- a/pkgs/applications/video/mirakurun/update.nix
+++ b/pkgs/applications/video/mirakurun/update.nix
@@ -17,7 +17,7 @@ let
 
     # exclude prerelease versions
     versionLister = writers.writeBash "list-mirakurun-versions" ''
-      ${common-updater-scripts}/bin/list-git-tags ${homepage} \
+      ${common-updater-scripts}/bin/list-git-tags --url=${homepage} \
         | grep '^[0-9]\+\.[0-9]\+\.[0-9]\+$'
     '';
   };

--- a/pkgs/applications/video/shotcut/default.nix
+++ b/pkgs/applications/video/shotcut/default.nix
@@ -17,8 +17,7 @@
 , qtgraphicaleffects
 , qmake
 , qttools
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 }:
 
 assert lib.versionAtLeast mlt.version "6.24.0";
@@ -76,9 +75,8 @@ mkDerivation rec {
     cp -r src/qml $out/share/shotcut/
   '';
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
     rev-prefix = "v";
   };
 

--- a/pkgs/common-updater/generic-updater.nix
+++ b/pkgs/common-updater/generic-updater.nix
@@ -55,7 +55,7 @@ let
       return 1
     }
 
-    tags=$($version_lister $pname ${fileForGitCommands}) || exit 1
+    tags=$($version_lister --pname=${pname} --file="${fileForGitCommands}") || exit 1
 
     # print available tags
     for tag in $tags; do

--- a/pkgs/common-updater/git-updater.nix
+++ b/pkgs/common-updater/git-updater.nix
@@ -1,0 +1,17 @@
+{ genericUpdater
+, common-updater-scripts
+}:
+
+{ pname
+, version
+, attrPath ? pname
+, ignoredVersions ? ""
+, rev-prefix ? ""
+, odd-unstable ? false
+, patchlevel-unstable ? false
+}:
+
+genericUpdater {
+  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  versionLister = "${common-updater-scripts}/bin/list-git-tags";
+}

--- a/pkgs/common-updater/http-two-levels-updater.nix
+++ b/pkgs/common-updater/http-two-levels-updater.nix
@@ -1,0 +1,19 @@
+{ lib
+, genericUpdater
+, common-updater-scripts
+}:
+
+{ pname
+, version
+, attrPath ? pname
+, ignoredVersions ? ""
+, rev-prefix ? ""
+, odd-unstable ? false
+, patchlevel-unstable ? false
+, url ? null
+}:
+
+genericUpdater {
+  inherit pname version attrPath ignoredVersions rev-prefix odd-unstable patchlevel-unstable;
+  versionLister = "${common-updater-scripts}/bin/list-archive-two-levels-versions ${lib.optionalString (url != null) "--url=${url}"}";
+}

--- a/pkgs/common-updater/scripts/list-archive-two-level-versions
+++ b/pkgs/common-updater/scripts/list-archive-two-level-versions
@@ -2,25 +2,38 @@
 
 # lists all available versions listed for a package in a site (http)
 
-scriptName=list-archive-two-level-versions # do not use the .wrapped name
-
-usage() {
-    echo "Usage: $scriptName <archive url> [<package name> [<debug file path>]]"
-}
-
 archive="$1"  # archive url
 pname="$2"  # package name
 file="$3"  # file for writing debugging information
 
+while (( $# > 0 )); do
+    flag="$1"
+    shift 1
+    case "$flag" in
+        --url=*)
+            archive="${flag#*=}"
+            ;;
+        --pname=*)
+            pname="${flag#*=}"
+            ;;
+        --file=*)
+            version="${flag#*=}"
+            ;;
+        *)
+            echo "$0: unknown option ‘${flag}’"
+            exit 1
+            ;;
+    esac
+done
+
 if [ -z "$archive" ]; then
     echo "$scriptName: Missing archive url"
-    usage
     exit 1
 fi
 
 # print a debugging message
 if [ -n "$file" ]; then
-    echo "# Listing versions for $pname at $archive" >> $file
+    echo "# Listing versions for '$pname' at $archive" >> $file
 fi
 
 # list all major-minor versions from archive

--- a/pkgs/common-updater/scripts/list-archive-two-levels-versions
+++ b/pkgs/common-updater/scripts/list-archive-two-levels-versions
@@ -2,9 +2,9 @@
 
 # lists all available versions listed for a package in a site (http)
 
-archive="$1"  # archive url
-pname="$2"  # package name
-file="$3"  # file for writing debugging information
+archive=""  # archive url
+pname=""  # package name
+file=""  # file for writing debugging information
 
 while (( $# > 0 )); do
     flag="$1"
@@ -17,7 +17,7 @@ while (( $# > 0 )); do
             pname="${flag#*=}"
             ;;
         --file=*)
-            version="${flag#*=}"
+            file="${flag#*=}"
             ;;
         *)
             echo "$0: unknown option ‘${flag}’"
@@ -26,13 +26,19 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ -z "$archive" ]; then
-    echo "$scriptName: Missing archive url"
-    exit 1
+# by default set url to the base dir of the first url in src.urls
+if [[ -z "$archive" ]]; then
+    archive="$(nix-instantiate $systemArg --eval -E \
+                   "with import ./. {}; dirOf (dirOf (lib.head $UPDATE_NIX_ATTR_PATH.src.urls))" \
+            | tr -d '"')"
+fi
+
+if [[ -z "$pname" ]]; then
+    pname="$UPDATE_NIX_ATTR_PATH"
 fi
 
 # print a debugging message
-if [ -n "$file" ]; then
+if [[ -n "$file" ]]; then
     echo "# Listing versions for '$pname' at $archive" >> $file
 fi
 

--- a/pkgs/common-updater/scripts/list-git-tags
+++ b/pkgs/common-updater/scripts/list-git-tags
@@ -2,29 +2,50 @@
 
 # lists all available tags from a git repository
 
-scriptName=list-git-tags # do not use the .wrapped name
+echo "# pname=$UPDATE_NIX_ATTR_PATH" > /tmp/test.txt
 
-usage() {
-    echo "Usage: $scriptName <repository url> [<package name> [<debug file path>]]"
-}
+url="" # git repository url
+pname="" # package name
+file="" # file for writing debugging information
 
-repo="$1" # git repository url
-pname="$2" # package name
-file="$3" # file for writing debugging information
+while (( $# > 0 )); do
+    flag="$1"
+    shift 1
+    case "$flag" in
+        --url=*)
+            url="${flag#*=}"
+            ;;
+        --pname=*)
+            pname="${flag#*=}"
+            ;;
+        --file=*)
+            file="${flag#*=}"
+            ;;
+        *)
+            echo "$0: unknown option ‘${flag}’"
+            exit 1
+            ;;
+    esac
+done
 
-if [ -z "$repo" ]; then
-    echo "$scriptName: Missing git repository url"
-    usage
-    exit 1
+# By default we set url to src.url or src.meta.homepage
+if [[ -z "$url" ]]; then
+    url="$(nix-instantiate $systemArg --eval -E \
+               "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.url or $UPDATE_NIX_ATTR_PATH.src.meta.homepage" \
+        | tr -d '"')"
+fi
+
+if [[ -z "$pname" ]]; then
+    pname="$UPDATE_NIX_ATTR_PATH"
 fi
 
 # print a debugging message
-if [ -n "$file" ]; then
-    echo "# Listing tags for $pname at $repo" >> $file
+if [[ -n "$file" ]]; then
+    echo "# Listing tags for '$pname' at $url" >> $file
 fi
 
 # list all tags from the remote repository
-tags=$(git ls-remote --tags --refs "$repo")
+tags=$(git ls-remote --tags --refs "$url")
 
 # keep only the version part of the tag
 tags=$(echo "$tags" | cut --delimiter=/ --field=3)

--- a/pkgs/data/fonts/iosevka/update-default.sh
+++ b/pkgs/data/fonts/iosevka/update-default.sh
@@ -8,7 +8,7 @@ repo=https://github.com/be5invis/Iosevka
 
 # Discover the latest version.
 current_version=$(nix-instantiate "$nixpkgs" --eval --strict -A iosevka.version | tr -d '"')
-new_version=$(list-git-tags "$repo" | sort --reverse --version-sort | awk 'match($0, /^v([0-9.]+)$/, m) { print m[1]; exit; }')
+new_version=$(list-git-tags --url="$repo" | sort --reverse --version-sort | awk 'match($0, /^v([0-9.]+)$/, m) { print m[1]; exit; }')
 if [[ "$new_version" == "$current_version" ]]; then
     echo "iosevka: no update found"
     exit

--- a/pkgs/data/themes/marwaita/default.nix
+++ b/pkgs/data/themes/marwaita/default.nix
@@ -5,6 +5,7 @@
 , gtk-engine-murrine
 , gtk_engines
 , librsvg
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -36,6 +37,8 @@ stdenv.mkDerivation rec {
     cp -a Marwaita* $out/share/themes
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater {inherit pname version; };
 
   meta = with lib; {
     description = "GTK theme supporting Budgie, Pantheon, Mate, Xfce4 and GNOME desktops";

--- a/pkgs/desktops/lxqt/default.nix
+++ b/pkgs/desktops/lxqt/default.nix
@@ -4,10 +4,9 @@ let
 
     # Update script tailored to LXQt packages from git repository
     lxqtUpdateScript = { pname, version, src }:
-      pkgs.genericUpdater {
+      pkgs.gitUpdater {
         inherit pname version;
         attrPath = "lxqt.${pname}";
-        versionLister = "${pkgs.common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
       };
 
     # For compiling information, see:

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -10,7 +10,7 @@ let
       pkgs.genericUpdater {
         inherit pname version odd-unstable;
         attrPath = "mate.${pname}";
-        versionLister = "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions ${url}";
+        versionLister = "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions --url=${url}";
       };
 
     atril = callPackage ./atril { };

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -7,10 +7,9 @@ let
 
     # Update script tailored to mate packages from git repository
     mateUpdateScript = { pname, version, odd-unstable ? true, url ? "https://pub.mate-desktop.org/releases" }:
-      pkgs.genericUpdater {
-        inherit pname version odd-unstable;
+      pkgs.httpTwoLevelsUpdater {
+        inherit pname version odd-unstable url;
         attrPath = "mate.${pname}";
-        versionLister = "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions --url=${url}";
       };
 
     atril = callPackage ./atril { };

--- a/pkgs/desktops/mate/mate-tweak/default.nix
+++ b/pkgs/desktops/mate/mate-tweak/default.nix
@@ -9,8 +9,7 @@
 , gobject-introspection
 , wrapGAppsHook
 , glib
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -74,10 +73,9 @@ python3Packages.buildPythonApplication rec {
     done
   '';
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
     attrPath = "mate.${pname}";
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
   };
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister "apps" pname;

--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -38,10 +38,9 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
+  passthru.updateScript = xfce.archiveUpdater {
+    category = "apps";
     inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister "apps" pname;
   };
 
   meta = with lib; {

--- a/pkgs/desktops/xfce/art/xfce4-icon-theme/default.nix
+++ b/pkgs/desktops/xfce/art/xfce4-icon-theme/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/art/xfce4-icon-theme/default.nix
+++ b/pkgs/desktops/xfce/art/xfce4-icon-theme/default.nix
@@ -28,11 +28,7 @@ stdenv.mkDerivation rec {
 
   dontDropIconThemeCache = true;
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://www.xfce.org/";

--- a/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
+++ b/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
@@ -13,11 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MhTV8A6XA7XoyefDKH1gbe3scoXOtNXbMy6TraZv1XU=";
   };
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://www.xfce.org/";

--- a/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
+++ b/pkgs/desktops/xfce/art/xfwm4-themes/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MhTV8A6XA7XoyefDKH1gbe3scoXOtNXbMy6TraZv1XU=";
   };
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -3,13 +3,10 @@
 lib.makeScope pkgs.newScope (self: with self; {
   #### NixOS support
 
-  updateScript = pkgs.genericUpdater;
-
-  gitLister = url:
-    "${pkgs.common-updater-scripts}/bin/list-git-tags ${url}";
+  genericUpdater = pkgs.genericUpdater;
 
   archiveLister = category: name:
-    "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions https://archive.xfce.org/src/${category}/${name}";
+    "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions --url=https://archive.xfce.org/src/${category}/${name}";
 
   mkXfceDerivation = callPackage ./mkXfceDerivation.nix { };
 

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -5,8 +5,12 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   genericUpdater = pkgs.genericUpdater;
 
-  archiveLister = category: name:
-    "${pkgs.common-updater-scripts}/bin/list-archive-two-level-versions --url=https://archive.xfce.org/src/${category}/${name}";
+  archiveUpdater = { category, pname, version }:
+    pkgs.httpTwoLevelsUpdater {
+      inherit pname version;
+      attrPath = "xfce.${pname}";
+      url = "https://archive.xfce.org/src/${category}/${pname}";
+    };
 
   mkXfceDerivation = callPackage ./mkXfceDerivation.nix { };
 

--- a/pkgs/desktops/xfce/mkXfceDerivation.nix
+++ b/pkgs/desktops/xfce/mkXfceDerivation.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitLab, pkg-config, xfce4-dev-tools, hicolor-icon-theme, xfce, wrapGAppsHook }:
+{ lib, stdenv, fetchFromGitLab, pkg-config, xfce4-dev-tools, hicolor-icon-theme, xfce, wrapGAppsHook, gitUpdater }:
 
 { category
 , pname
@@ -41,9 +41,8 @@ let
 
     pos = builtins.unsafeGetAttrPos "pname" args;
 
-    passthru.updateScript = xfce.updateScript {
+    passthru.updateScript = gitUpdater {
       inherit pname version attrPath rev-prefix odd-unstable patchlevel-unstable;
-      versionLister = xfce.gitLister src.meta.homepage;
     };
 
     meta = with lib; {

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin/default.nix
@@ -45,11 +45,7 @@ in stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-cpugraph-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-cpugraph-plugin/default.nix
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
     hicolor-icon-theme
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     gtk2
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-embed-plugin/default.nix
@@ -33,11 +33,7 @@ in stdenv.mkDerivation rec {
     gtk2
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib;{
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-embed-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-eyes-plugin/default.nix
@@ -35,11 +35,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-eyes-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin/default.nix
@@ -35,11 +35,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-fsguard-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-fsguard-plugin/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin/default.nix
@@ -33,11 +33,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-genmon-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-genmon-plugin/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     libgcrypt
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin/default.nix
@@ -27,11 +27,7 @@ stdenv.mkDerivation rec {
     libgcrypt
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-mailwatch-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
@@ -27,11 +27,7 @@ stdenv.mkDerivation rec {
     exo
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-mpc-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     exo
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-namebar-plugin/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, pkg-config, fetchFromGitHub, python3, vala
-, gtk3, libwnck, libxfce4util, xfce4-panel, wafHook, xfce }:
+, gtk3, libwnck, libxfce4util, xfce4-panel, wafHook, xfce
+, gitUpdater
+}:
 
 stdenv.mkDerivation rec {
   pname = "xfce4-namebar-plugin";
@@ -20,10 +22,9 @@ stdenv.mkDerivation rec {
     substituteInPlace src/preferences.vala --replace 'var dir_strings = Environment.get_system_data_dirs()' "string[] dir_strings = { \"$out/share\" }"
   '';
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
-    versionLister = xfce.gitLister src.meta.homepage;
     rev-prefix = "v";
   };
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
@@ -31,11 +31,7 @@ in stdenv.mkDerivation rec {
     xfconf
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-notes-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-notes-plugin/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     xfconf
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
@@ -38,11 +38,7 @@ stdenv.mkDerivation rec {
     "--with-pathnetcat=${netcat-gnu}/bin/netcat"
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-sensors-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-sensors-plugin/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     "--with-pathnetcat=${netcat-gnu}/bin/netcat"
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
@@ -31,11 +31,7 @@ in stdenv.mkDerivation rec {
     xfconf
   ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-systemload-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-systemload-plugin/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     xfconf
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin/default.nix
@@ -28,11 +28,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-timer-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "format" ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = xfce.genericUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
     versionLister = xfce.archiveLister category pname;

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
@@ -31,11 +31,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = xfce.genericUpdater {
-    inherit pname version;
-    attrPath = "xfce.${pname}";
-    versionLister = xfce.archiveLister category pname;
-  };
+  passthru.updateScript = xfce.archiveUpdater { inherit category pname version; };
 
   meta = with lib; {
     homepage = "https://docs.xfce.org/panel-plugins/xfce4-weather-plugin";

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-windowck-plugin/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, intltool, python3, imagemagick, libwnck, libxfce4ui, xfce4-panel, xfconf, xfce4-dev-tools, xfce }:
+{ lib, stdenv, fetchFromGitHub, pkg-config, intltool, python3, imagemagick, libwnck, libxfce4ui, xfce4-panel, xfconf, xfce4-dev-tools, xfce, gitUpdater }:
 
 stdenv.mkDerivation rec {
   pname  = "xfce4-windowck-plugin";
@@ -33,10 +33,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
     attrPath = "xfce.${pname}";
-    versionLister = xfce.gitLister src.meta.homepage;
     rev-prefix = "v";
   };
 

--- a/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
+++ b/pkgs/desktops/xfce/thunar-plugins/dropbox/default.nix
@@ -6,6 +6,7 @@
 , cmake
 , ninja
 , xfce
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -30,10 +31,9 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
-  passthru.updateScript = xfce.updateScript {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
     attrPath = "xfce.thunar-dropbox-plugin";
-    versionLister = xfce.gitLister src.meta.homepage;
   };
 
   meta = with lib; {

--- a/pkgs/development/beam-modules/elvis-erlang/default.nix
+++ b/pkgs/development/beam-modules/elvis-erlang/default.nix
@@ -24,7 +24,7 @@ in rebar3Relx rec {
 
     set -euo pipefail
 
-    latest=$(list-git-tags https://github.com/${owner}/${repo}.git | sort -V | tail -1)
+    latest=$(list-git-tags --url=https://github.com/${owner}/${repo}.git | sort -V | tail -1)
     if [ "$latest" != "${version}" ]; then
       nixpkgs="$(git rev-parse --show-toplevel)"
       nix_path="$nixpkgs/pkgs/development/beam-modules/elvis-erlang"

--- a/pkgs/development/beam-modules/erlang-ls/default.nix
+++ b/pkgs/development/beam-modules/erlang-ls/default.nix
@@ -51,7 +51,7 @@ rebar3Relx {
     #! nix-shell -i bash -p common-updater-scripts coreutils git gnused gnutar gzip "rebar3WithPlugins { globalPlugins = [ beamPackages.rebar3-nix ]; }"
 
     set -ox errexit
-    latest=$(list-git-tags https://github.com/${owner}/${repo}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
+    latest=$(list-git-tags --url=https://github.com/${owner}/${repo}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
     if [[ "$latest" != "${version}" ]]; then
       nixpkgs="$(git rev-parse --show-toplevel)"
       nix_path="$nixpkgs/pkgs/development/beam-modules/erlang-ls"

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -154,7 +154,7 @@ stdenv.mkDerivation ({
         #!${stdenv.shell}
         set -ox errexit
         PATH=${lib.makeBinPath [ common-updater-scripts coreutils git gnused ]}
-        latest=$(list-git-tags https://github.com/erlang/otp.git | sed -n 's/^OTP-${major}/${major}/p' | sort -V | tail -1)
+        latest=$(list-git-tags --url=https://github.com/erlang/otp.git | sed -n 's/^OTP-${major}/${major}/p' | sort -V | tail -1)
         if [ "$latest" != "${version}" ]; then
           nixpkgs="$(git rev-parse --show-toplevel)"
           nix_file="$nixpkgs/pkgs/development/interpreters/erlang/R${major}.nix"

--- a/pkgs/development/libraries/gsettings-qt/default.nix
+++ b/pkgs/development/libraries/gsettings-qt/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitLab, pkg-config
 , qmake, qtbase, qtdeclarative, wrapQtAppsHook
 , glib, gobject-introspection
-, genericUpdater, common-updater-scripts
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -55,10 +55,9 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
     rev-prefix = "v";
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/libyang/default.nix
+++ b/pkgs/development/libraries/libyang/default.nix
@@ -10,8 +10,7 @@
 , pcre2
 
 # update script
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
@@ -40,9 +39,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE:String=Release"
   ];
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
     rev-prefix = "v";
   };
 

--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper
 , SDL, ffmpeg_4, frei0r, libjack2, libdv, libsamplerate, libexif
 , libvorbis, libxml2, movit, pkg-config, sox, fftw, opencv4, SDL2
-, gtk2, genericUpdater, common-updater-scripts, libebur128
+, gtk2, gitUpdater, libebur128
 , jack2, ladspa-sdk, swig, which, ncurses
 , enablePython ? false, python3
 }:
@@ -51,9 +51,8 @@ stdenv.mkDerivation rec {
     sed -i ${outPythonPath}/mlt/__init__.py -e "s|return importlib.import_module('_mlt')|return importlib.import_module('mlt._mlt')|g"
   '';
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
     rev-prefix = "v";
   };
 

--- a/pkgs/development/libraries/mlt/qt-5.nix
+++ b/pkgs/development/libraries/mlt/qt-5.nix
@@ -18,8 +18,7 @@
 , vid-stab
 , opencv3
 , ladspa-sdk
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 , ladspaPlugins
 , mkDerivation
 , which
@@ -70,9 +69,8 @@ mkDerivation rec {
     inherit ffmpeg;
   };
 
-  passthru.updateScript = genericUpdater {
+  passthru.updateScript = gitUpdater {
     inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
     rev-prefix = "v";
   };
 

--- a/pkgs/development/tools/build-managers/rebar3/default.nix
+++ b/pkgs/development/tools/build-managers/rebar3/default.nix
@@ -81,7 +81,7 @@ let
           (rebar3WithPlugins { globalPlugins = [rebar3-nix]; })
         ]
       }
-      latest=$(list-git-tags https://github.com/${owner}/${pname}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
+      latest=$(list-git-tags --url=https://github.com/${owner}/${pname}.git | sed -n '/[\d\.]\+/p' | sort -V | tail -1)
       if [ "$latest" != "${version}" ]; then
         nixpkgs="$(git rev-parse --show-toplevel)"
         nix_path="$nixpkgs/pkgs/development/tools/build-managers/rebar3"

--- a/pkgs/tools/backup/stenc/default.nix
+++ b/pkgs/tools/backup/stenc/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, genericUpdater
-, common-updater-scripts
+, gitUpdater
 , autoreconfHook
 }:
 
@@ -19,10 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  passthru.updateScript = genericUpdater {
-    inherit pname version;
-    versionLister = "${common-updater-scripts}/bin/list-git-tags ${src.meta.homepage}";
-  };
+  passthru.updateScript = gitUpdater { inherit pname version; };
 
   meta = {
     description = "SCSI Tape Encryption Manager";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -109,6 +109,8 @@ with pkgs;
 
   gitUpdater = callPackage ../common-updater/git-updater.nix { };
 
+  httpTwoLevelsUpdater = callPackage ../common-updater/http-two-levels-updater.nix { };
+
   unstableGitUpdater = callPackage ../common-updater/unstable-updater.nix { };
 
   nix-update-script = callPackage ../common-updater/nix-update.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -107,6 +107,8 @@ with pkgs;
 
   genericUpdater = callPackage ../common-updater/generic-updater.nix { };
 
+  gitUpdater = callPackage ../common-updater/git-updater.nix { };
+
   unstableGitUpdater = callPackage ../common-updater/unstable-updater.nix { };
 
   nix-update-script = callPackage ../common-updater/nix-update.nix { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Add the 'gitUpdater' helper function to update git based packages, using the 'genericUpdater' function.
- Rework argument passing to the `list-git-tags' and 'list-archive-two-level-versions' scripts.
- Replace 'genericUpdater' plus 'list-git-tags' by 'gitUpdater'

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
