### PR TITLE
vtm: init at 0.6.0

### DIFF
--- a/pkgs/tools/misc/vtm/default.nix
+++ b/pkgs/tools/misc/vtm/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv
+, fetchFromGitHub
+, cmake
+}:
+stdenv.mkDerivation rec {
+  pname = "vtm";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "netxs-group";
+    repo = "vtm";
+    rev = "v${version}";
+    sha256 = "sha256-Z6PSx7TwarQx0Mc3fSRPwV7yIPJK3xtW4k0LJ6RPYRY=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ ];
+
+  cmakeFlags = [ "../src" ];
+
+  meta = {
+    homepage = "https://vtm.netxs.online/";
+    description = "Terminal multiplexer with window manager and session sharing";
+
+    license = lib.licenses.mit;
+
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ahuzik ];
+  };
+}

--- a/pkgs/tools/misc/vtm/default.nix
+++ b/pkgs/tools/misc/vtm/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
 , cmake
 }:
@@ -15,16 +16,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ ];
-
   cmakeFlags = [ "../src" ];
 
   meta = {
     homepage = "https://vtm.netxs.online/";
     description = "Terminal multiplexer with window manager and session sharing";
-
     license = lib.licenses.mit;
-
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ahuzik ];
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10814,6 +10814,8 @@ with pkgs;
     SDL = SDL_sixel;
   };
 
+  vtm = callPackage ../tools/misc/vtm { };
+
   witness = callPackage ../tools/security/witness { };
 
   openconnect = openconnect_gnutls;


### PR DESCRIPTION
###### Motivation for this change

Package https://github.com/netxs-group/vtm . It's kinda like screen/tmux but more fun :)
Platforms are set to `all` because it explicitly supports unix-like platforms, as well as Windows.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
