### PR TITLE
automathemely: init at 2022-02-24

### DIFF
--- a/pkgs/applications/misc/automathemely/default.nix
+++ b/pkgs/applications/misc/automathemely/default.nix
@@ -1,0 +1,84 @@
+{ lib, fetchFromGitHub, fetchpatch, python3, libnotify, gobject-introspection, wrapGAppsHook, gtk3, stdenv }:
+
+# need to override this as astral 2.0 has breaking changes
+let
+  python3_ = python3.override {
+    packageOverrides = self: super: {
+      astral = super.astral.overrideAttrs (old: rec {
+        version = "1.10.1";
+        src = super.fetchPypi {
+          inherit version;
+          pname = "astral";
+          sha256 = "sha256-0qZyQ8RQMTHIVsr7GxJ23lKobluKHVB7fgi+5Ry2e/E=";
+        };
+      });
+    };
+  };
+
+in python3_.pkgs.buildPythonApplication rec {
+  pname = "automathemely";
+  version = "2022-02-24";
+
+  src = fetchFromGitHub {
+    owner = "C2N14";
+    repo = "AutomaThemely";
+    rev = "3f6f9973eb78c707454b53a26dbe746f8667a924";
+    sha256 = "sha256-90EKU1ycu+AY+ZVRPIC9sKn1w292r6wFMWp+qHC6czE=";
+  };
+
+  patches = [
+    # fixes restrictive permissions caused by copying files from the nix store
+    (fetchpatch {
+      name = "fix-copying-from-nix-store.patch";
+      url = "https://github.com/LuisChDev/AutomaThemely/commit/b9c26ad7e476809b9e8038c8cdafa1637380f11d.patch";
+      sha256 = "sha256-qmLKvog65TWdRfQTjSVJaS82kMqJdAv1QeGacwpbOEM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ];
+
+  propagatedBuildInputs = with python3_.pkgs; [
+    astral
+    requests
+    pytz
+    tzlocal
+    schedule
+    pygobject3 # implicit dependency
+    gobject-introspection
+
+    libnotify
+    gtk3
+  ];
+
+  strictDeps = false;
+
+  postPatch = ''
+    find -name "*.py" -print0 | while IFS= read -r -d ''' file; do
+      patchShebangs "$file"
+    done
+
+    substituteInPlace automathemely/lib/installation_files/autostart.desktop \
+    --replace '/usr/bin/env python3' '${python3}/bin/python3'
+
+    substituteInPlace automathemely/lib/installation_files/sun-times.service \
+    --replace '/usr/bin/env python3' '${python3}/bin/python3'
+
+    substituteInPlace automathemely/lib/installation_files/sun-times.service \
+    --replace '/bin/bash' '${stdenv.shell}'
+
+    # tries to call itself during install just to read the version. And this causes  an attempt to read $HOME
+    substituteInPlace setup.py --replace 'from automathemely import __version__ as version' ' '
+    substituteInPlace setup.py --replace 'version=version' 'version="${version}"'
+  '';
+
+  doCheck = false; # no tests anyway, and again tries to access $HOME
+
+  meta = with lib; {
+    description =
+      "Simple, set-and-forget python application for changing between desktop themes according to light and dark hours";
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -196,6 +196,8 @@ with pkgs;
 
   atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };
 
+  automathemely = callPackage ../applications/misc/automathemely { };
+
   atuin = callPackage ../tools/misc/atuin {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
App to automatically change themes based on local time (just like it can be configured in OS X for instance). Will keep it in draft until it's been tested, in the meantime, please do take a look and request changes as you see fit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
