### PR TITLE
pandoc-acro: init at 0.10.1

### DIFF
--- a/pkgs/tools/misc/pandoc-acro/default.nix
+++ b/pkgs/tools/misc/pandoc-acro/default.nix
@@ -1,0 +1,69 @@
+{ buildPythonApplication
+, fetchPypi
+, pandocfilters
+, panflute
+, lib
+, pandoc
+, pandoc-acro
+, texlive
+, runCommand
+}:
+
+let
+  pname = "pandoc-acro";
+  version = "0.10.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-JMfSQXX+BCGdFQYPFB+r08WRnhT3aXfnBNINROxCUA0=";
+  };
+in
+buildPythonApplication {
+  inherit pname version src;
+
+  propagatedBuildInputs = [
+    pandocfilters
+    panflute
+  ];
+
+  # Something in the tests does not typecheck, but the tool works well.
+  doCheck = false;
+
+  passthru.tests.example-doc =
+    let
+        env = {
+          nativeBuildInputs = [
+            pandoc
+            pandoc-acro
+            (texlive.combine {
+              inherit (texlive)
+                scheme-tetex
+                acro
+                translations
+                ;
+            })
+          ];
+        };
+      in
+      runCommand "pandoc-acro-example-docs" env ''
+        set -euo pipefail
+        exampleFile="${pname}-${version}/tests/example.md"
+        metadataFile="${pname}-${version}/tests/metadata.yaml"
+        tar --extract "--file=${src}" "$exampleFile" "$metadataFile"
+        mkdir $out
+
+        pandoc -F pandoc-acro "$exampleFile" "--metadata-file=$metadataFile" \
+          -T pdf -o $out/example.pdf
+        pandoc -F pandoc-acro  "$exampleFile" "--metadata-file=$metadataFile" \
+          -T txt -o $out/example.txt
+
+        ! grep -q "\+afaik" $out/example.txt
+      '';
+
+  meta = with lib; {
+    homepage = "https://pypi.org/project/pandoc-acro/";
+    description = "Pandoc filter which manages acronyms in Pandoc flavored Markdown sources";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ tfc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8273,6 +8273,8 @@ with pkgs;
 
   pa_applet = callPackage ../tools/audio/pa-applet { };
 
+  pandoc-acro = python3Packages.callPackage ../tools/misc/pandoc-acro { };
+
   pandoc-imagine = python3Packages.callPackage ../tools/misc/pandoc-imagine { };
 
   pandoc-drawio-filter = python3Packages.callPackage ../tools/misc/pandoc-drawio-filter { };


### PR DESCRIPTION
Add the pandoc-acro tool to nixpkgs

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
