### PR TITLE
Revert "buildDotnetModule: enable RestoreUseStaticGraphEvaluation"

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -158,7 +158,6 @@ in stdenvNoCC.mkDerivation (args // {
           ${lib.optionalString (!enableParallelBuilding) "--disable-parallel"} \
           -p:ContinuousIntegrationBuild=true \
           -p:Deterministic=true \
-          -p:RestoreUseStaticGraphEvaluation=true \
           --packages "$HOME/nuget_pkgs" \
           ${lib.optionalString (dotnetRestoreFlags != []) (builtins.toString dotnetRestoreFlags)} \
           ${lib.optionalString (dotnetFlags != []) (builtins.toString dotnetFlags)}

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
@@ -16,7 +16,6 @@ dotnetConfigureHook() {
             dotnet restore "$project" \
                 -p:ContinuousIntegrationBuild=true \
                 -p:Deterministic=true \
-                -p:RestoreUseStaticGraphEvaluation=true \
                 --source "@nugetSource@/lib" \
                 ${parallelFlag-} \
                 "${dotnetRestoreFlags[@]}" \


### PR DESCRIPTION
This reverts commit 0b1856bfe3837b4509b180b4e9e51d19a88231ba.

This broke one of our clients projects where a local libary could no
longer be found. Since there is no easy way to disable it's better
if this flag is set per project using `dotnetRestoreFlags`.