### PR TITLE
powerdns-admin: fix build

### DIFF
--- a/pkgs/applications/networking/powerdns-admin/default.nix
+++ b/pkgs/applications/networking/powerdns-admin/default.nix
@@ -15,8 +15,11 @@ let
         version = "1.16.0";
         src = oldAttrs.src.override {
           inherit version;
+          extension = "zip";
           sha256 = "36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01";
         };
+        # Needs networking for some tests
+        doCheck = false;
       });
     };
   };

--- a/pkgs/development/python-modules/bravado-core/default.nix
+++ b/pkgs/development/python-modules/bravado-core/default.nix
@@ -1,7 +1,31 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python-dateutil, jsonref, jsonschema,
+{ lib, buildPythonPackage, fetchFromGitHub, fetchPypi, python-dateutil, jsonref, jsonschema,
   pyyaml, simplejson, six, pytz, msgpack, swagger-spec-validator, rfc3987,
   strict-rfc3339, webcolors, mypy-extensions, jsonpointer, idna, pytest, mock,
   pytest-benchmark, isPy27, enum34 }:
+
+let
+  jsonschema320 = jsonschema.overridePythonAttrs (oldAttrs: rec {
+    version = "3.2.0";
+
+    src = fetchPypi {
+      inherit (oldAttrs) pname;
+      inherit version;
+      hash = "sha256-yKhbKNN3zHc35G4tnytPRO48Dh3qxr9G3e/HGH0weXo=";
+    };
+
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+    doCheck = false;
+  });
+
+  swagger-spec-validator' = swagger-spec-validator.overridePythonAttrs (oldAttrs: rec {
+    propagatedBuildInputs = [
+      pyyaml
+      jsonschema320
+      six
+    ];
+  });
+in
 
 buildPythonPackage rec {
   pname = "bravado-core";
@@ -26,13 +50,13 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     python-dateutil
     jsonref
-    jsonschema
+    jsonschema320
     pyyaml
     simplejson
     six
     pytz
     msgpack
-    swagger-spec-validator
+    swagger-spec-validator'
 
     # the following 3 packages are included when jsonschema (3.2) is installed
     # as jsonschema[format], which reflects what happens in setup.py


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Since the last python updates, powerdns-admin failed to build.

Fix the dnspython pin (it was updated) and pin jsonschema in bravado-core to fix the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
