### PR TITLE
accountsservice: 0.6.55 → 22.07.5

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -14,18 +14,19 @@
 , dbus
 , ninja
 , python3
+, vala
 , gettext
 }:
 
 stdenv.mkDerivation rec {
   pname = "accountsservice";
-  version = "0.6.55";
+  version = "22.07.5";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "16wwd633jak9ajyr1f1h047rmd09fhf3kzjz6g5xjsz0lwcj8azz";
+    url = "https://www.freedesktop.org/software/accountsservice/accountsservice-${version}.tar.xz";
+    sha256 = "IdRJwN6tilQ86o8R5x6wSWwDXXMOpIOTOXowKzpMfBo=";
   };
 
   nativeBuildInputs = [
@@ -36,6 +37,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
+    vala
   ];
 
   buildInputs = [
@@ -48,7 +50,6 @@ stdenv.mkDerivation rec {
     "-Dadmin_group=wheel"
     "-Dlocalstatedir=/var"
     "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
-    "-Dsystemd=true"
   ];
 
   postPatch = ''
@@ -57,11 +58,6 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    # https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/55
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/58.patch";
-      sha256 = "1pnwq4ycnryb2kkgvnz44qzm71240ybqj6507wynlkdsw8180fdw";
-    })
     (substituteAll {
       src = ./fix-paths.patch;
       inherit shadow coreutils;
@@ -70,21 +66,6 @@ stdenv.mkDerivation rec {
     ./Disable-methods-that-change-files-in-etc.patch
     # Fixes https://github.com/NixOS/nixpkgs/issues/72396
     ./drop-prefix-check-extensions.patch
-    # Systemd unit improvements. Notably using StateDirectory eliminating the
-    # need of an ad-hoc script.
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/commit/152b845bbd3ca2a64516691493a160825f1a2046.patch";
-      sha256 = "114wrf5mwj5bgc5v1g05md4ridcnwdrwppr3bjz96sknwh5hk8s5";
-    })
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/commit/0e712e935abd26499ff5995ab363e5bfd9ee7c4c.patch";
-      sha256 = "1y60a5fmgfqjzprwpizilrazqn3mggdlgc5sgcpsprsp62fv78rl";
-    })
-    # Don't use etc/dbus-1/system.d
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/commit/ced73d0fcbd2a54085a660d260482fc70d79bd5c.patch";
-      sha256 = "0s7fknfgxl8hnf6givmhfg4586fjb2n64i9arh1w7xnq7x9x8d4c";
-    })
   ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -29,6 +29,24 @@ stdenv.mkDerivation rec {
     sha256 = "IdRJwN6tilQ86o8R5x6wSWwDXXMOpIOTOXowKzpMfBo=";
   };
 
+  patches = [
+    # Hardcode dependency paths.
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit shadow coreutils;
+    })
+
+    # Do not try to create directories in /var, that will not work in Nix sandbox.
+    ./no-create-dirs.patch
+
+    # Disable mutating D-Bus methods with immutable /etc.
+    ./Disable-methods-that-change-files-in-etc.patch
+
+    # Do not ignore third-party (e.g Pantheon) extensions not matching FHS path scheme.
+    # Fixes https://github.com/NixOS/nixpkgs/issues/72396
+    ./drop-prefix-check-extensions.patch
+  ];
+
   nativeBuildInputs = [
     dbus
     gettext
@@ -57,22 +75,11 @@ stdenv.mkDerivation rec {
     patchShebangs meson_post_install.py
   '';
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit shadow coreutils;
-    })
-    ./no-create-dirs.patch
-    ./Disable-methods-that-change-files-in-etc.patch
-    # Fixes https://github.com/NixOS/nixpkgs/issues/72396
-    ./drop-prefix-check-extensions.patch
-  ];
-
   meta = with lib; {
     description = "D-Bus interface for user account query and manipulation";
     homepage = "https://www.freedesktop.org/wiki/Software/AccountsService";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ pSub ];
+    license = licenses.gpl3Plus;
+    maintainers = teams.freedesktop.members ++ (with maintainers; [ pSub ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -45,6 +45,15 @@ stdenv.mkDerivation rec {
     # Do not ignore third-party (e.g Pantheon) extensions not matching FHS path scheme.
     # Fixes https://github.com/NixOS/nixpkgs/issues/72396
     ./drop-prefix-check-extensions.patch
+
+    # Work around not being able to set profile picture in GNOME Settings.
+    # https://github.com/NixOS/nixpkgs/issues/85357
+    # https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/98
+    # https://gitlab.gnome.org/GNOME/gnome-control-center/-/issues/1629
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/1ef3add46983af875adfed5d29954cbfb184f688.patch";
+      sha256 = "N4siK4SWkwYBnFa0JJUFgahi9XBkB/nS5yc+PyH3/iM=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/accountsservice/fix-paths.patch
+++ b/pkgs/development/libraries/accountsservice/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/daemon.c b/src/daemon.c
-index c52bda3..75d214e 100644
+index c8b6320..2b74949 100644
 --- a/src/daemon.c
 +++ b/src/daemon.c
-@@ -1106,7 +1106,7 @@ daemon_create_user_authorized_cb (Daemon                *daemon,
+@@ -1102,7 +1102,7 @@ daemon_create_user_authorized_cb (Daemon                *daemon,
  
          sys_log (context, "create user '%s'", cd->user_name);
  
@@ -11,9 +11,9 @@ index c52bda3..75d214e 100644
          argv[1] = "-m";
          argv[2] = "-c";
          argv[3] = cd->real_name;
-@@ -1318,7 +1318,7 @@ daemon_delete_user_authorized_cb (Daemon                *daemon,
- 
-         user_set_saved (user, FALSE);
+@@ -1335,7 +1335,7 @@ daemon_delete_user_authorized_cb (Daemon                *daemon,
+         }
+         free (resolved_homedir);
  
 -        argv[0] = "/usr/sbin/userdel";
 +        argv[0] = "@shadow@/bin/userdel";
@@ -21,19 +21,19 @@ index c52bda3..75d214e 100644
                  argv[1] = "-f";
                  argv[2] = "-r";
 diff --git a/src/user.c b/src/user.c
-index 9f57af5..e65289d 100644
+index 189b2c5..5358c02 100644
 --- a/src/user.c
 +++ b/src/user.c
-@@ -844,7 +844,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
-                          accounts_user_get_uid (ACCOUNTS_USER (user)),
-                          name);
+@@ -1145,7 +1145,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
+                         new_gecos = g_strdup (name);
+                 }
  
 -                argv[0] = "/usr/sbin/usermod";
 +                argv[0] = "@shadow@/bin/usermod";
                  argv[1] = "-c";
-                 argv[2] = name;
+                 argv[2] = new_gecos;
                  argv[3] = "--";
-@@ -913,7 +913,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
+@@ -1218,7 +1218,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           name);
  
@@ -42,7 +42,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = "-l";
                  argv[2] = name;
                  argv[3] = "--";
-@@ -1321,7 +1321,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
+@@ -1627,7 +1627,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           home_dir);
  
@@ -51,7 +51,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = "-m";
                  argv[2] = "-d";
                  argv[3] = home_dir;
-@@ -1378,7 +1378,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
+@@ -1683,7 +1683,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           shell);
  
@@ -60,7 +60,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = "-s";
                  argv[2] = shell;
                  argv[3] = "--";
-@@ -1520,7 +1520,7 @@ user_change_icon_file_authorized_cb (Daemon                *daemon,
+@@ -1824,7 +1824,7 @@ user_change_icon_file_authorized_cb (Daemon                *daemon,
                          return;
                  }
  
@@ -69,7 +69,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = filename;
                  argv[2] = NULL;
  
-@@ -1601,7 +1601,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
+@@ -1904,7 +1904,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
                           locked ? "locking" : "unlocking",
                           accounts_user_get_user_name (ACCOUNTS_USER (user)),
                           accounts_user_get_uid (ACCOUNTS_USER (user)));
@@ -78,7 +78,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = locked ? "-L" : "-U";
                  argv[2] = "--";
                  argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -1726,7 +1726,7 @@ user_change_account_type_authorized_cb (Daemon                *daemon,
+@@ -2026,7 +2026,7 @@ user_change_account_type_authorized_cb (Daemon                *daemon,
  
                  g_free (groups);
  
@@ -87,7 +87,7 @@ index 9f57af5..e65289d 100644
                  argv[1] = "-G";
                  argv[2] = str->str;
                  argv[3] = "--";
-@@ -1794,7 +1794,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2093,7 +2093,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                  if (mode == PASSWORD_MODE_SET_AT_LOGIN ||
                      mode == PASSWORD_MODE_NONE) {
  
@@ -96,7 +96,7 @@ index 9f57af5..e65289d 100644
                          argv[1] = "-d";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -1806,7 +1806,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2105,7 +2105,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                          }
  
                          if (mode == PASSWORD_MODE_SET_AT_LOGIN) {
@@ -105,7 +105,7 @@ index 9f57af5..e65289d 100644
                                  argv[1] = "-d";
                                  argv[2] = "0";
                                  argv[3] = "--";
-@@ -1827,7 +1827,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -2126,7 +2126,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                          accounts_user_set_locked (ACCOUNTS_USER (user), FALSE);
                  }
                  else if (accounts_user_get_locked (ACCOUNTS_USER (user))) {
@@ -114,7 +114,7 @@ index 9f57af5..e65289d 100644
                          argv[1] = "-U";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -1905,7 +1905,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
+@@ -2203,7 +2203,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
  
          g_object_freeze_notify (G_OBJECT (user));
  

--- a/pkgs/development/libraries/accountsservice/no-create-dirs.patch
+++ b/pkgs/development/libraries/accountsservice/no-create-dirs.patch
@@ -1,15 +1,17 @@
 diff --git a/meson_post_install.py b/meson_post_install.py
-index 5cc2dc4..dd27ad5 100644
+index d8c3dd1..620f714 100644
 --- a/meson_post_install.py
 +++ b/meson_post_install.py
-@@ -9,8 +9,8 @@ localstatedir = os.path.normpath(destdir + os.sep + sys.argv[1])
+@@ -9,9 +9,9 @@ localstatedir = os.path.normpath(destdir + os.sep + sys.argv[1])
  # FIXME: meson will not track the creation of these directories
  #        https://github.com/mesonbuild/meson/blob/master/mesonbuild/scripts/uninstall.py#L39
  dst_dirs = [
+-  (os.path.join(localstatedir, 'lib'), 0o755),
 -  (os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'), 0o775),
 -  (os.path.join(localstatedir, 'lib', 'AccountsService', 'users'), 0o700),
-+#  (os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'), 0o775),
-+#  (os.path.join(localstatedir, 'lib', 'AccountsService', 'users'), 0o700),
++  # (os.path.join(localstatedir, 'lib'), 0o755),
++  # (os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'), 0o775),
++  # (os.path.join(localstatedir, 'lib', 'AccountsService', 'users'), 0o700),
  ]
  
  for (dst_dir, dst_dir_mode) in dst_dirs:


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Update, clean up and fix https://github.com/NixOS/nixpkgs/issues/85357.

Not yet tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
