### PR TITLE
logrotate: move mail dependency from package to service

### DIFF
--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -1,26 +1,33 @@
 # Test logrotate service works and is enabled by default
 
-import ./make-test-python.nix ({ pkgs, ...} : rec {
+import ./make-test-python.nix ({ pkgs, ... }: rec {
   name = "logrotate";
   meta = with pkgs.lib.maintainers; {
     maintainers = [ martinetd ];
   };
 
-  # default machine
-  machine = { ... }: {
+  nodes = {
+    defaultMachine = { ... }: { };
+    machine = { config, ... }: {
+      services.logrotate.paths = {
+        # using mail somewhere should add --mail to logrotate invokation
+        sendmail = {
+          extraConfig = "mail user@domain.tld";
+        };
+      };
+    };
   };
 
   testScript =
     ''
       with subtest("whether logrotate works"):
-          machine.succeed(
-              # we must rotate once first to create logrotate stamp
-              "systemctl start logrotate.service")
+          # we must rotate once first to create logrotate stamp
+          defaultMachine.succeed("systemctl start logrotate.service")
           # we need to wait for console text once here to
           # clear console buffer up to this point for next wait
-          machine.wait_for_console_text('logrotate.service: Deactivated successfully')
+          defaultMachine.wait_for_console_text('logrotate.service: Deactivated successfully')
 
-          machine.succeed(
+          defaultMachine.succeed(
               # wtmp is present in default config.
               "rm -f /var/log/wtmp*",
               # we need to give it at least 1MB
@@ -28,10 +35,14 @@ import ./make-test-python.nix ({ pkgs, ...} : rec {
 
               # move into the future and check rotation.
               "date -s 'now + 1 month + 1 day'")
-          machine.wait_for_console_text('logrotate.service: Deactivated successfully')
-          machine.succeed(
+          defaultMachine.wait_for_console_text('logrotate.service: Deactivated successfully')
+          defaultMachine.succeed(
               # check rotate worked
               "[ -e /var/log/wtmp.1 ]",
           )
+      with subtest("default config does not have mail"):
+          defaultMachine.fail("systemctl cat logrotate.service | grep -- --mail")
+      with subtest("using mails adds mail option"):
+          machine.succeed("systemctl cat logrotate.service | grep -- --mail")
     '';
 })

--- a/pkgs/tools/system/logrotate/default.nix
+++ b/pkgs/tools/system/logrotate/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchFromGitHub, gzip, popt, autoreconfHook
-, mailutils ? null
 , aclSupport ? true, acl
 , nixosTests
 }:
@@ -19,8 +18,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-compress-command=${gzip}/bin/gzip"
     "--with-uncompress-command=${gzip}/bin/gunzip"
-  ] ++ lib.optionals (mailutils != null) [
-    "--with-default-mail-command=${mailutils}/bin/mail"
   ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

having pkgs.logrotate depend on mailutils brings in quite a bit of dependencies
through mailutil itself and recursive dependency to guile when most people
do not need it.

Remove mailutils dependency from the package, and conditionally add it to the
service if the user specify the mail option either at top level or in a path

Fixes #162001

This supersedes the "mail" part of #162063 which has grown bigger/more complicated than planned, and will continue its own life at a slower pace.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
