### PR TITLE
fix: dvc daemon patch, instantiate env to a copy of os.environ

### DIFF
--- a/pkgs/applications/version-management/dvc/dvc-daemon.patch
+++ b/pkgs/applications/version-management/dvc/dvc-daemon.patch
@@ -12,7 +12,7 @@ index 9854a0e1..fefdd613 100644
 -    file_path = os.path.abspath(inspect.stack()[0][1])
 -    env["PYTHONPATH"] = os.path.dirname(os.path.dirname(file_path))
 +    cmd = [ "@dvc@" , "daemon", "-q"] + args
-+    env = None
++    env = os.environ.copy()
      env[DVC_DAEMON] = "1"
  
      _spawn(cmd, env)


### PR DESCRIPTION
this line in the patch previously removed the dvc utility `fix_env` which works around
pyenv (irrelevant for nix I think), `fix_env` instantiates its `env` argument
as a copy of `os.environ` if its `env` argument is `None`, so I think
this behaviour is close to what the dvc authors intended.

###### Motivation for this change

issue #157998, the dvc commands including dvc init fail with an error about NoneType object does not support item assignment. In the dvc patch, the env variable that is being set into is explicitly set to None, I think to work around dvc working around issues with pyenv as mentioned above. The env is supposed to be `os.environ` with some hackish modifications, so I just set env to a copy of `os.environ` (this mirrors what is done internally in dvc but isn't actually that useful because os environment variables can still be modified by the copy).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (although this built when based on the previous working PR (15087b82725755fbae5c985e94880a1db5c25be7), I had build errors with master due to a dependency no longer building
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
