### PR TITLE
jupyter-lsp: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/jupyter-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyter-lsp/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, jupyter_server
+}:
+
+buildPythonPackage rec {
+  pname = "jupyter-lsp";
+  version = "1.5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-dRq9NUE76ZpDMfNZewk0Gtx1VYntMgkawvaG2z1hJn4=";
+  };
+
+  propagatedBuildInputs = [
+    jupyter_server
+  ];
+  # tests require network
+  doCheck = false;
+  pythonImportsCheck = [ "jupyter_lsp" ];
+
+  meta = with lib; {
+    description = "Multi-Language Server WebSocket proxy for your Jupyter notebook or lab server";
+    homepage = "https://pypi.org/project/jupyter-lsp";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}
+

--- a/pkgs/development/python-modules/jupyterlab-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-lsp/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, jupyterlab
+, jupyter-lsp
+}:
+
+buildPythonPackage rec {
+  pname = "jupyterlab-lsp";
+  version = "3.10.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-8/ZGTIwpFuPiYVGZZLF+1Gc8aJcWc3BirtXdahYKwt8=";
+  };
+
+  propagatedBuildInputs = [
+    jupyterlab
+    jupyter-lsp
+  ];
+  # No tests
+  doCheck = false;
+  pythonImportsCheck = [ "jupyterlab_lsp" ];
+
+  meta = with lib; {
+    description = "Language Server Protocol integration for Jupyter(Lab)";
+    homepage = "https://github.com/jupyter-lsp/jupyterlab-lsp";
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4340,6 +4340,8 @@ in {
 
   jupyter_core = callPackage ../development/python-modules/jupyter_core { };
 
+  jupyter-lsp = callPackage ../development/python-modules/jupyter-lsp { };
+
   jupyter_server = callPackage ../development/python-modules/jupyter_server { };
 
   jupyterhub = callPackage ../development/python-modules/jupyterhub { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4364,6 +4364,8 @@ in {
 
   jupyterlab-widgets = callPackage ../development/python-modules/jupyterlab-widgets { };
 
+  jupyterlab-lsp = callPackage ../development/python-modules/jupyterlab-lsp { };
+
   jupyter-packaging = callPackage ../development/python-modules/jupyter-packaging { };
 
   jupyter-repo2docker = callPackage ../development/python-modules/jupyter-repo2docker {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
