### PR TITLE
lispPackages: add slynk and mmap

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/mmap.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/mmap.nix
@@ -1,0 +1,33 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "mmap";
+  version = "20201220-git";
+
+  description = "Portable mmap (file memory mapping) utility library.";
+
+  deps = [ args."alexandria" args."babel" args."cffi" args."documentation-utils" args."trivial-features" args."trivial-indent" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/mmap/2020-12-20/mmap-20201220-git.tgz";
+    sha256 = "147xw351xh90k3yvc1fn7k418afmgngd56i8a6d7p41fzs54g6ij";
+  };
+
+  packageName = "mmap";
+
+  asdFilesToKeep = ["mmap.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM mmap DESCRIPTION
+    Portable mmap (file memory mapping) utility library. SHA256
+    147xw351xh90k3yvc1fn7k418afmgngd56i8a6d7p41fzs54g6ij URL
+    http://beta.quicklisp.org/archive/mmap/2020-12-20/mmap-20201220-git.tgz MD5
+    e2dbeb48b59735bd2ed54ea7f9cdfe0f NAME mmap FILENAME mmap DEPS
+    ((NAME alexandria FILENAME alexandria) (NAME babel FILENAME babel)
+     (NAME cffi FILENAME cffi)
+     (NAME documentation-utils FILENAME documentation-utils)
+     (NAME trivial-features FILENAME trivial-features)
+     (NAME trivial-indent FILENAME trivial-indent))
+    DEPENDENCIES
+    (alexandria babel cffi documentation-utils trivial-features trivial-indent)
+    VERSION 20201220-git SIBLINGS (mmap-test) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/slynk.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/slynk.nix
@@ -1,0 +1,30 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "slynk";
+  version = "sly-20210411-git";
+
+  parasites = [ "slynk/arglists" "slynk/fancy-inspector" "slynk/indentation" "slynk/mrepl" "slynk/package-fu" "slynk/profiler" "slynk/retro" "slynk/stickers" "slynk/trace-dialog" ];
+
+  description = "System lacks description";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/sly/2021-04-11/sly-20210411-git.tgz";
+    sha256 = "1a96aapsz3fhnnnb8njn8v2ddrh6kwisppd90cc7v8knh043xgks";
+  };
+
+  packageName = "slynk";
+
+  asdFilesToKeep = ["slynk.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM slynk DESCRIPTION System lacks description SHA256
+    1a96aapsz3fhnnnb8njn8v2ddrh6kwisppd90cc7v8knh043xgks URL
+    http://beta.quicklisp.org/archive/sly/2021-04-11/sly-20210411-git.tgz MD5
+    7f0ff6b8a07d23599c77cd33c6d59ea6 NAME slynk FILENAME slynk DEPS NIL
+    DEPENDENCIES NIL VERSION sly-20210411-git SIBLINGS NIL PARASITES
+    (slynk/arglists slynk/fancy-inspector slynk/indentation slynk/mrepl
+     slynk/package-fu slynk/profiler slynk/retro slynk/stickers
+     slynk/trace-dialog)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -208,6 +208,7 @@ salza2
 serapeum
 simple-date
 simple-date-time
+slynk
 smart-buffer
 smug
 spinneret

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -178,6 +178,7 @@ mgl-pax
 minheap
 misc-extensions
 mk-string-metrics
+mmap
 moptilities
 more-conditions
 mt19937

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2338,6 +2338,14 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "slynk" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."slynk" or (x: {}))
+       (import ./quicklisp-to-nix-output/slynk.nix {
+         inherit fetchurl;
+       }));
+
+
   "simple-date-time" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."simple-date-time" or (x: {}))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -2702,6 +2702,20 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "mmap" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."mmap" or (x: {}))
+       (import ./quicklisp-to-nix-output/mmap.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "documentation-utils" = quicklisp-to-nix-packages."documentation-utils";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "trivial-indent" = quicklisp-to-nix-packages."trivial-indent";
+       }));
+
+
   "mk-string-metrics" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."mk-string-metrics" or (x: {}))


### PR DESCRIPTION
###### Motivation for this change
I just edited the txt file and ran the update script.

@7c6f434c Can you review this please?

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
