### PR TITLE
nixos/slurm: rewrite module to RFC 0042 style settings

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2305.section.xml
@@ -150,6 +150,55 @@
       </listitem>
       <listitem>
         <para>
+          The NixOS module for
+          <link linkend="opt-services.slurm.enableStools">Slurm</link>
+          has been converted to a
+          <link xlink:href="https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md">RFC
+          0042</link> conforming configuration. All settings related to
+          <literal>slurm.conf</literal>,
+          <literal>cgroups.conf</literal>, and
+          <literal>slurmdbd.conf</literal> are now in
+          <link linkend="opt-services.slurm.settings">services.slurm.settings</link>,
+          <link linkend="opt-services.slurm.settingsCgroup">services.slurm.settingsCgroup</link>,
+          and
+          <link linkend="opt-services.slurm.dbdserver.settings">services.slurm.dbdserver.settings</link>
+          respectively. The following example outlines how an existing
+          configuration can be re-written. Before NixOS 23.05:
+        </para>
+        <programlisting language="nix">
+  services.slurm = {
+    controlMachine = &quot;control&quot;;
+    nodeName = [ &quot;node[1-3] CPUs=1 State=UNKNOWN&quot; ];
+    partitionName = [ &quot;debug Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP&quot; ];
+    extraConfig = ''
+      AccountingStorageHost=dbd
+      AccountingStorageType=accounting_storage/slurmdbd
+    '';
+  };
+</programlisting>
+        <para>
+          From NixOS 23.05 onwards:
+        </para>
+        <programlisting language="nix">
+  services.slurm.settings = {
+    SlurmctldHost = &quot;control&quot;;
+    nodeName.&quot;node[1-3]&quot; = {
+      CPUs = 1;
+      State = &quot;UNKNOWN&quot;;
+    };
+    partitionName.debug = {
+      Nodes = &quot;node[1-3]&quot;;
+      Default = true;
+      MaxTime = &quot;INFINITE&quot;;
+      State = &quot;UP&quot;;
+    };
+    AccountingStorageHost = &quot;dbd&quot;;
+    AccountingStorageType = &quot;accounting_storage/slurmdbd&quot;;
+  };
+</programlisting>
+      </listitem>
+      <listitem>
+        <para>
           The EC2 image module previously detected and automatically
           mounted ext3-formatted instance store devices and partitions
           in stage-1 (initramfs), storing <literal>/tmp</literal> on the

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -45,6 +45,40 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The Nginx module now validates the syntax of config files at build time. For more complex configurations (using `include` with out-of-store files notably) you may need to disable this check by setting [services.nginx.validateConfig](#opt-services.nginx.validateConfig) to `false`.
 
+- The NixOS module for [Slurm](#opt-services.slurm.enableStools) has been converted to a [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) conforming configuration. All settings related to `slurm.conf`, `cgroups.conf`, and `slurmdbd.conf` are now in [services.slurm.settings](#opt-services.slurm.settings),
+[services.slurm.settingsCgroup](#opt-services.slurm.settingsCgroup), and [services.slurm.dbdserver.settings](#opt-services.slurm.dbdserver.settings) respectively.
+  The following example outlines how an existing configuration can be re-written.
+  Before NixOS 23.05:
+  ```nix
+    services.slurm = {
+      controlMachine = "control";
+      nodeName = [ "node[1-3] CPUs=1 State=UNKNOWN" ];
+      partitionName = [ "debug Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP" ];
+      extraConfig = ''
+        AccountingStorageHost=dbd
+        AccountingStorageType=accounting_storage/slurmdbd
+      '';
+    };
+  ```
+  From NixOS 23.05 onwards:
+  ```nix
+    services.slurm.settings = {
+      SlurmctldHost = "control";
+      nodeName."node[1-3]" = {
+        CPUs = 1;
+        State = "UNKNOWN";
+      };
+      partitionName.debug = {
+        Nodes = "node[1-3]";
+        Default = true;
+        MaxTime = "INFINITE";
+        State = "UP";
+      };
+      AccountingStorageHost = "dbd";
+      AccountingStorageType = "accounting_storage/slurmdbd";
+    };
+  ```
+
 - The EC2 image module previously detected and automatically mounted ext3-formatted instance store devices and partitions in stage-1 (initramfs), storing `/tmp` on the first discovered device. This behaviour, which only catered to very specific use cases and could not be disabled, has been removed. Users relying on this should provide their own implementation, and probably use ext4 and perform the mount in stage-2.
 
 - The EC2 image module previously detected and activated swap-formatted instance store devices and partitions in stage-1 (initramfs). This behaviour has been removed. Users relying on this should provide their own implementation.

--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -227,15 +227,36 @@ in {
 
   };
 
-  imports = [
-    (mkRemovedOptionModule [ "services" "slurm" "dbdserver" "storagePass" ] ''
-      This option has been removed so that the database password is not exposed via the nix store.
-      Use services.slurm.dbdserver.storagePassFile to provide the database password.
+  imports = let
+    removeMessage = "This option has been removed. Please have a look at the 23.05 release notes.";
+    in [
+    (mkRemovedOptionModule [ "services" "slurm" "nodeName" ] ''
+      ${removedMessage}
+      The nodes are now defined in services.slurm.settings.
     '')
-    (mkRemovedOptionModule [ "services" "slurm" "dbdserver" "configFile" ] ''
-      This option has been removed. Use services.slurm.dbdserver.storagePassFile
-      and services.slurm.dbdserver.extraConfig instead.
+    (mkRemovedOptionModule [ "services" "slurm" "partitionName" ] ''
+      ${removedMessage}
+      The partitions are now defined in services.slurm.settings.
     '')
+    (mkRemovedOptionModule [ "services" "slurm" "extraConfig" ] ''
+      ${removedMessage}
+      The configuration for slurm.conf is now defined in services.slurm.settings.
+    '')
+    (mkRemovedOptionModule [ "services" "slurm" "extraCgroupConfig" ] ''
+      ${removedMessage}
+      The configuration for cgroup.conf is now defined in services.slurm.settingsCgroup.
+    '')
+    (mkRemovedOptionModule [ "services" "slurm" "dbdserver" "extraConfig" ] ''
+      ${removedMessage}
+      The configuration for dbdserver.conf is now defined in services.slurm.dbdserver.settings.
+    '')
+    (mkRemovedOptionModule [ "services" "slurm" "controlAddr" ] ''
+     This option is deprecated. See slurm.conf manual.
+    '')
+    (mkRenamedOptionModule [ "services" "slurm" "stateSaveLocation" ] [ "services" "slurm" "settings" "StateSaveLocation" ] )
+    (mkRenamedOptionModule [ "services" "slurm" "procTrackType" ] [ "services" "slurm" "settings" "ProcTrackType" ] )
+    (mkRenamedOptionModule [ "services" "slurm" "controlMachine" ] [ "services" "slurm" "settings" "SlurmctldHost" ] )
+    (mkRenamedOptionModule [ "services" "slurm" "clusterName" ] [ "services" "slurm" "settings" "ClusterName" ] )
   ];
 
   ###### implementation

--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -2,13 +2,21 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
 let
     slurmconfig = {
       services.slurm = {
-        controlMachine = "control";
-        nodeName = [ "node[1-3] CPUs=1 State=UNKNOWN" ];
-        partitionName = [ "debug Nodes=node[1-3] Default=YES MaxTime=INFINITE State=UP" ];
-        extraConfig = ''
-          AccountingStorageHost=dbd
-          AccountingStorageType=accounting_storage/slurmdbd
-        '';
+        settings = {
+          SlurmctldHost = "control";
+          nodeName."node[1-3]" = {
+            CPUs = 1;
+            State = "UNKNOWN";
+          };
+          partitionName.debug = {
+            Nodes = "node[1-3]";
+            Default = true;
+            MaxTime = "INFINITE";
+            State = "UP";
+          };
+          AccountingStorageHost = "dbd";
+          AccountingStorageType = "accounting_storage/slurmdbd";
+        };
       };
       environment.systemPackages = [ mpitest ];
       networking.firewall.enable = false;


### PR DESCRIPTION
###### Motivation for this change
Use free-form `settings` following [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) to generate config files. This should make the module more flexible, but it also is a breaking change, which requires users to adapt their config. In either case, it should make the module easier to maintain.

See also https://github.com/NixOS/nixpkgs/issues/144575
###### Things done
* Added a note to the release notes
* Re-write of module to use settings for `slurm.conf`, `slurmdbd.cong`, and `cgroup.conf`
* Adapted the slurm test.
* Remove and older "removed" options message
* Removed the Slurm tools wrapper, which fed `SLURM_CONF` to all binaries. It is now exported directly as a system-wide environment variable.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
