### PR TITLE
pythonPackages.rbfopt: init at 4.2.3

### DIFF
--- a/pkgs/development/python-modules/rbfopt/default.nix
+++ b/pkgs/development/python-modules/rbfopt/default.nix
@@ -1,0 +1,48 @@
+{ lib, buildPythonPackage, fetchPypi, nose2, numpy, pyomo, scipy, bonmin, ipopt }:
+
+buildPythonPackage rec {
+  pname = "rbfopt";
+  version = "4.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-Q0iGUWMQBSFtvNkSYk4JgvC+eIrLqFiPB9ZwYppmtNE=";
+  };
+
+  postPatch = ''
+    # patch in the absolute paths
+    # note that tests for rbfopt_settings.py ensure the default values match the actual
+    # value, so we have to patch those as well
+    substituteInPlace src/rbfopt/rbfopt_settings.py \
+      --replace "minlp_solver_path='bonmin'," "minlp_solver_path='${bonmin}/bin/bonmin'," \
+      --replace "nlp_solver_path='ipopt'," "nlp_solver_path='${ipopt}/bin/ipopt'," \
+      --replace "Default 'bonmin'." "Default '${bonmin}/bin/bonmin'." \
+      --replace "Default 'ipopt'." "Default '${ipopt}/bin/ipopt'."
+  '';
+
+  propagatedBuildInputs = [
+    nose2
+    numpy
+    pyomo
+    scipy
+  ];
+
+  checkInputs = [
+    nose2
+  ];
+
+  # tests never finish
+  # see https://github.com/coin-or/rbfopt/issues/44
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "rbfopt"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/coin-or/rbfopt";
+    description = "A Python library for black-box optimization (also known as derivative-free optimization)";
+    maintainers = with maintainers; [ aanderse ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8587,6 +8587,8 @@ in {
 
   rawkit = callPackage ../development/python-modules/rawkit { };
 
+  rbfopt = callPackage ../development/python-modules/rbfopt { };
+
   rbtools = callPackage ../development/python-modules/rbtools { };
 
   rcssmin = callPackage ../development/python-modules/rcssmin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
missing library

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
