### PR TITLE
libpwquality: 1.4.2 -> 1.4.4

### DIFF
--- a/pkgs/development/libraries/libpwquality/default.nix
+++ b/pkgs/development/libraries/libpwquality/default.nix
@@ -1,36 +1,57 @@
-{ stdenv, lib, fetchFromGitHub, autoreconfHook, perl, cracklib, python3, fetchpatch }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, perl
+, cracklib
+, enablePAM ? stdenv.hostPlatform.isLinux
+, pam
+, enablePython ? false
+, python
+}:
+
+# python binding generates a shared library which are unavailable with musl build
+assert enablePython -> !stdenv.hostPlatform.isStatic;
 
 stdenv.mkDerivation rec {
   pname = "libpwquality";
-  version = "1.4.2";
+  version = "1.4.4";
+
+  outputs = [ "out" "dev" "lib" "man" ] ++ lib.optionals enablePython [ "py" ];
 
   src = fetchFromGitHub {
     owner = "libpwquality";
     repo = "libpwquality";
     rev = "${pname}-${version}";
-    sha256 = "0n4pjhm7wfivk0wizggaxq4y4mcxic876wcarjabkp5z9k14y36h";
+    sha256 = "sha256-7gAzrx5VP1fEBwAt6E5zGM8GyuPRR+JxYifYfirY+U8=";
   };
 
-  nativeBuildInputs = [ autoreconfHook perl python3 ];
-  buildInputs = [ cracklib ];
-
-  patches = lib.optional stdenv.hostPlatform.isStatic [
-    (fetchpatch {
-      name = "static-build.patch";
-      url = "https://github.com/libpwquality/libpwquality/pull/40.patch";
-      sha256 = "1ypccq437wxwgddd98cvd330jfm7jscdlzlyxgy05g6yzrr68xyk";
-    })
+  patches = [
+    # ensure python site-packages goes in $py output
+    ./python-binding-prefix.patch
   ];
 
-  configureFlags = lib.optional stdenv.hostPlatform.isStatic [
-    # Python binding generates a shared library which are unavailable with musl build
-    "--disable-python-bindings"
-  ];
+  nativeBuildInputs = [ autoreconfHook perl ] ++ lib.optionals enablePython [ python ];
+  buildInputs = [ cracklib ] ++ lib.optionals enablePAM [ pam ];
+
+  configureFlags = lib.optionals (!enablePython) [ "--disable-python-bindings" ];
 
   meta = with lib; {
-    description = "Password quality checking and random password generation library";
     homepage = "https://github.com/libpwquality/libpwquality";
-    license = licenses.bsd3;
+    description = "Password quality checking and random password generation library";
+    longDescription = ''
+      The libpwquality library purpose is to provide common functions for
+      password quality checking and also scoring them based on their apparent
+      randomness. The library also provides a function for generating random
+      passwords with good pronounceability. The library supports reading and
+      parsing of a configuration file.
+
+      In the package there are also very simple utilities that use the library
+      function and PAM module that can be used instead of pam_cracklib. The
+      module supports all the options of pam_cracklib.
+    '';
+    license = with licenses; [ bsd3 /* or */ gpl2Plus ];
+    maintainers = with maintainers; [ jk ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/libpwquality/python-binding-prefix.patch
+++ b/pkgs/development/libraries/libpwquality/python-binding-prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/python/Makefile.am b/python/Makefile.am
+index 1d00c0c..0987690 100644
+--- a/python/Makefile.am
++++ b/python/Makefile.am
+@@ -14,7 +14,7 @@ all-local:
+ 	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV)
+ 
+ install-exec-local:
+-	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --prefix=${DESTDIR}${prefix}
++	CFLAGS="${CFLAGS} -fno-strict-aliasing" @PYTHONBINARY@ setup.py build --build-base py$(PYTHONREV) install --prefix=${DESTDIR}${py}
+ 
+ clean-local:
+ 	rm -rf py$(PYTHONREV)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18714,7 +18714,9 @@ with pkgs;
 
   libpulsar = callPackage ../development/libraries/libpulsar { };
 
-  libpwquality = callPackage ../development/libraries/libpwquality { };
+  libpwquality = callPackage ../development/libraries/libpwquality {
+    python = python3;
+  };
 
   libqalculate = callPackage ../development/libraries/libqalculate {
     readline = readline81;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4665,6 +4665,13 @@ in {
 
   libpyvivotek = callPackage ../development/python-modules/libpyvivotek { };
 
+  libpwquality = pipe pkgs.libpwquality [
+    toPythonModule
+    (p: p.overrideAttrs (super: { meta = super.meta // { outputsToInstall = [ "py" ]; }; }))
+    (p: p.override { enablePython = true; inherit python; })
+    (p: p.py)
+  ];
+
   libredwg = toPythonModule (pkgs.libredwg.override {
     enablePython = true;
     inherit (self) python libxml2;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Updated `libpwquality`

- corrected the license: https://github.com/libpwquality/libpwquality/blob/libpwquality-1.4.4/COPYING
- added long description
- added myself as a maintainer
- removed unnecessary patch (it's part of the releases now) **Edit:** :facepalm: the nixpkgs release is on 1.4.2 not 1.4.4 ...
  - **Edit:** updated
- split outputs
- added pam for building the pam module

This change is done in preparation of adding libpwquality to pam:

![image](https://user-images.githubusercontent.com/9866621/155527880-baf6a1e8-30d9-4e61-9e6b-75effbdd5c32.png)


I just want to check:

- there aren't too many rebuilds and master is fine
- ~that adding pam as a build input doesn't have to be linux only?~
  - broke the mac build but after making pam linux only it builds fine
- that splitting outputs doesn't break any other builds
- that $lib/lib/python3.9/site-packages is the right place for the python stuff
  - without the patch it goes in $out/lib instead separate from all the other lib stuff
  - there also might be a better way to do this than the patch method I've gone with

cc: @baloo since you've modified libpwquality not too long ago
also @jonringer and @jtojnar since you both know how to use outputs properly :slightly_smiling_face:  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
