### PR TITLE
llvmPackages_14: Mark broken packages

### DIFF
--- a/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/14/libcxxabi/default.nix
@@ -82,5 +82,6 @@ stdenv.mkDerivation rec {
     # the UIUC License (a BSD-like license)":
     license = with lib.licenses; [ mit ncsa ];
     maintainers = llvm_meta.maintainers ++ [ lib.maintainers.vlstill ];
+    broken = true; # TODO: gnu-install-dirs.patch fails to apply
   };
 }

--- a/pkgs/development/compilers/llvm/14/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/14/libunwind/default.nix
@@ -43,5 +43,6 @@ stdenv.mkDerivation rec {
       I). It is a dependency of the C++ ABI library, and sometimes is a
       dependency of other runtimes.
     '';
+    broken = true; # TODO: gnu-install-dirs.patch fails to apply
   };
 }

--- a/pkgs/development/compilers/llvm/14/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/14/lldb/default.nix
@@ -115,6 +115,7 @@ stdenv.mkDerivation (rec {
       larger LLVM Project, such as the Clang expression parser and LLVM
       disassembler.
     '';
+    broken = stdenv.isDarwin; # error: use of undeclared identifier 'CPU_SUBTYPE_ARM64E'
   };
 } // lib.optionalAttrs enableManpages {
   pname = "lldb-manpages";

--- a/pkgs/development/compilers/llvm/14/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/14/openmp/default.nix
@@ -50,5 +50,6 @@ stdenv.mkDerivation rec {
     # "All of the code is dual licensed under the MIT license and the UIUC
     # License (a BSD-like license)":
     license = with lib.licenses; [ mit ncsa ];
+    broken = true; # TODO: gnu-install-dirs.patch fails to apply
   };
 }


### PR DESCRIPTION
I quickly went over the latest Hydra evaluation:
https://hydra.nixos.org/eval/1746327?filter=llvmPackages_14&compare=1746266&full=#tabs-still-fail

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
