### PR TITLE
libxmlb: 0.3.1 → 0.3.7

### DIFF
--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , docbook_xml_dtd_43
 , docbook_xsl
@@ -11,11 +12,12 @@
 , python3
 , shared-mime-info
 , nixosTests
+, xz
 }:
 
 stdenv.mkDerivation rec {
   pname = "libxmlb";
-  version = "0.3.1";
+  version = "0.3.7";
 
   outputs = [ "out" "lib" "dev" "devdoc" "installedTests" ];
 
@@ -23,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "hughsie";
     repo = "libxmlb";
     rev = version;
-    sha256 = "sha256-4gJBmSbo5uGj12Y2Ov4gmS8nJshQxuBM9BAevY/lwjg=";
+    sha256 = "sha256-ZzA1YJYxTR91X79NU9dWd11Ze+PX2wuZeumuEuNdC48=";
   };
 
   patches = [
@@ -38,12 +40,13 @@ stdenv.mkDerivation rec {
     meson
     ninja
     pkg-config
-    (python3.withPackages (pkgs: with pkgs; [ setuptools ]))
+    python3
     shared-mime-info
   ];
 
   buildInputs = [
     glib
+    xz
   ];
 
   mesonFlags = [

--- a/pkgs/development/libraries/libxmlb/installed-tests-path.patch
+++ b/pkgs/development/libraries/libxmlb/installed-tests-path.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index 38486c9..c567613 100644
+index c98e1a7..025d9c8 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -110,8 +110,8 @@
+@@ -110,8 +110,8 @@ else
    prefix = get_option('prefix')
    datadir = join_paths(prefix, get_option('datadir'))
    libexecdir = join_paths(prefix, get_option('libexecdir'))
@@ -14,11 +14,11 @@ index 38486c9..c567613 100644
  
  gio = dependency('gio-2.0', version : '>= 2.45.8')
 diff --git a/meson_options.txt b/meson_options.txt
-index 27e8cb6..74548ae 100644
+index 54ab698..8a7122a 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -2,3 +2,4 @@
- option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
+@@ -3,3 +3,4 @@ option('introspection', type : 'boolean', value : true, description : 'generate
  option('tests', type : 'boolean', value : true, description : 'enable tests')
  option('stemmer', type : 'boolean', value : false, description : 'enable stemmer support')
+ option('cli', type : 'boolean', value : true, description : 'build and install the xb-tool CLI')
 +option('installed_test_prefix', type: 'string', value: '', description: 'Prefix for installed tests')


### PR DESCRIPTION
###### Motivation for this change

Try to bump `appstream` and `libxmlb >= 0.3.6` is a new dependency.

https://github.com/hughsie/libxmlb/blob/0.3.7/NEWS
https://github.com/hughsie/libxmlb/compare/0.3.1...0.3.7

`xz` is needed by https://github.com/hughsie/libxmlb/commit/d277ace303bd7eb91db5a471d4b88bc891fcc941

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
