### PR TITLE
kmod-blacklist-ubuntu: don't refer to grep/xargs

### DIFF
--- a/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
+++ b/pkgs/os-specific/linux/kmod-blacklist-ubuntu/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, gnugrep, findutils }:
+{ lib, stdenv, fetchurl }:
 
 let
   version = "28-1ubuntu4"; # impish 2021-06-24
@@ -26,8 +26,8 @@ in stdenv.mkDerivation {
       --replace /sbin/lsmod /run/booted-system/sw/bin/lsmod \
       --replace /sbin/rmmod /run/booted-system/sw/bin/rmmod \
       --replace /sbin/modprobe /run/booted-system/sw/bin/modprobe \
-      --replace " grep " " ${gnugrep}/bin/grep " \
-      --replace " xargs " " ${findutils}/bin/xargs "
+      --replace " grep " " /run/booted-system/sw/bin/grep " \
+      --replace " xargs " " /run/booted-system/sw/bin/xargs "
   '';
 
   meta = with lib; {


### PR DESCRIPTION
#146456 ("Misc") doubled the size of the default initramfs.  This happened because the upgrade introduced this configuration:

	remove iwlwifi \
	(/sbin/lsmod | grep -o -e ^iwlmvm -e ^iwldvm -e ^iwlwifi | xargs /sbin/rmmod) \
	&& /sbin/modprobe -r mac80211

This meant that the grep and xargs substitutions, which had been inactive for years, suddenly became active again and became part of kmod-blacklist-ubuntu's closure.

Since we're already using /run/booted-system for the kmod binaries, I think it's okay to use it for grep and xargs as well.  Both are required NixOS packages, so they're guaranteed to be there.

Large increases in initramfs size are problematic, because it's often not possible for users to do anything about them.  It's not always possible to increase the size of /boot, because some filesystems like ZFS don't support being shrunk to make way for a bigger /boot.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
