### PR TITLE
writers: Add writeFSharp and makeFSharpWriter functions to writers

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, linkFarmFromDrvs, callPackage, nuget-to-nix, writeScript, makeWrapper, fetchurl, xml2, dotnetCorePackages, dotnetPackages, cacert }:
+{ lib, stdenvNoCC, linkFarmFromDrvs, callPackage, nuget-to-nix, writeScript, makeWrapper, fetchurl, xml2, dotnetCorePackages, dotnetPackages, mkNugetSource, mkNugetDeps, cacert }:
 
 { name ? "${args.pname}-${args.version}"
 , pname ? name
@@ -74,40 +74,13 @@ let
     inherit dotnet-sdk dotnet-test-sdk disabledTests nuget-source dotnet-runtime runtimeDeps buildType;
   }) dotnetConfigureHook dotnetBuildHook dotnetCheckHook dotnetInstallHook dotnetFixupHook;
 
-  _nugetDeps = linkFarmFromDrvs "${name}-nuget-deps" (import nugetDeps {
-    fetchNuGet = { pname, version, sha256 }: fetchurl {
-      name = "${pname}-${version}.nupkg";
-      url = "https://www.nuget.org/api/v2/package/${pname}/${version}";
-      inherit sha256;
-    };
-  });
+  _nugetDeps = mkNugetDeps { name = "${name}-nuget-deps"; nugetDeps = import nugetDeps; };
   _localDeps = linkFarmFromDrvs "${name}-local-nuget-deps" projectReferences;
 
-  nuget-source = stdenvNoCC.mkDerivation rec {
-    name = "${pname}-nuget-source";
-    meta.description = "A Nuget source with the dependencies for ${pname}";
-
-    nativeBuildInputs = [ dotnetPackages.Nuget xml2 ];
-    buildCommand = ''
-      export HOME=$(mktemp -d)
-      mkdir -p $out/{lib,share}
-
-      nuget sources Add -Name nixos -Source "$out/lib"
-      nuget init "${_nugetDeps}" "$out/lib"
-      ${lib.optionalString (projectReferences != [])
-        "nuget init \"${_localDeps}\" \"$out/lib\""}
-
-      # Generates a list of all unique licenses' spdx ids.
-      find "$out/lib" -name "*.nuspec" -exec sh -c \
-        "xml2 < {} | grep "license=" | cut -d'=' -f2" \; | sort -u > $out/share/licenses
-    '';
-  } // { # This is done because we need data from `$out` for `meta`. We have to use overrides as to not hit infinite recursion.
-    meta.licence = let
-      depLicenses = lib.splitString "\n" (builtins.readFile "${nuget-source}/share/licenses");
-      getLicence = spdx: lib.filter (license: license.spdxId or null == spdx) (builtins.attrValues lib.licenses);
-    in (lib.flatten (lib.forEach depLicenses (spdx:
-      if (getLicence spdx) != [] then (getLicence spdx) else [] ++ lib.optional (spdx != "") spdx
-    )));
+  nuget-source = mkNugetSource {
+    name = "${args.pname}-nuget-source";
+    description = "A Nuget source with the dependencies for ${args.pname}";
+    deps = [ _nugetDeps _localDeps ];
   };
 
 in stdenvNoCC.mkDerivation (args // {

--- a/pkgs/build-support/dotnet/make-nuget-deps/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-deps/default.nix
@@ -1,0 +1,9 @@
+{ linkFarmFromDrvs, fetchurl }:
+{ name, nugetDeps }:
+  linkFarmFromDrvs "${name}-nuget-deps" (nugetDeps {
+    fetchNuGet = { pname, version, sha256 }: fetchurl {
+      name = "${pname}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${pname}/${version}";
+      inherit sha256;
+    };
+  })

--- a/pkgs/build-support/dotnet/make-nuget-source/default.nix
+++ b/pkgs/build-support/dotnet/make-nuget-source/default.nix
@@ -1,0 +1,30 @@
+{ dotnetPackages, lib, xml2, stdenvNoCC }:
+{ name, description ? "", deps ? [] }:
+let
+  _nuget-source = stdenvNoCC.mkDerivation rec {
+    inherit name;
+    meta.description = description;
+
+    nativeBuildInputs = [ dotnetPackages.Nuget xml2 ];
+    buildCommand = ''
+      export HOME=$(mktemp -d)
+      mkdir -p $out/{lib,share}
+
+      nuget sources Add -Name nixos -Source "$out/lib"
+      ${ lib.concatMapStringsSep "\n" (dep:
+          ''nuget init "${dep}" "$out/lib"''
+        ) deps }
+
+      # Generates a list of all unique licenses' spdx ids.
+      find "$out/lib" -name "*.nuspec" -exec sh -c \
+        "xml2 < {} | grep "license=" | cut -d'=' -f2" \; | sort -u > $out/share/licenses
+    '';
+} // { # This is done because we need data from `$out` for `meta`. We have to use overrides as to not hit infinite recursion.
+  meta.licence = let
+    depLicenses = lib.splitString "\n" (builtins.readFile "${_nuget-source}/share/licenses");
+    getLicence = spdx: lib.filter (license: license.spdxId or null == spdx) (builtins.attrValues lib.licenses);
+  in (lib.flatten (lib.forEach depLicenses (spdx:
+    if (getLicence spdx) != [] then (getLicence spdx) else [] ++ lib.optional (spdx != "") spdx
+  )));
+};
+in _nuget-source

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, buildPackages, lib, stdenv, libiconv, gawk, gnused, gixy }:
+{ pkgs, config, buildPackages, lib, stdenv, libiconv, mkNugetDeps, mkNugetSource, gawk, gnused, gixy }:
 
 let
   aliases = if (config.allowAliases or true) then (import ./aliases.nix lib) else prev: {};
@@ -300,6 +300,42 @@ let
   # writePyPy3Bin takes the same arguments as writePyPy3 but outputs a directory (like writeScriptBin)
   writePyPy3Bin = name:
     writePyPy3 "/bin/${name}";
+
+
+  makeFSharpWriter = { dotnet-sdk ? pkgs.dotnet-sdk, fsi-flags ? "", libraries ? _: [] }: nameOrPath:
+  let
+    fname = last (builtins.split "/" nameOrPath);
+    path = if strings.hasSuffix ".fsx" nameOrPath then nameOrPath else "${nameOrPath}.fsx";
+    _nugetDeps = mkNugetDeps { name = "${fname}-nuget-deps"; nugetDeps = libraries; };
+
+    nuget-source = mkNugetSource {
+      name = "${fname}-nuget-source";
+      description = "A Nuget source with the dependencies for ${fname}";
+      deps = [ _nugetDeps ];
+    };
+
+    fsi = writeBash "fsi" ''
+      export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+      export DOTNET_CLI_TELEMETRY_OPTOUT=1
+      export DOTNET_NOLOGO=1
+      script="$1"; shift
+      ${dotnet-sdk}/bin/dotnet fsi --quiet --nologo --readline- ${fsi-flags} "$@" < "$script"
+    '';
+
+  in content: writers.makeScriptWriter {
+    interpreter = fsi;
+  } path
+  ''
+    #i "nuget: ${nuget-source}/lib"
+    ${ content }
+    exit 0
+  '';
+
+  writeFSharp =
+    makeFSharpWriter {};
+
+  writeFSharpBin = name:
+    writeFSharp "/bin/${name}";
 
 };
 in

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -150,6 +150,29 @@ let
       print(y[0]['test'])
     '';
 
+    fsharp = makeFSharpWriter {
+      libraries = { fetchNuGet }: [
+        (fetchNuGet { pname = "FSharp.SystemTextJson"; version = "0.17.4"; sha256 = "1bplzc9ybdqspii4q28l8gmfvzpkmgq5l1hlsiyg2h46w881lwg2"; })
+      ];
+    } "test-writers-fsharp" ''
+      #r "nuget: FSharp.SystemTextJson, 0.17.4"
+
+      module Json =
+          open System.Text.Json
+          open System.Text.Json.Serialization
+          let options = JsonSerializerOptions()
+          options.Converters.Add(JsonFSharpConverter())
+          let serialize<'a> (o: 'a) = JsonSerializer.Serialize<'a>(o, options)
+          let deserialize<'a> (str: string) = JsonSerializer.Deserialize<'a>(str, options)
+
+      type Letter = A | B
+      let a = {| Hello = Some "World"; Letter = A |}
+      if a |> Json.serialize |> Json.deserialize |> (=) a
+      then "success"
+      else "failed"
+      |> printfn "%s"
+    '';
+
     pypy2NoLibs = writePyPy2 "test-writers-pypy2-no-libs" {} ''
       print("success")
     '';
@@ -160,6 +183,10 @@ let
 
     pypy3NoLibs = writePyPy3 "test-writers-pypy3-no-libs" {} ''
       print("success")
+    '';
+
+    fsharpNoNugetDeps = writeFSharp "test-writers-fsharp-no-nuget-deps" ''
+      printfn "success"
     '';
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -464,6 +464,8 @@ with pkgs;
 
   buildDotnetModule = callPackage ../build-support/dotnet/build-dotnet-module { };
   nuget-to-nix = callPackage ../build-support/dotnet/nuget-to-nix { };
+  mkNugetSource = callPackage ../build-support/dotnet/make-nuget-source { };
+  mkNugetDeps = callPackage ../build-support/dotnet/make-nuget-deps { };
 
   dotnetenv = callPackage ../build-support/dotnet/dotnetenv {
     dotnetfx = dotnetfx40;


### PR DESCRIPTION
Uses fsharp interactive (fsi) to run fsx script

Add tests

###### Motivation for this change

It would be awesome to leverage the scripting power of F# in the Nix ecosystem.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
