### PR TITLE
brmodelo: init at 3.31

### DIFF
--- a/pkgs/applications/science/engineering/brmodelo/default.nix
+++ b/pkgs/applications/science/engineering/brmodelo/default.nix
@@ -1,0 +1,109 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, openjdk8
+, ant
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "brmodelo";
+  version = "3.31";
+
+  src = fetchFromGitHub {
+    owner = "chcandido";
+    repo = pname;
+    rev = version;
+    sha256 = "09qrhqhv264x8phnf3pnb0cwq75l7xdsj9xkwlvhry81nxz0d5v0";
+  };
+
+  nativeBuildInputs = [ ant makeWrapper copyDesktopItems ];
+
+  buildInputs = [ openjdk8 ];
+
+  patches = [
+    # Fixes for building with Ant.
+    # https://github.com/chcandido/brModelo/pull/22
+    (fetchpatch {
+      name = "fix-self-closing-element-not-allowed.patch";
+      url = "https://github.com/yuuyins/brModelo/commit/0d712b74fd5d29d67be07480ed196da28a77893b.patch";
+      sha256 = "sha256-yy03arE6xetotzyvpToi9o9crg3KnMRn1J70jDUvSXE=";
+    })
+    (fetchpatch {
+      name = "fix-tag-closing.patch";
+      url = "https://github.com/yuuyins/brModelo/commit/e8530ff75f024cf6effe0408ed69985405e9709c.patch";
+      sha256 = "sha256-MNuh/ORbaAkB5qDSlA/nPrXN+tqzz4oOglVyEtSangI=";
+    })
+    (fetchpatch {
+      name = "fix-bad-use-greater-than.patch";
+      url = "https://github.com/yuuyins/brModelo/commit/498a6ef8129daff5a472b318f93c8f7f2897fc7f.patch";
+      sha256 = "sha256-MmAwYUmx38DGRsiSxCWCObtpqxk0ykUQiDSC76bCpFc=";
+    })
+    (fetchpatch {
+      name = "fix-param-errors.patch";
+      url = "https://github.com/yuuyins/brModelo/commit/8a508aaba0bcffe13a3f95cff495230beea36bc4.patch";
+      sha256 = "sha256-qME9gZChSMzu1vs9HaosD+snb+jlOrQLY97meNoA8oU=";
+    })
+
+    # Add SVG icons.
+    # https://github.com/chcandido/brModelo/pull/23
+    (fetchpatch {
+      name = "add-brmodelo-logo-icons-svg.patch";
+      url = "https://github.com/yuuyins/brModelo/commit/f260b82b664fad3325bbf3ebd7a15488d496946b.patch";
+      sha256 = "sha256-UhgcWxsHkNFS1GgaRnmlZohjDR8JwHof2cIb3SBetYs=";
+    })
+  ];
+
+  buildPhase = ''
+    ant
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "brmodelo";
+      desktopName = "brModelo";
+      genericName = "Entity-relationship diagramming tool";
+      exec = "brmodelo";
+      icon = "brmodelo";
+      comment = meta.description;
+      categories = "Development;Education;Database;2DGraphics;ComputerScience;DataVisualization;Engineering;Java;";
+    })
+  ];
+
+  installPhase = ''
+    install -d $out/bin $out/share/doc/${pname} $out/share/java
+
+    cp -rv ./dist/javadoc $out/share/doc/${pname}/
+
+    install -Dm755 ./dist/brModelo.jar -t $out/share/java/
+    # NOTE: The standard Java GUI toolkit has a
+    # hard-coded list of "non-reparenting" window managers,
+    # which cause issues while running brModelo
+    # in WMs that are not in that list (e.g. XMonad).
+    # Solution/Workaround: set the environment variable
+    # _JAVA_AWT_WM_NONREPARENTING=1.
+    makeWrapper ${openjdk8}/bin/java $out/bin/brmodelo \
+       --prefix _JAVA_AWT_WM_NONREPARENTING : 1 \
+       --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on" \
+       --add-flags "-jar $out/share/java/brModelo.jar"
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    for size in 16 24 32 48 64 128 256; do
+      install -Dm644 ./src/imagens/icone_"$size"x"$size".svg \
+        $out/share/icons/hicolor/"$size"x"$size"/apps/brmodelo.svg
+    done
+  '';
+
+  meta = with lib; {
+    description = "Entity-relationship diagram tool for making conceptual and logical database models";
+    homepage = "https://github.com/chcandido/brModelo";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yuu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32497,6 +32497,10 @@ with pkgs;
 
   lingeling = callPackage ../applications/science/logic/lingeling {};
 
+  ### SCIENCE / ENGINEERING
+
+  brmodelo = callPackage ../applications/science/engineering/brmodelo { };
+
   ### SCIENCE / ELECTRONICS
 
   adms = callPackage ../applications/science/electronics/adms { };


### PR DESCRIPTION
re-created at https://github.com/NixOS/nixpkgs/pull/167729

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add entity-relationship diagram tool https://github.com/chcandido/brModelo.

Part of https://github.com/NixOS/nixpkgs/issues/164019

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<s>I'm experiencing some strange stuff like the app won't get in appropriate dimension, and trying to click on the menu items won't work.</s> Edit: The standard Java GUI toolkit has a hard-coded list of "non-reparenting" window managers, which cause issues while running brModelo in WMs that are not in that list (e.g. XMonad). Solution/Workaround: set the environment variable `_JAVA_AWT_WM_NONREPARENTING=1`.

https://user-images.githubusercontent.com/86538850/155588131-20ed373b-6f8c-4ad1-8568-d5e425c6e5f8.mp4

