### PR TITLE
pgcli: 3.3.1 -> 3.4.0

### DIFF
--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , buildPythonApplication
 , fetchPypi
 , isPy3k
@@ -16,17 +17,18 @@
 , pendulum
 , pytestCheckHook
 , mock
+, sshtunnel
 }:
 
 buildPythonApplication rec {
   pname = "pgcli";
-  version = "3.3.1";
+  version = "3.4.0";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-/MyeVcpopK0Ih6z6KZGvs7ivk/PM6a2iSeatiYeZM6E=";
+    sha256 = "sha256-1WbG7amarRonaAvf10ZX4lvAWG0E6vCxYmu1i951z7Y=";
   };
 
   propagatedBuildInputs = [
@@ -42,6 +44,7 @@ buildPythonApplication rec {
     setproctitle
     keyring
     pendulum
+    sshtunnel
   ];
 
   checkInputs = [ pytestCheckHook mock ];


### PR DESCRIPTION
Also added sshtunnel as a dependency following its addition: https://github.com/dbcli/pgcli/commit/ed9d123073eacbef4199e77113078cc6add02ad9

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
