### PR TITLE
tree-sitter: unquote latest version in update script

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-go.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-go",
-  "rev": "0fa917a7022d1cd2e9b779a6a8fc5dc7fad69c75",
-  "date": "2022-01-06T10:54:10+01:00",
-  "path": "/nix/store/bw2hilbj37ys9lig2fzz58cvjy7nhn3l-tree-sitter-go",
-  "sha256": "0kgy4yyd0z8pydldnfwsfw2iwbhn4f43qxfhy94wvpwiwi74kfmg",
+  "rev": "07d722831382a043b16547b6d9202f3da07f3cb3",
+  "date": "2022-03-22T15:34:30+01:00",
+  "path": "/nix/store/9ay5gjwnip3jcmi096sw5fyi1kxqg1pk-tree-sitter-go",
+  "sha256": "0rc1p5jab08v1r81gzaz5xmxmbspl5i5zxba9immzax8ahzhhaxn",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -380,7 +380,7 @@ let
     if [[ "$(printf "%s" "$res" | ${jq}/bin/jq '.message?')" =~ "rate limit" ]]; then
       echo "rate limited" >&2
     fi
-    release="$(printf "%s" "$res" | ${jq}/bin/jq -r '.tag_name')"
+    release="$(printf "%s" "$res" | ${jq}/bin/jq -r '.tag_name' | tr -d \")"
     # github sometimes returns an empty list even tough there are releases
     if [ "$release" = "null" ]; then
       echo "uh-oh, latest for ${orga + "/" + repo} is not there, using HEAD" >&2


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Otherwise if a tag was found it would try to fetch `refs/tag/"v1.2.0". 

```
fetching list of grammars
checking the tree-sitter repo list against the grammars we know
writing files to /etc/nixos/nixpkgs/pkgs/development/tools/parsing/tree-sitter/grammars
Fetching latest release ("v1.2.1") of tree-sitter-agda …
Initialized empty Git repository in /tmp/git-checkout-tmp-RU9DUpjM/tree-sitter-agda/.git/
fatal: couldn't find remote ref refs/tags/"v1.2.1"
From https://github.com/tree-sitter/tree-sitter-agda
 * branch            HEAD       -> FETCH_HEAD
fatal: Not a valid object name 
Unrecognized git object type: 
Unable to checkout refs/tags/"v1.2.1" from https://github.com/tree-sitter/tree-sitter-agda.
```

Could probably be part of the `latestGIthubRelease` function, but I had no luck with adding the same pipe after the jq call that extracts `.name`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
