### PR TITLE
linux: Disable bond0 creation by bonding driver

### DIFF
--- a/pkgs/os-specific/linux/kernel/bonding-dont-create-bond0.patch
+++ b/pkgs/os-specific/linux/kernel/bonding-dont-create-bond0.patch
@@ -1,0 +1,18 @@
+Prevent the bonding driver to create a bond0 interface by default when
+loaded, as that conflicts with declarative configuration management and
+instead feels much like a side-effect.
+
+
+diff --git a/include/uapi/linux/if_bonding.h b/include/uapi/linux/if_bonding.h
+index d174914a837d..bf8e2af101a3 100644
+--- a/include/uapi/linux/if_bonding.h
++++ b/include/uapi/linux/if_bonding.h
+@@ -82,7 +82,7 @@
+ #define BOND_STATE_ACTIVE       0   /* link is active */
+ #define BOND_STATE_BACKUP       1   /* link is backup */
+ 
+-#define BOND_DEFAULT_MAX_BONDS  1   /* Default maximum number of devices to support */
++#define BOND_DEFAULT_MAX_BONDS  0   /* Default maximum number of devices to support */
+ 
+ #define BOND_DEFAULT_TX_QUEUES 16   /* Default number of tx queues per device */
+ 

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -14,6 +14,11 @@
     };
   };
 
+  bonding_dont_create_bond0 =
+    { name = "bonding-dont-create-bond0";
+      patch = ./bonding-dont-create-bond0.patch;
+    };
+
   bridge_stp_helper =
     { name = "bridge-stp-helper";
       patch = ./bridge-stp-helper.patch;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -131,6 +131,7 @@ in {
 
     linux_5_4 = callPackage ../os-specific/linux/kernel/linux-5.4.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.rtl8761b_support
@@ -139,6 +140,7 @@ in {
 
     linux_rt_5_4 = callPackage ../os-specific/linux/kernel/linux-rt-5.4.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
@@ -146,6 +148,7 @@ in {
 
     linux_5_10 = callPackage ../os-specific/linux/kernel/linux-5.10.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
@@ -153,6 +156,7 @@ in {
 
     linux_rt_5_10 = callPackage ../os-specific/linux/kernel/linux-rt-5.10.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
         kernelPatches.export-rt-sched-migrate
@@ -161,6 +165,7 @@ in {
 
     linux_5_15 = callPackage ../os-specific/linux/kernel/linux-5.15.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
@@ -168,6 +173,7 @@ in {
 
     linux_5_16 = callPackage ../os-specific/linux/kernel/linux-5.16.nix {
       kernelPatches = [
+        kernelPatches.bonding_dont_create_bond0
         kernelPatches.bridge_stp_helper
         kernelPatches.request_key_helper
       ];
@@ -176,6 +182,7 @@ in {
     linux_testing = let
       testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
         kernelPatches = [
+          kernelPatches.bonding_dont_create_bond0
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
         ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Linux defaults to creating a `bond0` interface when modprobing the
`bonding` driver, because the `max_bonds` option defaults to `1`¹.

This `bond0` interface is created with the default bond mode
`balance-rr`, which is most often undesirable.
Networkd in turn is unable to change this mode, since it does not
implement netdev recreation on parameter mismatch².

If we instead default `max_bonds=0` the driver will be loaded, but no
default interface will be created, leaving networkd in a better position
to set up the network configuration.

[1] https://www.kernel.org/doc/Documentation/networking/bonding.txt
[2] https://github.com/systemd/systemd/issues/9627

Alternative to #161238. I'm not sure how fond we are of carrying
patches that we very likely are not going to be able to upstream
but this is an annoying papercut in combination with systemd-networkd
and the original behaviour just isn't very useful.

The line in question wasn't changed since before the git migration, 
the surrounding lines were last changed 12 years ago, so the patch
is probably very stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
