### PR TITLE
mednafen,mednaffe: Enable for Darwin

### DIFF
--- a/pkgs/applications/emulators/mednafen/default.nix
+++ b/pkgs/applications/emulators/mednafen/default.nix
@@ -15,6 +15,7 @@
 , libsndfile
 , pkg-config
 , zlib
+, libiconv
 }:
 
 stdenv.mkDerivation rec {
@@ -31,20 +32,25 @@ stdenv.mkDerivation rec {
   buildInputs = [
     SDL2
     SDL2_net
-    alsa-lib
     flac
     freeglut
-    libGL
-    libGLU
-    libX11
     libcdio
     libjack2
     libsamplerate
     libsndfile
     zlib
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    libGL
+    libGLU
+    libX11
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
   ];
 
-  hardeningDisable = [ "pic" ];
+  hardeningDisable = [ "pic" "format" ];
+
+  enableParallelBuilding = true;
 
   postInstall = ''
     mkdir -p $out/share/doc
@@ -87,6 +93,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/emulators/mednaffe/default.nix
+++ b/pkgs/applications/emulators/mednaffe/default.nix
@@ -20,11 +20,15 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config wrapGAppsHook ];
+
   buildInputs = [ gtk3 mednafen ];
 
-  postInstall = ''
-    wrapProgram $out/bin/mednaffe \
+  enableParallelBuilding = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=(
       --prefix PATH ':' "${mednafen}/bin"
+    )
    '';
 
   meta = with lib; {
@@ -32,6 +36,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/AmatCoder/mednaffe";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ sheenobu yana AndersonTorres ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7820,7 +7820,9 @@ with pkgs;
 
   mdp = callPackage ../applications/misc/mdp { };
 
-  mednafen = callPackage ../applications/emulators/mednafen { };
+  mednafen = callPackage ../applications/emulators/mednafen {
+    inherit (darwin) libiconv;
+  };
 
   mednafen-server = callPackage ../applications/emulators/mednafen/server.nix { };
 


### PR DESCRIPTION
###### Motivation for this change
It's supposed to be cross-platform, so let's *make* it cross-platform :wink:

![image](https://user-images.githubusercontent.com/23431373/155212637-17c7beb5-7e93-4da5-b16e-db48de1497cc.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
