### PR TITLE
soundfile: Fix build on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , fetchpatch
-, pytest
+, pytestCheckHook
 , numpy
 , libsndfile
 , cffi
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
   '';
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
   propagatedBuildInputs = [ numpy libsndfile cffi ];
   propagatedNativeBuildInputs = [ cffi ];
 

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -13,6 +13,8 @@
 buildPythonPackage rec {
   pname = "soundfile";
   version = "0.10.3.post1";
+  # https://github.com/bastibe/python-soundfile/issues/157
+  disabled = isPyPy || stdenv.isi686;
 
   src = fetchPypi {
     pname = "SoundFile";
@@ -28,6 +30,10 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
+
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ numpy libsndfile cffi ];
   propagatedNativeBuildInputs = [ cffi ];
@@ -39,15 +45,7 @@ buildPythonPackage rec {
   meta = {
     description = "An audio library based on libsndfile, CFFI and NumPy";
     license = lib.licenses.bsd3;
-    homepage = "https://github.com/bastibe/PySoundFile";
+    homepage = "https://github.com/bastibe/python-soundfile";
     maintainers = with lib.maintainers; [ fridh ];
   };
-
-  postPatch = ''
-    substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
-  '';
-
-  # https://github.com/bastibe/PySoundFile/issues/157
-  disabled = isPyPy ||  stdenv.isi686;
-
 }

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , pytest
 , numpy
 , libsndfile
@@ -19,9 +20,21 @@ buildPythonPackage rec {
     sha256 = "0yqhrfz7xkvqrwdxdx2ydy4h467sk7z3gf984y1x2cq7cm1gy329";
   };
 
+  patches = [
+    # Fix build on macOS arm64, https://github.com/bastibe/python-soundfile/pull/332
+    (fetchpatch {
+      url = "https://github.com/bastibe/python-soundfile/commit/e554e9ce8bed96207d587e6aa661e4b08f1c6a79.patch";
+      sha256 = "sha256-vu/7s5q4I3yBnoNHmmFmcXvOLFcPwY9ri9ri6cKLDwU=";
+    })
+  ];
+
   checkInputs = [ pytest ];
   propagatedBuildInputs = [ numpy libsndfile cffi ];
   propagatedNativeBuildInputs = [ cffi ];
+
+  # Test fails on aarch64-darwin with `MemoryError`, 53 failed, 31 errors, see
+  # https://github.com/bastibe/python-soundfile/issues/331
+  doCheck = stdenv.system != "aarch64-darwin";
 
   meta = {
     description = "An audio library based on libsndfile, CFFI and NumPy";

--- a/pkgs/development/python-modules/soundfile/default.nix
+++ b/pkgs/development/python-modules/soundfile/default.nix
@@ -19,22 +19,22 @@ buildPythonPackage rec {
     sha256 = "0yqhrfz7xkvqrwdxdx2ydy4h467sk7z3gf984y1x2cq7cm1gy329";
   };
 
-    checkInputs = [ pytest ];
-    propagatedBuildInputs = [ numpy libsndfile cffi ];
-    propagatedNativeBuildInputs = [ cffi ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy libsndfile cffi ];
+  propagatedNativeBuildInputs = [ cffi ];
 
-    meta = {
-      description = "An audio library based on libsndfile, CFFI and NumPy";
-      license = lib.licenses.bsd3;
-      homepage = "https://github.com/bastibe/PySoundFile";
-      maintainers = with lib.maintainers; [ fridh ];
-    };
+  meta = {
+    description = "An audio library based on libsndfile, CFFI and NumPy";
+    license = lib.licenses.bsd3;
+    homepage = "https://github.com/bastibe/PySoundFile";
+    maintainers = with lib.maintainers; [ fridh ];
+  };
 
-    postPatch = ''
-      substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
-    '';
+  postPatch = ''
+    substituteInPlace soundfile.py --replace "_find_library('sndfile')" "'${libsndfile.out}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}'"
+  '';
 
-    # https://github.com/bastibe/PySoundFile/issues/157
-    disabled = isPyPy ||  stdenv.isi686;
+  # https://github.com/bastibe/PySoundFile/issues/157
+  disabled = isPyPy ||  stdenv.isi686;
 
 }


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
