### PR TITLE
clightning: add darwin support

### DIFF
--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   # when building on darwin we need dawin.cctools to provide the correct libtool
   # as libwally-core detects the host as darwin and tries to add the -static
   # option to libtool, also we have to add the modified gsed package.
-  nativeBuildInputs = [ autogen autoconf automake gettext pkg-config py3 unzip which ] 
+  nativeBuildInputs = [ autogen autoconf automake gettext pkg-config py3 unzip which ]
     ++ lib.optionals stdenv.isDarwin [ darwin.cctools ] ++ [ libtool ];
 
   buildInputs = [ gmp libsodium sqlite zlib ];

--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, darwin
 , fetchurl
 , autoconf
 , automake
@@ -27,16 +28,25 @@ stdenv.mkDerivation rec {
     sha256 = "3c9dcb686217b2efe0e988e90b95777c4591e3335e259e01a94af87e0bf01809";
   };
 
-  nativeBuildInputs = [ autogen autoconf automake gettext libtool pkg-config py3 unzip which ];
+  # when building on darwin we need dawin.cctools to provide the correct libtool
+  # as libwally-core detects the host as darwin and tries to add the -static
+  # option to libtool, also we have to add the modified gsed package.
+  nativeBuildInputs = [ autogen autoconf automake gettext pkg-config py3 unzip which ] 
+    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ] ++ [ libtool ];
 
   buildInputs = [ gmp libsodium sqlite zlib ];
 
-  postPatch = ''
+  # this causes some python trouble on a darwin host so we skip this step.
+  # also we have to tell libwally-core to use sed instead of gsed.
+  postPatch = if !stdenv.isDarwin then ''
     patchShebangs \
       tools/generate-wire.py \
       tools/update-mocks.sh \
       tools/mockup.sh \
       devtools/sql-rewrite.py
+  '' else ''
+    substituteInPlace external/libwally-core/tools/autogen.sh --replace gsed sed && \
+    substituteInPlace external/libwally-core/configure.ac --replace gsed sed
   '';
 
   configureFlags = [ "--disable-developer" "--disable-valgrind" ];
@@ -56,6 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ElementsProject/lightning";
     maintainers = with maintainers; [ jb55 prusnak ];
     license = licenses.mit;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ [ "x86_64-darwin" ];
   };
 }

--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   # as libwally-core detects the host as darwin and tries to add the -static
   # option to libtool, also we have to add the modified gsed package.
   nativeBuildInputs = [ autogen autoconf automake gettext pkg-config py3 unzip which ]
-    ++ lib.optionals stdenv.isDarwin [ darwin.cctools ] ++ [ libtool ];
+    ++ lib.optionals stdenv.isDarwin [ darwin.cctools darwin.autoSignDarwinBinariesHook ] ++ [ libtool ];
 
   buildInputs = [ gmp libsodium sqlite zlib ];
 
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ElementsProject/lightning";
     maintainers = with maintainers; [ jb55 prusnak ];
     license = licenses.mit;
-    platforms = platforms.linux ++ [ "x86_64-darwin" ];
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This PR adds darwin (x86_64) support to the clightning package.

###### Things done
To get this package build on darwin we need a few changes (only on darwin)
- Patch `sed` to `gsed` in libwally-core files because of host detection in libwally-core
- Add darwin.cctools to select the correct libtool library (needed because of the way libwally-core detects the host)
- Remove postPatch shebang patch as this causes trouble for python on darwin 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

@prusnak @jb55