### PR TITLE
bats: 1.5.0 -> 1.6.0

### DIFF
--- a/pkgs/development/interpreters/bats/default.nix
+++ b/pkgs/development/interpreters/bats/default.nix
@@ -1,22 +1,24 @@
 { resholvePackage
 , lib
+, stdenv
 , fetchFromGitHub
 , bash
 , coreutils
 , gnugrep
 , ncurses
+, lsof
 , doInstallCheck ? true
 }:
 
 resholvePackage rec {
   pname = "bats";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "bats-core";
     repo = "bats-core";
     rev = "v${version}";
-    sha256 = "sha256-MEkMi2w8G9FZhE3JvzzbqObcErQ9WFXy5mtKwQOoxbk=";
+    sha256 = "sha256-s+SAqX70WeTz6s5ObXYFBVPVUEqvD1d7AX2sGHkjVQ4=";
   };
 
   patchPhase = ''
@@ -45,7 +47,7 @@ resholvePackage rec {
   };
 
   inherit doInstallCheck;
-  installCheckInputs = [ ncurses ];
+  installCheckInputs = [ ncurses ] ++ lib.optionals stdenv.isDarwin [ lsof ];
   installCheckPhase = ''
     # TODO: cut if https://github.com/bats-core/bats-core/issues/418 allows
     sed -i '/test works even if PATH is reset/a skip' test/bats.bats


### PR DESCRIPTION
Same as r-ryantm PR (#161762), but fixes a Darwin test failure.

Upstream [added a test case that depends on `lsof`](https://github.com/bats-core/bats-core/pull/525/files#diff-d57b87d2c1503a4b63d2f10db15eed94ebd20e117b779abe26ccd3e38e98eee1R13) on Darwin (but uses `/proc/` on Linux).