### PR TITLE
php.extensions.datadog_trace: init at 0.70.0

### DIFF
--- a/pkgs/development/php-packages/datadog_trace/default.nix
+++ b/pkgs/development/php-packages/datadog_trace/default.nix
@@ -1,0 +1,22 @@
+{ buildPecl, curl, fetchFromGitHub, lib, pcre2 }:
+
+buildPecl rec {
+  pname = "ddtrace";
+  version = "0.70.0";
+
+  src = fetchFromGitHub {
+    owner = "DataDog";
+    repo = "dd-trace-php";
+    rev = "${version}";
+    sha256 = "sha256-AYRBzE0Detg/IHXYutZUfPRMtfthxdkSjqD0M+VcTpY=";
+  };
+
+  buildInputs = [ curl pcre2 ];
+
+  meta = with lib; {
+    description = "Datadog Tracing PHP Client";
+    homepage = "https://github.com/DataDog/dd-trace-php";
+    license = licenses.apsl20;
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -179,6 +179,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     couchbase = callPackage ../development/php-packages/couchbase { };
 
+    datadog_trace = callPackage ../development/php-packages/datadog_trace { };
+
     ds = callPackage ../development/php-packages/ds { };
 
     event = callPackage ../development/php-packages/event { };


### PR DESCRIPTION
###### Motivation for this change

integration for popular service, Datadog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
