### PR TITLE
libsecret: 0.20.4 → 0.20.5

### DIFF
--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -1,29 +1,64 @@
-{ lib, stdenv, fetchurl, fetchpatch, glib, pkg-config, gettext, libxslt, python3
-, docbook_xsl, docbook_xml_dtd_42 , libgcrypt, gobject-introspection, vala
-, gtk-doc, gnome, gjs, libintl, dbus, xvfb-run }:
+{ stdenv
+, lib
+, fetchurl
+, glib
+, pkg-config
+, gettext
+, libxslt
+, python3
+, docbook-xsl-nons
+, docbook_xml_dtd_42
+, libgcrypt
+, gobject-introspection
+, vala
+, gtk-doc
+, gnome
+, gjs
+, libintl
+, dbus
+, xvfb-run
+}:
 
 stdenv.mkDerivation rec {
   pname = "libsecret";
   version = "0.20.4";
+
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0a4xnfmraxchd9cq5ai66j12jv2vrgjmaaxz25kl031jvda4qnij";
   };
 
-  postPatch = ''
-    patchShebangs .
-  '';
-
-  outputs = [ "out" "dev" "devdoc" ];
-
-  propagatedBuildInputs = [ glib ];
   nativeBuildInputs = [
-    pkg-config gettext libxslt docbook_xsl docbook_xml_dtd_42 libintl
-    gobject-introspection vala gtk-doc glib
+    pkg-config
+    gettext
+    libxslt
+    docbook-xsl-nons
+    docbook_xml_dtd_42
+    libintl
+    gobject-introspection
+    vala
+    gtk-doc
+    glib
   ];
-  buildInputs = [ libgcrypt ];
-  # optional: build docs with gtk-doc? (probably needs a flag as well)
+
+  buildInputs = [
+    libgcrypt
+  ];
+
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  installCheckInputs = [
+    python3
+    python3.pkgs.dbus-python
+    python3.pkgs.pygobject3
+    xvfb-run
+    dbus
+    gjs
+  ];
 
   configureFlags = [
     "--with-libgcrypt-prefix=${libgcrypt.dev}"
@@ -31,17 +66,24 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  installCheckInputs = [
-    python3 python3.pkgs.dbus-python python3.pkgs.pygobject3 xvfb-run dbus gjs
-  ];
-
   # needs to run after install because typelibs point to absolute paths
   doInstallCheck = false; # Failed to load shared library '/force/shared/libmock_service.so.0' referenced by the typelib
+
+  postPatch = ''
+    patchShebangs \
+      ./tool/test-*.sh \
+      build/tap-unittest
+  '';
+
   installCheckPhase = ''
+    runHook preInstallCheck
+
     export NO_AT_BRIDGE=1
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       make check
+
+    runHook postInstallCheck
   '';
 
   passthru = {

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -18,7 +18,6 @@
 , gjs
 , libintl
 , dbus
-, xvfb-run
 }:
 
 stdenv.mkDerivation rec {
@@ -55,32 +54,44 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  installCheckInputs = [
+  checkInputs = [
     python3
     python3.pkgs.dbus-python
     python3.pkgs.pygobject3
-    xvfb-run
     dbus
     gjs
   ];
 
-  # needs to run after install because typelibs point to absolute paths
-  doInstallCheck = false; # Failed to load shared library '/force/shared/libmock_service.so.0' referenced by the typelib
+  doCheck = true;
 
   postPatch = ''
     patchShebangs \
       ./tool/test-*.sh
   '';
 
-  installCheckPhase = ''
-    runHook preInstallCheck
+  preCheck = ''
+    # Our gobject-introspection patches make the shared library paths absolute
+    # in the GIR files. When running tests, the library is not yet installed,
+    # though, so we need to replace the absolute path with a local one during build.
+    # We are using a symlink that will be overwitten during installation.
+    mkdir -p $out/lib $out/lib
+    ln -s "$PWD/libsecret/libmock-service.so" "$out/lib/libmock-service.so"
+    ln -s "$PWD/libsecret/libsecret-1.so.0" "$out/lib/libsecret-1.so.0"
+  '';
 
-    export NO_AT_BRIDGE=1
-    xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+  checkPhase = ''
+    runHook preCheck
+
+    dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       meson test --print-errorlogs
 
-    runHook postInstallCheck
+    runHook postCheck
+  '';
+
+  postCheck = ''
+    # This is test-only so it won’t be overwritten during installation.
+    rm "$out/lib/libmock-service.so"
   '';
 
   postFixup = ''

--- a/pkgs/development/libraries/libsecret/default.nix
+++ b/pkgs/development/libraries/libsecret/default.nix
@@ -2,6 +2,8 @@
 , lib
 , fetchurl
 , glib
+, meson
+, ninja
 , pkg-config
 , gettext
 , libxslt
@@ -11,7 +13,7 @@
 , libgcrypt
 , gobject-introspection
 , vala
-, gtk-doc
+, gi-docgen
 , gnome
 , gjs
 , libintl
@@ -21,25 +23,27 @@
 
 stdenv.mkDerivation rec {
   pname = "libsecret";
-  version = "0.20.4";
+  version = "0.20.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0a4xnfmraxchd9cq5ai66j12jv2vrgjmaaxz25kl031jvda4qnij";
+    sha256 = "P7PONA/NfbVNh8iT5pv8Kx9uTUsnkGX/5m2snw/RK00=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
     gettext
-    libxslt
+    libxslt # for xsltproc for building man pages
     docbook-xsl-nons
     docbook_xml_dtd_42
     libintl
     gobject-introspection
     vala
-    gtk-doc
+    gi-docgen
     glib
   ];
 
@@ -60,19 +64,12 @@ stdenv.mkDerivation rec {
     gjs
   ];
 
-  configureFlags = [
-    "--with-libgcrypt-prefix=${libgcrypt.dev}"
-  ];
-
-  enableParallelBuilding = true;
-
   # needs to run after install because typelibs point to absolute paths
   doInstallCheck = false; # Failed to load shared library '/force/shared/libmock_service.so.0' referenced by the typelib
 
   postPatch = ''
     patchShebangs \
-      ./tool/test-*.sh \
-      build/tap-unittest
+      ./tool/test-*.sh
   '';
 
   installCheckPhase = ''
@@ -81,9 +78,14 @@ stdenv.mkDerivation rec {
     export NO_AT_BRIDGE=1
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
-      make check
+      meson test --print-errorlogs
 
     runHook postInstallCheck
+  '';
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
   '';
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.gnome.org/GNOME/libsecret/-/compare/0.20.4...0.20.5

Picked from https://github.com/NixOS/nixpkgs/pull/160343

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
