### PR TITLE
linux-rt: Fix incorrect ordering of kernel version numbers when determining latest version

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -6,7 +6,7 @@
 , ... } @ args:
 
 let
-  version = "5.10.78-rt55"; # updated by ./update-rt.sh
+  version = "5.10.100-rt62"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in buildLinux (args // {
@@ -18,14 +18,14 @@ in buildLinux (args // {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-    sha256 = "03q5lrv8gr9hnm7984pxi9kwsvxrn21qwykj60amisi2wac6r05y";
+    sha256 = "16892wnfkdpqy3v4xmdzlqn5zlfrgz9wqh6vadnx58xnr6pnasfm";
   };
 
   kernelPatches = let rt-patch = {
     name = "rt";
     patch = fetchurl {
       url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-      sha256 = "1wcw682r238qi5jgn5zk9m6j2506p9ypfax13bzhjfyjzz3h98kp";
+      sha256 = "1wimp4ckaqp5cfvkf50gv3s5biyr0sjifz4faw23m07ciydm15k0";
     };
   }; in [ rt-patch ] ++ kernelPatches;
 

--- a/pkgs/os-specific/linux/kernel/update-rt.sh
+++ b/pkgs/os-specific/linux/kernel/update-rt.sh
@@ -38,6 +38,7 @@ latest-rt-version() {
     curl -sL "$mirror/projects/rt/$branch/sha256sums.asc" |
         sed -ne '/.patch.xz/ { s/.*patch-\(.*\).patch.xz/\1/p}' |
         grep -v '\-rc' |
+        sort --version-sort |
         tail -n 1
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The `update-rt.sh` script incorrectly downgraded linux-rt_5_10 in #159261, since it assumed that https://mirrors.edge.kernel.org/pub/linux/kernel/projects/rt/5.10/sha256sums.asc would be sorted in version order when it was actually sorted lexicographically. This breaks the build of linux-rt_5_10 in combination with #154994, which requires all 5.10 kernels to be 5.10.90 or later. This PR fixes the script to sort kernel versions correctly, and re-runs the fixed script to update linux-rt_5_10 to the correct latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
