### PR TITLE
irods: 4.2.7 -> 4.2.11

### DIFF
--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -1,10 +1,13 @@
-{ lib, stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, libkrb5, gcc, libcxx, which, catch2 }:
+{ lib, stdenv, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man, texinfo, libtool, cppzmq, libarchive
+, avro-cpp, boost, jansson, zeromq, openssl, pam, libiodbc, libkrb5, gcc, libcxx, which, catch2, nanodbc, fmt
+, nlohmann_json, spdlog }:
 
 # Common attributes of irods packages
 
 {
   nativeBuildInputs = [ autoconf automake cmake gnumake help2man texinfo which gcc ];
-  buildInputs = [ bzip2 zlib libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc libkrb5 boost libcxx catch2 ];
+  buildInputs = [ bzip2 zlib libtool cppzmq libarchive avro-cpp jansson zeromq openssl pam libiodbc libkrb5 boost
+                  libcxx catch2 nanodbc fmt nlohmann_json spdlog ];
 
   cmakeFlags = [
     "-DIRODS_EXTERNALS_FULLPATH_CLANG=${stdenv.cc}"
@@ -16,18 +19,23 @@
     "-DIRODS_EXTERNALS_FULLPATH_ZMQ=${zeromq}"
     "-DIRODS_EXTERNALS_FULLPATH_CPPZMQ=${cppzmq}"
     "-DIRODS_EXTERNALS_FULLPATH_CATCH2=${catch2}"
+    "-DIRODS_EXTERNALS_FULLPATH_NANODBC=${nanodbc}"
+    "-DIRODS_EXTERNALS_FULLPATH_FMT=${fmt}"
+    "-DIRODS_EXTERNALS_FULLPATH_JSON=${nlohmann_json}"
+    "-DIRODS_EXTERNALS_FULLPATH_SPDLOG=${spdlog}"
     "-DIRODS_LINUX_DISTRIBUTION_NAME=nix"
     "-DIRODS_LINUX_DISTRIBUTION_VERSION_MAJOR=1.0"
     "-DCPACK_GENERATOR=TGZ"
     "-DCMAKE_CXX_FLAGS=-I${lib.getDev libcxx}/include/c++/v1"
   ];
 
-  preConfigure = ''
-    patchShebangs ./packaging
-    patchShebangs ./scripts
-    substituteInPlace CMakeLists.txt --replace "DESTINATION usr/bin" "DESTINATION bin"
-    substituteInPlace CMakeLists.txt --replace "INCLUDE_DIRS usr/include/" "INCLUDE_DIRS include/"
-    substituteInPlace CMakeLists.txt --replace "DESTINATION usr/lib/" "DESTINATION lib/"
+  postPatch = ''
+    patchShebangs ./packaging ./scripts
+    substituteInPlace CMakeLists.txt \
+      --replace "DESTINATION usr/bin" "DESTINATION bin" \
+      --replace "INCLUDE_DIRS usr/include/" "INCLUDE_DIRS include/" \
+      --replace "DESTINATION usr/lib/" "DESTINATION lib/" \
+      --replace "{IRODS_EXTERNALS_FULLPATH_JSON}/include" "{IRODS_EXTERNALS_FULLPATH_JSON}/include/nlohmann"
     export cmakeFlags="$cmakeFlags
       -DCMAKE_INSTALL_PREFIX=$out
     "

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -1,27 +1,32 @@
-{ lib, stdenv, fetchFromGitHub, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man , texinfo, libtool , cppzmq , libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl , pam, libiodbc, libkrb5, gcc, libcxx, which, catch2 }:
+{ lib, stdenv, fetchFromGitHub, bzip2, zlib, autoconf, automake, cmake, gnumake, help2man, texinfo, libtool, cppzmq
+, libarchive, avro-cpp_llvm, boost, jansson, zeromq, openssl, pam, libiodbc, libkrb5, gcc, libcxx, which, catch2
+, nanodbc_llvm, fmt, nlohmann_json, spdlog }:
 
 let
-  avro-cpp=avro-cpp_llvm;
+  avro-cpp = avro-cpp_llvm;
+  nanodbc = nanodbc_llvm;
 in
 let
   common = import ./common.nix {
     inherit lib stdenv bzip2 zlib autoconf automake cmake gnumake
-            help2man texinfo libtool cppzmq libarchive jansson
-            zeromq openssl pam libiodbc libkrb5 gcc libcxx
-            boost avro-cpp which catch2;
+      help2man texinfo libtool cppzmq libarchive jansson
+      zeromq openssl pam libiodbc libkrb5 gcc libcxx
+      boost avro-cpp which catch2 nanodbc fmt nlohmann_json
+      spdlog;
   };
-in rec {
+in
+rec {
 
   # irods: libs and server package
   irods = stdenv.mkDerivation (common // rec {
-    version = "4.2.7";
+    version = "4.2.11";
     pname = "irods";
 
     src = fetchFromGitHub {
       owner = "irods";
       repo = "irods";
       rev = version;
-      sha256 = "1pd4l42z4igzf0l8xbp7yz0nhzsv47ziv5qj8q1hh6pfhmwlzp9s";
+      sha256 = "0prcsiddk8n3h515jjapgfz1d6hjqywhrkcf6giqd7xc7b0slz44";
       fetchSubmodules = true;
     };
 
@@ -33,7 +38,7 @@ in rec {
     # fix build with recent llvm versions
     NIX_CFLAGS_COMPILE = "-Wno-deprecated-register -Wno-deprecated-declarations";
 
-    preConfigure = common.preConfigure + ''
+    postPatch = common.postPatch + ''
       patchShebangs ./test
       substituteInPlace plugins/database/CMakeLists.txt --replace "COMMAND cpp" "COMMAND ${gcc.cc}/bin/cpp"
       substituteInPlace cmake/server.cmake --replace "DESTINATION usr/sbin" "DESTINATION sbin"
@@ -62,36 +67,36 @@ in rec {
 
   # icommands (CLI) package, depends on the irods package
   irods-icommands = stdenv.mkDerivation (common // rec {
-     version = "4.2.7";
-     pname = "irods-icommands";
+    version = "4.2.11";
+    pname = "irods-icommands";
 
-     src = fetchFromGitHub {
-       owner = "irods";
-       repo = "irods_client_icommands";
-       rev = version;
-       sha256 = "08hqrc9iaw0y9rrrcknnl5mzbcrsvqc39pwvm62fipl3vnfqryli";
-     };
+    src = fetchFromGitHub {
+      owner = "irods";
+      repo = "irods_client_icommands";
+      rev = version;
+      sha256 = "0wgs585j2lp820py2pbizsk54xgz5id96fhxwwk9lqhbzxhfjhcg";
+    };
 
-     patches = [ ./zmqcpp-deprecated-send_recv.patch ];
+    patches = [ ./zmqcpp-deprecated-send_recv.patch ];
 
-     buildInputs = common.buildInputs ++ [ irods ];
+    buildInputs = common.buildInputs ++ [ irods ];
 
-     preConfigure = common.preConfigure + ''
-       patchShebangs ./bin
-     '';
+    postPatch = common.postPatch + ''
+      patchShebangs ./bin
+    '';
 
-     cmakeFlags = common.cmakeFlags ++ [
-       "-DCMAKE_INSTALL_PREFIX=${stdenv.out}"
-       "-DIRODS_DIR=${irods}/lib/irods/cmake"
-       "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
-       "-DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
-       "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+    cmakeFlags = common.cmakeFlags ++ [
+      "-DCMAKE_INSTALL_PREFIX=${stdenv.out}"
+      "-DIRODS_DIR=${irods}/lib/irods/cmake"
+      "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+      "-DCMAKE_MODULE_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
+      "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,${irods}/lib"
     ];
 
-     meta = common.meta // {
-       description = common.meta.description + " CLI clients";
-       longDescription = common.meta.longDescription + "This package provides the CLI clients, called 'icommands'.";
-     };
+    meta = common.meta // {
+      description = common.meta.description + " CLI clients";
+      longDescription = common.meta.longDescription + "This package provides the CLI clients, called 'icommands'.";
+    };
   });
 }
 

--- a/pkgs/tools/filesystems/irods/irods_root_path.patch
+++ b/pkgs/tools/filesystems/irods/irods_root_path.patch
@@ -1,25 +1,3 @@
-diff -r -u irods-4.2.0.orig/lib/core/src/irods_default_paths.cpp irods-4.2.0/lib/core/src/irods_default_paths.cpp
---- irods-4.2.0.orig/lib/core/src/irods_default_paths.cpp	2016-11-15 06:23:55.000000000 +0000
-+++ irods-4.2.0/lib/core/src/irods_default_paths.cpp	2016-12-20 18:03:17.156883399 +0000
-@@ -18,7 +18,7 @@
-         try {
-             boost::filesystem::path path{dl_info.dli_fname};
-             path = boost::filesystem::canonical(path);
--            path.remove_filename().remove_filename().remove_filename(); // Removes filename and the two directories (usr and lib) between libirods_common.so and base of irods install
-+            path.remove_filename().remove_filename(); // Removes filename and the two directories (usr and lib) between libirods_common.so and base of irods install
-             return path;
-         } catch(const boost::filesystem::filesystem_error& e) {
-             THROW(-1, e.what());
-@@ -27,8 +27,7 @@
- 
-     boost::filesystem::path
-     get_irods_config_directory() {
--        boost::filesystem::path path{get_irods_root_directory()};
--        path.append("etc").append("irods");
-+        boost::filesystem::path path("/etc/irods");
-         return path;
-     }
- 
 diff -r -u irods-4.2.0.orig/scripts/irods/paths.py irods-4.2.0/scripts/irods/paths.py
 --- irods-4.2.0.orig/scripts/irods/paths.py	2016-11-15 06:23:55.000000000 +0000
 +++ irods-4.2.0/scripts/irods/paths.py	2016-12-21 15:17:07.437864606 +0000

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6609,13 +6609,15 @@ with pkgs;
   };
 
   inherit (callPackages ../tools/filesystems/irods rec {
-            stdenv = llvmPackages.libcxxStdenv;
-            libcxx = llvmPackages.libcxx;
-            boost = boost160.override { inherit stdenv; };
-            avro-cpp_llvm = avro-cpp.override { inherit stdenv boost; };
-          })
-      irods
-      irods-icommands;
+    stdenv = llvmPackages.libcxxStdenv;
+    libcxx = llvmPackages.libcxx;
+    boost = boost17x.override { inherit stdenv; };
+    fmt = fmt_8.override { inherit stdenv; };
+    nanodbc_llvm = nanodbc.override { inherit stdenv; };
+    avro-cpp_llvm = avro-cpp.override { inherit stdenv boost; };
+  })
+    irods
+    irods-icommands;
 
   ignite = callPackage ../applications/virtualization/ignite { };
 


### PR DESCRIPTION
This commit should work once #129416 and #161196 merged

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
- upgrade irods
- fix as a dependency of #129416

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
