### PR TITLE
whitesur-gtk-theme: 2021-12-28 -> 2022-02-21

### DIFF
--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -7,7 +7,27 @@
 , libxml2
 , sassc
 , util-linux
+, altVariants ? [] # default: normal
+, colorVariants ? [] # default: all
+, opacityVariants ? [] # default: all
+, themeVariants ? [] # default: default (BigSur-like theme)
+, nautilusSize ? null # default: 200px
+, panelOpacity ? null # default: 15%
+, panelSize ? null # default: 32px
 }:
+
+let
+  pname = "whitesur-gtk-theme";
+  single = x: lib.optional (x != null) x;
+
+in
+lib.checkListOfEnum "${pname}: alt variants" [ "normal" "alt" "all" ] altVariants
+lib.checkListOfEnum "${pname}: color variants" [ "light" "dark" ] colorVariants
+lib.checkListOfEnum "${pname}: opacity variants" [ "normal" "solid" ] opacityVariants
+lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
+lib.checkListOfEnum "${pname}: nautilus sidebar minimum width" [ "default" "180" "220" "240" "260" "280" ] (single nautilusSize)
+lib.checkListOfEnum "${pname}: panel opacity" [ "default" "30" "45" "60" "75" ] (single panelOpacity)
+lib.checkListOfEnum "${pname}: panel size" [ "default" "smaller" "bigger" ] (single panelSize)
 
 stdenv.mkDerivation rec {
   pname = "whitesur-gtk-theme";
@@ -48,8 +68,19 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/share/themes
-    ./install.sh --dest $out/share/themes --alt all --theme all
+
+    ./install.sh  \
+      ${toString (map (x: "--alt " + x) altVariants)} \
+      ${toString (map (x: "--color " + x) colorVariants)} \
+      ${toString (map (x: "--opacity " + x) opacityVariants)} \
+      ${toString (map (x: "--theme " + x) themeVariants)} \
+      ${lib.optionalString (nautilusSize != null) ("--size " + nautilusSize)} \
+      ${lib.optionalString (panelOpacity != null) ("--panel-opacity " + panelOpacity)} \
+      ${lib.optionalString (panelSize != null) ("--panel-size " + panelSize)} \
+      --dest $out/share/themes
+
     runHook postInstall
   '';
 

--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "whitesur-gtk-theme";
-  version = "2021-12-28";
+  version = "2022-02-21";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "0i81aickccfp8fffilhi335hj5ijz2n38yj3zw2fnbwgm667i0fc";
+    sha256 = "1bqgbkx7qhpj9vbqcxb69p67m8ix3avxr81pdpdi56g9gqbnkpfc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -4,6 +4,7 @@
 , glib
 , gnome-shell
 , gnome-themes-extra
+, jdupes
 , libxml2
 , sassc
 , util-linux
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     glib
     gnome-shell
+    jdupes
     libxml2
     sassc
     util-linux
@@ -80,6 +82,8 @@ stdenv.mkDerivation rec {
       ${lib.optionalString (panelOpacity != null) ("--panel-opacity " + panelOpacity)} \
       ${lib.optionalString (panelSize != null) ("--panel-size " + panelSize)} \
       --dest $out/share/themes
+
+    jdupes --link-soft --recurse $out/share
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Update to version [2022-02-21](https://github.com/vinceliuice/WhiteSur-gtk-theme/releases/tag/2022-02-21)
- Add optional arguments
- Replace duplicate files with links

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
