### PR TITLE
ligo: 0.34.0 -> 0.36.0

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -1,17 +1,19 @@
 { lib
 , fetchFromGitLab
+, git
 , coq
 , cacert
 }:
 
 coq.ocamlPackages.buildDunePackage rec {
   pname = "ligo";
-  version = "0.34.0";
+  version = "0.36.0";
   src = fetchFromGitLab {
     owner = "ligolang";
     repo = "ligo";
     rev = version;
-    sha256 = "sha256-MHkIr+XkW/zrRt+Cg48q4fOWTkNGH0hbf+oU7cAivNE=";
+    sha256 = "0zx8ai79ha3npm3aybzgisil27v9i052cqdllfri0fsc67dig78b";
+    fetchSubmodules = true;
   };
 
   # The build picks this up for ligo --version
@@ -19,32 +21,59 @@ coq.ocamlPackages.buildDunePackage rec {
 
   useDune2 = true;
 
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    git
+    coq
+    coq.ocamlPackages.menhir
+    coq.ocamlPackages.ocaml-recovery-parser
+  ];
+
   buildInputs = with coq.ocamlPackages; [
     coq
     menhir
     menhirLib
     qcheck
     ocamlgraph
+    bisect_ppx
     ppx_deriving
     ppx_deriving_yojson
     ppx_expect
-    tezos-base
-    tezos-shell-services
-    tezos-010-PtGRANAD-test-helpers
-    tezos-011-PtHangz2-test-helpers
-    tezos-protocol-010-PtGRANAD-parameters
-    tezos-protocol-010-PtGRANAD
-    tezos-protocol-environment
+    ppx_import
+    terminal_size
+    ocaml-recovery-parser
     yojson
     getopt
-    terminal_size
+    core
     pprint
     linenoise
+
+    # Test helpers deps
+    qcheck
+    qcheck-alcotest
+    alcotest-lwt
+
+    # vendored tezos' deps
+    ctypes
+    hacl-star
+    hacl-star-raw
+    lwt-canceler
+    ipaddr
+    bls12-381-unix
+    bls12-381-legacy
+    ptime
+    mtime
+    lwt_log
+    ringo
+    ringo-lwt
+    secp256k1-internal
+    resto
+    resto-directory
+    resto-cohttp-self-serving-client
+    irmin-pack
+    ezjsonm
     data-encoding
-    bisect_ppx
-    cmdliner
-    core
-    ocaml-recovery-parser
   ];
 
   checkInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Update ligo to the latest released version.
Since ligo now have their own fork of tezos that they are using we're also using that instead of the ones in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
