### PR TITLE
llvmPackages_14: 2022-01-07 -> 14.0.0-rc1

### DIFF
--- a/pkgs/development/compilers/llvm/14/clang/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/14/clang/gnu-install-dirs.patch
@@ -1,77 +1,26 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7ea37850ad60..ac0f2d4f60b4 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.13.4)
- if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-   project(Clang)
- 
-+  include(GNUInstallDirs)
-+
-   set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
-   set(CMAKE_CXX_STANDARD_REQUIRED YES)
-   set(CMAKE_CXX_EXTENSIONS NO)
-@@ -424,7 +426,7 @@ include_directories(BEFORE
- 
- if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-   install(DIRECTORY include/clang include/clang-c
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     COMPONENT clang-headers
-     FILES_MATCHING
-     PATTERN "*.def"
-@@ -433,7 +435,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-     )
- 
-   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/clang
--    DESTINATION include
-+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-     COMPONENT clang-headers
-     FILES_MATCHING
-     PATTERN "CMakeFiles" EXCLUDE
-@@ -453,7 +455,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
- 
-   add_custom_target(bash-autocomplete DEPENDS utils/bash-autocomplete.sh)
-   install(PROGRAMS utils/bash-autocomplete.sh
--          DESTINATION share/clang
-+          DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-           COMPONENT bash-autocomplete)
-   if(NOT LLVM_ENABLE_IDE)
-     add_llvm_install_targets(install-bash-autocomplete
 diff --git a/cmake/modules/AddClang.cmake b/cmake/modules/AddClang.cmake
-index 5752f4277444..5bf08dbf5e83 100644
+index 9bbbfc032b7d..947bd0da865d 100644
 --- a/cmake/modules/AddClang.cmake
 +++ b/cmake/modules/AddClang.cmake
-@@ -118,9 +118,9 @@ macro(add_clang_library name)
+@@ -119,8 +119,8 @@ macro(add_clang_library name)
          install(TARGETS ${lib}
            COMPONENT ${lib}
            ${export_to_clangtargets}
 -          LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
 -          ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
--          RUNTIME DESTINATION bin)
 +          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}
 +          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}
-+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
- 
+           RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
          if (NOT LLVM_ENABLE_IDE)
-           add_llvm_install_targets(install-${lib}
-@@ -159,7 +159,7 @@ macro(add_clang_tool name)
-     get_target_export_arg(${name} Clang export_to_clangtargets)
-     install(TARGETS ${name}
-       ${export_to_clangtargets}
--      RUNTIME DESTINATION bin
-+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-       COMPONENT ${name})
- 
-     if(NOT LLVM_ENABLE_IDE)
-@@ -174,7 +174,7 @@ endmacro()
+@@ -175,7 +175,7 @@ endmacro()
  macro(add_clang_symlink name dest)
    add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
    # Always generate install targets
 -  llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE)
 +  llvm_install_symlink(${name} ${dest} ${CMAKE_INSTALL_FULL_BINDIR} ALWAYS_GENERATE)
  endmacro()
- 
+
  function(clang_target_link_libraries target type)
 diff --git a/lib/Headers/CMakeLists.txt b/lib/Headers/CMakeLists.txt
 index 078988980c52..14b58614b40a 100644
@@ -80,84 +29,16 @@ index 078988980c52..14b58614b40a 100644
 @@ -234,7 +234,7 @@ set_target_properties(clang-resource-headers PROPERTIES
    FOLDER "Misc"
    RUNTIME_OUTPUT_DIRECTORY "${output_dir}")
- 
+
 -set(header_install_dir lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include)
 +set(header_install_dir ${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include)
- 
+
  install(
    FILES ${files} ${generated_files}
-diff --git a/tools/c-index-test/CMakeLists.txt b/tools/c-index-test/CMakeLists.txt
-index 99c6081db2d6..0887102febb3 100644
---- a/tools/c-index-test/CMakeLists.txt
-+++ b/tools/c-index-test/CMakeLists.txt
-@@ -49,7 +49,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
-     set_property(TARGET c-index-test APPEND PROPERTY INSTALL_RPATH
-        "@executable_path/../../lib")
-   else()
--    set(INSTALL_DESTINATION bin)
-+    set(INSTALL_DESTINATION ${CMAKE_INSTALL_BINDIR})
-   endif()
- 
-   install(TARGETS c-index-test
-diff --git a/tools/clang-format/CMakeLists.txt b/tools/clang-format/CMakeLists.txt
-index 35ecdb11253c..d77d75de0094 100644
---- a/tools/clang-format/CMakeLists.txt
-+++ b/tools/clang-format/CMakeLists.txt
-@@ -21,20 +21,20 @@ if( LLVM_LIB_FUZZING_ENGINE OR LLVM_USE_SANITIZE_COVERAGE )
- endif()
- 
- install(PROGRAMS clang-format-bbedit.applescript
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-format)
- install(PROGRAMS clang-format-diff.py
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-format)
- install(PROGRAMS clang-format-sublime.py
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-format)
- install(PROGRAMS clang-format.el
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-format)
- install(PROGRAMS clang-format.py
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-format)
- install(PROGRAMS git-clang-format
--  DESTINATION bin
-+  DESTINATION ${CMAKE_INSTALL_BINDIR}
-   COMPONENT clang-format)
-diff --git a/tools/clang-rename/CMakeLists.txt b/tools/clang-rename/CMakeLists.txt
-index cda8e29ec5b1..0134d8ccd70b 100644
---- a/tools/clang-rename/CMakeLists.txt
-+++ b/tools/clang-rename/CMakeLists.txt
-@@ -19,8 +19,8 @@ clang_target_link_libraries(clang-rename
-   )
- 
- install(PROGRAMS clang-rename.py
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-rename)
- install(PROGRAMS clang-rename.el
--  DESTINATION share/clang
-+  DESTINATION ${CMAKE_INSTALL_DATADIR}/clang
-   COMPONENT clang-rename)
 diff --git a/tools/libclang/CMakeLists.txt b/tools/libclang/CMakeLists.txt
-index bf88dca0a34b..7a10181e7738 100644
+index 4e0647971ab4..68dd67fcc476 100644
 --- a/tools/libclang/CMakeLists.txt
 +++ b/tools/libclang/CMakeLists.txt
-@@ -186,7 +186,7 @@ endif()
- if(INTERNAL_INSTALL_PREFIX)
-   set(LIBCLANG_HEADERS_INSTALL_DESTINATION "${INTERNAL_INSTALL_PREFIX}/include")
- else()
--  set(LIBCLANG_HEADERS_INSTALL_DESTINATION include)
-+  set(LIBCLANG_HEADERS_INSTALL_DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- endif()
- 
- install(DIRECTORY ../../include/clang-c
 @@ -216,7 +216,7 @@ foreach(PythonVersion ${CLANG_PYTHON_BINDINGS_VERSIONS})
            COMPONENT
              libclang-python-bindings
@@ -167,69 +48,3 @@ index bf88dca0a34b..7a10181e7738 100644
  endforeach()
  if(NOT LLVM_ENABLE_IDE)
    add_custom_target(libclang-python-bindings)
-diff --git a/tools/scan-build/CMakeLists.txt b/tools/scan-build/CMakeLists.txt
-index 74334e53c9b1..ebaae33e4324 100644
---- a/tools/scan-build/CMakeLists.txt
-+++ b/tools/scan-build/CMakeLists.txt
-@@ -47,7 +47,7 @@ if(CLANG_INSTALL_SCANBUILD)
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/${BinFile})
-     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/${BinFile})
-     install(PROGRAMS bin/${BinFile}
--            DESTINATION bin
-+            DESTINATION ${CMAKE_INSTALL_BINDIR}
-             COMPONENT scan-build)
-   endforeach()
- 
-@@ -61,7 +61,7 @@ if(CLANG_INSTALL_SCANBUILD)
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libexec/${LibexecFile})
-     list(APPEND Depends ${CMAKE_BINARY_DIR}/libexec/${LibexecFile})
-     install(PROGRAMS libexec/${LibexecFile}
--            DESTINATION libexec
-+            DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}
-             COMPONENT scan-build)
-   endforeach()
- 
-@@ -89,7 +89,7 @@ if(CLANG_INSTALL_SCANBUILD)
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/share/scan-build/${ShareFile})
-     list(APPEND Depends ${CMAKE_BINARY_DIR}/share/scan-build/${ShareFile})
-     install(FILES share/scan-build/${ShareFile}
--            DESTINATION share/scan-build
-+            DESTINATION ${CMAKE_INSTALL_DATADIR}/scan-build
-             COMPONENT scan-build)
-   endforeach()
- 
-diff --git a/tools/scan-view/CMakeLists.txt b/tools/scan-view/CMakeLists.txt
-index eccc6b83195b..ff72d9cf0666 100644
---- a/tools/scan-view/CMakeLists.txt
-+++ b/tools/scan-view/CMakeLists.txt
-@@ -20,7 +20,7 @@ if(CLANG_INSTALL_SCANVIEW)
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/${BinFile})
-     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/${BinFile})
-     install(PROGRAMS bin/${BinFile}
--            DESTINATION bin
-+            DESTINATION ${CMAKE_INSTALL_BINDIR}
-             COMPONENT scan-view)
-   endforeach()
- 
-@@ -34,7 +34,7 @@ if(CLANG_INSTALL_SCANVIEW)
-                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/share/${ShareFile})
-     list(APPEND Depends ${CMAKE_BINARY_DIR}/share/scan-view/${ShareFile})
-     install(FILES share/${ShareFile}
--            DESTINATION share/scan-view
-+            DESTINATION ${CMAKE_INSTALL_DATADIR}/scan-view
-             COMPONENT scan-view)
-   endforeach()
- 
-diff --git a/utils/hmaptool/CMakeLists.txt b/utils/hmaptool/CMakeLists.txt
-index 62f2de0cb15c..6aa66825b6ec 100644
---- a/utils/hmaptool/CMakeLists.txt
-+++ b/utils/hmaptool/CMakeLists.txt
-@@ -10,7 +10,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/${CLANG_HM
- 
- list(APPEND Depends ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin/${CLANG_HMAPTOOL})
- install(PROGRAMS ${CLANG_HMAPTOOL}
--        DESTINATION bin
-+        DESTINATION ${CMAKE_INSTALL_BINDIR}
-         COMPONENT hmaptool)
- 
- add_custom_target(hmaptool ALL DEPENDS ${Depends})

--- a/pkgs/development/compilers/llvm/14/compiler-rt/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/14/compiler-rt/gnu-install-dirs.patch
@@ -1,21 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c5003b5efa1d..4fffb9721284 100644
+index 3a41aa43e406..f000cee6eae0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -5,6 +5,8 @@
- 
+
  cmake_minimum_required(VERSION 3.13.4)
- 
+
 +include(GNUInstallDirs)
 +
  # Check if compiler-rt is built as a standalone project.
  if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR COMPILER_RT_STANDALONE_BUILD)
    project(CompilerRT C CXX ASM)
 diff --git a/cmake/base-config-ix.cmake b/cmake/base-config-ix.cmake
-index 1ada0ab30ba0..b4be6c4a3c73 100644
+index d7b0124f3546..3e111146df4d 100644
 --- a/cmake/base-config-ix.cmake
 +++ b/cmake/base-config-ix.cmake
-@@ -66,7 +66,7 @@ if (LLVM_TREE_AVAILABLE)
+@@ -67,7 +67,7 @@ if (LLVM_TREE_AVAILABLE)
  else()
      # Take output dir and install path from the user.
    set(COMPILER_RT_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH
@@ -24,7 +24,7 @@ index 1ada0ab30ba0..b4be6c4a3c73 100644
    set(COMPILER_RT_EXEC_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin CACHE PATH
      "Path where built compiler-rt executables should be stored.")
    set(COMPILER_RT_INSTALL_PATH "" CACHE PATH
-@@ -98,23 +98,23 @@ endif()
+@@ -99,13 +99,13 @@ endif()
  if(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR AND NOT APPLE)
    set(COMPILER_RT_OUTPUT_LIBRARY_DIR
      ${COMPILER_RT_OUTPUT_DIR}/lib)
@@ -40,16 +40,3 @@ index 1ada0ab30ba0..b4be6c4a3c73 100644
    set(COMPILER_RT_INSTALL_LIBRARY_DIR "${default_install_path}" CACHE PATH
      "Path where built compiler-rt libraries should be installed.")
  endif()
--extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" bin)
-+extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "${CMAKE_INSTALL_BINDIR}")
- set(COMPILER_RT_INSTALL_BINARY_DIR "${default_install_path}" CACHE PATH
-   "Path where built compiler-rt executables should be installed.")
--extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" include)
-+extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "${CMAKE_INSTALL_INCLUDEDIR}")
- set(COMPILER_RT_INSTALL_INCLUDE_DIR "${default_install_path}" CACHE PATH
-   "Path where compiler-rt headers should be installed.")
--extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" share)
-+extend_path(default_install_path "${COMPILER_RT_INSTALL_PATH}" "${CMAKE_INSTALL_DATADIR}")
- set(COMPILER_RT_INSTALL_DATA_DIR "${default_install_path}" CACHE PATH
-   "Path where compiler-rt data files should be installed.")
- 

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -19,10 +19,10 @@
 
 let
   release_version = "14.0.0";
-  candidate = "rc0"; # empty or "rcN"
+  candidate = "rc1"; # empty or "rcN"
   dash-candidate = lib.optionalString (candidate != "") "-${candidate}";
-  rev = "fb1582f6c54422995c6fb61ba4c55126b357f64e"; # When using a Git commit
-  rev-version = "unstable-2022-01-07"; # When using a Git commit
+  rev = ""; # When using a Git commit
+  rev-version = ""; # When using a Git commit
   version = if rev != "" then rev-version else "${release_version}${dash-candidate}";
   targetConfig = stdenv.targetPlatform.config;
 
@@ -30,7 +30,7 @@ let
     owner = "llvm";
     repo = "llvm-project";
     rev = if rev != "" then rev else "llvmorg-${version}";
-    sha256 = "1pkgdsscvf59i22ix763lp2z3sg0v2z2ywh0n07k3ki7q1qpqbhk";
+    sha256 = "sha256-bO13J5bhE4YVGvoaTuzFgf62HYh+Shv6T0u07CFjI9E=";
   };
 
   llvm_meta = {

--- a/pkgs/development/compilers/llvm/14/lld/default.nix
+++ b/pkgs/development/compilers/llvm/14/lld/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./gnu-install-dirs.patch
-	# On Darwin the llvm-config is perhaps not working fine as the
-	# LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as
-	# the include path is not correct.
+    # On Darwin the llvm-config is perhaps not working fine as the
+    # LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as
+    # the include path is not correct.
     ./fix-root-src-dir.patch
   ];
 

--- a/pkgs/development/compilers/llvm/git/lld/default.nix
+++ b/pkgs/development/compilers/llvm/git/lld/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./gnu-install-dirs.patch
-	# On Darwin the llvm-config is perhaps not working fine as the
-	# LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as
-	# the include path is not correct.
+    # On Darwin the llvm-config is perhaps not working fine as the
+    # LLVM_MAIN_SRC_DIR is not getting set correctly, and the build fails as
+    # the include path is not correct.
     ./fix-root-src-dir.patch
   ];
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
