### PR TITLE
krunner-ssh: init at 1.0

### DIFF
--- a/pkgs/desktops/plasma-5/3rdparty/addons/krunner-ssh.nix
+++ b/pkgs/desktops/plasma-5/3rdparty/addons/krunner-ssh.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitLab, python3 }:
+let
+  pythonEnv = python3.withPackages (p: with p; [ dbus-python pygobject3 ]);
+in
+stdenv.mkDerivation rec {
+  pname = "krunner-ssh";
+  version = "1.0";
+
+  src = fetchFromGitLab {
+    owner = "Programie";
+    repo = "krunner-ssh";
+    rev = version;
+    sha256 = "sha256-rFTTvmetDeN6t0axVc+8t1TRiuyPBpwqhvsq2IFxa/A=";
+  };
+
+  postPatch = ''
+    sed -e "s|Exec=.*|Exec=$out/libexec/runner.py|" -i ssh-runner.service
+  '';
+
+  nativeBuildInputs = [
+    pythonEnv
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    patchShebangs runner.py
+
+    install -m 0755 -D runner.py $out/libexec/runner.py
+    install -m 0755 -D ssh-runner.desktop $out/share/kservices5/ssh-runner.desktop
+    install -m 0755 -D ssh-runner.service $out/share/dbus-1/services/com.selfcoders.ssh-runner.service
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple backend for KRunner providing SSH hosts from your .ssh/known_hosts file as search results";
+    homepage = "https://selfcoders.com/projects/krunner-ssh";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aanderse ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -161,6 +161,7 @@ let
         kwin-dynamic-workspaces = callPackage ./3rdparty/kwin/scripts/dynamic-workspaces.nix { };
         kwin-tiling = callPackage ./3rdparty/kwin/scripts/tiling.nix { };
         krohnkite = callPackage ./3rdparty/kwin/scripts/krohnkite.nix { };
+        krunner-ssh = callPackage ./3rdparty/addons/krunner-ssh.nix { };
         krunner-symbols = callPackage ./3rdparty/addons/krunner-symbols.nix { };
         lightly = callPackage ./3rdparty/lightly { };
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1327,6 +1327,7 @@ mapAliases ({
     kwin-dynamic-workspaces
     kwin-tiling
     krohnkite
+    krunner-ssh
     krunner-symbols
   ;
   inherit (libsForQt5)


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I like `krunner`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
