### PR TITLE
trilinos: disable auto updates

### DIFF
--- a/pkgs/development/libraries/science/math/trilinos/default.nix
+++ b/pkgs/development/libraries/science/math/trilinos/default.nix
@@ -59,7 +59,9 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "trilinos";
-  version = "12.12.1"; # Xyce 7.4 requires version 12.12.1
+  # Xyce 7.4 requires version 12.12.1
+  # nixpkgs-update: no auto update
+  version = "12.12.1";
 
   src = fetchFromGitHub {
     owner = "trilinos";


### PR DESCRIPTION
###### Motivation for this change
The library `trilinos` was added as a dependency of `xyce` which currently is still the only package making use of that library. `xyce` needs a specific version to build. Hence we disable auto updates.

###### Things done
I added the comment
```
# nixpkgs-update: no auto update
```
as suggested in https://github.com/NixOS/nixpkgs/pull/162233.


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
