### PR TITLE
python3Packages.torch-tb-profiler: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/torch-tb-profiler/default.nix
+++ b/pkgs/development/python-modules/torch-tb-profiler/default.nix
@@ -1,0 +1,48 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pandas
+, pytestCheckHook
+, pytorch
+, tensorflow-tensorboard
+, torchvision
+}:
+
+let
+  version = "0.3.1";
+  repo = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "kineto";
+    rev = "v${version}";
+    hash = "sha256-Yg001XzOPDmz9wEP2b7Ggz/uU6x5PFzaaBeUBwWKFS0=";
+  };
+in
+buildPythonPackage rec {
+  pname = "torch_tb_profiler";
+  inherit version;
+  format = "setuptools";
+
+  # See https://discourse.nixos.org/t/extracting-sub-directory-from-fetchgit-or-fetchurl-or-any-derivation/8830.
+  src = "${repo}/tb_plugin";
+
+  propagatedBuildInputs = [ pandas tensorflow-tensorboard ];
+
+  checkInputs = [ pytestCheckHook pytorch torchvision ];
+
+  disabledTests = [
+    # Tests that attempt to access the filesystem in naughty ways.
+    "test_profiler_api_without_gpu"
+    "test_tensorboard_end2end"
+    "test_tensorboard_with_path_prefix"
+    "test_tensorboard_with_symlinks"
+  ];
+
+  pythonImportsCheck = [ "torch_tb_profiler" ];
+
+  meta = with lib; {
+    description = "PyTorch Profiler TensorBoard Plugin";
+    homepage = "https://github.com/pytorch/kineto";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9987,6 +9987,8 @@ in {
 
   toposort = callPackage ../development/python-modules/toposort { };
 
+  torch-tb-profiler = callPackage ../development/python-modules/torch-tb-profiler/default.nix { };
+
   torchaudio-bin = callPackage ../development/python-modules/torchaudio/bin.nix { };
 
   torchgpipe = callPackage ../development/python-modules/torchgpipe { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the torch-tb-profiler package, essentially for handling pytorch profiling data in tensor board. See eg https://pytorch.org/blog/introducing-pytorch-profiler-the-new-and-improved-performance-tool/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
