### PR TITLE
sanctity: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9333,6 +9333,13 @@
     githubId = 71795;
     name = "Mica Semrick";
   };
+  papojari = {
+    email = "papojari-git.ovoid@aleeas.com";
+    matrix = "@papojari:artemislena.eu";
+    github = "papojari";
+    githubId = 81317317;
+    name = "papojari";
+  };
   paraseba = {
     email = "paraseba@gmail.com";
     github = "paraseba";

--- a/pkgs/tools/misc/sanctity/default.nix
+++ b/pkgs/tools/misc/sanctity/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitea }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sanctity";
+  version = "1.2.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "papojari";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-rK4em0maJQS50zPfnuFSxRoXUuFCaw9ZOfmgf70Sdac=";
+  };
+
+  cargoSha256 = "sha256-IQp/sSVgKY1j6N+UcifEi74dg/PkZJoeqLekeLc/vMU=";
+
+  meta = with lib; {
+    description = "Test the 16 terminal colors in all combinations";
+    homepage = "https://codeberg.org/papojari/sanctity";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9605,6 +9605,8 @@ with pkgs;
 
   samplicator = callPackage ../tools/networking/samplicator { };
 
+  sanctity = callPackage ../tools/misc/sanctity { };
+
   sandboxfs = callPackage ../tools/filesystems/sandboxfs { };
 
   sasquatch = callPackage ../tools/filesystems/sasquatch { };


### PR DESCRIPTION
###### Motivation for this change

Make it easy to install sanctity.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
