### PR TITLE
python3Packages.lark: 1.0.0 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/hypothesmith/default.nix
+++ b/pkgs/development/python-modules/hypothesmith/default.nix
@@ -9,10 +9,15 @@ buildPythonPackage rec {
     sha256 = "0fb7b3fd03d76eddd4474b0561e1c2662457593a74cc300fd27e5409cd4d7922";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "lark-parser" "lark"
+  '';
+
   propagatedBuildInputs = [ hypothesis lark libcst ];
 
   checkInputs = [ black parso pytestCheckHook pytest-cov pytest-xdist ];
 
+  pytestFlagsArray = [ "-v" ];  # tests are fairly slow, prevents timeout due to no stdout printing
   pythonImportsCheck = [ "hypothesmith" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/kaldi-active-grammar/0001-stub.patch
+++ b/pkgs/development/python-modules/kaldi-active-grammar/0001-stub.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 66e6d49..78f7b42 100644
+index 17c7032..12ed398 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1,23 +1,6 @@
+@@ -1,87 +1,12 @@
  cmake_minimum_required(VERSION 3.13.0)
  project(kaldi_binaries)
  
@@ -24,9 +24,8 @@ index 66e6d49..78f7b42 100644
 -endif()
 -
  set(BINARIES
-   tools/openfst/bin/fstarcsort${CMAKE_EXECUTABLE_SUFFIX}
-   tools/openfst/bin/fstcompile${CMAKE_EXECUTABLE_SUFFIX}
-@@ -29,63 +12,6 @@ set(LIBRARIES
+   )
+ set(LIBRARIES
    src/lib/libkaldi-dragonfly${CMAKE_SHARED_LIBRARY_SUFFIX}
    )
  
@@ -87,30 +86,33 @@ index 66e6d49..78f7b42 100644
 -  message(FATAL_ERROR "KALDI_BRANCH not set! Use 'origin/master'?")
 -  # set(KALDI_BRANCH "origin/master")
 -endif()
- 
+-
  message("MAKE_EXE                  = ${MAKE_EXE}")
  message("PYTHON_EXECUTABLE         = ${PYTHON_EXECUTABLE}")
-@@ -99,63 +25,4 @@ message("CMAKE_CURRENT_BINARY_DIR  = ${CMAKE_CURRENT_BINARY_DIR}")
+ message("PYTHON_INCLUDE_DIR        = ${PYTHON_INCLUDE_DIR}")
+@@ -94,65 +19,4 @@ message("CMAKE_CURRENT_BINARY_DIR  = ${CMAKE_CURRENT_BINARY_DIR}")
  
  # CXXFLAGS are set and exported in kaldi-configure-wrapper.sh
  
 -if(NOT "${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
 -  set(STRIP_LIBS_COMMAND find src/lib tools/openfst/lib -name *${CMAKE_SHARED_LIBRARY_SUFFIX} | xargs strip)
--  set(STRIP_DST_COMMAND find ${DST} | xargs strip)
+-  # set(STRIP_DST_COMMAND find ${DST} [[[other specifiers]]] | xargs strip)
 -  if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
 -    list(APPEND STRIP_LIBS_COMMAND -x)
--    list(APPEND STRIP_DST_COMMAND -x)
+-    # list(APPEND STRIP_DST_COMMAND -x)
 -  endif()
+-  # set(STRIP_LIBS_COMMAND true)
+-  set(STRIP_DST_COMMAND true)
 -  ExternalProject_Add(kaldi
 -    GIT_CONFIG        advice.detachedHead=false
 -    GIT_REPOSITORY    https://github.com/daanzu/kaldi-fork-active-grammar.git
 -    GIT_TAG           ${KALDI_BRANCH}
 -    GIT_SHALLOW       TRUE
--    CONFIGURE_COMMAND sed -i.bak -e "s/status=0/exit 0/g" tools/extras/check_dependencies.sh && cp ${PROJECT_SOURCE_DIR}/building/kaldi-configure-wrapper.sh src/
+-    CONFIGURE_COMMAND sed -i.bak -e "s/status=0/exit 0/g" tools/extras/check_dependencies.sh && sed -i.bak -e "s/openfst_add_CXXFLAGS = -g -O2/openfst_add_CXXFLAGS = -g0 -O3/g" tools/Makefile && cp ${PROJECT_SOURCE_DIR}/building/kaldi-configure-wrapper.sh src/
 -    BUILD_IN_SOURCE   TRUE
--    BUILD_COMMAND     ${MATHLIB_BUILD_COMMAND} && cd tools && ${MAKE_EXE} ${MAKE_FLAGS} && cd openfst && autoreconf && cd ../../src && bash ./kaldi-configure-wrapper.sh ./configure ${KALDI_CONFIG_FLAGS} && ${MAKE_EXE} ${MAKE_FLAGS} depend && ${MAKE_EXE} ${MAKE_FLAGS} dragonfly dragonflybin bin fstbin lmbin
+-    BUILD_COMMAND     ${MATHLIB_BUILD_COMMAND} && cd tools && ${MAKE_EXE} ${MAKE_FLAGS} && cd openfst && autoreconf && cd ../../src && bash ./kaldi-configure-wrapper.sh ./configure ${KALDI_CONFIG_FLAGS} && ${MAKE_EXE} ${MAKE_FLAGS} depend && ${MAKE_EXE} ${MAKE_FLAGS} dragonfly
 -    LIST_SEPARATOR    " "
--    INSTALL_COMMAND   ${STRIP_LIBS_COMMAND} && mkdir -p ${DST} && cp ${BINARIES} ${LIBRARIES} ${DST}
+-    INSTALL_COMMAND   ${STRIP_LIBS_COMMAND} && mkdir -p ${DST} && cp ${BINARIES} ${LIBRARIES} ${DST} && ${STRIP_DST_COMMAND}
 -    )
 -endif()
 -

--- a/pkgs/development/python-modules/kaldi-active-grammar/0002-exec-path.patch
+++ b/pkgs/development/python-modules/kaldi-active-grammar/0002-exec-path.patch
@@ -1,5 +1,5 @@
 diff --git a/kaldi_active_grammar/utils.py b/kaldi_active_grammar/utils.py
-index 0b70c7f..21e1d62 100644
+index 823f997..3850336 100644
 --- a/kaldi_active_grammar/utils.py
 +++ b/kaldi_active_grammar/utils.py
 @@ -79,7 +79,7 @@ elif sys.platform.startswith('linux'): platform = 'linux'
@@ -8,10 +8,10 @@ index 0b70c7f..21e1d62 100644
  
 -exec_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'exec', platform)
 +exec_dir = '/'
- library_extension = dict(windows='.dll', linux='.so', macos='.dylib')[platform]
- subprocess_seperator = '^&' if platform == 'windows' else ';'
  
-@@ -89,13 +89,13 @@ class ExternalProcess(object):
+ import ush
+ 
+@@ -87,13 +87,13 @@ class ExternalProcess(object):
  
      shell = ush.Shell(raise_on_error=True)
  

--- a/pkgs/development/python-modules/kaldi-active-grammar/default.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/default.nix
@@ -50,6 +50,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ scikit-build cmake ];
   propagatedBuildInputs = [ ush requests numpy cffi ];
 
+  doCheck = false;  # no tests exist
+
   meta = with lib; {
     description = "Python Kaldi speech recognition";
     homepage = "https://github.com/daanzu/kaldi-active-grammar";

--- a/pkgs/development/python-modules/lark/default.nix
+++ b/pkgs/development/python-modules/lark/default.nix
@@ -3,17 +3,18 @@
 , fetchFromGitHub
 , python
 , regex
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "lark";
-  version = "1.0.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "lark-parser";
     repo = "lark";
     rev = version;
-    sha256 = "0pfvjh4ydc49gs6m8b3ip85c8nd4da2bhz9714fwcyl3hdp33q7n";
+    sha256 = "sha256-Y1bDSiFnqAKTlIcd8aAgtc+I3TLnWF8hhQK2ez96TQs=";
   };
 
   # Optional import, but fixes some re known bugs & allows advanced regex features
@@ -26,15 +27,11 @@ buildPythonPackage rec {
     "lark.grammars"
   ];
 
-  checkPhase = ''
-    runHook preCheck
+  checkInputs = [ pytestCheckHook ];
 
-    # Official way to run the tests. Runs unittest internally.
-    # pytest produces issues with some test resource paths (relies on __main__)
-    ${python.interpreter} -m tests
-
-    runHook postCheck
-  '';
+  disabledTestPaths = [
+    "tests/test_nearley/test_nearley.py"  # requires unpackaged Js2Py library
+  ];
 
   meta = with lib; {
     description = "A modern parsing library for Python, implementing Earley & LALR(1) and an easy interface";

--- a/pkgs/tools/package-management/pdm/default.nix
+++ b/pkgs/tools/package-management/pdm/default.nix
@@ -47,6 +47,9 @@ buildPythonApplication rec {
       hash = "sha256:1dizf9j3z7zk4lxvnszwx63xzd9r68f2iva5sszzf8s8na831dvd";
     })
   ];
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace "pdm-pep517>=0.9,<0.10" "pdm-pep517"
+  '';
 
   propagatedBuildInputs = [
     blinker


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
