### PR TITLE
update for raspberry pi (kernel 5.10.52 -> 5.10.92 and firmwares 20210805 -> 20220120)

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2021-06-28";
+  version = "2022-01-20";
 
   srcs = [
     (fetchFromGitHub {
@@ -16,8 +16,8 @@ stdenv.mkDerivation {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "00de3194a96397c913786945ac0af1fd6fbec45b";
-      sha256 = "1xnr364dkiq6gmr21lcrj23hwc0g9y5qad8dm2maij647bgzp07r";
+      rev = "99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc";
+      sha256 = "0pfgadblxs8cji8d227v6wsml8x6vzsz7j12jfidvvp01dhry3n6";
     })
   ];
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "0a54gyrq6jfxxvimaa4yjfiyfwf7wv58v0a32l74yrzyarr3ldby";
+  outputHash = "0gipxq1j0rp9x8psl5zfh14yg09q39dd6ixkysh3bczkb05h83qp";
 
   meta = with lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3+ and Zero W";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/armstubs.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation {
   pname = "raspberrypi-armstubs";
-  version = "2021-07-05";
+  version = "2021-11-01";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "tools";
-    rev = "2e59fc67d465510179155973d2b959e50a440e47";
-    sha256 = "1ysdl4qldy6ldf8cm1igxjisi14xl3s2pi6cnqzpxb38sgihb1vy";
+    rev = "13474ee775d0c5ec8a7da4fb0a9fa84187abfc87";
+    sha256 = "13nsw8z5fbwy29sfbc4kxgdcivm4c3zh08gp87l3jjshi8q4zx5k";
   };
 
   NIX_CFLAGS_COMPILE = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,13 +3,13 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20210805";
+  version = "1.20220120";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
     rev = version;
-    sha256 = "1nndhjv4il42yw3pq8ni3r4nlp1m0r229fadrf4f9v51mgcg11i1";
+    sha256 = "0s75fw4n83bkh78xh5rdgpiyp1bkvv1v18pawl4cs9v4gjkn6pi2";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -2,8 +2,8 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "5.10.52";
-  tag = "1.20210805";
+  modDirVersion = "5.10.92";
+  tag = "1.20220120";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -13,7 +13,7 @@ lib.overrideDerivation (buildLinux (args // {
     owner = "raspberrypi";
     repo = "linux";
     rev = tag;
-    sha256 = "1j71xblflslfi4c3zx2srw6fahnhp3bjx4yjfqrp39kzaa41ij0b";
+    sha256 = "1hawkjn9nyxpbkisfnifrp7m3a1abbyqmpab5mkw56zavksz281r";
   };
 
   defconfig = {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,13 +3,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2021.04.29-138a1";
+  version = "2022.01.25-138a1";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
     rev = "v${version}";
-    sha256 = "sha256-nzAMPa4gqCAcROFa7z34IoMA3aoMHX9fYCsPFde9dac=";
+    sha256 = "0sc6k9avvkbbazcq4r1kygfpsvv6jmhk38yxljl9i8v6kkp33yl4";
   };
 
   buildInputs = [ python3 ];
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/share/rpi-eeprom
 
-    cp rpi-eeprom-config rpi-eeprom-update $out/bin
+    cp rpi-eeprom-digest rpi-eeprom-config rpi-eeprom-update $out/bin
     cp -r firmware/{beta,critical,old,stable} $out/share/rpi-eeprom
     cp -P firmware/default firmware/latest $out/share/rpi-eeprom
   '';


### PR DESCRIPTION
 update for raspberry pi:
* vendor kernel (5.10.52 -> 5.10.92)
* firmware (20210805 -> 20220120)
* wireless-firmware (20210805 -> 20220120)
* eeprom (20210805 -> 20220120 + add rpi-eeprom-digest)
* armstubs (2021-07-05 -> 2021-11-01

###### Motivation for this change
Latest kernel is fixing issues related to the Media Controller API (see here: https://forums.raspberrypi.com/viewtopic.php?t=322076) that are useful when using cameras. Rest of the updates are to be in sync with latest updates from the Pi Foundation.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
