### PR TITLE
calamares: fix calamares modules, add nixos modules, and add new iso

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13268,6 +13268,12 @@
     githubId = 1771332;
     name = "László Vaskó";
   };
+  vlinkz = {
+    email = "vmfuentes64@gmail.com";
+    github = "vlinkz";
+    githubId = 20145996;
+    name = "Victor Fuentes";
+  };
   vlstill = {
     email = "xstill@fi.muni.cz";
     github = "vlstill";

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -108,6 +108,14 @@
           default.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          The GNOME and Plasma installation CDs now use
+          <literal>pkgs.calamares</literal> and
+          <literal>pkgs.calamares-nixos-extensions</literal> to allow
+          users to easily install and set up NixOS with a GUI.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
   <section xml:id="sec-release-22.05-new-services">

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -35,6 +35,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The default GHC version has been updated from 8.10.7 to 9.0.2. `pkgs.haskellPackages` and `pkgs.ghc` will now use this version by default.
 
+- The GNOME and Plasma installation CDs now use `pkgs.calamares` and `pkgs.calamares-nixos-extensions` to allow users to easily install and set up NixOS with a GUI.
+
 ## New Services {#sec-release-22.05-new-services}
 
 - [aesmd](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw), the Intel SGX Architectural Enclave Service Manager. Available as [services.aesmd](#opt-services.aesmd.enable).

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -35,22 +35,28 @@ with lib;
   # Enable sound in graphical iso's.
   hardware.pulseaudio.enable = true;
 
-  environment.systemPackages = [
+  # Spice guest additions
+  services.spice-vdagentd.enable = true;
+
+  # Enable plymouth
+  boot.plymouth.enable = true;
+
+  environment.defaultPackages = with pkgs; [
     # Include gparted for partitioning disks.
-    pkgs.gparted
+    gparted
 
     # Include some editors.
-    pkgs.vim
-    pkgs.bvi # binary editor
-    pkgs.joe
+    vim
+    nano
 
     # Include some version control tools.
-    pkgs.git
+    git
+    rsync
 
     # Firefox for reading the manual.
-    pkgs.firefox
+    firefox
 
-    pkgs.glxinfo
+    glxinfo
   ];
 
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
@@ -1,0 +1,59 @@
+# This module defines a NixOS installation CD that contains GNOME.
+
+{ pkgs, ... }:
+
+{
+  imports = [ ./installation-cd-graphical-calamares.nix ];
+
+  isoImage.edition = "gnome";
+
+  services.xserver.desktopManager.gnome = {
+    # Add Firefox and other tools useful for installation to the launcher
+    favoriteAppsOverride = ''
+      [org.gnome.shell]
+      favorite-apps=[ 'firefox.desktop', 'nixos-manual.desktop', 'org.gnome.Console.desktop', 'org.gnome.Nautilus.desktop', 'gparted.desktop', 'io.calamares.calamares.desktop' ]
+    '';
+
+    # Override GNOME defaults to disable GNOME tour and disable suspend
+    extraGSettingsOverrides = ''
+      [org.gnome.shell]
+      welcome-dialog-last-shown-version='9999999999'
+
+      [org.gnome.settings-daemon.plugins.power]
+      sleep-inactive-ac-type='nothing'
+      sleep-inactive-battery-type='nothing'
+    '';
+
+    extraGSettingsOverridePackages = [ pkgs.gnome.gnome-settings-daemon ];
+
+    enable = true;
+  };
+
+  # Theme calamares with GNOME theme
+  qt5 = {
+    enable = true;
+    platformTheme = "gnome";
+  };
+
+  # Fix scaling for calamares on wayland
+  environment.variables = {
+    QT_QPA_PLATFORM = "$([[ $XDG_SESSION_TYPE = \"wayland\" ]] && echo \"wayland\")";
+  };
+
+  services.xserver.displayManager = {
+    gdm = {
+      enable = true;
+      # autoSuspend makes the machine automatically suspend after inactivity.
+      # It's possible someone could/try to ssh'd into the machine and obviously
+      # have issues because it's inactive.
+      # See:
+      # * https://github.com/NixOS/nixpkgs/pull/63790
+      # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
+      autoSuspend = false;
+    };
+    autoLogin = {
+      enable = true;
+      user = "nixos";
+    };
+  };
+}

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma5.nix
@@ -4,7 +4,7 @@
 { pkgs, ... }:
 
 {
-  imports = [ ./installation-cd-graphical-base.nix ];
+  imports = [ ./installation-cd-graphical-calamares.nix ];
 
   isoImage.edition = "plasma5";
 
@@ -43,6 +43,7 @@
     ln -sfT ${manualDesktopFile} ${desktopDir + "nixos-manual.desktop"}
     ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop ${desktopDir + "gparted.desktop"}
     ln -sfT ${pkgs.konsole}/share/applications/org.kde.konsole.desktop ${desktopDir + "org.kde.konsole.desktop"}
+    ln -sfT ${pkgs.calamares-nixos}/share/applications/io.calamares.calamares.desktop ${desktopDir + "io.calamares.calamares.desktop"}
   '';
 
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares.nix
@@ -1,0 +1,20 @@
+# This module adds the calamares installer to the basic graphical NixOS
+# installation CD.
+
+{ pkgs, ... }:
+let
+  calamares-nixos-autostart = pkgs.makeAutostartItem { name = "io.calamares.calamares"; package = pkgs.calamares-nixos; };
+in
+{
+  imports = [ ./installation-cd-graphical-base.nix ];
+
+  environment.systemPackages = with pkgs; [
+    # Calamares for graphical installation
+    libsForQt5.kpmcore
+    calamares-nixos
+    calamares-nixos-autostart
+    calamares-nixos-extensions
+    # Needed for calamares QML module packagechooserq
+    libsForQt5.full
+  ];
+}

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -1,8 +1,6 @@
 # This module defines a NixOS installation CD that contains GNOME.
 
-{ lib, ... }:
-
-with lib;
+{ ... }:
 
 {
   imports = [ ./installation-cd-graphical-base.nix ];

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -150,13 +150,13 @@ in rec {
   });
 
   iso_plasma5 = forMatchingSystems [ "x86_64-linux" ] (system: makeIso {
-    module = ./modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix;
+    module = ./modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma5.nix;
     type = "plasma5";
     inherit system;
   });
 
   iso_gnome = forMatchingSystems [ "x86_64-linux" ] (system: makeIso {
-    module = ./modules/installer/cd-dvd/installation-cd-graphical-gnome.nix;
+    module = ./modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix;
     type = "gnome";
     inherit system;
   });

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, extra-cmake-modules
+{ stdenv, lib, fetchurl, extra-cmake-modules
 , qca-qt5, kauth, kio, polkit-qt, qtbase
 , util-linux
 }:
@@ -6,25 +6,14 @@
 stdenv.mkDerivation rec {
   pname = "kpmcore";
   # NOTE: When changing this version, also change the version of `partition-manager`.
-  version = "4.2.0";
+  version = "22.04.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
-    hash = "sha256-MvW0CqvFZtzcJlya6DIpzorPbKJai6fxt7nKsKpJn54=";
+    url = "mirror://kde/stable/release-service/${version}/src/${pname}-${version}.tar.xz";
+    hash = "sha256-sO8WUJL6072H1ghMZd7j0xNMwEn4bJF5PXMhfEb2jbs=";
   };
 
-  patches = [
-    # Fix build with `kcoreaddons` >= 5.77.0
-    (fetchpatch {
-      url = "https://github.com/KDE/kpmcore/commit/07e5a3ac2858e6d38cc698e0f740e7a693e9f302.patch";
-      sha256 = "sha256-LYzea888euo2HXM+acWaylSw28iwzOdZBvPBt/gjP1s=";
-    })
-    # Fix crash when `fstab` omits mount options.
-    (fetchpatch {
-      url = "https://github.com/KDE/kpmcore/commit/eea84fb60525803a789e55bb168afb968464c130.patch";
-      sha256 = "sha256-NJ3PvyRC6SKNSOlhJPrDDjepuw7IlAoufPgvml3fap0=";
-    })
-  ];
+  nativeBuildInputs = [ extra-cmake-modules ];
 
   buildInputs = [
     qca-qt5
@@ -35,9 +24,12 @@ stdenv.mkDerivation rec {
     util-linux # Needs blkid in configure script (note that this is not provided by util-linux-compat)
   ];
 
-  nativeBuildInputs = [ extra-cmake-modules ];
-
   dontWrapQtApps = true;
+
+  preConfigure = ''
+    substituteInPlace src/util/CMakeLists.txt \
+      --replace \$\{POLKITQT-1_POLICY_FILES_INSTALL_DIR\} $out/share/polkit-1/actions
+  '';
 
   meta = with lib; {
     description = "KDE Partition Manager core library";

--- a/pkgs/tools/misc/calamares-nixos-extensions/default.nix
+++ b/pkgs/tools/misc/calamares-nixos-extensions/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "calamares-nixos-extensions";
+  version = "0.3.8";
+
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "calamares-nixos-extensions";
+    rev = version;
+    sha256 = "MtqAOwlY5euVNAGRl2pRkbg/OolJPNOSQcR4DS5gFz4=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{lib,share}/calamares
+    cp -r modules $out/lib/calamares/
+    cp -r config/* $out/share/calamares/
+    cp -r branding $out/share/calamares/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Calamares modules for NixOS";
+    homepage = "https://github.com/NixOS/calamares-nixos-extensions";
+    license = with licenses; [ gpl3Plus bsd2 cc-by-40 cc-by-sa-40 cc0 ];
+    maintainers = with maintainers; [ vlinkz ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -1,24 +1,48 @@
-{ lib, fetchurl, boost, cmake, extra-cmake-modules, kparts, kpmcore
-, kservice, libatasmart, libxcb, libyamlcpp, parted, polkit-qt, python, qtbase
-, qtquickcontrols, qtsvg, qttools, qtwebengine, util-linux, tzdata
+{ lib, fetchurl, boost, cmake, extra-cmake-modules, kparts, kpmcore, kirigami2
+, kservice, libatasmart, libxcb, libyamlcpp, libpwquality, parted, polkit-qt, python
+, qtbase, qtquickcontrols, qtsvg, qttools, qtwebengine, util-linux, tzdata
 , ckbcomp, xkeyboard_config, mkDerivation
+, nixos-extensions ? false
 }:
 
 mkDerivation rec {
   pname = "calamares";
-  version = "3.2.55";
+  version = "3.2.56";
 
   # release including submodule
   src = fetchurl {
-    url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-1xf02rjy6+83zbU2yxGUGjcIGJfYS8ryqi4CBzrh7kI=";
+    url = "https://github.com/calamares/calamares/releases/download/v${version}/${pname}-${version}.tar.gz";
+    sha256 = "e1402d7693659b85c5e553481a7252d91350c3f33ffea413488d7712d3281e03";
   };
+
+  patches = lib.optionals nixos-extensions [
+    # Modifies the users module to only set passwords of user and root
+    # as the users will have already been created in the configuration.nix file
+    ./userjob.patch
+    # Makes calamares search /run/current-system/sw/share/calamares/ for extra configuration files
+    # as by default it only searches /usr/share/calamares/ and /nix/store/<hash>-calamares-<version>/share/calamares/
+    # but calamares-nixos-extensions is not in either of these locations
+    ./nixos-extensions-paths.patch
+    # Uses pkexec within modules in order to run calamares without root permissions as a whole
+    # Also fixes storage check in the welcome module
+    ./nonroot.patch
+    # Adds unfree qml to packagechooserq
+    ./unfreeq.patch
+    # Adds config to change name of packagechooserq
+    # Upstreamed in PR: https://github.com/calamares/calamares/pull/1932
+    ./packagechooserq.patch
+    # Modifies finished module to add some NixOS resources
+    # Modifies packagechooser module to change the UI
+    ./uimod.patch
+    # Remove options for unsupported partition types
+    ./partitions.patch
+  ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
   buildInputs = [
-    boost kparts.dev kpmcore.out kservice.dev
-    libatasmart libxcb libyamlcpp parted polkit-qt python qtbase
-    qtquickcontrols qtsvg qttools qtwebengine.dev util-linux
+    boost kparts.dev kpmcore.out kservice.dev kirigami2
+    libatasmart libxcb libyamlcpp libpwquality parted polkit-qt python
+    qtbase qtquickcontrols qtsvg qttools qtwebengine.dev util-linux
   ];
 
   cmakeFlags = [
@@ -32,15 +56,28 @@ mkDerivation rec {
   POLKITQT-1_POLICY_FILES_INSTALL_DIR = "$(out)/share/polkit-1/actions";
 
   postPatch = ''
+    # Run calamares without root. Other patches make it functional as a normal user
+    sed -e "s,pkexec calamares,calamares," \
+        -i calamares.desktop
+
+    sed -e "s,X-AppStream-Ignore=true,&\nStartupWMClass=io.calamares.calamares," \
+        -i calamares.desktop
+
+    # Fix desktop reference with wayland
+    mv calamares.desktop io.calamares.calamares.desktop
+
+    sed -e "s,calamares.desktop,io.calamares.calamares.desktop," \
+        -i CMakeLists.txt
+
     sed -e "s,/usr/bin/calamares,$out/bin/calamares," \
-        -i calamares.desktop \
         -i com.github.calamares.calamares.policy
 
     sed -e 's,/usr/share/zoneinfo,${tzdata}/share/zoneinfo,' \
-        -i src/modules/locale/SetTimezoneJob.cpp
+        -i src/modules/locale/SetTimezoneJob.cpp \
+        -i src/libcalamares/locale/TimeZone.cpp
 
     sed -e 's,/usr/share/X11/xkb/rules/base.lst,${xkeyboard_config}/share/X11/xkb/rules/base.lst,' \
-        -i src/modules/keyboard/keyboardwidget/keyboardglobal.h
+        -i src/modules/keyboard/keyboardwidget/keyboardglobal.cpp
 
     sed -e 's,"ckbcomp","${ckbcomp}/bin/ckbcomp",' \
         -i src/modules/keyboard/keyboardwidget/keyboardpreview.cpp
@@ -51,8 +88,9 @@ mkDerivation rec {
 
   meta = with lib; {
     description = "Distribution-independent installer framework";
-    license = with licenses; [ gpl3Plus bsd2 ];
-    maintainers = with maintainers; [ manveru ];
+    homepage = "https://calamares.io/";
+    license = with licenses; [ gpl3Plus bsd2 cc0 ];
+    maintainers = with maintainers; [ manveru vlinkz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/calamares/nixos-extensions-paths.patch
+++ b/pkgs/tools/misc/calamares/nixos-extensions-paths.patch
@@ -1,0 +1,46 @@
+diff --git a/src/calamares/main.cpp b/src/calamares/main.cpp
+index de709156f..a0b6c5faf 100644
+--- a/src/calamares/main.cpp
++++ b/src/calamares/main.cpp
+@@ -131,6 +132,8 @@ main( int argc, char* argv[] )
+     // TODO: umount anything in /tmp/calamares-... as an emergency save function
+ #endif
+ 
++    CalamaresUtils::setNixosDirs();
++
+     bool is_debug = handle_args( a );
+ 
+ #ifdef WITH_KF5DBus
+diff --git a/src/libcalamares/utils/Dirs.cpp b/src/libcalamares/utils/Dirs.cpp
+index f333d6e64..6118fb412 100644
+--- a/src/libcalamares/utils/Dirs.cpp
++++ b/src/libcalamares/utils/Dirs.cpp
+@@ -115,6 +116,14 @@ setXdgDirs()
+     s_haveExtraDirs = !( s_extraConfigDirs.isEmpty() && s_extraDataDirs.isEmpty() );
+ }
+ 
++void
++setNixosDirs()
++{
++    s_extraConfigDirs << "/run/current-system/sw/share/calamares/";
++    s_extraDataDirs << "/run/current-system/sw/share/calamares/";
++    s_haveExtraDirs = !( s_extraConfigDirs.isEmpty() && s_extraDataDirs.isEmpty() ); 
++}
++
+ QStringList
+ extraConfigDirs()
+ {
+diff --git a/src/libcalamares/utils/Dirs.h b/src/libcalamares/utils/Dirs.h
+index 445cbe1f1..da869d446 100644
+--- a/src/libcalamares/utils/Dirs.h
++++ b/src/libcalamares/utils/Dirs.h
+@@ -50,6 +50,9 @@ DLLEXPORT bool isAppDataDirOverridden();
+ /** @brief Setup extra config and data dirs from the XDG variables.
+  */
+ DLLEXPORT void setXdgDirs();
++/** @brief Setup extra config and data dirs fir NixOS.
++ */
++DLLEXPORT void setNixosDirs();
+ /** @brief Are any extra directories configured? */
+ DLLEXPORT bool haveExtraDirs();
+ /** @brief XDG_CONFIG_DIRS, each guaranteed to end with / */

--- a/pkgs/tools/misc/calamares/nonroot.patch
+++ b/pkgs/tools/misc/calamares/nonroot.patch
@@ -1,0 +1,105 @@
+diff --git a/src/libcalamares/utils/Runner.cpp b/src/libcalamares/utils/Runner.cpp
+index c7146c2d7..e165d9a8f 100644
+--- a/src/libcalamares/utils/Runner.cpp
++++ b/src/libcalamares/utils/Runner.cpp
+@@ -140,13 +140,13 @@ Calamares::Utils::Runner::run()
+     }
+     if ( m_location == RunLocation::RunInTarget )
+     {
+-        process.setProgram( "chroot" );
+-        process.setArguments( QStringList { workingDirectory.absolutePath() } << m_command );
++        process.setProgram( "pkexec" );
++        process.setArguments( QStringList { "chroot" } + QStringList { workingDirectory.absolutePath() } << m_command );
+     }
+     else
+     {
+-        process.setProgram( "env" );
+-        process.setArguments( m_command );
++        process.setProgram( "pkexec" );
++        process.setArguments( QStringList { "env" } + m_command );
+     }
+ 
+     if ( m_output )
+diff --git a/src/modules/mount/main.py b/src/modules/mount/main.py
+index a3318d1a0..5fbe202fd 100644
+--- a/src/modules/mount/main.py
++++ b/src/modules/mount/main.py
+@@ -152,7 +152,8 @@ def mount_partition(root_mount_point, partition, partitions):
+ 
+     # Ensure that the created directory has the correct SELinux context on
+     # SELinux-enabled systems.
+-    os.makedirs(mount_point, exist_ok=True)
++    subprocess.check_call(["pkexec", "mkdir", "-p", mount_point])
++
+     try:
+         subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
+     except FileNotFoundError as e:
+@@ -193,13 +194,13 @@ def mount_partition(root_mount_point, partition, partitions):
+         for s in btrfs_subvolumes:
+             if not s["subvolume"]:
+                 continue
+-            os.makedirs(root_mount_point + os.path.dirname(s["subvolume"]), exist_ok=True)
+-            subprocess.check_call(["btrfs", "subvolume", "create",
++            subprocess.check_call(["pkexec", "mkdir", "-p", root_mount_point + os.path.dirname(s["subvolume"])])
++            subprocess.check_call(["pkexec", "btrfs", "subvolume", "create",
+                                    root_mount_point + s["subvolume"]])
+             if s["mountPoint"] == "/":
+                 # insert the root subvolume into global storage
+                 libcalamares.globalstorage.insert("btrfsRootSubvolume", s["subvolume"])
+-        subprocess.check_call(["umount", "-v", root_mount_point])
++        subprocess.check_call(["pkexec", "umount", "-v", root_mount_point])
+ 
+         device = partition["device"]
+ 
+diff --git a/src/modules/welcome/checker/GeneralRequirements.cpp b/src/modules/welcome/checker/GeneralRequirements.cpp
+index ca7219ca4..6ac682ba4 100644
+--- a/src/modules/welcome/checker/GeneralRequirements.cpp
++++ b/src/modules/welcome/checker/GeneralRequirements.cpp
+@@ -371,10 +371,34 @@ GeneralRequirements::checkEnoughStorage( qint64 requiredSpace )
+     cWarning() << "GeneralRequirements is configured without libparted.";
+     return false;
+ #else
+-    return check_big_enough( requiredSpace );
++    return big_enough( requiredSpace );
+ #endif
+ }
+ 
++bool
++GeneralRequirements::big_enough( qint64 requiredSpace )
++{
++    FILE *fpipe;
++    char command[128];
++    snprintf(command, sizeof(command), "lsblk --bytes -no SIZE,TYPE | grep disk | awk '$1 > %llu {print $1}'", requiredSpace);
++    char c = 0;
++
++    if (0 == (fpipe = (FILE*)popen(command, "r")))
++    {
++        cWarning() << "Failed to check storage size.";
++        return false;
++    }
++
++    while (fread(&c, sizeof c, 1, fpipe))
++    {
++        pclose(fpipe);
++        return true;
++    }
++
++    pclose(fpipe);
++
++    return false;
++}
+ 
+ bool
+ GeneralRequirements::checkEnoughRam( qint64 requiredRam )
+diff --git a/src/modules/welcome/checker/GeneralRequirements.h b/src/modules/welcome/checker/GeneralRequirements.h
+index b6646da11..ea27324fa 100644
+--- a/src/modules/welcome/checker/GeneralRequirements.h
++++ b/src/modules/welcome/checker/GeneralRequirements.h
+@@ -36,6 +36,7 @@ private:
+     bool checkHasPower();
+     bool checkHasInternet();
+     bool checkIsRoot();
++    bool big_enough( qint64 requiredSpace );
+ 
+     qreal m_requiredStorageGiB;
+     qreal m_requiredRamGiB;

--- a/pkgs/tools/misc/calamares/packagechooserq.patch
+++ b/pkgs/tools/misc/calamares/packagechooserq.patch
@@ -1,0 +1,136 @@
+diff --git a/src/modules/packagechooser/Config.cpp b/src/modules/packagechooser/Config.cpp
+index 491fe5c25..667621597 100644
+--- a/src/modules/packagechooser/Config.cpp
++++ b/src/modules/packagechooser/Config.cpp
+@@ -237,6 +237,12 @@ Config::setPackageChoice( const QString& packageChoice )
+     emit packageChoiceChanged( m_packageChoice.value_or( QString() ) );
+ }
+ 
++QString
++Config::prettyName() const
++{
++    return m_stepName ? m_stepName->get() : tr( "Packages" );
++}
++
+ QString
+ Config::prettyStatus() const
+ {
+@@ -343,4 +349,14 @@ Config::setConfigurationMap( const QVariantMap& configurationMap )
+             cWarning() << "Single-selection QML module must use 'Legacy' method.";
+         }
+     }
++
++    bool labels_ok = false;
++    auto labels = CalamaresUtils::getSubMap( configurationMap, "labels", labels_ok );
++    if ( labels_ok )
++    {
++        if ( labels.contains( "step" ) )
++        {
++            m_stepName = new CalamaresUtils::Locale::TranslatedString( labels, "step" );
++        }
++    }
+ }
+diff --git a/src/modules/packagechooser/Config.h b/src/modules/packagechooser/Config.h
+index b04b1c30b..d1b783a8d 100644
+--- a/src/modules/packagechooser/Config.h
++++ b/src/modules/packagechooser/Config.h
+@@ -98,6 +98,7 @@ public:
+     QString packageChoice() const { return m_packageChoice.value_or( QString() ); }
+     void setPackageChoice( const QString& packageChoice );
+ 
++    QString prettyName() const;
+     QString prettyStatus() const;
+ 
+ signals:
+@@ -120,6 +121,7 @@ private:
+      * Reading the property will return an empty QString.
+      */
+     std::optional< QString > m_packageChoice;
++    CalamaresUtils::Locale::TranslatedString* m_stepName;  // As it appears in the sidebar
+ };
+ 
+ 
+diff --git a/src/modules/packagechooser/PackageChooserViewStep.cpp b/src/modules/packagechooser/PackageChooserViewStep.cpp
+index 9057004de..8eacf82ec 100644
+--- a/src/modules/packagechooser/PackageChooserViewStep.cpp
++++ b/src/modules/packagechooser/PackageChooserViewStep.cpp
+@@ -29,7 +29,6 @@ PackageChooserViewStep::PackageChooserViewStep( QObject* parent )
+     : Calamares::ViewStep( parent )
+     , m_config( new Config( this ) )
+     , m_widget( nullptr )
+-    , m_stepName( nullptr )
+ {
+     emit nextStatusChanged( false );
+ }
+@@ -41,14 +40,12 @@ PackageChooserViewStep::~PackageChooserViewStep()
+     {
+         m_widget->deleteLater();
+     }
+-    delete m_stepName;
+ }
+ 
+-
+ QString
+ PackageChooserViewStep::prettyName() const
+ {
+-    return m_stepName ? m_stepName->get() : tr( "Packages" );
++    return m_config->prettyName();
+ }
+ 
+ 
+@@ -139,16 +136,6 @@ PackageChooserViewStep::setConfigurationMap( const QVariantMap& configurationMap
+     m_config->setDefaultId( moduleInstanceKey() );
+     m_config->setConfigurationMap( configurationMap );
+ 
+-    bool labels_ok = false;
+-    auto labels = CalamaresUtils::getSubMap( configurationMap, "labels", labels_ok );
+-    if ( labels_ok )
+-    {
+-        if ( labels.contains( "step" ) )
+-        {
+-            m_stepName = new CalamaresUtils::Locale::TranslatedString( labels, "step" );
+-        }
+-    }
+-
+     if ( m_widget )
+     {
+         hookupModel();
+diff --git a/src/modules/packagechooser/PackageChooserViewStep.h b/src/modules/packagechooser/PackageChooserViewStep.h
+index 7561f2bd7..76b35aed8 100644
+--- a/src/modules/packagechooser/PackageChooserViewStep.h
++++ b/src/modules/packagechooser/PackageChooserViewStep.h
+@@ -50,7 +50,6 @@ private:
+ 
+     Config* m_config;
+     PackageChooserPage* m_widget;
+-    CalamaresUtils::Locale::TranslatedString* m_stepName;  // As it appears in the sidebar
+ };
+ 
+ CALAMARES_PLUGIN_FACTORY_DECLARATION( PackageChooserViewStepFactory )
+diff --git a/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp b/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp
+index 543c9771d..7c4d5fda7 100644
+--- a/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp
++++ b/src/modules/packagechooserq/PackageChooserQmlViewStep.cpp
+@@ -29,7 +29,7 @@ PackageChooserQmlViewStep::PackageChooserQmlViewStep( QObject* parent )
+ QString
+ PackageChooserQmlViewStep::prettyName() const
+ {
+-    return tr( "Packages" );
++    return m_config->prettyName();
+ }
+ 
+ QString
+@@ -83,4 +83,13 @@ PackageChooserQmlViewStep::setConfigurationMap( const QVariantMap& configuration
+     m_config->setDefaultId( moduleInstanceKey() );
+     m_config->setConfigurationMap( configurationMap );
+     Calamares::QmlViewStep::setConfigurationMap( configurationMap );  // call parent implementation last
++    /*bool labels_ok = false;
++    auto labels = CalamaresUtils::getSubMap( configurationMap, "labels", labels_ok );
++    if ( labels_ok )
++    {
++        if ( labels.contains( "step" ) )
++        {
++            m_stepName = new CalamaresUtils::Locale::TranslatedString( labels, "step" );
++        }
++    }*/
+ }

--- a/pkgs/tools/misc/calamares/partitions.patch
+++ b/pkgs/tools/misc/calamares/partitions.patch
@@ -1,0 +1,28 @@
+diff --git a/src/modules/partition/gui/CreatePartitionDialog.cpp b/src/modules/partition/gui/CreatePartitionDialog.cpp
+index c5b17c69e..353b6f964 100644
+--- a/src/modules/partition/gui/CreatePartitionDialog.cpp
++++ b/src/modules/partition/gui/CreatePartitionDialog.cpp
+@@ -107,7 +107,8 @@ CreatePartitionDialog::CreatePartitionDialog( Device* device,
+     {
+         // We need to ensure zfs is added to the list if the zfs module is enabled
+         if ( ( fs->type() == FileSystem::Type::Zfs && Calamares::Settings::instance()->isModuleEnabled( "zfs" ) )
+-             || ( fs->supportCreate() != FileSystem::cmdSupportNone && fs->type() != FileSystem::Extended ) )
++             || ( fs->supportCreate() != FileSystem::cmdSupportNone && fs->type() != FileSystem::Extended
++             && fs->type() != FileSystem::Luks && fs->type() != FileSystem::Luks2 && fs->type() != FileSystem::Minix ) )
+         {
+             fsNames << userVisibleFS( fs );  // This is put into the combobox
+             if ( fs->type() == defaultFSType )
+diff --git a/src/modules/partition/gui/EditExistingPartitionDialog.cpp b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
+index 0bc35cabe..3cf8a7fa2 100644
+--- a/src/modules/partition/gui/EditExistingPartitionDialog.cpp
++++ b/src/modules/partition/gui/EditExistingPartitionDialog.cpp
+@@ -95,7 +95,8 @@ EditExistingPartitionDialog::EditExistingPartitionDialog( Device* device,
+     {
+         // We need to ensure zfs is added to the list if the zfs module is enabled
+         if ( ( fs->type() == FileSystem::Type::Zfs && Calamares::Settings::instance()->isModuleEnabled( "zfs" ) )
+-             || ( fs->supportCreate() != FileSystem::cmdSupportNone && fs->type() != FileSystem::Extended ) )
++             || ( fs->supportCreate() != FileSystem::cmdSupportNone && fs->type() != FileSystem::Extended
++             && fs->type() != FileSystem::Luks && fs->type() != FileSystem::Luks2 && fs->type() != FileSystem::Minix) )
+         {
+             fsNames << userVisibleFS( fs );  // For the combo box
+         }

--- a/pkgs/tools/misc/calamares/uimod.patch
+++ b/pkgs/tools/misc/calamares/uimod.patch
@@ -1,0 +1,85 @@
+diff --git a/src/modules/finished/FinishedPage.cpp b/src/modules/finished/FinishedPage.cpp
+index 6c5f9ad16..24d75e07b 100644
+--- a/src/modules/finished/FinishedPage.cpp
++++ b/src/modules/finished/FinishedPage.cpp
+@@ -71,7 +71,10 @@ FinishedPage::retranslate()
+         {
+             ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
+                                        "%1 has been set up on your computer.<br/>"
+-                                       "You may now start using your new system." )
++                                       "You may now start using your new system.<br/>"
++                                       "You can change every setting later except the bootloader.<br/>"
++                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"
++                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>")
+                                        .arg( branding->versionedName() ) );
+             ui->restartCheckBox->setToolTip( tr( "<html><head/><body>"
+                                                  "<p>When this box is checked, your system will "
+@@ -84,7 +87,10 @@ FinishedPage::retranslate()
+             ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
+                                        "%1 has been installed on your computer.<br/>"
+                                        "You may now restart into your new system, or continue "
+-                                       "using the %2 Live environment." )
++                                       "using the %2 Live environment.<br/>"
++                                       "You can change every setting later except the bootloader.<br/>"
++                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"
++                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>")
+                                        .arg( branding->versionedName(), branding->productName() ) );
+             ui->restartCheckBox->setToolTip( tr( "<html><head/><body>"
+                                                  "<p>When this box is checked, your system will "
+diff --git a/src/modules/packagechooser/PackageChooserPage.cpp b/src/modules/packagechooser/PackageChooserPage.cpp
+index 721329c1b..164b9945e 100644
+--- a/src/modules/packagechooser/PackageChooserPage.cpp
++++ b/src/modules/packagechooser/PackageChooserPage.cpp
+@@ -52,6 +52,7 @@ PackageChooserPage::currentChanged( const QModelIndex& index )
+     if ( !index.isValid() || !ui->products->selectionModel()->hasSelection() )
+     {
+         ui->productName->setText( m_introduction.name.get() );
++        ui->productName->setStyleSheet("font-weight: bold");
+         ui->productScreenshot->setPixmap( m_introduction.screenshot );
+         ui->productDescription->setText( m_introduction.description.get() );
+     }
+diff --git a/src/modules/packagechooser/page_package.ui b/src/modules/packagechooser/page_package.ui
+index d021b08b3..fecfa3060 100644
+--- a/src/modules/packagechooser/page_package.ui
++++ b/src/modules/packagechooser/page_package.ui
+@@ -38,19 +38,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
+      </item>
+      <item>
+-      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,30,1">
++      <layout class="QVBoxLayout" name="verticalLayout" stretch="30,1,1">
+-       <item>
+-        <widget class="QLabel" name="productName">
+-         <property name="sizePolicy">
+-          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+-           <horstretch>0</horstretch>
+-           <verstretch>0</verstretch>
+-          </sizepolicy>
+-         </property>
+-         <property name="text">
+-          <string>Product Name</string>
+-         </property>
+-        </widget>
+-       </item>
+        <item>
+         <widget class="FixedAspectRatioLabel" name="productScreenshot">
+          <property name="sizePolicy">
+@@ -67,6 +54,19 @@ SPDX-License-Identifier: GPL-3.0-or-later
+          </property>
+         </widget>
+        </item>
++       <item>
++        <widget class="QLabel" name="productName">
++         <property name="sizePolicy">
++          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
++           <horstretch>0</horstretch>
++           <verstretch>0</verstretch>
++          </sizepolicy>
++         </property>
++         <property name="text">
++          <string>Product Name</string>
++         </property>
++        </widget>
++       </item>
+        <item>
+         <widget class="QLabel" name="productDescription">
+          <property name="sizePolicy">

--- a/pkgs/tools/misc/calamares/unfreeq.patch
+++ b/pkgs/tools/misc/calamares/unfreeq.patch
@@ -1,0 +1,109 @@
+diff --git a/src/modules/packagechooserq/packagechooserq.qrc b/src/modules/packagechooserq/packagechooserq.qrc
+index 1b892dce1..ee80a934b 100644
+--- a/src/modules/packagechooserq/packagechooserq.qrc
++++ b/src/modules/packagechooserq/packagechooserq.qrc
+@@ -4,5 +4,6 @@
+         <file>images/libreoffice.jpg</file>
+         <file>images/no-selection.png</file>
+         <file>images/plasma.png</file>
++        <file>packagechooserq@unfree.qml</file>
+     </qresource>
+ </RCC>
+diff --git a/src/modules/packagechooserq/packagechooserq@unfree.qml b/src/modules/packagechooserq/packagechooserq@unfree.qml
+new file mode 100644
+index 000000000..cb87d864a
+--- /dev/null
++++ b/src/modules/packagechooserq/packagechooserq@unfree.qml
+@@ -0,0 +1,75 @@
++/* === This file is part of Calamares - <https://calamares.io> ===
++ *
++ *   SPDX-FileCopyrightText: 2021 Anke Boersma <demm@kaosx.us>
++ *   SPDX-License-Identifier: GPL-3.0-or-later
++ *
++ *   Calamares is Free Software: see the License-Identifier above.
++ *
++ */
++
++import io.calamares.core 1.0
++import io.calamares.ui 1.0
++
++import QtQuick 2.15
++import QtQuick.Controls 2.15
++import QtQuick.Layouts 1.3
++
++Item {
++    
++    SystemPalette {
++        id: palette
++        colorGroup: SystemPalette.Active
++    }
++
++    width:  parent.width
++    height: parent.height
++
++    Rectangle {
++        anchors.fill: parent
++        color: palette.window
++
++        ButtonGroup {
++            id: switchGroup
++        }
++
++        Column {
++            id: column
++            anchors.centerIn: parent
++            spacing: 5
++
++            Rectangle {
++                width: 700
++                height: 200
++                color: palette.base
++                radius: 10
++                border.width: 0
++                Text {
++                    color: palette.text
++                    width: 600
++                    height: 150
++                    anchors.centerIn: parent
++                    text: qsTr("NixOS is fully open source, but it also provides software packages with unfree licenses. By default unfree packages are not allowed, but you can enable it here. If you check this box, software installed might have additional End User License Agreements (EULAs) attached. If not enabled, some hardware might not work fully when no suitable open source drivers are available.<br/>")
++                    font.pointSize: 12
++                    wrapMode: Text.WordWrap
++                }
++
++                CheckBox {
++                    id: element2
++                    anchors.horizontalCenter: parent.horizontalCenter
++                    y: 145
++                    text: qsTr("Allow unfree software")
++                    checked: false
++
++                    onCheckedChanged: {
++                        if ( checked ) {
++                            config.packageChoice = "unfree"
++                        } else {
++                            config.packageChoice = "free"
++                        }
++                    }
++                }
++            }
++        }
++    }
++
++}
+diff --git a/src/modules/packagechooserq/unfree.conf b/src/modules/packagechooserq/unfree.conf
+new file mode 100644
+index 000000000..da79a8eac
+--- /dev/null
++++ b/src/modules/packagechooserq/unfree.conf
+@@ -0,0 +1,11 @@
++# SPDX-FileCopyrightText: no
++# SPDX-License-Identifier: CC0-1.0
++#
++---
++qmlLabel:
++    label: "Unfree Software"
++method: legacy
++mode: required
++labels:
++    step: "Unfree Software"
++packageChoice: free

--- a/pkgs/tools/misc/calamares/userjob.patch
+++ b/pkgs/tools/misc/calamares/userjob.patch
@@ -1,0 +1,31 @@
+diff --git a/src/modules/users/Config.cpp b/src/modules/users/Config.cpp
+index eedfd274d..0f3e78848 100644
+--- a/src/modules/users/Config.cpp
++++ b/src/modules/users/Config.cpp
+@@ -972,26 +972,11 @@ Config::createJobs() const
+ 
+     Calamares::Job* j;
+ 
+-    if ( !m_sudoersGroup.isEmpty() )
+-    {
+-        j = new SetupSudoJob( m_sudoersGroup, m_sudoStyle );
+-        jobs.append( Calamares::job_ptr( j ) );
+-    }
+-
+-    j = new SetupGroupsJob( this );
+-    jobs.append( Calamares::job_ptr( j ) );
+-
+-    j = new CreateUserJob( this );
+-    jobs.append( Calamares::job_ptr( j ) );
+-
+     j = new SetPasswordJob( loginName(), userPassword() );
+     jobs.append( Calamares::job_ptr( j ) );
+ 
+     j = new SetPasswordJob( "root", rootPassword() );
+     jobs.append( Calamares::job_ptr( j ) );
+ 
+-    j = new SetHostNameJob( this );
+-    jobs.append( Calamares::job_ptr( j ) );
+-
+     return jobs;
+ }

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, fetchurl, lib, makeWrapper
 , extra-cmake-modules, kdoctools, wrapGAppsHook, wrapQtAppsHook
-, kconfig, kcrash, kinit, kpmcore
+, kconfig, kcrash, kinit, kpmcore, polkit-qt
 , cryptsetup, lvm2, mdadm, smartmontools, systemdMinimal, util-linux
 , btrfs-progs, dosfstools, e2fsprogs, exfat, f2fs-tools, fatresize, hfsprogs
 , jfsutils, nilfs-utils, ntfs3g, reiser4progs, reiserfsprogs, udftools, xfsprogs, zfs
@@ -41,16 +41,16 @@ let
 in mkDerivation rec {
   pname = "partitionmanager";
   # NOTE: When changing this version, also change the version of `kpmcore`.
-  version = "4.2.0";
+  version = "22.04.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${version}/src/${pname}-${version}.tar.xz";
-    hash = "sha256-6Qlt1c47Eek6TkWWBzTyBZYJ1jfhtwsC9X5q5h6IhPg=";
+    url = "mirror://kde/stable/release-service/${version}/src/${pname}-${version}.tar.xz";
+    hash = "sha256-eChn3OkdLHC9pedDBBwszTeTj2l7ky2W79INqvjrkBo=";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook makeWrapper ];
 
-  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
+  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore polkit-qt ];
 
   postFixup = ''
     wrapProgram $out/bin/partitionmanager \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2855,6 +2855,7 @@ with pkgs;
     python = python3;
     boost = boost.override { enablePython = true; python = python3; };
   };
+  calamares-nixos-extensions = callPackage ../tools/misc/calamares-nixos-extensions {};
 
   calendar-cli = callPackage ../tools/networking/calendar-cli { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2855,6 +2855,7 @@ with pkgs;
     python = python3;
     boost = boost.override { enablePython = true; python = python3; };
   };
+  calamares-nixos = lowPrio (calamares.override { nixos-extensions = true; });
   calamares-nixos-extensions = callPackage ../tools/misc/calamares-nixos-extensions {};
 
   calendar-cli = callPackage ../tools/networking/calendar-cli { };


### PR DESCRIPTION
###### Motivation for this change

Currently, installing NixOS is rather difficult for new users, and the new experience when booting into one of the graphical ISOs is a blank GNOME or Plasma desktop with no super obvious indication of what to do next. Even though following the guide is not all that hard, I believe that integrating Calamares into the current NixOS isos would help make the installation experience better for new users.

Closes #15573
Closes #21662
Closes #100475

###### Things done

This draft PR contains 3 things:

1) Updates the calamares package to fix the functionality of multiple modules.
2) Adds a package for [calamares-nixos-extensions](https://github.com/vlinkz/calamares-nixos-extensions), which implements NixOS backend for some calamares modules 
3) Adds configuration for a GNOME and Plasma5 ISOs with calamares installer

The GNOME test ISO can be downloaded here [nixos-gnome-22.05pre375061.c777cdf5c56-x86_64-linux.iso](https://releases.nixos.org/nixos/unstable/nixos-22.05pre375061.c777cdf5c56/nixos-gnome-22.05pre375061.c777cdf5c56-x86_64-linux.iso)
The Plasma5 test ISO is also available here: [nixos-plasma5-22.05pre375061.c777cdf5c56-x86_64-linux.iso](https://releases.nixos.org/nixos/unstable/nixos-22.05pre375061.c777cdf5c56/nixos-plasma5-22.05pre375061.c777cdf5c56-x86_64-linux.iso).

All feedback is appreciated!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

# Current Issues
- ~~No way to enable unfree drivers~~
  - ~~Laptops with Broadcom wifi cards will not have it enabled after installation~~ 