### PR TITLE
ruby-modules/bundler-env: Replace makeWrapper with makeBinaryWrapper to make bundled ruby apps work on macOS

### DIFF
--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -1,6 +1,6 @@
 { stdenv, runCommand, ruby, lib, rsync
 , defaultGemConfig, buildRubyGem, buildEnv
-, makeWrapper
+, makeBinaryWrapper
 , bundler
 }@defs:
 
@@ -118,7 +118,7 @@ let
 
       wrappedRuby = stdenv.mkDerivation {
         name = "wrapped-ruby-${pname'}";
-        nativeBuildInputs = [ makeWrapper ];
+        nativeBuildInputs = [ makeBinaryWrapper ];
         inherit (ruby) gemPath meta;
         buildCommand = ''
           mkdir -p $out/bin

--- a/pkgs/development/ruby-modules/bundled-common/default.nix
+++ b/pkgs/development/ruby-modules/bundled-common/default.nix
@@ -118,9 +118,12 @@ let
 
       wrappedRuby = stdenv.mkDerivation {
         name = "wrapped-ruby-${pname'}";
+
         nativeBuildInputs = [ makeBinaryWrapper ];
-        inherit (ruby) gemPath meta;
-        buildCommand = ''
+
+        dontUnpack = true;
+
+        buildPhase = ''
           mkdir -p $out/bin
           for i in ${ruby}/bin/*; do
             makeWrapper "$i" $out/bin/$(basename "$i") \
@@ -131,6 +134,15 @@ let
               --set GEM_PATH ${basicEnv}/${ruby.gemPath}
           done
         '';
+
+        dontInstall = true;
+
+        doCheck = true;
+        checkPhase = ''
+          $out/bin/ruby --help > /dev/null
+        '';
+
+        inherit (ruby) meta;
       };
 
       env = let


### PR DESCRIPTION
Fixes the following error on macOS when trying to run cewl:
```
$ nix-shell -p cewl --run cewl

/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 20: VERSION: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 22: puts: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 24: begin: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 25: require: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 26: require: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 27: require: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 28: require: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 29: rescue: command not found
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 31: syntax error near unexpected token `('
/nix/store/zallj5aaf22ic1ic44sy4fpaiq1jvhij-cewl-5.5.2/bin/cewl: line 31: `	if e.to_s =~ /cannot load such file -- (.*)/'
```

Likely also fixes other ruby programs depending on ruby-modules/bundler-env for macOS. According to nixpkgs-review, this seems to affect the following packages:
```
cewl discourse discourse gitaly gitlab gitlab-ee mastodon mikutter mpdcron redmine
```

Test it out:
```sh
env NIX_PATH=nixpkgs=https://github.com/bergkvist/nixpkgs/archive/macos-shebang.tar.gz \
nix-shell -p cewl --run "cewl --help"
```

###### Motivation for this change
nixpkgs uses bash wrapper scripts to modify environment variables that are used by executables. Sometimes these executables are interpreters, and placed in the shebang line of a script. On macOS, shebangs can't point to shell scripts, unlike on Linux.

`pkgs.makeBinaryWrapper` is a [recent addition to nixpkgs](https://github.com/NixOS/nixpkgs/pull/124556), which is an alternative to `pkgs.makeWrapper`. It solves this particular problem by generating and compiling C code instead of generating a shell script. That means you can put it in a shebang line on macOS. The runtime overhead is also less than that of bash wrappers - with some disadvantages being a larger wrapper file size, and less features (no `--run <shell-command>` being the biggest one).

Relevant issues:
- https://github.com/NixOS/nixpkgs/issues/123067#issuecomment-1046646027
- https://github.com/NixOS/nixpkgs/issues/11133
- https://github.com/NixOS/nixpkgs/issues/2146

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
