### PR TITLE
python3Packages.zcs: patch to fix the test

### DIFF
--- a/pkgs/development/python-modules/zcs/default.nix
+++ b/pkgs/development/python-modules/zcs/default.nix
@@ -15,6 +15,10 @@ buildPythonPackage rec {
     sha256 = "sha256-ZoQgAaJy3kKHLljyKA0Oo/D1kefE8X9FlsGDSNt1nPw=";
   };
 
+  patches = [
+    ./fix-test-yaml.patch
+  ];
+
   propagatedBuildInputs = [ yacs ];
 
   pythonImportsCheck = [ "zcs" ];

--- a/pkgs/development/python-modules/zcs/fix-test-yaml.patch
+++ b/pkgs/development/python-modules/zcs/fix-test-yaml.patch
@@ -1,0 +1,13 @@
+diff --git a/test/test_zcs.py b/test/test_zcs.py
+index e4981d3..893999f 100644
+--- a/test/test_zcs.py
++++ b/test/test_zcs.py
+@@ -65,7 +65,7 @@ class TestCfgNode(unittest.TestCase):
+         cfg = self.cfg.clone()
+         yamlp = pathjoin(tmpboxx(), "test.yaml")
+         cfg.dump(yamlp)
+-        cfg_dict = yaml.load(open(yamlp))
++        cfg_dict = yaml.load(open(yamlp), yaml.Loader)
+         cfgd = CfgNode(cfg_dict)
+         self.assertTrue(str(cfg.dump()) == str(cfgd.dump()))
+ 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#153896 introduced a build failure in a new package (zcs) because of a requirement in pyyaml reported by @c0bw3b on that PR. This PR fixes that build failure.

###### Things done
Applied a patch to the zcs test file passing the required loader
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
