### PR TITLE
python3Packages.nextcord: init at 2.0.0a8

### DIFF
--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, substituteAll
+, ffmpeg
+, libopus
+, aiohttp
+, aiodns
+, brotli
+, cchardet
+, orjson
+, pynacl
+}:
+
+buildPythonPackage rec {
+  pname = "nextcord";
+  version = "2.0.0a8";
+
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "nextcord";
+    repo = "nextcord";
+    rev = version;
+    hash = "sha256-aYFY58zWZlZwW3xwa1iAK4w29AofKIkTyCjQ2nR8JrY=";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./paths.patch;
+      ffmpeg = "${ffmpeg}/bin/ffmpeg";
+      libopus = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
+    })
+  ];
+
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    brotli
+    cchardet
+    orjson
+    pynacl
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "nextcord"
+    "nextcord.ext.commands"
+    "nextcord.ext.tasks"
+  ];
+
+  meta = with lib; {
+    description = "Python wrapper for the Discord API forked from discord.py";
+    homepage = "https://github.com/nextcord/nextcord";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/nextcord/paths.patch
+++ b/pkgs/development/python-modules/nextcord/paths.patch
@@ -1,0 +1,26 @@
+diff --git a/nextcord/opus.py b/nextcord/opus.py
+index 97d437a3..755e1a5c 100644
+--- a/nextcord/opus.py
++++ b/nextcord/opus.py
+@@ -213,7 +213,7 @@ def _load_default() -> bool:
+             _filename = os.path.join(_basedir, 'bin', f'libopus-0.{_target}.dll')
+             _lib = libopus_loader(_filename)
+         else:
+-            _lib = libopus_loader(ctypes.util.find_library('opus'))
++            _lib = libopus_loader('@libopus@')
+     except Exception:
+         _lib = None
+ 
+diff --git a/nextcord/player.py b/nextcord/player.py
+index bedefc5a..34de0459 100644
+--- a/nextcord/player.py
++++ b/nextcord/player.py
+@@ -140,7 +140,7 @@ class FFmpegAudio(AudioSource):
+     .. versionadded:: 1.3
+     """
+ 
+-    def __init__(self, source: Union[str, io.BufferedIOBase], *, executable: str = 'ffmpeg', args: Any, **subprocess_kwargs: Any):
++    def __init__(self, source: Union[str, io.BufferedIOBase], *, executable: str = '@ffmpeg@', args: Any, **subprocess_kwargs: Any):
+         piping = subprocess_kwargs.get('stdin') == subprocess.PIPE
+         if piping and isinstance(source, str):
+             raise TypeError("parameter conflict: 'source' parameter cannot be a string when piping to stdin")

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5468,6 +5468,8 @@ in {
 
   nextcloudmonitor = callPackage ../development/python-modules/nextcloudmonitor { };
 
+  nextcord = callPackage ../development/python-modules/nextcord { };
+
   nghttp2 = (toPythonModule (pkgs.nghttp2.override {
     inherit (self) python cython setuptools;
     inherit (pkgs) ncurses;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/home-assistant/core/pull/66540

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
