### PR TITLE
[21.11] python3Packages.hydra: exclude failing Python versions

### DIFF
--- a/pkgs/development/python-modules/hydra/default.nix
+++ b/pkgs/development/python-modules/hydra/default.nix
@@ -1,11 +1,21 @@
-{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pytestCheckHook
-, importlib-resources, omegaconf, jre_headless, antlr4-python3-runtime }:
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, isPy39
+, fetchFromGitHub
+, pytestCheckHook
+, antlr4-python3-runtime
+, importlib-resources
+, jre_headless
+, omegaconf
+}:
 
 buildPythonPackage rec {
   pname = "hydra";
   version = "1.1.1";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.6" || !pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "facebookresearch";
@@ -23,7 +33,7 @@ buildPythonPackage rec {
   disabledTests = [
     "test_bash_completion_with_dot_in_path"
     "test_install_uninstall"
-  ];
+  ] ++ lib.optionals (!isPy39) [ "test_config_search_path" ];
   disabledTestPaths = [ "tests/test_hydra.py" ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://hydra.nixos.org/build/167354800/nixlog/4

Deactivated broken test on Python 3.7 and 3.8, disabled for unsupported 3.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
