### PR TITLE
schildichat: 1.10.3-sc.0.test.1 -> 1.10.4-sc.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/schildichat/pin.json
+++ b/pkgs/applications/networking/instant-messengers/schildichat/pin.json
@@ -1,7 +1,9 @@
 {
-  "version": "1.10.3-sc.0.test.1",
-  "rev": "3a8eecb023c832acc4390d3a51c0940eafb2b3bd",
-  "srcHash": "07amc69ghfz39jbps14ysfql4m42dmzbdjq9hqvzirhqz52mshf3",
-  "webYarnHash": "0knkl8sanqcx0lxjclz6s8vm5wpn8aywx9vydz7lda3l6c2g5zqf",
+  "version": "1.10.4-sc.1",
+  "rev": "v1.10.4-sc.1",
+  "srcHash": "0sxibzskbw9pa6wmbk1y3n7p74cfj9zvm2hsw76sp6wfac1wnbwl",
+  "webYarnHash": "1z8xr35gh74y2iv9kfk6d6b6f3iclcrpkdds5q7rh2irpf14fwpw",
+  "jsSdkYarnHash": "1cwvb0hwq19dh2937fmcbfvnkkfmalk9wrxf1yv81nsbyjnx86di",
+  "reactSdkYarnHash": "0j4rxg11q35idfzvjrpmyrwkz9yqgzpwps3xqx1k4qcs844jjs9f",
   "desktopYarnHash": "0akmgib212gkygvs2snn9c43k3ika3ipg85d480j3hqyb6yxwqmn"
 }

--- a/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
+++ b/pkgs/applications/networking/instant-messengers/schildichat/schildichat-web.nix
@@ -25,9 +25,17 @@ in stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  offlineCache = fetchYarnDeps {
+  webOfflineCache = fetchYarnDeps {
     yarnLock = src + "/element-web/yarn.lock";
     sha256 = pinData.webYarnHash;
+  };
+  jsSdkOfflineCache = fetchYarnDeps {
+    yarnLock = src + "/matrix-js-sdk/yarn.lock";
+    sha256 = pinData.jsSdkYarnHash;
+  };
+  reactSdkOfflineCache = fetchYarnDeps {
+    yarnLock = src + "/matrix-react-sdk/yarn.lock";
+    sha256 = pinData.reactSdkYarnHash;
   };
 
   nativeBuildInputs = [ yarn fixup_yarn_lock jq nodejs ];
@@ -37,14 +45,30 @@ in stdenv.mkDerivation rec {
 
     export HOME=$PWD/tmp
     mkdir -p $HOME
+
     pushd element-web
-    yarn config --offline set yarn-offline-mirror $offlineCache
     fixup_yarn_lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $webOfflineCache
     yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs node_modules
     rm -rf node_modules/matrix-react-sdk
-    patchShebangs node_modules/ ../matrix-react-sdk/scripts/
     ln -s $PWD/../matrix-react-sdk node_modules/
-    ln -s $PWD/node_modules ../matrix-react-sdk/
+    rm -rf node_modules/matrix-js-sdk
+    ln -s $PWD/../matrix-js-sdk node_modules/
+    popd
+
+    pushd matrix-js-sdk
+    fixup_yarn_lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $jsSdkOfflineCache
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs node_modules
+    popd
+
+    pushd matrix-react-sdk
+    fixup_yarn_lock yarn.lock
+    yarn config --offline set yarn-offline-mirror $reactSdkOfflineCache
+    yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+    patchShebangs node_modules scripts
     popd
 
     runHook postConfigure
@@ -54,7 +78,7 @@ in stdenv.mkDerivation rec {
     runHook preBuild
 
     pushd matrix-react-sdk
-    node_modules/.bin/reskindex -h ../element-web/src/header
+    ../element-web/node_modules/.bin/reskindex -h ../element-web/src/header
     popd
 
     pushd element-web

--- a/pkgs/applications/networking/instant-messengers/schildichat/update.sh
+++ b/pkgs/applications/networking/instant-messengers/schildichat/update.sh
@@ -27,6 +27,8 @@ src_hash=$(echo $src_data | jq -r .sha256)
 
 web_yarn_hash=$(prefetch-yarn-deps $src/element-web/yarn.lock)
 desktop_yarn_hash=$(prefetch-yarn-deps $src/element-desktop/yarn.lock)
+js_sdk_yarn_hash=$(prefetch-yarn-deps $src/matrix-js-sdk/yarn.lock)
+react_sdk_yarn_hash=$(prefetch-yarn-deps $src/matrix-react-sdk/yarn.lock)
 
 cat > pin.json << EOF
 {
@@ -34,6 +36,8 @@ cat > pin.json << EOF
   "rev": "$rev",
   "srcHash": "$src_hash",
   "webYarnHash": "$web_yarn_hash",
+  "jsSdkYarnHash": "$js_sdk_yarn_hash",
+  "reactSdkYarnHash": "$react_sdk_yarn_hash",
   "desktopYarnHash": "$desktop_yarn_hash"
 }
 EOF


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
