### PR TITLE
python3Packages.sybil: 3.0.0 -> 3.0.1, python3Packages.testfixtures: 6.18.3 -> 6.18.5

### DIFF
--- a/pkgs/development/python-modules/sybil/default.nix
+++ b/pkgs/development/python-modules/sybil/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonApplication rec {
   pname = "sybil";
-  version = "3.0.0";
+  version = "3.0.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-dpLtZueT5eea5qcM8s+GGRftSOr/DYrfgl5k2Fgg8lE=";
+    hash = "sha256-bwLcIgSvflohIDeSTZdPcngfbcGP08RMx85GOhIPUw0=";
   };
 
   checkInputs = [
@@ -22,7 +22,7 @@ buildPythonApplication rec {
   ];
 
   disabledTests = [
-    # sensitive to output of other commands
+    # Sensitive to output of other commands
     "test_namespace"
     "test_unittest"
   ];

--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "testfixtures";
-  version = "6.18.4";
+  version = "6.18.5";
   format = "setuptools";
   # DO NOT CONTACT upstream.
   # https://github.com/simplistix/ is only concerned with internal CI process.
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-h49hfEEXk/FVwms5MwoJWhzFiETYi83HZ6Zcf8IJa1Q=";
+    hash = "sha256-Atrog/Vn9bcP0608nu+5WRLniskL5sdES14vRr9XLIQ=";
   };
 
   checkInputs = [

--- a/pkgs/development/python-modules/testfixtures/default.nix
+++ b/pkgs/development/python-modules/testfixtures/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "testfixtures";
-  version = "6.18.3";
+  version = "6.18.4";
   format = "setuptools";
   # DO NOT CONTACT upstream.
   # https://github.com/simplistix/ is only concerned with internal CI process.
@@ -25,12 +25,9 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JgAQCulv/QgjNLN441VVD++LSlKab6TDT0cTCQXHQm0=";
+    hash = "sha256-h49hfEEXk/FVwms5MwoJWhzFiETYi83HZ6Zcf8IJa1Q=";
   };
 
-  # no longer compatible with sybil
-  # https://github.com/simplistix/testfixtures/issues/169
-  doCheck = false;
   checkInputs = [
     mock
     pytestCheckHook
@@ -42,19 +39,6 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Django is too much hasle to setup at the moment
     "testfixtures/tests/test_django"
-  ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.10") [
-    # https://github.com/simplistix/testfixtures/issues/168
-    "test_invalid_communicate_call"
-    "test_invalid_kill"
-    "test_invalid_parameters"
-    "test_invalid_poll"
-    "test_invalid_send_signal"
-    "test_invalid_terminate"
-    "test_invalid_wait_call"
-    "test_replace_delattr_cant_remove"
-    "test_replace_delattr_cant_remove_not_strict"
   ];
 
   pytestFlagsArray = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/simplistix/testfixtures/blob/master/CHANGELOG.rst#6184-25-feb-2022
https://sybil.readthedocs.io/en/latest/changes.html#feb-2022

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
