### PR TITLE
python27Packages.gtkme: init at version 1.5.1

### DIFF
--- a/pkgs/development/python2-modules/gtkme/default.nix
+++ b/pkgs/development/python2-modules/gtkme/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pkg-config
+, gobject-introspection
+, pygobject3
+, gtk3
+, glib
+}:
+
+buildPythonPackage rec {
+  pname = "gtkme";
+  version = "1.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-NIUgnbfcHjbPfsH3CF2Bywo8owrdsi1wqDoMxOa+2U4=";
+  };
+
+  nativeBuildInputs = [ pkg-config gobject-introspection gtk3 ];
+  buildInputs = [ pygobject3 glib ];
+  propagatedBuildInputs = [ gtk3 ];
+
+  pythonImportsCheck = [
+    "gtkme"
+  ];
+
+  meta = with lib; {
+    description = "Manages an Application with Gtk windows, forms, lists and other complex items easily";
+    homepage = "https://gitlab.com/doctormo/gtkme";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [
+      revol-xut
+    ];
+  };
+}

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -46,6 +46,8 @@ with self; with super; {
 
   google-apputils = callPackage ../development/python2-modules/google-apputils { };
 
+  gtkme = callPackage ../development/python2-modules/gtkme { };
+
   httpretty = callPackage ../development/python2-modules/httpretty { };
 
   hypothesis = callPackage ../development/python2-modules/hypothesis { };


### PR DESCRIPTION
Adding Python2 Package gtkme

###### Motivation for this change
Some inkscape plugins need this package. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
