### PR TITLE
nixos-version: output configurationRevision

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -486,6 +486,13 @@
           <literal>libax25</literal> package.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          <literal>nixos-version</literal> now accepts
+          <literal>--configuration-revision</literal> to display more
+          information about the current generation revision
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/man-nixos-version.xml
+++ b/nixos/doc/manual/man-nixos-version.xml
@@ -22,6 +22,10 @@
    </arg>
 
    <arg>
+    <option>--configuration-revision</option>
+   </arg>
+
+   <arg>
     <option>--json</option>
    </arg>
 
@@ -113,6 +117,23 @@
       was built, e.g.
 <screen><prompt>$ </prompt>nixos-version --hash
 6317da40006f6bc2480c6781999c52d88dde2acf
+</screen>
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--configuration-revision</option>
+    </term>
+    <listitem>
+     <para>
+      Show the configuration revision if available. This could be the full SHA1
+      hash of the Git commit of the system flake, if you add
+      <screen>{ system.configurationRevision = self.rev or "dirty"; }</screen>
+      to the <screen>modules</screen> array of your flake.nix system configuration e.g.
+<screen><prompt>$ </prompt>nixos-version --configuration-revision
+aa314ebd1592f6cdd53cb5bba8bcae97d9323de8
 </screen>
      </para>
     </listitem>

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -128,3 +128,5 @@ In addition to numerous new and upgraded packages, this release has the followin
 - The new option `services.tailscale.useRoutingFeatures` controls various settings for using Tailscale features like exit nodes and subnet routers. If you wish to use your machine as an exit node, you can set this setting to `server`, otherwise if you wish to use an exit node you can set this setting to `client`. The strict RPF warning has been removed as the RPF will be loosened automatically based on the value of this setting.
 
 - [Xastir](https://xastir.org/index.php/Main_Page) can now access AX.25 interfaces via the `libax25` package.
+
+- `nixos-version` now accepts `--configuration-revision` to display more information about the current generation revision

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -13,6 +13,13 @@ case "$1" in
     fi
     echo "@revision@"
     ;;
+  --configuration-revision)
+    if [[ "@configurationRevision@" =~ "@" ]]; then
+      echo "$0: configuration revision is unknown" >&2
+      exit 1
+    fi
+    echo "@configurationRevision@"
+    ;;
   --json)
     cat <<EOF
 @json@

--- a/nixos/modules/installer/tools/nixos-version.sh
+++ b/nixos/modules/installer/tools/nixos-version.sh
@@ -8,7 +8,7 @@ case "$1" in
     ;;
   --hash|--revision)
     if ! [[ @revision@ =~ ^[0-9a-f]+$ ]]; then
-      echo "$0: Nixpkgs commit hash is unknown"
+      echo "$0: Nixpkgs commit hash is unknown" >&2
       exit 1
     fi
     echo "@revision@"


### PR DESCRIPTION
It would be nice to be able to get the `configurationRevision` of the current system.

This allows the user to figure out more information about the generation. 


###### Motivation for this change

It might also be used for #105910 to show additional information for generations in the list of all generations so that the user can have a better understanding of which generation is what.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable: => could not find relevant tests
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
