### PR TITLE
rbspy: init at 0.11.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12692,6 +12692,12 @@
     githubId = 118959;
     name = "VinyMeuh";
   };
+  viraptor = {
+    email = "nix@viraptor.info";
+    github = "viraptor";
+    githubId = 188063;
+    name = "Stanisław Pitucha";
+  };
   viric = {
     email = "viric@viric.name";
     github = "viric";

--- a/pkgs/development/tools/rbspy/default.nix
+++ b/pkgs/development/tools/rbspy/default.nix
@@ -1,0 +1,25 @@
+{rustPlatform, fetchFromGitHub, lib}:
+rustPlatform.buildRustPackage rec {
+  pname = "rbspy";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v0.10.0";
+    sha256 = "sha256-zvH2oPm2tOdk4C5EDNhNgO9nt4usnuBTp+fh6xfwraQ=";
+  };
+
+  cargoSha256 = "sha256-Es4COQiNZmbGdWeSyOvx4tiV1ygic3VPQLTiispVWpM=";
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://rbspy.github.io/";
+    description = ''
+      A Sampling CPU Profiler for Ruby.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ viraptor ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/rbspy/default.nix
+++ b/pkgs/development/tools/rbspy/default.nix
@@ -1,17 +1,17 @@
 {rustPlatform, fetchFromGitHub, lib}:
 rustPlatform.buildRustPackage rec {
   pname = "rbspy";
-  version = "0.10.0";
+  version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "v0.10.0";
-    sha256 = "sha256-zvH2oPm2tOdk4C5EDNhNgO9nt4usnuBTp+fh6xfwraQ=";
+    rev = "v${version}";
+    sha256 = "sha256-9BeQHwwnirK5Wquj6Tal8yCU/NXZGaPjXZe3cy5m98s=";
   };
 
-  cargoSha256 = "sha256-Es4COQiNZmbGdWeSyOvx4tiV1ygic3VPQLTiispVWpM=";
-  doCheck = false;
+  cargoSha256 = "sha256-DHdfv6210wAkL9vXxLr76ejFWU/eV/q3lmgsYa5Rn54=";
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://rbspy.github.io/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33729,6 +33729,8 @@ with pkgs;
 
   rauc = callPackage ../tools/misc/rauc { };
 
+  rbspy = callPackage ../development/tools/rbspy { };
+
   redprl = callPackage ../applications/science/logic/redprl { };
 
   renderizer = callPackage ../development/tools/renderizer {};


### PR DESCRIPTION
###### Motivation for this change

Add a new package for profiling Ruby

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
