### PR TITLE
bloat: init at unstable-2022-03-31

### DIFF
--- a/pkgs/servers/bloat/default.nix
+++ b/pkgs/servers/bloat/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildGoModule
+, fetchgit
+, unstableGitUpdater
+}:
+
+buildGoModule {
+  pname = "bloat";
+  version = "unstable-2022-03-31";
+
+  src = fetchgit {
+    url = "git://git.freesoftwareextremist.com/bloat";
+    rev = "a38d29a43592601d37d671db8748f0980071c0c4";
+    sha256 = "sha256-7Hxt0QlOYMBMvDS40fpfSItGkd5nYFQmmjJIevNyeF8=";
+  };
+
+  vendorSha256 = null;
+
+  postInstall = ''
+    mkdir -p $out/share/bloat
+    cp -r templates $out/share/bloat/templates
+    cp -r static $out/share/bloat/static
+    sed \
+      -e "s%=templates%=$out/share/bloat/templates%g" \
+      -e "s%=static%=$out/share/bloat/static%g"       \
+      < bloat.conf > $out/share/bloat/bloat.conf.example
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "A web client for Pleroma and Mastodon";
+    longDescription = ''
+      A lightweight web client for Pleroma and Mastodon.
+      Does not require JavaScript to display text, images, audio and videos.
+    '';
+    homepage = "https://bloat.freesoftwareextremist.com";
+    downloadPage = "https://git.freesoftwareextremist.com/bloat/";
+    license = licenses.cc0;
+    maintainers = with maintainers; [ fgaz ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21201,6 +21201,8 @@ with pkgs;
 
   bird = callPackage ../servers/bird { };
 
+  bloat = callPackage ../servers/bloat { };
+
   bosun = callPackage ../servers/monitoring/bosun { };
 
   cayley = callPackage ../servers/cayley { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
