### PR TITLE
usbguard: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/os-specific/linux/usbguard/default.nix
+++ b/pkgs/os-specific/linux/usbguard/default.nix
@@ -24,14 +24,14 @@
 assert libgcrypt != null -> libsodium == null;
 
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "1.1.0";
   pname = "usbguard";
 
   src = fetchFromGitHub {
     owner = "USBGuard";
     repo = pname;
     rev = "usbguard-${version}";
-    sha256 = "sha256-CPuBQmDOpXWn0jPo4HRyDCZUpDy5NmbvUHxXoVbMd/I=";
+    sha256 = "sha256-lnHeU/X/2N81WPLakRYLs8TjpBhxBPhiXDJ+wNW0sU0=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

> ## 1.1.0 - 2022-02-24
> 
> ### Added
> - Started building with C++17
> - Tree-like list-devices output
> - Added CAP_AUDIT_WRITE capability to service file
> - Added support for lower OpenSSL versions prior to 1.1.0
> - Added a new signal: DevicePolicyApplied
> 
> ### Fixed/Changed
> - Moved PIDFile from /var/run to /run
> - Fixed linker isssues with disable-static
> - Enhanced bash-completion script
> - Make username/group checking consistent with useradd manual page definition 
>   (with addition of capital letters)
> - Fixed multiple IPC related bugs
> - Fixed race condition when accessing port/connect_type for USB devices
> - Using bundled catch v2.13.8 
> - Using bundled PEGTL v3.2.5
> - Fixed usbguard-rule-parser file opening
> - Fix unauthorized access via D-Bus [CVE-2019-25058]

https://github.com/USBGuard/usbguard/releases/tag/usbguard-1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of ~~all~~ usbguard, usbguard-daemon  binary files (usually in `./result/bin/`) (not tested: dbus, rule-parser)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
