### PR TITLE
ipfs: 0.11.0 -> 0.12.0

### DIFF
--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "ipfs";
-  version = "0.11.0"; # When updating, also check if the repo version changed and adjust repoVersion below
+  version = "0.12.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
 
-  repoVersion = "11"; # Also update ipfs-migrator when changing the repo version
+  repoVersion = "12"; # Also update ipfs-migrator when changing the repo version
 
   # go-ipfs makes changes to it's source tarball that don't match the git source.
   src = fetchurl {
     url = "https://github.com/ipfs/go-ipfs/releases/download/${rev}/go-ipfs-source.tar.gz";
-    sha256 = "lTPGnFqDgyMWmSCPmLHguGNnJQMWi9LPrOZfDgeS9Y4=";
+    sha256 = "jWoMm/xIp3Zn/FiHWQ5/q39i6Lh4Fdoi9OdnRVc51Xk=";
   };
 
   # tarball contains multiple files/directories


### PR DESCRIPTION
###### Motivation for this change
https://github.com/ipfs/go-ipfs/releases/tag/v0.12.0
Resolves the conflict in #160914.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).