### PR TITLE
lbry: 0.52.4 -> 0.52.5

### DIFF
--- a/pkgs/applications/video/lbry/default.nix
+++ b/pkgs/applications/video/lbry/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "lbry-desktop";
-  version = "0.52.4";
+  version = "0.52.5";
 in appimageTools.wrapAppImage rec {
   name = "${pname}-${version}";
 
@@ -12,7 +12,7 @@ in appimageTools.wrapAppImage rec {
     src = fetchurl {
       url = "https://github.com/lbryio/lbry-desktop/releases/download/v${version}/LBRY_${version}.AppImage";
       # Gotten from latest-linux.yml
-      sha512 = "TWRFCVktSKs5PORtm8FvM6qNWuiL/1HN98ilr1busVUGvain0QXGZwB/Dzvsox1c+X9VofUdapzozSOT6r58qw==";
+      sha512 = "i0t1Ygf3el7Brh6TA804V6n5r5UczvOPxAdhyJ7Gvvg9VqN1+QXB6hsqF4jYTW3jcKxvorVALwrFDVezBTPv5g==";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

[New upstream release.](https://github.com/lbryio/lbry-desktop/releases/tag/v0.52.5)

###### Things done

Watched a video. No problems found.