### PR TITLE
wxwidgets: remove unused asserts, remove darwin from inputs

### DIFF
--- a/pkgs/development/libraries/wxwidgets/wxGTK28.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK28.nix
@@ -17,8 +17,6 @@
 , withMesa ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
 }:
 
-assert withMesa -> libGLU != null && libGL != null;
-
 stdenv.mkDerivation rec {
   pname = "wxGTK";
   version = "2.8.12.1";

--- a/pkgs/development/libraries/wxwidgets/wxGTK29.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK29.nix
@@ -17,7 +17,6 @@
 , darwin
 }:
 
-assert withMesa -> libGLU != null && libGL != null;
 let
   inherit (darwin.stubs) setfile;
   inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;

--- a/pkgs/development/libraries/wxwidgets/wxGTK29.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK29.nix
@@ -14,13 +14,14 @@
 , compat26 ? true
 , unicode ? true
 , withMesa ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
-, darwin
+, setfile
+, AGL
+, Carbon
+, Cocoa
+, Kernel
+, QuickTime
 }:
 
-let
-  inherit (darwin.stubs) setfile;
-  inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;
-in
 stdenv.mkDerivation rec {
   pname = "wxGTK";
   version = "2.9.5";

--- a/pkgs/development/libraries/wxwidgets/wxGTK30.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK30.nix
@@ -28,7 +28,6 @@
 assert withGtk2 -> (!withWebKit);
 
 let
-  inherit (gst_all_1) gstreamer gst-plugins-base;
   gtk = if withGtk2 then gtk2 else gtk3;
 in
 stdenv.mkDerivation rec {
@@ -47,8 +46,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gstreamer
-    gst-plugins-base
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
     gtk
     libSM
     libXinerama

--- a/pkgs/development/libraries/wxwidgets/wxGTK30.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK30.nix
@@ -17,14 +17,17 @@
 , unicode ? true
 , withGtk2 ? true
 , withWebKit ? false, webkitgtk
-, darwin
+, setfile
+, AGL
+, Carbon
+, Cocoa
+, Kernel
+, QTKit
 }:
 
 assert withGtk2 -> (!withWebKit);
 
 let
-  inherit (darwin.stubs) setfile;
-  inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   inherit (gst_all_1) gstreamer gst-plugins-base;
   gtk = if withGtk2 then gtk2 else gtk3;
 in

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -31,8 +31,6 @@
 assert withGtk2 -> (!withWebKit);
 
 let
-  inherit (gnome2) GConf;
-  inherit (gst_all_1) gst-plugins-base gstreamer;
   gtk = if withGtk2 then gtk2 else gtk3;
 in
 stdenv.mkDerivation rec {
@@ -55,8 +53,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    gst-plugins-base
-    gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
     gtk
     libSM
     libXinerama
@@ -65,7 +63,7 @@ stdenv.mkDerivation rec {
     xorgproto
   ]
   ++ lib.optionals withGtk2 [
-    GConf
+    gnome2.GConf
   ]
   ++ lib.optional withMesa libGLU
   ++ lib.optional withWebKit webkitgtk

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -23,9 +23,6 @@
 , darwin
 }:
 
-assert withMesa -> libGLU != null && libGL != null;
-assert withWebKit -> webkitgtk != null;
-
 assert withGtk2 -> (!withWebKit);
 
 let

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -20,14 +20,17 @@
 , withGtk2 ? true
 , withMesa ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
 , withWebKit ? false, webkitgtk
-, darwin
+, setfile
+, AGL
+, Carbon
+, Cocoa
+, Kernel
+, QTKit
 }:
 
 assert withGtk2 -> (!withWebKit);
 
 let
-  inherit (darwin.stubs) setfile;
-  inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   inherit (gnome2) GConf;
   inherit (gst_all_1) gst-plugins-base gstreamer;
   gtk = if withGtk2 then gtk2 else gtk3;

--- a/pkgs/development/libraries/wxwidgets/wxmac30.nix
+++ b/pkgs/development/libraries/wxwidgets/wxmac30.nix
@@ -7,13 +7,15 @@
 , libpng
 , libtiff
 , zlib
-, darwin
+, AGL
+, Cocoa
+, Kernel
+, WebKit
+, derez
+, rez
+, setfile
 }:
 
-let
-  inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel WebKit;
-  inherit (darwin.stubs) derez rez setfile;
-in
 stdenv.mkDerivation rec {
   pname = "wxmac";
   version = "3.0.5.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20523,7 +20523,7 @@ with pkgs;
   };
   wxmac = callPackage ../development/libraries/wxwidgets/wxmac30.nix {
     inherit (darwin.stubs) derez rez setfile;
-    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel WebKit;
+    inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel WebKit;
   };
 
   wxGTK30-gtk2 = wxGTK30.override { withGtk2 = true; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20509,10 +20509,22 @@ with pkgs;
   wxGTK = wxGTK28;
 
   wxGTK28 = callPackage ../development/libraries/wxwidgets/wxGTK28.nix { };
-  wxGTK29 = callPackage ../development/libraries/wxwidgets/wxGTK29.nix { };
-  wxGTK30 = callPackage ../development/libraries/wxwidgets/wxGTK30.nix { };
-  wxGTK31 = callPackage ../development/libraries/wxwidgets/wxGTK31.nix { };
-  wxmac = callPackage ../development/libraries/wxwidgets/wxmac30.nix { };
+  wxGTK29 = callPackage ../development/libraries/wxwidgets/wxGTK29.nix {
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;
+  };
+  wxGTK30 = callPackage ../development/libraries/wxwidgets/wxGTK30.nix {
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+  };
+  wxGTK31 = callPackage ../development/libraries/wxwidgets/wxGTK31.nix {
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+  };
+  wxmac = callPackage ../development/libraries/wxwidgets/wxmac30.nix {
+    inherit (darwin.stubs) derez rez setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel WebKit;
+  };
 
   wxGTK30-gtk2 = wxGTK30.override { withGtk2 = true; };
   wxGTK30-gtk3 = wxGTK30.override { withGtk2 = false; };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
