### PR TITLE
pngpaste: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11444,6 +11444,12 @@
     githubId = 107703;
     name = "Samuel Rivas";
   };
+  samw = {
+    email = "sam@wlcx.cc";
+    github = "wlcx";
+    githubId = 3065381;
+    name = "Sam Willcocks";
+  };
   samyak = {
     name = "Samyak Sarnayak";
     email = "samyak201@gmail.com";

--- a/pkgs/os-specific/darwin/pngpaste/default.nix
+++ b/pkgs/os-specific/darwin/pngpaste/default.nix
@@ -1,0 +1,37 @@
+{ lib, stdenv, fetchFromGitHub, AppKit, Cocoa }:
+
+let
+  pname = "pngpaste";
+  version = "0.2.3";
+in stdenv.mkDerivation {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "jcsalterego";
+    repo = pname;
+    rev = version;
+    sha256 = "uvajxSelk1Wfd5is5kmT2fzDShlufBgC0PDCeabEOSE=";
+  };
+
+  buildInputs = [ AppKit Cocoa ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp pngpaste $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Paste image files from clipboard to file on MacOS";
+    longDescription = ''
+      Paste PNG into files on MacOS, much like pbpaste does for text.
+      Supported input formats are PNG, PDF, GIF, TIF, JPEG.
+      Supported output formats are PNG, GIF, JPEG, TIFF.  Output
+      formats are determined by the provided filename extension,
+      falling back to PNG.
+    '';
+    homepage = "https://github.com/jcsalterego/pngpaste";
+    changelog = "https://github.com/jcsalterego/pngpaste/raw/${version}/CHANGELOG.md";
+    platforms = platforms.darwin;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ samw ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9806,6 +9806,10 @@ with pkgs;
     libpng = libpng12;
   };
 
+  pngpaste = callPackage ../os-specific/darwin/pngpaste {
+    inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
+  };
+
   pngtools = callPackage ../tools/graphics/pngtools { };
 
   pngpp = callPackage ../development/libraries/png++ { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
