### PR TITLE
yoshimi: unstable-2020-05-10 -> 2.1.2.2

### DIFF
--- a/pkgs/applications/audio/yoshimi/default.nix
+++ b/pkgs/applications/audio/yoshimi/default.nix
@@ -1,33 +1,64 @@
-{ lib, stdenv, fetchFromGitHub , alsa-lib, boost, cairo, cmake, fftwSinglePrec, fltk, pcre
-, libjack2, libsndfile, libXdmcp, readline, lv2, libGLU, libGL, minixml, pkg-config, zlib, xorg
+{ lib
+, stdenv
+, fetchFromGitHub
+, alsa-lib
+, boost
+, cairo
+, cmake
+, fftwSinglePrec
+, fltk
+, libGLU
+, libjack2
+, libsndfile
+, libXdmcp
+, lv2
+, minixml
+, pcre
+, pkg-config
+, readline
+, xorg
+, zlib
 }:
 
 assert stdenv ? glibc;
 
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation rec {
   pname = "yoshimi";
-  # Fix build with lv2 1.18: https://github.com/Yoshimi/yoshimi/pull/102/commits/86996cbb235f0fe138ae814a6758c2c8ba1c2a38
-  version = "unstable-2020-05-10";
+  version = "2.1.2.2";
 
   src = fetchFromGitHub {
     owner = "Yoshimi";
     repo = pname;
-    rev = "86996cbb235f0fe138ae814a6758c2c8ba1c2a38";
-    sha256 = "0bgcc5fbgwpdjircq00wlii30pakf45yzligpbnf02a554hh4j01";
+    rev = version;
+    hash = "sha256-6YsA6tC94yJuuWp5rXXqHzqRy28tvmJzjOR92YwQYO0=";
   };
-  buildInputs = [
-    alsa-lib boost cairo fftwSinglePrec fltk libjack2 libsndfile libXdmcp readline lv2 libGLU libGL
-    minixml zlib xorg.libpthreadstubs pcre
-  ];
+
+  sourceRoot = "source/src";
+
+  postPatch = ''
+    substituteInPlace Misc/Config.cpp --replace /usr $out
+    substituteInPlace Misc/Bank.cpp --replace /usr $out
+  '';
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  patchPhase = ''
-    substituteInPlace src/Misc/Config.cpp --replace /usr $out
-    substituteInPlace src/Misc/Bank.cpp --replace /usr $out
-  '';
-
-  preConfigure = "cd src";
+  buildInputs = [
+    alsa-lib
+    boost
+    cairo
+    fftwSinglePrec
+    fltk
+    libGLU
+    libjack2
+    libsndfile
+    libXdmcp
+    lv2
+    minixml
+    pcre
+    readline
+    xorg.libpthreadstubs
+    zlib
+  ];
 
   cmakeFlags = [ "-DFLTK_MATH_LIBRARY=${stdenv.glibc.out}/lib/libm.so" ];
 
@@ -38,8 +69,8 @@ stdenv.mkDerivation  rec {
       ZynAddSubFX along with very good Jack and Alsa midi/audio
       functionality on Linux
     '';
-    homepage = "http://yoshimi.sourceforge.net";
-    license = licenses.gpl2;
+    homepage = "https://yoshimi.github.io/";
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.goibhniu ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
