### PR TITLE
filebot: 4.9.4 -> 4.9.5

### DIFF
--- a/pkgs/applications/video/filebot/default.nix
+++ b/pkgs/applications/video/filebot/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, openjdk11, makeWrapper, autoPatchelfHook
+{ lib, stdenv, fetchurl, openjdk17, makeWrapper, autoPatchelfHook
 , zlib, libzen, libmediainfo, curl, libmms, glib
 }:
 
@@ -10,11 +10,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "filebot";
-  version = "4.9.4";
+  version = "4.9.5";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20210326102451/https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
-    sha256 = "sha256-fz0B9P/UBrlKGPZkheMd/4cFnWHt+brS3zRTv4nVt9o=";
+    url = "https://web.archive.org/web/20220226124706/https://get.filebot.net/filebot/FileBot_${version}/FileBot_${version}-portable.tar.xz";
+    sha256 = "sha256-LNvfAueDMd2TedK6bqnNG+J/4YhhbmUca9iyUkoUNkE=";
   };
 
   unpackPhase = "tar xvf $src";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       --replace 'APP_DATA="$FILEBOT_HOME/data/$(id -u)"' 'APP_DATA=''${XDG_DATA_HOME:-$HOME/.local/share}/filebot/data' \
       --replace '$FILEBOT_HOME/data/.license' '$APP_DATA/.license'
     wrapProgram $out/opt/filebot.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk11 ]}
+      --prefix PATH : ${lib.makeBinPath [ openjdk17 ]}
     # Expose the binary in bin to make runnable.
     ln -s $out/opt/filebot.sh $out/bin/filebot
   '';


### PR DESCRIPTION
###### Motivation for this change
Update filebot to latest release, supersedeeding #161962 to include the correct web archive timestamp.
I've also updated `openjdk11` to `openjdk17` since the changelog mentions Java 17 support.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
