### PR TITLE
jujutsu: init at 0.3.1

### DIFF
--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -15,16 +15,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "jujutsu";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "martinvonz";
     repo = "jj";
     rev = "v${version}";
-    sha256 = "sha256-FG+Wibd45YOjQlHdQ4cQzPmOzLphpc6UaBoGYLE+OEM=";
+    sha256 = "sha256-BOT2pKcOSOha28fba62X+GgILcplhkMWhZo7Q0gGTQ8=";
   };
 
-  cargoSha256 = "sha256-YfbHHEDrCmxo133+w38ykj5uphSDVa7cYw0gJ2u2c+c=";
+  cargoSha256 = "sha256-uvR+WXX2iIWFhcPYpOoOS1WBvOXuhTmgVVT2446c6XE=";
+
+  # Needed to get openssl-sys to use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "jujutsu";
-  version = "unstable-2022-02-21";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "martinvonz";
     repo = "jj";
-    rev = "f9298582a78a4d06e6b9c5b51c67e034e7406739";
-    sha256 = "sha256-BQldf1AQr91cvfvlajjfzXt8BVToKV7eq5k11MiX9QY=";
+    rev = "v${version}";
+    sha256 = "sha256-FG+Wibd45YOjQlHdQ4cQzPmOzLphpc6UaBoGYLE+OEM=";
   };
 
-  cargoSha256 = "sha256-VWI3GQImPMy5a/c3QkDNXONoXvuuI2ofAmdZaiWSFvc=";
+  cargoSha256 = "sha256-YfbHHEDrCmxo133+w38ykj5uphSDVa7cYw0gJ2u2c+c=";
 
   nativeBuildInputs = [
     pkg-config
@@ -44,14 +44,13 @@ rustPlatform.buildRustPackage rec {
     version = testVersion {
       package = jujutsu;
       command = "jj --version";
-      # Remove version on release builds
-      version = "0.2.0";
     };
   };
 
   meta = with lib; {
     description = "A Git-compatible DVCS that is both simple and powerful";
     homepage = "https://github.com/martinvonz/jj";
+    changelog = "https://github.com/martinvonz/jj/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ _0x4A6F ];
   };

--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, stdenv
+, dbus
+, sqlite
+, Security
+, SystemConfiguration
+, libiconv
+, testVersion
+, jujutsu
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "jujutsu";
+  version = "unstable-2022-02-21";
+
+  src = fetchFromGitHub {
+    owner = "martinvonz";
+    repo = "jj";
+    rev = "f9298582a78a4d06e6b9c5b51c67e034e7406739";
+    sha256 = "sha256-BQldf1AQr91cvfvlajjfzXt8BVToKV7eq5k11MiX9QY=";
+  };
+
+  cargoSha256 = "sha256-VWI3GQImPMy5a/c3QkDNXONoXvuuI2ofAmdZaiWSFvc=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    dbus
+    sqlite
+  ] ++ lib.optionals stdenv.isDarwin [
+    Security
+    SystemConfiguration
+    libiconv
+  ];
+
+  passthru.tests = {
+    version = testVersion {
+      package = jujutsu;
+      command = "jj --version";
+      # Remove version on release builds
+      version = "0.2.0";
+    };
+  };
+
+  meta = with lib; {
+    description = "A Git-compatible DVCS that is both simple and powerful";
+    homepage = "https://github.com/martinvonz/jj";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ _0x4A6F ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27454,6 +27454,11 @@ with pkgs;
 
   clerk = callPackage ../applications/audio/clerk { };
 
+  jujutsu = callPackage ../applications/version-management/jujutsu {
+    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+    inherit (darwin) libiconv;
+  };
+
   nbstripout = callPackage ../applications/version-management/nbstripout { python = python3; };
 
   ncmpc = callPackage ../applications/audio/ncmpc { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add [jujutsu | jj](https://github.com/martinvonz/jj) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @colemickens 