### PR TITLE
[21.11] python3Packages.b2sdk: 1.13.0 -> 1.14.1

### DIFF
--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -16,12 +16,12 @@
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "1.13.0";
+  version = "1.14.0";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-Q9B85c+WhazDeXsMR2S0aId32xLY8BAuYRj4QD21x1k=";
+    sha256 = "900da60f9e569e02405b85db35541a79e1cac776ace5d054498b107982ea443c";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -48,7 +48,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace 'setuptools_scm<6.0' 'setuptools_scm'
     substituteInPlace requirements.txt \
-      --replace 'arrow>=0.8.0,<1.0.0' 'arrow'
+      --replace 'arrow>=0.8.0,<1.0.0' 'arrow' \
+      --replace 'arrow>=1.0.2,<2.0.0' 'arrow'
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -16,12 +16,12 @@
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "1.14.0";
+  version = "1.14.1";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "900da60f9e569e02405b85db35541a79e1cac776ace5d054498b107982ea443c";
+    sha256 = "sha256-fYOeyhKm9mRT61NcQVaXFKeRC8AS9lfIZMO/s6iFaeg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , fetchPypi
 , importlib-metadata
-, isPy27
 , logfury
 , pytestCheckHook
 , pytest-lazy-fixture
@@ -17,11 +16,13 @@
 buildPythonPackage rec {
   pname = "b2sdk";
   version = "1.14.1";
-  disabled = isPy27;
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-fYOeyhKm9mRT61NcQVaXFKeRC8AS9lfIZMO/s6iFaeg=";
+    hash = "sha256-fYOeyhKm9mRT61NcQVaXFKeRC8AS9lfIZMO/s6iFaeg=";
   };
 
   nativeBuildInputs = [
@@ -65,5 +66,6 @@ buildPythonPackage rec {
     description = "Client library and utilities for access to B2 Cloud Storage (backblaze)";
     homepage = "https://github.com/Backblaze/b2-sdk-python";
     license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2022-23651
https://nvd.nist.gov/vuln/detail/CVE-2022-23653

This addresses **both** CVEs **without** bumping `backblaze-b2` to 3.2.1. The `backblaze-b2` 3.2.1 release is merely a change to the tool's `requirements` of `b2sdk` to 1.14.1.

Backport of #151948 and #161609

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
