### PR TITLE
synaesthesia: init at 2.4

### DIFF
--- a/pkgs/applications/audio/synaesthesia/default.nix
+++ b/pkgs/applications/audio/synaesthesia/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, fetchzip
+, SDL
+, pkg-config
+, libSM
+}:
+stdenv.mkDerivation rec {
+  pname = "synaesthesia";
+  version = "2.4";
+
+  src = fetchzip {
+    url = "https://logarithmic.net/pfh-files/synaesthesia/synaesthesia-${version}.tar.gz";
+    sha256 = "0nzsdxbah0shm2vlziaaw3ilzlizd3d35rridkpg40nfxmq84qnx";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL
+    libSM
+  ];
+
+  meta = {
+    homepage = "https://logarithmic.net/pfh/synaesthesia";
+    description = "Program for representing sounds visually";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.infinisil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10140,6 +10140,8 @@ with pkgs;
 
   symengine = callPackage ../development/libraries/symengine { };
 
+  synaesthesia = callPackage ../applications/audio/synaesthesia { };
+
   sysbench = callPackage ../development/tools/misc/sysbench {};
 
   system-config-printer = callPackage ../tools/misc/system-config-printer {


### PR DESCRIPTION
###### Motivation for this change
Neat music visualizer, [homepage](https://www.logarithmic.net/pfh/synaesthesia). Can be run with pulseaudio using
```
padsp synaesthesia line
```

It has some configuration, but here's what it can look like (tested on [Starfish (Blanco Remix) by Savant](https://savantofficial.bandcamp.com/track/starfish-blanco-remix)):


https://user-images.githubusercontent.com/20525370/155359128-76797116-b1d6-4e24-b9e3-47e43dbbfcb9.mp4

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
