### PR TITLE
mido: Reduce dependances

### DIFF
--- a/pkgs/development/python-modules/mido/default.nix
+++ b/pkgs/development/python-modules/mido/default.nix
@@ -4,9 +4,7 @@
 , fetchPypi
 , substituteAll
 , portmidi
-, pygame
 , python-rtmidi
-, rtmidi-python
 , pytestCheckHook
 }:
 
@@ -27,9 +25,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    pygame
     python-rtmidi
-    rtmidi-python
   ];
 
   checkInputs = [


### PR DESCRIPTION
According to [mido document][1], python-rtmidi is the default
recommended backend, the other backends are optional, and don't have all
features.

Remove pygame and rtmidi-python will reduce closure size from 930M to
87M, without losing functionality.

I've check nixpkgs, no other package use specific mido backends. Even if
they do need one, they can and should add the specific backend to their
own buildInputs/propagatedBuildInputs, as mido dynamically load these
python libraries, it will work as expected.

For reference, [ArchLinux][2] and [Debian][3] both make some backends
optional.

[1]: https://mido.readthedocs.io/en/latest/backends/index.html
[2]: https://aur.archlinux.org/packages/python-mido
[3]: https://packages.debian.org/buster/python3-mido

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
