### PR TITLE
Mycroft

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -409,6 +409,14 @@ with lib.maintainers; {
     enableFeatureFreezePing = true;
   };
 
+  mycroft = {
+    members = [
+      hexa
+      mic92
+    ];
+    scope = "Maintain the ecosystem around Mycroft, an open source voice assistant.";
+  };
+
   openstack = {
     members = [
       emilytrau

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -465,6 +465,7 @@
   ./services/hardware/xow.nix
   ./services/home-automation/home-assistant.nix
   ./services/home-automation/zigbee2mqtt.nix
+  ./services/home-automation/mycroft.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/filebeat.nix

--- a/nixos/modules/services/home-automation/mycroft.nix
+++ b/nixos/modules/services/home-automation/mycroft.nix
@@ -1,0 +1,137 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.mycroft;
+
+  format = pkgs.formats.json {};
+  configFile = format.generate "mycroft.conf" cfg.settings;
+in
+{
+  meta = {
+    buildDocsInSandbox = false;
+    maintainers = teams.mycroft.members;
+  };
+
+  options.services.mycroft = {
+    enable = mkEnableOption "Mycroft, the private and open voice assistant";
+
+    settings = mkOption {
+      default = {};
+      description = ''
+      Configuration options for the <literal>mycroft.conf</literal>.
+
+      Check the <link xlink:href="https://github.com/MycroftAI/mycroft-core/blob/release/${pkgs.mycroft.core.version}/mycroft/configuration/mycroft.conf">example configuration</link> for both possible and default values.
+      '';
+      type = types.submodule {
+        freeformType = format.type;
+        options = {
+          data_dir = mkOption {
+            type = types.str;
+            default = "/var/lib/mycroft";
+            description = ''
+              Path to Mycroft's state directory.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.mycroft = {
+      group = "mycroft";
+      home = cfg.settings.data_dir;
+      createHome = true;
+      isSystemUser = true;
+    };
+
+    users.groups.mycroft = {
+    };
+
+    environment.etc."mycroft/mycroft.conf".source = configFile;
+
+    systemd.targets.mycroft = {
+      description = "Mycroft Voice Assistant";
+      after = [
+        "network-online.target"
+      ];
+      wantedBy = [
+        "multi-user.target"
+      ];
+    };
+
+    systemd.services = let
+      commonUnitConfig = name: {
+        description = "Mycroft ${name}";
+        partOf = [
+          "mycroft.target"
+        ];
+        wantedBy = [
+          "mycroft.target"
+        ];
+        restartTriggers = [
+          configFile
+        ];
+      };
+
+      commonServiceConfig = {
+        User = "mycroft";
+        Group = "mycroft";
+        WorkingDirectory = "/var/lib/mycroft";
+      };
+    in
+    {
+      mycroft-messagebus = {
+        serviceConfig = {
+          ExecStart = "${pkgs.mycroft.core}/bin/mycroft-messagebus";
+        } // commonServiceConfig;
+      } // commonUnitConfig "Message Bus";
+
+      mycroft-skills = {
+        requires = [
+          "mycroft-messagebus.service"
+        ];
+        serviceConfig = {
+          ExecStart = "${pkgs.mycroft.core}/bin/mycroft-skills";
+        } // commonServiceConfig;
+      } // commonUnitConfig "Skills";
+
+      mycroft-audio = {
+        requires = [
+          "mycroft-messagebus.service"
+        ];
+        path = with pkgs; [
+          mpg123
+          pulseaudio
+          vorbis-tools
+        ];
+        serviceConfig = {
+          ExecStart = "${pkgs.mycroft.core}/bin/mycroft-audio";
+          SupplementaryGroups = [
+            "audio"
+            "pipewire"
+          ];
+        } // commonServiceConfig;
+      } // commonUnitConfig "Audio Playback";
+
+      mycroft-speech-client = {
+        requires = [
+          "mycroft-messagebus.service"
+        ];
+        serviceConfig = {
+          ExecStart = "${pkgs.mycroft.core}/bin/mycroft-speech-client";
+          SupplementaryGroups = [
+            "audio"
+            "pipewire"
+          ];
+        } // commonServiceConfig;
+      } // commonUnitConfig "Voice capture";
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -330,6 +330,7 @@ in
   munin = handleTest ./munin.nix {};
   mutableUsers = handleTest ./mutable-users.nix {};
   mxisd = handleTest ./mxisd.nix {};
+  mycroft = handleTest ./mycroft.nix {};
   mysql = handleTest ./mysql/mysql.nix {};
   mysql-autobackup = handleTest ./mysql/mysql-autobackup.nix {};
   mysql-backup = handleTest ./mysql/mysql-backup.nix {};

--- a/nixos/tests/mycroft.nix
+++ b/nixos/tests/mycroft.nix
@@ -1,0 +1,23 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+
+with lib;
+
+{
+  name = "mycroft";
+  meta.maintainers = teams.mycroft.members;
+
+  machine = { pkgs, ... }:
+  {
+    services.mycroft = {
+      enable = true;
+      settings = {};
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("mycroft.target")
+
+    machine.wait_for_open_port(18181)
+    machine.succeed("curl --fail http://localhost:18181/gui")
+  '';
+})

--- a/pkgs/development/python-modules/adapt-parser/default.nix
+++ b/pkgs/development/python-modules/adapt-parser/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, six
+, pytestCheckHook
+}:
+
+let
+  pname = "adapt-parser";
+  version = "1.0.0";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = "adapt";
+    rev = "release/v${version}";
+    hash = "sha256-1BDVhcjgf3OTrIwwKZnFxmtUUkwhfhYc+/pElQrVips=";
+  };
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "test/*"
+  ];
+
+  pythonImportsCheck = [
+    "adapt"
+  ];
+
+  meta = with lib; {
+    description = "Adapt Intent Parser";
+    homepage = "https://github.com/MycroftAI/adapt";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/fann2/default.nix
+++ b/pkgs/development/python-modules/fann2/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, swig
+, libfann
+}:
+
+let
+  pname = "fann2";
+  version = "1.1.2";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-zcoKZa1I4IMgZyr/44w91OoV4ngh5eHbn6KzQpm91B4=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "  find_fann()" "  # find_fann()" \
+      --replace "= find_swig()" "= '${swig}/bin/swig'"
+  '';
+
+  nativeBuildInputs = [
+    swig
+  ];
+
+  buildInputs = [
+    libfann.dev
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fann2"
+  ];
+
+  meta = with lib; {
+    description = "Fast Artificial Neural Network Library (FANN) Python bindings";
+    homepage = "https://github.com/FutureLinkCorporation/fann2";
+    license = licenses.lgpl2Plus;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/lingua-franca/default.nix
+++ b/pkgs/development/python-modules/lingua-franca/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python-dateutil
+, pytestCheckHook
+}:
+
+let
+  pname = "lingua-franca";
+  version = "0.4.2";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    pname = "lingua_franca";
+    inherit version;
+    sha256 = "sha256-c0qrlKkM8bqzgW92Jf6y7jcXmb3kmMs3vU2j5JkOXzI=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "python-dateutil==2.6.0" "python-dateutil>=2.6.0"
+  '';
+
+  propagatedBuildInputs = [
+    python-dateutil
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "lingua_franca"
+  ];
+
+  meta = with lib; {
+    description = "Mycroft's multilingual text parsing and formatting library";
+    homepage = "https://github.com/MycroftAI/lingua-franca";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/msk/default.nix
+++ b/pkgs/development/python-modules/msk/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# runtime
+, GitPython
+, PyGithub
+, colorama
+, msm
+, requests
+}:
+
+let
+  pname = "msm";
+  version = "0.3.16";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = "mycroft-skills-kit";
+    rev = "v${version}";
+    hash = "sha256-yeiDpqaTzFFWXHMyvE8zHWKYoqSEtuU85De9m94+obo=";
+  };
+
+  propagatedBuildInputs = [
+    GitPython
+    PyGithub
+    colorama
+    msm
+    requests
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "msk"
+  ];
+
+
+  meta = with lib; {
+    description = "Mycroft Skills Kit";
+    longDescription = ''
+      A tool to help with creating, uploading, and upgrading Mycroft
+      skills on the skills repo.
+    '';
+    homepage = "https://github.com/MycroftAI/mycroft-skills-kit";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/msm/default.nix
+++ b/pkgs/development/python-modules/msm/default.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# runtime
+, GitPython
+, fasteners
+, lazy
+, pako
+, pyxdg
+, pyyaml
+, requests
+
+# tests
+, pytestCheckHook
+}:
+
+let
+  pname = "msm";
+  version = "0.9.0";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = "mycroft-skills-manager";
+    rev = "release/v${version}";
+    hash = "sha256-FJ3HJ86yoQvo6lTaWhAbY27fUnKDuiIf82a+9SceXVg=";
+  };
+
+  propagatedBuildInputs = [
+    GitPython
+    fasteners
+    lazy
+    pako
+    pyxdg
+    pyyaml
+    requests
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # fatal: unable to access 'https://github.com/mycroftai/mycroft-skills-manager/': Could not resolve host: github.com
+    "--deselect tests/test_main.py::TestMain::test"
+    "--deselect tests/test_skill_repo.py::TestSkillRepo::test_read_file"
+    "--deselect tests/test_skill_repo.py::TestSkillRepo::test_get_skill_data"
+    "--deselect tests/test_skill_repo.py::TestSkillRepo::test_get_shas"
+    "--deselect tests/test_skill_repo.py::TestSkillRepo::test_get_default_skill_names"
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  pythonImportsCheck = [
+    "msm"
+  ];
+
+
+  meta = with lib; {
+    description = "Mycroft Skills Manager";
+    longDescription = ''
+      Mycroft Skills Manager is a command line tool and a python module
+      for interacting with the mycroft-skills repository.
+
+      It allows querying the repository for information (skill listings,
+      skill meta data, etc) and of course installing and removing skills
+      from the system.
+    '';
+    homepage = "https://github.com/MycroftAI/mycroft-skills-manager";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+
+  };
+}

--- a/pkgs/development/python-modules/mycroft-messagebus-client/default.nix
+++ b/pkgs/development/python-modules/mycroft-messagebus-client/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+# runtime
+, pyee
+, websocket-client
+
+# tests
+, pytestCheckHook
+}:
+
+let
+  pname = "mycroft-messagebus-client";
+  version = "0.9.6";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-u7jpSzuNvO5faAuUv4MOAM37oPVLmLu5ODoKLlZoZUY=";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "pyee==8.1.0" "pyee>=8.1.0"
+  '';
+
+  propagatedBuildInputs = [
+    pyee
+    websocket-client
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "mycroft_bus_client"
+  ];
+
+  meta = with lib; {
+    description = "Python module for connecting to the mycroft messagebus";
+    homepage = "https://github.com/MycroftAI/mycroft-messagebus-client";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/padaos/default.nix
+++ b/pkgs/development/python-modules/padaos/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+}:
+
+let
+  pname = "padaos";
+  version = "0.1.10";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = "padaos";
+    rev = "v${version}";
+    hash = "sha256-fzKewg0olo15b8ce/FMM/0acotSzIYePVq3Arh1lDxM=";
+  };
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "A rigid, lightweight, dead-simple intent parser";
+    homepage = "https://github.com/MycroftAI/padaos";
+    license = licenses.mit;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/padatious/default.nix
+++ b/pkgs/development/python-modules/padatious/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# runtime
+, fann2
+, padaos
+, xxhash
+
+# tests
+, pytestCheckHook
+}:
+
+let
+  pname = "padatious";
+  version = "0.4.8";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-1vn/UyDSqM//eeSJSMk0ADDGgvCN6ksqty+M5Z+dxwg=";
+  };
+
+  propagatedBuildInputs = [
+    fann2
+    padaos
+    xxhash
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # uses low timeouts
+    "test_train_timeout_subprocess"
+  ];
+
+  pythonImportsCheck = [
+    "padatious"
+  ];
+
+  meta = with lib; {
+    description = "A neural network intent parser";
+    longDescription = ''
+      An efficient and agile neural network intent parser. Padatious is
+      a core component of Mycroft AI.
+    '';
+    homepage = "https://github.com/MycroftAI/padatious";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/pako/default.nix
+++ b/pkgs/development/python-modules/pako/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, appdirs
+}:
+
+let
+  pname = "pako";
+  version = "0.3.1";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-wDOgc7uBjKM2rh/MuiZVvWDf53dE+F1FF6vTFg1yIx8=";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pako"
+  ];
+
+  meta = with lib; {
+    description = "The universal package manager library";
+    homepage = "https://github.com/MycroftAI/pako";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/petact/default.nix
+++ b/pkgs/development/python-modules/petact/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+let
+  pname = "petact";
+  version = "0.1.2";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-XcsNRPhqYB5Bot75dwmTzQ6kXHbTfrPzXj3WGqUDUOY=";
+  };
+
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "petact"
+  ];
+
+  meta = with lib; {
+    description = "A package extraction tool";
+    homepage = "https://github.com/matthewscholefield/petact";
+    license = licenses.mit;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/pixel-ring/default.nix
+++ b/pkgs/development/python-modules/pixel-ring/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# runtime
+, pyusb
+, spidev
+}:
+
+let
+  version = "0.1.0";
+in
+buildPythonPackage {
+  pname = "pixel-ring";
+  inherit version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "respeaker";
+    repo = "pixel_ring";
+    rev = version;
+    hash = "sha256-J9kScjD6Xon0YWGxFU881bIbjmDpY7cnWzJ8G0SOKaw=";
+  };
+
+  propagatedBuildInputs = [
+    pyusb
+    spidev
+  ];
+
+  # no tests
+  doCheck = false;
+
+  # tries to communicate with SPI device on import
+  pythonImportsCheck = [
+  ];
+
+  meta = with lib; {
+    description = "RGB LED library for Respeaker Mic Arrays";
+    longDescription = ''
+       RGB LED library for ReSpeaker 4 Mic Array, ReSpeaker V2 & ReSpeaker USB 6+1 Mic Array.
+    '';
+    homepage = "https://github.com/respeaker/pixel_ring";
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/pocketsphinx/default.nix
+++ b/pkgs/development/python-modules/pocketsphinx/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# compile time
+, swig
+
+# runtime
+, alsa-lib
+, pulseaudio
+
+# tests
+, python
+}:
+
+let
+  pname = "pocketsphinx";
+  version = "0.1.15";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "AzatAI";
+    repo = "pocketsphinx-python";
+    rev = "v${version}";
+    #hash = "sha256:KJj4unrcqhvKREKFnMgbgrldy1FuKIWettr/serzGzc=";
+    hash = "sha256-6Lf5Y2mF7Hvjn7Z98axgXDDx08zmS+Ze7I2iERKXIaI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    swig
+  ];
+
+  buildInputs = [
+    alsa-lib.dev
+    pulseaudio.dev
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [
+    "pocketsphinx"
+  ];
+
+  meta = with lib; {
+    description = "Python interface to CMU Sphinxbase and Pocketsphinx libraries";
+    homepage = "https://github.com/AzatAI/pocketsphinx-python";
+    license = licenses.bsd2;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/precise-runner/default.nix
+++ b/pkgs/development/python-modules/precise-runner/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyaudio
+, pytestCheckHook
+}:
+
+let
+  pname = "precise-runner";
+  version = "0.3.1";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-GkZCCftL8KP11aQoMQyypwSHoBprw6lg0d2pCviWuA0=";
+  };
+
+  propagatedBuildInputs = [
+    pyaudio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "precise_runner"
+  ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/speechrecognition/default.nix
+++ b/pkgs/development/python-modules/speechrecognition/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, substituteAll
+
+# runtime
+, flac
+, pocketsphinx
+, pyaudio
+
+# tests
+, pytestCheckHook
+}:
+
+let
+  pname = "speechrecognition";
+  version = "3.8.1";
+in
+buildPythonPackage {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "Uberi";
+    repo = "speech_recognition";
+    rev = version;
+    hash = "sha256:5OsffPcP95+WBI2qWO41fZDj+5mRmzUgIyv4QSd5BtM=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./flac-path.patch;
+      flac = "${flac}/bin/flac";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    pocketsphinx
+    pyaudio
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Requires network access
+    "test_google_chinese"
+    "test_google_english"
+    "test_google_french "
+    "test_sphinx_english"
+    # AssertionError: 'three  two  two  one  one ' != 'three  two  two  one '
+    "test_sphinx_keywords"
+  ];
+
+  pythonImportsCheck = [
+    "speech_recognition"
+  ];
+
+  meta = with lib; {
+    description = "Speech recognition module for Python, supporting several engines and APIs, online and offline";
+    homepage = "https://github.com/Uberi/speech_recognition";
+    license = licenses.bsd3;
+    maintainers = teams.mycroft.members;
+  };
+}

--- a/pkgs/development/python-modules/speechrecognition/flac-path.patch
+++ b/pkgs/development/python-modules/speechrecognition/flac-path.patch
@@ -1,0 +1,41 @@
+diff --git a/speech_recognition/__init__.py b/speech_recognition/__init__.py
+index 37b1729..1ca41b3 100644
+--- a/speech_recognition/__init__.py
++++ b/speech_recognition/__init__.py
+@@ -1411,35 +1411,7 @@ class Recognizer(AudioSource):
+ 
+ def get_flac_converter():
+     """Returns the absolute path of a FLAC converter executable, or raises an OSError if none can be found."""
+-    flac_converter = shutil_which("flac")  # check for installed version first
+-    if flac_converter is None:  # flac utility is not installed
+-        base_path = os.path.dirname(os.path.abspath(__file__))  # directory of the current module file, where all the FLAC bundled binaries are stored
+-        system, machine = platform.system(), platform.machine()
+-        if system == "Windows" and machine in {"i686", "i786", "x86", "x86_64", "AMD64"}:
+-            flac_converter = os.path.join(base_path, "flac-win32.exe")
+-        elif system == "Darwin" and machine in {"i686", "i786", "x86", "x86_64", "AMD64"}:
+-            flac_converter = os.path.join(base_path, "flac-mac")
+-        elif system == "Linux" and machine in {"i686", "i786", "x86"}:
+-            flac_converter = os.path.join(base_path, "flac-linux-x86")
+-        elif system == "Linux" and machine in {"x86_64", "AMD64"}:
+-            flac_converter = os.path.join(base_path, "flac-linux-x86_64")
+-        else:  # no FLAC converter available
+-            raise OSError("FLAC conversion utility not available - consider installing the FLAC command line application by running `apt-get install flac` or your operating system's equivalent")
+-
+-    # mark FLAC converter as executable if possible
+-    try:
+-        # handle known issue when running on docker:
+-        # run executable right after chmod() may result in OSError "Text file busy"
+-        # fix: flush FS with sync
+-        if not os.access(flac_converter, os.X_OK):
+-            stat_info = os.stat(flac_converter)
+-            os.chmod(flac_converter, stat_info.st_mode | stat.S_IEXEC)
+-            if 'Linux' in platform.system():
+-                os.sync() if sys.version_info >= (3, 3) else os.system('sync')
+-
+-    except OSError: pass
+-
+-    return flac_converter
++    return "@flac@"
+ 
+ 
+ def shutil_which(pgm):

--- a/pkgs/servers/mycroft/core.nix
+++ b/pkgs/servers/mycroft/core.nix
@@ -1,0 +1,152 @@
+{ lib
+, fetchFromGitHub
+
+# runtime
+, python3
+
+}:
+
+let
+  pname = "mycroft-core";
+  version = "21.2.2";
+
+  python = python3.override {
+    packageOverrides = self: super: {
+      msm = super.msm.overridePythonAttrs (oldAttrs: rec {
+        version = "0.8.9";
+        src = fetchFromGitHub {
+          owner = "MycroftAI";
+          repo = "mycroft-skills-manager";
+          rev = "release/v${version}";
+          hash = "sha256-u6ueeRuJOu5fETlJDLCBACnYlbSsd9L1U32PK2YLw80=";
+        };
+      });
+
+      websocket-client = super.websocket-client.overridePythonAttrs (oldAttrs: rec {
+        version = "1.2.3";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "sha256-ExWBbArMUImX6zrgO50/9hnJ0S1UTJqbVTcEscxPavU=";
+        };
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication {
+  inherit pname version;
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "MycroftAI";
+    repo = pname;
+    rev = "release/v${version}";
+    hash = "sha256-SCz4rQYTHB1wKeQnJwjmc/jJr/aOWB73tjBqCHjfIAs=";
+  };
+
+  postPatch = let
+    relaxedConstraints = [
+      "adapt-parser"
+      "fann2"
+      "fasteners"
+      "inflection"
+      "mycroft-messagebus-client"
+      "padaos"
+      "padatious"
+      "pillow"
+      "pocketsphinx"
+      "precise-runner"
+      "psutil"
+      "pyee"
+      "pyserial"
+      "python-dateutil"
+      "pyxdg"
+      "PyYAML"
+      "requests"
+      "requests-futures"
+      "websocket-client"
+    ];
+  in ''
+    sed -r -i \
+      ${lib.concatStringsSep "\n" (map (package:
+        ''-e 's@${package}[<>~=]+.*@${package}@g' \''
+      ) relaxedConstraints)}
+    requirements/requirements.txt
+  '';
+
+  propagatedBuildInputs = with python.pkgs; [
+    adapt-parser
+    fann2
+    fasteners
+    gtts
+    inflection
+    lingua-franca
+    msk
+    msm
+    mycroft-messagebus-client
+    padaos
+    padatious
+    petact
+    pillow
+    pocketsphinx
+    precise-runner
+    psutil
+    pyaudio
+    PyChromecast
+    pyee
+    pyserial
+    python-dateutil
+    python-vlc
+    pyxdg
+    pyyaml
+    requests
+    requests-futures
+    speechrecognition
+    tornado
+    websocket-client
+  ];
+
+  preCheck = ''
+    # creates paths according to xdg spec
+    export HOME=$TMPDIR
+  '';
+
+  checkInputs = with python.pkgs; [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # AssertionError: 'ZZZZZZZZZ' != 'HH EY . M AY K R AO F T'
+    # https://github.com/MycroftAI/mycroft-core/issues/2574
+    "--deselect test/unittests/client/test_hotword_factory.py::PocketSphinxTest::testInvalid"
+
+    # AssertionError: 'hey victoria' != 'hey mycroft'
+    # https://github.com/MycroftAI/mycroft-core/issues/2574
+    "--deselect test/unittests/client/test_local_recognizer.py::LocalRecognizerInitTest::testListenerConfig"
+
+    # Requires network access
+    "--deselect test/unittests/util/test_network_utils.py::TestNetworkConnected::test_default_config_succeeds"
+    "--deselect test/unittests/util/test_network_utils.py::TestNetworkFailure::test_secondary_dns_succeeds"
+
+    # Expects zoneinfo in /usr/share/zoneinfo
+    "--deselect test/unittests/util/test_time.py::TestTimeFuncs::test_default_timezone"
+    "--deselect test/unittests/util/test_time.py::TestTimeFuncs::test_now_local"
+  ];
+
+  disabledTests = [
+    # mycroft.api.InternetDown
+    "test_is_paired_error_remote"
+  ];
+
+  disabledTestPaths = [
+    # breaks the tests by deleting /build/source
+    "test/unittests/util/test_file_utils.py"
+  ];
+
+  meta = with lib; {
+    description = "Mycroft Core, the Mycroft Artificial Intelligence platform";
+    homepage = "https://github.com/MycroftAI/mycroft-core";
+    license = licenses.asl20;
+    maintainers = teams.mycroft.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/mycroft/default.nix
+++ b/pkgs/servers/mycroft/default.nix
@@ -1,0 +1,4 @@
+{ callPackage, ... }:
+{
+  core = callPackage ./core.nix { };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21781,6 +21781,8 @@ with pkgs;
     buildGoModule = buildGo116Module;
   };
 
+  mycroft = recurseIntoAttrs (callPackage ../servers/mycroft { });
+
   napalm = with python3Packages; toPythonApplication (
     napalm.overridePythonAttrs (attrs: {
       # add community frontends that depend on the napalm python package

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5967,6 +5967,8 @@ in {
 
   paho-mqtt = callPackage ../development/python-modules/paho-mqtt { };
 
+  pako = callPackage ../development/python-modules/pako { };
+
   palace = callPackage ../development/python-modules/palace { };
 
   palettable = callPackage ../development/python-modules/palettable { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5352,6 +5352,8 @@ in {
 
   msldap = callPackage ../development/python-modules/msldap { };
 
+  msm = callPackage ../development/python-modules/msm { };
+
   msoffcrypto-tool = callPackage ../development/python-modules/msoffcrypto-tool { };
 
   mss = callPackage ../development/python-modules/mss { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5350,6 +5350,8 @@ in {
 
   msgpack-numpy = callPackage ../development/python-modules/msgpack-numpy { };
 
+  msk = callPackage ../development/python-modules/msk { };
+
   msldap = callPackage ../development/python-modules/msldap { };
 
   msm = callPackage ../development/python-modules/msm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9551,6 +9551,10 @@ in {
 
   spectral-cube = callPackage ../development/python-modules/spectral-cube { };
 
+  speechrecognition = callPackage ../development/python-modules/speechrecognition {
+    inherit (pkgs) flac;
+  };
+
   speedtest-cli = callPackage ../development/python-modules/speedtest-cli { };
 
   spglib = callPackage ../development/python-modules/spglib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2803,6 +2803,10 @@ in {
 
   falcon = callPackage ../development/python-modules/falcon { };
 
+  fann2 = callPackage ../development/python-modules/fann2 {
+    inherit (pkgs) libfann;
+  };
+
   faraday-agent-parameters-types = callPackage ../development/python-modules/faraday-agent-parameters-types { };
 
   faraday-plugins = callPackage ../development/python-modules/faraday-plugins { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5969,6 +5969,8 @@ in {
 
   padaos = callPackage ../development/python-modules/padaos { };
 
+  padatious = callPackage ../development/python-modules/padatious { };
+
   pafy = callPackage ../development/python-modules/pafy { };
 
   pagelabels = callPackage ../development/python-modules/pagelabels { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5416,6 +5416,8 @@ in {
 
   mxnet = callPackage ../development/python-modules/mxnet { };
 
+  mycroft-messagebus-client = callPackage ../development/python-modules/mycroft-messagebus-client { };
+
   myfitnesspal = callPackage ../development/python-modules/myfitnesspal { };
 
   mygpoclient = callPackage ../development/python-modules/mygpoclient { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6446,6 +6446,10 @@ in {
 
   pocket = callPackage ../development/python-modules/pocket { };
 
+  pocketsphinx = callPackage ../development/python-modules/pocketsphinx {
+    inherit (pkgs) alsa-lib pulseaudio;
+  };
+
   podcastparser = callPackage ../development/python-modules/podcastparser { };
 
   podcats = callPackage ../development/python-modules/podcats { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -175,6 +175,8 @@ in {
 
   adal = callPackage ../development/python-modules/adal { };
 
+  adapt-parser = callPackage ../development/python-modules/adapt-parser { };
+
   adax = callPackage ../development/python-modules/adax { };
 
   adax-local = callPackage ../development/python-modules/adax-local { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6567,6 +6567,8 @@ in {
 
   precis-i18n = callPackage ../development/python-modules/precis-i18n { };
 
+  precise-runner = callPackage ../development/python-modules/precise-runner { };
+
   prefixed = callPackage ../development/python-modules/prefixed { };
 
   pre-commit-hooks = callPackage ../development/python-modules/pre-commit-hooks { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6167,6 +6167,8 @@ in {
 
   pescea = callPackage ../development/python-modules/pescea { };
 
+  petact = callPackage ../development/python-modules/petact { };
+
   pex = callPackage ../development/python-modules/pex { };
 
   pexif = callPackage ../development/python-modules/pexif { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5967,6 +5967,8 @@ in {
 
   packet-python = callPackage ../development/python-modules/packet-python { };
 
+  padaos = callPackage ../development/python-modules/padaos { };
+
   pafy = callPackage ../development/python-modules/pafy { };
 
   pagelabels = callPackage ../development/python-modules/pagelabels { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6278,6 +6278,8 @@ in {
     inherit (pkgs.libsForQt5) soqt;
   };
 
+  pixel-ring = callPackage ../development/python-modules/pixel-ring { };
+
   pixelmatch = callPackage ../development/python-modules/pixelmatch { };
 
   pkce = callPackage ../development/python-modules/pkce { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4820,6 +4820,8 @@ in {
 
   line_profiler = callPackage ../development/python-modules/line_profiler { };
 
+  lingua-franca = callPackage ../development/python-modules/lingua-franca { };
+
   linkify-it-py = callPackage ../development/python-modules/linkify-it-py { };
 
   linode-api = callPackage ../development/python-modules/linode-api { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
After the Rhasspy repositories were archived when the main dev was hired by Mycroft it is probably time to move on.

My initial target was `mycroft-core` and these are all its dependencies. I had to generously unpin version constraints, because some of their project are a bit undermaintained.

If anyone wants to co-maintain Mycroft please speak up.

###### TODO
- Module
- Tests
- a Hotword Engine, probably https://github.com/forslund/mycroft-porcupine-plugin/commits/master
- a few popular skills to test out the skills integration
  - Respeaker Mic Array
  - Home Assistant

###### Out of scope
Mostly things that are too difficult to package right now
- Precise (requires `tensorflow==1.13.1`, binary distribution would require heaps of patching)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
