### PR TITLE
moltenvk: 1.1.7 -> 1.1.8

### DIFF
--- a/pkgs/os-specific/darwin/moltenvk/default.nix
+++ b/pkgs/os-specific/darwin/moltenvk/default.nix
@@ -29,7 +29,7 @@ let
 in
 stdenvNoCC.mkDerivation rec {
   pname = "MoltenVK";
-  version = "1.1.7";
+  version = "1.1.8";
 
   buildInputs = [
     AppKit
@@ -47,7 +47,7 @@ stdenvNoCC.mkDerivation rec {
       src = fetchFromGitHub {
         owner = "KhronosGroup";
         repo = "glslang";
-        rev = "2742e959347ae2fac58acd0d022c92a0ff1f24bf";
+        rev = "90d4bd05cd77ef5782a6779a0fe3d084440dc80d";
         hash = "sha256-Q0sk4bPj/skPat1n4GJyuXAlZqpfEn4Td8Bm2IBNUqE=";
       };
     })).override {
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "MoltenVK";
     rev = "v${version}";
-    hash = "sha256-I9QcjyE09qclWPCLAVfKEaifP89q1ftLh9cXWy9m7kw=";
+    hash = "sha256-IfTBtA2fM7YN4qaSDUTfsiCXzn+omSV6oroL1ivKiVA=";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Keep in sync with upstream.

###### Things done

Tested that MoltenVK still works with Wine + DXVK.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
