### PR TITLE
Vala updates 2022-02-21

### DIFF
--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -18,8 +18,6 @@ let
       {
         "0.48" = ./disable-graphviz-0.46.1.patch;
 
-        "0.52" = ./disable-graphviz-0.46.1.patch;
-
         "0.54" = ./disable-graphviz-0.46.1.patch;
 
       }.${lib.versions.majorMinor version} or (throw "no graphviz patch for this version of vala");
@@ -89,11 +87,6 @@ in rec {
   vala_0_48 = generic {
     version = "0.48.23";
     sha256 = "sha256-3jzIWNmV4HR0IZ4lo+Hw7ZmAcNLiBtOjE9Q3ml93oGo=";
-  };
-
-  vala_0_52 = generic {
-    version = "0.52.10";
-    sha256 = "sha256-nCAb+BLZh04hveU/jZwU9lF0ixqBRB/1ySkSJESQEAg=";
   };
 
   vala_0_54 = generic {

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -87,8 +87,8 @@ let
 
 in rec {
   vala_0_48 = generic {
-    version = "0.48.22";
-    sha256 = "sha256-27NHjEvjZvCTFkrGHNOu29zz5EQE2eNkFK4VEk525os=";
+    version = "0.48.23";
+    sha256 = "sha256-3jzIWNmV4HR0IZ4lo+Hw7ZmAcNLiBtOjE9Q3ml93oGo=";
   };
 
   vala_0_52 = generic {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13416,7 +13416,6 @@ with pkgs;
 
   inherit (callPackage ../development/compilers/vala { })
     vala_0_48
-    vala_0_52
     vala_0_54
     vala;
 


### PR DESCRIPTION
###### Motivation for this change

Or we just drop 0.52 as it is [marked as EOL](https://wiki.gnome.org/Projects/Vala) and no package use it.

~~https://gitlab.gnome.org/GNOME/vala/raw/0.52.11/NEWS~~
~~https://gitlab.gnome.org/GNOME/vala/-/compare/0.52.10...0.52.11~~

https://gitlab.gnome.org/GNOME/vala/raw/0.48.23/NEWS
https://gitlab.gnome.org/GNOME/vala/-/compare/0.48.22...0.48.23

Changes are mostly a subset of [0.54.6 -> 0.54.7](https://gitlab.gnome.org/GNOME/vala/raw/0.54.7/NEWS):

---

Various improvements and bug fixes:
  - codegen:
    + Generated SimpleType structs don't have a type id
    + Avoid symbol clashes with "va_*" from "stdarg.h"
    + Access of inline allocated array is guaranteed to be non null [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1282">#1282</a>]
    + Don't uncoditionally null check callback_func for GLib.Closure [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1282">#1282</a>]
    + Access of stack allocated struct is guaranteed to be non null [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1282">#1282</a>]
    + Use correct target/destroy of delegate field initializer [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1285">#1285</a>]
  - gtkmodule: Recurse inner classes of ObjectTypeSymbols
  - vala:
    + Show source location when reporting deprecations
    + Require lvalue access of delegate target/destroy "fields" [<a href="https://gitlab.gnome.org/GNOME/vala/issues/857">#857</a>]
    + Transform assignment of an array element as needed [<a href="https://gitlab.gnome.org/GNOME/vala/issues/889">#889</a>] [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1258">#1258</a>]
    + Add missing TraverseVisitor.visit_data_type()
    + Make sure to drop our "trap" jump target in case of an error [<a href="https://gitlab.gnome.org/GNOME/vala/issues/1287">#1287</a>]
    + Move dynamic property errors to semantic analyzer pass
    + Free empty stack list for code contexts
    + Clear SemanticAnalyzer.current_{symbol,source_file} when not needed anymore
  - parser: Reduce the source reference of main block method to its beginning
  - parser: Improve handling of nullable VarType in with-statement
  - manual: Update from wiki.gnome.org

Bindings:
  - alsa: Add/fix *.alloca() functions
  - glib-2.0: Fix criticals in string.joinv() with arrays that start with null
  - libgeoclue-2.0: Fix Simple.with_thresholds() contructor binding
  - libsoup-2.4: Cherry-pick bindings fixes from 0.56
  - v4l2: Update V4l2.Capabilities and fix some inline arrays



###### Things done

I don't think we need to build any extra packages this time...

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
