### PR TITLE
pwgen_secure: fix missing words.txt

### DIFF
--- a/pkgs/tools/security/pwgen-secure/default.nix
+++ b/pkgs/tools/security/pwgen-secure/default.nix
@@ -1,7 +1,9 @@
 { lib, python3Packages, fetchFromGitHub }:
 
-with python3Packages;
+let
+  inherit (python3Packages) buildPythonApplication pythonOlder;
 
+in
 buildPythonApplication rec {
   pname = "pwgen-secure";
   version = "0.9.1";
@@ -18,10 +20,18 @@ buildPythonApplication rec {
     sha256 = "15md5606hzy1xfhj2lxmc0nvynyrcs4vxa5jdi34kfm31rdklj28";
   };
 
-  propagatedBuildInputs = [ docopt ];
+  postPatch = ''
+    shareDir=$out/share/${pname}
+
+    substituteInPlace pwgen_secure/rpg.py \
+      --replace "os.path.join(path, 'words.txt')" "os.path.join('$shareDir', 'words.txt')"
+  '';
+
+  propagatedBuildInputs = with python3Packages; [ docopt ];
 
   postInstall = ''
-    install -Dm755 spwgen.py $out/bin/spwgen
+    install -Dm555 spwgen.py $out/bin/spwgen
+    install -Dm444 pwgen_secure/words.txt -t $shareDir
   '';
 
   # there are no checks

--- a/pkgs/tools/security/pwgen-secure/default.nix
+++ b/pkgs/tools/security/pwgen-secure/default.nix
@@ -42,5 +42,6 @@ buildPythonApplication rec {
     homepage = "https://github.com/mjmunger/pwgen_secure/";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
+    mainProgram = "spwgen";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes #161552

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
