### PR TITLE
nixos/installer: add kexec-boot

### DIFF
--- a/nixos/modules/installer/kexec/kexec-boot.nix
+++ b/nixos/modules/installer/kexec/kexec-boot.nix
@@ -27,8 +27,9 @@
             echo "kexec not found: please install kexec-tools" 2>&1
             exit 1
           fi
-          kexec --load ./bzImage \
-            --initrd=./initrd.gz \
+          SCRIPT_DIR=$( cd -- "$( dirname -- "''${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+          kexec --load ''${SCRIPT_DIR}/bzImage \
+            --initrd=''${SCRIPT_DIR}/initrd.gz \
             --command-line "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
           kexec -e
         ''; in

--- a/nixos/modules/installer/kexec/kexec-boot.nix
+++ b/nixos/modules/installer/kexec/kexec-boot.nix
@@ -1,0 +1,50 @@
+# This module exposes a config.system.build.kexecBoot attribute,
+# which returns a directory with kernel, initrd and a shell script
+# running the necessary kexec commands.
+
+# It's meant to be scp'ed to a machine with working ssh and kexec binary
+# installed.
+
+# This is useful for (cloud) providers where you can't boot a custom image, but
+# get some Debian or Ubuntu installation.
+
+{ pkgs
+, modulesPath
+, config
+, ...
+}:
+{
+  imports = [
+    (modulesPath + "/installer/netboot/netboot-minimal.nix")
+  ];
+
+  config = {
+    system.build.kexecBoot =
+      let
+        kexecScript = pkgs.writeScript "kexec-boot" ''
+          #!/usr/bin/env bash
+          if ! kexec -v >/dev/null 2>&1; then
+            echo "kexec not found: please install kexec-tools" 2>&1
+            exit 1
+          fi
+          kexec --load ./bzImage \
+            --initrd=./initrd.gz \
+            --command-line "init=${config.system.build.toplevel}/init ${toString config.boot.kernelParams}"
+          kexec -e
+        ''; in
+      pkgs.linkFarm "kexec-tree" [
+        {
+          name = "initrd.gz";
+          path = "${config.system.build.netbootRamdisk}/initrd";
+        }
+        {
+          name = "bzImage";
+          path = "${config.system.build.kernel}/bzImage";
+        }
+        {
+          name = "kexec-boot";
+          path = kexecScript;
+        }
+      ];
+  };
+}

--- a/nixos/tests/kexec.nix
+++ b/nixos/tests/kexec.nix
@@ -1,22 +1,44 @@
 # Test whether fast reboots via kexec work.
 
-import ./make-test-python.nix ({ pkgs, lib, ...} : {
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "kexec";
   meta = with lib.maintainers; {
     maintainers = [ eelco ];
   };
 
-  nodes.machine = { ... }:
-    { virtualisation.vlans = [ ]; };
+  nodes = {
+    node1 = { ... }: {
+      virtualisation.vlans = [ ];
+      virtualisation.memorySize = 2 * 1024;
+    };
 
-  testScript =
-    ''
-      machine.wait_for_unit("multi-user.target")
-      machine.succeed('kexec --load /run/current-system/kernel --initrd /run/current-system/initrd --command-line "$(</proc/cmdline)"')
-      machine.execute("systemctl kexec >&2 &", check_return=False)
-      machine.connected = False
-      machine.connect()
-      machine.wait_for_unit("multi-user.target")
-      machine.shutdown()
-    '';
+    node2 = { modulesPath, ... }: {
+      virtualisation.vlans = [ ];
+      imports = [
+        "${modulesPath}/installer/kexec/kexec-boot.nix"
+      ];
+    };
+  };
+
+  testScript = { nodes, ... }: ''
+    node1.wait_for_unit("multi-user.target")
+    node1.succeed('kexec --load /run/current-system/kernel --initrd /run/current-system/initrd --command-line "$(</proc/cmdline)"')
+    node1.execute("systemctl kexec >&2 &", check_return=False)
+    node1.connected = False
+    node1.connect()
+    node1.wait_for_unit("multi-user.target")
+
+
+    # Check the machine with kexec-boot.nix profile boots up
+    node2.wait_for_unit("multi-user.target")
+    node2.shutdown()
+
+    # Kexec node1 to the toplevel of node2 via the kexec-boot script
+    node1.execute('${nodes.node2.config.system.build.kexecBoot}/kexec-boot', check_return=False)
+    node1.connected = False
+    node1.connect()
+    node1.wait_for_unit("multi-user.target")
+
+    node1.shutdown()
+  '';
 })


### PR DESCRIPTION
This module exposes a config.system.build.kexecBoot attribute,
which returns a directory with kernel, initrd and a shell script
running the necessary kexec commands.

It's meant to be scp'ed to a machine with working ssh and kexec binary
installed.

This is useful for (cloud) providers where you can't boot a custom image, but
get some Debian or Ubuntu installation.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
