### PR TITLE
wp-cli: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/development/tools/wp-cli/default.nix
+++ b/pkgs/development/tools/wp-cli/default.nix
@@ -1,19 +1,25 @@
-{ stdenv, lib, fetchurl, writeText, php, makeWrapper }:
+{ stdenv
+, lib
+, fetchurl
+, formats
+, installShellFiles
+, makeWrapper
+, php
+}:
+
 let
-  version = "2.5.0";
+  version = "2.6.0";
 
   completion = fetchurl {
     url = "https://raw.githubusercontent.com/wp-cli/wp-cli/v${version}/utils/wp-completion.bash";
-    sha256 = "sha256-RDygYQzK6NLWrOug7EqnkpuH7Wz1T2Zq/tGNZjoYo5U=";
+    hash = "sha256-RDygYQzK6NLWrOug7EqnkpuH7Wz1T2Zq/tGNZjoYo5U=";
   };
 
-  ini = writeText "php.ini" ''
-    [PHP]
-    memory_limit = -1 ; no limit as composer uses a lot of memory
+  ini = (formats.ini { }).generate "php.ini" {
+    PHP.memory_limit = -1; # no limit as composer uses a lot of memory
+    Phar."phar.readonly" = "Off";
+  };
 
-    [Phar]
-    phar.readonly = Off
-  '';
 in
 stdenv.mkDerivation rec {
   pname = "wp-cli";
@@ -21,19 +27,18 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/wp-cli/wp-cli/releases/download/v${version}/${pname}-${version}.phar";
-    sha256 = "sha256-vghT6fRD84SFZgcIcdNE6K2B6x4V0V3PkyS0p14nJ4k=";
+    hash = "sha256-0WZSjKtgvIIpwGcp5wc4OPu6aNaytXRQTLAniDXIeIg=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
 
   buildCommand = ''
     dir=$out/share/wp-cli
-    mkdir -p $out/bin $dir
-
     install -Dm444 ${src}        $dir/wp-cli
     install -Dm444 ${ini}        $dir/php.ini
-    install -Dm444 ${completion} $out/share/bash-completion/completions/wp
+    installShellCompletion --bash --name wp ${completion}
 
+    mkdir -p $out/bin
     makeWrapper ${lib.getBin php}/bin/php $out/bin/wp \
       --add-flags "-c $dir/php.ini" \
       --add-flags "-f $dir/wp-cli"


### PR DESCRIPTION
###### Motivation for this change

Sadly I still have a need for this, so I can confirm that it works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
