### PR TITLE
.github/CODEOWNERS: remove non-committer users/teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,6 @@
 # IMPORTANT NOTE: in order to actually get pinged, commit access is required.
 # This also holds true for GitHub teams. Since almost none of our teams have write
 # permissions, you need to list all members of the team with commit access individually.
-# We still add the team to the list next to its members, this helps keeping things
-# in sync. (Put non team members before the team to distinguish them.)
-# See https://github.com/NixOS/nixpkgs/issues/124085 for more details
 
 # This file
 /.github/CODEOWNERS @edolstra
@@ -39,10 +36,10 @@
 /pkgs/top-level/stage.nix                        @nbp @Ericson2314 @matthewbauer
 /pkgs/top-level/splice.nix                       @Ericson2314 @matthewbauer
 /pkgs/top-level/release-cross.nix                @Ericson2314 @matthewbauer
-/pkgs/stdenv/generic                             @Ericson2314 @matthewbauer @cab404
+/pkgs/stdenv/generic                             @Ericson2314 @matthewbauer
 /pkgs/stdenv/cross                               @Ericson2314 @matthewbauer
-/pkgs/build-support/cc-wrapper                   @Ericson2314 @orivej
-/pkgs/build-support/bintools-wrapper             @Ericson2314 @orivej
+/pkgs/build-support/cc-wrapper                   @Ericson2314
+/pkgs/build-support/bintools-wrapper             @Ericson2314
 /pkgs/build-support/setup-hooks                  @Ericson2314
 /pkgs/build-support/setup-hooks/auto-patchelf.sh @aszlig
 
@@ -97,8 +94,7 @@
 /pkgs/development/python-modules                            @FRidh @jonringer
 /doc/languages-frameworks/python.section.md                 @FRidh
 /pkgs/development/tools/poetry2nix                          @adisbladis
-/pkgs/development/interpreters/python/hooks                 @FRidh @jonringer @DavHau
-/pkgs/development/interpreters/python/conda                 @DavHau
+/pkgs/development/interpreters/python/hooks                 @FRidh @jonringer
 
 # Haskell
 /doc/languages-frameworks/haskell.section.md  @cdepillabout @sternenseemann @maralorn @expipiplus1
@@ -115,8 +111,8 @@
 /pkgs/development/perl-modules      @stigtsp @zakame
 
 # R
-/pkgs/applications/science/math/R   @jbedo @bcdarwin
-/pkgs/development/r-modules         @jbedo @bcdarwin
+/pkgs/applications/science/math/R   @jbedo
+/pkgs/development/r-modules         @jbedo
 
 # Ruby
 /pkgs/development/interpreters/ruby @marsam
@@ -127,10 +123,6 @@
 /pkgs/build-support/rust @zowoq
 /doc/languages-frameworks/rust.section.md @zowoq
 
-# Darwin-related
-/pkgs/stdenv/darwin         @NixOS/darwin-maintainers
-/pkgs/os-specific/darwin    @NixOS/darwin-maintainers
-
 # C compilers
 /pkgs/development/compilers/gcc @matthewbauer
 /pkgs/development/compilers/llvm @matthewbauer
@@ -138,15 +130,6 @@
 # Compatibility stuff
 /pkgs/top-level/unix-tools.nix @matthewbauer
 /pkgs/development/tools/xcbuild @matthewbauer
-
-# Beam-related (Erlang, Elixir, LFE, etc)
-/pkgs/development/beam-modules                  @gleber
-/pkgs/development/interpreters/erlang           @gleber
-/pkgs/development/interpreters/lfe              @gleber
-/pkgs/development/interpreters/elixir           @gleber
-/pkgs/development/tools/build-managers/rebar    @gleber
-/pkgs/development/tools/build-managers/rebar3   @gleber
-/pkgs/development/tools/erlang                  @gleber
 
 # Audio
 /nixos/modules/services/audio/botamusique.nix @mweinelt
@@ -215,7 +198,7 @@
 /pkgs/development/idris-modules @Infinisil
 
 # Bazel
-/pkgs/development/tools/build-managers/bazel @mboes @Profpatsch
+/pkgs/development/tools/build-managers/bazel @Profpatsch
 
 # NixOS modules for e-mail and dns services
 /nixos/modules/services/mail/mailman.nix    @peti
@@ -243,22 +226,22 @@
 /nixos/tests/prometheus-exporters.nix                        @WilliButz
 
 # PHP interpreter, packages, extensions, tests and documentation
-/doc/languages-frameworks/php.section.md          @NixOS/php @aanderse @etu @globin @ma27 @talyz
-/nixos/tests/php                                  @NixOS/php @aanderse @etu @globin @ma27 @talyz
-/pkgs/build-support/build-pecl.nix                @NixOS/php @aanderse @etu @globin @ma27 @talyz
-/pkgs/development/interpreters/php       @jtojnar @NixOS/php @aanderse @etu @globin @ma27 @talyz
-/pkgs/development/php-packages                    @NixOS/php @aanderse @etu @globin @ma27 @talyz
-/pkgs/top-level/php-packages.nix         @jtojnar @NixOS/php @aanderse @etu @globin @ma27 @talyz
+/doc/languages-frameworks/php.section.md          @aanderse @etu @globin @ma27 @talyz
+/nixos/tests/php                                  @aanderse @etu @globin @ma27 @talyz
+/pkgs/build-support/build-pecl.nix                @aanderse @etu @globin @ma27 @talyz
+/pkgs/development/interpreters/php       @jtojnar @aanderse @etu @globin @ma27 @talyz
+/pkgs/development/php-packages                    @aanderse @etu @globin @ma27 @talyz
+/pkgs/top-level/php-packages.nix         @jtojnar @aanderse @etu @globin @ma27 @talyz
 
 # Podman, CRI-O modules and related
-/nixos/modules/virtualisation/containers.nix @NixOS/podman @zowoq @adisbladis
-/nixos/modules/virtualisation/cri-o.nix      @NixOS/podman @zowoq @adisbladis
-/nixos/modules/virtualisation/podman         @NixOS/podman @zowoq @adisbladis
-/nixos/tests/cri-o.nix                       @NixOS/podman @zowoq @adisbladis
-/nixos/tests/podman                          @NixOS/podman @zowoq @adisbladis
+/nixos/modules/virtualisation/containers.nix @zowoq @adisbladis
+/nixos/modules/virtualisation/cri-o.nix      @zowoq @adisbladis
+/nixos/modules/virtualisation/podman         @zowoq @adisbladis
+/nixos/tests/cri-o.nix                       @zowoq @adisbladis
+/nixos/tests/podman                          @zowoq @adisbladis
 
 # Docker tools
-/pkgs/build-support/docker                   @roberth @utdemir
+/pkgs/build-support/docker                   @roberth
 /nixos/tests/docker-tools-overlay.nix        @roberth
 /nixos/tests/docker-tools.nix                @roberth
 /doc/builders/images/dockertools.xml         @roberth
@@ -273,8 +256,8 @@
 /pkgs/development/go-packages  @kalbasit @Mic92 @zowoq
 
 # GNOME
-/pkgs/desktops/gnome                              @NixOS/GNOME @jtojnar @hedning
-/pkgs/desktops/gnome/extensions       @piegamesde @NixOS/GNOME @jtojnar @hedning
+/pkgs/desktops/gnome                              @jtojnar @hedning
+/pkgs/desktops/gnome/extensions       @piegamesde @jtojnar @hedning
 
 # Cinnamon
 /pkgs/desktops/cinnamon @mkg20001
@@ -295,10 +278,10 @@
 
 # Matrix
 /pkgs/servers/heisenbridge                                 @piegamesde
-/pkgs/servers/matrix-conduit                               @piegamesde @pstn
+/pkgs/servers/matrix-conduit                               @piegamesde
 /pkgs/servers/matrix-synapse/matrix-appservice-irc         @piegamesde
 /nixos/modules/services/misc/heisenbridge.nix              @piegamesde
 /nixos/modules/services/misc/matrix-appservice-irc.nix     @piegamesde
-/nixos/modules/services/misc/matrix-conduit.nix            @piegamesde @pstn
+/nixos/modules/services/misc/matrix-conduit.nix            @piegamesde
 /nixos/tests/matrix-appservice-irc.nix                     @piegamesde
-/nixos/tests/matrix-conduit.nix                            @piegamesde @pstn
+/nixos/tests/matrix-conduit.nix                            @piegamesde


### PR DESCRIPTION
these didn't work anyway and now github warns if they don't have commit access


https://github.com/NixOS/nixpkgs/blob/b71ebb32cedef576181e519380f42d1e2fc5d312/.github/CODEOWNERS

<img width="656" alt="codeowners" src="https://user-images.githubusercontent.com/59103226/155867936-c814e390-d4c7-4a10-87c6-65c1f5c77467.png">

