### PR TITLE
protoc-gen-grpc-web: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/development/tools/protoc-gen-grpc-web/default.nix
+++ b/pkgs/development/tools/protoc-gen-grpc-web/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "protoc-gen-grpc-web";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "grpc";
     repo = "grpc-web";
     rev = version;
-    sha256 = "sha256-piKpaylzuanhGR+7BzApplv8e/CWPoR9tG3vHrF7WXw=";
+    sha256 = "sha256-NRShN4X9JmCjqPVY/q9oSxSOvv1bP//vM9iOZ6ap5vc=";
   };
 
   sourceRoot = "source/javascript/net/grpc/web/generator";
@@ -17,7 +17,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ protobuf ];
   buildInputs = [ protobuf ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)" "STATIC=no" ];
+
+  patches = [
+    # https://github.com/grpc/grpc-web/pull/1210
+    ./optional-static.patch
+  ];
 
   doCheck = true;
   checkInputs = [ protobuf ];

--- a/pkgs/development/tools/protoc-gen-grpc-web/optional-static.patch
+++ b/pkgs/development/tools/protoc-gen-grpc-web/optional-static.patch
@@ -1,0 +1,19 @@
+--- a/Makefile
++++ b/Makefile
+@@ -18,12 +18,15 @@ CXXFLAGS += -std=c++11
+ LDFLAGS += -L/usr/local/lib -lprotoc -lprotobuf -lpthread -ldl
+ PREFIX ?= /usr/local
+ MIN_MACOS_VERSION := 10.7 # Supports OS X Lion
++STATIC ?= yes
+
+ UNAME_S := $(shell uname -s)
+ ifeq ($(UNAME_S),Darwin)
+   CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$(MIN_MACOS_VERSION)
+ else ifeq ($(UNAME_S),Linux)
+-  LDFLAGS += -static
++  ifeq ($(STATIC),yes)
++    LDFLAGS += -static
++  endif
+ endif
+
+ all: protoc-gen-grpc-web


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Bump protoc-gen-grpc-web `1.3.1`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
