### PR TITLE
nixos/redis: always bind on localhost by default

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -81,7 +81,9 @@ in {
             user = mkOption {
               type = types.str;
               default = redisName name;
-              defaultText = "\"redis\" or \"redis-\${name}\" if name != \"\"";
+              defaultText = literalExpression ''
+                if name == "" then "redis" else "redis-''${name}"
+              '';
               description = "The username and groupname for redis-server.";
             };
 
@@ -105,8 +107,7 @@ in {
 
             bind = mkOption {
               type = with types; nullOr str;
-              default = if name == "" then "127.0.0.1" else null;
-              defaultText = literalExpression ''if name == "" then "127.0.0.1" else null'';
+              default = "127.0.0.1";
               description = ''
                 The IP interface to bind to.
                 <literal>null</literal> means "all interfaces".
@@ -117,7 +118,9 @@ in {
             unixSocket = mkOption {
               type = with types; nullOr path;
               default = "/run/${redisName name}/redis.sock";
-              defaultText = "\"/run/redis/redis.sock\" or \"/run/redis-\${name}/redis.sock\" if name != \"\"";
+              defaultText = literalExpression ''
+                if name == "" then "/run/redis/redis.sock" else "/run/redis-''${name}/redis.sock"
+              '';
               description = "The path to the socket to bind to.";
             };
 
@@ -370,7 +373,7 @@ in {
         ProtectKernelTunables = true;
         ProtectControlGroups = true;
         RestrictAddressFamilies =
-          optionals (conf.bind != null) ["AF_INET" "AF_INET6"] ++
+          optionals (conf.port != 0) ["AF_INET" "AF_INET6"] ++
           optional (conf.unixSocket != null) "AF_UNIX";
         RestrictNamespaces = true;
         LockPersonality = true;


### PR DESCRIPTION
Restore the behaviour before https://github.com/NixOS/nixpkgs/pull/142635 for named servers, essentially redoing https://github.com/NixOS/nixpkgs/pull/100195.

I believe the default value of `bind` was changed because #142635 made the condition for listening on TCP `bind != null`. But after https://github.com/NixOS/nixpkgs/pull/156004, the condition becomes `port != 0` again, so `bind` should default to the sane localhost value.

See https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/merge_requests/268 for even more context