### PR TITLE
jschema_to_python: fix missing pbr dependency

### DIFF
--- a/pkgs/development/python-modules/jschema-to-python/default.nix
+++ b/pkgs/development/python-modules/jschema-to-python/default.nix
@@ -15,13 +15,10 @@ buildPythonPackage rec {
     sha256 = "76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91";
   };
 
-  nativeBuildInputs = [
-    pbr
-  ];
-
   propagatedBuildInputs = [
     attrs
     jsonpickle
+    pbr
   ];
 
   checkInputs =[


### PR DESCRIPTION
###### Motivation for this change

pbr is a runtime dependency when importing this module. Example failing package: cfn-lint.

```
➜  nixpkgs cfn-lint --help
Traceback (most recent call last):
  File "/nix/store/20c58m2qlg4vw64a3y69vanqiif77h4w-python3.9-cfn-lint-0.56.3/bin/.cfn-lint-wrapped", line 6, in <module>
    from cfnlint.__main__ import main
  File "/nix/store/20c58m2qlg4vw64a3y69vanqiif77h4w-python3.9-cfn-lint-0.56.3/lib/python3.9/site-packages/cfnlint/__main__.py", line 8, in <module>
    import cfnlint.core
  File "/nix/store/20c58m2qlg4vw64a3y69vanqiif77h4w-python3.9-cfn-lint-0.56.3/lib/python3.9/site-packages/cfnlint/core.py", line 16, in <module>
    import cfnlint.formatters
  File "/nix/store/20c58m2qlg4vw64a3y69vanqiif77h4w-python3.9-cfn-lint-0.56.3/lib/python3.9/site-packages/cfnlint/formatters/__init__.py", line 12, in <module>
    from jschema_to_python.to_json import to_json
  File "/nix/store/wynvm47yfn8wzdqfzb3cg6ij4gh6fw0a-python3.9-jschema-to-python-1.2.3/lib/python3.9/site-packages/jschema_to_python/__init__.py", line 1, in <module>
    import pbr
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
