### PR TITLE
python3Packages.types-paramiko: init at 2.8.13

### DIFF
--- a/pkgs/development/python-modules/types-cryptography/default.nix
+++ b/pkgs/development/python-modules/types-cryptography/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, types-enum34
+, types-ipaddress
+}:
+
+buildPythonPackage rec {
+  pname = "types-cryptography";
+  version = "3.3.15";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fr70phvg3zc4h41mv48g04x3f20y478y01ji3w1i2mqlxskm657";
+  };
+
+  pythonImportsCheck = [
+    "cryptography-stubs"
+  ];
+
+  propagatedBuildInputs = [ types-enum34 types-ipaddress ];
+
+  meta = with lib; {
+    description = "Typing stubs for cryptography";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/types-enum34/default.nix
+++ b/pkgs/development/python-modules/types-enum34/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-enum34";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0421lr89vv3fpg77kkj5nmzd7z3nmhw4vh8ibsjp6vfh86b7d73g";
+  };
+
+  pythonImportsCheck = [
+    "enum-python2-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for enum34";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/types-ipaddress/default.nix
+++ b/pkgs/development/python-modules/types-ipaddress/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "types-ipaddress";
+  version = "1.0.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0h9q9pjvw1ap5k70ygp750d096jkzymxlhx87yh0pr9mb6zg6gd0";
+  };
+
+  pythonImportsCheck = [
+    "ipaddress-python2-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for ipaddress";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/development/python-modules/types-paramiko/default.nix
+++ b/pkgs/development/python-modules/types-paramiko/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, types-cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "types-paramiko";
+  version = "2.8.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xk5xqhfl3xmzrnzb17c5hj5zbh7fpyfyj35zjma32iivfkqd8lp";
+  };
+
+  pythonImportsCheck = [
+    "paramiko-stubs"
+  ];
+
+  propagatedBuildInputs = [ types-cryptography ];
+
+  meta = with lib; {
+    description = "Typing stubs for paramiko";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jpetrucciani ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10169,6 +10169,8 @@ in {
 
   types-futures = callPackage ../development/python-modules/types-futures { };
 
+  types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
+
   types-protobuf = callPackage ../development/python-modules/types-protobuf { };
 
   types-pytz = callPackage ../development/python-modules/types-pytz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10165,6 +10165,8 @@ in {
 
   types-decorator = callPackage ../development/python-modules/types-decorator { };
 
+  types-enum34 = callPackage ../development/python-modules/types-enum34 { };
+
   types-freezegun = callPackage ../development/python-modules/types-freezegun { };
 
   types-futures = callPackage ../development/python-modules/types-futures { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10175,6 +10175,8 @@ in {
 
   types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
 
+  types-paramiko = callPackage ../development/python-modules/types-paramiko { };
+
   types-protobuf = callPackage ../development/python-modules/types-protobuf { };
 
   types-pytz = callPackage ../development/python-modules/types-pytz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10161,6 +10161,8 @@ in {
 
   typer = callPackage ../development/python-modules/typer { };
 
+  types-cryptography = callPackage ../development/python-modules/types-cryptography { };
+
   types-dateutil = callPackage ../development/python-modules/types-dateutil { };
 
   types-decorator = callPackage ../development/python-modules/types-decorator { };


### PR DESCRIPTION
###### Motivation for this change

I'd like to include these python type stubs in nixpkgs to allow mypy to work more consistently in projects that use the paramiko library and others


###### Things done

I've added the type stubs for paramiko, and the other stubs that it depends upon, including `types-cryptography`, `types-enum34`, and `types-ipaddress`. These were done in separate commits. Please let me know if you'd like this formatted differently!
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
