### PR TITLE
Libsystem: Replace cpio with copyHierarchy

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/Libsystem/headers.txt
+++ b/pkgs/os-specific/darwin/apple-source-releases/Libsystem/headers.txt
@@ -71,6 +71,7 @@ architecture/i386/table.h
 architecture/i386/tss.h
 arpa/ftp.h
 arpa/inet.h
+arpa/nameser.h
 arpa/nameser_compat.h
 arpa/telnet.h
 arpa/tftp.h
@@ -956,6 +957,7 @@ mpool.h
 msgcat.h
 nameser.h
 nc_tparm.h
+ncurses.h
 ncurses_dll.h
 ndbm.h
 net/bpf.h


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I noticed every time building Libsystem that there was a very slow phase where the output consisted of many lines like `42 blocks`. This is output from cpio and in brief testing it takes at least twice as long to go through cpio for the simple copies we want to make. The interface is very convenient but the performance penalty is very painful so I decided to implement a function that emulates cpio's interface.

On my machine with a 7200 RPM HDD this speeds up the build from about 250 minutes to about 75 seconds, a factor of 200! I'm not certain the results on modern hardware would be similarly positive so this could use further testing.

I'm running [a full rebuild on Hydra](https://hydra.nixos.org/eval/1746179?compare=1746103) to make sure this doesn't break anything. This is only for x86_64-darwin so testing on aarch64-darwin would be welcome, though maybe unnecessary since that probably gets Libsystem from the SDK instead.

There is potential further work that could be done on this. We could do more than `cpio -pd` did and preserve the permissions from the source completely. This would involve going over all the created directories and fixing their permissions, because we need write permissions as long as we might have to copy a file into them.

The current function is also not very efficient, potentially calling `mkdir -p` many times for the same directory. It would be possible to sort input paths and only create each directory along the hierarchy once but this does complicate the implementation and the current speed up is already so great.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
