### PR TITLE
voms: init at 2021-05-04, xrootd: add voms support

### DIFF
--- a/pkgs/tools/networking/voms/default.nix
+++ b/pkgs/tools/networking/voms/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+  # Native build inputs
+, autoreconfHook
+, bison
+, flex
+, pkg-config
+  # Build inputs
+, expat
+, gsoap
+, openssl
+, zlib
+}:
+
+stdenv.mkDerivation rec{
+  pname = "voms-unstable";
+  version = "2021-05-04";
+
+  src = fetchFromGitHub {
+    owner = "italiangrid";
+    repo = "voms";
+    rev = "61563152fce3a4e6860dd8ab8ab6e72b7908d8b8";
+    sha256 = "LNR0G4XrgxqjQmjyaKoZJLNoxtAGiTM93FG3jIU1u+Y=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    bison
+    flex
+    pkg-config
+  ];
+
+  buildInputs = [
+    expat
+    gsoap
+    openssl
+    zlib
+  ];
+
+  outputs = [ "bin" "out" "dev" "man" ];
+
+  preAutoreconf = ''
+    mkdir -p aux src/autogen
+  '';
+
+  postAutoreconf = ''
+    # FHS patching
+    substituteInPlace configure \
+      --replace "/usr/bin/soapcpp2" "${gsoap}/bin/soapcpp2"
+
+    # Tell gcc about the location of zlib
+    # See https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=voms
+    export GSOAP_SSL_PP_CFLAGS="$(pkg-config --cflags gsoapssl++ zlib)"
+    export GSOAP_SSL_PP_LIBS="$(pkg-config --libs gsoapssl++ zlib)"
+  '';
+
+  configureFlags = [
+    "--with-gsoap-wsdl2h=${gsoap}/bin/wsdl2h"
+  ];
+
+  meta = with lib; {
+    description = "The VOMS native service and APIs";
+    homepage = "https://italiangrid.github.io/voms/";
+    changelog = "https://github.com/italiangrid/voms/blob/master/ChangeLog";
+    license = licenses.asl20;
+    platforms = platforms.linux; # gsoap is currently Linux-only in Nixpkgs
+    maintainers = with maintainers; [ ShamrockLee ];
+  };
+}

--- a/pkgs/tools/networking/xrootd/default.nix
+++ b/pkgs/tools/networking/xrootd/default.nix
@@ -4,15 +4,16 @@
 , fetchFromGitHub
 , cmake
 , cppunit
+, pkg-config
 , curl
 , fuse
 , libkrb5
 , libuuid
 , libxml2
 , openssl
-, pkg-config
 , readline
 , systemd
+, voms
 , zlib
 , enableTests ? true
 }:
@@ -52,6 +53,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.isLinux [
     fuse
     systemd
+    voms
   ]
   ++ lib.optionals enableTests [
     cppunit

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1088,6 +1088,8 @@ with pkgs;
 
   ventoy-bin = callPackage ../tools/cd-dvd/ventoy-bin { };
 
+  voms = callPackage ../tools/networking/voms { };
+
   vopono = callPackage ../tools/networking/vopono { };
 
   winbox = callPackage ../tools/admin/winbox {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
*   Package VOMS, the authentication framework of CERN GRID, into Nixpkgs.
*   Add VOMS support to XRootD, a network-based data storage/access framework
*   ~~Add XRootD support to ROOT, the data analysis framework commonly used in the field of High Energy Physics.
    This way, we can (finally) open URLs prefixed with `root://` using ROOT on LXPLUS and CERN GRID! (Not tested yet.)~~
    Due to #169677, the package `xrootd` is not functioning. It is unsuitable to add it to ROOT before the issue is solved or a workaround is found.

###### Status
*   All build successfully.
*   ~~Need to test on LXPLUS and HTCondor is needed to see if ROOT built by us can now accepts URLs with `root` schema.~~
*   ~~This PR will be ready to merge after these tests.~~
*   `gsoap`, a required dependency of `voms`, is currently set to build only on Linux. ~~I'm trying to loosen it and let it build by OfBorg, since MacPorts does have it packed.
*   ~~Should it fails to work on Mac, I'll modify the xrootd Nix expression to inject voms where gsoap are able to build.~~ Voms is now injected on Linux only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`) (More tests need to be done on LXPLUS.)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
