### PR TITLE
LibreArp: init at 2.2

### DIFF
--- a/pkgs/applications/audio/LibreArp/default.nix
+++ b/pkgs/applications/audio/LibreArp/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, fetchFromGitLab, cmake, pkg-config, cairo, libxkbcommon
+, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor
+, alsa-lib, libjack2, lv2, gcc-unwrapped, curl}:
+
+stdenv.mkDerivation rec {
+  pname = "LibreArp";
+  version = "2.2";
+
+  src = fetchFromGitLab {
+    owner = "LibreArp";
+    repo = "LibreArp";
+    rev = version;
+    hash = "sha256-jCUT/sflO9L57xRTqNR90RbwJ0uZ+xJVXnB3n+FhWBo=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    cairo
+    libxkbcommon
+    xcbutilcursor
+    xcbutilkeysyms
+    xcbutil
+    libXrandr
+    libXinerama
+    libXcursor
+    alsa-lib
+    libjack2
+    lv2
+    curl
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/vst3
+    cd LibreArp_artefacts/Release
+    cp -r VST3/LibreArp.vst3 $out/lib/vst3
+  '';
+
+  meta = with lib; {
+    description =
+      "A pattern-based arpeggio generator plugin.";
+    homepage = "https://librearp.gitlab.io/";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/applications/audio/LibreArp/lv2.nix
+++ b/pkgs/applications/audio/LibreArp/lv2.nix
@@ -1,0 +1,53 @@
+{ stdenv, lib, fetchFromGitLab, cmake, pkg-config, cairo, libxkbcommon
+, xcbutilcursor, xcbutilkeysyms, xcbutil, libXrandr, libXinerama, libXcursor
+, alsa-lib, libjack2, lv2, gcc-unwrapped, curl}:
+
+stdenv.mkDerivation rec {
+  pname = "LibreArp-lv2";
+  version = "2.2";
+
+  src = fetchFromGitLab {
+    owner = "LibreArp";
+    repo = "LibreArp";
+    rev = "${version}-lv2";
+    hash = "sha256-j5SksuhC4ZXXILfOpwXNqIu5fO07a/6tiZ5qUo+p0Ug=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [
+    cairo
+    libxkbcommon
+    xcbutilcursor
+    xcbutilkeysyms
+    xcbutil
+    libXrandr
+    libXinerama
+    libXcursor
+    alsa-lib
+    libjack2
+    lv2
+    curl
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar"
+    "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib"
+    "-DCMAKE_NM=${gcc-unwrapped}/bin/gcc-nm"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/lv2
+    cd LibreArp_artefacts/Release
+    cp -r LV2/LibreArp.lv2 $out/lib/lv2
+  '';
+
+  meta = with lib; {
+    description =
+      "A pattern-based arpeggio generator plugin.";
+    homepage = "https://librearp.gitlab.io/";
+    license = licenses.gpl3Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ magnetophon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26049,6 +26049,10 @@ with pkgs;
 
   libquvi = callPackage ../applications/video/quvi/library.nix { };
 
+  LibreArp = callPackage ../applications/audio/LibreArp { };
+
+  LibreArp-lv2 = callPackage ../applications/audio/LibreArp/lv2.nix { };
+
   librespot = callPackage ../applications/audio/librespot {
     withALSA = stdenv.isLinux;
     withPulseAudio = config.pulseaudio or stdenv.isLinux;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
