### PR TITLE
vscode-extensions.skellock.just: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7747,6 +7747,12 @@
     githubId = 1187050;
     name = "Maximilian Huber";
   };
+  maximsmol = {
+    email = "maximsmol@gmail.com";
+    github = "maximsmol";
+    githubId = 1472826;
+    name = "Max Smolin";
+  };
   maxxk = {
     email = "maxim.krivchikov@gmail.com";
     github = "maxxk";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1783,6 +1783,23 @@ let
         };
       };
 
+      skellock.just = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "just";
+          publisher = "skellock";
+          version = "2.0.0";
+          sha256 = "sha256-FOp/dcW0+07rADEpUMzx+SGYjhvE4IhcCOqUQ38yCN4=";
+        };
+        meta = with lib; {
+          changelog = "https://github.com/skellock/vscode-just/blob/master/CHANGELOG.md";
+          description = "Provides syntax and recipe launcher for Just scripts";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=skellock.just";
+          homepage = "https://github.com/skellock/vscode-just";
+          license = licenses.mit;
+          maintainers = with maintainers; [ maximsmol ];
+        };
+      };
+
       skyapps.fish-vscode = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "fish-vscode";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add a VSCode extension for [just](https://github.com/casey/just)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [N/A] x86_64-linux
  - [N/A] aarch64-linux
  - [N/A] x86_64-darwin
  - [N/A] aarch64-darwin
- [N/A] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [N/A] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [N/A] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [N/A] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [N/A] (Package updates) Added a release notes entry if the change is major or breaking
  - [N/A] (Module updates) Added a release notes entry if the change is significant
  - [N/A] (Module addition) Added a release notes entry if adding a new NixOS module
  - [N/A] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
