### PR TITLE
ruby: specify RUBY_REVISION

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -17,7 +17,7 @@ let
   # Contains the ruby version heuristics
   rubyVersion = import ./ruby-version.nix { inherit lib; };
 
-  generic = { version, sha256 }: let
+  generic = { version, revision, sha256 }: let
     ver = version;
     tag = ver.gitTag;
     atLeast30 = lib.versionAtLeast ver.majMin "3.0";
@@ -118,6 +118,11 @@ let
           rm -rf $sourceRoot/{lib,test}/rubygems*
           cp -r ${rubygems}/lib/rubygems* $sourceRoot/lib
           cp -r ${rubygems}/test/rubygems $sourceRoot/test
+        '' + opString buildFromGit ''
+          cat <<EOF > $sourceRoot/revision.h
+          #define RUBY_REVISION "${lib.substring 0 8 revision}"
+          #define RUBY_FULL_REVISION "${revision}"
+          EOF
         '';
 
         postPatch = ''
@@ -255,6 +260,7 @@ let
 in {
   ruby_2_7 = generic {
     version = rubyVersion "2" "7" "5" "";
+    revision = "f69aeb83146be640995753667fdd6c6f157527f5";
     sha256 = {
       src = "1wc1hwmz4m6iqlmqag8liyld917p6a8dvnhnpd1v8d8jl80bjm97";
       git = "16565fyl7141hr6q6d74myhsz46lvgam8ifnacshi68vzibwjbbh";
@@ -263,6 +269,7 @@ in {
 
   ruby_3_0 = generic {
     version = rubyVersion "3" "0" "3" "";
+    revision = "3fb7d2cadc18472ec107b14234933b017a33c14d";
     sha256 = {
       src = "1b4j39zyyvdkf1ax2c6qfa40b4mxfkr87zghhw19fmnzn8f8d1im";
       git = "1q19w5i1jkfxn7qq6f9v9ngax9h52gxwijk7hp312dx6amwrkaim";
@@ -271,6 +278,7 @@ in {
 
   ruby_3_1 = generic {
     version = rubyVersion "3" "1" "1" "";
+    revision = "53f5fc4236a754ddf94b20dbb70ab63bd5109b18";
     sha256 = {
       src = "sha256-/m5Hgt6XRDl43bqLpL440iKqJNw+PwKmqOdwHA7rYZ0=";
       git = "sha256-76t/tGyK5nz7nvcRdHJTjjckU+Kv+/kbTMiNWJ93jU8=";

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -17,7 +17,7 @@ let
   # Contains the ruby version heuristics
   rubyVersion = import ./ruby-version.nix { inherit lib; };
 
-  generic = { version, revision, sha256 }: let
+  generic = { version, sha256 }: let
     ver = version;
     tag = ver.gitTag;
     atLeast30 = lib.versionAtLeast ver.majMin "3.0";
@@ -49,26 +49,19 @@ let
       , libiconv, libobjc, libunwind, Foundation
       , makeWrapper, buildRubyGem, defaultGemConfig
       , baseRuby ? buildPackages.ruby.override {
-          buildFromGit = false;
           useRailsExpress = false;
           docSupport = false;
           rubygemsSupport = false;
         }
-      , buildFromGit ? true
-      , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform || useRailsExpress || buildFromGit
+      , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform || useRailsExpress
       }:
       stdenv.mkDerivation rec {
         pname = "ruby";
         inherit version;
 
-        src = if buildFromGit then fetchFromGitHub {
-          owner  = "ruby";
-          repo   = "ruby";
-          rev    = tag;
-          sha256 = sha256.git;
-        } else fetchurl {
+        src = fetchurl {
           url = "https://cache.ruby-lang.org/pub/ruby/${ver.majMin}/ruby-${ver}.tar.gz";
-          sha256 = sha256.src;
+          inherit sha256;
         };
 
         # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
@@ -123,11 +116,6 @@ let
           rm -rf $sourceRoot/{lib,test}/rubygems*
           cp -r ${rubygems}/lib/rubygems* $sourceRoot/lib
           cp -r ${rubygems}/test/rubygems $sourceRoot/test
-        '' + opString buildFromGit ''
-          cat <<EOF > $sourceRoot/revision.h
-          #define RUBY_REVISION "${lib.substring 0 8 revision}"
-          #define RUBY_FULL_REVISION "${revision}"
-          EOF
         '';
 
         postPatch = ''
@@ -270,28 +258,16 @@ let
 in {
   ruby_2_7 = generic {
     version = rubyVersion "2" "7" "5" "";
-    revision = "f69aeb83146be640995753667fdd6c6f157527f5";
-    sha256 = {
-      src = "1wc1hwmz4m6iqlmqag8liyld917p6a8dvnhnpd1v8d8jl80bjm97";
-      git = "16565fyl7141hr6q6d74myhsz46lvgam8ifnacshi68vzibwjbbh";
-    };
+    sha256 = "1wc1hwmz4m6iqlmqag8liyld917p6a8dvnhnpd1v8d8jl80bjm97";
   };
 
   ruby_3_0 = generic {
     version = rubyVersion "3" "0" "3" "";
-    revision = "3fb7d2cadc18472ec107b14234933b017a33c14d";
-    sha256 = {
-      src = "1b4j39zyyvdkf1ax2c6qfa40b4mxfkr87zghhw19fmnzn8f8d1im";
-      git = "1q19w5i1jkfxn7qq6f9v9ngax9h52gxwijk7hp312dx6amwrkaim";
-    };
+    sha256 = "1b4j39zyyvdkf1ax2c6qfa40b4mxfkr87zghhw19fmnzn8f8d1im";
   };
 
   ruby_3_1 = generic {
     version = rubyVersion "3" "1" "1" "";
-    revision = "53f5fc4236a754ddf94b20dbb70ab63bd5109b18";
-    sha256 = {
-      src = "sha256-/m5Hgt6XRDl43bqLpL440iKqJNw+PwKmqOdwHA7rYZ0=";
-      git = "sha256-76t/tGyK5nz7nvcRdHJTjjckU+Kv+/kbTMiNWJ93jU8=";
-    };
+    sha256 = "sha256-/m5Hgt6XRDl43bqLpL440iKqJNw+PwKmqOdwHA7rYZ0=";
   };
 }

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -49,17 +49,19 @@ let
       , libiconv, libobjc, libunwind, Foundation
       , makeWrapper, buildRubyGem, defaultGemConfig
       , baseRuby ? buildPackages.ruby.override {
+          buildFromGit = false;
           useRailsExpress = false;
           docSupport = false;
           rubygemsSupport = false;
         }
-      , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform || useRailsExpress
+      , buildFromGit ? true
+      , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform || useRailsExpress || buildFromGit
       }:
       stdenv.mkDerivation rec {
         pname = "ruby";
         inherit version;
 
-        src = if useRailsExpress then fetchFromGitHub {
+        src = if buildFromGit then fetchFromGitHub {
           owner  = "ruby";
           repo   = "ruby";
           rev    = tag;
@@ -100,7 +102,7 @@ let
             patchLevel = ver.patchLevel;
           }).${ver.majMinTiny}
           ++ op (lib.versionOlder ver.majMin "3.1") ./do-not-regenerate-revision.h.patch
-          ++ op (atLeast30 && useRailsExpress) ./do-not-update-gems-baseruby.patch
+          ++ op (atLeast30 && useBaseRuby) ./do-not-update-gems-baseruby.patch
           # Ruby prior to 3.0 has a bug the installer (tools/rbinstall.rb) but
           # the resulting error was swallowed. Newer rubygems no longer swallows
           # this error. We upgrade rubygems when rubygemsSupport is enabled, so

--- a/pkgs/development/interpreters/ruby/rbinstall-new-rubygems-compat.patch
+++ b/pkgs/development/interpreters/ruby/rbinstall-new-rubygems-compat.patch
@@ -1,0 +1,87 @@
+From 8e85d27f9ccfe152fc1b891c19f125915a907493 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?V=C3=ADt=20Ondruch?= <vondruch@redhat.com>
+Date: Tue, 1 Oct 2019 12:03:33 +0200
+Subject: [PATCH] Use `Gem::Package` like object instead of monkey patching.
+
+1. This is similar to what RubyGems does and it is less magic [[1]].
+2. It avoids deprecated code paths in RubyGems [[2]].
+
+[1]: https://github.com/rubygems/rubygems/blob/92892bbc3adba86a90756c385433835f6761b8da/lib/rubygems/installer.rb#L151
+[2]: https://github.com/rubygems/rubygems/blob/92892bbc3adba86a90756c385433835f6761b8da/lib/rubygems/installer.rb#L187
+
+(cherry picked from commit e960ef6f18a25c637c54f00c75bb6c24f8ab55d0)
+---
+ tool/rbinstall.rb | 47 +++++++++++++++++++++++++++--------------------
+ 1 file changed, 27 insertions(+), 20 deletions(-)
+
+diff --git a/tool/rbinstall.rb b/tool/rbinstall.rb
+index 060390626f..28ae8c409a 100755
+--- a/tool/rbinstall.rb
++++ b/tool/rbinstall.rb
+@@ -710,28 +710,34 @@ def remove_prefix(prefix, string)
+     end
+   end
+ 
+-  class UnpackedInstaller < Gem::Installer
+-    module DirPackage
+-      def extract_files(destination_dir, pattern = "*")
+-        path = File.dirname(@gem.path)
+-        return if path == destination_dir
+-        File.chmod(0700, destination_dir)
+-        mode = pattern == "bin/*" ? $script_mode : $data_mode
+-        spec.files.each do |f|
+-          src = File.join(path, f)
+-          dest = File.join(without_destdir(destination_dir), f)
+-          makedirs(dest[/.*(?=\/)/m])
+-          install src, dest, :mode => mode
+-        end
+-        File.chmod($dir_mode, destination_dir)
++  class DirPackage
++    attr_reader :spec
++
++    attr_accessor :dir_mode
++    attr_accessor :prog_mode
++    attr_accessor :data_mode
++
++    def initialize(spec)
++      @spec = spec
++      @src_dir = File.dirname(@spec.loaded_from)
++    end
++
++    def extract_files(destination_dir, pattern = "*")
++      path = @src_dir
++      return if path == destination_dir
++      File.chmod(0700, destination_dir)
++      mode = pattern == "bin/*" ? $script_mode : $data_mode
++      spec.files.each do |f|
++        src = File.join(path, f)
++        dest = File.join(without_destdir(destination_dir), f)
++        makedirs(dest[/.*(?=\/)/m])
++        install src, dest, :mode => mode
+       end
++      File.chmod($dir_mode, destination_dir)
+     end
++  end
+ 
+-    def initialize(spec, *options)
+-      super(spec.loaded_from, *options)
+-      @package.extend(DirPackage).spec = spec
+-    end
+-
++  class UnpackedInstaller < Gem::Installer
+     def write_cache_file
+     end
+ 
+@@ -890,7 +896,8 @@ def install_default_gem(dir, srcdir)
+     if File.directory?(ext = "#{gem_ext_dir}/#{spec.full_name}")
+       spec.extensions[0] ||= "-"
+     end
+-    ins = RbInstall::UnpackedInstaller.new(spec, options)
++    package = RbInstall::DirPackage.new spec
++    ins = RbInstall::UnpackedInstaller.new(package, options)
+     puts "#{INDENT}#{spec.name} #{spec.version}"
+     ins.install
+     File.chmod($data_mode, File.join(install_dir, "specifications", "#{spec.full_name}.gemspec"))
+-- 
+2.35.1
+


### PR DESCRIPTION
###### Motivation for this change

Correct the value of `RUBY_REVISION` which is currently defaulting to head `"HEAD"`, to be compatible with [bootsnap's version guards](https://github.com/Shopify/bootsnap/pull/387/files#diff-d1a11f96e76086aab1b9cb2f0f05224d3b2f8fa6e94571d05862c48e54da68a2R11).

```
# Before
❯ nix shell nixpkgs#ruby -c ruby -e 'puts RUBY_REVISION'
HEAD

# After
❯ nix shell nixpkgs#ruby -c ruby -e 'puts RUBY_REVISION'
f69aeb83146be640995753667fdd6c6f157527f5
```

The current build for ruby supports building from git sources and from the upstream tarball. I don't think this is justified, so I simplified to only supporting the upstream tarball, which includes a pregenerated value for `RUBY_REVISION` . The tarball includes a set of gems ("Bundled gems") to be installed by default, which is a change from the current ruby build in nixpkgs.

---

Current Results

| Platform       | Version | Base    | With Rails Express      |
| -------------- | ------- | ------- | ----------------------- |
| aarch64-darwin | 2.7     | ✅      | ✅                      |
| aarch64-darwin | 3.0     | ✅      | ✅                      |
| aarch64-darwin | 3.1     | ✅      | ✅                      |
| x86_64-linux   | 2.7     | ✅      | ✅                      |
| x86_64-linux   | 3.0     | ✅      | ✅                      |
| x86_64-linux   | 3.1     | ✅      | ✅                      |
| x86_64-linux -> aarch64-linux (cross)  | 2.7     | ✅      | ✅                      |
| x86_64-linux -> aarch64-linux (cross)  | 3.0     | ✅      | ✅                      |
| x86_64-linux -> aarch64-linux (cross)  | 3.1     | ❌      | ❌                      |

<details>

<summary>Failure details</summary>


### x86_64-linux -> aarch64-linux, 3.1
```
installing bundled gems:            /nix/store/9gvjx5v5hrmwhy3ja6d87x7fn4d8shg3-ruby-aarch64-unknown-linux-gnu-3.1.0/lib/ruby/gems/3.1.0
                                    minitest 5.15.0
                                    power_assert 2.0.1
                                    rake 13.0.6
                                    test-unit 3.5.3
                                    rexml 3.2.5
                                    rss 0.2.9
                                    net-ftp 0.1.3
                                    net-imap 0.2.2
                                    net-pop 0.1.1
                                    net-smtp 0.3.1
                                    matrix 0.4.2
                                    prime 0.1.2
                                    rbs 2.0.0
Building native extensions. This could take a while...
Traceback (most recent call last):
        18: from ./tool/rbinstall.rb:1124:in `<main>'
        17: from ./tool/rbinstall.rb:1124:in `each'
        16: from ./tool/rbinstall.rb:1127:in `block in <main>'
        15: from ./tool/rbinstall.rb:1043:in `block in <main>'
        14: from ./tool/rbinstall.rb:1043:in `foreach'
        13: from ./tool/rbinstall.rb:1068:in `block (2 levels) in <main>'
        12: from ./tool/rbinstall.rb:899:in `install'
        11: from ./tool/rbinstall.rb:713:in `no_write'
        10: from ./tool/rbinstall.rb:899:in `block in install'
         9: from /build/ruby-3.1.0/lib/rubygems/installer.rb:312:in `install'
         8: from /build/ruby-3.1.0/lib/rubygems/installer.rb:837:in `build_extensions'
         7: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:189:in `build_extensions'
         6: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:189:in `each'
         5: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:192:in `block in build_extensions'
         4: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:158:in `build_extension'
         3: from /build/ruby-3.1.0/lib/rubygems/ext/ext_conf_builder.rb:26:in `build'
         2: from /build/ruby-3.1.0/lib/tempfile.rb:317:in `open'
         1: from /build/ruby-3.1.0/lib/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
/build/ruby-3.1.0/lib/rubygems/ext/builder.rb:92:in `run': extconf failed, exit code 1 (Gem::InstallError)
        18: from ./tool/rbinstall.rb:1124:in `<main>'
        17: from ./tool/rbinstall.rb:1124:in `each'
        16: from ./tool/rbinstall.rb:1127:in `block in <main>'
        15: from ./tool/rbinstall.rb:1043:in `block in <main>'
        14: from ./tool/rbinstall.rb:1043:in `foreach'
        13: from ./tool/rbinstall.rb:1068:in `block (2 levels) in <main>'
        12: from ./tool/rbinstall.rb:899:in `install'
        11: from ./tool/rbinstall.rb:713:in `no_write'
        10: from ./tool/rbinstall.rb:899:in `block in install'
         9: from /build/ruby-3.1.0/lib/rubygems/installer.rb:312:in `install'
         8: from /build/ruby-3.1.0/lib/rubygems/installer.rb:837:in `build_extensions'
         7: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:189:in `build_extensions'
         6: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:189:in `each'
         5: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:192:in `block in build_extensions'
         4: from /build/ruby-3.1.0/lib/rubygems/ext/builder.rb:158:in `build_extension'
         3: from /build/ruby-3.1.0/lib/rubygems/ext/ext_conf_builder.rb:26:in `build'
         2: from /build/ruby-3.1.0/lib/tempfile.rb:317:in `open'
         1: from /build/ruby-3.1.0/lib/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
/build/ruby-3.1.0/lib/rubygems/ext/builder.rb:92:in `run': ERROR: Failed to build gem native extension. (Gem::Ext::BuildError)

    current directory: /nix/store/9gvjx5v5hrmwhy3ja6d87x7fn4d8shg3-ruby-aarch64-unknown-linux-gnu-3.1.0/lib/ruby/gems/3.1.0/gems/rbs-2.0.0/ext/rbs_extension
/nix/store/z3mw099xvy75a65a3gc4lcc067lfiva8-ruby-2.7.5/bin/ruby --disable\\=gems -I/build/ruby-3.1.0 -I /build/ruby-3.1.0/lib -r ./siteconf20220314-35968-n2awmt.rb extconf.rb
/build/ruby-3.1.0/rbconfig.rb:13:in `<module:RbConfig>': ruby lib version (3.1.0) doesn't match executable version (2.7.5) (RuntimeError)
        from /build/ruby-3.1.0/rbconfig.rb:11:in `<top (required)>'
        from /nix/store/9gvjx5v5hrmwhy3ja6d87x7fn4d8shg3-ruby-aarch64-unknown-linux-gnu-3.1.0/lib/ruby/gems/3.1.0/gems/rbs-2.0.0/ext/rbs_extension/siteconf20220314-35968-n2awmt.rb:1:in `require'
        from /nix/store/9gvjx5v5hrmwhy3ja6d87x7fn4d8shg3-ruby-aarch64-unknown-linux-gnu-3.1.0/lib/ruby/gems/3.1.0/gems/rbs-2.0.0/ext/rbs_extension/siteconf20220314-35968-n2awmt.rb:1:in `<top (required)>'
        from extconf.rb:in `require'

extconf failed, exit code 1
```


</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
