### PR TITLE
libtiff: add some reverse dependencies to passthru.tests

### DIFF
--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -8,6 +8,16 @@
 , libjpeg
 , xz
 , zlib
+
+# for passthru.tests
+, libgeotiff
+, python3Packages
+, imagemagick
+, graphicsmagick
+, gdal
+, openimageio
+, freeimage
+, imlib
 }:
 
 #FIXME: fix aarch64-darwin build and get rid of ./aarch64-darwin.nix
@@ -52,6 +62,11 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  passthru.tests = {
+    inherit libgeotiff imagemagick graphicsmagick gdal openimageio freeimage imlib;
+    inherit (python3Packages) pillow imread;
+  };
 
   meta = with lib; {
     description = "Library and utilities for working with the TIFF image file format";


### PR DESCRIPTION
###### Motivation for this change
Packages that have a large reverse dependency set are hard to test because a full rebuild is infeasible. But on the other hand, it's tricky for reviewers to remember which reverse dependencies of a particular package are particularly important to ensure are working or are known to be particularly sensitive to changes in the depended package.

Therefore it makes sense to add a small selection of such packages to `passthru.tests`. Done here for `libtiff`. Testing mostly image loading libraries.

If you liked this PR, you may also like these in a similar vein:
 - #160057
 - #159900
 - #159637
