### PR TITLE
nixos/opentracker: add declarative configuration

### DIFF
--- a/nixos/modules/services/torrent/opentracker.nix
+++ b/nixos/modules/services/torrent/opentracker.nix
@@ -8,9 +8,10 @@ let
     if cfg."${attr}File" != null then
       cfg."${attr}File"
     else if cfg.${attr} != null then
-      pkgs.writeText
-        "opentracker-${attr}.txt"
-        (concatMapStrings (hash: "${hash}\n") cfg.${attr})
+      toString
+        (pkgs.writeText
+          "opentracker-${attr}.txt"
+          (concatMapStrings (hash: "${hash}\n") cfg.${attr}))
     else
       null;
 
@@ -22,6 +23,8 @@ let
     whitelist = whitelistFile != null;
     restrictStats = cfg.restrictStats.enable;
   };
+
+  escapeColon = replaceStrings [ ":" "\\" ] [ "\\:" "\\\\" ];
 
   mkService = { description, RestrictAddressFamilies, pkg, configFile }: {
     inherit description;
@@ -52,8 +55,8 @@ let
       MemoryDenyWriteExecute = true;
       RestrictRealtime = true;
       RestrictSUIDSGID = true;
-      BindReadOnlyPaths = optional (blacklistFile != null) "${blacklistFile}:/run/opentracker/blacklist.txt"
-                       ++ optional (whitelistFile != null) "${whitelistFile}:/run/opentracker/whitelist.txt";
+      BindReadOnlyPaths = optional (blacklistFile != null) "${escapeColon blacklistFile}:/run/opentracker/blacklist.txt"
+                       ++ optional (whitelistFile != null) "${escapeColon whitelistFile}:/run/opentracker/whitelist.txt";
     };
   };
 

--- a/nixos/modules/services/torrent/opentracker.nix
+++ b/nixos/modules/services/torrent/opentracker.nix
@@ -38,6 +38,21 @@ in {
         PrivateTmp = true;
         WorkingDirectory = "/var/empty";
         # By default opentracker drops all privileges and runs in chroot after starting up as root.
+
+        CapabilityBoundingSet = "CAP_SYS_CHROOT CAP_SETUID CAP_SETGID";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6";
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
       };
     };
   };

--- a/nixos/modules/services/torrent/opentracker.nix
+++ b/nixos/modules/services/torrent/opentracker.nix
@@ -3,57 +3,232 @@
 with lib;
 let
   cfg = config.services.opentracker;
-in {
-  options.services.opentracker = {
-    enable = mkEnableOption (lib.mdDoc "opentracker");
 
-    package = mkOption {
-      type = types.package;
-      description = lib.mdDoc ''
-        opentracker package to use
-      '';
-      default = pkgs.opentracker;
-      defaultText = literalExpression "pkgs.opentracker";
-    };
+  accessListFile = attr:
+    if cfg."${attr}File" != null then
+      cfg."${attr}File"
+    else if cfg.${attr} != null then
+      pkgs.writeText
+        "opentracker-${attr}.txt"
+        (concatMapStrings (hash: "${hash}\n") cfg.${attr})
+    else
+      null;
 
-    extraOptions = mkOption {
-      type = types.separatedString " ";
-      description = lib.mdDoc ''
-        Configuration Arguments for opentracker
-        See https://erdgeist.org/arts/software/opentracker/ for all params
-      '';
-      default = "";
+  blacklistFile = accessListFile "blacklist";
+  whitelistFile = accessListFile "whitelist";
+
+  overridenPkg = cfg.package.override {
+    blacklist = blacklistFile != null;
+    whitelist = whitelistFile != null;
+    restrictStats = cfg.restrictStats.enable;
+  };
+
+  mkService = { description, RestrictAddressFamilies, pkg, configFile }: {
+    inherit description;
+    after = [ "network.target" ];
+    requiredBy = [ "opentracker.target" ];
+    partOf = [ "opentracker.target" ];
+    unitConfig.ReloadPropagatedFrom = [ "opentracker.target" ];
+    restartIfChanged = true;
+    serviceConfig = {
+      ExecStart = "${pkg}/bin/opentracker -f ${configFile}";
+      ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+      PrivateTmp = true;
+      RuntimeDirectory = "opentracker";
+      WorkingDirectory = "/run/opentracker";
+      # By default opentracker drops all privileges and runs in chroot after starting up as root.
+
+      CapabilityBoundingSet = "CAP_SYS_CHROOT CAP_SETUID CAP_SETGID CAP_KILL";
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      PrivateDevices = true;
+      ProtectKernelTunables = true;
+      ProtectKernelModules = true;
+      ProtectKernelLogs = true;
+      ProtectControlGroups = true;
+      inherit RestrictAddressFamilies;
+      RestrictNamespaces = true;
+      LockPersonality = true;
+      MemoryDenyWriteExecute = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      BindReadOnlyPaths = optional (blacklistFile != null) "${blacklistFile}:/run/opentracker/blacklist.txt"
+                       ++ optional (whitelistFile != null) "${whitelistFile}:/run/opentracker/whitelist.txt";
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  mkConfig = { name, listenAddress, statsAddresses }:
+    let
+      config = {
+        "listen.tcp_udp" = "${listenAddress}:${toString cfg.listenPort}";
+        "tracker.rootdir" = ".";
+        "access.blacklist" = if blacklistFile == null then [] else "blacklist.txt";
+        "access.whitelist" = if whitelistFile == null then [] else "whitelist.txt";
+        "access.stats" = optionals cfg.restrictStats.enable statsAddresses;
+      } // cfg.extraConfig;
+    in
+      pkgs.writeText
+        name
+        (concatStrings
+          (mapAttrsToList
+            (name: values:
+              concatMapStrings
+                (value: "${name} ${value}\n")
+                (toList values)
+            )
+            config
+          )
+        );
+in {
+  imports = [
+    (mkRemovedOptionModule [ "services" "opentracker" "extraOptions" ] ''
+      Use services.opentracker.extraConfig instead.
+      See https://erdgeist.org/gitweb/opentracker/tree/opentracker.conf.sample
+    '')
+  ];
 
-    systemd.services.opentracker = {
-      description = "opentracker server";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      restartIfChanged = true;
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/opentracker ${cfg.extraOptions}";
-        PrivateTmp = true;
-        WorkingDirectory = "/var/empty";
-        # By default opentracker drops all privileges and runs in chroot after starting up as root.
+  options.services.opentracker = {
+    enable = mkEnableOption (lib.mdDoc "opentracker");
 
-        CapabilityBoundingSet = "CAP_SYS_CHROOT CAP_SETUID CAP_SETGID";
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        PrivateDevices = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectKernelLogs = true;
-        ProtectControlGroups = true;
-        RestrictAddressFamilies = "AF_INET AF_INET6";
-        RestrictNamespaces = true;
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
+    listenPort = mkOption {
+      type = types.port;
+      description = mdDoc ''
+        Port number to bind to.
+      '';
+      default = 6969;
+    };
+
+    listenAddress.ipv4 = mkOption {
+      type = with types; nullOr string;
+      description = mdDoc ''
+        IPv4 address to bind to. Set to null to disable IPv4 server.
+      '';
+      default = "0.0.0.0";
+    };
+
+    listenAddress.ipv6 = mkOption {
+      type = with types; nullOr string;
+      description = mdDoc ''
+        IPv6 address to bind to. Set to null to disable IPv6 server.
+      '';
+      default = "::";
+      example = "::1";
+    };
+
+    restrictStats = {
+      enable = mkOption {
+        type = types.bool;
+        description = mdDoc ''
+          Restrict access to tracker statistics.
+        '';
+        default = false;
       };
+
+      allow.ipv4 = mkOption {
+        type = with types; listOf string;
+        description = mdDoc ''
+          Allow these IPv4 addresses to access stats.
+        '';
+        default = [];
+      };
+
+      allow.ipv6 = mkOption {
+        type = with types; listOf string;
+        description = mdDoc ''
+          Allow these IPv6 addresses to access stats.
+        '';
+        default = [];
+        example = [ "::1" ];
+      };
+    };
+
+    blacklist = mkOption {
+      type = with types; nullOr (listOf string);
+      description = mdDoc ''
+        Do not track torrents with these hashes.
+      '';
+      default = null;
+    };
+
+    blacklistFile = mkOption {
+      type = with types; nullOr path;
+      description = mdDoc ''
+        Do not track torrents with the hashes from this file.
+      '';
+      default = null;
+    };
+
+    whitelist = mkOption {
+      type = with types; nullOr (listOf string);
+      description = mdDoc ''
+        Only track torrents with these hashes.
+      '';
+      default = null;
+    };
+
+    whitelistFile = mkOption {
+      type = with types; nullOr path;
+      description = mdDoc ''
+        Only track torrents with the hashes from this file.
+      '';
+      default = null;
+    };
+
+    package = mkPackageOption pkgs "opentracker" {};
+
+    extraConfig = mkOption {
+      type = with types; attrsOf (oneOf [ string (listOf string) ]);
+      description = mdDoc ''
+        Configuration options for opentracker
+        See <https://erdgeist.org/gitweb/opentracker/tree/opentracker.conf.sample> for all params
+      '';
+      default = {};
+      example = {
+        "tracker.redirect_url" = "https://nixos.org/";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      { assertion = cfg.listenAddress.ipv4 != null || cfg.listenAddress.ipv6 != null;
+        message = ''
+          config.opentracker.listenAddress.ipv4 or config.opentracker.listenAddress.ipv6
+          must be non-null.
+        '';
+      }
+      { assertion = blacklistFile == null || whitelistFile == null;
+        message = "Cannot use whitelist and blacklist at the same time.";
+      }
+    ];
+
+    systemd.services = (optionalAttrs (cfg.listenAddress.ipv4 != null) {
+      opentracker-v4 = mkService {
+        description = "opentracker IPv4 server";
+        RestrictAddressFamilies = "AF_INET";
+        pkg = overridenPkg.override { ipv6 = false; };
+        configFile = mkConfig {
+          name = "opentracker-v4.conf";
+          listenAddress = cfg.listenAddress.ipv4;
+          statsAddresses = cfg.restrictStats.allow.ipv4;
+        };
+      };
+    }) // (optionalAttrs (cfg.listenAddress.ipv6 != null) {
+      opentracker-v6 = mkService {
+        description = "opentracker IPv6 server";
+        RestrictAddressFamilies = "AF_INET6";
+        pkg = overridenPkg.override { ipv6 = true; };
+        configFile = mkConfig {
+          name = "opentracker-v6.conf";
+          listenAddress = "[${cfg.listenAddress.ipv6}]";
+          statsAddresses = cfg.restrictStats.allow.ipv6;
+        };
+      };
+    });
+
+    systemd.targets.opentracker = {
+      description = "opentracker server";
+      wantedBy = [ "multi-user.target" ];
     };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -458,6 +458,7 @@ in {
   openstack-image-metadata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).metadata or {};
   openstack-image-userdata = (handleTestOn ["x86_64-linux"] ./openstack-image.nix {}).userdata or {};
   opentabletdriver = handleTest ./opentabletdriver.nix {};
+  opentracker = handleTest ./opentracker.nix {};
   owncast = handleTest ./owncast.nix {};
   image-contents = handleTest ./image-contents.nix {};
   orangefs = handleTest ./orangefs.nix {};

--- a/nixos/tests/opentracker.nix
+++ b/nixos/tests/opentracker.nix
@@ -1,0 +1,43 @@
+import ./make-test-python.nix ({ lib, ...} : {
+  name = "opentracker";
+  meta = with lib.maintainers; {
+    maintainers = [ ];
+  };
+
+  nodes = {
+    server = { ... }: {
+      services.opentracker = {
+        enable = true;
+        whitelist = [ "e368633c136582fc3eab4a77b1c75c36151a8eef" ];
+        restrictStats.enable = true;
+        restrictStats.allow.ipv4 = [ "127.0.0.1" ];
+        extraConfig."tracker.redirect_url" = "https://nixos.org/";
+      };
+
+      networking.firewall = {
+        allowedTCPPorts = [ 6969 ];
+        allowedUDPPorts = [ 6969 ];
+      };
+    };
+
+    client = { ... }: { };
+  };
+
+  testScript = { ... }: ''
+    start_all()
+
+    server.wait_for_unit("opentracker.target")
+    server.wait_for_unit("network.target")
+    server.wait_for_open_port(6969)
+
+    assert "https://nixos.org/" in server.succeed(
+        "curl -f -s -v http://127.0.0.1:6969/ 2>&1"
+    ), "extraConfig was ignored"
+    server.succeed("curl -f -s 'http://127.0.0.1:6969/stats?mode=everything'")
+
+    client.wait_for_unit("network.target")
+
+    client.succeed("curl -f -s http://server:6969/")
+    client.fail("curl -f -s http://server:6969/stats")
+  '';
+})

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation {
     bittorrent-integration = nixosTests.bittorrent;
   };
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://erdgeist.org/arts/software/opentracker/";
     license = licenses.beerware;

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -1,4 +1,46 @@
-{ lib, stdenv, fetchgit, libowfat, zlib, nixosTests }:
+{ lib
+, stdenv
+, fetchgit
+, libowfat
+, zlib
+, nixosTests
+, ipv6 ? false
+, blacklist ? false
+, whitelist ? false
+, syncLive ? false
+, ipFromQueryString ? false
+, restrictStats ? true
+, ipFromProxy ? false
+, fullLogNetwork ? false
+, logNumWant ? false
+, modestFullScrape ? fullscrape
+, spotWoodpecker ? false
+, fullscrape ? false
+}:
+
+assert !blacklist || !whitelist;
+
+let
+  features = {
+    V6 = ipv6;
+    ACCESSLIST_BLACK = blacklist;
+    ACCESSLIST_WHITE = whitelist;
+    SYNC_LIVE = syncLive;
+    IP_FROM_QUERY_STRING = ipFromQueryString;
+    COMPRESSION_GZIP = true;
+    COMPRESSION_GZIP_ALWAYS = false;
+    LOG_NETWORKS = false;
+    RESTRICT_STATS = restrictStats;
+    IP_FROM_PROXY = ipFromProxy;
+    FULLLOG_NETWORKS = fullLogNetwork;
+    LOG_NUMWANT = logNumWant;
+    MODEST_FULLSCRAPES = modestFullScrape;
+    SPOT_WOODPECKER = spotWoodpecker;
+    SYSLOGS = false;
+    DEV_RANDOM = false;
+    FULLSCRAPE = fullscrape;
+  };
+in
 
 stdenv.mkDerivation {
   pname = "opentracker";
@@ -11,6 +53,18 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [ libowfat zlib ];
+
+  /* FEATURES flag contains spaces so we have to add it this way
+     see https://nixos.org/manual/nixpkgs/stable/#var-stdenv-makeFlagsArray
+  */
+  preBuild = ''
+    makeFlagsArray+=('FEATURES=${
+      lib.concatMapStringsSep
+        " "
+        (name: "-DWANT_${name}")
+        (lib.attrNames (lib.filterAttrs (_: use: use) features))
+    }')
+  '';
 
   makeFlags = [
     "LIBOWFAT_HEADERS=${libowfat}/include/libowfat"

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation {
 
   passthru.tests = {
     bittorrent-integration = nixosTests.bittorrent;
+    inherit (nixosTests) opentracker;
   };
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "opentracker";
-  version = "unstable-2018-05-26";
+  version = "unstable-2021-08-23";
 
   src = fetchgit {
     url = "https://erdgeist.org/gitweb/opentracker";
-    rev = "6411f1567f64248b0d145493c2e61004d2822623";
-    sha256 = "110nfb6n4clykwdzpk54iccsfjawq0krjfqhg114i1z0ri5dyl8j";
+    rev = "110868ec4ebe60521d5a4ced63feca6a1cf0aa2a";
+    sha256 = "1cphy0r4yabwmm7bzpk7jk4fzdxxf9587ciqjmlf7k1vd5z2bqaa";
   };
 
   buildInputs = [ libowfat zlib ];

--- a/pkgs/applications/networking/p2p/opentracker/default.nix
+++ b/pkgs/applications/networking/p2p/opentracker/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation {
   makeFlags = [
     "LIBOWFAT_HEADERS=${libowfat}/include/libowfat"
     "LIBOWFAT_LIBRARY=${libowfat}/lib"
+    "opentracker"
   ];
 
   installPhase = ''

--- a/pkgs/applications/networking/p2p/opentracker/update.sh
+++ b/pkgs/applications/networking/p2p/opentracker/update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts git jq nix nix-prefetch-git
+git_url='https://erdgeist.org/gitweb/opentracker'
+git_branch='master'
+git_dir='/var/tmp/opentracker.git'
+nix_file="$(dirname "${BASH_SOURCE[0]}")/default.nix"
+pkg='opentracker'
+
+set -euo pipefail
+
+info() {
+    if [ -t 2 ]; then
+        set -- '\033[32m%s\033[39m\n' "$@"
+    else
+        set -- '%s\n' "$@"
+    fi
+    printf "$@" >&2
+}
+
+old_rev=$(nix-instantiate --eval --strict --json -A "$pkg.src.rev" | jq -r)
+
+info "fetching $git_url..."
+if [ ! -d "$git_dir" ]; then
+    git init --initial-branch="$git_branch" "$git_dir"
+    git -C "$git_dir" remote add origin "$git_url"
+fi
+git -C "$git_dir" fetch origin "$git_branch"
+
+new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' "origin/$git_branch")
+info "latest commit: $new_rev"
+if [ "$new_rev" = "$old_rev" ]; then
+    info "$pkg is up-to-date."
+    exit
+fi
+
+new_version=$(
+    TZ=UTC0 git -C "$git_dir" \
+        log -n 1 \
+        --format='format:unstable-%cd' \
+        --date='format-local:%Y-%m-%d' \
+        "$new_rev"
+)
+new_sha256=$(nix-prefetch-git --rev "$new_rev" "$git_dir" | jq -r .sha256)
+update-source-version "$pkg" \
+    "$new_version" \
+    "$new_sha256" \
+    --rev="$new_rev"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Proper configuration of opentracker from nix. This depends on #156795.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).