### PR TITLE
appstream: 0.14.4 → 0.15.2

### DIFF
--- a/nixos/tests/installed-tests/appstream-qt.nix
+++ b/nixos/tests/installed-tests/appstream-qt.nix
@@ -1,0 +1,9 @@
+{ pkgs, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  tested = pkgs.libsForQt5.appstream-qt;
+
+  testConfig = {
+    appstream.enable = true;
+  };
+}

--- a/nixos/tests/installed-tests/appstream.nix
+++ b/nixos/tests/installed-tests/appstream.nix
@@ -1,0 +1,9 @@
+{ pkgs, makeInstalledTest, ... }:
+
+makeInstalledTest {
+  tested = pkgs.appstream;
+
+  testConfig = {
+    appstream.enable = true;
+  };
+}

--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -85,6 +85,7 @@ in
 
 {
   appstream = callInstalledTest ./appstream.nix {};
+  appstream-qt = callInstalledTest ./appstream-qt.nix {};
   colord = callInstalledTest ./colord.nix {};
   flatpak = callInstalledTest ./flatpak.nix {};
   flatpak-builder = callInstalledTest ./flatpak-builder.nix {};

--- a/nixos/tests/installed-tests/default.nix
+++ b/nixos/tests/installed-tests/default.nix
@@ -84,6 +84,7 @@ let
 in
 
 {
+  appstream = callInstalledTest ./appstream.nix {};
   colord = callInstalledTest ./colord.nix {};
   flatpak = callInstalledTest ./flatpak.nix {};
   flatpak-builder = callInstalledTest ./flatpak-builder.nix {};

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -28,6 +28,9 @@
 stdenv.mkDerivation rec {
   pname = "appstream";
   version = "0.15.2";
+  # When bumping this package, please also check whether
+  # fix-build-for-qt-olderthan-514.patch still applies by
+  # building libsForQt512.appstream-qt.
 
   outputs = [ "out" "dev" "installedTests" ];
 

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -14,19 +14,19 @@
 , glib
 , xapian
 , libxml2
+, libxmlb
 , libyaml
 , gobject-introspection
 , pcre
 , itstool
 , gperf
 , vala
-, lmdb
 , curl
 }:
 
 stdenv.mkDerivation rec {
   pname = "appstream";
-  version = "0.14.4";
+  version = "0.15.2";
 
   outputs = [ "out" "dev" ];
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     owner = "ximion";
     repo = "appstream";
     rev = "v${version}";
-    sha256 = "sha256-DJXCw50f+8c58bJw6xx0ECfkc9/KcWaeA+ne2zmTyhg=";
+    sha256 = "sha256-/JZ49wjtcInbGUOVVjevVSrLCHcA60FMT165rhfb78Q=";
   };
 
   patches = [
@@ -65,9 +65,9 @@ stdenv.mkDerivation rec {
     glib
     xapian
     libxml2
+    libxmlb
     libyaml
     gperf
-    lmdb
     curl
   ];
 
@@ -88,5 +88,5 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21Plus;
     platforms = platforms.unix;
- };
+  };
 }

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -22,13 +22,14 @@
 , gperf
 , vala
 , curl
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "appstream";
   version = "0.15.2";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "installedTests" ];
 
   src = fetchFromGitHub {
     owner = "ximion";
@@ -43,6 +44,9 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       libstemmer_includedir = "${lib.getDev libstemmer}/include";
     })
+
+    # Allow installing installed tests to a separate output.
+    ./installed-tests-path.patch
   ];
 
   nativeBuildInputs = [
@@ -75,7 +79,14 @@ stdenv.mkDerivation rec {
     "-Dapidocs=false"
     "-Ddocs=false"
     "-Dvapi=true"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
   ];
+
+  passthru = {
+    tests = {
+      installed-tests = nixosTests.installed-tests.appstream;
+    };
+  };
 
   meta = with lib; {
     description = "Software metadata handling library";

--- a/pkgs/development/libraries/appstream/fix-build-for-qt-olderthan-514.patch
+++ b/pkgs/development/libraries/appstream/fix-build-for-qt-olderthan-514.patch
@@ -1,0 +1,43 @@
+diff --git a/qt/component.h b/qt/component.h
+index 47abd1f3..74de943c 100644
+--- a/qt/component.h
++++ b/qt/component.h
+@@ -90,7 +90,7 @@ class APPSTREAMQT_EXPORT Component {
+             UrlKindContact,
+ 
+             // deprecated
+-            UrlTranslate   [[deprecated]] = UrlKindTranslate,
++            UrlTranslate    = UrlKindTranslate,
+         };
+         Q_ENUM(UrlKind)
+ 
+diff --git a/qt/pool.h b/qt/pool.h
+index b59829b7..5237f613 100644
+--- a/qt/pool.h
++++ b/qt/pool.h
+@@ -70,9 +70,9 @@ public:
+         FlagMonitor            = 1 << 7,
+ 
+         // deprecated
+-        FlagReadCollection   [[deprecated]] = FlagLoadOsCollection,
+-        FlagReadMetainfo     [[deprecated]] = FlagLoadOsMetainfo,
+-        FlagReadDesktopFiles [[deprecated]] = FlagLoadOsDesktopFiles,
++        FlagReadCollection    = FlagLoadOsCollection,
++        FlagReadMetainfo      = FlagLoadOsMetainfo,
++        FlagReadDesktopFiles  = FlagLoadOsDesktopFiles,
+     };
+ 
+     /**
+@@ -84,9 +84,9 @@ public:
+      * Flags on how caching should be used.
+      **/
+     enum CacheFlags {
+-        CacheFlagNone      [[deprecated]] = 0,
+-        CacheFlagUseUser   [[deprecated]] = 1 << 0,
+-        CacheFlagUseSystem [[deprecated]] = 1 << 1,
++        CacheFlagNone       = 0,
++        CacheFlagUseUser    = 1 << 0,
++        CacheFlagUseSystem  = 1 << 1,
+     };
+ 
+     /**

--- a/pkgs/development/libraries/appstream/fix-paths.patch
+++ b/pkgs/development/libraries/appstream/fix-paths.patch
@@ -1,18 +1,21 @@
 diff --git a/data/meson.build b/data/meson.build
-index 1eb3dfb0..623b66ec 100644
+index 53f31cb4..90f40e77 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -26,4 +26,4 @@ i18n.merge_file (
+@@ -68,7 +68,7 @@ test('as-validate_metainfo.cli',
  )
  
- install_data ('appstream.conf',
--              install_dir: get_option('sysconfdir'))
-+              install_dir: get_option('prefix') / 'etc')
+ install_data('appstream.conf',
+-             install_dir: get_option('sysconfdir'))
++             install_dir: get_option('prefix') / 'etc')
+ 
+ if get_option('compose')
+     ascompose_metainfo = 'org.freedesktop.appstream.compose.metainfo.xml'
 diff --git a/meson.build b/meson.build
-index dc1fb1a5..5ee03b73 100644
+index 2efe86b7..9dc79e28 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -108,12 +108,12 @@ if get_option ('gir')
+@@ -107,12 +107,12 @@ if get_option ('gir')
      dependency('gobject-introspection-1.0', version: '>=1.56')
  endif
  

--- a/pkgs/development/libraries/appstream/installed-tests-path.patch
+++ b/pkgs/development/libraries/appstream/installed-tests-path.patch
@@ -1,0 +1,27 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index 8dd8e0c7..e2a30b06 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -44,6 +44,11 @@ option('install-docs',
+        value : true,
+        description : 'Install documentation for API and specification'
+ )
++option('installed_test_prefix',
++       type : 'string',
++       value : '',
++       description : 'Prefix for installed tests'
++)
+ 
+ #
+ # For development
+diff --git a/tests/installed-tests/meson.build b/tests/installed-tests/meson.build
+index 405820ce..f592a753 100644
+--- a/tests/installed-tests/meson.build
++++ b/tests/installed-tests/meson.build
+@@ -10,5 +10,5 @@ configure_file(
+     output : 'metainfo-validate.test',
+     configuration : itconf,
+     install: true,
+-    install_dir: join_paths('share', 'installed-tests', 'appstream'),
++    install_dir: join_paths(get_option('installed_test_prefix'), 'share', 'installed-tests', 'appstream'),
+ )

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, appstream, qtbase, qttools }:
+{ mkDerivation, appstream, qtbase, qttools, nixosTests }:
 
 # TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
 
@@ -6,7 +6,7 @@ mkDerivation {
   pname = "appstream-qt";
   inherit (appstream) version src patches;
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "installedTests" ];
 
   buildInputs = appstream.buildInputs ++ [ appstream qtbase ];
 
@@ -18,6 +18,12 @@ mkDerivation {
     sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \
       -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${PACKAGE_PREFIX_DIR}@$dev@"
   '';
+
+  passthru = appstream.passthru // {
+    tests = {
+      installed-tests = nixosTests.installed-tests.appstream-qt;
+    };
+  };
 
   meta = appstream.meta // {
     description = "Software metadata handling library - Qt";

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -1,10 +1,10 @@
-{ mkDerivation, appstream, qtbase, qttools, nixosTests }:
+{ lib, mkDerivation, appstream, qtbase, qttools, nixosTests }:
 
 # TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
 
 mkDerivation {
   pname = "appstream-qt";
-  inherit (appstream) version src patches;
+  inherit (appstream) version src;
 
   outputs = [ "out" "dev" "installedTests" ];
 
@@ -13,6 +13,15 @@ mkDerivation {
   nativeBuildInputs = appstream.nativeBuildInputs ++ [ qttools ];
 
   mesonFlags = appstream.mesonFlags ++ [ "-Dqt=true" ];
+
+  patches = (appstream.patches or []) ++ lib.optionals (lib.versionOlder qtbase.version "5.14") [
+    # Fix darwin build for libsForQt5.appstream-qt
+    # Old Qt moc doesn't know about fancy C++14 features
+    # ../qt/component.h:93: Parse error at "UrlTranslate"
+    # Remove both this patch and related comment in default.nix
+    # once Qt 5.14 or later becomes default on darwin
+    ./fix-build-for-qt-olderthan-514.patch
+  ];
 
   postFixup = ''
     sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \

--- a/pkgs/development/libraries/libxmlb/default.nix
+++ b/pkgs/development/libraries/libxmlb/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , docbook_xml_dtd_43
 , docbook_xsl
 , glib
@@ -30,6 +31,13 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./installed-tests-path.patch
+    # Fix darwin build, can be removed on next release
+    # `--version-script` isn't supported by the macOS linker
+    # https://github.com/hughsie/libxmlb/pull/119
+    (fetchpatch {
+      url = "https://github.com/hughsie/libxmlb/commit/d83aac5bd78cfbbfa2ecd428ff54b811071dfe4d.patch";
+      sha256 = "sha256-UNRMbyNzdxfTZ8xV6J8a622hPnr3mowooP1q8Dg19yw=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -72,6 +80,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/hughsie/libxmlb";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ jtojnar ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/ximion/appstream/blob/v0.15.2/NEWS

- https://github.com/ximion/appstream/commit/fd5cdddeb6d0676e1d0024665c9037f8a63ad80a They provide installed tests now.
- https://github.com/ximion/appstream/commit/a8186ed96125f93b8963a8265ac42f56a837fb2b They use libxmlb instead of LMDB now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (using GitHub Actions)
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
