### PR TITLE
k3s: update script fixed

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -49,6 +49,9 @@ let
   k3sVersion = "1.23.3+k3s1";     # k3s git tag
   k3sCommit = "6f4217a3405d16a1a51bbb40872d7dcb87207bb9"; # k3s git commit at the above version
   k3sRepoSha256 = "sha256-0dRusG1vL+1KbmViIUNCZK1b+FEgV6otcVUyFonHmm4=";
+  k3sVendorSha256 = "sha256-8Yp9csyRNSYi9wo8E8mF8cu92wG1t3l18wJ8Y4L7HEA=";
+
+  k3sServerVendorSha256 = "sha256-9+2k/ipAOhc8JJU+L2dwaM01Dkw+0xyrF5kt6mL19G0=";
 
   # taken from ./manifests/traefik.yaml, extracted from '.spec.chart' https://github.com/k3s-io/k3s/blob/v1.23.3%2Bk3s1/scripts/download#L9
   # The 'patch' and 'minor' versions are currently hardcoded as single digits only, so ignore the trailing two digits. Weird, I know.
@@ -65,11 +68,11 @@ let
 
   # taken from go.mod, the 'github.com/containerd/containerd' line
   # run `grep github.com/containerd/containerd go.mod | head -n1 | awk '{print $4}'`
-  containerdVersion = "v1.5.9-k3s1";
+  containerdVersion = "1.5.9-k3s1";
   containerdSha256 = "sha256-7xlhBA6KuwFlw+jyThygv4Ow9F3xjjIUtS6x8YHwjic=";
 
   # run `grep github.com/kubernetes-sigs/cri-tools go.mod | head -n1 | awk '{print $4}'` in the k3s repo at the tag
-  criCtlVersion = "v1.22.0-k3s1";
+  criCtlVersion = "1.22.0-k3s1";
 
   baseMeta = {
     description = "A lightweight Kubernetes distribution";
@@ -91,10 +94,8 @@ let
     "-X k8s.io/component-base/version.gitCommit=${k3sCommit}"
     "-X k8s.io/component-base/version.gitTreeState=clean"
     "-X k8s.io/component-base/version.buildDate=1970-01-01T01:01:01Z"
-    "-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=${criCtlVersion}"
-    "-X github.com/containerd/containerd/version.Version=${containerdVersion}"
-    "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
-    "-X github.com/containerd/containerd/version.Version=${containerdVersion}"
+    "-X github.com/kubernetes-sigs/cri-tools/pkg/version.Version=v${criCtlVersion}"
+    "-X github.com/containerd/containerd/version.Version=v${containerdVersion}"
     "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
   ];
 
@@ -168,12 +169,13 @@ let
   # strip/patchelf/remove-references step ourselves in the installPhase of the
   # derivation when we've built all the binaries, but haven't bundled them in
   # with generated bindata yet.
+
   k3sServer = buildGoModule rec {
     pname = "k3s-server";
     version = k3sVersion;
 
     src = k3sRepo;
-    vendorSha256 = "sha256-9+2k/ipAOhc8JJU+L2dwaM01Dkw+0xyrF5kt6mL19G0=";
+    vendorSha256 = k3sServerVendorSha256;
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp ];
@@ -203,11 +205,11 @@ let
   };
   k3sContainerd = buildGoModule {
     pname = "k3s-containerd";
-    version = k3sVersion;
+    version = containerdVersion;
     src = fetchFromGitHub {
       owner = "k3s-io";
       repo = "containerd";
-      rev = containerdVersion;
+      rev = "v${containerdVersion}";
       sha256 = containerdSha256;
     };
     vendorSha256 = null;
@@ -222,7 +224,7 @@ buildGoModule rec {
 
   src = k3sRepo;
   proxyVendor = true;
-  vendorSha256 = "sha256-8Yp9csyRNSYi9wo8E8mF8cu92wG1t3l18wJ8Y4L7HEA=";
+  vendorSha256 = k3sVendorSha256;
 
   patches = [
     ./patches/0001-scrips-download-strip-downloading-just-package-CRD.patch

--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -78,7 +78,7 @@ let
     description = "A lightweight Kubernetes distribution";
     license = licenses.asl20;
     homepage = "https://k3s.io";
-    maintainers = with maintainers; [ euank mic92 ];
+    maintainers = with maintainers; [ euank mic92 superherointj ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/applications/networking/cluster/k3s/update.sh
+++ b/pkgs/applications/networking/cluster/k3s/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnugrep gnused jq
+#!nix-shell -i bash -p curl gnugrep gnused jq yq-go nix-prefetch
 
 set -x -eu -o pipefail
 
@@ -32,22 +32,33 @@ curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/scripts
 FILE_MANIFESTS_TRAEFIK=${WORKDIR}/manifests-traefik.yaml
 curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/manifests/traefik.yaml > $FILE_MANIFESTS_TRAEFIK
 
-TRAEFIK_CHART_VERSION=$(awk -F/ '/traefik-([[:digit:]]+\.)/ {sub(/traefik-/, "", $6) ; sub(/\.tgz/, "", $6); print $6}' $FILE_MANIFESTS_TRAEFIK)
+FILE_GO_MOD=${WORKDIR}/go.mod
+curl --silent https://raw.githubusercontent.com/k3s-io/k3s/${K3S_COMMIT}/go.mod > $FILE_GO_MOD
 
+TRAEFIK_CHART_VERSION=$(yq e '.spec.chart' $FILE_MANIFESTS_TRAEFIK | awk 'match($0, /([0-9.]+)([0-9]{2})/,
+m) { print m[1]; exit; }')
 TRAEFIK_CHART_SHA256=$(nix-prefetch-url --quiet "https://helm.traefik.io/traefik/traefik-${TRAEFIK_CHART_VERSION}.tgz")
 
-K3S_ROOT_VERSION=$(grep 'ROOT_VERSION=' ${FILE_SCRIPTS_DOWNLOAD} \
-    | cut -d'=' -f2 | cut -d' ' -f1 | sed 's/^v//')
+K3S_ROOT_VERSION=$(grep 'VERSION_ROOT=' ${FILE_SCRIPTS_VERSION} \
+    | cut -d'=' -f2 | sed -e 's/"//g' -e 's/^v//')
 K3S_ROOT_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/k3s-io/k3s-root/releases/download/v${K3S_ROOT_VERSION}/k3s-root-amd64.tar")
 
 CNIPLUGINS_VERSION=$(grep 'VERSION_CNIPLUGINS=' ${FILE_SCRIPTS_VERSION} \
-    | cut -d'=' -f2 | cut -d' ' -f1 | sed -e 's/"//g' -e 's/^v//')
+    | cut -d'=' -f2 | sed -e 's/"//g' -e 's/^v//')
 CNIPLUGINS_SHA256=$(nix-prefetch-url --quiet --unpack \
     "https://github.com/rancher/plugins/archive/refs/tags/v${CNIPLUGINS_VERSION}.tar.gz")
 
+CONTAINERD_VERSION=$(grep github.com/containerd/containerd ${FILE_GO_MOD} \
+    | head -n1 | awk '{print $4}' | sed -e 's/"//g' -e 's/^v//')
+CONTAINERD_SHA256=$(nix-prefetch-url --quiet --unpack \
+    "https://github.com/k3s-io/containerd/archive/refs/tags/v${CONTAINERD_VERSION}.tar.gz")
+
+CRI_CTL_VERSION=$(grep github.com/kubernetes-sigs/cri-tools ${FILE_GO_MOD} \
+    | head -n1 | awk '{print $4}' | sed -e 's/"//g' -e 's/^v//')
+
 setKV () {
-    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" ./default.nix
+    sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" default.nix
 }
 
 setKV k3sVersion ${K3S_VERSION}
@@ -62,3 +73,36 @@ setKV k3sRootSha256 ${K3S_ROOT_SHA256}
 
 setKV k3sCNIVersion ${CNIPLUGINS_VERSION}
 setKV k3sCNISha256 ${CNIPLUGINS_SHA256}
+
+setKV containerdVersion ${CONTAINERD_VERSION}
+setKV containerdSha256 ${CONTAINERD_SHA256}
+
+setKV criCtlVersion ${CRI_CTL_VERSION}
+
+setKV k3sServerVendorSha256 "0000000000000000000000000000000000000000000000000000"
+
+cd ../../../../../
+set +e
+K3S_SERVER_VENDOR_SHA256=$(nix-build --no-out-link -A k3s 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+set -e
+cd - > /dev/null
+
+if [ -n "${K3S_SERVER_VENDOR_SHA256:-}" ]; then
+    setKV k3sServerVendorSha256 ${K3S_SERVER_VENDOR_SHA256}
+else
+    echo "Update failed. K3S_SERVER_VENDOR_SHA256 is empty."
+    exit 1
+fi
+
+cd ../../../../../
+set +e
+K3S_VENDOR_SHA256=$(nix-prefetch -I nixpkgs=./. "{ sha256 }: (import ./. {}).k3s.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
+set -e
+cd - > /dev/null
+
+if [ -n "${K3S_VENDOR_SHA256:-}" ]; then
+    setKV k3sVendorSha256 ${K3S_VENDOR_SHA256}
+else
+    echo "Update failed. K3S_VENDOR_SHA256 is empty."
+    exit 1
+fi


### PR DESCRIPTION
k3s: update script fixed

Fixes #156615

## Changes

* Several fixes to update script for supporting Go Modules.

* Remove duplication of (I guess this is desirable?):
```
    "-X github.com/containerd/containerd/version.Version=${containerdVersion}"
    "-X github.com/containerd/containerd/version.Package=github.com/k3s-io/containerd"
```
  * Standardize on versions not having 'v', as Nix packages version are standardized to not have 'v'.

@euank

--

Check for logs at:
https://r.ryantm.com/log/updatescript/k3s/