### PR TITLE
htop: add test with expect

### DIFF
--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, stdenv, autoreconfHook
+{ lib, fetchFromGitHub, stdenv, autoreconfHook, callPackage
 , ncurses
 , IOKit
 , sensorsSupport ? stdenv.isLinux, lm_sensors
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
       ${optionalPatch sensorsSupport "${lm_sensors}/lib/libsensors.so"}
       ${optionalPatch systemdSupport "${systemd}/lib/libsystemd.so"}
     '';
+
+  passthru.tests.expect = callPackage ./test-with-expect.nix { };
 
   meta = {
     description = "An interactive process viewer for Linux";

--- a/pkgs/tools/system/htop/test-with-expect.nix
+++ b/pkgs/tools/system/htop/test-with-expect.nix
@@ -3,6 +3,8 @@
 let expect-script = writeScript "expect-script" ''
   #!${expect}/bin/expect -f
 
+  exp_internal 1
+
   # Load htop
   spawn htop
   expect "Load average"

--- a/pkgs/tools/system/htop/test-with-expect.nix
+++ b/pkgs/tools/system/htop/test-with-expect.nix
@@ -1,0 +1,42 @@
+{ htop, expect, runCommand, writeScript, runtimeShell }:
+
+let expect-script = writeScript "expect-script" ''
+  #!${expect}/bin/expect -f
+
+  # Load htop
+  spawn htop
+  expect "Load average"
+
+  # Load help (F1).
+  send "\033OP"
+  expect "htop ${htop.version}"
+  send "q"
+
+  # Filter processes.
+  send "\\sleep 123"
+  expect "sleep 123456"
+  send "\n"
+
+  send "k"
+  expect "Send signal"
+  send "\n"
+
+  sleep 2
+  send "q"
+  expect eof
+''; in
+runCommand "htop-test-expect"
+{
+  nativeBuildInputs = [ htop expect ];
+  passthru = { inherit expect-script; };
+} ''
+  # Process to manipulate.
+  sleep 123456 &
+
+  pid=$!
+  expect -f ${expect-script}
+
+  # Process should be killed.
+  ! kill -0 $pid
+  touch $out
+''


### PR DESCRIPTION
###### Motivation for this change

Based on #161707. Looking for more packages to test this way, feel free to suggest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
