### PR TITLE
odin2: int at unstable-2022-02-23

### DIFF
--- a/pkgs/applications/audio/odin2/default.nix
+++ b/pkgs/applications/audio/odin2/default.nix
@@ -1,0 +1,79 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, alsa-lib
+, freetype
+, libjack2
+, lv2
+, libX11
+, libXcursor
+, libXext
+, libXinerama
+, libXrandr
+, libGL
+, gcc-unwrapped
+}:
+
+stdenv.mkDerivation rec {
+  pname = "odin2";
+  version = "unstable-2022-02-23";
+
+  src = fetchFromGitHub {
+    owner = "baconpaul";
+    repo = "odin2";
+    rev = "ed02d06cfb5db8a118d291c00bd2e4cd6e262cde";
+    fetchSubmodules = true;
+    sha256 = "sha256-VkZ+mqCmqWQafdN0nQxJdPxbiaZ37/0jOhLvVbnGLvQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    libjack2
+    lv2
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libGL
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  NIX_LDFLAGS = (toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ]);
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/vst3
+    cd Odin2_artefacts/Release
+    cp -r VST3/Odin2.vst3 $out/lib/vst3
+    cp -r Standalone/Odin2 $out/bin
+'';
+
+
+  meta = with lib; {
+    description = "Odin 2 Synthesizer Plugin";
+    homepage = "https://thewavewarden.com/odin2";
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27668,6 +27668,8 @@ with pkgs;
 
   odo = callPackage ../applications/networking/cluster/odo { };
 
+  odin2 = callPackage ../applications/audio/odin2 { };
+
   onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };
 
   open-policy-agent = callPackage ../development/tools/open-policy-agent { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
