### PR TITLE
btcpayserver: 1.4.6 -> 1.4.7

### DIFF
--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -3,13 +3,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "1.4.6";
+  version = "1.4.7";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-G6/juGBdiOc8Gh9pKFQlBfUDJzDFMd9gMtILeoF8SMk=";
+    sha256 = "sha256-Qz4BNrhK+NPnKBgjXGYl4P2R878LCuMGZxLECawA12E=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";


### PR DESCRIPTION
Things done:
- Tested with the [nix-bitcoin VM test](https://gist.github.com/e1f05dcfe1c5a24444db928237184817).

This release is missing GPG signatures, so using the update script will fail.
According to @kukks, the releaser, future releases will be signed again.

cc @prusnak @nixbitcoin