### PR TITLE
prosody: add cloud_notify_encrypted module

### DIFF
--- a/nixos/modules/services/networking/prosody.nix
+++ b/nixos/modules/services/networking/prosody.nix
@@ -92,6 +92,12 @@ let
       description = "Push notifications to inform users of new messages or other pertinent information even when they have no XMPP clients online";
     };
 
+    cloud_notify_encrypted = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Push notifications to inform users of new messages or other pertinent information even when they have no XMPP clients online";
+    };
+
     pep = mkOption {
       type = types.bool;
       default = true;

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -22,7 +22,7 @@ let
   );
 in
 stdenv.mkDerivation rec {
-  version = "0.11.12"; # also update communityModules
+  version = "0.11.13"; # also update communityModules
   pname = "prosody";
   # The following community modules are necessary for the nixos module
   # prosody module to comply with XEP-0423 and provide a working
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   ];
   src = fetchurl {
     url = "https://prosody.im/downloads/source/${pname}-${version}.tar.gz";
-    sha256 = "03an206bl3h2lqcgv1wfvc2bqjq6m9vjb2idw0vyvczm43c55kan";
+    sha256 = "sha256-OcYbNGoJtRJbYEy5aeFCBsu8uGyBFW/8a6LWJSfPBDI=";
   };
 
   # A note to all those merging automated updates: Please also update this
@@ -44,8 +44,8 @@ stdenv.mkDerivation rec {
   # version.
   communityModules = fetchhg {
     url = "https://hg.prosody.im/prosody-modules";
-    rev = "bd0a1f917d98";
-    sha256 = "0figx0b0y5zfk5anf16h20y4crjmpb6bkg30vl7p0m594qnyqjcx";
+    rev = "7f8b0830bf40";
+    sha256 = "sha256-bpALReUXoEH6mKozsIJYiRx6lzQyhQ9aUwtSeWLRkrQ=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/xmpp/prosody/default.nix
+++ b/pkgs/servers/xmpp/prosody/default.nix
@@ -14,7 +14,7 @@ with lib;
 
 let
   luaEnv = lua.withPackages(p: with p; [
-      luasocket luasec luaexpat luafilesystem luabitop luadbi-sqlite3
+      luasocket luasec luaexpat luafilesystem luabitop luadbi-sqlite3 luaossl
     ]
     ++ lib.optional withLibevent p.luaevent
     ++ lib.optional withDBI p.luadbi
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
   nixosModuleDeps = [
     "bookmarks"
     "cloud_notify"
+    "cloud_notify_encrypted"
     "vcard_muc"
     "smacks"
     "http_upload"


### PR DESCRIPTION
###### Motivation for this change

I've been pointed out in https://github.com/tigase/siskin-im/issues/177 that this module exists: https://modules.prosody.im/mod_cloud_notify_encrypted
regardless of my success with the actual issue linked I think the module would be useful in general.

I'm not sure what to do with new modules, should I add it with default enable=false for a while first?


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
