### PR TITLE
logrotate/systemd: add 'minsize = 1M' to wtmp/btmp rotation

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -1224,6 +1224,7 @@ in
         keep = 1;
         extraConfig = ''
           create 0660 root ${config.users.groups.utmp.name}
+          minsize 1M
         '';
       };
       "/var/log/wtmp" = mapAttrs (_: mkDefault) {
@@ -1231,6 +1232,7 @@ in
         keep = 1;
         extraConfig = ''
           create 0664 root ${config.users.groups.utmp.name}
+          minsize 1M
         '';
       };
     };

--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -19,7 +19,8 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
 
               # wtmp is present in default config.
               "rm -f /var/log/wtmp*",
-              "echo test > /var/log/wtmp",
+              # we need to give it at least 1MB
+              "dd if=/dev/zero of=/var/log/wtmp bs=2M count=1",
 
               # move into the future and rotate
               "date -s 'now + 1 month + 1 day'",


### PR DESCRIPTION
###### Motivation for this change

align with upstream logrotate which added the minsize rule at some point.
This avoids needlessly rotating the files too often as brought up in
https://github.com/NixOS/nixpkgs/pull/159187#issuecomment-1052426774


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
