### PR TITLE
[DRAFT] nixos/opensnitch: Add option to configure rules

### DIFF
--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -5,10 +5,13 @@ with lib;
 let
   cfg = config.services.opensnitch;
   format = pkgs.formats.json {};
+  json = pkgs.formats.json {};
 in {
+
   options = {
     services.opensnitch = {
       enable = mkEnableOption (lib.mdDoc "Opensnitch application firewall");
+
       settings = mkOption {
         type = types.submodule {
           freeformType = format.type;
@@ -105,6 +108,193 @@ in {
           for details on supported values.
         '';
       };
+
+      # Values follow upstream default
+      # https://github.com/evilsocket/opensnitch/blob/master/daemon/default-config.json
+      # Documentation: https://github.com/evilsocket/opensnitch/wiki/Configurations
+      config = {
+
+        Server = {
+
+          Address = mkOption {
+            type = types.str;
+            default = "unix:///tmp/osui.sock";
+            description = ''
+              Unix socket path (unix:///tmp/osui.sock, the "unix:///" part is
+              mandatory) or TCP socket (192.168.1.100:50051).
+            '';
+          };
+
+          LogFile = mkOption {
+            type = types.path;
+            default = "/var/log/opensnitchd.log";
+            description = ''
+              File to write logs to (use /dev/stdout to write logs to standard
+              output).
+            '';
+          };
+
+        };
+
+        DefaultAction = mkOption {
+          type = types.enum [ "allow" "deny" ];
+          default = "deny";
+          description = ''
+            Default action whether to block or allow application network
+            access.
+          '';
+        };
+
+        DefaultDuration = mkOption {
+          type = types.enum [
+            "once" "always" "until restart" "30s" "5m" "15m" "30m" "1h"
+          ];
+          default = "once";
+          description = ''
+            Default duration of firewall rule.
+          '';
+        };
+
+        InterceptUnknown = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            Wheter to intercept spare connections.
+          '';
+        };
+
+        ProcMonitorMethod = mkOption {
+          type = types.enum [ "ebpf" "proc" "ftrace" "audit" ];
+          default = "proc";
+          description = ''
+            Which process monitoring method to use.
+          '';
+        };
+
+        LogLevel = mkOption {
+          type = types.enum [ 0 1 2 3 4 ];
+          default = 1;
+          description = ''
+            Default log level from 0 to 4 (debug, info, important, warning,
+            error).
+          '';
+        };
+
+        Firewall = mkOption {
+          type = types.enum [ "iptables" "nftables" ];
+          default = "nftables";
+          description = ''
+            Which firewall backend to use.
+          '';
+        };
+
+        Stats = {
+
+          MaxEvents = mkOption {
+            type = types.int;
+            default = 150;
+            description = ''
+              Max events to send to the GUI.
+            '';
+          };
+
+          MaxStats = mkOption {
+            type = types.int;
+            default = 25;
+            description = ''
+              Max stats per item to keep in backlog.
+            '';
+          };
+
+        };
+
+      };
+
+      rules = mkOption {
+        type = types.attrsOf (types.either types.path (types.submodule {
+          options = {
+
+            precedence = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Sets if a rule take precedence.";
+            };
+
+            action = mkOption {
+              type = types.enum [ "allow" "deny" ];
+              default = "allow";
+              description = "Whether to allow or deny network access.";
+            };
+
+            duration = mkOption {
+              type = types.enum [
+                "once" "always" "until restart" "30s" "5m" "15m" "30m" "1h"
+              ];
+              default = "always";
+              description = "Duration of firewall rule.";
+            };
+
+            operator = {
+
+              type = mkOption {
+                type = types.enum [ "simple" "regexp" ];
+                default = "simple";
+                description = ''
+                  Can be simple, in which case a simple == comparison will be
+                  performed, or regexp if the data field is a regular
+                  expression to match.
+                '';
+              };
+
+              operand = mkOption {
+                type = types.enum [
+                  "true" "process.path" "process.id" "process.command"
+                  "provess.env.ENV_VAR_NAME" "user.id" "protocol" "dest.ip"
+                  "dest.host" "dest.network" "dest.port" "lists.domains"
+                  "lists.domains_regexp" "lists.ips" "lists.nets" ];
+                default = "process.path";
+                description = "What element of the connection to compare.";
+              };
+
+              data = mkOption {
+                type = types.str;
+                description = ''
+                  The data to compare the operand to, can be a regular
+                  expression if type is regexp, or a path to a directory with
+                  list of IPs/domains in the case of lists.
+                '';
+                example = literalExpression ''"''${lib.getBin pkgs.firefox}/bin/firefox"'';
+              };
+
+            };
+
+          };
+        }));
+        default = {};
+        example = literalExpression ''
+          {
+            firefox = {
+              action = "allow";
+              duration = "until restart";
+              operator = {
+                data = "''${lib.getBin pkgs.firefox}/bin/firefox";
+              };
+            };
+            mpv = {
+              action = "deny";
+              duration = "always";
+              operator = {
+                executable = "''${lib.getBin pkgs.mpv}/bin/mpv";
+              };
+            };
+          }
+        '';
+        description = ''
+          Define set of rules for applications, whether to allow or deny
+          network acces for them.
+        '';
+      };
+
     };
   };
 
@@ -115,11 +305,22 @@ in {
 
     systemd = {
       packages = [ pkgs.opensnitch ];
-      services.opensnitchd.wantedBy = [ "multi-user.target" ];
+      services.opensnitchd = {
+        restartTriggers = [ config.environment.etc."opensnitchd/default-config.json".source ];
+        wantedBy = [ "multi-user.target" ];
+      };
+    };
+
+    environment.etc."opensnitchd/default-config.json" = {
+      source = json.generate "default-config.json" cfg.config;
     };
 
     environment.etc."opensnitchd/default-config.json".source = format.generate "default-config.json" cfg.settings;
+    # Upstream documentation on rule file format
+    # https://github.com/evilsocket/opensnitch/wiki/Rules
 
   };
+
+  meta.maintainers = with maintainers; [ onny ];
 }
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds the ability to pre-define rules for OpenSnitch application firewall like this:
```
services.opensnitch = {
  enable = true;
  rules = {
    firefox = {
      action = "allow";
      duration = "until restart";
      operator = {
        data = "''${lib.getBin pkgs.firefox}/bin/firefox";
      };
    };
    mpv = {
      action = "deny";
      duration = "always";
      operator = {
        data = "''${lib.getBin pkgs.mpv}/bin/mpv";
      };
    };
  };
};
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
