### PR TITLE
apple-source-release: deprecate phases

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/IOKit/default.nix
@@ -5,8 +5,6 @@ appleDerivation' stdenv {
   srcs = lib.attrValues IOKitSrcs;
   sourceRoot = ".";
 
-  phases = [ "unpackPhase" "installPhase" ];
-
   __propagatedImpureHostDeps = [
     "/System/Library/Frameworks/IOKit.framework/IOKit"
     "/System/Library/Frameworks/IOKit.framework/Resources"

--- a/pkgs/os-specific/darwin/apple-source-releases/Security/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/Security/boot.nix
@@ -1,8 +1,6 @@
 { appleDerivation', stdenv, darwin-stubs }:
 
 appleDerivation' stdenv {
-  phases = [ "unpackPhase" "installPhase" ];
-
   __propagatedImpureHostDeps = [
     "/System/Library/Frameworks/Security.framework/Security"
     "/System/Library/Frameworks/Security.framework/Resources"

--- a/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/mDNSResponder/default.nix
@@ -1,8 +1,7 @@
 { appleDerivation', stdenvNoCC }:
 
 appleDerivation' stdenvNoCC {
-  phases = [ "unpackPhase" "installPhase" ];
-
+  dontBuild = true;
   installPhase = ''
     mkdir -p $out/include
     cp mDNSShared/dns_sd.h $out/include

--- a/pkgs/os-specific/darwin/apple-source-releases/objc4/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/objc4/default.nix
@@ -1,8 +1,6 @@
 { appleDerivation, darwin-stubs }:
 
 appleDerivation {
-  phases = [ "unpackPhase" "installPhase" ];
-
   # Not strictly necessary, since libSystem depends on it, but it's nice to be explicit so we
   # can easily find out what's impure.
   __propagatedImpureHostDeps = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#28910

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
