### PR TITLE
micromamba: 0.18.1 -> 0.21.2

### DIFF
--- a/pkgs/tools/package-management/micromamba/default.nix
+++ b/pkgs/tools/package-management/micromamba/default.nix
@@ -21,16 +21,25 @@ let
       })
     ];
   });
+
+  spdlog' = spdlog.overrideAttrs (oldAttrs: {
+    # Required for header files. See alse:
+    # https://github.com/gabime/spdlog/pull/1241 (current solution)
+    # https://github.com/gabime/spdlog/issues/1897 (previous solution)
+    cmakeFlags = oldAttrs.cmakeFlags ++ [
+      "-DSPDLOG_FMT_EXTERNAL=OFF"
+    ];
+  });
 in
 stdenv.mkDerivation rec {
   pname = "micromamba";
-  version = "0.18.1";
+  version = "0.21.2";
 
   src = fetchFromGitHub {
     owner = "mamba-org";
     repo = "mamba";
-    rev = version;
-    sha256 = "1gr9r257l300hafp8zm61bn58rysdk9i4wv1879q96b6n6v8hwa6";
+    rev = "mamba-" + version;
+    sha256 = "0zsl0rhsx87vvwcwc1xn7gqgbxffprr8dyc9rkr6kcr4rjgy9yzp";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -43,16 +52,10 @@ stdenv.mkDerivation rec {
     libyamlcpp
     libsolv'
     reproc
-    spdlog
+    spdlog'
     termcolor
     ghc_filesystem
   ];
-
-  postPatch = ''
-    # See https://github.com/gabime/spdlog/issues/1897
-    sed -i '1a add_compile_definitions(SPDLOG_FMT_EXTERNAL)' CMakeLists.txt
-    echo 'target_link_libraries(micromamba PRIVATE -lspdlog -lfmt)' >> micromamba/CMakeLists.txt
-  '';
 
   cmakeFlags = [
     "-DBUILD_LIBMAMBA=ON"


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Updated version
- Override spdlog CMake flag SPDLOG_FMT_EXTERNAL to ensure all header
files are present to build libmamba. Without this fix, this
"spdlog/fmt/bundled/color.h" header file would not be found. See also:
https://github.com/gabime/spdlog/pull/1241


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
