### PR TITLE
remmina: Set WITH_VTE=true, so remmina usable as ssh client

### DIFF
--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitLab, cmake, ninja, pkg-config, wrapGAppsHook
 , glib, gtk3, gettext, libxkbfile, libX11
-, freerdp, libssh, libgcrypt, gnutls
+, freerdp, libssh, libgcrypt, gnutls, vte
 , pcre2, libdbusmenu-gtk3, libappindicator-gtk3
 , libvncserver, libpthreadstubs, libXdmcp, libxkbcommon
 , libsecret, libsoup, spice-protocol, spice-gtk, libepoxy, at-spi2-core
@@ -8,6 +8,7 @@
 # The themes here are soft dependencies; only icons are missing without them.
 , gnome
 , withLibsecret ? true
+, withVte ? true
 }:
 
 with lib;
@@ -33,10 +34,11 @@ stdenv.mkDerivation rec {
     libsoup spice-protocol spice-gtk libepoxy at-spi2-core
     openssl gnome.adwaita-icon-theme json-glib libsodium webkitgtk
     harfbuzz
-  ] ++ optionals withLibsecret [ libsecret ];
+  ] ++ optionals withLibsecret [ libsecret ]
+    ++ optionals withVte [ vte ];
 
   cmakeFlags = [
-    "-DWITH_VTE=OFF"
+    "-DWITH_VTE=${if withVte then "ON" else "OFF"}"
     "-DWITH_TELEPATHY=OFF"
     "-DWITH_AVAHI=OFF"
     "-DWITH_LIBSECRET=${if withLibsecret then "ON" else "OFF"}"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/51897 . 
As other distrubutions also ship remmina with VTE support, which is needed to have SSH plugin build, this PR changes the default for the `WITH_VTE` flag. As other users may still not want to pull VTE i have added a flag for that similar the `withLibsecret` flag.
I have checked at least Ubuntu and Archlinux for their default shipping. 

As this is my first PR here please be, i am not 100% sure if i have done everything right, so please leave me a hint if there is something missing.

Edit: i was not directly able to switch to the changed package via my flake, even after appending -I nixpkgs=<directory to my nixpkgs repo>`, but the code change does include all changes which i have done in my overlay. (which is posted in the linked issue). 
So if the reviewer verifies the change, there should be a "SSH" in the quick connect dialog after this change, which was missing before.

edit2: Guess i got a local copy working. I did remove my overlay to "see" a difference to the patch, did install nix-review, did a checkout of this PR, `nix run nixpkgs#nixpkgs-review pr 162274` and `./results/remmina/bin/.remmina-wrapped`. The version then provides the SSH plugin. So it should work.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
