### PR TITLE
xandikos: backport systemd socket activation

### DIFF
--- a/nixos/tests/xandikos.nix
+++ b/nixos/tests/xandikos.nix
@@ -15,8 +15,6 @@ import ./make-test-python.nix (
         xandikos_proxy = {
           networking.firewall.allowedTCPPorts = [ 80 8080 ];
           services.xandikos.enable = true;
-          services.xandikos.address = "localhost";
-          services.xandikos.port = 8080;
           services.xandikos.routePrefix = "/xandikos-prefix/";
           services.xandikos.extraOptions = [
             "--defaults"
@@ -39,9 +37,7 @@ import ./make-test-python.nix (
         start_all()
 
         with subtest("Xandikos default"):
-            xandikos_default.wait_for_unit("multi-user.target")
-            xandikos_default.wait_for_unit("xandikos.service")
-            xandikos_default.wait_for_open_port(8080)
+            xandikos_default.wait_for_unit("sockets.target")
             xandikos_default.succeed("curl --fail http://localhost:8080/")
             xandikos_default.succeed(
                 "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"
@@ -50,9 +46,7 @@ import ./make-test-python.nix (
             xandikos_client.fail("curl --fail http://xandikos_default:8080/")
 
         with subtest("Xandikos proxy"):
-            xandikos_proxy.wait_for_unit("multi-user.target")
-            xandikos_proxy.wait_for_unit("xandikos.service")
-            xandikos_proxy.wait_for_open_port(8080)
+            xandikos_proxy.wait_for_unit("sockets.target")
             xandikos_proxy.succeed("curl --fail http://localhost:8080/")
             xandikos_proxy.succeed(
                 "curl -s --fail --location http://localhost:8080/ | grep -i Xandikos"

--- a/pkgs/servers/xandikos/default.nix
+++ b/pkgs/servers/xandikos/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , python3Packages
 , nixosTests
 }:
@@ -15,6 +16,14 @@ python3Packages.buildPythonApplication rec {
     sha256 = "sha256-KDDk0QSOjwivJFz3vLk+g4vZMlSuX2FiOgHJfDJkpwg=";
   };
 
+  patches = [
+    # add support for systemd socket activation
+    (fetchpatch {
+      url = "https://github.com/jelmer/xandikos/pull/155.diff";
+      sha256 = "sha256-h2E0DSeWMkuUytMiu+uUsEJI22fszNCOxEqvPlXMYek=";
+    })
+  ];
+
   propagatedBuildInputs = with python3Packages; [
     aiohttp
     dulwich
@@ -23,6 +32,7 @@ python3Packages.buildPythonApplication rec {
     jinja2
     multidict
     prometheus-client
+    systemd
   ];
 
   passthru.tests.xandikos = nixosTests.xandikos;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Backported <https://github.com/jelmer/xandikos/pull/155> to add support for systemd socket activation. This also enables UNIX sockets with proper owner/permissions, because systemd creates them for us.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).