### PR TITLE
tmux-thumbs: init at 0.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4502,6 +4502,12 @@
     githubId = 3217744;
     name = "Peter Ferenczy";
   };
+  ghostbuster91 = {
+    name = "Kasper Kondzielski";
+    email = "kghost0@gmail.com";
+    github = "ghostbuster91";
+    githubId = 5662622;
+  };
   ghuntley = {
     email = "ghuntley@ghuntley.com";
     github = "ghuntley";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -556,6 +556,10 @@ in rec {
     };
   };
 
+  tmux-thumbs = pkgs.callPackage ./tmux-thumbs {
+    inherit mkTmuxPlugin;
+  };
+
   urlview = mkTmuxPlugin {
     pluginName = "urlview";
     version = "unstable-2016-01-06";

--- a/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-thumbs/default.nix
@@ -1,0 +1,29 @@
+{ lib, mkTmuxPlugin, fetchFromGitHub, thumbs, substituteAll }:
+
+mkTmuxPlugin rec {
+  pluginName = "tmux-thumbs";
+  version = "0.7.1";
+  rtpFilePath = "tmux-thumbs.tmux";
+
+  src = fetchFromGitHub {
+    owner = "fcsonline";
+    repo = pluginName;
+    rev = version;
+    sha256 = "sha256-PH1nscmVhxJFupS7dlbOb+qEwG/Pa/2P6XFIbR/cfaQ=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./fix.patch;
+      tmuxThumbsDir = "${thumbs}/bin";
+    })
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/fcsonline/tmux-thumbs";
+    description = "A lightning fast version of tmux-fingers written in Rust for copy pasting with vimium/vimperator like hints.";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ghostbuster91 ];
+  };
+}

--- a/pkgs/misc/tmux-plugins/tmux-thumbs/fix.patch
+++ b/pkgs/misc/tmux-plugins/tmux-thumbs/fix.patch
@@ -1,0 +1,45 @@
+diff --git a/tmux-thumbs.sh b/tmux-thumbs.sh
+index 34dd528..8c05d54 100755
+--- a/tmux-thumbs.sh
++++ b/tmux-thumbs.sh
+@@ -1,22 +1,8 @@
+ #!/usr/bin/env bash
+ set -Eeu -o pipefail
+ 
+-VERSION=$(grep 'version =' Cargo.toml | grep -oe "[0-9]\+.[0-9]\+.[0-9]\+")
+-
+ # Setup env variables to be compatible with compiled and bundled installations
+ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+-RELEASE_DIR="${CURRENT_DIR}/target/release"
+-
+-THUMBS_BINARY="${RELEASE_DIR}/thumbs"
+-TMUX_THUMBS_BINARY="${RELEASE_DIR}/tmux-thumbs"
+-
+-if [ ! -f "$THUMBS_BINARY" ]; then
+-  tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh"
+-  exit
+-elif [[ $(${THUMBS_BINARY} --version) != "thumbs ${VERSION}"  ]]; then
+-  tmux split-window "cd ${CURRENT_DIR} && bash ./tmux-thumbs-install.sh update"
+-  exit
+-fi
+ 
+ function get-opt-value() {
+   tmux show -vg "@thumbs-${1}" 2> /dev/null
+@@ -36,7 +22,7 @@ function get-opt-arg() {
+   fi
+ }
+ 
+-PARAMS=(--dir "${CURRENT_DIR}")
++PARAMS=(--dir @tmuxThumbsDir@)
+ 
+ function add-param() {
+   local type opt arg
+@@ -51,4 +37,4 @@ add-param upcase-command string
+ add-param multi-command  string
+ add-param osc52          boolean
+ 
+-"${TMUX_THUMBS_BINARY}" "${PARAMS[@]}" || true
++@tmuxThumbsDir@/tmux-thumbs "${PARAMS[@]}" || true
+
+
+

--- a/pkgs/tools/misc/thumbs/default.nix
+++ b/pkgs/tools/misc/thumbs/default.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "thumbs";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "fcsonline";
+    repo = "tmux-thumbs";
+    rev = version;
+    sha256 = "sha256-PH1nscmVhxJFupS7dlbOb+qEwG/Pa/2P6XFIbR/cfaQ=";
+  };
+
+  cargoSha256 = "sha256-6htKiXMMyYRFefJzvDnmdx3CJ3XL8zONhGlV2wcbr9g=";
+
+  cargoPatches = [ ./fix.patch ];
+  meta = with lib; {
+    homepage = "https://github.com/fcsonline/tmux-thumbs";
+    description = "A lightning fast version copy/pasting like vimium/vimperator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ghostbuster91 ];
+  };
+}

--- a/pkgs/tools/misc/thumbs/fix.patch
+++ b/pkgs/tools/misc/thumbs/fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/swapper.rs b/src/swapper.rs
+index 6cf1e89..bcb0969 100644
+--- a/src/swapper.rs
++++ b/src/swapper.rs
+@@ -215,7 +215,7 @@ impl<'a> Swapper<'a> {
+     };
+
+     let pane_command = format!(
+-        "tmux capture-pane -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/target/release/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
++        "tmux capture-pane -t {active_pane_id} -p{scroll_params} | tail -n {height} | {dir}/thumbs -f '%U:%H' -t {tmp} {args}; tmux swap-pane -t {active_pane_id}; {zoom_command} tmux wait-for -S {signal}",
+         active_pane_id = active_pane_id,
+         scroll_params = scroll_params,
+         height = self.active_pane_height.unwrap_or(i32::MAX),

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1137,6 +1137,8 @@ with pkgs;
 
   tfk8s = callPackage ../tools/misc/tfk8s { };
 
+  thumbs = callPackage ../tools/misc/thumbs { };
+
   tnat64 = callPackage ../tools/networking/tnat64 { };
 
   topicctl = callPackage ../tools/misc/topicctl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add https://github.com/fcsonline/tmux-thumbs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
