### PR TITLE
build-support/writeTextFile: fix for names with spaces

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -34,11 +34,6 @@
 , extraConfig ? {} # Additional values to be added literally to the final item, e.g. vendor extensions
 }:
 let
-  # FIXME: workaround until https://github.com/NixOS/nixpkgs/pull/162246 lands
-  cleanName = if lib.hasInfix " " name
-                then throw "makeDesktopItem: name must not contain spaces!"
-                else name;
-
   # There are multiple places in the FDO spec that make "boolean" values actually tristate,
   # e.g. StartupNotify, where "unset" is literally defined as "do something reasonable".
   # So, handle null values separately.
@@ -116,8 +111,8 @@ let
   content = [ mainSectionRendered ] ++ actionsRendered;
 in
 writeTextFile {
-  name = "${cleanName}.desktop";
-  destination = "/share/applications/${cleanName}.desktop";
+  name = "${name}.desktop";
+  destination = "/share/applications/${name}.desktop";
   text = builtins.concatStringsSep "\n" content;
-  checkPhase = "${buildPackages.desktop-file-utils}/bin/desktop-file-validate $target";
+  checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
 }

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -121,7 +121,7 @@ rec {
         allowSubstitutes = false;
       }
       ''
-        target=$out${destination}
+        target=$out${lib.escapeShellArg destination}
         mkdir -p "$(dirname "$target")"
 
         if [ -e "$textPath" ]; then

--- a/pkgs/build-support/trivial-builders/test/write-text-file.nix
+++ b/pkgs/build-support/trivial-builders/test/write-text-file.nix
@@ -1,0 +1,34 @@
+{ writeTextFile }:
+let
+  veryWeirdName = ''here's a name with some "bad" characters, like spaces and quotes'';
+in writeTextFile {
+  name = "weird-names";
+  destination = "/etc/${veryWeirdName}";
+  text = ''passed!'';
+  checkPhase = ''
+    # intentionally hardcode everything here, to make sure
+    # Nix does not mess with file paths
+
+    name="here's a name with some \"bad\" characters, like spaces and quotes"
+    fullPath="$out/etc/$name"
+
+    if [ -f "$fullPath" ]; then
+      echo "[PASS] File exists!"
+    else
+      echo "[FAIL] File was not created at expected path!"
+      exit 1
+    fi
+
+    content=$(<"$fullPath")
+    expected="passed!"
+
+    if [ "$content" = "$expected" ]; then
+      echo "[PASS] Contents match!"
+    else
+      echo "[FAIL] File contents don't match!"
+      echo "       Expected: $expected"
+      echo "       Got:      $content"
+      exit 2
+    fi
+  '';
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -59,6 +59,7 @@ with pkgs;
 
   trivial-builders = recurseIntoAttrs {
     writeStringReferencesToFile = callPackage ../build-support/trivial-builders/test/writeStringReferencesToFile.nix {};
+    writeTextFile = callPackage ../build-support/trivial-builders/test/write-text-file.nix {};
     references = callPackage ../build-support/trivial-builders/test/references.nix {};
     overriding = callPackage ../build-support/trivial-builders/test-overriding.nix {};
     concat = callPackage ../build-support/trivial-builders/test/concat-test.nix {};


### PR DESCRIPTION
I am sorry.

###### Motivation for this change
This fixes `pkgs.writeTextFile` when `destination` contains spaces. A simple repro:

```nix
(import ./. {}).writeTextFile {
  name = "bork";
  destination = "/path/with spaces/oh no";
  text = "bork bork";
}
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
