### PR TITLE
mpv-scripts: init autocrop, autodeint

### DIFF
--- a/pkgs/applications/video/mpv/scripts/autocrop.nix
+++ b/pkgs/applications/video/mpv/scripts/autocrop.nix
@@ -1,0 +1,19 @@
+{ stdenvNoCC, mpv-unwrapped, lib }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mpv-autocrop";
+  version = mpv-unwrapped.version;
+  src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/autocrop.lua";
+  dontBuild = true;
+  dontUnpack = true;
+  installPhase = ''
+    install -Dm644 ${src} $out/share/mpv/scripts/autocrop.lua
+  '';
+  passthru.scriptName = "autocrop.lua";
+
+  meta = {
+    description = "This script uses the lavfi cropdetect filter to automatically insert a crop filter with appropriate parameters for the currently playing video.";
+    homepage = "https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autocrop.lua";
+    license = lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/applications/video/mpv/scripts/autodeint.nix
+++ b/pkgs/applications/video/mpv/scripts/autodeint.nix
@@ -1,0 +1,19 @@
+{ stdenvNoCC, mpv-unwrapped, lib }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mpv-autodeint";
+  version = mpv-unwrapped.version;
+  src = "${mpv-unwrapped.src.outPath}/TOOLS/lua/autodeint.lua";
+  dontBuild = true;
+  dontUnpack = true;
+  installPhase = ''
+    install -Dm644 ${src} $out/share/mpv/scripts/autodeint.lua
+  '';
+  passthru.scriptName = "autodeint.lua";
+
+  meta = {
+    description = "This script uses the lavfi idet filter to automatically insert the appropriate deinterlacing filter based on a short section of the currently playing video.";
+    homepage = "https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autodeint.lua";
+    license = lib.licenses.gpl2Plus;
+  };
+}


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
I use these plugins from the mpv upstream, and this should make them accessible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
