### PR TITLE
starlum: use wrapGAppsHook

### DIFF
--- a/pkgs/tools/misc/staruml/default.nix
+++ b/pkgs/tools/misc/staruml/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, lib, fetchurl, makeWrapper
-, dpkg, patchelf
+{ stdenv, lib, fetchurl
+, dpkg, patchelf, wrapGAppsHook
+, hicolor-icon-theme
 , gtk3, glib, systemd
 , xorg, nss, nspr
 , atk, at-spi2-atk, dbus
@@ -30,7 +31,8 @@ stdenv.mkDerivation rec {
       sha256 = "sha256-CUOdpR8RExMLeOX8469egENotMNuPU4z8S1IGqA21z0=";
     };
 
-  nativeBuildInputs = [ makeWrapper dpkg ];
+  nativeBuildInputs = [ wrapGAppsHook dpkg ];
+  buildInputs = [ glib hicolor-icon-theme ];
 
   unpackPhase = ''
     mkdir pkg
@@ -39,8 +41,14 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
-    mv opt/StarUML $out/bin
+    mkdir -p $out/bin
+    mv opt $out
+
+    mv usr/share $out
+    rm -rf $out/share/doc
+
+    substituteInPlace $out/share/applications/staruml.desktop \
+      --replace "/opt/StarUML/staruml" "$out/bin/staruml"
 
     mkdir -p $out/lib
     ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
@@ -48,9 +56,15 @@ stdenv.mkDerivation rec {
 
     patchelf \
       --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      $out/bin/staruml
-    wrapProgram $out/bin/staruml \
-      --prefix LD_LIBRARY_PATH : $out/lib:${LD_LIBRARY_PATH}
+      $out/opt/StarUML/staruml
+
+    ln -s $out/opt/StarUML/staruml $out/bin/staruml
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH ':' $out/lib:${LD_LIBRARY_PATH}
+    )
   '';
 
   meta = with lib; {


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/158888

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
