### PR TITLE
bird: drop bird1 package & modules; hardening

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -548,6 +548,14 @@
       </listitem>
       <listitem>
         <para>
+          <literal>bird1</literal> and its modules
+          <literal>services.bird</literal> as well as
+          <literal>services.bird6</literal> have been removed. Upgrade
+          to <literal>services.bird2</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The options
           <literal>networking.interfaces.&lt;name&gt;.ipv4.routes</literal>
           and

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -178,6 +178,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `tilp2` was removed together with its module
 
+- `bird1` and its modules `services.bird` as well as `services.bird6` have been removed. Upgrade to `services.bird2`.
+
 - The options `networking.interfaces.<name>.ipv4.routes` and `networking.interfaces.<name>.ipv6.routes` are no longer ignored when using networkd instead of the default scripted network backend by setting `networking.useNetworkd` to `true`.
 
 - MultiMC has been replaced with the fork PolyMC due to upstream developers being hostile to 3rd party package maintainers. PolyMC removes all MultiMC branding and is aimed at providing proper 3rd party packages like the one contained in Nixpkgs. This change affects the data folder where game instances and other save and configuration files are stored. Users with existing installations should rename `~/.local/share/multimc` to `~/.local/share/polymc`. The main config file's path has also moved from `~/.local/share/multimc/multimc.cfg` to `~/.local/share/polymc/polymc.cfg`.

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -3,103 +3,103 @@
 let
   inherit (lib) mkEnableOption mkIf mkOption optionalString types;
 
-  generic = variant:
-    let
-      cfg = config.services.${variant};
-      pkg = pkgs.${variant};
-      birdBin = if variant == "bird6" then "bird6" else "bird";
-      birdc = if variant == "bird6" then "birdc6" else "birdc";
-      descr =
-        { bird = "1.6.x with IPv4 support";
-          bird6 = "1.6.x with IPv6 support";
-          bird2 = "2.x";
-        }.${variant};
-    in {
-      ###### interface
-      options = {
-        services.${variant} = {
-          enable = mkEnableOption "BIRD Internet Routing Daemon (${descr})";
-          config = mkOption {
-            type = types.lines;
-            description = ''
-              BIRD Internet Routing Daemon configuration file.
-              <link xlink:href='http://bird.network.cz/'/>
-            '';
-          };
-          checkConfig = mkOption {
-            type = types.bool;
-            default = true;
-            description = ''
-              Whether the config should be checked at build time.
-              When the config can't be checked during build time, for example when it includes
-              other files, either disable this option or use <code>preCheckConfig</code> to create
-              the included files before checking.
-            '';
-          };
-          preCheckConfig = mkOption {
-            type = types.lines;
-            default = "";
-            example = ''
-              echo "cost 100;" > include.conf
-            '';
-            description = ''
-              Commands to execute before the config file check. The file to be checked will be
-              available as <code>${variant}.conf</code> in the current directory.
-
-              Files created with this option will not be available at service runtime, only during
-              build time checking.
-            '';
-          };
-        };
+  cfg = config.services.bird2;
+in
+{
+  ###### interface
+  options = {
+    services.bird2 = {
+      enable = mkEnableOption "BIRD Internet Routing Daemon";
+      config = mkOption {
+        type = types.lines;
+        description = ''
+          BIRD Internet Routing Daemon configuration file.
+          <link xlink:href='http://bird.network.cz/'/>
+        '';
       };
+      checkConfig = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether the config should be checked at build time.
+          When the config can't be checked during build time, for example when it includes
+          other files, either disable this option or use <code>preCheckConfig</code> to create
+          the included files before checking.
+        '';
+      };
+      preCheckConfig = mkOption {
+        type = types.lines;
+        default = "";
+        example = ''
+          echo "cost 100;" > include.conf
+        '';
+        description = ''
+          Commands to execute before the config file check. The file to be checked will be
+          available as <code>bird2.conf</code> in the current directory.
 
-      ###### implementation
-      config = mkIf cfg.enable {
-        environment.systemPackages = [ pkg ];
-
-        environment.etc."bird/${variant}.conf".source = pkgs.writeTextFile {
-          name = "${variant}.conf";
-          text = cfg.config;
-          checkPhase = optionalString cfg.checkConfig ''
-            ln -s $out ${variant}.conf
-            ${cfg.preCheckConfig}
-            ${pkg}/bin/${birdBin} -d -p -c ${variant}.conf
-          '';
-        };
-
-        systemd.services.${variant} = {
-          description = "BIRD Internet Routing Daemon (${descr})";
-          wantedBy = [ "multi-user.target" ];
-          reloadIfChanged = true;
-          restartTriggers = [ config.environment.etc."bird/${variant}.conf".source ];
-          serviceConfig = {
-            Type = "forking";
-            Restart = "on-failure";
-            ExecStart = "${pkg}/bin/${birdBin} -c /etc/bird/${variant}.conf -u ${variant} -g ${variant}";
-            ExecReload = "/bin/sh -c '${pkg}/bin/${birdBin} -c /etc/bird/${variant}.conf -p && ${pkg}/bin/${birdc} configure'";
-            ExecStop = "${pkg}/bin/${birdc} down";
-            CapabilityBoundingSet = [ "CAP_CHOWN" "CAP_FOWNER" "CAP_DAC_OVERRIDE" "CAP_SETUID" "CAP_SETGID"
-                                      # see bird/sysdep/linux/syspriv.h
-                                      "CAP_NET_BIND_SERVICE" "CAP_NET_BROADCAST" "CAP_NET_ADMIN" "CAP_NET_RAW" ];
-            ProtectSystem = "full";
-            ProtectHome = "yes";
-            SystemCallFilter="~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
-            MemoryDenyWriteExecute = "yes";
-          };
-        };
-        users = {
-          users.${variant} = {
-            description = "BIRD Internet Routing Daemon user";
-            group = variant;
-            isSystemUser = true;
-          };
-          groups.${variant} = {};
-        };
+          Files created with this option will not be available at service runtime, only during
+          build time checking.
+        '';
       };
     };
+  };
 
-in
 
-{
-  imports = map generic [ "bird" "bird6" "bird2" ];
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "bird" ] "Use services.bird2 instead")
+    (lib.mkRemovedOptionModule [ "services" "bird6" ] "Use services.bird2 instead")
+  ];
+
+  ###### implementation
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.bird ];
+
+    environment.etc."bird/bird2.conf".source = pkgs.writeTextFile {
+      name = "bird2";
+      text = cfg.config;
+      checkPhase = optionalString cfg.checkConfig ''
+        ln -s $out bird2.conf
+        ${cfg.preCheckConfig}
+        ${pkgs.bird}/bin/bird -d -p -c bird2.conf
+      '';
+    };
+
+    systemd.services.bird2 = {
+      description = "BIRD Internet Routing Daemon";
+      wantedBy = [ "multi-user.target" ];
+      reloadIfChanged = true;
+      restartTriggers = [ config.environment.etc."bird/bird2.conf".source ];
+      serviceConfig = {
+        Type = "forking";
+        Restart = "on-failure";
+        ExecStart = "${pkgs.bird}/bin/bird -c /etc/bird/bird2.conf -u bird2 -g bird2";
+        ExecReload = "/bin/sh -c '${pkgs.bird}/bin/bird -c /etc/bird/bird2.conf -p && ${pkgs.bird}/bin/birdc configure'";
+        ExecStop = "${pkgs.bird}/bin/birdc down";
+        CapabilityBoundingSet = [
+          "CAP_CHOWN"
+          "CAP_FOWNER"
+          "CAP_DAC_OVERRIDE"
+          "CAP_SETUID"
+          "CAP_SETGID"
+          # see bird/sysdep/linux/syspriv.h
+          "CAP_NET_BIND_SERVICE"
+          "CAP_NET_BROADCAST"
+          "CAP_NET_ADMIN"
+          "CAP_NET_RAW"
+        ];
+        ProtectSystem = "full";
+        ProtectHome = "yes";
+        SystemCallFilter = "~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
+        MemoryDenyWriteExecute = "yes";
+      };
+    };
+    users = {
+      users.bird2 = {
+        description = "BIRD Internet Routing Daemon user";
+        group = "bird2";
+        isSystemUser = true;
+      };
+      groups.bird2 = { };
+    };
+  };
 }

--- a/nixos/modules/services/networking/bird.nix
+++ b/nixos/modules/services/networking/bird.nix
@@ -72,23 +72,27 @@ in
       serviceConfig = {
         Type = "forking";
         Restart = "on-failure";
+        # We need to start as root so bird can open netlink sockets i.e. for ospf
         ExecStart = "${pkgs.bird}/bin/bird -c /etc/bird/bird2.conf -u bird2 -g bird2";
         ExecReload = "/bin/sh -c '${pkgs.bird}/bin/bird -c /etc/bird/bird2.conf -p && ${pkgs.bird}/bin/birdc configure'";
         ExecStop = "${pkgs.bird}/bin/birdc down";
+        RuntimeDirectory = "bird";
         CapabilityBoundingSet = [
           "CAP_CHOWN"
           "CAP_FOWNER"
-          "CAP_DAC_OVERRIDE"
           "CAP_SETUID"
           "CAP_SETGID"
-          # see bird/sysdep/linux/syspriv.h
-          "CAP_NET_BIND_SERVICE"
-          "CAP_NET_BROADCAST"
           "CAP_NET_ADMIN"
+          "CAP_NET_BROADCAST"
+          "CAP_NET_BIND_SERVICE"
           "CAP_NET_RAW"
         ];
         ProtectSystem = "full";
         ProtectHome = "yes";
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
         SystemCallFilter = "~@cpu-emulation @debug @keyring @module @mount @obsolete @raw-io";
         MemoryDenyWriteExecute = "yes";
       };

--- a/nixos/tests/bird.nix
+++ b/nixos/tests/bird.nix
@@ -9,7 +9,7 @@ let
   inherit (import ../lib/testing-python.nix { inherit system pkgs; }) makeTest;
   inherit (pkgs.lib) optionalString;
 
-  hostShared = hostId: { pkgs, ... }: {
+  makeBird2Host = hostId: { pkgs, ... }: {
     virtualisation.vlans = [ 1 ];
 
     environment.systemPackages = with pkgs; [ jq ];
@@ -24,105 +24,6 @@ let
       name = "eth1";
       networkConfig.Address = "10.0.0.${hostId}/24";
     };
-  };
-
-  birdTest = v4:
-    let variant = "bird${optionalString (!v4) "6"}"; in
-    makeTest {
-      name = variant;
-
-      nodes.host1 = makeBirdHost variant "1";
-      nodes.host2 = makeBirdHost variant "2";
-
-      testScript = makeTestScript variant v4 (!v4);
-    };
-
-  bird2Test = makeTest {
-    name = "bird2";
-
-    nodes.host1 = makeBird2Host "1";
-    nodes.host2 = makeBird2Host "2";
-
-    testScript = makeTestScript "bird2" true true;
-  };
-
-  makeTestScript = variant: v4: v6: ''
-    start_all()
-
-    host1.wait_for_unit("${variant}.service")
-    host2.wait_for_unit("${variant}.service")
-
-    ${optionalString v4 ''
-    with subtest("Waiting for advertised IPv4 routes"):
-      host1.wait_until_succeeds("ip --json r | jq -e 'map(select(.dst == \"10.10.0.2\")) | any'")
-      host2.wait_until_succeeds("ip --json r | jq -e 'map(select(.dst == \"10.10.0.1\")) | any'")
-    ''}
-    ${optionalString v6 ''
-    with subtest("Waiting for advertised IPv6 routes"):
-      host1.wait_until_succeeds("ip --json -6 r | jq -e 'map(select(.dst == \"fdff::2\")) | any'")
-      host2.wait_until_succeeds("ip --json -6 r | jq -e 'map(select(.dst == \"fdff::1\")) | any'")
-    ''}
-
-    with subtest("Check fake routes in preCheckConfig do not exists"):
-      ${optionalString v4 ''host1.fail("ip --json r | jq -e 'map(select(.dst == \"1.2.3.4\")) | any'")''}
-      ${optionalString v4 ''host2.fail("ip --json r | jq -e 'map(select(.dst == \"1.2.3.4\")) | any'")''}
-
-      ${optionalString v6 ''host1.fail("ip --json -6 r | jq -e 'map(select(.dst == \"fd00::\")) | any'")''}
-      ${optionalString v6 ''host2.fail("ip --json -6 r | jq -e 'map(select(.dst == \"fd00::\")) | any'")''}
-  '';
-
-  makeBirdHost = variant: hostId: { pkgs, ... }: {
-    imports = [ (hostShared hostId) ];
-
-    services.${variant} = {
-      enable = true;
-
-      config = ''
-        log syslog all;
-
-        debug protocols all;
-
-        router id 10.0.0.${hostId};
-
-        protocol device {
-        }
-
-        protocol kernel {
-          import none;
-          export all;
-        }
-
-        protocol static {
-          include "static.conf";
-        }
-
-        protocol ospf {
-          export all;
-          area 0 {
-            interface "eth1" {
-              hello 5;
-              wait 5;
-            };
-          };
-        }
-      '';
-
-      preCheckConfig =
-        let
-          route = { bird = "1.2.3.4/32"; bird6 = "fd00::/128"; }.${variant};
-        in
-        ''echo "route ${route} blackhole;" > static.conf'';
-    };
-
-    systemd.tmpfiles.rules =
-      let
-        route = { bird = "10.10.0.${hostId}/32"; bird6 = "fdff::${hostId}/128"; }.${variant};
-      in
-      [ "f /etc/bird/static.conf - - - - route ${route} blackhole;" ];
-  };
-
-  makeBird2Host = hostId: { pkgs, ... }: {
-    imports = [ (hostShared hostId) ];
 
     services.bird2 = {
       enable = true;
@@ -198,8 +99,30 @@ let
     ];
   };
 in
-{
-  bird = birdTest true;
-  bird6 = birdTest false;
-  bird2 = bird2Test;
+makeTest {
+  name = "bird2";
+
+  nodes.host1 = makeBird2Host "1";
+  nodes.host2 = makeBird2Host "2";
+
+  testScript = ''
+    start_all()
+
+    host1.wait_for_unit("bird2.service")
+    host2.wait_for_unit("bird2.service")
+
+    with subtest("Waiting for advertised IPv4 routes"):
+      host1.wait_until_succeeds("ip --json r | jq -e 'map(select(.dst == \"10.10.0.2\")) | any'")
+      host2.wait_until_succeeds("ip --json r | jq -e 'map(select(.dst == \"10.10.0.1\")) | any'")
+    with subtest("Waiting for advertised IPv6 routes"):
+      host1.wait_until_succeeds("ip --json -6 r | jq -e 'map(select(.dst == \"fdff::2\")) | any'")
+      host2.wait_until_succeeds("ip --json -6 r | jq -e 'map(select(.dst == \"fdff::1\")) | any'")
+
+    with subtest("Check fake routes in preCheckConfig do not exists"):
+      host1.fail("ip --json r | jq -e 'map(select(.dst == \"1.2.3.4\")) | any'")
+      host2.fail("ip --json r | jq -e 'map(select(.dst == \"1.2.3.4\")) | any'")
+
+      host1.fail("ip --json -6 r | jq -e 'map(select(.dst == \"fd00::\")) | any'")
+      host2.fail("ip --json -6 r | jq -e 'map(select(.dst == \"fd00::\")) | any'")
+  '';
 }

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -1,66 +1,34 @@
 { lib, stdenv, fetchurl, fetchpatch, flex, bison, readline, libssh, nixosTests }:
 
-with lib;
+stdenv.mkDerivation rec {
+  pname = "bird";
+  version = "2.0.9";
 
-let
-
-  generic = { version, sha256, enableIPv6 ? false }:
-    stdenv.mkDerivation rec {
-      pname = "bird";
-      inherit version;
-
-      src = fetchurl {
-        inherit sha256;
-        url = "ftp://bird.network.cz/pub/bird/${pname}-${version}.tar.gz";
-      };
-
-      nativeBuildInputs = [ flex bison ];
-      buildInputs = [ readline libssh ];
-
-      patches = [
-        (./. + "/dont-create-sysconfdir-${builtins.substring 0 1 version}.patch")
-      ]
-      ++ optional (lib.versionOlder version "2")
-        # https://github.com/BIRD/bird/pull/4
-        (fetchpatch {
-          url = "https://github.com/BIRD/bird/commit/fca9ab48e3823c734886f47156a92f6b804c16e9.patch";
-          sha256 = "1pnndc3n56lqqcy74ln0w5kn3i9rbzsm2dqiyp1qw7j33dpkln1b";
-        })
-        ;
-
-      CPP="${stdenv.cc.targetPrefix}cpp -E";
-
-      configureFlags = [
-        "--localstatedir=/var"
-      ] ++ optional enableIPv6 "--enable-ipv6";
-
-      passthru.tests = nixosTests.bird;
-
-      meta = {
-        description = "BIRD Internet Routing Daemon";
-        homepage = "http://bird.network.cz";
-        license = licenses.gpl2Plus;
-        maintainers = with maintainers; [ fpletz globin ];
-        platforms = platforms.linux;
-      };
-    };
-
-in
-
-{
-  bird = generic {
-    version = "1.6.8";
-    sha256 = "1ch0pkkhd7axdjlvhprynh9q08x0nm984nvkm1cjb7gm5rfsnqbc";
-  };
-
-  bird6 = generic {
-    version = "1.6.8";
-    sha256 = "1ch0pkkhd7axdjlvhprynh9q08x0nm984nvkm1cjb7gm5rfsnqbc";
-    enableIPv6 = true;
-  };
-
-  bird2 = generic {
-    version = "2.0.9";
+  src = fetchurl {
     sha256 = "sha256-dnhrvN7TBh4bsiGwEfLMACIewGPenNoASn2bBhoJbV4=";
+    url = "ftp://bird.network.cz/pub/bird/${pname}-${version}.tar.gz";
+  };
+
+  nativeBuildInputs = [ flex bison ];
+  buildInputs = [ readline libssh ];
+
+  patches = [
+    (./. + "/dont-create-sysconfdir-${builtins.substring 0 1 version}.patch")
+  ];
+
+  CPP="${stdenv.cc.targetPrefix}cpp -E";
+
+  configureFlags = [
+    "--localstatedir=/var"
+  ];
+
+  passthru.tests = nixosTests.bird;
+
+  meta = with lib; {
+    description = "BIRD Internet Routing Daemon";
+    homepage = "http://bird.network.cz";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fpletz globin ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/servers/bird/default.nix
+++ b/pkgs/servers/bird/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--localstatedir=/var"
+    "--runstatedir=/run/bird"
   ];
 
   passthru.tests = nixosTests.bird;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -110,6 +110,8 @@ mapAliases ({
   bridge_utils = bridge-utils; # Added 2015-02-20
   bro = zeek; # Added 2019-09-29
   btrfsProgs = btrfs-progs; # Added 2016-01-03
+  bird2 = bird;
+  bird6 = throw "bird6 was dropped. Use bird instead, which has support for both ipv4/ipv6";
 
   # bitwarden_rs renamed to vaultwarden with release 1.21.0 (2021-04-30)
   bitwarden_rs = vaultwarden;
@@ -117,6 +119,7 @@ mapAliases ({
   bitwarden_rs-postgresql = vaultwarden-postgresql;
   bitwarden_rs-sqlite = vaultwarden-sqlite;
   bitwarden_rs-vault = vaultwarden-vault;
+
 
   blink = throw "blink has been removed from nixpkgs, it was unmaintained and required python2 at the time of removal."; # Added 2022-01-12
   bs1770gain = throw "bs1770gain has been removed from nixpkgs, as it had no maintainer or reverse dependencies."; # Added 2021-01-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21018,8 +21018,7 @@ with pkgs;
   dnsutils = bind.dnsutils;
   dig = bind.dnsutils;
 
-  inherit (callPackages ../servers/bird { })
-    bird bird6 bird2;
+  bird = callPackage ../servers/bird { };
 
   bosun = callPackage ../servers/monitoring/bosun { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

reason: no longer maintained upstream.
No testing beyond running the nixos test has been conducted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).