### PR TITLE
commitizen: 2.20.4 -> 2.21.2

### DIFF
--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -21,13 +21,13 @@
 
 buildPythonApplication rec {
   pname = "commitizen";
-  version = "2.20.4";
+  version = "2.21.2";
 
   src = fetchFromGitHub {
     owner = "commitizen-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-2DhWiUAkAkyNxYB1CGzUB2nGZeCWvFqSztrxasUPSXw=";
+    sha256 = "sha256-ZFKUG8dE1hpWPGitdQlYeBSzWn3LPR7VGWsuq1Le5OQ=";
     deepClone = true;
   };
 

--- a/pkgs/applications/version-management/commitizen/default.nix
+++ b/pkgs/applications/version-management/commitizen/default.nix
@@ -1,23 +1,36 @@
 { buildPythonApplication
-, lib
-, fetchFromGitHub
-, poetry
-, termcolor
-, questionary
 , colorama
 , decli
-, tomlkit
+, fetchFromGitHub
+, git
 , jinja2
-, pyyaml
-, argcomplete
-, typing-extensions
+, lib
 , packaging
-, pytestCheckHook
+, poetry
 , pytest-freezegun
 , pytest-mock
 , pytest-regressions
-, git
+, pytestCheckHook
+, pyyaml
+, questionary
+, termcolor
+, tomlkit
+, typing-extensions
+
+, argcomplete, fetchPypi
 }:
+
+let
+  # NOTE: Upstream requires argcomplete <2, so we make it here.
+  argcomplete_1 = argcomplete.overrideAttrs (old: rec {
+    version = "1.12.3";
+    src = fetchPypi {
+      inherit (old) pname;
+      inherit version;
+      sha256 = "sha256-LH2//YwEXqU0kh5jsL5v5l6IWZmQ2NxAisjFQrcqVEU=";
+    };
+  });
+in
 
 buildPythonApplication rec {
   pname = "commitizen";
@@ -43,7 +56,7 @@ buildPythonApplication rec {
     tomlkit
     jinja2
     pyyaml
-    argcomplete
+    argcomplete_1
     typing-extensions
     packaging
   ];
@@ -54,7 +67,7 @@ buildPythonApplication rec {
     pytest-freezegun
     pytest-mock
     pytest-regressions
-    argcomplete
+    argcomplete_1
     git
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
