### PR TITLE
bamf: 0.5.5 -> 0.5.6

### DIFF
--- a/pkgs/development/libraries/bamf/default.nix
+++ b/pkgs/development/libraries/bamf/default.nix
@@ -1,8 +1,7 @@
-{ lib, stdenv
-, pantheon
-, autoconf
-, automake
-, libtool
+{ stdenv
+, lib
+, autoreconfHook
+, gitUpdater
 , gnome
 , which
 , fetchgit
@@ -23,26 +22,24 @@
 
 stdenv.mkDerivation rec {
   pname = "bamf";
-  version = "0.5.5";
+  version = "0.5.6";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchgit {
     url = "https://git.launchpad.net/~unity-team/bamf";
-    rev = "${version}+21.10.20210710-0ubuntu1";
-    sha256 = "0iwz5z5cz9r56pmfjvjd2kcjlk416dw6g38svs33ynssjgsqbdm0";
+    rev = version;
+    sha256 = "7U+2GcuDjPU8quZjkd8bLADGlG++tl6wSo0mUQkjAXQ=";
   };
 
   nativeBuildInputs = [
     (python3.withPackages (ps: with ps; [ lxml ])) # Tests
-    autoconf
-    automake
+    autoreconfHook
     dbus
     docbook_xsl
     gnome.gnome-common
     gobject-introspection
     gtk-doc
-    libtool
     pkg-config
     vala
     which
@@ -69,21 +66,22 @@ stdenv.mkDerivation rec {
     "--enable-headless-tests"
   ];
 
-  # fix paths
+  # Fix paths
   makeFlags = [
     "INTROSPECTION_GIRDIR=${placeholder "dev"}/share/gir-1.0/"
     "INTROSPECTION_TYPELIBDIR=${placeholder "out"}/lib/girepository-1.0"
   ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
   # TODO: Requires /etc/machine-id
   doCheck = false;
 
-  # glib-2.62 deprecations
+  # Ignore deprecation errors
   NIX_CFLAGS_COMPILE = "-DGLIB_DISABLE_DEPRECATION_WARNINGS";
+
+  passthru.updateScript = gitUpdater {
+    inherit pname version;
+    ignoredVersions = ".ubuntu.*";
+  };
 
   meta = with lib; {
     description = "Application matching framework";


### PR DESCRIPTION
###### Motivation for this change

https://git.launchpad.net/~unity-team/bamf/log/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
