### PR TITLE
mimalloc: 2.0.2 -> 2.0.5

### DIFF
--- a/pkgs/development/libraries/mimalloc/default.nix
+++ b/pkgs/development/libraries/mimalloc/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, ninja
+, fetchpatch
 , secureBuild ? false
 }:
 
@@ -7,14 +8,28 @@ let
 in
 stdenv.mkDerivation rec {
   pname   = "mimalloc";
-  version = "2.0.2";
+  version = "2.0.5";
 
   src = fetchFromGitHub {
     owner  = "microsoft";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "sha256-n4FGld3bq6ZOSLTzXcVlucCGbQ5/eSFbijU0dfBD/T0=";
+    sha256 = "sha256-q3W/w1Ofqt6EbKF/Jf9wcC+7jAxh59B3cOGxudWQXlA=";
   };
+  patches = [
+    (fetchpatch {
+      name = "older-macos-fixes.patch";
+      url = "https://github.com/microsoft/mimalloc/commit/40e0507a5959ee218f308d33aec212c3ebeef3bb.patch";
+      sha256 = "15qx2a3axhhwbfzxdis98b8j14y9cfgca0i484aj2pjpqnm0pb8c";
+    })
+  ];
+
+  doCheck = true;
+  preCheck = let
+    ldLibraryPathEnv = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+  in ''
+    export ${ldLibraryPathEnv}="$(pwd)/build:''${${ldLibraryPathEnv}}"
+  '';
 
   nativeBuildInputs = [ cmake ninja ];
   cmakeFlags = [ "-DMI_INSTALL_TOPLEVEL=ON" ] ++ lib.optional secureBuild [ "-DMI_SECURE=ON" ];
@@ -25,10 +40,9 @@ stdenv.mkDerivation rec {
   in ''
     # first, move headers and cmake files, that's easy
     mkdir -p $dev/lib
-    mv $out/include $dev/include
-    mv $out/cmake $dev/lib/
+    mv $out/lib/cmake $dev/lib/
 
-    find $out/lib
+    find $dev $out -type f
   '' + (lib.optionalString secureBuild ''
     # pretend we're normal mimalloc
     ln -sfv $out/lib/libmimalloc-secure${suffix} $out/lib/libmimalloc${suffix}
@@ -44,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://github.com/microsoft/mimalloc";
     license     = licenses.bsd2;
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice ];
+    maintainers = with maintainers; [ kamadorueda thoughtpolice ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
