### PR TITLE
python39Packages.pymc3: fix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8770,6 +8770,12 @@
     githubId = 8214542;
     name = "Nicolò Balzarotti";
   };
+  nidabdella = {
+    name = "Mohamed Nidabdella";
+    email = "nidabdella.mohamed@gmail.com";
+    github = "nidabdella";
+    githubId = 8083813;
+  };
   NieDzejkob = {
     email = "kuba@kadziolka.net";
     github = "NieDzejkob";
@@ -13976,11 +13982,5 @@
     email = "nigel.g.banks@gmail.com";
     github = "nigelgbanks";
     githubId = 487373;
-  };
-  nidabdella = {
-    name = "Mohamed Nidabdella";
-    email = "nidabdella.mohamed@gmail.com";
-    github = "nidabdella";
-    githubId = 8083813;
   };
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13977,4 +13977,10 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  nidabdella = {
+    name = "Mohamed Nidabdella";
+    email = "nidabdella.mohamed@gmail.com";
+    github = "nidabdella";
+    githubId = 8083813;
+  };
 }

--- a/pkgs/development/python-modules/pymc3/default.nix
+++ b/pkgs/development/python-modules/pymc3/default.nix
@@ -2,10 +2,11 @@
 , fetchPypi
 , buildPythonPackage
 , pythonOlder
-, Theano
+, theano-pymc
 , pandas
 , patsy
 , joblib
+, cachetools
 , tqdm
 , six
 , h5py
@@ -16,6 +17,8 @@
 , parameterized
 , fastprogress
 , typing-extensions
+, dill
+, semver
 }:
 
 buildPythonPackage rec {
@@ -34,7 +37,6 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    Theano
     pandas
     patsy
     joblib
@@ -45,12 +47,10 @@ buildPythonPackage rec {
     packaging
     fastprogress
     typing-extensions
-  ];
-
-  checkInputs = [
-    pytest
-    nose
-    parameterized
+    dill
+    theano-pymc
+    cachetools
+    semver
   ];
 
   # The test suite is computationally intensive and test failures are not
@@ -67,9 +67,6 @@ buildPythonPackage rec {
     description = "Bayesian estimation, particularly using Markov chain Monte Carlo (MCMC)";
     homepage = "https://github.com/pymc-devs/pymc3";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ilya-kolpakov ];
-    # several dependencies are not declared and in the end it requires theano-pymc3
-    # instead of Theano. The former is currently not packaged.
-    broken = true;
+    maintainers = with lib.maintainers; [ nidabdella ];
   };
 }

--- a/pkgs/development/python-modules/theano-pymc/default.nix
+++ b/pkgs/development/python-modules/theano-pymc/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, pythonOlder
+, pandas
+, numpy
+, scipy
+, filelock
+, pytest
+, nose
+, parameterized
+}:
+
+buildPythonPackage rec {
+  pname = "theano-pymc";
+  version = "1.1.2";
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    pname = "Theano-PyMC";
+    inherit version;
+    sha256 = "5da6c2242ea72a991c8446d7fe7d35189ea346ef7d024c890397011114bf10fc";
+  };
+
+  # No need for coverage stats in Nix builds
+  postPatch = ''
+    substituteInPlace setup.py --replace ", 'pytest-cov'" ""
+  '';
+
+  propagatedBuildInputs = [
+    pandas
+    numpy
+    scipy
+    filelock
+  ];
+
+  # The test suite is computationally intensive and test failures are not
+  # indicative for package usability hence tests are disabled by default.
+  doCheck = false;
+  pythonImportsCheck = [ "theano" ];
+
+  meta = {
+    description = "PyMC theano fork";
+    homepage = "https://github.com/majidaldo/Theano-PyMC";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nidabdella ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9854,6 +9854,8 @@ in {
 
   tgcrypto = callPackage ../development/python-modules/tgcrypto { };
 
+  theano-pymc = callPackage ../development/python-modules/theano-pymc { };
+
   Theano = callPackage ../development/python-modules/Theano rec {
     cudaSupport = pkgs.config.cudaSupport or false;
     cudnnSupport = cudaSupport;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR fixes [PyMC3](https://docs.pymc.io/en/v3/) version 3.11.4
[theano-pymc](https://pypi.org/project/Theano-PyMC/) is also packaged since it is a dependency 
of this version of PyMC3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests) : **I run package tests but they seem to stale at 53%**, that is probably why they're not included in the previous commits of `default.nix`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).