### PR TITLE
python3Packages.XlsxWriter: 1.2.9 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/XlsxWriter/default.nix
+++ b/pkgs/development/python-modules/XlsxWriter/default.nix
@@ -1,24 +1,36 @@
-{lib, buildPythonPackage, fetchFromGitHub}:
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
 
 buildPythonPackage rec {
+  pname = "xlsxwriter";
+  version = "3.0.2";
+  format = "setuptools";
 
-  pname = "XlsxWriter";
-  version = "1.2.9";
+  disabled = pythonOlder "3.7";
 
-  # PyPI release tarball doesn't contain tests so let's use GitHub. See:
-  # https://github.com/jmcnamara/XlsxWriter/issues/327
-  src = fetchFromGitHub{
+  src = fetchFromGitHub {
     owner = "jmcnamara";
-    repo = pname;
+    repo = "XlsxWriter";
     rev = "RELEASE_${version}";
-    sha256 = "08pdca5ssi50bx2xz52gkmjix2ybv5i4bjw7yd6yfiph0y0qsbsb";
+    hash = "sha256-I87/8OhMoI9/BRXdmTZ1Ul+d+/x+Kg/9CuqMgTsP8Eo=";
   };
 
-  meta = {
-    description = "A Python module for creating Excel XLSX files";
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "xlsxwriter"
+  ];
+
+  meta = with lib; {
+    description = "Module for creating Excel XLSX files";
     homepage = "https://xlsxwriter.readthedocs.io/";
-    maintainers = with lib.maintainers; [ jluttine ];
-    license = lib.licenses.bsd2;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ jluttine ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/jmcnamara/XlsxWriter/blob/main/Changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
