### PR TITLE
rubyripper: 0.6.2 -> 0.8.0rc3

### DIFF
--- a/pkgs/applications/audio/rubyripper/default.nix
+++ b/pkgs/applications/audio/rubyripper/default.nix
@@ -1,26 +1,38 @@
-{ lib, stdenv, fetchurl, ruby, cdparanoia, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper
+, cdparanoia, cddiscid, ruby }:
+
 stdenv.mkDerivation rec {
-  version = "0.6.2";
+  version = "0.8.0rc3";
   pname = "rubyripper";
-  src = fetchurl {
-    url = "https://rubyripper.googlecode.com/files/rubyripper-${version}.tar.bz2";
-    sha256 = "1fwyk3y0f45l2vi3a481qd7drsy82ccqdb8g2flakv58m45q0yl1";
+
+  src = fetchFromGitHub {
+    owner = "bleskodev";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qfwv8bgc9pyfh3d40bvyr9n7sjc2na61481693wwww640lm0f9f";
   };
 
   preConfigure = "patchShebangs .";
 
   configureFlags = [ "--enable-cli" ];
+
   nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ ruby cdparanoia ];
-  postInstall = ''
-    wrapProgram "$out/bin/rrip_cli" \
-      --prefix PATH : "${ruby}/bin" \
-      --prefix PATH : "${cdparanoia}/bin"
+
+  buildInputs = [
+    cddiscid
+    cdparanoia
+    ruby
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/rrip_cli \
+      --prefix PATH : ${lib.makeBinPath [ cddiscid cdparanoia ruby ]}
   '';
 
   meta = with lib; {
     description = "High quality CD audio ripper";
     platforms = platforms.linux;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/bleskodev/rubyripper";
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
The original rubyripper has been unmaintained for quite some time, and this
fork improves certain features (such as replacing the now-defunct Freedb with Gnudb).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
