### PR TITLE
git-annex: patch for aeson 2.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -88,7 +88,7 @@ self: super: {
       name = "git-annex-${super.git-annex.version}-src";
       url = "git://git-annex.branchable.com/";
       rev = "refs/tags/" + super.git-annex.version;
-      sha256 = "11idvicisp4wnw15lk7f9fs0kqpssngs1j8f98050f3jrqsccj0j";
+      sha256 = "1f656rcc6z3jp1n7hh4bczj3inahg1asayxc93vzk3im28a8gr2f";
       # delete android and Android directories which cause issues on
       # darwin (case insensitive directory). Since we don't need them
       # during the build process, we can delete it to prevent a hash
@@ -97,6 +97,21 @@ self: super: {
         rm -r $out/doc/?ndroid*
       '';
     };
+
+    patches = drv.patches or [] ++ [
+      # Intermediate, inconsequential patch we need to add so the next one applies
+      (pkgs.fetchpatch {
+        name = "git-annex-enable-package-imports.patch";
+        url = "https://git.joeyh.name/index.cgi/git-annex.git/patch/?id=952664641a38ee4da940c1bb8f1bf6c3e699137f";
+        sha256 = "0ablfa5jh98rgpx9wd0kgjdr6j1vyqygfnsisvn45dh7f3svkhx9";
+      })
+      # Allows compilation with aeson >= 2.0, submitted upstream as well
+      (pkgs.fetchpatch {
+        name = "git-annex-aeson-2.0.patch";
+        url = "https://git.joeyh.name/index.cgi/git-annex.git/patch/?id=ca596e7c54ed08e2bec3b6b3e669ccf5ded9aff8";
+        sha256 = "18m164xwx6axw50bm2c833772rqcyqk3aqzap2pzawbb5d024ss6";
+      })
+    ];
 
     # Git annex provides a restricted login shell. Setting
     # passthru.shellPath here allows a user's login shell to be set to


### PR DESCRIPTION
This patch was submitted to Joey Hess via email, ~~so far no response~~.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
