### PR TITLE
treewide: rename name to pname&version

### DIFF
--- a/pkgs/development/libraries/cwiid/default.nix
+++ b/pkgs/development/libraries/cwiid/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, bison, flex, bluez, pkg-config, gtk2 }:
 
 stdenv.mkDerivation rec {
-  name = "cwiid-${version}-git";
-  version = "2010-02-21";
+  pname = "cwiid";
+  version = "unstable-2010-02-21";
 
   src = fetchFromGitHub {
     owner  = "abstrakraft";

--- a/pkgs/development/libraries/cxxopts/default.nix
+++ b/pkgs/development/libraries/cxxopts/default.nix
@@ -8,12 +8,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "cxxopts";
+  pname = "cxxopts";
   version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "jarro2783";
-    repo = name;
+    repo = "cxxopts";
     rev = "v${version}";
     sha256 = "08x7j168l1xwj0r3rv89cgghmfhsx98lpq35r3vkh504m1pd55a6";
   };

--- a/pkgs/development/libraries/dotconf/default.nix
+++ b/pkgs/development/libraries/dotconf/default.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, lib, stdenv, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "dotconf-" + version;
+  pname = "dotconf";
   version = "1.3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -4,7 +4,7 @@
 }:
 
 stdenvNoLibs.mkDerivation rec {
-  name = "libgcc-${version}";
+  pname = "libgcc";
   inherit (gcc.cc) src version;
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/ggz_base_libs/default.nix
+++ b/pkgs/development/libraries/ggz_base_libs/default.nix
@@ -1,12 +1,11 @@
 { lib, stdenv, fetchurl, intltool, openssl, expat, libgcrypt }:
 
 stdenv.mkDerivation rec {
+  pname = "ggz-base-libs";
   version = "0.99.5";
-  baseName = "ggz-base-libs";
-  name = "${baseName}-snapshot-${version}";
 
   src = fetchurl {
-    url = "http://mirrors.ibiblio.org/pub/mirrors/ggzgamingzone/ggz/snapshots/${name}.tar.gz";
+    url = "http://mirrors.ibiblio.org/pub/mirrors/ggzgamingzone/ggz/snapshots/ggz-base-libs-snapshot-${version}.tar.gz";
     sha256 = "1cw1vg0fbj36zyggnzidx9cbjwfc1yr4zqmsipxnvns7xa2awbdk";
   };
 

--- a/pkgs/development/libraries/gtkmm/2.x.nix
+++ b/pkgs/development/libraries/gtkmm/2.x.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, pkg-config, gtk2, glibmm, cairomm, pangomm, atkmm }:
 
 stdenv.mkDerivation rec {
-  name = "gtkmm-${minVer}.5";
-  minVer = "2.24";
+  pname = "gtkmm";
+  version = "2.24.5";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtkmm/${minVer}/${name}.tar.xz";
+    url = "mirror://gnome/sources/gtkmm/${lib.versions.majorMinor version}/gtkmm-${version}.tar.xz";
     sha256 = "0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72";
   };
 

--- a/pkgs/development/libraries/hspell/dicts.nix
+++ b/pkgs/development/libraries/hspell/dicts.nix
@@ -2,7 +2,7 @@
 
 let
   dict = variant: a: stdenv.mkDerivation ({
-    inherit (hspell) src patchPhase nativeBuildInputs;
+    inherit (hspell) version src patchPhase nativeBuildInputs;
     buildFlags = [ variant ];
 
     meta = hspell.meta // {
@@ -15,7 +15,7 @@ in
   recurseForDerivations = true;
 
   aspell = dict "aspell" {
-    name = "aspell-dict-he-${hspell.version}";
+    pname = "aspell-dict-he";
 
     installPhase = ''
       mkdir -p $out/lib/aspell
@@ -23,7 +23,7 @@ in
   };
 
   myspell = dict "myspell" {
-    name = "myspell-dict-he-${hspell.version}";
+    pname = "myspell-dict-he";
 
     installPhase = ''
       mkdir -p $out/lib/myspell
@@ -31,7 +31,7 @@ in
   };
 
   hunspell = dict "hunspell" {
-    name = "hunspell-dict-he-${hspell.version}";
+    pname = "hunspell-dict-he";
 
     installPhase = ''
       mkdir -p $out/lib

--- a/pkgs/development/libraries/jcal/default.nix
+++ b/pkgs/development/libraries/jcal/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "jcal";
+  pname = "jcal";
   version = "0.4.1";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
+++ b/pkgs/development/libraries/khronos-ocl-icd-loader/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, opencl-headers, cmake, withTracing ? false }:
 
 stdenv.mkDerivation rec {
-  name = "khronos-ocl-icd-loader-${version}";
+  pname = "khronos-ocl-icd-loader";
   version = "2022.01.04";
 
   src = fetchFromGitHub {

--- a/pkgs/development/libraries/languagemachines/frog.nix
+++ b/pkgs/development/libraries/languagemachines/frog.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "frog-${release.version}";
+  pname = "frog";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frog-v${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/frogdata.nix
+++ b/pkgs/development/libraries/languagemachines/frogdata.nix
@@ -7,7 +7,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "frogdata-${release.version}";
+  pname = "frogdata";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frogdata-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/libfolia.nix
+++ b/pkgs/development/libraries/languagemachines/libfolia.nix
@@ -8,7 +8,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "libfolia-${release.version}";
+  pname = "libfolia";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "libfolia-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/mbt.nix
+++ b/pkgs/development/libraries/languagemachines/mbt.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "mbt-${release.version}";
+  pname = "mbt";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "mbt-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/ticcutils.nix
+++ b/pkgs/development/libraries/languagemachines/ticcutils.nix
@@ -7,7 +7,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "ticcutils-${release.version}";
+  pname = "ticcutils";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ticcutils-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/timbl.nix
+++ b/pkgs/development/libraries/languagemachines/timbl.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "timbl-${release.version}";
+  pname = "timbl";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timbl-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/timblserver.nix
+++ b/pkgs/development/libraries/languagemachines/timblserver.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "timblserver-${release.version}";
+  pname = "timblserver";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timblserver-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/ucto.nix
+++ b/pkgs/development/libraries/languagemachines/ucto.nix
@@ -9,7 +9,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "ucto-${release.version}";
+  pname = "ucto";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ucto-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/languagemachines/uctodata.nix
+++ b/pkgs/development/libraries/languagemachines/uctodata.nix
@@ -7,7 +7,7 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "uctodata-${release.version}";
+  pname = "uctodata";
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "uctodata-${release.version}.tar.gz"; };

--- a/pkgs/development/libraries/libcollectdclient/default.nix
+++ b/pkgs/development/libraries/libcollectdclient/default.nix
@@ -2,7 +2,8 @@
 with lib;
 
 collectd.overrideAttrs (oldAttrs: {
-  name = "libcollectdclient-${collectd.version}";
+  pname = "libcollectdclient";
+  inherit (collectd) version;
   buildInputs = [ ];
 
   configureFlags = (oldAttrs.configureFlags or []) ++ [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
