### PR TITLE
kde-frameworks: rename name to pname

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/attica.nix
+++ b/pkgs/development/libraries/kde-frameworks/attica.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, qtbase }:
 
 mkDerivation {
-  name = "attica";
+  pname = "attica";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/baloo.nix
+++ b/pkgs/development/libraries/kde-frameworks/baloo.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "baloo";
+  pname = "baloo";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kauth kconfig kcrash kdbusaddons ki18n kio kidletime lmdb qtdeclarative

--- a/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/bluez-qt.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "bluez-qt";
+  pname = "bluez-qt";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtdeclarative ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
+++ b/pkgs/development/libraries/kde-frameworks/breeze-icons.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, gtk3, qtsvg, hicolor-icon-theme }:
 
 mkDerivation {
-  name = "breeze-icons";
+  pname = "breeze-icons";
   nativeBuildInputs = [ extra-cmake-modules gtk3 ];
   buildInputs = [ qtsvg ];
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/kde-frameworks/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/default.nix
@@ -70,8 +70,8 @@ let
         mkDerivation = args:
           let
 
-            inherit (args) name;
-            inherit (srcs.${name}) src version;
+            inherit (args) pname;
+            inherit (srcs.${pname}) src version;
 
             outputs = args.outputs or [ "bin" "dev" "out" ];
             hasSeparateDev = lib.elem "dev" outputs;
@@ -90,8 +90,7 @@ let
               };
 
           in mkDerivation (args // {
-            name = "${name}-${version}";
-            inherit meta outputs setupHook src version;
+            inherit pname meta outputs setupHook src version;
           });
 
       };

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, cmake, pkg-config }:
 
 mkDerivation {
-  name = "extra-cmake-modules";
+  pname = "extra-cmake-modules";
 
   patches = [
     ./nix-lib-path.patch

--- a/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
+++ b/pkgs/development/libraries/kde-frameworks/frameworkintegration.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "frameworkintegration";
+  pname = "frameworkintegration";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kbookmarks kcompletion kconfig ki18n kio knewstuff knotifications kpackage

--- a/pkgs/development/libraries/kde-frameworks/kactivities-stats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kactivities-stats.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kactivities-stats";
+  pname = "kactivities-stats";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ boost kactivities kconfig ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kactivities.nix
+++ b/pkgs/development/libraries/kde-frameworks/kactivities.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kactivities";
+  pname = "kactivities";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     boost kconfig kcoreaddons kio kwindowsystem qtdeclarative

--- a/pkgs/development/libraries/kde-frameworks/kapidox.nix
+++ b/pkgs/development/libraries/kde-frameworks/kapidox.nix
@@ -1,7 +1,7 @@
 { mkDerivation, lib, extra-cmake-modules, python3 }:
 
 mkDerivation {
-  name = "kapidox";
+  pname = "kapidox";
   nativeBuildInputs = [ extra-cmake-modules python3 python3.pkgs.setuptools ];
   postFixup = ''
     moveToOutput bin $bin

--- a/pkgs/development/libraries/kde-frameworks/karchive.nix
+++ b/pkgs/development/libraries/kde-frameworks/karchive.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "karchive";
+  pname = "karchive";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ bzip2 xz zlib zstd ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kauth/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kauth/default.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kauth";
+  pname = "kauth";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ polkit-qt qttools ];
   propagatedBuildInputs = [ kcoreaddons ];

--- a/pkgs/development/libraries/kde-frameworks/kbookmarks.nix
+++ b/pkgs/development/libraries/kde-frameworks/kbookmarks.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kbookmarks";
+  pname = "kbookmarks";
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [
     kcodecs kconfig kconfigwidgets kcoreaddons kiconthemes kxmlgui

--- a/pkgs/development/libraries/kde-frameworks/kcalendarcore.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcalendarcore.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kcalendarcore";
+  pname = "kcalendarcore";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ libical ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcmutils/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kcmutils";
+  pname = "kcmutils";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kcoreaddons kdeclarative ki18n kiconthemes kitemviews kpackage kxmlgui

--- a/pkgs/development/libraries/kde-frameworks/kcodecs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcodecs.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, qtbase, qttools, gperf }:
 
 mkDerivation {
-  name = "kcodecs";
+  pname = "kcodecs";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools gperf ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kcompletion.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcompletion.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcompletion";
+  pname = "kcompletion";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kconfig kwidgetsaddons qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfig.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, qtbase, qttools }:
 
 mkDerivation {
-  name = "kconfig";
+  pname = "kconfig";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kconfigwidgets/default.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kconfigwidgets";
+  pname = "kconfigwidgets";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kguiaddons ki18n qtbase qttools ];
   propagatedBuildInputs = [ kauth kcodecs kconfig kwidgetsaddons ];

--- a/pkgs/development/libraries/kde-frameworks/kcontacts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcontacts.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcontacts";
+  pname = "kcontacts";
   meta = {
     license = [ lib.licenses.lgpl21 ];
   };

--- a/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcoreaddons.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcoreaddons";
+  pname = "kcoreaddons";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools shared-mime-info ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kcrash.nix
+++ b/pkgs/development/libraries/kde-frameworks/kcrash.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kcrash";
+  pname = "kcrash";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcoreaddons kwindowsystem qtx11extras ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kdav.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdav.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdav";
+  pname = "kdav";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
   };

--- a/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdbusaddons.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdbusaddons";
+  pname = "kdbusaddons";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools qtx11extras ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kdeclarative.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdeclarative.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdeclarative";
+  pname = "kdeclarative";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     libepoxy kglobalaccel kguiaddons ki18n kiconthemes kio kwidgetsaddons

--- a/pkgs/development/libraries/kde-frameworks/kded.nix
+++ b/pkgs/development/libraries/kde-frameworks/kded.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kded";
+  pname = "kded";
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
   buildInputs = [
     gsettings-desktop-schemas kconfig kcoreaddons kcrash kdbusaddons

--- a/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdelibs4support/default.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "kdelibs4support";
+  pname = "kdelibs4support";
   patches = [
     ./nix-kde-include-dir.patch
   ];

--- a/pkgs/development/libraries/kde-frameworks/kdesignerplugin.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdesignerplugin.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kdesignerplugin";
+  pname = "kdesignerplugin";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kcompletion kconfig kconfigwidgets kcoreaddons kiconthemes kio kitemviews

--- a/pkgs/development/libraries/kde-frameworks/kdesu/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdesu/default.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdesu";
+  pname = "kdesu";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcoreaddons ki18n kpty kservice qtbase ];
   propagatedBuildInputs = [ kpty ];

--- a/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdewebkit.nix
@@ -3,7 +3,7 @@
 }:
 
 mkDerivation {
-  name = "kdewebkit";
+  pname = "kdewebkit";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kconfig kcoreaddons kio kparts ];
   propagatedBuildInputs = [ qtwebkit ];

--- a/pkgs/development/libraries/kde-frameworks/kdnssd.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdnssd.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kdnssd";
+  pname = "kdnssd";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ avahi qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kdoctools";
+  pname = "kdoctools";
   nativeBuildInputs = [
     extra-cmake-modules
     # The build system insists on having native Perl.

--- a/pkgs/development/libraries/kde-frameworks/kemoticons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kemoticons.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kemoticons";
+  pname = "kemoticons";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive kcoreaddons ];
   propagatedBuildInputs = [ kservice qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -15,7 +15,7 @@
 }:
 
 mkDerivation {
-  name = "kfilemetadata";
+  pname = "kfilemetadata";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     attr

--- a/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
+++ b/pkgs/development/libraries/kde-frameworks/kglobalaccel.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kglobalaccel";
+  pname = "kglobalaccel";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kconfig kcoreaddons kcrash kdbusaddons kservice kwindowsystem qttools

--- a/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kguiaddons.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kguiaddons";
+  pname = "kguiaddons";
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtx11extras wayland ];

--- a/pkgs/development/libraries/kde-frameworks/kholidays.nix
+++ b/pkgs/development/libraries/kde-frameworks/kholidays.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kholidays";
+  pname = "kholidays";
   meta = {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = with lib.maintainers; [ bkchr ];

--- a/pkgs/development/libraries/kde-frameworks/khtml.nix
+++ b/pkgs/development/libraries/kde-frameworks/khtml.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "khtml";
+  pname = "khtml";
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [
     giflib karchive kcodecs kglobalaccel ki18n kiconthemes kio knotifications

--- a/pkgs/development/libraries/kde-frameworks/ki18n.nix
+++ b/pkgs/development/libraries/kde-frameworks/ki18n.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "ki18n";
+  pname = "ki18n";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedNativeBuildInputs = [ gettext python3 ];
   buildInputs = [ qtdeclarative qtscript ];

--- a/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kiconthemes/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kiconthemes";
+  pname = "kiconthemes";
   patches = [
     ./default-theme-breeze.patch
   ];

--- a/pkgs/development/libraries/kde-frameworks/kidletime.nix
+++ b/pkgs/development/libraries/kde-frameworks/kidletime.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kidletime";
+  pname = "kidletime";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtx11extras ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kimageformats.nix
+++ b/pkgs/development/libraries/kde-frameworks/kimageformats.nix
@@ -7,7 +7,7 @@
 let inherit (lib) getDev; in
 
 mkDerivation {
-  name = "kimageformats";
+  pname = "kimageformats";
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ karchive openexr libavif qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kinit/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kinit/default.nix
@@ -7,7 +7,7 @@
 let inherit (lib) getLib; in
 
 mkDerivation {
-  name = "kinit";
+  pname = "kinit";
   outputs = [ "out" "dev" ];
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [

--- a/pkgs/development/libraries/kde-frameworks/kio/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kio/default.nix
@@ -9,7 +9,7 @@
 }:
 
 mkDerivation {
-  name = "kio";
+  pname = "kio";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     karchive kconfigwidgets kdbusaddons ki18n kiconthemes knotifications

--- a/pkgs/development/libraries/kde-frameworks/kirigami2.nix
+++ b/pkgs/development/libraries/kde-frameworks/kirigami2.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, qtbase, qtquickcontrols2, qttranslations, qtgraphicaleffects }:
 
 mkDerivation {
-  name = "kirigami2";
+  pname = "kirigami2";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase qtquickcontrols2 qttranslations qtgraphicaleffects ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemmodels.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kitemmodels";
+  pname = "kitemmodels";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kitemviews.nix
+++ b/pkgs/development/libraries/kde-frameworks/kitemviews.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kitemviews";
+  pname = "kitemviews";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kjobwidgets.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjobwidgets.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kjobwidgets";
+  pname = "kjobwidgets";
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [ kcoreaddons kwidgetsaddons qtx11extras ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kjs.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjs.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kjs";
+  pname = "kjs";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ pcre qtbase ];
 }

--- a/pkgs/development/libraries/kde-frameworks/kjsembed.nix
+++ b/pkgs/development/libraries/kde-frameworks/kjsembed.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kjsembed";
+  pname = "kjsembed";
   nativeBuildInputs = [ extra-cmake-modules kdoctools qttools ];
   buildInputs = [ ki18n qtsvg ];
   propagatedBuildInputs = [ kjs ];

--- a/pkgs/development/libraries/kde-frameworks/kmediaplayer.nix
+++ b/pkgs/development/libraries/kde-frameworks/kmediaplayer.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kmediaplayer";
+  pname = "kmediaplayer";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kparts kxmlgui ];
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "knewstuff";
+  pname = "knewstuff";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     karchive kcompletion kconfig kcoreaddons ki18n kiconthemes kio kitemviews

--- a/pkgs/development/libraries/kde-frameworks/knotifications.nix
+++ b/pkgs/development/libraries/kde-frameworks/knotifications.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "knotifications";
+  pname = "knotifications";
   nativeBuildInputs = [ extra-cmake-modules qttools ];
   buildInputs = [
     kcodecs kconfig kcoreaddons kwindowsystem libdbusmenu phonon qtx11extras

--- a/pkgs/development/libraries/kde-frameworks/knotifyconfig.nix
+++ b/pkgs/development/libraries/kde-frameworks/knotifyconfig.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "knotifyconfig";
+  pname = "knotifyconfig";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcompletion kconfig ki18n kio phonon ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpackage/default.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kpackage";
+  pname = "kpackage";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ karchive kconfig kcoreaddons ki18n qtbase ];
   patches = [

--- a/pkgs/development/libraries/kde-frameworks/kparts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kparts.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kparts";
+  pname = "kparts";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kconfig kcoreaddons ki18n kiconthemes kjobwidgets knotifications kservice

--- a/pkgs/development/libraries/kde-frameworks/kpeople.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpeople.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kpeople";
+  pname = "kpeople";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kcoreaddons ki18n kitemviews kservice kwidgetsaddons qtdeclarative

--- a/pkgs/development/libraries/kde-frameworks/kplotting.nix
+++ b/pkgs/development/libraries/kde-frameworks/kplotting.nix
@@ -3,7 +3,7 @@
 }:
 
 mkDerivation {
-  name = "kplotting";
+  pname = "kplotting";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase qttools ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kpty.nix
+++ b/pkgs/development/libraries/kde-frameworks/kpty.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, kcoreaddons, ki18n, qtbase, }:
 
 mkDerivation {
-  name = "kpty";
+  pname = "kpty";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcoreaddons ki18n qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kquickcharts.nix
+++ b/pkgs/development/libraries/kde-frameworks/kquickcharts.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kquickcharts";
+  pname = "kquickcharts";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtquickcontrols2 ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kross.nix
+++ b/pkgs/development/libraries/kde-frameworks/kross.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "kross";
+  pname = "kross";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [ kcompletion kcoreaddons kxmlgui ];
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/kde-frameworks/krunner.nix
+++ b/pkgs/development/libraries/kde-frameworks/krunner.nix
@@ -7,7 +7,7 @@
 
 let
   self = mkDerivation {
-    name = "krunner";
+    pname = "krunner";
     nativeBuildInputs = [ extra-cmake-modules ];
     buildInputs = [
       kconfig kcoreaddons ki18n kio kservice qtdeclarative solid

--- a/pkgs/development/libraries/kde-frameworks/kservice/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kservice/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kservice";
+  pname = "kservice";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   propagatedNativeBuildInputs = [ bison flex ];
   buildInputs = [

--- a/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktexteditor.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "ktexteditor";
+  pname = "ktexteditor";
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [
     karchive kconfig kguiaddons ki18n kiconthemes kio libgit2 qtscript

--- a/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
+++ b/pkgs/development/libraries/kde-frameworks/ktextwidgets.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "ktextwidgets";
+  pname = "ktextwidgets";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     kcompletion kconfig kconfigwidgets kiconthemes kservice kwindowsystem

--- a/pkgs/development/libraries/kde-frameworks/kunitconversion.nix
+++ b/pkgs/development/libraries/kde-frameworks/kunitconversion.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, ki18n, qtbase, }:
 
 mkDerivation {
-  name = "kunitconversion";
+  pname = "kunitconversion";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ ki18n qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/kwallet.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwallet.nix
@@ -7,7 +7,7 @@
 }:
 
 mkDerivation {
-  name = "kwallet";
+  pname = "kwallet";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kconfig kconfigwidgets kcoreaddons kdbusaddons ki18n kiconthemes

--- a/pkgs/development/libraries/kde-frameworks/kwayland.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwayland.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kwayland";
+  pname = "kwayland";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ plasma-wayland-protocols wayland wayland-protocols ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwidgetsaddons.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "kwidgetsaddons";
+  pname = "kwidgetsaddons";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kwindowsystem/default.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kwindowsystem";
+  pname = "kwindowsystem";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ libpthreadstubs libXdmcp qttools qtx11extras ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
+++ b/pkgs/development/libraries/kde-frameworks/kxmlgui.nix
@@ -6,7 +6,7 @@
 }:
 
 mkDerivation {
-  name = "kxmlgui";
+  pname = "kxmlgui";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
     attica kglobalaccel ki18n kiconthemes kitemviews ktextwidgets kwindowsystem

--- a/pkgs/development/libraries/kde-frameworks/kxmlrpcclient.nix
+++ b/pkgs/development/libraries/kde-frameworks/kxmlrpcclient.nix
@@ -1,7 +1,7 @@
 { mkDerivation, extra-cmake-modules, ki18n, kio }:
 
 mkDerivation {
-  name = "kxmlrpcclient";
+  pname = "kxmlrpcclient";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ ki18n ];
   propagatedBuildInputs = [ kio ];

--- a/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/modemmanager-qt.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "modemmanager-qt";
+  pname = "modemmanager-qt";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ modemmanager qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
+++ b/pkgs/development/libraries/kde-frameworks/networkmanager-qt.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "networkmanager-qt";
+  pname = "networkmanager-qt";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ networkmanager qtbase ];
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kde-frameworks/oxygen-icons5.nix
+++ b/pkgs/development/libraries/kde-frameworks/oxygen-icons5.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "oxygen-icons5";
+  pname = "oxygen-icons5";
   meta.license = lib.licenses.lgpl3Plus;
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
+++ b/pkgs/development/libraries/kde-frameworks/plasma-framework.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "plasma-framework";
+  pname = "plasma-framework";
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     kactivities karchive kconfig kconfigwidgets kcoreaddons kdbusaddons

--- a/pkgs/development/libraries/kde-frameworks/prison.nix
+++ b/pkgs/development/libraries/kde-frameworks/prison.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "prison";
+  pname = "prison";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ libdmtx qrencode ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/purpose.nix
+++ b/pkgs/development/libraries/kde-frameworks/purpose.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "purpose";
+  pname = "purpose";
   nativeBuildInputs = [ extra-cmake-modules intltool ];
   buildInputs = [
     qtbase accounts-qt qtdeclarative kaccounts-integration kconfig kcoreaddons

--- a/pkgs/development/libraries/kde-frameworks/qqc2-desktop-style.nix
+++ b/pkgs/development/libraries/kde-frameworks/qqc2-desktop-style.nix
@@ -8,7 +8,7 @@
 }:
 
 mkDerivation {
-  name = "qqc2-desktop-style";
+  pname = "qqc2-desktop-style";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ qtx11extras qtquickcontrols2 kconfig kiconthemes kirigami2 ];
 }

--- a/pkgs/development/libraries/kde-frameworks/solid.nix
+++ b/pkgs/development/libraries/kde-frameworks/solid.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "solid";
+  pname = "solid";
   nativeBuildInputs = [ bison extra-cmake-modules flex media-player-info ];
   buildInputs = [ qtdeclarative qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/sonnet.nix
+++ b/pkgs/development/libraries/kde-frameworks/sonnet.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "sonnet";
+  pname = "sonnet";
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ aspell qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/syndication.nix
+++ b/pkgs/development/libraries/kde-frameworks/syndication.nix
@@ -4,7 +4,7 @@
 }:
 
 mkDerivation {
-  name = "syndication";
+  pname = "syndication";
   meta.maintainers = [ lib.maintainers.bkchr ];
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [ kcodecs ];

--- a/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
+++ b/pkgs/development/libraries/kde-frameworks/syntax-highlighting.nix
@@ -3,7 +3,7 @@
 }:
 
 mkDerivation {
-  name = "syntax-highlighting";
+  pname = "syntax-highlighting";
   nativeBuildInputs = [ extra-cmake-modules perl ];
   buildInputs = [ qttools ];
   propagatedBuildInputs = [ qtbase ];

--- a/pkgs/development/libraries/kde-frameworks/threadweaver.nix
+++ b/pkgs/development/libraries/kde-frameworks/threadweaver.nix
@@ -5,7 +5,7 @@
 }:
 
 mkDerivation {
-  name = "threadweaver";
+  pname = "threadweaver";
   nativeBuildInputs = [ extra-cmake-modules ];
   propagatedBuildInputs = [ qtbase ];
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
