### PR TITLE
gaphor: 2.6.5 -> 2.8.2

### DIFF
--- a/pkgs/tools/misc/gaphor/default.nix
+++ b/pkgs/tools/misc/gaphor/default.nix
@@ -1,44 +1,55 @@
 { lib
 , buildPythonApplication
 , fetchPypi
-, poetry-core
-, gobject-introspection
-, pango
-, gtksourceview4
-, wrapGAppsHook
-, makeDesktopItem
 , copyDesktopItems
+, gobject-introspection
+, poetry-core
+, wrapGAppsHook
+, gtksourceview4
+, pango
 , gaphas
 , generic
+, jedi
 , pycairo
 , pygobject3
-, python
 , tinycss2
+, gtk3
+, librsvg
+, makeDesktopItem
+, python
 }:
 
 buildPythonApplication rec {
   pname = "gaphor";
-  version = "2.6.5";
+  version = "2.8.2";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-IFsbWx5lblKsnEibVihM6ZPRoydXC+JM1gdZEUUTKxw=";
+    sha256 = "sha256-+qqsSLjdY2I19fxdfkOEQ9DhTTHccUDll4O5yqtLiz0=";
   };
 
   nativeBuildInputs = [
-    poetry-core copyDesktopItems gobject-introspection wrapGAppsHook
+    copyDesktopItems
+    gobject-introspection
+    poetry-core
+    wrapGAppsHook
   ];
 
   # Setting gobject-introspection on booth nativeBuildInputs and
   # buildInputs because of #56943. This recognizes pango, avoiding
   # a "ValueError: Namespace PangoCairo not available".
-  buildInputs = [ gobject-introspection gtksourceview4 pango ];
+  buildInputs = [
+    gobject-introspection
+    gtksourceview4
+    pango
+  ];
 
   propagatedBuildInputs = [
     gaphas
     generic
+    jedi
     pycairo
     pygobject3
     tinycss2
@@ -52,8 +63,18 @@ buildPythonApplication rec {
     desktopName = "Gaphor";
   };
 
+  # We need to wrap it manually to resolve all icons
+  dontWrapGApps = true;
+
   postInstall = ''
     install -Dm644 $out/${python.sitePackages}/gaphor/ui/icons/hicolor/scalable/apps/org.gaphor.Gaphor.svg $out/share/pixmaps/gaphor.svg
+  '';
+
+  preFixup = ''
+    wrapProgram $out/bin/gaphor \
+        ''${gappsWrapperArgs[@]} \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
