### PR TITLE
python3Packages.videocr: init at 0.1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9253,6 +9253,12 @@
     githubId = 15930073;
     name = "Moritz Scheuren";
   };
+  ozkutuk = {
+    email = "ozkutuk@protonmail.com";
+    github = "ozkutuk";
+    githubId = 5948762;
+    name = "Berk Özkütük";
+  };
   pablovsky = {
     email = "dealberapablo07@gmail.com";
     github = "pablo1107";

--- a/pkgs/development/python-modules/videocr/default.nix
+++ b/pkgs/development/python-modules/videocr/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     description = "Extract hardcoded subtitles from videos using machine learning";
     homepage = "https://github.com/apm1467/videocr";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ozkutuk ];
   };
 }

--- a/pkgs/development/python-modules/videocr/default.nix
+++ b/pkgs/development/python-modules/videocr/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python-Levenshtein
+, pytesseract
+, opencv4
+, fuzzywuzzy
+}:
+
+buildPythonPackage rec {
+  pname = "videocr";
+  version = "0.1.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1clifwczvhvbaw2spgxkkyqsbqh21vyfw3rh094pxfmq89ylyj63";
+  };
+
+  propagatedBuildInputs = [
+    python-Levenshtein
+    pytesseract
+    opencv4
+    fuzzywuzzy
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "opencv-python" "opencv"
+    substituteInPlace videocr/constants.py \
+      --replace "master" "main"
+    substituteInPlace videocr/video.py \
+      --replace '--tessdata-dir "{}"' '--tessdata-dir="{}"'
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "videocr" ];
+
+  meta = with lib; {
+    description = "Extract hardcoded subtitles from videos using machine learning";
+    homepage = "https://github.com/apm1467/videocr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10387,6 +10387,8 @@ in {
 
   veryprettytable = callPackage ../development/python-modules/veryprettytable { };
 
+  videocr = callPackage ../development/python-modules/videocr { };
+
   vidstab = callPackage ../development/python-modules/vidstab { };
 
   ViennaRNA = toPythonModule pkgs.ViennaRNA;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
