### PR TITLE
febio: init at 3.5.1

### DIFF
--- a/pkgs/development/libraries/febio/default.nix
+++ b/pkgs/development/libraries/febio/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchFromGitHub, cmake, boost, eigen, libxml2, mpi, python3
+, mklSupport ? true, mkl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "FEBio";
+  version = "3.6";
+
+  src = fetchFromGitHub {
+    owner = "febiosoftware";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "187s4lyzr806xla3smq3lsvj3f6wxlhfkban89w0fnyfmfb8w9am";
+  };
+
+  patches = [
+    ./fix-cmake.patch  # cannot find mkl libraries without this
+  ];
+
+  cmakeFlags = lib.optional mklSupport "-DUSE_MKL=On"
+    ++ lib.optional mklSupport "-DMKLROOT=${mkl}"
+  ;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include
+    cp -R lib bin $out/
+    cp -R ../FECore \
+      ../FEBioFluid \
+      ../FEBioLib \
+      ../FEBioMech \
+      ../FEBioMix \
+      ../FEBioOpt \
+      ../FEBioPlot \
+      ../FEBioXML \
+      ../NumCore \
+      $out/include
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost eigen libxml2 mpi python3 python3.pkgs.numpy ]
+   ++ lib.optional mklSupport mkl
+  ;
+
+  meta = {
+    description = "FEBio Suite Solver";
+    license = with lib.licenses; [ mit ];
+    homepage = "https://febio.org/";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Scriptkiddi ];
+  };
+}

--- a/pkgs/development/libraries/febio/fix-cmake.patch
+++ b/pkgs/development/libraries/febio/fix-cmake.patch
@@ -1,0 +1,26 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ function(findLib libName libDir libOut)
+         find_library(TEMP NAMES ${libName}.lib ${ARGV3}.lib ${ARGV4}.lib ${ARGV5}.lib ${ARGV6}.lib
+             PATHS ${${libDir}} NO_DEFAULT_PATH)
+     else()
+-        find_library(TEMP NAMES lib${libName}.a lib${ARGV3}.a lib${ARGV4}.a lib${ARGV5}.a lib${ARGV6}.a
++        find_library(TEMP NAMES lib${libName}.a lib${ARGV3}.a lib${ARGV4}.a lib${ARGV5}.a lib${ARGV6}.a lib${libName}.so lib${ARGV3}.so lib${ARGV4}.so lib${ARGV5}.so lib${ARGV6}.so
+             PATHS ${${libDir}} NO_DEFAULT_PATH)
+     endif()
+     
+diff --git a/FindDependencies.cmake b/FindDependencies.cmake
+index 2d644005f..7261ba923 100644
+--- a/FindDependencies.cmake
++++ b/FindDependencies.cmake
+@@ -46,8 +46,8 @@ if(MKLROOT)
+             NO_DEFAULT_PATH)
+             
+         find_library(MKL_OMP_LIB 
+-            NAMES iomp5 iomp5md libiomp5md.lib
+-            PATHS ${MKLROOT}/../lib ${MKLROOT}/../compiler/lib
++            NAMES libiomp5.so libiomp5 iomp5 iomp5md libiomp5md.lib
++            PATHS ${MKLROOT}/lib ${MKLROOT}/../lib ${MKLROOT}/../compiler/lib
+             PATH_SUFFIXES "intel64" "intel32"
+             NO_DEFAULT_PATH
+             DOC "MKL OMP Library")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16523,6 +16523,8 @@ with pkgs;
 
   fcl = callPackage ../development/libraries/fcl { };
 
+  febio = callPackage ../development/libraries/febio { };
+
   ffcast = callPackage ../tools/X11/ffcast { };
 
   fflas-ffpack = callPackage ../development/libraries/fflas-ffpack { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
