### PR TITLE
libtracefs: 1.2.5 -> 1.3.0

### DIFF
--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -1,23 +1,36 @@
-{ lib, stdenv, fetchgit, pkg-config, libtraceevent, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl }:
+{ lib
+, stdenv
+, fetchgit
+, pkg-config
+, libtraceevent
+, asciidoc
+, xmlto
+, docbook_xml_dtd_45
+, docbook_xsl
+, coreutils
+, which
+, valgrind
+, sourceHighlight
+}:
 
 stdenv.mkDerivation rec {
   pname = "libtracefs";
-  version = "1.2.5";
+  version = "1.3.0";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
     rev = "libtracefs-${version}";
-    sha256 = "1rva9ysspf1wqd0zf52qwgpaasrn7jcbns4dwldc59ksk0n93qdb";
+    sha256 = "sha256-Kg1mPjTZ2UCeco18Fa8GqmLo2R35XvUE/q2J1HAmtEc=";
   };
 
-  # Don't build and install html documentation
   postPatch = ''
-    sed -i -e '/^all:/ s/html//' -e '/^install:/ s/install-html//' Documentation/Makefile
+    substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
+    patchShebangs check-manpages.sh
   '';
 
-  outputs = [ "out" "dev" "devman" ];
+  outputs = [ "out" "dev" "devman" "doc" ];
   enableParallelBuilding = true;
-  nativeBuildInputs = [ pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
+  nativeBuildInputs = [ pkg-config asciidoc xmlto docbook_xml_dtd_45 docbook_xsl which valgrind sourceHighlight ];
   buildInputs = [ libtraceevent ];
   makeFlags = [
     "prefix=${placeholder "out"}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

New upstream release ([release notes](https://lore.kernel.org/lkml/20220223190952.084f4685@rorschach.local.home/T/)). Tested by running `trace-cmd` and `kernelshark`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
