### PR TITLE
linuxPackages.rtl88x2bu: switch to the new, maintained repo

### DIFF
--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rtl88x2bu";
-  version = "${kernel.version}-unstable-2021-11-04";
+  version = "${kernel.version}-unstable-2022-02-22";
 
   src = fetchFromGitHub {
     owner = "morrownr";
-    repo = "88x2bu";
-    rev = "745d134080b74b92389ffe59c03dcfd6658f8655";
-    sha256 = "0f1hsfdw3ar78kqzr4hi04kpp5wnx0hd29f9rm698k0drxaw1g44";
+    repo = "88x2bu-20210702";
+    rev = "6a5b7f005c071ffa179b6183ee034c98ed30db80";
+    sha256 = "sha256-BqTyJpICW3D4EfHHoN5svasteJnunu2Uz449u/CmNE0=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Realtek rtl88x2bu driver";
-    homepage = "https://github.com/morrownr/88x2bu";
+    homepage = "https://github.com/morrownr/88x2bu-20210702";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.ralith ];


### PR DESCRIPTION
The new repo has the same maintainer and is the continuation of the repo
used prior to this commit.

Closes #147053

I think this should be backported to 21.11 to extend its hardware support. As it is a continuation of the old repo, I don't expect any more breakage than from a normal update.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The repo currently used is not maintained anymore and does not support some of the network adapters using the rtl88x2bu chipset. See #147053

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [X] Tested, as applicable:
  - This is a driver, and I'm not aware of any automated tests in NixOS. I described how I tested this [in this comment](https://github.com/NixOS/nixpkgs/issues/147053#issuecomment-1045980340).
  - In addition to the above, I tested the specific commit in this PR on top of 21.11 before cherry-picking it to master.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - I don't expect breaking changes, so I did not update Release notes.
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
