### PR TITLE
bind: 9.16.25 -> 9.18.0

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,6 +1,6 @@
 { config, stdenv, lib, fetchurl, fetchpatch
 , perl, pkg-config
-, libcap, libtool, libxml2, openssl, libuv
+, libcap, libtool, libxml2, openssl, libuv, nghttp2, jemalloc
 , enableGSSAPI ? true, libkrb5
 , enablePython ? false, python3
 , enableSeccomp ? false, libseccomp
@@ -9,11 +9,11 @@
 
 stdenv.mkDerivation rec {
   pname = "bind";
-  version = "9.16.25";
+  version = "9.18.0";
 
   src = fetchurl {
     url = "https://downloads.isc.org/isc/bind9/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-n6MohQ+ChD74t78f9TIstosRAnOjPzdbpB81Jw9eH/M=";
+    sha256 = "sha256-VlJb9crwH9j9nZCRCIDMD4qQonqX0WkYfWUdTs8MQRw=";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ perl pkg-config ];
-  buildInputs = [ libtool libxml2 openssl libuv ]
+  buildInputs = [ libtool libxml2 openssl libuv nghttp2 jemalloc ]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional enableSeccomp libseccomp
     ++ lib.optional enableGSSAPI libkrb5
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     "--with-aes"
   ] ++ lib.optional stdenv.isLinux "--with-libcap=${libcap.dev}"
     ++ lib.optional enableSeccomp "--enable-seccomp"
-    ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}"
+    ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}/bin/krb5-config"
     ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
 
   postInstall = ''

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   passthru.tests = { inherit (nixosTests) bind; };
 
   meta = with lib; {
-    homepage = "https://www.isc.org/downloads/bind/";
+    homepage = "https://www.isc.org/bind/";
     description = "Domain name server";
     license = licenses.mpl20;
 

--- a/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
+++ b/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
@@ -2,38 +2,38 @@ diff --git a/bin/named/include/named/globals.h b/bin/named/include/named/globals
 index 82b632ef04..dedfd4d33b 100644
 --- a/bin/named/include/named/globals.h
 +++ b/bin/named/include/named/globals.h
-@@ -71,7 +71,9 @@ EXTERN const char *named_g_version	  INIT(VERSION);
- EXTERN const char *named_g_product	  INIT(PRODUCT);
- EXTERN const char *named_g_description	  INIT(DESCRIPTION);
- EXTERN const char *named_g_srcid	  INIT(SRCID);
+@@ -69,7 +69,9 @@ EXTERN const char *named_g_version	INIT(PACKAGE_VERSION);
+ EXTERN const char *named_g_product	INIT(PACKAGE_NAME);
+ EXTERN const char *named_g_description	INIT(PACKAGE_DESCRIPTION);
+ EXTERN const char *named_g_srcid	INIT(PACKAGE_SRCID);
 +#if 0
- EXTERN const char *named_g_configargs	  INIT(CONFIGARGS);
+ EXTERN const char *named_g_configargs	INIT(PACKAGE_CONFIGARGS);
 +#endif
- EXTERN const char *named_g_builder	  INIT(BUILDER);
- EXTERN in_port_t named_g_port		  INIT(0);
- EXTERN isc_dscp_t named_g_dscp		  INIT(-1);
+ EXTERN const char *named_g_builder	INIT(PACKAGE_BUILDER);
+ EXTERN in_port_t named_g_port		INIT(0);
+ EXTERN in_port_t named_g_tlsport	INIT(0);
 diff --git a/bin/named/main.c b/bin/named/main.c
 index 9ad2d0e277..9729a2b3fc 100644
 --- a/bin/named/main.c
 +++ b/bin/named/main.c
-@@ -521,7 +521,9 @@ printversion(bool verbose) {
+@@ -481,7 +481,9 @@ printversion(bool verbose) {
  	}
  
  	printf("running on %s\n", named_os_uname());
 +#if 0
- 	printf("built by %s with %s\n", named_g_builder, named_g_configargs);
+ 	printf("built by %s with %s\n", PACKAGE_BUILDER, PACKAGE_CONFIGARGS);
 +#endif
  #ifdef __clang__
  	printf("compiled by CLANG %s\n", __VERSION__);
  #else /* ifdef __clang__ */
-@@ -1089,9 +1091,11 @@ setup(void) {
+@@ -1027,9 +1029,11 @@ setup(void) {
  		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE, "running on %s",
  		      named_os_uname());
  
 +#if 0
  	isc_log_write(named_g_lctx, NAMED_LOGCATEGORY_GENERAL,
  		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE, "built with %s",
- 		      named_g_configargs);
+ 		      PACKAGE_CONFIGARGS);
 +#endif
  
  	isc_log_write(named_g_lctx, NAMED_LOGCATEGORY_GENERAL,


### PR DESCRIPTION
###### Motivation for this change
https://downloads.isc.org/isc/bind9/9.18.0/doc/arm/html/notes.html#notes-for-bind-9-18-0

The new dependency nghttp2 is required for DNS-over-HTTPS support.
Using jemalloc as the memory allocator is now recommended according to the release notes.
Without the change to the configureFlags, configure would complain:
configure: error: --with-gssapi requires yes|no|auto|/path/to/krb5-config
The patch also needed adjusting as it didn't apply anymore.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).