### PR TITLE
darwin: deprecate phases

### DIFF
--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -98,6 +98,7 @@ rec {
 
       doSign = localSystem.isAarch64 && last != null;
       doUpdateAutoTools = localSystem.isAarch64 && last != null;
+      inherit (last.pkgs) runCommandLocal;
 
       mkExtraBuildCommands = cc: ''
         rsrc="$out/resource-root"
@@ -223,23 +224,15 @@ rec {
         '';
       };
 
-      pbzx = stdenv.mkDerivation {
-        name = "bootstrap-stage0-pbzx";
-        phases = [ "installPhase" ];
-        installPhase = ''
-          mkdir -p $out/bin
-          ln -s ${bootstrapTools}/bin/pbzx $out/bin
-        '';
-      };
+      pbzx = self.runCommandLocal "bootstrap-stage0-pbzx" { } ''
+        mkdir -p $out/bin
+        ln -s ${bootstrapTools}/bin/pbzx $out/bin
+      '';
 
-      cpio = stdenv.mkDerivation {
-        name = "bootstrap-stage0-cpio";
-        phases = [ "installPhase" ];
-        installPhase = ''
-          mkdir -p $out/bin
-          ln -s ${bootstrapFiles.cpio} $out/bin/cpio
-        '';
-      };
+      cpio = self.runCommandLocal "bootstrap-stage0-cpio" { } ''
+        mkdir -p $out/bin
+        ln -s ${bootstrapFiles.cpio} $out/bin/cpio
+      '';
 
       darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
         darwin-stubs = superDarwin.darwin-stubs.override { inherit (self) stdenvNoCC fetchurl; };
@@ -253,43 +246,21 @@ rec {
           '';
         };
 
-        sigtool = stdenv.mkDerivation {
-          name = "bootstrap-stage0-sigtool";
-          phases = [ "installPhase" ];
-          installPhase = ''
-            mkdir -p $out/bin
-            ln -s ${bootstrapTools}/bin/sigtool $out/bin
+        sigtool = self.runCommandLocal "bootstrap-stage0-sigtool" { } ''
+           mkdir -p $out/bin
+           ln -s ${bootstrapTools}/bin/sigtool  $out/bin
+           ln -s ${bootstrapTools}/bin/codesign $out/bin
+        '';
 
-            # Rewrite nuked references
-            sed -e "s|[^( ]*\bsigtool\b|$out/bin/sigtool|g" \
-              ${bootstrapTools}/bin/codesign > $out/bin/codesign
-            chmod a+x $out/bin/codesign
-          '';
-          # on next bootstrap tools update, use the following:
-          # installPhase = ''
-          #   mkdir -p $out/bin
-          #   ln -s ${bootstrapTools}/bin/sigtool  $out/bin
-          #   ln -s ${bootstrapTools}/bin/codesign $out/bin
-          # '';
-        };
+        print-reexports = self.runCommandLocal "bootstrap-stage0-print-reexports" { } ''
+          mkdir -p $out/bin
+          ln -s ${bootstrapTools}/bin/print-reexports $out/bin
+        '';
 
-        print-reexports = stdenv.mkDerivation {
-          name = "bootstrap-stage0-print-reexports";
-          phases = [ "installPhase" ];
-          installPhase = ''
-            mkdir -p $out/bin
-            ln -s ${bootstrapTools}/bin/print-reexports $out/bin
-          '';
-        };
-
-        rewrite-tbd = stdenv.mkDerivation {
-          name = "bootstrap-stage0-rewrite-tbd";
-          phases = [ "installPhase" ];
-          installPhase = ''
-            mkdir -p $out/bin
-            ln -s ${bootstrapTools}/bin/rewrite-tbd $out/bin
-          '';
-        };
+        rewrite-tbd = self.runCommandLocal "bootstrap-stage0-rewrite-tbd" { } ''
+          mkdir -p $out/bin
+          ln -s ${bootstrapTools}/bin/rewrite-tbd $out/bin
+        '';
 
         binutils-unwrapped = { name = "bootstrap-stage0-binutils"; outPath = bootstrapTools; };
 
@@ -359,7 +330,7 @@ rec {
 
         libcxx = stdenv.mkDerivation {
           name = "bootstrap-stage0-libcxx";
-          phases = [ "installPhase" "fixupPhase" ];
+          dontUnpack = true;
           installPhase = ''
             mkdir -p $out/lib $out/include
             ln -s ${bootstrapTools}/lib/libc++.dylib $out/lib/libc++.dylib


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
