### PR TITLE
[21.11] wolfssl: add patches for CVE-2022-25638 & CVE-2022-25640

### DIFF
--- a/pkgs/development/libraries/wolfssl/5.0.0-CVE-2022-25638.patch
+++ b/pkgs/development/libraries/wolfssl/5.0.0-CVE-2022-25638.patch
@@ -1,0 +1,82 @@
+Based on upstream https://github.com/wolfSSL/wolfssl/commit/f6d79ff598f5a007f2455d1c3f9e22c9e0875b5c.patch
+with sections handling falcon signatures removed (because they weren't added
+until 5.1.0)
+
+diff --git a/src/tls13.c b/src/tls13.c
+index e36dcd56b..e4e345f6c 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -6432,6 +6432,8 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
+ 
+         case TLS_ASYNC_BUILD:
+         {
++            int validSigAlgo;
++
+             /* Signature algorithm. */
+             if ((args->idx - args->begin) + ENUM_LEN + ENUM_LEN > totalSz) {
+                 ERROR_OUT(BUFFER_ERROR, exit_dcv);
+@@ -6456,41 +6458,44 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
+             }
+ 
+             /* Check for public key of required type. */
++            /* Assume invalid unless signature algo matches the key provided */
++            validSigAlgo = 0;
+         #ifdef HAVE_ED25519
+-            if (args->sigAlgo == ed25519_sa_algo &&
+-                                                  !ssl->peerEd25519KeyPresent) {
+-                WOLFSSL_MSG("Peer sent ED25519 sig but not ED25519 cert");
+-                ret = SIG_VERIFY_E;
+-                goto exit_dcv;
++            if (args->sigAlgo == ed25519_sa_algo) {
++                WOLFSSL_MSG("Peer sent ED25519 sig");
++                validSigAlgo = (ssl->peerEd25519Key != NULL) &&
++                                                     ssl->peerEd25519KeyPresent;
+             }
+         #endif
+         #ifdef HAVE_ED448
+-            if (args->sigAlgo == ed448_sa_algo && !ssl->peerEd448KeyPresent) {
+-                WOLFSSL_MSG("Peer sent ED448 sig but not ED448 cert");
+-                ret = SIG_VERIFY_E;
+-                goto exit_dcv;
++            if (args->sigAlgo == ed448_sa_algo) {
++                WOLFSSL_MSG("Peer sent ED448 sig");
++                validSigAlgo = (ssl->peerEd448Key != NULL) &&
++                                                       ssl->peerEd448KeyPresent;
+             }
+         #endif
+         #ifdef HAVE_ECC
+-            if (args->sigAlgo == ecc_dsa_sa_algo &&
+-                                                   !ssl->peerEccDsaKeyPresent) {
+-                WOLFSSL_MSG("Peer sent ECC sig but not ECC cert");
+-                ret = SIG_VERIFY_E;
+-                goto exit_dcv;
++            if (args->sigAlgo == ecc_dsa_sa_algo) {
++                WOLFSSL_MSG("Peer sent ECC sig");
++                validSigAlgo = (ssl->peerEccDsaKey != NULL) &&
++                                                      ssl->peerEccDsaKeyPresent;
+             }
+         #endif
+         #ifndef NO_RSA
+             if (args->sigAlgo == rsa_sa_algo) {
+-                WOLFSSL_MSG("Peer sent PKCS#1.5 algo but not in certificate");
++                WOLFSSL_MSG("Peer sent PKCS#1.5 algo - not valid TLS 1.3");
+                 ERROR_OUT(INVALID_PARAMETER, exit_dcv);
+             }
+-            if (args->sigAlgo == rsa_pss_sa_algo &&
+-                         (ssl->peerRsaKey == NULL || !ssl->peerRsaKeyPresent)) {
+-                WOLFSSL_MSG("Peer sent RSA sig but not RSA cert");
+-                ret = SIG_VERIFY_E;
+-                goto exit_dcv;
++            if (args->sigAlgo == rsa_pss_sa_algo) {
++                WOLFSSL_MSG("Peer sent RSA sig");
++                validSigAlgo = (ssl->peerRsaKey != NULL) &&
++                                                         ssl->peerRsaKeyPresent;
+             }
+         #endif
++            if (!validSigAlgo) {
++                WOLFSSL_MSG("Sig algo doesn't correspond to certficate");
++                ERROR_OUT(SIG_VERIFY_E, exit_dcv);
++            }
+ 
+             sig->buffer = (byte*)XMALLOC(args->sz, ssl->heap,
+                                          DYNAMIC_TYPE_SIGNATURE);

--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/wolfSSL/wolfssl/commit/73b4cc9476f6355a91138f545f3fd007ce058255.patch";
       sha256 = "0r3z6ybmx3ylnw9zdva3gq4jy691r471qvhy6dvdgmdksh2kx63v";
     })
+    ./5.0.0-CVE-2022-25638.patch
+    (fetchpatch {
+      name = "CVE-2022-25640.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/67b2a1be4027bc1d09baff6e93562c61a44998ab.patch";
+      sha256 = "1bcc6kfpn8wh7hbdb80yr16ik2mh0zg11cbzbi41z2rp4kc6d1ni";
+    })
   ];
 
   # Almost same as Debian but for now using --enable-all --enable-reproducible-build instead of --enable-distro to ensure options.h gets installed


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-25640
https://nvd.nist.gov/vuln/detail/CVE-2022-25638

See #161884 for master.

`CVE-2022-25638.patch` reorders some logic to ensure unrecognized signature algorithms don't get misinterpreted as matching the key. Only references to a pre-existing macro and pre-existing struct fields are added (and are used in the same way as in other parts of the code).

`CVE-2022-25640.patch` adds a new check referencing existing fields which will trigger an abort using an existing mechanism. The error-printing function was also updated to understand this failure condition.

Also tested on listed platforms with test enablement from #156105 temporarily added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux `pkgsMusl`
  - [x] x86_64-linux `pkgsCross.aarch64-multiplatform`
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
