### PR TITLE
Go: Better subPackages and excludedPackages

### DIFF
--- a/doc/languages-frameworks/go.section.md
+++ b/doc/languages-frameworks/go.section.md
@@ -142,4 +142,8 @@ Removes the pre-existing vendor directory. This should only be used if the depen
 
 ### `subPackages` {#var-go-subPackages}
 
-Limits the builder from building child packages that have not been listed. If `subPackages` is not specified, all child packages will be built.
+Specified as a string or list of strings. Limits the builder from building child packages that have not been listed. If `subPackages` is not specified, all child packages will be built.
+
+### `excludedPackages` {#var-go-excludedPackages}
+
+Specified as a string or list of strings. Causes the builder to skip building child packages that match any of the provided values. If `excludedPackages` is not specified, all child packages will be built.

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  excludedPackages = "\\(tools\\|docgen\\)";
+  excludedPackages = [ "tools" "docgen" ];
 
   ldflags =
     let t = "github.com/rancher/k3d/v5/version"; in

--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
 
   # third_party/VENDOR-LICENSE breaks build/check as go files are still included
   # docs is a tool for generating docs
-  excludedPackages = "\\(third_party\\|cmd/docs\\)";
+  excludedPackages = [ "third_party" "cmd/docs" ];
 
   preCheck = ''
     # some tests try to write to the home dir

--- a/pkgs/applications/networking/instant-messengers/pond/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pond/default.nix
@@ -24,7 +24,7 @@ buildGoPackage rec {
     ++ lib.optional stdenv.hostPlatform.isx86_64 dclxvi
     ++ lib.optionals gui [ wrapGAppsHook ];
   tags = lib.optionals (!gui) [ "nogui" ];
-  excludedPackages = "\\(appengine\\|bn256cgo\\)";
+  excludedPackages = [ "appengine" "bn256cgo" ];
   postPatch = lib.optionalString stdenv.hostPlatform.isx86_64 ''
     grep -r 'bn256' | awk -F: '{print $1}' | xargs sed -i \
       -e "s,golang.org/x/crypto/bn256,github.com/agl/pond/bn256cgo,g" \

--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -171,13 +171,20 @@ let
     buildPhase = args.buildPhase or ''
       runHook preBuild
 
+      exclude='\(/_\|examples\|Godeps\|testdata'
+      if [[ -n "$excludedPackages" ]]; then
+        IFS=' ' read -r -a excludedArr <<<$excludedPackages
+        printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
+        excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
+        exclude+='\\|'"$excludedAlternates"
+      fi
+      exclude+='\)'
+
       buildGoDir() {
         local d; local cmd;
         cmd="$1"
         d="$2"
         . $TMPDIR/buildFlagsArray
-        echo "$d" | grep -q "\(/_\|examples\|Godeps\|testdata\)" && return 0
-        [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
         local OUT
         if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" ''${tags:+-tags=${lib.concatStringsSep "," tags}} ''${ldflags:+-ldflags="$ldflags"} -v -p $NIX_BUILD_CORES $d 2>&1)"; then
           if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
@@ -214,6 +221,7 @@ let
           export NIX_BUILD_CORES=1
       fi
       for pkg in $(getGoDirs ""); do
+        grep -q "$exclude" <<<$pkg && continue
         echo "Building subPackage $pkg"
         buildGoDir install "$pkg"
       done

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -150,13 +150,20 @@ let
 
       runHook renameImports
 
+      exclude='\(/_\|examples\|Godeps\|testdata'
+      if [[ -n "$excludedPackages" ]]; then
+        IFS=' ' read -r -a excludedArr <<<$excludedPackages
+        printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
+        excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
+        exclude+='\\|'"$excludedAlternates"
+      fi
+      exclude+='\)'
+
       buildGoDir() {
         local d; local cmd;
         cmd="$1"
         d="$2"
         . $TMPDIR/buildFlagsArray
-        echo "$d" | grep -q "\(/_\|examples\|Godeps\)" && return 0
-        [ -n "$excludedPackages" ] && echo "$d" | grep -q "$excludedPackages" && return 0
         local OUT
         if ! OUT="$(go $cmd $buildFlags "''${buildFlagsArray[@]}" ''${tags:+-tags=${lib.concatStringsSep "," tags}} ''${ldflags:+-ldflags="$ldflags"} -v -p $NIX_BUILD_CORES $d 2>&1)"; then
           if ! echo "$OUT" | grep -qE '(no( buildable| non-test)?|build constraints exclude all) Go (source )?files'; then
@@ -195,6 +202,8 @@ let
           export NIX_BUILD_CORES=1
       fi
       for pkg in $(getGoDirs ""); do
+        grep -q "$exclude" <<<$pkg && continue
+        echo "Building subPackage $pkg"
         buildGoDir install "$pkg"
       done
     '' + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''

--- a/pkgs/development/tools/deadcode/default.nix
+++ b/pkgs/development/tools/deadcode/default.nix
@@ -11,7 +11,7 @@ buildGoPackage rec {
   rev = "210d2dc333e90c7e3eedf4f2242507a8e83ed4ab";
 
   goPackagePath = "github.com/tsenart/deadcode";
-  excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
+  excludedPackages = "cmd/fillswitch/test-fixtures";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -5,7 +5,7 @@ buildGoPackage rec {
   version = "1.8.1";
 
   goPackagePath = "github.com/go-delve/delve";
-  excludedPackages = "\\(_fixtures\\|scripts\\|service/test\\)";
+  excludedPackages = [ "_fixtures" "scripts" "service/test" ];
 
   src = fetchFromGitHub {
     owner = "go-delve";

--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   pname = "gauge";
   version = "1.4.3";
 
-  excludedPackages = ''\(build\|man\)'';
+  excludedPackages = [ "build" "man" ];
 
   src = fetchFromGitHub {
     owner = "getgauge";

--- a/pkgs/development/tools/ginkgo/default.nix
+++ b/pkgs/development/tools/ginkgo/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
 
   # integration tests expect more file changes
   # types tests are missing CodeLocation
-  excludedPackages = "\\(integration\\|types\\)";
+  excludedPackages = [ "integration" "types" ];
 
   meta = with lib; {
     homepage = "https://onsi.github.io/ginkgo/";

--- a/pkgs/development/tools/go-motion/default.nix
+++ b/pkgs/development/tools/go-motion/default.nix
@@ -9,7 +9,6 @@ buildGoPackage rec {
   rev = "218875ebe23806e7af82f3b5b14bb3355534f679";
 
   goPackagePath = "github.com/fatih/motion";
-  excludedPackages = "testdata";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/gocode-gomod/default.nix
+++ b/pkgs/development/tools/gocode-gomod/default.nix
@@ -9,8 +9,6 @@ buildGoModule rec {
   # standard packages.
   allowGoReference = true;
 
-  excludedPackages = "internal/suggest/testdata";
-
   src = fetchFromGitHub {
     owner = "stamblerre";
     repo = "gocode";

--- a/pkgs/development/tools/gocode/default.nix
+++ b/pkgs/development/tools/gocode/default.nix
@@ -6,7 +6,6 @@ buildGoPackage rec {
   rev = "4acdcbdea79de6b3dee1c637eca5cbea0fdbe37c";
 
   goPackagePath = "github.com/mdempsky/gocode";
-  excludedPackages = "internal/suggest/testdata";
 
   # we must allow references to the original `go` package,
   # because `gocode` needs to dig into $GOROOT to provide completions for the

--- a/pkgs/development/tools/gogetdoc/default.nix
+++ b/pkgs/development/tools/gogetdoc/default.nix
@@ -12,8 +12,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  excludedPackages = "\\(testdata\\)";
-
   src = fetchFromGitHub {
     inherit rev;
 

--- a/pkgs/development/tools/golint/default.nix
+++ b/pkgs/development/tools/golint/default.nix
@@ -5,8 +5,6 @@ buildGoModule rec {
   version = "20201208-${lib.strings.substring 0 7 rev}";
   rev = "83fdc39ff7b56453e3793356bcff3070b9b96445";
 
-  excludedPackages = "testdata";
-
   # we must allow references to the original `go` package, as golint uses
   # compiler go/build package to load the packages it's linting.
   allowGoReference = true;

--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -40,7 +40,7 @@ buildGoModule rec {
   '';
 
   excludedPackages = "\\("
-    + lib.concatStringsSep "\\|" ([ "testdata" "vet" "cover" ])
+    + lib.concatStringsSep "\\|" ([ "vet" "cover" ])
     + "\\)";
 
   # Set GOTOOLDIR for derivations adding this to buildInputs

--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -39,9 +39,7 @@ buildGoModule rec {
     export GOTOOLDIR=$out/bin
   '';
 
-  excludedPackages = "\\("
-    + lib.concatStringsSep "\\|" ([ "vet" "cover" ])
-    + "\\)";
+  excludedPackages = [ "vet" "cover" ];
 
   # Set GOTOOLDIR for derivations adding this to buildInputs
   postInstall = ''

--- a/pkgs/development/tools/ineffassign/default.nix
+++ b/pkgs/development/tools/ineffassign/default.nix
@@ -9,7 +9,6 @@ buildGoPackage rec {
   rev = "1003c8bd00dc2869cb5ca5282e6ce33834fed514";
 
   goPackagePath = "github.com/gordonklaus/ineffassign";
-  excludedPackages = "testdata";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/interfacer/default.nix
+++ b/pkgs/development/tools/interfacer/default.nix
@@ -9,7 +9,6 @@ buildGoPackage rec {
   rev = "c20040233aedb03da82d460eca6130fcd91c629a";
 
   goPackagePath = "mvdan.cc/interfacer";
-  excludedPackages = "check/testdata";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/development/tools/reftools/default.nix
+++ b/pkgs/development/tools/reftools/default.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   doCheck = false;
 
-  excludedPackages = "\\(cmd/fillswitch/test-fixtures\\)";
+  excludedPackages = "cmd/fillswitch/test-fixtures";
 
   src = fetchFromGitHub {
     inherit rev;

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -4,7 +4,7 @@ buildGoModule rec {
   pname = "grafana";
   version = "8.4.2";
 
-  excludedPackages = "\\(alert_webhook_listener\\|clean-swagger\\|release_publisher\\|slow_proxy\\|slow_proxy_mac\\|macaron\\)";
+  excludedPackages = [ "alert_webhook_listener" "clean-swagger" "release_publisher" "slow_proxy" "slow_proxy_mac" "macaron" ];
 
   src = fetchFromGitHub {
     rev = "v${version}";

--- a/pkgs/tools/security/cosign/default.nix
+++ b/pkgs/tools/security/cosign/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-d3aOX4iMlhlxgYbqCHCIFKXunVha0Fw4ZBmy4OA6EhI=";
 
-  excludedPackages = "\\(sample\\|webhook\\|help\\)";
+  excludedPackages = [ "sample" "webhook" "help" ];
 
   tags = [] ++ lib.optionals pivKeySupport [ "pivkey" ] ++ lib.optionals pkcs11Support [ "pkcs11key" ];
 


### PR DESCRIPTION
###### Motivation for this change

buildGo* functions had poor documentation for the `subPackages` and `excludedPackages` options, leading to incorrect usage. I've added documentation for them, updated the implementation of `excludedPackages` to match a common mis-use that actually seems easier to use. I've also updated the previously correct usage of `excludedPackages` (which is still correct) to the easier to manage list-of-strings that was previously incorrect.

I also got rid of instances of `testdata` in `excludedPackages` that were unnecessary.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I've built all the affected packages but not with nixpkgs-review (yet, its currently running) and verified functionality of a subset of the affected packages.