### PR TITLE
gnome.updateScript: Various improvements

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -147,7 +147,7 @@ let
 
     to run update script for specific package, or
 
-        % nix-shell maintainers/scripts/update.nix --arg predicate '(path: pkg: builtins.isList pkg.updateScript && builtins.length pkg.updateScript >= 1 && (let script = builtins.head pkg.updateScript; in builtins.isAttrs script && script.name == "gnome-update-script"))'
+        % nix-shell maintainers/scripts/update.nix --arg predicate '(path: pkg: pkg.updateScript.name or null == "gnome-update-script")'
 
     to run update script for all packages matching given predicate, or
 

--- a/maintainers/scripts/update.py
+++ b/maintainers/scripts/update.py
@@ -88,6 +88,10 @@ async def commit_changes(name: str, merge_lock: asyncio.Lock, worktree: str, bra
         async with merge_lock:
             await check_subprocess('git', 'add', *change['files'], cwd=worktree)
             commit_message = '{attrPath}: {oldVersion} → {newVersion}'.format(**change)
+            if 'commitMessage' in change:
+                commit_message = change['commitMessage']
+            elif 'commitBody' in change:
+                commit_message = commit_message + '\n\n' + change['commitBody']
             await check_subprocess('git', 'commit', '--quiet', '-m', commit_message, cwd=worktree)
             await check_subprocess('git', 'cherry-pick', branch)
 

--- a/pkgs/desktops/gnome/update.nix
+++ b/pkgs/desktops/gnome/update.nix
@@ -3,10 +3,10 @@
 
 let
   python = python3.withPackages (p: [ p.requests p.libversion ]);
+  package = lib.attrByPath (lib.splitString "." attrPath) (throw "Cannot find attribute ‘${attrPath}’.") pkgs;
+  packageVersion = lib.getVersion package;
   upperBoundFlag =
     let
-      package = lib.attrByPath (lib.splitString "." attrPath) (throw "Cannot find attribute ‘${attrPath}’.") pkgs;
-      packageVersion = lib.getVersion package;
       versionComponents = lib.versions.splitVersion packageVersion;
       minorVersion = lib.versions.minor packageVersion;
       minorAvailable = builtins.length versionComponents > 1 && builtins.match "[0-9]+" minorVersion != null;
@@ -16,11 +16,19 @@ let
   updateScript = writeScript "gnome-update-script" ''
     #!${stdenv.shell}
     set -o errexit
-    package_name="$1"
-    attr_path="$2"
-    version_policy="$3"
+    attr_path="$1"
+    package_name="$2"
+    package_version="$3"
+    version_policy="$4"
     PATH=${lib.makeBinPath [ common-updater-scripts python ]}
     latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
     update-source-version "$attr_path" "$latest_tag"
+    echo '[ { "commitBody": "https://gitlab.gnome.org/GNOME/'$package_name'/-/compare/'$package_version'...'$latest_tag'" } ]'
   '';
-in [ updateScript packageName attrPath versionPolicy ]
+in {
+  name = "gnome-update-script";
+  command = [ updateScript attrPath packageName packageVersion versionPolicy ];
+  supportedFeatures = [
+    "commit"
+  ];
+}

--- a/pkgs/desktops/gnome/update.nix
+++ b/pkgs/desktops/gnome/update.nix
@@ -21,7 +21,7 @@ let
     package_version="$3"
     version_policy="$4"
 
-    flvFlags=("$package_name" "$version_policy" "stable")
+    flvFlags=("$package_name" "$version_policy" "''${GNOME_UPDATE_STABILITY:-stable}")
 
     if (( $# >= 5 )); then
       upper_bound="$5"

--- a/pkgs/desktops/gnome/update.nix
+++ b/pkgs/desktops/gnome/update.nix
@@ -1,33 +1,41 @@
-{ stdenv, pkgs, lib, writeScript, python3, common-updater-scripts }:
+{ stdenv, bash, pkgs, lib, writeScript, python3, common-updater-scripts }:
 { packageName, attrPath ? packageName, versionPolicy ? "tagged", freeze ? false }:
 
 let
   python = python3.withPackages (p: [ p.requests p.libversion ]);
   package = lib.attrByPath (lib.splitString "." attrPath) (throw "Cannot find attribute ‘${attrPath}’.") pkgs;
   packageVersion = lib.getVersion package;
-  upperBoundFlag =
+  upperBound =
     let
       versionComponents = lib.versions.splitVersion packageVersion;
       minorVersion = lib.versions.minor packageVersion;
       minorAvailable = builtins.length versionComponents > 1 && builtins.match "[0-9]+" minorVersion != null;
       nextMinor = builtins.fromJSON minorVersion + 1;
       upperBound = "${lib.versions.major packageVersion}.${builtins.toString nextMinor}";
-    in lib.optionalString (freeze && minorAvailable) ''--upper-bound="${upperBound}"'';
+    in lib.optionals (freeze && minorAvailable) [ upperBound ];
   updateScript = writeScript "gnome-update-script" ''
-    #!${stdenv.shell}
+    #!${bash}/bin/bash
     set -o errexit
     attr_path="$1"
     package_name="$2"
     package_version="$3"
     version_policy="$4"
+
+    flvFlags=("$package_name" "$version_policy" "stable")
+
+    if (( $# >= 5 )); then
+      upper_bound="$5"
+      flvFlags+=("--upper-bound=$upper_bound")
+    fi
+
     PATH=${lib.makeBinPath [ common-updater-scripts python ]}
-    latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable" ${upperBoundFlag})
+    latest_tag=$(python "${./find-latest-version.py}" "''${flvFlags[@]}")
     update-source-version "$attr_path" "$latest_tag"
     echo '[ { "commitBody": "https://gitlab.gnome.org/GNOME/'$package_name'/-/compare/'$package_version'...'$latest_tag'" } ]'
   '';
 in {
   name = "gnome-update-script";
-  command = [ updateScript attrPath packageName packageVersion versionPolicy ];
+  command = [ updateScript attrPath packageName packageVersion versionPolicy ] ++ upperBound;
   supportedFeatures = [
     "commit"
   ];


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Picked from https://github.com/NixOS/nixpkgs/pull/160343

- maintainers/scripts/update.nix: Add experimental support for customizing commit message
- gnome.updateScript: Use experimental support for custom commit messages
- gnome.updateScript: avoid rebuilding the derivation
- gnome.updateScript: allow updating to unstable releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
