### PR TITLE
logrotate: do not enable logrotate.service itself

### DIFF
--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -167,7 +167,6 @@ in
 
     systemd.services.logrotate = {
       description = "Logrotate Service";
-      wantedBy = [ "multi-user.target" ];
       startAt = "hourly";
 
       serviceConfig = {

--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -15,19 +15,20 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
       with subtest("whether logrotate works"):
           machine.succeed(
               # we must rotate once first to create logrotate stamp
-              "systemctl start --wait logrotate.service",
+              "systemctl start logrotate.service")
+          # we need to wait for console text once here to
+          # clear console buffer up to this point for next wait
+          machine.wait_for_console_text('logrotate.service: Deactivated successfully')
 
+          machine.succeed(
               # wtmp is present in default config.
               "rm -f /var/log/wtmp*",
               "echo test > /var/log/wtmp",
 
-              # move into the future and rotate
-              "date -s 'now + 1 month + 1 day'",
-              # systemd will run logrotate from logrotate.timer automatically
-              # on date change, but if we want to wait for it to terminate
-              # it's easier to run again...
-              "systemctl start --wait logrotate.service",
-
+              # move into the future and check rotation.
+              "date -s 'now + 1 month + 1 day'")
+          machine.wait_for_console_text('logrotate.service: Deactivated successfully')
+          machine.succeed(
               # check rotate worked
               "[ -e /var/log/wtmp.1 ]",
           )

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -283,6 +283,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
           systemd.services.test-watch = {
             serviceConfig = {
               Type = "oneshot";
+              RemainAfterExit = true;
               ExecStart = "${pkgs.coreutils}/bin/touch /testpath-modified";
             };
           };
@@ -723,6 +724,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
         machine.succeed("touch /testpath")
         machine.wait_until_succeeds("test -f /testpath-modified")
         machine.succeed("rm /testpath /testpath-modified")
+        machine.systemctl("stop test-watch.service")
         switch_to_specialisation("${machine}", "pathModified")
         machine.succeed("touch /testpath")
         machine.fail("test -f /testpath-modified")


### PR DESCRIPTION
logrotate.timer is enough for rotating logs. Enabling logrotate.service would
make the service start on every configuration switch, leading to tests failure when
logrotate is enabled.
Also update test to make sure the timer is active and runs the service
on date change.

supersedes #161859 as a fix for testSwitch, I've taken the second commit that was unrelated as well...
cc @ncfavier @vcunat @dasJ 