### PR TITLE
terminus-cli: init at 3.0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14066,4 +14066,10 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  asimpson = {
+    name = "Adam Simpson";
+    email = "adam@adamsimpson.net";
+    github = "asimpson";
+    githubId = 1048831;
+  };
 }

--- a/pkgs/development/php-packages/terminus-cli/default.nix
+++ b/pkgs/development/php-packages/terminus-cli/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchurl, makeWrapper, unzip, lib, php }:
+
+stdenv.mkDerivation rec {
+  name = "terminus-cli";
+  version = "3.0.6";
+
+  src = fetchurl {
+    url = "https://github.com/pantheon-systems/terminus/releases/download/${version}/terminus.phar";
+    sha256 = "11abwsdfp66dqx3lqk6jw82xq3cvsrjpz336m90kmnq487fqrhhx";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/terminus.phar
+    makeWrapper ${php}/bin/php $out/bin/terminus \
+      --add-flags "$out/libexec/terminus.phar" \
+      --prefix PATH : ${lib.makeBinPath [ unzip ]}
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A standalone utility for performing operations on the Pantheon Platform";
+    homepage = "https://pantheon.io/docs/terminus";
+    changelog = "https://github.com/pantheon-systems/terminus/blob/3.x/CHANGELOG.md";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ asimpson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34757,4 +34757,6 @@ with pkgs;
   honeytail = callPackage ../servers/tracing/honeycomb/honeytail { };
 
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
+
+  terminus-cli = callPackage ../development/php-packages/terminus-cli { };
 }


### PR DESCRIPTION
###### Motivation for this change
Adds [Terminus](https://pantheon.io/docs/terminus) to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
