### PR TITLE
schildichat: 1.9.8-sc.1 -> 1.10.3-sc.0.test.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/schildichat/pin.json
+++ b/pkgs/applications/networking/instant-messengers/schildichat/pin.json
@@ -1,6 +1,7 @@
 {
-  "version": "1.9.8-sc.1",
-  "srcHash": "1ki4ccsa2i0mv10ypxg6bx9njikipdqkc5bsq5h7bi86scjm4lni",
-  "webYarnHash": "1za6r0snrflh2605xw4m19p88chx19ip8jj592bqjdagildqm50l",
-  "desktopYarnHash": "176ih0nzzx2yds6kp3lzdsrlp0glb9nqw146z0s1az7pjp6nrf18"
+  "version": "1.10.3-sc.0.test.1",
+  "rev": "3a8eecb023c832acc4390d3a51c0940eafb2b3bd",
+  "srcHash": "07amc69ghfz39jbps14ysfql4m42dmzbdjq9hqvzirhqz52mshf3",
+  "webYarnHash": "0knkl8sanqcx0lxjclz6s8vm5wpn8aywx9vydz7lda3l6c2g5zqf",
+  "desktopYarnHash": "0akmgib212gkygvs2snn9c43k3ika3ipg85d480j3hqyb6yxwqmn"
 }

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-desktop.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://github.com/SchildiChat/schildichat-desktop/";
-    rev = "v${version}";
+    inherit (pinData) rev;
     sha256 = pinData.srcHash;
     fetchSubmodules = true;
   };

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "https://github.com/SchildiChat/schildichat-desktop/";
-    rev = "v${version}";
+    inherit (pinData) rev;
     sha256 = pinData.srcHash;
     fetchSubmodules = true;
   };

--- a/pkgs/applications/networking/instant-messengers/schildichat/update.sh
+++ b/pkgs/applications/networking/instant-messengers/schildichat/update.sh
@@ -1,24 +1,27 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -I nixpkgs=../../../../../ -i bash -p nix wget prefetch-yarn-deps nix-prefetch-git jq
 
-if [[ "$#" -gt 1 || "$1" == -* ]]; then
+if [[ "$#" -gt 2 || "$1" == -* ]]; then
   echo "Regenerates packaging data for the SchildiChat packages."
-  echo "Usage: $0 [git release tag]"
+  echo "Usage: $0 [git revision or tag] [version string override]"
   exit 1
 fi
 
-version="$1"
+rev="$1"
+version="$2"
 
 set -euo pipefail
 
-if [ -z "$version" ]; then
-  version="$(wget -O- "https://api.github.com/repos/SchildiChat/schildichat-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
+if [ -z "$rev" ]; then
+  rev="$(wget -O- "https://api.github.com/repos/SchildiChat/schildichat-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
 fi
 
-# strip leading "v"
-version="${version#v}"
+if [ -z "$version" ]; then
+  # strip leading "v"
+  version="${rev#v}"
+fi
 
-src_data=$(nix-prefetch-git https://github.com/SchildiChat/schildichat-desktop --fetch-submodules --rev v${version})
+src_data=$(nix-prefetch-git https://github.com/SchildiChat/schildichat-desktop --fetch-submodules --rev $rev)
 src=$(echo $src_data | jq -r .path)
 src_hash=$(echo $src_data | jq -r .sha256)
 
@@ -28,6 +31,7 @@ desktop_yarn_hash=$(prefetch-yarn-deps $src/element-desktop/yarn.lock)
 cat > pin.json << EOF
 {
   "version": "$version",
+  "rev": "$rev",
   "srcHash": "$src_hash",
   "webYarnHash": "$web_yarn_hash",
   "desktopYarnHash": "$desktop_yarn_hash"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5011,7 +5011,7 @@ with pkgs;
 
   schildichat-desktop = callPackage ../applications/networking/instant-messengers/schildichat/schildichat-desktop.nix {
     inherit (darwin.apple_sdk.frameworks) Security AppKit CoreServices;
-    electron = electron_13;
+    electron = electron_15;
   };
   schildichat-desktop-wayland = writeScriptBin "schildichat-desktop" ''
     #!/bin/sh


### PR DESCRIPTION
The latest release is being held back because there is an issue with
Electron 15 crashing on some platforms.
NixOS seems to be not affected by this issue, and the upstream
developers say this test release should be fine otherwise.
This also means we can have a SchildiChat build that is not using the
EOL/insecure Electron 13.x.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
