### PR TITLE
headset-charge-indicator: init at 2021-08-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13970,6 +13970,13 @@
     githubId = 6191421;
     name = "Edward d'Albon";
   };
+  zebreus = {
+    matrix = "@lennart:cicen.net";
+    email = "lennarteichhorn+nixpkgs@gmail.com";
+    github = "Zebreus";
+    githubId = 1557253;
+    name = "Lennart Eichhorn";
+  };
   zef = {
     email = "zef@zef.me";
     name = "Zef Hemel";

--- a/pkgs/tools/audio/headset-charge-indicator/default.nix
+++ b/pkgs/tools/audio/headset-charge-indicator/default.nix
@@ -1,0 +1,63 @@
+{ lib, stdenv, fetchFromGitHub, headsetcontrol, wrapGAppsHook, python3, gtk3
+, gobject-introspection, libayatana-appindicator-gtk3 }:
+
+stdenv.mkDerivation rec {
+  # The last versioned release is 1.0.0.0 from 2020, since then there were updates but no versioned release.
+  # This is not marked unstable because upstream encourages installation from source.
+  pname = "headset-charge-indicator";
+  version = "2021-08-15";
+
+  src = fetchFromGitHub {
+    owner = "centic9";
+    repo = "headset-charge-indicator";
+    rev = "6e20f81a4d6118c7385b831044c468af83103193";
+    sha256 = "sha256-eaAbqeFY+B3CcKJywC3vaRsWZNQENTbALc7L7uW0W6U=";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+
+  buildInputs = [
+    (python3.withPackages (ps: with ps; [ pygobject3 ]))
+    headsetcontrol
+    gtk3
+    gobject-introspection
+    libayatana-appindicator-gtk3
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src/headset-charge-indicator.py $out/bin/headset-charge-indicator.py
+    chmod +x $out/bin/headset-charge-indicator.py
+
+    substituteInPlace \
+      $out/bin/headset-charge-indicator.py \
+      --replace "default='headsetcontrol'" "default='${headsetcontrol}/bin/headsetcontrol'"
+
+    cat << EOF > ${pname}.desktop
+    [Desktop Entry]
+    Name=Wireless headset app-indicator
+    Categories=Application;System
+    Exec=$out/bin/headset-charge-indicator.py
+    Terminal=false
+    Type=Application
+    X-GNOME-AutoRestart=true
+    X-GNOME-Autostart-enabled=true
+    EOF
+
+    mkdir -p $out/share/applications
+    mkdir -p $out/etc/xdg/autostart
+    cp ${pname}.desktop $out/share/applications/${pname}.desktop
+    cp ${pname}.desktop $out/etc/xdg/autostart/${pname}.desktop
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/centic9/headset-charge-indicator";
+    description =
+      "A app-indicator for GNOME desktops for controlling some features of various wireless headsets";
+    longDescription =
+      "A simple app-indicator for GNOME desktops to display the battery charge of some wireless headsets which also allows to control some functions like LEDs, sidetone and others.";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ zebreus ];
+    license = licenses.bsd2;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1151,6 +1151,8 @@ with pkgs;
 
   headsetcontrol = callPackage ../tools/audio/headsetcontrol { };
 
+  headset-charge-indicator = callPackage ../tools/audio/headset-charge-indicator { };
+
   httm = callPackage ../tools/filesystems/httm { };
 
   ksnip = libsForQt5.callPackage ../tools/misc/ksnip { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

[headset-charge-indicator](https://github.com/centic9/headset-charge-indicator) not yet packaged for nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
