### PR TITLE
witness: 0.1.1 -> 0.1.6

### DIFF
--- a/pkgs/tools/security/witness/default.nix
+++ b/pkgs/tools/security/witness/default.nix
@@ -1,25 +1,57 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "witness";
-  version = "0.1.1";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "testifysec";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-NnDsiDUTCdjsHVA/mHnB8WRnvwFTzETkWUOd7IgMIWE=";
+    sha256 = "sha256-/35hIA6Wm/F5hwyLZbt4JXpwWISWbzVAWrX29r6pejY=";
   };
 
-  vendorSha256 = "sha256-zkLparWJsuqrhOQxxV37dBqt6fwpSinTO+paJkbl+sM=";
+  vendorSha256 = "sha256-vXDsHHJknw9hsHx1mJA2c0CWwFbRXjCjitNWPh6V4yw=";
+
+  nativeBuildInputs = [ installShellFiles ];
 
   # We only want the witness binary, not the helper utilities for generating docs.
   subPackages = [ "cmd/witness" ];
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/testifysec/witness/cmd/witness/cmd.Version=v${version}"
+  ];
+
+  # Feed in all tests for testing
+  # This is because subPackages above limits what is built to just what we
+  # want but also limits the tests
+  preCheck = ''
+    unset subPackages
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd witness \
+      --bash <($out/bin/witness completion bash) \
+      --fish <($out/bin/witness completion fish) \
+      --zsh <($out/bin/witness completion zsh)
+  '';
+
   meta = with lib; {
     description = "A pluggable framework for software supply chain security. Witness prevents tampering of build materials and verifies the integrity of the build process from source to target";
+    longDescription = ''
+      Witness prevents tampering of build materials and verifies the integrity
+      of the build process from source to target. It works by wrapping commands
+      executed in a continuous integration process. Its attestation system is
+      pluggable and offers support out of the box for most major CI and
+      infrastructure providers. Verification of Witness metadata and a secure
+      PKI distribution system will mitigate against many software supply chain
+      attack vectors and can be used as a framework for automated governance.
+    '';
     homepage = "https://github.com/testifysec/witness";
+    changelog = "https://github.com/testifysec/witness/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ fkautz ];
+    maintainers = with maintainers; [ fkautz jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump witness to `0.1.6`

also:
- added completions
- minified the build and added version
- enabled tests
- added longDescription
- added changelog
- added myself as a maintainer



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
