### PR TITLE
python3Packages.skyfield: init at 1.42

### DIFF
--- a/pkgs/development/python-modules/assay/default.nix
+++ b/pkgs/development/python-modules/assay/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchFromGitHub }:
+
+buildPythonPackage rec {
+  pname = "assay";
+  version = "unstable-2022-01-19";
+
+  src = fetchFromGitHub {
+    owner = "brandon-rhodes";
+    repo = pname;
+    rev = "bb62d1f7d51d798b05a88045fff3a2ff92c299c3";
+    sha256 = "sha256-FuAD74mFJ9F9AMgB3vPmODAlZKgPR7FQ4yn7HEBS5Rw=";
+  };
+
+  pythonImportsCheck = [ "assay" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/brandon-rhodes/assay";
+    description = "Attempt to write a Python testing framework I can actually stand";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/development/python-modules/jplephem/default.nix
+++ b/pkgs/development/python-modules/jplephem/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, fetchPypi, numpy, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "jplephem";
+  version = "2.17";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4cblVlxNAEhfEGMkG00e/wRFhcIrjpf60P8vbvuKqic=";
+  };
+
+  propagatedBuildInputs = [ numpy ];
+
+  # Weird import error, only happens in testing:
+  #   File "/build/jplephem-2.17/jplephem/daf.py", line 10, in <module>
+  #     from numpy import array as numpy_array, ndarray
+  # ImportError: cannot import name 'array' from 'sys' (unknown location)
+  doCheck = false;
+
+  pythonImportsCheck = [ "jplephem" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/brandon-rhodes/python-jplephem/";
+    description = "Python version of NASA DE4xx ephemerides, the basis for the Astronomical Alamanac";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/development/python-modules/sgp4/default.nix
+++ b/pkgs/development/python-modules/sgp4/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, tox, numpy }:
+
+buildPythonPackage rec {
+  pname = "sgp4";
+  version = "2.21";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-YXm4dQRId+lBYzwgr3ci/SMaiNiomvAb8wvWTzPN7O8=";
+  };
+
+  checkInputs = [ tox numpy ];
+
+  pythonImportsCheck = [ "sgp4" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/brandon-rhodes/python-sgp4";
+    description = "Python version of the SGP4 satellite position library";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/development/python-modules/skyfield/default.nix
+++ b/pkgs/development/python-modules/skyfield/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchFromGitHub, certifi, numpy, sgp4, jplephem
+, pandas, ipython, matplotlib, assay
+}:
+
+buildPythonPackage rec {
+  pname = "skyfield";
+  version = "1.42";
+
+  src = fetchFromGitHub {
+    owner = "skyfielders";
+    repo = "python-skyfield";
+    rev = version;
+    sha256 = "sha256-aoSkuLhZcEy+13EJQOBHV2/rgmN6aZQHqfj4OOirOG0=";
+  };
+
+  propagatedBuildInputs = [ certifi numpy sgp4 jplephem ];
+
+  checkInputs = [ pandas ipython matplotlib assay ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    cd ci
+    assay --batch skyfield.tests
+
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "skyfield" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/skyfielders/python-skyfield";
+    description = "Elegant astronomy for Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ zane ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -754,6 +754,8 @@ in {
 
   aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
 
+  assay = callPackage ../development/python-modules/assay { };
+
   assertpy = callPackage ../development/python-modules/assertpy { };
 
   asterisk-mbox = callPackage ../development/python-modules/asterisk-mbox { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4724,6 +4724,8 @@ in {
     inherit (self) systemd pytest;
   };
 
+  jplephem = callPackage ../development/python-modules/jplephem { };
+
   jproperties = callPackage ../development/python-modules/jproperties { };
 
   jpylyzer = callPackage ../development/python-modules/jpylyzer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9958,6 +9958,8 @@ in {
 
   sgmllib3k = callPackage ../development/python-modules/sgmllib3k { };
 
+  sgp4 = callPackage ../development/python-modules/sgp4 { };
+
   shamir-mnemonic = callPackage ../development/python-modules/shamir-mnemonic { };
 
   shap = callPackage ../development/python-modules/shap { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10070,6 +10070,8 @@ in {
 
   skybellpy = callPackage ../development/python-modules/skybellpy { };
 
+  skyfield = callPackage ../development/python-modules/skyfield { };
+
   skytemple-dtef = callPackage ../development/python-modules/skytemple-dtef { };
 
   skytemple-eventserver = callPackage ../development/python-modules/skytemple-eventserver { };


### PR DESCRIPTION
###### Motivation for this change

Packaging skyfield and dependencies (assay, sgp4, and jplephem).

Can't run `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`, my system keeps OOM'ing due to an unrelated issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
