### PR TITLE
nanodbc: init at 2.13.0

### DIFF
--- a/pkgs/development/libraries/nanodbc/default.nix
+++ b/pkgs/development/libraries/nanodbc/default.nix
@@ -1,0 +1,39 @@
+{ lib, stdenv, fetchFromGitHub, cmake, unixODBC }:
+
+stdenv.mkDerivation rec {
+  pname = "nanodbc";
+  version = "2.13.0";
+
+  src = fetchFromGitHub {
+    owner = "nanodbc";
+    repo = "nanodbc";
+    rev = "v${version}";
+    sha256 = "1q80p7yv9mcl4hyvnvcjdr70y8nc940ypf368lp97vpqn5yckkgm";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ unixODBC ];
+
+  cmakeFlags = if (stdenv.hostPlatform.isStatic) then
+    [ "-DBUILD_STATIC_LIBS=ON" ]
+  else
+    [ "-DBUILD_SHARED_LIBS=ON" ];
+
+  # fix compilation on macOS
+  # https://github.com/nanodbc/nanodbc/issues/274
+  # remove after the next version update
+  postUnpack = if stdenv.isDarwin then ''
+    mv $sourceRoot/VERSION $sourceRoot/VERSION.txt
+    substituteInPlace $sourceRoot/CMakeLists.txt \
+       --replace 'file(STRINGS VERSION' 'file(STRINGS VERSION.txt'
+  '' else "";
+
+  meta = with lib; {
+    homepage = "https://github.com/nanodbc/nanodbc";
+    changelog = "https://github.com/nanodbc/nanodbc/raw/v${version}/CHANGELOG.md";
+    description = "Small C++ wrapper for the native C ODBC API";
+    license = licenses.mit;
+    maintainers = [ maintainers.bzizou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19112,6 +19112,8 @@ with pkgs;
 
   mythes = callPackage ../development/libraries/mythes { };
 
+  nanodbc = callPackage ../development/libraries/nanodbc { };
+
   nanoflann = callPackage ../development/libraries/nanoflann { };
 
   nanomsg = callPackage ../development/libraries/nanomsg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Package request #130134

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
