### PR TITLE
treewide: fix some desktop file names

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = "PrusaSlicer";
+      name = "prusa-slicer";
       exec = "prusa-slicer";
       icon = "PrusaSlicer";
       comment = "G-code generator for 3D printers";
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
       categories = [ "Development" ];
     })
     (makeDesktopItem {
-      name = "PrusaSlicer G-code Viewer";
+      name = "prusa-gcodeviewer";
       exec = "prusa-gcodeviewer";
       icon = "PrusaSlicer-gcodeviewer";
       comment = "G-code viewer for 3D printers";

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -33,7 +33,7 @@ let
 
     desktopItems = [
       (makeDesktopItem {
-        name = appname;
+        name = "superslicer";
         exec = "superslicer";
         icon = appname;
         comment = description;

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -34,6 +34,11 @@
 , extraConfig ? {} # Additional values to be added literally to the final item, e.g. vendor extensions
 }:
 let
+  # FIXME: workaround until https://github.com/NixOS/nixpkgs/pull/162246 lands
+  cleanName = if lib.hasInfix " " name
+                then throw "Name must not contain spaces!"
+                else name;
+
   # There are multiple places in the FDO spec that make "boolean" values actually tristate,
   # e.g. StartupNotify, where "unset" is literally defined as "do something reasonable".
   # So, handle null values separately.
@@ -111,8 +116,8 @@ let
   content = [ mainSectionRendered ] ++ actionsRendered;
 in
 writeTextFile {
-  name = "${name}.desktop";
-  destination = "/share/applications/${name}.desktop";
+  name = "${cleanName}.desktop";
+  destination = "/share/applications/${cleanName}.desktop";
   text = builtins.concatStringsSep "\n" content;
   checkPhase = "${desktop-file-utils}/bin/desktop-file-validate $target";
 }

--- a/pkgs/development/tools/scenebuilder/default.nix
+++ b/pkgs/development/tools/scenebuilder/default.nix
@@ -64,11 +64,11 @@ let
   '';
 
   desktopItem = makeDesktopItem {
-    name = "Scene Builder";
+    name = "scenebuilder";
     exec = "scenebuilder";
     icon = "scenebuilder";
     comment = "A visual, drag'n'drop, layout tool for designing JavaFX application user interfaces.";
-    desktopName = pname;
+    desktopName = "Scene Builder";
     mimeTypes = [ "application/java" "application/java-vm" "application/java-archive" ];
     categories = [ "Development" ];
   };

--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -11,13 +11,13 @@
 
 let
   desktopItem = makeDesktopItem {
-    name = "Domination";
+    name = "domination";
     desktopName = "Domination";
     exec = "domination";
     icon = "domination";
   };
   editorDesktopItem = makeDesktopItem {
-    name = "Domination Map Editor";
+    name = "domination-map-editor";
     desktopName = "Domination Map Editor";
     exec = "domination-map-editor";
     icon = "domination";

--- a/pkgs/games/lunar-client/default.nix
+++ b/pkgs/games/lunar-client/default.nix
@@ -5,7 +5,7 @@ let
   version = "2.9.3";
 
   desktopItem = makeDesktopItem {
-    name = "Lunar Client";
+    name = "lunar-client";
     exec = "lunar-client";
     icon = "lunarclient";
     comment = "Minecraft 1.7, 1.8, 1.12, 1.15, and 1.16 Client";


### PR DESCRIPTION
###### Motivation for this change
pkgs.writeTextFile doesn't like spaces in filenames.

This is fixed in #162246, but other tools will probably dislike spaces in .desktop file names as well, and that PR will take forever, so let's fix this anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
