### PR TITLE
mysql-shell: init at 8.0.28

### DIFF
--- a/pkgs/development/tools/mysql-shell/default.nix
+++ b/pkgs/development/tools/mysql-shell/default.nix
@@ -1,0 +1,155 @@
+{ lib
+, stdenv
+, pkg-config
+, cmake
+, fetchurl
+, git
+, bison
+, openssl
+, protobuf
+, curl
+, zlib
+, libssh
+, zstd
+, lz4
+, boost
+, readline
+, libtirpc
+, rpcsvc-proto
+, libedit
+, libevent
+, icu
+, re2
+, ncurses
+, libfido2
+, v8
+, python3
+, cyrus_sasl
+, openldap
+, numactl
+, cctools
+, CoreServices
+, developer_cmds
+, DarwinTools
+, testVersion
+, mysql-shell
+}:
+
+let
+  pythonDeps = [
+    python3.pkgs.certifi
+    python3.pkgs.paramiko
+  ];
+  site = ''
+
+    import sys; sys.path.extend([${lib.concatStringsSep ", " (map (x: ''"${x}/${python3.sitePackages}"'') pythonDeps)}])
+  '';
+in
+stdenv.mkDerivation rec{
+  pname = "mysql-shell";
+  version = "8.0.28";
+
+  srcs = [
+    (fetchurl {
+      url = "https://cdn.mysql.com//Downloads/MySQL-Shell/mysql-shell-${version}-src.tar.gz";
+      sha256 = "sha256-xm2sepVgI0MPs25vu+BcRQeksaVhHcQlymreN1myu6c=";
+    })
+    (fetchurl {
+      url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor version}/mysql-${version}.tar.gz";
+      sha256 = "sha256-2Gk2nrbeTyuy2407Mbe3OWjjVuX/xDVPS5ZlirHkiyI=";
+    })
+  ];
+
+  sourceRoot = "mysql-shell-${version}-src";
+
+  postPatch = ''
+    patch ../mysql-${version}/cmake/fido2.cmake ${./fido2.cmake.patch}
+
+    substituteInPlace ../mysql-${version}/cmake/libutils.cmake --replace /usr/bin/libtool libtool
+    substituteInPlace ../mysql-${version}/cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+
+    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
+
+    # For python dependencies
+    echo '${site}' >> python/packages/mysqlsh/__init__.py
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    git
+    bison
+  ] ++ lib.optionals (!stdenv.isDarwin) [ rpcsvc-proto ];
+
+  buildInputs = [
+    boost
+    curl
+    libedit
+    libssh
+    lz4
+    openssl
+    protobuf
+    readline
+    zlib
+    zstd
+    libevent
+    icu
+    re2
+    ncurses
+    libfido2
+    cyrus_sasl
+    openldap
+    v8
+  ] ++ pythonDeps ++ lib.optionals stdenv.isLinux [
+    numactl
+    libtirpc
+  ] ++ lib.optionals stdenv.isDarwin [
+    cctools
+    CoreServices
+    developer_cmds
+    DarwinTools
+  ];
+
+  preConfigure = ''
+    # Build MySQL
+    cmake -DWITH_BOOST=system \
+      -DWITH_SYSTEM_LIBS=ON \
+      -DWITH_ROUTER=OFF \
+      -DWITH_UNIT_TESTS=OFF \
+      -DFORCE_UNSUPPORTED_COMPILER=1 \
+      -S ../mysql-${version} -B ../mysql-${version}/build
+
+    cmake --build ../mysql-${version}/build --parallel ''${NIX_BUILD_CORES:-1} --target mysqlclient mysqlxclient
+
+    # Get libv8_monolith
+    mkdir -p ../v8/lib
+    ln -s ${v8}/lib/libv8.a ../v8/lib/libv8_monolith.a
+  '';
+
+  cmakeFlags = [
+    "-DMYSQL_SOURCE_DIR=../mysql-${version}"
+    "-DMYSQL_BUILD_DIR=../mysql-${version}/build"
+    "-DMYSQL_CONFIG_EXECUTABLE=../../mysql-${version}/build/scripts/mysql_config"
+    "-DWITH_ZSTD=system"
+    "-DWITH_LZ4=system"
+    "-DWITH_ZLIB=system"
+    "-DWITH_PROTOBUF=${protobuf}"
+    "-DHAVE_V8=1"
+    "-DV8_INCLUDE_DIR=${v8}/include"
+    "-DV8_LIB_DIR=../v8/lib"
+    "-DHAVE_PYTHON=1"
+  ];
+
+  CXXFLAGS = [
+    "-DV8_COMPRESS_POINTERS=1"
+    "-DV8_31BIT_SMIS_ON_64BIT_ARCH=1"
+  ];
+
+  meta = with lib; {
+    homepage = "https://dev.mysql.com/doc/mysql-shell/${lib.versions.majorMinor version}/en/";
+    description = "A new command line scriptable shell for MySQL";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ aaronjheng ];
+    mainProgram = "mysqlsh";
+  };
+}

--- a/pkgs/development/tools/mysql-shell/fido2.cmake.patch
+++ b/pkgs/development/tools/mysql-shell/fido2.cmake.patch
@@ -1,0 +1,25 @@
+diff --git a/cmake/fido2.cmake b/cmake/fido2.cmake
+index c20e6e75c0d..f2d5cbd8430 100644
+--- a/cmake/fido2.cmake
++++ b/cmake/fido2.cmake
+@@ -30,19 +30,8 @@ MACRO(FIND_FIDO_VERSION)
+   IF(WITH_FIDO STREQUAL "bundled")
+     SET(FIDO_VERSION "1.7.0")
+   ELSE()
+-    # This does not set any version information:
+-    # PKG_CHECK_MODULES(SYSTEM_FIDO fido2)
+-
+     MYSQL_CHECK_PKGCONFIG()
+-    EXECUTE_PROCESS(
+-      COMMAND ${MY_PKG_CONFIG_EXECUTABLE} --modversion libfido2
+-      OUTPUT_VARIABLE MY_FIDO_MODVERSION
+-      OUTPUT_STRIP_TRAILING_WHITESPACE
+-      RESULT_VARIABLE MY_MODVERSION_RESULT
+-      )
+-    IF(MY_MODVERSION_RESULT EQUAL 0)
+-      SET(FIDO_VERSION ${MY_FIDO_MODVERSION})
+-    ENDIF()
++    PKG_CHECK_MODULES(FIDO libfido2)
+   ENDIF()
+   MESSAGE(STATUS "FIDO_VERSION (${WITH_FIDO}) is ${FIDO_VERSION}")
+ ENDMACRO(FIND_FIDO_VERSION)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -598,6 +598,15 @@ with pkgs;
 
   mod = callPackage ../development/tools/mod { };
 
+  mysql-shell = callPackage ../development/tools/mysql-shell {
+    inherit (darwin) cctools developer_cmds DarwinTools;
+    inherit (darwin.apple_sdk.frameworks) CoreServices;
+    boost = boost173; # Configure checks for specific version.
+    protobuf = protobuf3_11;
+    icu =  icu67;
+    v8 = v8_8_x;
+  };
+
   broadlink-cli = callPackage ../tools/misc/broadlink-cli {};
 
   fetchpatch = callPackage ../build-support/fetchpatch { }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
