### PR TITLE
aspell: Build with ncurses

### DIFF
--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, fetchzip, perl
+{ lib, stdenv, fetchurl, fetchpatch, fetchzip, perl, ncurses
 , searchNixProfiles ? true
 }:
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ perl ];
-  buildInputs = [ perl ];
+  buildInputs = [ ncurses perl ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/aspell/default.nix
+++ b/pkgs/development/libraries/aspell/default.nix
@@ -1,4 +1,8 @@
 { lib, stdenv, fetchurl, fetchpatch, fetchzip, perl, ncurses
+
+  # for tests
+, aspell, glibc, runCommand
+
 , searchNixProfiles ? true
 }:
 
@@ -54,6 +58,19 @@ stdenv.mkDerivation rec {
   postInstall = ''
     cp ${devaMapsSource}/u-deva.{cmap,cset} $out/lib/aspell/
   '';
+
+  passthru.tests = {
+    uses-curses = runCommand "${pname}-curses" {
+      buildInputs = [ glibc ];
+    } ''
+      if ! ldd ${aspell}/bin/aspell | grep -q ${ncurses}
+      then
+        echo "Test failure: It does not look like aspell picked up the curses dependency."
+        exit 1
+      fi
+      touch $out
+    '';
+  };
 
   meta = {
     description = "Spell checker for many languages";


### PR DESCRIPTION
###### Motivation for this change

fix #161203: Enable curses support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).