### PR TITLE
netdata: fix protobuf support

### DIFF
--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -47,6 +47,8 @@ in stdenv.mkDerivation rec {
     # Therefore we put it into `/run/netdata`, which is owned
     # by netdata only.
     ./ipc-socket-in-run.patch
+    # This is only needed for 1.33.1, remove on the next release
+    ./fix-protobuf.patch
   ];
 
   NIX_CFLAGS_COMPILE = optionalString withDebug "-O1 -ggdb -DNETDATA_INTERNAL_CHECKS=1";

--- a/pkgs/tools/system/netdata/fix-protobuf.patch
+++ b/pkgs/tools/system/netdata/fix-protobuf.patch
@@ -1,0 +1,23 @@
+diff --git a/daemon/buildinfo.c b/daemon/buildinfo.c
+index b64a78f29..ccd1c884d 100644
+--- a/daemon/buildinfo.c
++++ b/daemon/buildinfo.c
+@@ -60,7 +60,6 @@
+ // Optional libraries
+ 
+ #ifdef HAVE_PROTOBUF
+-#if defined(ACLK_NG) || defined(ENABLE_PROMETHEUS_REMOTE_WRITE)
+ #define FEAT_PROTOBUF 1
+ #ifdef BUNDLED_PROTOBUF
+ #define FEAT_PROTOBUF_BUNDLED " (bundled)"
+@@ -71,10 +70,6 @@
+ #define FEAT_PROTOBUF 0
+ #define FEAT_PROTOBUF_BUNDLED ""
+ #endif
+-#else
+-#define FEAT_PROTOBUF 0
+-#define FEAT_PROTOBUF_BUNDLED ""
+-#endif
+ 
+ #ifdef ENABLE_JSONC
+ #define FEAT_JSONC 1


### PR DESCRIPTION
###### Motivation for this change

From tomorrow, hosts without protobuf support won't be able to use NetData Cloud.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
