### PR TITLE
rust-{lib-}src: deprecate phases

### DIFF
--- a/pkgs/development/compilers/rust/make-rust-platform.nix
+++ b/pkgs/development/compilers/rust/make-rust-platform.nix
@@ -1,4 +1,4 @@
-{ buildPackages, callPackage, stdenv }@prev:
+{ buildPackages, callPackage, stdenv, runCommand }@prev:
 
 { rustc, cargo, stdenv ? prev.stdenv, ... }:
 
@@ -21,11 +21,11 @@ rec {
   importCargoLock = buildPackages.callPackage ../../../build-support/rust/import-cargo-lock.nix {};
 
   rustcSrc = callPackage ./rust-src.nix {
-    inherit stdenv rustc;
+    inherit runCommand rustc;
   };
 
   rustLibSrc = callPackage ./rust-lib-src.nix {
-    inherit stdenv rustc;
+    inherit runCommand rustc;
   };
 
   # Hooks

--- a/pkgs/development/compilers/rust/rust-lib-src.nix
+++ b/pkgs/development/compilers/rust/rust-lib-src.nix
@@ -1,11 +1,6 @@
-{ stdenv, rustc }:
+{ runCommand, rustc }:
 
-stdenv.mkDerivation {
-  name = "rust-lib-src";
-  src = rustc.src;
-  phases = [ "unpackPhase" "installPhase" ];
-
-  installPhase = ''
-    mv library $out
-  '';
-}
+runCommand "rust-lib-src" { } ''
+  tar --strip-components=1 -xzf ${rustc.src}
+  mv library $out
+''

--- a/pkgs/development/compilers/rust/rust-src.nix
+++ b/pkgs/development/compilers/rust/rust-src.nix
@@ -1,25 +1,21 @@
-{ lib, stdenv, rustc, minimalContent ? true }:
+{ lib, runCommand, rustc, minimalContent ? true }:
 
-stdenv.mkDerivation {
-  name = "rust-src";
-  src = rustc.src;
-  phases = [ "unpackPhase" "installPhase" ];
-  installPhase = ''
-    mv src $out
-    rm -rf $out/{${lib.concatStringsSep "," ([
-      "ci"
-      "doc"
-      "etc"
-      "grammar"
-      "llvm-project"
-      "llvm-emscripten"
-      "rtstartup"
-      "rustllvm"
-      "test"
-      "vendor"
-    ] ++ lib.optionals minimalContent [
-      "tools"
-      "stdarch"
-    ])}}
-  '';
-}
+runCommand "rust-src" { } ''
+  tar -xzf ${rustc.src}
+  mv rustc-${rustc.version}-src $out
+  rm -rf $out/{${lib.concatStringsSep "," ([
+    "ci"
+    "doc"
+    "etc"
+    "grammar"
+    "llvm-project"
+    "llvm-emscripten"
+    "rtstartup"
+    "rustllvm"
+    "test"
+    "vendor"
+  ] ++ lib.optionals minimalContent [
+    "tools"
+    "stdarch"
+  ])}}
+''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
