### PR TITLE
nixos/tests: fix switchTest

### DIFF
--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -528,7 +528,6 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         assert_lacks(out, "reloading the following units:")
         assert_contains(out, "\nrestarting the following units: test.service\n")
         assert_lacks(out, "\nstarting the following units:")
-        assert_lacks(out, "the following new units were started:")
         assert_lacks(out, "as well:")
 
         # Rename it

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -283,6 +283,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           systemd.services.test-watch = {
             serviceConfig = {
               Type = "oneshot";
+              RemainAfterExit = true;
               ExecStart = "${pkgs.coreutils}/bin/touch /testpath-modified";
             };
           };
@@ -722,6 +723,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         machine.succeed("touch /testpath")
         machine.wait_until_succeeds("test -f /testpath-modified")
         machine.succeed("rm /testpath /testpath-modified")
+        machine.systemctl("stop test-watch.service")
         switch_to_specialisation("${machine}", "pathModified")
         machine.succeed("touch /testpath")
         machine.fail("test -f /testpath-modified")


### PR DESCRIPTION
Fixes failures like https://hydra.nixos.org/build/168083601/nixlog/102, as well as https://github.com/NixOS/nixpkgs/pull/159187#issuecomment-1051005649