### PR TITLE
kakoune.cr: init at unstable-2021-11-12

### DIFF
--- a/pkgs/tools/misc/kakoune-cr/default.nix
+++ b/pkgs/tools/misc/kakoune-cr/default.nix
@@ -1,0 +1,49 @@
+{ lib, crystal, fetchFromGitHub, fetchurl, jq }:
+let
+  icon = fetchurl {
+    url = "https://github.com/mawww/kakoune/raw/master/doc/kakoune_logo.svg";
+    hash = "sha256-JxhIEmjiGrisaarA1sX1AfzNjHNIm9xjyPs/nG1uL/U=";
+  };
+in
+crystal.buildCrystalPackage rec {
+  pname = "kakoune.cr";
+  version = "unstable-2021-11-12";
+
+  src = fetchFromGitHub {
+    owner = "alexherbo2";
+    repo = "kakoune.cr";
+    rev = "43d4276e1d173839f335ff60f205b89705892e00";
+    hash = "sha256-xFrxbnZl/49vGKdkESPa6LpK0ckq4Jv5GNLL/G0qA1w=";
+  };
+
+  propagatedUserEnvPkgs = [ jq ];
+
+  format = "shards";
+  shardsFile = ./shards.nix;
+  lockFile = ./shard.lock;
+
+  preConfigure = ''
+    substituteInPlace src/kakoune/version.cr --replace \
+      '`git describe --tags --always`' \
+      '"${version}"'
+  '';
+
+  postInstall = ''
+    install -Dm555 share/kcr/commands/*/kcr-* -t $out/bin
+    install -Dm444 share/kcr/applications/kcr.desktop -t $out/share/applications
+    install -Dm444 ${icon} $out/share/icons/hicolor/scalable/apps/kcr.svg
+    cp -r share/kcr $out/share/
+  '';
+
+  installCheckPhase = ''
+    $out/bin/kcr --help
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/alexherbo2/kakoune.cr";
+    description = "A command-line tool for Kakoune";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ malvo ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/kakoune-cr/shard.lock
+++ b/pkgs/tools/misc/kakoune-cr/shard.lock
@@ -1,0 +1,10 @@
+version: 2.0
+shards:
+  fifo:
+    git: https://github.com/alexherbo2/fifo.cr.git
+    version: 0.1.0+git.commit.37a2cc2718af0f8a1c50071106d7a5ca3a0d3da2
+
+  rsub:
+    git: https://github.com/alexherbo2/rsub.cr.git
+    version: 0.1.0+git.commit.43c6b9836ee281328bccfdf8c669bab26448e3b3
+

--- a/pkgs/tools/misc/kakoune-cr/shards.nix
+++ b/pkgs/tools/misc/kakoune-cr/shards.nix
@@ -1,0 +1,14 @@
+{
+  fifo = {
+    owner = "alexherbo2";
+    repo = "fifo.cr";
+    rev = "37a2cc2718af0f8a1c50071106d7a5ca3a0d3da2";
+    sha256 = "0syh2819dzsfb562z645sajfh7xplhh3mxdachjnzlsdfqkxw85r";
+  };
+  rsub = {
+    owner = "alexherbo2";
+    repo = "rsub.cr";
+    rev = "43c6b9836ee281328bccfdf8c669bab26448e3b3";
+    sha256 = "144p83y3d02jy4gapify53x3i4i51yva6ajbvgi8rx0zj2ajgr0d";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6950,6 +6950,8 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 
+  kakoune-cr = callPackage ../tools/misc/kakoune-cr { };
+
   kbdd = callPackage ../applications/window-managers/kbdd { };
 
   kbs2 = callPackage ../tools/security/kbs2 {


### PR DESCRIPTION
Co-authored-by: Sebastian Zivota <sebastian.zivota@mailbox.org>

This PR continues the work of @loewenheim on #115011. I've updated the program to the latest revision and removed the dependencies on `bat`, `fd` and `fzf`, since these are strictly optional and not at all required for `kakoune.cr`'s functionality.

Additionally, I've moved the files to the location in the source tree where `kak-lsp` already is, since `kakoune.cr` is not an editor unto itself but rather an add-on tool for Kakoune, just like `kak-lsp`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
