### PR TITLE
webtorrent_desktop: run in fhsenv

### DIFF
--- a/pkgs/applications/video/webtorrent_desktop/default.nix
+++ b/pkgs/applications/video/webtorrent_desktop/default.nix
@@ -1,95 +1,76 @@
+## FIXME: see ../../../servers/code-server/ for a proper yarn packaging
+##  - export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+##  - jq "del(.scripts.preinstall)" node_modules/shellcheck/package.json | sponge node_modules/shellcheck/package.json
 {
-  alsa-lib, atk, cairo, cups, dbus, dpkg, expat, fetchurl, fetchzip, fontconfig, freetype,
-  gdk-pixbuf, glib, gtk3, libX11, libXScrnSaver, libXcomposite, libXcursor,
-  libXdamage, libXext, libXfixes, libXi, libXrandr, libXrender, libXtst,
-  libxcb, nspr, nss, lib, stdenv, udev, libuuid, pango, at-spi2-atk, at-spi2-core
+  lib, stdenv, buildFHSUserEnvBubblewrap, runCommand, writeScript, fetchurl, fetchzip
 }:
+let
+  pname = "webtorrent-desktop";
+  version = "0.21.0";
+in
+runCommand "${pname}-${version}" rec {
+  inherit (stdenv) shell;
+  inherit pname version;
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchzip {
+        url = "https://github.com/webtorrent/webtorrent-desktop/releases/download/v${version}/WebTorrent-v${version}-linux.zip";
+        sha256 = "13gd8isq2l10kibsc1bsc15dbgpnwa7nw4cwcamycgx6pfz9a852";
+      }
+    else
+      throw "Webtorrent is not currently supported on ${stdenv.hostPlatform.system}";
 
-  let
-    rpath = lib.makeLibraryPath ([
-    alsa-lib
-    atk
-    at-spi2-core
-    at-spi2-atk
-    cairo
-    cups
-    dbus
-    expat
-    fontconfig
-    freetype
-    gdk-pixbuf
-    glib
-    gtk3
-    pango
-    libuuid
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
-    libxcb
-    nspr
-    nss
-    stdenv.cc.cc
-    udev
-    ]);
-  in stdenv.mkDerivation rec {
-    pname = "webtorrent-desktop";
-    version = "0.21.0";
+  fhs = buildFHSUserEnvBubblewrap rec {
+    name = "fhsEnterWebTorrent";
+    runScript = "${src}/WebTorrent";
+    ## use the trampoline, if you need to shell into the fhsenv
+    # runScript = writeScript "trampoline" ''
+    #   #!/bin/sh
+    #   exec "$@"
+    # '';
+    targetPkgs = pkgs: with pkgs; with xorg; [
+      alsa-lib atk at-spi2-core at-spi2-atk cairo cups dbus expat
+      fontconfig freetype gdk-pixbuf glib gtk3 pango libuuid libX11
+      libXScrnSaver libXcomposite libXcursor libXdamage libXext
+      libXfixes libXi libXrandr libXrender libXtst libxcb nspr nss
+      stdenv.cc.cc udev
+    ];
+    # extraBwrapArgs = [
+    #   "--ro-bind /run/user/$(id -u)/pulse /run/user/$(id -u)/pulse"
+    # ];
+  };
 
-    src =
-      if stdenv.hostPlatform.system == "x86_64-linux" then
-        fetchzip {
-          url = "https://github.com/webtorrent/webtorrent-desktop/releases/download/v${version}/WebTorrent-v${version}-linux.zip";
-          sha256 = "13gd8isq2l10kibsc1bsc15dbgpnwa7nw4cwcamycgx6pfz9a852";
-        }
-        else
-          throw "Webtorrent is not currently supported on ${stdenv.hostPlatform.system}";
-    desktopFile = fetchurl {
-      url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/applications/webtorrent-desktop.desktop";
-      sha256 = "1v16dqbxqds3cqg3xkzxsa5fyd8ssddvjhy9g3i3lz90n47916ca";
-    };
-    icon256File = fetchurl {
-      url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/icons/hicolor/256x256/apps/webtorrent-desktop.png";
-      sha256 = "1dapxvvp7cx52zhyaby4bxm4rll9xc7x3wk8k0il4g3mc7zzn3yk";
-    };
-    icon48File = fetchurl {
-      url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/icons/hicolor/48x48/apps/webtorrent-desktop.png";
-      sha256 = "00y96w9shbbrdbf6xcjlahqd08154kkrxmqraik7qshiwcqpw7p4";
-    };
-    nativeBuildInputs = [ dpkg ];
-    installPhase = ''
-      mkdir -p $out/share/{applications,icons/hicolor/{48x48,256x256}/apps}
-      cp -R . $out/libexec
+  desktopFile = fetchurl {
+    url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/applications/webtorrent-desktop.desktop";
+    sha256 = "1v16dqbxqds3cqg3xkzxsa5fyd8ssddvjhy9g3i3lz90n47916ca";
+  };
+  icon256File = fetchurl {
+    url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/icons/hicolor/256x256/apps/webtorrent-desktop.png";
+    sha256 = "1dapxvvp7cx52zhyaby4bxm4rll9xc7x3wk8k0il4g3mc7zzn3yk";
+  };
+  icon48File = fetchurl {
+    url = "https://raw.githubusercontent.com/webtorrent/webtorrent-desktop/v${version}/static/linux/share/icons/hicolor/48x48/apps/webtorrent-desktop.png";
+    sha256 = "00y96w9shbbrdbf6xcjlahqd08154kkrxmqraik7qshiwcqpw7p4";
+  };
 
-      # Patch WebTorrent
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-               --set-rpath ${rpath}:$out/libexec $out/libexec/WebTorrent
+  meta = with lib; {
+    description = "Streaming torrent app for Mac, Windows, and Linux";
+    homepage = "https://webtorrent.io/desktop";
+    license = licenses.mit;
+    maintainers = [ maintainers.flokli maintainers.bendlas ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
 
-      # Symlink to bin
-      mkdir -p $out/bin
-      ln -s $out/libexec/WebTorrent $out/bin/WebTorrent
+} ''
+  mkdir -p $out/{bin,share/{applications,icons/hicolor/{48x48,256x256}/apps}}
 
-      cp $icon48File $out/share/icons/hicolor/48x48/apps/webtorrent-desktop.png
-      cp $icon256File $out/share/icons/hicolor/256x256/apps/webtorrent-desktop.png
-      ## Fix the desktop link
-      substitute $desktopFile $out/share/applications/webtorrent-desktop.desktop \
-        --replace /opt/webtorrent-desktop $out/libexec
-    '';
+  cp $fhs/bin/fhsEnterWebTorrent $out/bin/WebTorrent
 
-    meta = with lib; {
-      description = "Streaming torrent app for Mac, Windows, and Linux";
-      homepage = "https://webtorrent.io/desktop";
-      license = licenses.mit;
-      maintainers = [ maintainers.flokli ];
-      platforms = [
-        "x86_64-linux"
-      ];
-    };
-  }
+  cp $icon48File $out/share/icons/hicolor/48x48/apps/webtorrent-desktop.png
+  cp $icon256File $out/share/icons/hicolor/256x256/apps/webtorrent-desktop.png
+  ## Fix the desktop link
+  substitute $desktopFile $out/share/applications/webtorrent-desktop.desktop \
+    --replace /opt/webtorrent-desktop $out/libexec
+''


### PR DESCRIPTION
this fixes current breakage, and should be a more durable solution for
running the binary distribution

long term goal would be to do a proper yarn packaging

###### Motivation for this change

webtorrent desktop has been broken, and transitioning to a source build turned out to be non-trivial

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
