### PR TITLE
gitlab-runner: 14.7.0 -> 14.8.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,30 +1,53 @@
-{ lib, buildGoPackage, fetchFromGitLab, fetchurl }:
+{ lib, buildGoModule, fetchFromGitLab, fetchurl }:
 
 let
-  version = "14.7.0";
+  version = "14.8.0";
 in
-buildGoPackage rec {
+buildGoModule rec {
   inherit version;
   pname = "gitlab-runner";
-  goPackagePath = "gitlab.com/gitlab-org/gitlab-runner";
-  subPackages = [ "." ];
-  commonPackagePath = "${goPackagePath}/common";
+
+  commonPackagePath = "gitlab.com/gitlab-org/gitlab-runner/common";
   ldflags = [
     "-X ${commonPackagePath}.NAME=gitlab-runner"
     "-X ${commonPackagePath}.VERSION=${version}"
     "-X ${commonPackagePath}.REVISION=v${version}"
   ];
 
+  vendorSha256 = "sha256-MdGLl77DFXPudt26qICSH+1UuQAR8Rb/nl0Ykb0hjgE=";
+
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "0l7bbmhvgz12nq52nmvgs1qmcknikw8f2dn9l93ijb1sr495fygl";
+    sha256 = "sha256-+DwOKlFu9m2kt4DwaSp/Jq3eZ/+FFxV1Q7bKOy5DfoE=";
   };
 
   patches = [
     ./fix-shell-path.patch
   ];
+
+  prePatch = ''
+    # Remove some tests that can't work during a nix build
+
+    # Requires to run in a git repo
+    sed -i "s/func TestCacheArchiverAddingUntrackedFiles/func OFF_TestCacheArchiverAddingUntrackedFiles/" commands/helpers/file_archiver_test.go
+    sed -i "s/func TestCacheArchiverAddingUntrackedUnicodeFiles/func OFF_TestCacheArchiverAddingUntrackedUnicodeFiles/" commands/helpers/file_archiver_test.go
+
+    # No writable developer environment
+    rm common/build_test.go
+    rm executors/custom/custom_test.go
+
+    # No docker during build
+    rm executors/docker/terminal_test.go
+    rm executors/docker/docker_test.go
+    rm helpers/docker/auth/auth_test.go
+  '';
+
+  preCheck = ''
+    # Make the tests pass outside of GitLab CI
+    export CI=0
+  '';
 
   meta = with lib; {
     description = "GitLab Runner the continuous integration executor of GitLab";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://gitlab.com/gitlab-org/gitlab-runner/blob/v14.8.0/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

/cc @bachp @zimbatm @globin @dlouzan