### PR TITLE
python3Packages.shodan: 1.26.1 -> 1.27.0

### DIFF
--- a/pkgs/development/python-modules/shodan/default.nix
+++ b/pkgs/development/python-modules/shodan/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "shodan";
-  version = "1.26.1";
+  version = "1.27.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-8oJ7QNaRiYjvn18W3LihM4OqrhooRYmPcBLqyJBru4c=";
+    sha256 = "sha256-XkrnBuALYxZ6n/f34PM0QvxqxvC08mKci9Mswwf41VA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/slowapi/default.nix
+++ b/pkgs/development/python-modules/slowapi/default.nix
@@ -7,6 +7,7 @@
 , hiro
 , poetry-core
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 , redis
 , starlette
@@ -50,9 +51,11 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # E       AssertionError: Regex pattern 'parameter `request` must be an instance of starlette.requests.Request' does not match 'This portal is not running'.
+    # AssertionError: Regex pattern 'parameter `request` must be an instance of starlette.requests.Request' does not match 'This portal is not running'.
     "test_endpoint_request_param_invalid"
     "test_endpoint_response_param_invalid"
+  ] ++ lib.optionals (pythonAtLeast "3.10") [
+    "test_multiple_decorators"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/slowapi/default.nix
+++ b/pkgs/development/python-modules/slowapi/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   pname = "slowapi";
   version = "0.1.5";
   format = "pyproject";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -42,13 +43,21 @@ buildPythonPackage rec {
     starlette
   ];
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'limits = "^1.5"' 'limits = "*"' \
+      --replace 'redis = "^3.4.1"' 'redis = "*"'
+  '';
+
   disabledTests = [
     # E       AssertionError: Regex pattern 'parameter `request` must be an instance of starlette.requests.Request' does not match 'This portal is not running'.
     "test_endpoint_request_param_invalid"
     "test_endpoint_response_param_invalid"
   ];
 
-  pythonImportsCheck = [ "slowapi" ];
+  pythonImportsCheck = [
+    "slowapi"
+  ];
 
   meta = with lib; {
     description = "Python library for API rate limiting";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/achillean/shodan-python/blob/master/CHANGELOG.md#1270

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
