### PR TITLE
ocamlPackages tree-wide: Move buildInputs that should be nativeBuildInputs

### DIFF
--- a/pkgs/applications/science/logic/alt-ergo/default.nix
+++ b/pkgs/applications/science/logic/alt-ergo/default.nix
@@ -12,36 +12,33 @@ let
   };
 
   useDune2 = true;
-
-  nativeBuildInputs = [ which ];
-
 in
 
 let alt-ergo-lib = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-lib";
-  inherit version src useDune2 nativeBuildInputs;
+  inherit version src useDune2;
   configureFlags = pname;
+  nativeBuildInputs = [ which ];
   buildInputs = with ocamlPackages; [ dune-configurator ];
   propagatedBuildInputs = with ocamlPackages; [ num ocplib-simplex stdlib-shims zarith ];
 }; in
 
 let alt-ergo-parsers = ocamlPackages.buildDunePackage rec {
   pname = "alt-ergo-parsers";
-  inherit version src useDune2 nativeBuildInputs;
+  inherit version src useDune2;
   configureFlags = pname;
-  buildInputs = with ocamlPackages; [ menhir ];
+  nativeBuildInputs = [ which ocamlPackages.menhir ];
   propagatedBuildInputs = [ alt-ergo-lib ] ++ (with ocamlPackages; [ camlzip psmt2-frontend ]);
 }; in
 
 ocamlPackages.buildDunePackage {
 
-  inherit pname version src useDune2 nativeBuildInputs;
+  inherit pname version src useDune2;
 
   configureFlags = pname;
 
-  buildInputs = [ alt-ergo-parsers ] ++ (with ocamlPackages; [
-    cmdliner menhir ])
-  ;
+  nativeBuildInputs = [ which ocamlPackages.menhir ];
+  buildInputs = [ alt-ergo-parsers ocamlPackages.cmdliner ];
 
   meta = {
     description = "High-performance theorem prover and SMT solver";

--- a/pkgs/applications/science/logic/anders/default.nix
+++ b/pkgs/applications/science/logic/anders/default.nix
@@ -13,7 +13,10 @@ ocamlPackages.buildDunePackage rec {
     sha256 = "sha256-JUiZoo2rNLfgs94TlJqUNzul/7ODisCjSFAzhgSp1z4=";
   };
 
-  buildInputs = with ocamlPackages; [ zarith menhir ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ ocamlPackages.menhir ];
+  buildInputs = [ ocamlPackages.zarith ];
 
   meta = with lib; {
     description = "Modal Homotopy Type System";

--- a/pkgs/build-support/ocaml/default.nix
+++ b/pkgs/build-support/ocaml/default.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation (args // {
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ] ++ nativeBuildInputs;
 
+  strictDeps = true;
+
   setupHook = if setupHook == null && hasSharedObjects
   then writeText "setupHook.sh" ''
     export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/${pname}/"

--- a/pkgs/build-support/ocaml/oasis.nix
+++ b/pkgs/build-support/ocaml/oasis.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, ocaml_oasis, ocaml, findlib, ocamlbuild }:
 
-{ pname, version, buildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
+{ pname, version, nativeBuildInputs ? [], meta ? { platforms = ocaml.meta.platforms or []; },
   minimumOCamlVersion ? null,
   createFindlibDestdir ? true,
   dontStrip ? true,
@@ -15,10 +15,12 @@ else
 stdenv.mkDerivation (args // {
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
-  buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ] ++ buildInputs;
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ocaml_oasis ] ++ nativeBuildInputs;
 
   inherit createFindlibDestdir;
   inherit dontStrip;
+
+  strictDeps = true;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -11,20 +11,26 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-bK3McF/wTjT9q6luihPaEXjx7Lu6+ZbQ9G61Mc4KoB0=";
   };
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  strictDeps = true;
 
-  buildInputs = [
-    z3
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
   ] ++ (with ocamlPackages; [
     ocaml
     findlib
     ocamlbuild
+    menhir
+  ]);
+
+  buildInputs = [
+    z3
+  ] ++ (with ocamlPackages; [
     batteries
     zarith
     stdint
     yojson
     fileutils
-    menhir
     menhirLib
     pprint
     sedlex_2

--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation {
       --replace "-linkpkg" "-thread -linkpkg"
   '';
 
-  nativeBuildInputs = [ autoreconfHook which ];
-  buildInputs = [ ocaml bap findlib ctypes ];
+  nativeBuildInputs = [ autoreconfHook which ocaml findlib ];
+  buildInputs = [ bap ctypes ];
 
   preInstall = ''
     mkdir -p $out/lib

--- a/pkgs/development/ocaml-modules/apron/default.nix
+++ b/pkgs/development/ocaml-modules/apron/default.nix
@@ -10,8 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "14ymjahqdxj26da8wik9d5dzlxn81b3z1iggdl7rn2nn06jy7lvy";
   };
 
-  buildInputs = [ perl gmp mpfr ppl ocaml findlib camlidl ];
+  nativeBuildInputs = [ ocaml findlib perl ];
+  buildInputs = [ gmp mpfr ppl camlidl ];
   propagatedBuildInputs = [ mlgmpidl ];
+
+  strictDeps = true;
 
   outputs = [ "out" "bin" "dev" ];
 

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -13,8 +13,10 @@ buildDunePackage rec {
     sha256 = "17jm79np69ixp53a4njxnlb1pg8sd1g47nm3nyki9clkc8d4qsyv";
   };
 
-  buildInputs = [ which menhir ];
+  nativeBuildInputs = [ which menhir ];
   propagatedBuildInputs = [ easy-format re ];
+
+  strictDeps = true;
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -36,10 +36,9 @@ stdenv.mkDerivation rec {
     export CAML_LD_LIBRARY_PATH="''${CAML_LD_LIBRARY_PATH-}''${CAML_LD_LIBRARY_PATH:+:}''$1/lib/ocaml/${ocaml.version}/site-lib/ocaml${ocaml.version}-bap-${version}-llvm-plugins/"
   '';
 
-  nativeBuildInputs = [ which makeWrapper ];
+  nativeBuildInputs = [ which makeWrapper ocaml findlib ocamlbuild ocaml_oasis ];
 
-  buildInputs = [ ocaml findlib ocamlbuild ocaml_oasis
-                  linenoise
+  buildInputs = [ linenoise
                   ounit
                   ppx_bitstring
                   z3

--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, num
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, num, ounit
 , doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
 }:
 
@@ -17,9 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:1cd7475n1mxhq482aidmhh27mq5p2vmb8d9fkb1mlza9pz5z66yq";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-  checkInputs = [ qtest ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  checkInputs = [ qtest ounit ];
   propagatedBuildInputs = [ num ];
+
+  strictDeps = !doCheck;
 
   inherit doCheck;
   checkTarget = "test";

--- a/pkgs/development/ocaml-modules/benchmark/default.nix
+++ b/pkgs/development/ocaml-modules/benchmark/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "16wi8ld7c3mq77ylpgbnj8qqqqimyzwxs47v06vyrwpma5pab5xa";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ocaml_pcre ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocaml_pcre ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
+++ b/pkgs/development/ocaml-modules/bigarray-overlap/default.nix
@@ -14,9 +14,12 @@ buildDunePackage rec {
   minimumOCamlVersion = "4.07";
   useDune2 = true;
 
+  strictDeps = !doCheck;
+
   propagatedBuildInputs = [ bigarray-compat ];
 
-  checkInputs = [ alcotest astring fpath bos findlib pkg-config ];
+  nativeBuildInputs = [ findlib pkg-config ];
+  checkInputs = [ alcotest astring fpath bos ];
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, bigarray-compat }:
+{ lib, fetchFromGitHub, buildDunePackage, ocaml, alcotest, bigarray-compat, pkg-config }:
 
 buildDunePackage rec {
   pname = "bigstringaf";
@@ -15,6 +15,10 @@ buildDunePackage rec {
     sha256 = "1q1sqxzdnlrpl95ccrhl7lwy3zswgd9rbn19ildclh0lyi2vazbj";
   };
 
+  # This currently fails with dune
+  strictDeps = false;
+
+  nativeBuildInputs = [ pkg-config ];
   checkInputs = [ alcotest ];
   propagatedBuildInputs = [ bigarray-compat ];
   doCheck = lib.versionAtLeast ocaml.version "4.05";

--- a/pkgs/development/ocaml-modules/biniou/1.0.nix
+++ b/pkgs/development/ocaml-modules/biniou/1.0.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "14j3hrhbjqxbizr1pr8fcig9dmfzhbjjwzwyc99fcsdic67w8izb";
   };
 
-  buildInputs = [ ocaml findlib easy-format ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ easy-format ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/biniou/default.nix
+++ b/pkgs/development/ocaml-modules/biniou/default.nix
@@ -15,6 +15,8 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [ easy-format ];
 
+  strictDeps = true;
+
   postPatch = ''
    patchShebangs .
   '';

--- a/pkgs/development/ocaml-modules/bitv/default.nix
+++ b/pkgs/development/ocaml-modules/bitv/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sZwq6c10hBBS9tGvKlWD9GE3JBrZPByfDrXE6xIPcG4=";
   };
 
-  buildInputs = [ autoreconfHook which ocaml findlib ];
+  nativeBuildInputs = [ autoreconfHook which ocaml findlib ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/bolt/default.nix
+++ b/pkgs/development/ocaml-modules/bolt/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
     sha256 = "1c807wrpxra9sbb34lajhimwra28ldxv04m570567lh2b04n38zy";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild which camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild which camlp4 ];
+
+  strictDeps = true;
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/ocaml-modules/bos/default.nix
+++ b/pkgs/development/ocaml-modules/bos/default.nix
@@ -11,9 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1s10iqx8rgnxr5n93lf4blwirjf8nlm272yg5sipr7lsr35v49wc";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
   propagatedBuildInputs = [ astring fmt fpath logs rresult ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/bz2/default.nix
+++ b/pkgs/development/ocaml-modules/bz2/default.nix
@@ -19,9 +19,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
-  ];
-
-  buildInputs = [
     ocaml
     findlib
   ];
@@ -29,6 +26,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     bzip2
   ];
+
+  strictDeps = true;
 
   preInstall = "mkdir -p $OCAMLFIND_DESTDIR/stublibs";
 

--- a/pkgs/development/ocaml-modules/calendar/default.nix
+++ b/pkgs/development/ocaml-modules/calendar/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "04pvhwb664g3s644c7v7419a3kvf5s3pynkhmk5j59dvlfm1yf0f";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/camlimages/default.nix
+++ b/pkgs/development/ocaml-modules/camlimages/default.nix
@@ -17,7 +17,10 @@ buildDunePackage rec {
     sha256 = "1m2c76ghisg73dikz2ifdkrbkgiwa0hcmp21f2fm2rkbf02rq3f4";
   };
 
-  buildInputs = [ dune-configurator cppo graphics lablgtk stdio ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ dune-configurator graphics lablgtk stdio ];
 
   meta = with lib; {
     branch = "5.0";

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:1qmsa0xgi960y7r20mvf8hxiiml7l1908s4dm7nq262f19w51gsl";
   };
 
-  buildInputs = [ which ocaml findlib ];
+  nativeBuildInputs = [ which ocaml findlib ];
+
+  strictDeps = true;
 
   preInstall = ''
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs

--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -33,9 +33,11 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
 
   propagatedBuildInputs = [zlib];
+
+  strictDeps = true;
 
   inherit (param) patches;
 

--- a/pkgs/development/ocaml-modules/camomile/0.8.2.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.2.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "0x43pjxx70kgip86mmdn08s97k4qzdqc8i79xfyyx28smy1bsa00";
   };
 
-  buildInputs = [ocaml findlib camlp4];
+  nativeBuildInputs = [ ocaml findlib camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/camomile/0.8.5.nix
+++ b/pkgs/development/ocaml-modules/camomile/0.8.5.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation {
     sha256 = "167279lia6qx62mdcyc5rjsi4gf4yi52wn9mhgd9y1v3754z7fwb";
   })];
 
-  buildInputs = [ocaml findlib camlp4];
+  nativeBuildInputs = [ocaml findlib camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/camomile/default.nix
+++ b/pkgs/development/ocaml-modules/camomile/default.nix
@@ -13,7 +13,9 @@ buildDunePackage rec {
     sha256 = "00i910qjv6bpk0nkafp5fg97isqas0bwjf7m6rz11rsxilpalzad";
   };
 
-  buildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo ];
+
+  strictDeps = true;
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -14,7 +14,7 @@ buildDunePackage rec {
     sha256 = "1vl61kdyj89whc3mh4k9bis6rbj9x2scf6hnv9afyalp4j65sqx1";
   };
 
-  buildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo ];
   propagatedBuildInputs = [ logs ptime uri ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -48,13 +48,15 @@ buildDunePackage rec {
   ];
 
   doCheck = true;
+  nativeBuildInputs = [
+    findlib
+  ];
   checkInputs = [
     base64
     alcotest
     alcotest-lwt
     crowbar
     lwt
-    findlib
     mirage-flow
   ];
 

--- a/pkgs/development/ocaml-modules/cfstream/default.nix
+++ b/pkgs/development/ocaml-modules/cfstream/default.nix
@@ -17,7 +17,10 @@ buildDunePackage rec {
 
   patches = [ ./git_commit.patch ];
 
-  buildInputs = [ m4 ];
+  # This currently fails with dune
+  strictDeps = false;
+
+  nativeBuildInputs = [ m4 ];
   checkInputs = [ ounit ];
   propagatedBuildInputs = [ core_kernel ];
 

--- a/pkgs/development/ocaml-modules/checkseum/default.nix
+++ b/pkgs/development/ocaml-modules/checkseum/default.nix
@@ -18,10 +18,8 @@ buildDunePackage rec {
     sha256 = "9cdd282ea1cfc424095d7284e39e4d0ad091de3c3f2580539d03f6966d45ccd5";
   };
 
-  nativeBuildInputs = [
-    dune-configurator
-    pkg-config
-  ];
+  buildInputs = [ dune-configurator ];
+  nativeBuildInputs = [ pkg-config ];
   propagatedBuildInputs = [
     bigarray-compat
     optint

--- a/pkgs/development/ocaml-modules/cil/default.nix
+++ b/pkgs/development/ocaml-modules/cil/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
     sha256 = "05739da0b0msx6kmdavr3y2bwi92jbh3szc35d7d8pdisa8g5dv9";
   };
 
-  buildInputs = [ perl ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ perl ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     inherit (param) sha256;
   };
 
-  nativeBuildInputs = [ ocaml ocamlbuild findlib ];
+  nativeBuildInputs = [ ocaml ocamlbuild findlib topkg ];
   buildInputs = [ topkg ];
   propagatedBuildInputs = [ result ];
 

--- a/pkgs/development/ocaml-modules/coin/default.nix
+++ b/pkgs/development/ocaml-modules/coin/default.nix
@@ -24,9 +24,11 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  nativeBuildInputs = [ menhir ];
+  nativeBuildInputs = [ menhir findlib ];
+  buildInputs = [ re ];
 
-  checkInputs = [ re ];
+  strictDeps = true;
+
   doCheck = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/comparelib/default.nix
+++ b/pkgs/development/ocaml-modules/comparelib/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildOcaml, fetchFromGitHub, type_conv }:
+{ lib, buildOcaml, fetchFromGitHub, type_conv, camlp4 }:
 
 buildOcaml rec {
   pname = "comparelib";
@@ -13,6 +13,7 @@ buildOcaml rec {
     sha256 = "sha256-gtJvXAUxiIt/L9bCzS+8wHcCQ+QpBubwcjDcyN0K2MA=";
   };
 
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ type_conv ];
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/config-file/default.nix
+++ b/pkgs/development/ocaml-modules/config-file/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1b02yxcnsjhr05ssh2br2ka4hxsjpdw34ldl3nk33wfnkwk7g67q";
   };
 
-  buildInputs = [ ocaml findlib camlp4 ];
+  nativeBuildInputs = [ ocaml findlib camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -15,8 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:1qmx229nij7g6qmiacmyy4mcgx3k9509p4slahivshqm79d6wiwl";
   };
 
-  buildInputs = [ ocaml findlib ncurses ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ ncurses ];
   propagatedBuildInputs = [ camlpdf ];
+
+  strictDeps = true;
 
   preInstall = ''
     mkdir -p $OCAMLFIND_DESTDIR

--- a/pkgs/development/ocaml-modules/cryptgps/default.nix
+++ b/pkgs/development/ocaml-modules/cryptgps/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation {
     sha256 = "1mp7i42cm9w9grmcsa69m3h1ycpn6a48p43y4xj8rsc12x9nav3s";
   };
 
-  buildInputs = [ocaml findlib];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   dontConfigure = true;	# Skip configure phase
 

--- a/pkgs/development/ocaml-modules/csv/1.5.nix
+++ b/pkgs/development/ocaml-modules/csv/1.5.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1ca7jgg58j24pccs5fshis726s06fdcjshnwza5kwxpjgdbvc63g";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -15,9 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-eu5RAuPYC97IM4XUsUw3HQ1BJlEHQ+eBpsdUE6hd+Q8=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib ncurses ];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
+  buildInputs = [ ncurses ];
   propagatedBuildInputs = [ integers libffi bigarray-compat ];
+
+  strictDeps = true;
 
   buildPhase = ''
     make XEN=false libffi.config ctypes-base ctypes-stubs

--- a/pkgs/development/ocaml-modules/digestif/default.nix
+++ b/pkgs/development/ocaml-modules/digestif/default.nix
@@ -1,4 +1,5 @@
 { lib, ocaml, fetchurl, buildDunePackage
+, pkg-config, which
 , bigarray-compat, eqaf, stdlib-shims
 , alcotest, astring, bos, findlib, fpath
 }:
@@ -14,7 +15,12 @@ buildDunePackage rec {
     sha256 = "01gwkbrznci4xdcbww4ysgsciz2qs0r8jsmhp0siwbcgcrf1jjv5";
   };
 
+  nativeBuildInputs = [ findlib which ];
+  buildInputs = [ ocaml ];
+
   propagatedBuildInputs = [ bigarray-compat eqaf stdlib-shims ];
+
+  strictDeps = !doCheck;
 
   checkInputs = [ alcotest astring bos fpath ];
   doCheck = lib.versionAtLeast ocaml.version "4.05";

--- a/pkgs/development/ocaml-modules/dolmen/default.nix
+++ b/pkgs/development/ocaml-modules/dolmen/default.nix
@@ -16,7 +16,9 @@ buildDunePackage rec {
     sha256 = "133l23mwxa9xy340izvk4zp5jqjz2cwsm2innsgs2kg85pd39c41";
   };
 
-  buildInputs = [ menhir ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ menhir ];
   propagatedBuildInputs = [ menhirLib fmt ];
 
   # Testr are not compatible with menhir 20211128

--- a/pkgs/development/ocaml-modules/dolog/default.nix
+++ b/pkgs/development/ocaml-modules/dolog/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-6wfqT5sqo4YA8XoHH3QhG6/TyzzXCzqjmnPuBArRoj8=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/dum/default.nix
+++ b/pkgs/development/ocaml-modules/dum/default.nix
@@ -13,8 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "0yrxl97szjc0s2ghngs346x3y0xszx2chidgzxk93frjjpsr1mlr";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ easy-format ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/dypgen/default.nix
+++ b/pkgs/development/ocaml-modules/dypgen/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     sha256 = "ecb53d6e469e9ec4d57ee6323ff498d45b78883ae13618492488e7c5151fdd97";
   };
 
-  buildInputs = [ocaml findlib];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -8,9 +8,11 @@ stdenv.mkDerivation rec {
     sha256 = "1nymykskq1yx87y4xl6hl9i4q6kv0qaq25rniqgl1bfn883p1ysc";
   };
 
-  buildInputs = [ perl ocaml findlib ];
+  nativeBuildInputs = [ perl ocaml findlib ];
 
   propagatedBuildInputs = [ apron camlidl gmp mpfr ];
+
+  strictDeps = true;
 
   prefixKey = "--prefix ";
   configureFlags = [

--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -6,6 +6,7 @@
 , ocaml
 , lwt_react
 , opaline
+, ocamlbuild
 , ppx_deriving
 , findlib
 , js_of_ocaml-ocamlbuild
@@ -28,13 +29,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VNxzpVpXEGlixyjadbW0GjL83jcKV5TWd46UReNYO6w=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     ocaml
     which
     findlib
+    opaline
+    ocamlbuild
+  ];
+  buildInputs = [
     js_of_ocaml-ocamlbuild
     js_of_ocaml-ppx_deriving_json
-    opaline
     ocamlnet
   ];
 
@@ -47,6 +51,8 @@ stdenv.mkDerivation rec {
     ocsigen_server
     ppx_deriving
   ];
+
+  strictDeps = true;
 
   installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
 

--- a/pkgs/development/ocaml-modules/enumerate/default.nix
+++ b/pkgs/development/ocaml-modules/enumerate/default.nix
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "0b6mx5p01lcpimvak4wx6aj2119707wsfzd83rwgb91bhpgzh156";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ type_conv camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/erm_xml/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xml/default.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-OQdLTq9tJZc6XlcuPv2gxzYiQAUGd6AiBzfSi169XL0=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/erm_xmpp/default.nix
+++ b/pkgs/development/ocaml-modules/erm_xmpp/default.nix
@@ -13,8 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0spzyd9kbyizzwl8y3mq8z19zlkzxnkh2fppry4lyc7vaw7bqrwq";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ];
+  buildInputs = [ camlp4 ];
   propagatedBuildInputs = [ erm_xml mirage-crypto mirage-crypto-rng base64 ];
+
+  strictDeps = true;
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/ocaml-modules/expat/0.9.nix
+++ b/pkgs/development/ocaml-modules/expat/0.9.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation rec {
     sha256 = "16n2j3y0jc9xgqyshw9plrwqnjiz30vnpbhahmgxlidbycw8rgjz";
   };
 
-  buildInputs = [ocaml findlib ounit expat];
+  nativeBuildInputs = [ocaml findlib ];
+  buildInputs = [ ounit expat];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/expat/default.nix
+++ b/pkgs/development/ocaml-modules/expat/default.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace "gcc" "\$(CC)"
   '';
 
-  buildInputs = [ ocaml findlib expat ounit ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ expat ounit ];
+
+  strictDeps = true;
 
   doCheck = !lib.versionAtLeast ocaml.version "4.06";
   checkTarget = "testall";

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -12,7 +12,9 @@ stdenv.mkDerivation rec {
     sha256 = "0npq4hq3zym8nmlyji7l5cqk6drx2rkcx73d60rxqh5g8dla8p4k";
   };
 
-  buildInputs = [ ocaml findlib cppo ];
+  nativeBuildInputs = [ ocaml findlib cppo ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/farfadet/default.nix
+++ b/pkgs/development/ocaml-modules/farfadet/default.nix
@@ -15,9 +15,12 @@ stdenv.mkDerivation rec {
     sha256 = "0nlafnp0pwx0n4aszpsk6nvcvqi9im306p4jhx70si7k3xprlr2j";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
 
   propagatedBuildInputs = [ faraday ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -13,9 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0gkkkj4x678vxdda4xaw2dd44qjacavsvn5nx8gydfwah6pjbkxk";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg cmdliner ];
-  propagatedBuildInputs = [ seq stdlib-shims ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
+  propagatedBuildInputs = [ cmdliner seq stdlib-shims ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/fontconfig/default.nix
+++ b/pkgs/development/ocaml-modules/fontconfig/default.nix
@@ -11,8 +11,11 @@ stdenv.mkDerivation {
     sha256 = "1fw6bzydmnyh2g4x35mcbg0hypnxqhynivk4nakcsx7prr8zr3yh";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml fontconfig ];
+  nativeBuildInputs = [ pkg-config ocaml ];
+  buildInputs = [ fontconfig ];
+
+  strictDeps = true;
+
   makeFlags = [
     "OCAML_STDLIB_DIR=$(out)/lib/ocaml/${lib.getVersion ocaml}/site-lib/"
     "OCAML_HAVE_OCAMLOPT=yes"

--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -13,9 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "03z7mj0sqdz465rc4drj1gr88l9q3nfs374yssvdjdyhjbqqzc0j";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
 
   propagatedBuildInputs = [ astring ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/frontc/default.nix
+++ b/pkgs/development/ocaml-modules/frontc/default.nix
@@ -18,7 +18,9 @@ stdenv.mkDerivation rec {
     sha256 = "1dq5nks0c9gsbr1m8k39m1bniawr5hqcy1r8x5px7naa95ch06ak";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/development/ocaml-modules/functory/default.nix
+++ b/pkgs/development/ocaml-modules/functory/default.nix
@@ -21,7 +21,9 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   installTargets = [ "ocamlfind-install" ];
 

--- a/pkgs/development/ocaml-modules/getopt/default.nix
+++ b/pkgs/development/ocaml-modules/getopt/default.nix
@@ -9,11 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0bng2mmdixpmj23xn8krlnaq66k22iclwz46r8zjrsrq3wcn1xgn";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     ocaml
     findlib
     ocamlbuild
   ];
+
+  strictDeps = true;
 
   doCheck = true;
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/gg/default.nix
+++ b/pkgs/development/ocaml-modules/gg/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
     sha256 = "sha256:0j7bpj8k17csnz6v6frkz9aycywsb7xmznnb31g8rbfk3626f3ci";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/gmetadom/default.nix
+++ b/pkgs/development/ocaml-modules/gmetadom/default.nix
@@ -21,10 +21,11 @@ stdenv.mkDerivation rec {
     configureFlags="--with-ocaml-lib-prefix=$out/lib/ocaml/${ocaml.version}/site-lib"
   '';
 
-
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ocaml findlib gdome2 libxslt];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
+  buildInputs = [ gdome2 libxslt];
   propagatedBuildInputs = [gdome2];
+
+  strictDeps = true;
 
   meta = {
     homepage = "http://gmetadom.sourceforge.net/";

--- a/pkgs/development/ocaml-modules/hacl-star/default.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/default.nix
@@ -12,7 +12,9 @@ buildDunePackage {
     zarith
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     cppo
   ];
+
+  strictDeps = true;
 }

--- a/pkgs/development/ocaml-modules/hacl-star/raw.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/raw.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   dontAddStaticConfigureFlags = true;
   configurePlatforms = [];
 
-  buildInputs = [
+  nativeBuildInputs = [
     which
     ocaml
     findlib
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
   checkInputs = [
     cppo
   ];
+
+  strictDeps = true;
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/herelib/default.nix
+++ b/pkgs/development/ocaml-modules/herelib/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildOcaml, fetchFromGitHub }:
+{ lib, buildOcaml, fetchFromGitHub, camlp4 }:
 
 buildOcaml rec {
   version = "112.35.00";
@@ -12,6 +12,10 @@ buildOcaml rec {
     rev = version;
     sha256 = "sha256-EuMhHu2na3lcpsJ1wMVOgBr6VKndlonq8jgAW01eelI=";
   };
+
+  strictDeps = true;
+
+  buildInputs = [ camlp4 ];
 
   meta = with lib; {
     homepage = "https://github.com/janestreet/herelib";

--- a/pkgs/development/ocaml-modules/hidapi/default.nix
+++ b/pkgs/development/ocaml-modules/hidapi/default.nix
@@ -13,9 +13,12 @@ buildDunePackage rec {
     sha256 = "1j7rd7ajrzla76r3sxljx6fb18f4f4s3jd7vhv59l2ilxyxycai2";
   };
 
+  strictDeps = true;
+
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ pkgs.hidapi pkg-config dune-configurator ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pkgs.hidapi dune-configurator ];
   propagatedBuildInputs = [ bigstring ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/hmap/default.nix
+++ b/pkgs/development/ocaml-modules/hmap/default.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
     sha256 = "10xyjy4ab87z7jnghy0wnla9wrmazgyhdwhr4hdmxxdn28dxn03a";
   };
 
-  buildInputs = [ ocaml ocamlbuild findlib topkg ];
+  nativeBuildInputs = [ ocaml ocamlbuild findlib topkg ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
 
   inherit (topkg) installPhase;
 

--- a/pkgs/development/ocaml-modules/hxd/default.nix
+++ b/pkgs/development/ocaml-modules/hxd/default.nix
@@ -21,14 +21,11 @@ buildDunePackage rec {
     sed -i 's|yes ".\+"|& 2> /dev/null|' test/*.t
   '';
 
-  nativeBuildInputs = [
-    dune-configurator
-  ];
-
   propagatedBuildInputs = lib.optional withLwt lwt;
 
   buildInputs = [
     cmdliner
+    dune-configurator
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/inifiles/default.nix
+++ b/pkgs/development/ocaml-modules/inifiles/default.nix
@@ -16,8 +16,10 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
   propagatedBuildInputs = [ ocaml_pcre ];
+
+  strictDeps = true;
 
   buildFlags = [ "all" "opt" ];
 

--- a/pkgs/development/ocaml-modules/inotify/default.nix
+++ b/pkgs/development/ocaml-modules/inotify/default.nix
@@ -19,8 +19,12 @@ stdenv.mkDerivation rec {
     sha256 = "04lfxrrsmk2mc704kaln8jqx93jc4bkxhijmfy2d4cmk1cim7r6k";
   }) ];
 
-  buildInputs = [ ocaml findlib ocamlbuild ocaml_lwt ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocaml_lwt ];
   checkInputs = [ ounit fileutils ];
+
+  # Otherwise checkInputs can't be found
+  strictDeps = false;
 
   configureFlags = [ "--enable-lwt"
     (lib.optionalString doCheck "--enable-tests") ];

--- a/pkgs/development/ocaml-modules/iso8601/default.nix
+++ b/pkgs/development/ocaml-modules/iso8601/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-sXnYAJcU88797orzzfbA2XG91Lk8mDV677J1Am5o7Xo=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
+
   createFindlibDestdir = true;
 
   meta = {

--- a/pkgs/development/ocaml-modules/janestreet/0.12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.12.nix
@@ -24,6 +24,7 @@ with self;
     hash = "0gl89zpgsf3n30nb6v5cns27g2bfg4rf3s2427gqvwbkr5gcf7ri";
     meta.description = "Full standard library replacement for OCaml";
     propagatedBuildInputs = [ sexplib0 ];
+    buildInputs = [ dune-configurator ];
   };
 
   stdio = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -203,6 +203,8 @@ with self;
     meta.description = "Trivial metaprogramming tool";
     propagatedBuildInputs = [ re ];
     checkInputs = [ ppx_jane ];
+    # This currently fails with dune
+    strictDeps = false;
   };
 
   core = janePackage {
@@ -761,6 +763,8 @@ with self;
     buildInputs = [ jst-config ];
     propagatedBuildInputs = [ textutils ];
     checkInputs = [ ounit ];
+    # This currently fails with dune
+    strictDeps = false;
   };
 
   shexp = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/janePackage.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage.nix
@@ -1,9 +1,9 @@
 { lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.11.0" }:
 
-{ pname, version ? defaultVersion, hash, ...}@args:
+{ pname, version ? defaultVersion, hash, buildInputs ? [], ...}@args:
 
 buildDunePackage (args // {
-  inherit version;
+  inherit version buildInputs;
 
   minimumOCamlVersion = "4.04";
 
@@ -13,6 +13,8 @@ buildDunePackage (args // {
     rev = "v${version}";
     sha256 = hash;
   };
+
+  strictDeps = true;
 
   meta = {
     license = lib.licenses.asl20;

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_12.nix
@@ -1,11 +1,13 @@
 { lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.12.0" }:
 
-{ pname, version ? defaultVersion, hash, ...}@args:
+{ pname, version ? defaultVersion, hash, buildInputs ? [], ...}@args:
 
 buildDunePackage (args // {
-  inherit version;
+  inherit version buildInputs;
 
   minimumOCamlVersion = "4.07";
+
+  useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "janestreet";
@@ -13,6 +15,8 @@ buildDunePackage (args // {
     rev = "v${version}";
     sha256 = hash;
   };
+
+  strictDeps = true;
 
   meta = {
     license = lib.licenses.mit;

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_14.nix
@@ -5,11 +5,13 @@
 , hash
 , minimumOCamlVersion ? "4.08"
 , doCheck ? true
+, buildInputs ? []
+, strictDeps ? true
 , ...}@args:
 
 buildDunePackage (args // {
   useDune2 = true;
-  inherit version;
+  inherit version buildInputs strictDeps;
 
   inherit minimumOCamlVersion;
 

--- a/pkgs/development/ocaml-modules/javalib/default.nix
+++ b/pkgs/development/ocaml-modules/javalib/default.nix
@@ -23,7 +23,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-du1h+S+A7CetMXofsYxdGeSsobCgspDB9oUE9WNUbbo=";
   };
 
-  buildInputs = [ which ocaml findlib ];
+  nativeBuildInputs = [ which ocaml findlib ];
+
+  strictDeps = true;
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -9,9 +9,11 @@ stdenv.mkDerivation rec {
     sha256 = "1176dcmxb11fnw49b7yysvkjh0kpzx4s48lmdn5psq9vshp5c29w";
   };
 
-  buildInputs = [ findlib topkg ];
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
   propagatedBuildInputs = [ uutf ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/lablgl/default.nix
+++ b/pkgs/development/ocaml-modules/lablgl/default.nix
@@ -15,7 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:141kc816iv59z96738i3vn9m9iw9g2zhi45hk4cchpwd99ar5l6k";
   };
 
-  buildInputs = [ ocaml findlib freeglut ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ freeglut ];
   propagatedBuildInputs = [ libGLU libGL ];
 
   patches = [ ./Makefile.config.patch ./META.patch ];

--- a/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/1.4.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "09fqxwdib7r9yxynknc9gv3jw2hnhj5cak7q5jngk6m8rzvmhfcc";
   };
 
-  buildInputs = [ ocaml findlib camlp4 ];
+  nativeBuildInputs = [ ocaml findlib camlp4 ];
   propagatedBuildInputs = [ config-file lablgtk xmlm ];
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk-extras/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "1bbdp5j18s582mmyd7qiaq1p08g2ag4gl7x65pmzahbhg719hjda";
   };
 
-  buildInputs = [ ocaml findlib camlp4 ];
+  nativeBuildInputs = [ ocaml findlib camlp4 ];
   propagatedBuildInputs = [ config-file lablgtk xmlm ];
 
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/2.14.0.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation (rec {
     sha256 = "1fnh0amm7lwgyjdhmlqgsp62gwlar1140425yc1j6inwmgnsp0a9";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib gtk2 libgnomecanvas gtksourceview camlp4 ];
+  nativeBuildInputs = [ pkg-config ocaml findlib camlp4 ];
+  buildInputs = [ gtk2 libgnomecanvas gtksourceview ];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = [ "world" ];

--- a/pkgs/development/ocaml-modules/lablgtk/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk/default.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation {
   pname = "lablgtk";
   inherit (param) version src;
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib gtk2 libgnomecanvas gtksourceview ];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
+  buildInputs = [ gtk2 libgnomecanvas gtksourceview ];
 
   configureFlags = [ "--with-libdir=$(out)/lib/ocaml/${ocaml.version}/site-lib" ];
   buildFlags = [ "world" ];

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -51,7 +51,8 @@ stdenv.mkDerivation rec {
   inherit (param) version src;
   pname = "ocaml${ocaml.version}-labltk";
 
-  buildInputs = [ ocaml findlib tcl tk makeWrapper ];
+  nativeBuildInputs = [ ocaml findlib makeWrapper ];
+  buildInputs = [ tcl tk ];
 
   configureFlags = [ "--use-findlib" "--installbindir" "$(out)/bin" ];
   dontAddPrefix = true;

--- a/pkgs/development/ocaml-modules/llvm/default.nix
+++ b/pkgs/development/ocaml-modules/llvm/default.nix
@@ -8,9 +8,11 @@ stdenv.mkDerivation {
 
   inherit (libllvm) src;
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ python2 ocaml findlib ctypes ];
+  nativeBuildInputs = [ cmake python2 ocaml findlib ];
+  buildInputs = [ ctypes ];
   propagatedBuildInputs = [ libllvm ];
+
+  strictDeps = true;
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=YES" # fixes bytecode builds

--- a/pkgs/development/ocaml-modules/logs/default.nix
+++ b/pkgs/development/ocaml-modules/logs/default.nix
@@ -21,10 +21,12 @@ stdenv.mkDerivation rec {
     sha256 = "1jnmd675wmsmdwyb5mx5b0ac66g4c6gpv5s4mrx2j6pb0wla1x46";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg fmt cmdliner lwt ]
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ fmt cmdliner lwt topkg ]
     ++ lib.optional jsooSupport js_of_ocaml;
   propagatedBuildInputs = [ result ];
+
+  strictDeps = true;
 
   buildPhase = "${topkg.run} build --with-js_of_ocaml ${lib.boolToString jsooSupport}";
 

--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -16,8 +16,9 @@ stdenv.mkDerivation rec {
     sha256 = "04lv98nxmzanvyn4c0k6k0ax29f5xfdl8qzpf5hwadslq213a044";
   };
 
-  nativeBuildInputs = [ opaline ];
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ opaline ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   buildFlags = [ "lib" ];
 

--- a/pkgs/development/ocaml-modules/lwt-exit/default.nix
+++ b/pkgs/development/ocaml-modules/lwt-exit/default.nix
@@ -24,7 +24,8 @@ buildDunePackage rec {
     ptime
   ];
 
-  doCheck = true;
+  # for some reason this never exits
+  doCheck = false;
 
   meta = {
     description = "An opinionated clean-exit and signal-handling library for Lwt programs";

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -19,9 +19,12 @@ buildDunePackage rec {
     sha256 = "sha256-XpoRKcdNo2j05Gxm5wmKSdwqimFDSWvmLyooPYTHAjM=";
   };
 
-  nativeBuildInputs = [ pkg-config cppo dune-configurator ];
-  buildInputs = optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
-   ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config cppo ];
+  buildInputs = [ dune-configurator ]
+    ++ optional (!versionAtLeast ocaml.version "4.08") ocaml-syntax-shims
+    ++ optional (!versionAtLeast ocaml.version "4.07") ncurses;
   propagatedBuildInputs = [ libev mmap ocplib-endian seq result ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/macaque/default.nix
+++ b/pkgs/development/ocaml-modules/macaque/default.nix
@@ -11,8 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-W9ZFaINYYtIikKy/ZqdlKeFQSA7DQT9plc3+ZhlSIJI=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild camlp4 ];
-  propagatedBuildInputs = [ pgocaml ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ];
+  propagatedBuildInputs = [ pgocaml camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/magick/default.nix
+++ b/pkgs/development/ocaml-modules/magick/default.nix
@@ -13,8 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "0gn9l2qdr8gby2x8c2mb59x1kipb2plr45rbq6ymcxyi0wmzfh3q";
   };
 
-  nativeBuildInputs = [ which pkg-config ];
-  buildInputs = [ ocaml findlib imagemagick ];
+  nativeBuildInputs = [ which pkg-config ocaml findlib ];
+  buildInputs = [ imagemagick ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/merlin-extend/default.nix
+++ b/pkgs/development/ocaml-modules/merlin-extend/default.nix
@@ -11,7 +11,9 @@ buildDunePackage rec {
     sha256 = "0hvc4mz92x3rl2dxwrhvhzwl4gilnyvvwcqgr45vmdpyjyp3dwn2";
   };
 
-  buildInputs = [ cppo ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ cppo ];
 
   meta = with lib; {
     homepage = "https://github.com/let-def/merlin-extend";

--- a/pkgs/development/ocaml-modules/mirage-crypto/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/default.nix
@@ -19,12 +19,15 @@ buildDunePackage rec {
   doCheck = true;
   checkInputs = [ ounit ];
 
-  nativeBuildInputs = [ dune-configurator pkg-config ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator  ];
   propagatedBuildInputs = [
     cstruct eqaf
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding
   ];
+
+  strictDeps = !doCheck;
 
   meta = with lib; {
     homepage = "https://github.com/mirage/mirage-crypto";

--- a/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/ec.nix
@@ -1,4 +1,5 @@
 { lib
+, ocaml
 , buildDunePackage
 , mirage-crypto
 , dune-configurator
@@ -16,18 +17,18 @@
 , ocaml-freestanding
 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "mirage-crypto-ec";
 
   inherit (mirage-crypto)
     minimumOCamlVersion
     src
     version
-    useDune2
-    ;
+    useDune2;
 
-  nativeBuildInputs = [
-    pkg-config
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    ocaml
     dune-configurator
   ];
   propagatedBuildInputs = [
@@ -37,6 +38,8 @@ buildDunePackage {
   ] ++ lib.optionals withFreestanding [
     ocaml-freestanding
   ];
+
+  strictDeps = !doCheck;
 
   doCheck = true;
   checkInputs = [

--- a/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/pk.nix
@@ -1,7 +1,7 @@
 { buildDunePackage, ounit, randomconv, mirage-crypto, mirage-crypto-rng
 , cstruct, sexplib0, zarith, eqaf, gmp }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "mirage-crypto-pk";
 
   inherit (mirage-crypto) version src useDune2 minimumOCamlVersion;
@@ -9,6 +9,8 @@ buildDunePackage {
   buildInputs = [ gmp ];
   propagatedBuildInputs = [ cstruct mirage-crypto mirage-crypto-rng
                             zarith eqaf sexplib0 ];
+
+  strictDeps = !doCheck;
 
   doCheck = true;
   checkInputs = [ ounit randomconv ];

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-async.nix
@@ -8,7 +8,7 @@ buildDunePackage {
 
   inherit (mirage-crypto) useDune2 version minimumOCamlVersion src;
 
-  nativeBuildInputs = [
+  buildInputs = [
     dune-configurator
   ];
 
@@ -18,6 +18,8 @@ buildDunePackage {
     mirage-crypto
     mirage-crypto-rng
   ];
+
+  strictDeps = true;
 
   meta = mirage-crypto.meta // {
     description = "Feed the entropy source in an Async-friendly way";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng-mirage.nix
@@ -3,7 +3,7 @@
 , logs, lwt
 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "mirage-crypto-rng-mirage";
 
   inherit (mirage-crypto-rng) version src useDune2 minimumOCamlVersion;
@@ -13,6 +13,8 @@ buildDunePackage {
 
   propagatedBuildInputs = [ duration cstruct mirage-crypto-rng mirage-runtime
                             mirage-time mirage-clock logs lwt ];
+
+  strictDeps = !doCheck;
 
   meta = mirage-crypto-rng.meta // {
     description = "Entropy collection for a cryptographically secure PRNG";

--- a/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
+++ b/pkgs/development/ocaml-modules/mirage-crypto/rng.nix
@@ -1,7 +1,7 @@
 { buildDunePackage, mirage-crypto, ounit, randomconv, dune-configurator
 , cstruct, duration, logs, mtime, ocaml_lwt }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "mirage-crypto-rng";
 
   inherit (mirage-crypto) version src useDune2 minimumOCamlVersion;
@@ -9,8 +9,10 @@ buildDunePackage {
   doCheck = true;
   checkInputs = [ ounit randomconv ];
 
-  nativeBuildInputs = [ dune-configurator ];
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ cstruct mirage-crypto duration logs mtime ocaml_lwt ];
+
+  strictDeps = !doCheck;
 
   meta = mirage-crypto.meta // {
     description = "A cryptographically secure PRNG";

--- a/pkgs/development/ocaml-modules/mlgmp/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmp/default.nix
@@ -21,7 +21,10 @@ stdenv.mkDerivation rec {
   ];
 
   preConfigure = "make clean";
-  buildInputs = [ocaml findlib gmp mpfr ncurses];
+  nativeBuildInputs = [ocaml findlib ];
+  buildInputs = [ gmp mpfr ncurses];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -10,7 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "17xqiclaqs4hmnb92p9z6z9a1xfr31vcn8nlnj8ykk57by31vfza";
   };
 
-  buildInputs = [ perl gmp mpfr ocaml findlib camlidl ];
+  nativeBuildInputs = [ perl ocaml findlib mpfr camlidl ];
+  buildInputs = [ gmp mpfr ];
+
+  strictDeps = true;
 
   prefixKey = "-prefix ";
   configureFlags = [
@@ -20,7 +23,7 @@ stdenv.mkDerivation rec {
 
   postConfigure = ''
     sed -i Makefile \
-      -e 's|^	/bin/rm |	rm |'
+      -e 's|/bin/rm|rm|'
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
   '';
 

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -24,9 +24,10 @@ stdenv.mkDerivation {
     inherit (param) sha256;
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg ]
-  ++ optional jsooSupport js_of_ocaml;
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ] ++ optional jsooSupport js_of_ocaml;
+
+  strictDeps = true;
 
   buildPhase = "${topkg.buildPhase} --with-js_of_ocaml ${boolToString jsooSupport}";
 

--- a/pkgs/development/ocaml-modules/mysql/default.nix
+++ b/pkgs/development/ocaml-modules/mysql/default.nix
@@ -22,11 +22,13 @@ stdenv.mkDerivation rec {
      "--libdir=$out/lib/ocaml/${ocaml.version}/site-lib/mysql"
   ];
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
 
   createFindlibDestdir = true;
 
   propagatedBuildInputs = [ libmysqlclient ];
+
+  strictDeps = true;
 
   patches = [
     (fetchpatch {

--- a/pkgs/development/ocaml-modules/nocrypto/default.nix
+++ b/pkgs/development/ocaml-modules/nocrypto/default.nix
@@ -56,8 +56,10 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild cc-wrapper ];
-  buildInputs = [ ocamlbuild findlib topkg cpuid ocb-stubblr ];
+  buildInputs = [ topkg cpuid ocb-stubblr ocamlbuild ];
   propagatedBuildInputs = [ cstruct ppx_deriving ppx_sexp_conv sexplib zarith ] ++ optional withLwt cstruct-lwt;
+
+  strictDeps = true;
 
   buildPhase = "${topkg.buildPhase} --accelerate false --with-lwt ${boolToString withLwt}";
   inherit (topkg) installPhase;

--- a/pkgs/development/ocaml-modules/notty/default.nix
+++ b/pkgs/development/ocaml-modules/notty/default.nix
@@ -19,9 +19,12 @@ stdenv.mkDerivation rec {
     sha256 = "1y3hx8zjri3x50nyiqal5gak1sw54gw3xssrqbj7srinvkdmrz1q";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ocb-stubblr ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ ocb-stubblr topkg ocamlbuild ];
   propagatedBuildInputs = [ result uucp uuseg uutf ] ++
                           optional withLwt lwt;
+
+  strictDeps = true;
 
   buildPhase = topkg.buildPhase
   + " --with-lwt ${boolToString withLwt}";

--- a/pkgs/development/ocaml-modules/num/default.nix
+++ b/pkgs/development/ocaml-modules/num/default.nix
@@ -17,10 +17,10 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional withStatic ./enable-static.patch;
 
   nativeBuildInputs = [ ocaml findlib ];
-  buildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
-
 
   meta = {
     description = "Legacy Num library for arbitrary-precision integer and rational arithmetic";

--- a/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-cairo/default.nix
@@ -19,9 +19,8 @@ stdenv.mkDerivation rec {
 
   patches = [ ./META.patch ];
 
-  nativeBuildInputs = [ pkg-config unzip ];
-  buildInputs = [ ocaml automake gnum4 autoconf
-                  findlib freetype lablgtk cairo gdk-pixbuf gtk2 pango ];
+  nativeBuildInputs = [ pkg-config unzip ocaml automake gnum4 autoconf findlib ];
+  buildInputs = [ freetype lablgtk cairo gdk-pixbuf gtk2 pango ];
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-libvirt/default.nix
@@ -13,9 +13,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ libvirt ];
 
-  nativeBuildInputs = [ autoreconfHook pkg-config findlib perl ];
+  nativeBuildInputs = [ autoreconfHook pkg-config findlib perl ocaml ];
 
-  buildInputs = [ ocaml ];
+  strictDeps = true;
 
   buildFlags = [ "all" "opt" "CPPFLAGS=-Wno-error" ];
   installTargets = "install-opt";

--- a/pkgs/development/ocaml-modules/ocaml-r/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-r/default.nix
@@ -27,7 +27,11 @@ buildDunePackage rec {
     ' libRmath"' '"'
   '';
 
-  buildInputs = [ pkg-config R dune-configurator stdio ];
+  # This currently fails with dune
+  strictDeps = false;
+
+  nativeBuildInputs = [ pkg-config R ];
+  buildInputs = [ dune-configurator stdio R ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/ocamlfuse/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlfuse/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchFromGitHub, camlidl, fuse }:
+{ lib, buildDunePackage, fetchFromGitHub, camlidl, fuse, dune-configurator }:
 
 buildDunePackage {
   pname = "ocamlfuse";
@@ -11,6 +11,11 @@ buildDunePackage {
     sha256 = "1v9g0wh7rnjkrjrnw50145g6ry38plyjs8fq8w0nlzwizhf3qhff";
   };
 
+  # This currently fails with dune
+  strictDeps = false;
+
+  nativeBuildInputs = [ camlidl ];
+  buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ camlidl fuse ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocamlnat/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnat/default.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "0dyvy0j6f47laxhnadvm71z1py9hz9zd49hamf6bij99cggb2ij1";
   };
 
-  buildInputs = [ocaml findlib ounit];
+  nativeBuildInputs = [ocaml findlib ];
+  buildInputs = [ ounit];
+
+  strictDeps = true;
 
   prefixKey = "--prefix ";
 

--- a/pkgs/development/ocaml-modules/ocamlnet/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlnet/default.nix
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "1vlwxjxr946gdl61a1d7yk859cijq45f60dhn54ik3w4g6cx33pr";
   };
 
-  nativeBuildInputs = [ pkg-config which ];
-  buildInputs = [ ncurses ocaml findlib ocaml_pcre camlzip gnutls nettle ];
+  nativeBuildInputs = [ pkg-config which ocaml findlib ];
+  buildInputs = [ ncurses ocaml_pcre camlzip gnutls nettle ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/ocamlsdl/default.nix
+++ b/pkgs/development/ocaml-modules/ocamlsdl/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     sha256 = "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ocaml findlib SDL SDL_image SDL_mixer SDL_ttf SDL_gfx lablgl];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
+  buildInputs = [ SDL SDL_image SDL_mixer SDL_ttf SDL_gfx lablgl ];
 
   propagatedBuildInputs = [ SDL SDL_image SDL_mixer SDL_ttf SDL_gfx pkg-config ];
   createFindlibDestdir = true;

--- a/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
+++ b/pkgs/development/ocaml-modules/ocb-stubblr/default.nix
@@ -12,9 +12,12 @@ stdenv.mkDerivation rec {
 
   patches = [ ./pkg-config.patch ];
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ocamlbuild ];
 
   propagatedBuildInputs = [ astring ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
+++ b/pkgs/development/ocaml-modules/ocp-ocamlres/default.nix
@@ -14,7 +14,11 @@ stdenv.mkDerivation rec {
     sha256 = "0smfwrj8qhzknhzawygxi0vgl2af4vyi652fkma59rzjpvscqrnn";
   };
 
-  buildInputs = [ ocaml findlib astring pprint ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ astring pprint ];
+
+  strictDeps = true;
+
   createFindlibDestdir = true;
 
   installFlags = [ "BINDIR=$(out)/bin" ];

--- a/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/default.nix
@@ -15,8 +15,9 @@ stdenv.mkDerivation {
     sha256 = "09niyidrjzrj8g1qwx4wgsdf5m6cwrnzg7zsgala36jliic4di60";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ autoreconfHook ocaml findlib ];
+
+  strictDeps = true;
 
   installFlags = [ "LIBDIR=$(OCAMLFIND_DESTDIR)" ];
 

--- a/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-deriving/default.nix
@@ -26,7 +26,10 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  buildInputs = [ ocaml findlib ocamlbuild oasis camlp4 num ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild oasis camlp4 ];
+  buildInputs = [ oasis camlp4 ocamlbuild num ];
+
+  strictDeps = true;
 
   meta = {
     homepage = "https://github.com/ocsigen/deriving";

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
-, cohttp-lwt-unix
+, cohttp-lwt-unix, eliom
 , resource-pooling
 , ocamlnet
 }:
@@ -8,8 +8,10 @@ stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocsigen-start";
   version = "4.3.0";
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib eliom ];
   propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ocamlnet ];
+
+  strictDeps = true;
 
   patches = [ ./templates-dir.patch ];
 

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -8,7 +8,9 @@ stdenv.mkDerivation rec {
  version = "3.0.1";
 
  propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
- buildInputs = [ ocaml findlib opaline ];
+ nativeBuildInputs = [ ocaml findlib opaline eliom ];
+
+  strictDeps = true;
 
  installPhase = ''
     runHook preInstall

--- a/pkgs/development/ocaml-modules/ocurl/default.nix
+++ b/pkgs/development/ocaml-modules/ocurl/default.nix
@@ -13,8 +13,12 @@ stdenv.mkDerivation rec {
     sha256 = "0n621cxb9012pj280c7821qqsdhypj8qy9qgrah79dkh6a8h2py6";
   };
 
-  buildInputs = [ pkg-config ocaml findlib ncurses ];
+  nativeBuildInputs = [ pkg-config ocaml findlib ];
+  buildInputs = [ ncurses ];
   propagatedBuildInputs = [ curl lwt ];
+
+  strictDeps = true;
+
   createFindlibDestdir = true;
   meta = {
     description = "OCaml bindings to libcurl";

--- a/pkgs/development/ocaml-modules/odate/default.nix
+++ b/pkgs/development/ocaml-modules/odate/default.nix
@@ -17,7 +17,9 @@ buildDunePackage rec {
     sha256 = "1dk33lr0g2jnia2gqsm6nnc7nf256qgkm3v30w477gm6y2ppfm3h";
   };
 
-  buildInputs = [ menhir ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ menhir ];
 
   meta = {
     description = "Date and duration in OCaml";

--- a/pkgs/development/ocaml-modules/odn/default.nix
+++ b/pkgs/development/ocaml-modules/odn/default.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "09a8zdyifpc2nl4hdvg9206142y31cq95ajgij011s1qcg3z93lj";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild type_conv ounit camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ type_conv ounit camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/omd/default.nix
+++ b/pkgs/development/ocaml-modules/omd/default.nix
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "1sgdgzpx96br7npj8mh91cli5mqmzsjpngwm7x4212n3k1d0ivwa";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/opam-repository/default.nix
+++ b/pkgs/development/ocaml-modules/opam-repository/default.nix
@@ -15,8 +15,9 @@ buildDunePackage rec {
       --replace "SUBSTITUTE_NIXOS_CURL_PATH" "\"${curl}/bin/curl\""
   '';
 
-  nativeBuildInputs = [ unzip ];
-  buildInputs = [ curl ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ unzip curl ];
   propagatedBuildInputs = [ opam-format ];
 
   meta = opam-format.meta // {

--- a/pkgs/development/ocaml-modules/otfm/default.nix
+++ b/pkgs/development/ocaml-modules/otfm/default.nix
@@ -17,9 +17,12 @@ stdenv.mkDerivation {
     sha256 = "054s82539k3kc9na6s47g3scsl04icjahpas7pv5351jmsgqcq3k";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
 
   propagatedBuildInputs = [ uutf result ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/otoml/default.nix
+++ b/pkgs/development/ocaml-modules/otoml/default.nix
@@ -19,7 +19,9 @@ buildDunePackage rec {
     sha256 = "0l0c60rzgk11y8xq05kr8q9hkzb3c8vi995mq84x98ys73wb42j3";
   };
 
-  buildInputs = [ menhir ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ menhir ];
 
   propagatedBuildInputs = [ menhirLib uutf ];
 

--- a/pkgs/development/ocaml-modules/ounit/default.nix
+++ b/pkgs/development/ocaml-modules/ounit/default.nix
@@ -4,8 +4,10 @@ stdenv.mkDerivation {
   pname = "ocaml${ocaml.version}-ounit";
   inherit (ounit2) version src meta;
 
-  buildInputs = [ findlib ];
+  nativeBuildInputs = [ findlib ];
   propagatedBuildInputs = [ ounit2 ];
+
+  strictDeps = true;
 
   dontBuild = true;
 

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildOcaml, fetchFromGitHub }:
+{ lib, buildOcaml, fetchFromGitHub, camlp4 }:
 
 buildOcaml rec {
   pname = "pipebang";
@@ -12,6 +12,10 @@ buildOcaml rec {
     rev = version;
     sha256 = "sha256-9A3X/ciL5HtuKQ5awS+hDDBLL5ytOr12wHsmJLNRn+Q=";
   };
+
+  strictDeps = true;
+
+  buildInputs = [ camlp4 ];
 
   meta = with lib; {
     homepage = "https://github.com/janestreet/pipebang";

--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "1913jpsb8mvqi8609j4g4sm5jhg50dq0xqxgy8nmvknfryyc89nm";
   };
 
-  buildInputs = [ ocaml findlib piqi stdlib-shims ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ piqi stdlib-shims ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/piqi/default.nix
+++ b/pkgs/development/ocaml-modules/piqi/default.nix
@@ -12,8 +12,10 @@ stdenv.mkDerivation rec {
     sha256 = "0v04hs85xv6d4ysqxyv1dik34dx49yab9shpi4x7iv19qlzl7csb";
   };
 
-  buildInputs = [ ocaml findlib which ];
+  nativeBuildInputs = [ ocaml findlib which ];
   propagatedBuildInputs = [ sedlex_2 xmlm easy-format base64 ];
+
+  strictDeps = true;
 
   patches = [ ./no-ocamlpath-override.patch ];
 

--- a/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
@@ -9,6 +9,7 @@
 , num
 , ppxlib
 , re
+, findlib
 }:
 
 buildDunePackage rec {
@@ -26,16 +27,20 @@ buildDunePackage rec {
     sha256 = "15cjb9ygnvp2kv85rrb7ncz7yalifyl7wd2hp2cl8r1qrpgi1d0w";
   };
 
+  nativeBuildInputs = [ cppo ];
+
   buildInputs = [
     bigarray-compat
     containers
-    cppo
     ctypes
     integers
     num
     ppxlib
     re
+    findlib
   ];
+
+  strictDeps = true;
 
   meta = with lib; {
     homepage = "https://github.com/fdopen/ppx_cstubs";

--- a/pkgs/development/ocaml-modules/ppx_deriving/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving/default.nix
@@ -5,7 +5,7 @@
 , ppxlib
 , ppx_derivers
 , result
-, ounit
+, ounit2
 , ocaml-migrate-parsetree
 , ocaml-migrate-parsetree-2
 }:
@@ -37,7 +37,11 @@ buildDunePackage rec {
     inherit (params) sha256;
   };
 
-  buildInputs = [ ppxlib cppo ];
+  # This currently fails with dune
+  strictDeps = false;
+
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ ppxlib ];
   propagatedBuildInputs = [
     (if params.useOMP2
     then ocaml-migrate-parsetree-2
@@ -47,7 +51,7 @@ buildDunePackage rec {
   ];
 
   doCheck = true;
-  checkInputs = [ ounit ];
+  checkInputs = [ ounit2 ];
 
   meta = with lib; {
     description = "deriving is a library simplifying type-driven code generation on OCaml >=4.02.";

--- a/pkgs/development/ocaml-modules/ppx_tools/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_tools/default.nix
@@ -5,6 +5,7 @@ let param =
     version = "6.4";
     sha256 = "15v7yfv6gyp8lzlgwi9garz10wpg34dk4072jdv19n6v20zfg7n1";
     useDune2 = true;
+    nativeBuildInputs = [cppo];
     buildInputs = [cppo];
   }; in
 {
@@ -54,7 +55,9 @@ if lib.versionAtLeast param.version "6.0"
 then
   buildDunePackage {
     inherit pname src meta;
-    inherit (param) version useDune2 buildInputs;
+    inherit (param) version useDune2 buildInputs nativeBuildInputs;
+
+    strictDeps = true;
   }
 else
   stdenv.mkDerivation {
@@ -63,7 +66,8 @@ else
     inherit src;
 
     nativeBuildInputs = [ ocaml findlib ];
-    buildInputs = [ ocaml findlib ];
+
+    strictDeps = true;
 
     createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
+++ b/pkgs/development/ocaml-modules/psmt2-frontend/default.nix
@@ -15,7 +15,9 @@ buildDunePackage rec {
 
   minimumOCamlVersion = "4.03";
 
-  buildInputs = [ menhir ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ menhir ];
 
   meta = {
     description = "A simple parser and type-checker for polomorphic extension of the SMT-LIB 2 language";

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -11,9 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1fxq57xy1ajzfdnvv5zfm7ap2nf49znw5f9gbi4kb9vds942ij27";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  buildInputs = [ findlib topkg ]
-    ++ lib.optional jsooSupport js_of_ocaml;
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ] ++ lib.optional jsooSupport js_of_ocaml;
+
+  strictDeps = true;
 
   propagatedBuildInputs = [ result ];
 

--- a/pkgs/development/ocaml-modules/ptmap/default.nix
+++ b/pkgs/development/ocaml-modules/ptmap/default.nix
@@ -14,11 +14,12 @@ buildDunePackage rec {
     sha256 = "1apk61fc1y1g7x3m3c91fnskvxp6i0vk5nxwvipj56k7x2pzilgb";
   };
 
+  strictDeps = true;
+
+  buildInputs = [ stdlib-shims ];
   propagatedBuildInputs = [ seq ];
 
   doCheck = true;
-
-  checkInputs = [ stdlib-shims ];
 
   meta = {
     homepage = "https://www.lri.fr/~filliatr/software.en.html";

--- a/pkgs/development/ocaml-modules/pyml/default.nix
+++ b/pkgs/development/ocaml-modules/pyml/default.nix
@@ -11,9 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-GCO6KlRhJmADFjQ5QF4naMQBskF63yqnJnLnuQsagEk=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     ocaml
     findlib
+  ];
+  buildInputs = [
     utop
     ncurses
   ];
@@ -22,6 +24,8 @@ stdenv.mkDerivation rec {
     python3
     stdcompat
   ];
+
+  strictDeps = true;
 
   buildPhase = ''
     make all pymltop pymlutop PREFIX=$out

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -9,7 +9,10 @@ stdenv.mkDerivation rec {
     sha256 = "1aj8w79gdd9xnrbz7s5p8glcb4pmimi8jp9f439dqnf6ih3mqb3v";
   };
 
-  buildInputs = [ ocaml findlib topkg ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/reactivedata/default.nix
+++ b/pkgs/development/ocaml-modules/reactivedata/default.nix
@@ -15,8 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YLkacIbjxZQ/ThgSxjTqviBYih6eW2GX5H7iybQDv1A=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild opaline ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild opaline ];
   propagatedBuildInputs = [ react ];
+
+  strictDeps = true;
 
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=true";
 

--- a/pkgs/development/ocaml-modules/reason-native/cli.nix
+++ b/pkgs/development/ocaml-modules/reason-native/cli.nix
@@ -3,9 +3,12 @@
 {
   pname = "cli";
 
+  nativeBuildInputs = [
+    reason
+  ];
+
   buildInputs = [
     re
-    reason
     pastel
   ];
 }

--- a/pkgs/development/ocaml-modules/reason-native/console.nix
+++ b/pkgs/development/ocaml-modules/reason-native/console.nix
@@ -3,7 +3,7 @@
 {
   pname = "console";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/dir.nix
+++ b/pkgs/development/ocaml-modules/reason-native/dir.nix
@@ -3,7 +3,7 @@
 {
   pname = "dir";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/file-context-printer.nix
+++ b/pkgs/development/ocaml-modules/reason-native/file-context-printer.nix
@@ -3,7 +3,7 @@
 {
   pname = "file-context-printer";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/fp.nix
+++ b/pkgs/development/ocaml-modules/reason-native/fp.nix
@@ -3,7 +3,7 @@
 {
   pname = "fp";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/pastel-console.nix
+++ b/pkgs/development/ocaml-modules/reason-native/pastel-console.nix
@@ -3,7 +3,7 @@
 {
   pname = "pastel-console";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/pastel.nix
+++ b/pkgs/development/ocaml-modules/reason-native/pastel.nix
@@ -5,7 +5,7 @@
 
   minimalOCamlVersion = "4.05";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/qcheck-rely.nix
@@ -3,7 +3,7 @@
 {
   pname = "qcheck-rely";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/refmterr.nix
+++ b/pkgs/development/ocaml-modules/reason-native/refmterr.nix
@@ -3,7 +3,7 @@
 {
   pname = "refmterr";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/reason-native/rely-junit-reporter.nix
+++ b/pkgs/development/ocaml-modules/reason-native/rely-junit-reporter.nix
@@ -3,9 +3,12 @@
 {
   pname = "rely-junit-reporter";
 
+  nativeBuildInputs = [
+    reason
+  ];
+
   buildInputs = [
     atdgen
-    reason
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/reason-native/rely.nix
+++ b/pkgs/development/ocaml-modules/reason-native/rely.nix
@@ -3,7 +3,7 @@
 {
   pname = "rely";
 
-  buildInputs = [
+  nativeBuildInputs = [
     reason
   ];
 

--- a/pkgs/development/ocaml-modules/rope/default.nix
+++ b/pkgs/development/ocaml-modules/rope/default.nix
@@ -6,7 +6,7 @@ let param =
     version = "0.6.2";
     url = "https://github.com/Chris00/ocaml-rope/releases/download/${version}/rope-${version}.tbz";
     sha256 = "15cvfa0s1vjx7gjd07d3fkznilishqf4z4h2q5f20wm9ysjh2h2i";
-    buildInputs = [ dune_2 ];
+    nativeBuildInputs = [ dune_2 ];
     extra = {
       buildPhase = "dune build -p rope";
       installPhase = ''
@@ -17,7 +17,7 @@ let param =
     version = "0.5";
     url = "https://forge.ocamlcore.org/frs/download.php/1156/rope-0.5.tar.gz";
     sha256 = "05fr2f5ch2rqhyaj06rv5218sbg99p1m9pq5sklk04hpslxig21f";
-    buildInputs = [ ocamlbuild ];
+    nativeBuildInputs = [ ocamlbuild ];
     extra = { createFindlibDestdir = true; };
   };
 in
@@ -30,7 +30,10 @@ stdenv.mkDerivation ({
     inherit (param) url sha256;
   };
 
-  buildInputs = [ ocaml findlib benchmark ] ++ param.buildInputs;
+  nativeBuildInputs = [ ocaml findlib ] ++ param.nativeBuildInputs;
+  buildInputs = [ benchmark ] ;
+
+  strictDeps = true;
 
   meta = {
     homepage = "http://rope.forge.ocamlcore.org/";

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -8,9 +8,12 @@ stdenv.mkDerivation rec {
     sha256 = "1k69a3gvrk7f2cshwjzvk7818f0bwxhacgd14wxy6d4gmrggci86";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
 
   propagatedBuildInputs = [ result ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/sawja/default.nix
+++ b/pkgs/development/ocaml-modules/sawja/default.nix
@@ -23,9 +23,9 @@ stdenv.mkDerivation {
     sha256 = "sha256:0k51rscs9mdgpg3qn4cahql5ncdvlb207m015hr8v6r1vfgn0ddq";
   };
 
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [ which ocaml findlib ];
 
-  buildInputs = [ ocaml findlib ];
+  strictDeps = true;
 
   patches = [ ./configure.sh.patch ./Makefile.config.example.patch ];
 

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -15,9 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VhzlDTYBFXgKWT69PqZYLuHkiaDwzhmyX2XfaqzHFl4=";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
 
   propagatedBuildInputs = [ gen ocaml-migrate-parsetree ppx_tools_versioned ];
+
+  strictDeps = true;
 
   buildFlags = [ "all" "opt" ];
 

--- a/pkgs/development/ocaml-modules/sha/default.nix
+++ b/pkgs/development/ocaml-modules/sha/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage, stdlib-shims, ounit }:
+{ lib, fetchurl, buildDunePackage, stdlib-shims, dune-configurator, ounit }:
 
 buildDunePackage rec {
   pname = "sha";
@@ -10,6 +10,8 @@ buildDunePackage rec {
   };
 
   useDune2 = true;
+
+  buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [
     stdlib-shims

--- a/pkgs/development/ocaml-modules/sodium/default.nix
+++ b/pkgs/development/ocaml-modules/sodium/default.nix
@@ -16,8 +16,10 @@ stdenv.mkDerivation rec {
     ./lib-gen-link-bigarray.patch
   ];
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = [ ctypes libsodium ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/sosa/default.nix
+++ b/pkgs/development/ocaml-modules/sosa/default.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation rec {
     sha256 = "053hdv6ww0q4mivajj4iyp7krfvgq8zajq9d8x4mia4lid7j0dyk";
   };
 
-  buildInputs = [ ocaml ocamlbuild findlib ];
+  nativeBuildInputs = [ ocaml ocamlbuild findlib ];
+
+  strictDeps = true;
 
   buildPhase = "make build";
 

--- a/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
+++ b/pkgs/development/ocaml-modules/sqlite3EZ/default.nix
@@ -17,9 +17,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pKysvth0efxJeyJQY2Dnqarg7OtsKyyLnFV/1ZhsfDY=";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild twt ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ twt ];
 
   propagatedBuildInputs = [ ocaml_sqlite3 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/stdcompat/default.nix
+++ b/pkgs/development/ocaml-modules/stdcompat/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:01y67rndjlzfp5zq0gbqpg9skqq2hfbvhbq9lfhhk5xidr98sfj8";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
+
   # build fails otherwise
   enableParallelBuilding = false;
 

--- a/pkgs/development/ocaml-modules/tezos/legacy-store.nix
+++ b/pkgs/development/ocaml-modules/tezos/legacy-store.nix
@@ -23,9 +23,11 @@ buildDunePackage {
     lwt-watcher
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     tezos-protocol-compiler
   ];
+
+  strictDeps = true;
 
   checkInputs = [
     alcotest-lwt

--- a/pkgs/development/ocaml-modules/tezos/lmdb.nix
+++ b/pkgs/development/ocaml-modules/tezos/lmdb.nix
@@ -25,7 +25,7 @@ buildDunePackage {
 
   useDune2 = true;
 
-  buildInputs = [
+  nativeBuildInputs = [
     pkg-config
   ];
 
@@ -33,6 +33,8 @@ buildDunePackage {
     rresult
     lmdb
   ];
+
+  strictDeps = true;
 
   checkInputs = [
     cstruct

--- a/pkgs/development/ocaml-modules/tezos/protocol-010-PtGRANAD.nix
+++ b/pkgs/development/ocaml-modules/tezos/protocol-010-PtGRANAD.nix
@@ -2,6 +2,7 @@
 , buildDunePackage
 , tezos-stdlib
 , tezos-protocol-compiler
+, tezos-protocol-environment
 }:
 
 buildDunePackage {
@@ -9,9 +10,15 @@ buildDunePackage {
   inherit (tezos-stdlib) version useDune2;
   src = "${tezos-stdlib.base_src}/src";
 
-  buildInputs = [
+  nativeBuildInputs = [
     tezos-protocol-compiler
   ];
+
+  buildInputs = [
+    tezos-protocol-environment
+  ];
+
+  strictDeps = true;
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/tezos/protocol-011-PtHangz2.nix
+++ b/pkgs/development/ocaml-modules/tezos/protocol-011-PtHangz2.nix
@@ -2,6 +2,7 @@
 , buildDunePackage
 , tezos-stdlib
 , tezos-protocol-compiler
+, tezos-protocol-environment
 }:
 
 buildDunePackage {
@@ -9,9 +10,15 @@ buildDunePackage {
   inherit (tezos-stdlib) version useDune2;
   src = "${tezos-stdlib.base_src}/src";
 
-  buildInputs = [
+  nativeBuildInputs = [
     tezos-protocol-compiler
   ];
+
+  buildInputs = [
+    tezos-protocol-environment
+  ];
+
+  strictDeps = true;
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/tezos/store.nix
+++ b/pkgs/development/ocaml-modules/tezos/store.nix
@@ -31,9 +31,11 @@ buildDunePackage {
     tezos-legacy-store
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     tezos-protocol-compiler
   ];
+
+  strictDeps = true;
 
   checkInputs = [
     alcotest-lwt

--- a/pkgs/development/ocaml-modules/tezos/validation.nix
+++ b/pkgs/development/ocaml-modules/tezos/validation.nix
@@ -14,9 +14,11 @@ buildDunePackage {
     tezos-protocol-updater
   ];
 
-  buildInputs = [
+  nativeBuildInputs = [
     tezos-protocol-compiler
   ];
+
+  strictDeps = true;
 
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/toml/default.nix
+++ b/pkgs/development/ocaml-modules/toml/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
     sha256 = "08ywzqckllvwawl1wpgg7qzvx6jhq7d6vysa0d5hj7qdwq213ggm";
   };
 
-  buildInputs = [ menhir ];
+  nativeBuildInputs = [ menhir ];
   propagatedBuildInputs = [ iso8601 ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -38,6 +38,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
   propagatedBuildInputs = param.propagatedBuildInputs or [];
 
+  strictDeps = true;
+
   buildPhase = "${run} build";
   createFindlibDestdir = true;
   installPhase = "${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
     sha256 = "1zwv0ixkigh1gzk5n49rwvz2f2m62jdkkqg40j7dclg4gri7691f";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ pkg-config ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
   propagatedBuildInputs = [ SDL2 ctypes ];
 
   preConfigure = ''

--- a/pkgs/development/ocaml-modules/twt/default.nix
+++ b/pkgs/development/ocaml-modules/twt/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-xbjLPd7P1KyuC3i6WHLBcdLwd14atcBsd5ER+l97KAk=";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   preInstall = ''
     mkdir -p $out/bin

--- a/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
+++ b/pkgs/development/ocaml-modules/type_conv/108.08.00.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "08ysikwwp69zvc147lzzg79nwlrzrk738rj0ggcfadi8h5il42sl";
   };
 
-  buildInputs = [ ocaml findlib camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/109.60.01.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-8Oz/fPL3+RghyxQp5u6seSEdf0BgfP6XNcsMYty0rNs=";
   };
 
-  buildInputs = [ ocaml findlib camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ];
+  buildInputs = [ camlp4 ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
+++ b/pkgs/development/ocaml-modules/type_conv/112.01.01.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildOcaml}:
+{ lib, fetchFromGitHub, buildOcaml, camlp4}:
 
 buildOcaml rec {
   minimumSupportedOcamlVersion = "4.02";
@@ -12,6 +12,10 @@ buildOcaml rec {
     rev = version;
     sha256 = "sha256-HzH0hnceCQ2kDRATjl+tfKk3XSBDsGnPzVUGYpDQUmU=";
   };
+
+  strictDeps = true;
+
+  buildInputs = [ camlp4 ];
 
   meta = {
     homepage = "https://github.com/janestreet/type_conv/";

--- a/pkgs/development/ocaml-modules/uchar/default.nix
+++ b/pkgs/development/ocaml-modules/uchar/default.nix
@@ -10,7 +10,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml ocamlbuild findlib ];
-  buildInputs = [ findlib ocaml ocamlbuild ];
+
+  strictDeps = true;
+
   buildPhase = "ocaml pkg/build.ml native=true native-dynlink=${lib.boolToString withShared}";
   installPhase = "${opaline}/bin/opaline -libdir $OCAMLFIND_DESTDIR";
   configurePlatforms = [ ];

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -25,8 +25,9 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
-  propagatedBuildInputs = [ camlp4 ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ];
+
+  strictDeps = true;
 
   buildFlags = [ "all" "all.opt" ];
 

--- a/pkgs/development/ocaml-modules/uucd/default.nix
+++ b/pkgs/development/ocaml-modules/uucd/default.nix
@@ -13,7 +13,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:0fc737v5gj3339jx4x9xr096lxrpwvp6vaiylhavcvsglcwbgm30";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/uucp/default.nix
+++ b/pkgs/development/ocaml-modules/uucp/default.nix
@@ -21,9 +21,12 @@ stdenv.mkDerivation {
     sha256 = "sha256:1yx9nih3d9prb9zizq8fzmmqylf24a6yifhf81h33znrj5xn1mpj";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg uutf uunf ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg uutf uunf uucd ];
 
   propagatedBuildInputs = [ uchar ];
+
+  strictDeps = true;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/ocaml-modules/uuidm/default.nix
+++ b/pkgs/development/ocaml-modules/uuidm/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1ivxb3hxn9bk62rmixx6px4fvn52s4yr1bpla7rgkcn8981v45r8";
   };
 
-  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
   configurePlatforms = [];
   buildInputs = [ topkg cmdliner ];
 

--- a/pkgs/development/ocaml-modules/uunf/default.nix
+++ b/pkgs/development/ocaml-modules/uunf/default.nix
@@ -18,9 +18,12 @@ stdenv.mkDerivation {
     sha256 = "sha256:17wv0nm3vvwcbzb1b09akw8jblmigyhbfmh1sy9lkb5756ni94a2";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg uutf cmdliner ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg uutf cmdliner ];
 
   propagatedBuildInputs = [ uchar ];
+
+  strictDeps = true;
 
   prePatch = lib.optionalString stdenv.isAarch64 "ulimit -s 16384";
 

--- a/pkgs/development/ocaml-modules/uuseg/default.nix
+++ b/pkgs/development/ocaml-modules/uuseg/default.nix
@@ -15,8 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256:1g9zyzjkhqxgbb9mh3cgaawscwdazv6y8kdqvmy6yhnimmfqv25p";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild cmdliner topkg uutf ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [  topkg cmdliner  uutf ];
   propagatedBuildInputs = [ uucp ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/uutf/default.nix
+++ b/pkgs/development/ocaml-modules/uutf/default.nix
@@ -13,9 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "1nx1rly3qj23jzn9yk3x6fwqimcxjd84kv5859vvhdg56psq26p6";
   };
 
-  nativeBuildInputs = [ ocaml ocamlbuild findlib ];
-  buildInputs = [ findlib topkg cmdliner ];
+  nativeBuildInputs = [ ocaml ocamlbuild findlib topkg ];
+  buildInputs = [ topkg cmdliner ];
   propagatedBuildInputs = [ uchar ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/uuuu/default.nix
+++ b/pkgs/development/ocaml-modules/uuuu/default.nix
@@ -24,9 +24,11 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  nativeBuildInputs = [ menhir ];
+  nativeBuildInputs = [ menhir findlib ];
 
   buildInputs = [ angstrom ];
+
+  strictDeps = !doCheck;
 
   checkInputs = [ re ];
   doCheck = true;

--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -28,11 +28,14 @@ stdenv.mkDerivation {
     sha256 = "181sz6l5xrj5jvwg4m2yqsjzwp2s5h8v0mwhjcwbam90kdfx2nak";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild ];
+  buildInputs = [ topkg ];
 
   propagatedBuildInputs = [ uchar result gg ]
                           ++ optionals pdfBackend [ uutf otfm ]
                           ++ optionals htmlcBackend [ js_of_ocaml js_of_ocaml-ppx ];
+
+  strictDeps = true;
 
   buildPhase = topkg.buildPhase
     + " --with-uutf ${boolToString pdfBackend}"

--- a/pkgs/development/ocaml-modules/webbrowser/default.nix
+++ b/pkgs/development/ocaml-modules/webbrowser/default.nix
@@ -11,8 +11,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
-  buildInputs = [];
+  buildInputs = [ topkg ];
   propagatedBuildInputs = [ astring bos cmdliner rresult ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/xml-light/default.nix
+++ b/pkgs/development/ocaml-modules/xml-light/default.nix
@@ -11,7 +11,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2txmkl/ZN5RGaLQJmr+orqwB4CbFk2RpLJd4gr7kPiE=";
   };
 
-  buildInputs = [ ocaml findlib ];
+  nativeBuildInputs = [ ocaml findlib ];
+
+  strictDeps = true;
 
   createFindlibDestdir = true;
 

--- a/pkgs/development/ocaml-modules/xmlm/default.nix
+++ b/pkgs/development/ocaml-modules/xmlm/default.nix
@@ -17,7 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "1rrdxg5kh9zaqmgapy9bhdqyxbbvxxib3bdfg1vhw4rrkp1z0x8n";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild topkg ];
+  nativeBuildInputs = [ ocaml findlib ocamlbuild topkg ];
+  buildInputs = [ topkg ];
+
+  strictDeps = true;
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/z3/default.nix
+++ b/pkgs/development/ocaml-modules/z3/default.nix
@@ -29,8 +29,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  buildInputs = [ findlib ];
+  nativeBuildInputs = [ findlib ];
   propagatedBuildInputs = [ zarith ];
+
+  strictDeps = true;
 
   meta = z3.meta // {
     description = "Z3 Theorem Prover (OCaml API)";

--- a/pkgs/development/tools/ocaml/camlidl/default.nix
+++ b/pkgs/development/tools/ocaml/camlidl/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0483cs66zsxsavcllpw1qqvyhxb39ddil3h72clcd69g7fyxazl5";
   };
 
-  buildInputs = [ ocaml ];
+  nativeBuildInputs = [ ocaml ];
 
   # build fails otherwise
   enableParallelBuilding = false;

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -57,11 +57,19 @@ buildDunePackage {
 
   useDune2 = true;
 
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    menhir
+    jq
+  ];
   buildInputs = [
     dot-merlin-reader
     yojson
     csexp
     result
+    menhirSdk
+    menhirLib
   ];
 
   doCheck = true;
@@ -71,12 +79,6 @@ buildDunePackage {
     dune runtest # filtering with -p disables tests
     runHook postCheck
   '';
-  checkInputs = [
-    jq
-    menhir
-    menhirLib
-    menhirSdk
-  ];
 
   meta = with lib; {
     description = "An editor-independent tool to ease the development of programs in OCaml";

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, buildDunePackage, substituteAll
-, dot-merlin-reader, dune_2, yojson, csexp, result }:
+, dot-merlin-reader, dune_2, yojson, csexp, result, menhirSdk }:
 
 buildDunePackage rec {
   pname = "merlin";
@@ -22,7 +22,9 @@ buildDunePackage rec {
     })
   ];
 
-  buildInputs = [ dot-merlin-reader yojson csexp result ];
+  strictDeps = true;
+
+  buildInputs = [ dot-merlin-reader yojson csexp result menhirSdk ];
 
   meta = with lib; {
     description = "An editor-independent tool to ease the development of programs in OCaml";

--- a/pkgs/development/tools/ocaml/oasis/default.nix
+++ b/pkgs/development/tools/ocaml/oasis/default.nix
@@ -13,10 +13,14 @@ stdenv.mkDerivation {
 
   createFindlibDestdir = true;
 
-  buildInputs =
+  strictDeps = true;
+
+  nativeBuildInputs =
     [
       ocaml findlib ocamlbuild ocamlmod ocamlify
     ];
+
+  buildInputs = [ ocamlbuild ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/tools/ocaml/obelisk/default.nix
+++ b/pkgs/development/tools/ocaml/obelisk/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, ocamlPackages }:
+{ lib, fetchFromGitHub, ocamlPackages, menhir }:
 
 ocamlPackages.buildDunePackage rec {
   pname = "obelisk";
@@ -11,7 +11,10 @@ ocamlPackages.buildDunePackage rec {
     sha256 = "1jjaqa2b7msl9qd3x7j34vdh1s9alq8hbvzk8a5srb4yyfyim15b";
   };
 
-  buildInputs = with ocamlPackages; [ menhir re ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ menhir ];
+  buildInputs = with ocamlPackages; [ re ];
 
   meta = {
     description = "A simple tool which produces pretty-printed output from a Menhir parser file (.mly)";

--- a/pkgs/development/tools/ocaml/ocamlformat/generic.nix
+++ b/pkgs/development/tools/ocaml/ocamlformat/generic.nix
@@ -48,6 +48,12 @@ buildDunePackage {
 
   useDune2 = true;
 
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    menhir
+  ];
+
   buildInputs =
     if lib.versionAtLeast version "0.20.0"
     then [
@@ -57,7 +63,6 @@ buildDunePackage {
       either
       fix
       fpath
-      menhir
       menhirLib
       menhirSdk
       ocaml-version
@@ -78,7 +83,6 @@ buildDunePackage {
       uuseg
       uutf
       fix
-      menhir
       menhirLib
       menhirSdk
       ocp-indent
@@ -96,7 +100,6 @@ buildDunePackage {
       uuseg
       uutf
       fix
-      menhir
       menhirLib
       menhirSdk
       dune-build-info
@@ -115,7 +118,6 @@ buildDunePackage {
       uuseg
       uutf
       fix
-      menhir
       menhirLib
       menhirSdk
       dune-build-info
@@ -135,7 +137,6 @@ buildDunePackage {
       uuseg
       uutf
       fix
-      menhir
       menhirLib
       menhirSdk
       (ppxlib.override { version = "0.18.0"; })
@@ -154,7 +155,6 @@ buildDunePackage {
       uuseg
       uutf
       fix
-      menhir
       menhirLib
       menhirSdk
     ] else [

--- a/pkgs/development/tools/ocaml/ocp-index/default.nix
+++ b/pkgs/development/tools/ocaml/ocp-index/default.nix
@@ -13,7 +13,10 @@ buildDunePackage rec {
     sha256 = "120w72fqymjp6ibicbp31jyx9yv34mdvgkr0zdfpzvfb7lgd8rc7";
   };
 
-  buildInputs = [ cppo cmdliner re ];
+  strictDeps = true;
+
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ cmdliner re ];
 
   propagatedBuildInputs = [ ocp-indent ];
 

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -17,8 +17,7 @@ buildDunePackage rec {
     sha256 = "0mi571ifjzq4wcjarn8q1b7yl8nxjm1jfx3afac224lqwn6bhb2d";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ cppo ];
+  nativeBuildInputs = [ makeWrapper cppo ];
 
   propagatedBuildInputs = [ lambdaTerm ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15322,7 +15322,7 @@ with pkgs;
 
   nrfutil = callPackage ../development/tools/misc/nrfutil { };
 
-  obelisk = callPackage ../development/tools/ocaml/obelisk { };
+  obelisk = callPackage ../development/tools/ocaml/obelisk { menhir = ocamlPackages.menhir; };
 
   obuild = callPackage ../development/tools/ocaml/obuild { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To make cross compilation better we need to move a bunch of stuff to `nativeBuildInputs`.
Another good reason is that we should get much smaller closures when building ocaml projects.
This PR supersedes #145448 I think.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
