### PR TITLE
micro: add test with expect

### DIFF
--- a/pkgs/applications/editors/micro/default.nix
+++ b/pkgs/applications/editors/micro/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, callPackage }:
 
 buildGoModule rec {
   pname = "micro";
@@ -23,6 +23,8 @@ buildGoModule rec {
     installManPage assets/packaging/micro.1
     install -Dt $out/share/applications assets/packaging/micro.desktop
   '';
+
+  passthru.tests.expect = callPackage ./test-with-expect.nix {};
 
   meta = with lib; {
     homepage = "https://micro-editor.github.io";

--- a/pkgs/applications/editors/micro/test-with-expect.nix
+++ b/pkgs/applications/editors/micro/test-with-expect.nix
@@ -1,0 +1,30 @@
+{ micro, expect, runCommand, writeScript, runtimeShell }:
+
+let expect-script = writeScript "expect-script" ''
+  #!${expect}/bin/expect -f
+
+  spawn micro file.txt
+  expect "file.txt"
+
+  send "Hello world!"
+  expect "Hello world!"
+
+  # Send ctrl-q (exit)
+  send "\021"
+
+  expect "Save changes to file.txt before closing?"
+  send "y"
+
+  expect eof
+''; in
+runCommand "micro-test-expect"
+{
+  nativeBuildInputs = [ micro expect ];
+  passthru = { inherit expect-script; };
+} ''
+  # Micro really wants a writable $HOME for its config directory.
+  export HOME=$(pwd)
+  expect -f ${expect-script}
+  grep "Hello world!" file.txt
+  touch $out
+''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
