### PR TITLE
ChowPhaser: init at 1.1.1

### DIFF
--- a/pkgs/applications/audio/ChowPhaser/default.nix
+++ b/pkgs/applications/audio/ChowPhaser/default.nix
@@ -1,0 +1,76 @@
+{ alsa-lib, at-spi2-core, cmake, curl, dbus, libepoxy, fetchFromGitHub, freeglut
+, freetype, gcc-unwrapped, gtk3, lib, libGL, libXcursor, libXdmcp, libXext
+, libXinerama, libXrandr, libXtst, libdatrie, libjack2, libpsl, libselinux
+, libsepol, libsysprof-capture, libthai, libxkbcommon, pcre, pkg-config
+, python3, sqlite, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "ChowPhaser";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "jatinchowdhury18";
+    repo = "ChowPhaser";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-9wo7ZFMruG3QNvlpILSvrFh/Sx6J1qnlWc8+aQyS4tQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config cmake ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    curl
+    dbus
+    libepoxy
+    freeglut
+    freetype
+    gtk3
+    libGL
+    libXcursor
+    libXdmcp
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+    libdatrie
+    libjack2
+    libpsl
+    libselinux
+    libsepol
+    libsysprof-capture
+    libthai
+    libxkbcommon
+    pcre
+    python3
+    sqlite
+    gcc-unwrapped
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2 $out/lib/vst3 $out/bin $out/share/doc/ChowPhaser/
+    cd ChowPhaserMono_artefacts/Release
+    cp libChowPhaserMono_SharedCode.a  $out/lib
+    cp -r VST3/ChowPhaserMono.vst3 $out/lib/vst3
+    cp Standalone/ChowPhaserMono  $out/bin
+    cd ../../ChowPhaserStereo_artefacts/Release
+    cp libChowPhaserStereo_SharedCode.a  $out/lib
+    cp -r VST3/ChowPhaserStereo.vst3 $out/lib/vst3
+    cp Standalone/ChowPhaserStereo  $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/jatinchowdhury18/ChowPhaser";
+    description = "Phaser effect based loosely on the Schulte Compact Phasing 'A'";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24861,6 +24861,8 @@ with pkgs;
 
   ChowKick  = callPackage ../applications/audio/ChowKick { };
 
+  ChowPhaser  = callPackage ../applications/audio/ChowPhaser { };
+
   CHOWTapeModel = callPackage ../applications/audio/CHOWTapeModel { };
 
   chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
