### PR TITLE
[21.11] Prepare for backporting Chromium M99

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -220,7 +220,7 @@ let
       # Link to our own Node.js and Java (required during the build):
       mkdir -p third_party/node/linux/node-linux-x64/bin
       ln -s "${pkgsBuildHost.nodejs}/bin/node" third_party/node/linux/node-linux-x64/bin/node
-      ln -s "${pkgsBuildHost.jre8}/bin/java" third_party/jdk/current/bin/
+      ln -s "${pkgsBuildHost.jre8_headless}/bin/java" third_party/jdk/current/bin/
 
       # Allow building against system libraries in official builds
       sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' tools/generate_shim_headers/generate_shim_headers.py

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -96,7 +96,7 @@ let
     "libpng"
     "libwebp"
     "libxslt"
-    "opus"
+    # "opus"
   ];
 
   opusWithCustomModes = libopus.override {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -182,8 +182,8 @@ in stdenv.mkDerivation {
   in with lib; ''
     mkdir -p "$out/bin"
 
-    eval makeWrapper "${browserBinary}" "$out/bin/chromium" \
-      --add-flags ${escapeShellArg (escapeShellArg commandLineArgs)}
+    makeWrapper "${browserBinary}" "$out/bin/chromium" \
+      --add-flags ${escapeShellArg commandLineArgs}
 
     ed -v -s "$out/bin/chromium" << EOF
     2i

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,5 +1,5 @@
 { newScope, config, stdenv, fetchurl, makeWrapper
-, llvmPackages_13, ed, gnugrep, coreutils, xdg-utils
+, llvmPackages_13, llvmPackages_14, ed, gnugrep, coreutils, xdg-utils
 , glib, gtk3, gnome, gsettings-desktop-schemas, gn, fetchgit
 , libva, pipewire, wayland
 , gcc, nspr, nss, runCommand
@@ -54,6 +54,9 @@ let
           inherit (upstream-info.deps.gn) url rev sha256;
         };
       });
+    } // lib.optionalAttrs (chromiumVersionAtLeast "99") rec {
+      llvmPackages = llvmPackages_14;
+      stdenv = llvmPackages_14.stdenv;
     });
 
     browser = callPackage ./browser.nix {

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -206,8 +206,8 @@ in stdenv.mkDerivation {
 
     export XDG_DATA_DIRS=$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH\''${XDG_DATA_DIRS:+:}\$XDG_DATA_DIRS
 
-    # Mainly for xdg-open but also other xdg-* tools:
-    export PATH="${xdg-utils}/bin\''${PATH:+:}\$PATH"
+    # Mainly for xdg-open but also other xdg-* tools (this is only a fallback; \$PATH is suffixed so that other implementations can be used):
+    export PATH="\$PATH\''${PATH:+:}${xdg-utils}/bin"
 
     .
     w

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "100.0.4867.0",
-    "sha256": "1ay6p2aky90lf3gk3n87m4mrxyyhg4anr389kl648ijigsg6wlrd",
-    "sha256bin64": "11g8rlw5aahpn4cd2fl4b942g1giv05zcs10y0qrvirnwmp2i3ha",
+    "version": "100.0.4878.0",
+    "sha256": "0ac8fdbh3f66wq3y1l4s1i906zriajff84hpx9df9cwavj6r9svr",
+    "sha256bin64": "1q37q02v6aaqkxwyavljga0h60cclklxj8adr1jc1fqs0irks8a8",
     "deps": {
       "gn": {
         "version": "2022-01-21",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,15 +19,15 @@
     }
   },
   "beta": {
-    "version": "98.0.4758.80",
-    "sha256": "0wa1jhsw7qrym4x8wxmdvdvbilb8jdv0mizzib2342l61zi6cwn8",
-    "sha256bin64": "12a69cbv2sbrly6g477ln4pssh8n1rdg6mr6cc17iy2jhfihry0q",
+    "version": "99.0.4844.17",
+    "sha256": "18bhfy64rz4bilbzml33856azwzq4bhiisc2jlbncdnmk3x6n71s",
+    "sha256bin64": "1vaxcfgiww4skanny5ks431jyrnf0rgx7g850m29v8v49c3qflm8",
     "deps": {
       "gn": {
-        "version": "2021-12-07",
+        "version": "2022-01-10",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "fc295f3ac7ca4fe7acc6cb5fb052d22909ef3a8f",
-        "sha256": "02bx3bp85kkis704gndb6jvjph7gv3ij746bq4anl30kfrkpcifh"
+        "rev": "80a40b07305373617eba2d5878d353532af77da3",
+        "sha256": "1103lf38h7412949j6nrk48m2vv2rrxacn42sjg33lg88nyv7skv"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "100.0.4892.0",
-    "sha256": "03f003prk0vqxac7l0sp3nfhh3adlrdx60dklm74v504ykdw84yn",
-    "sha256bin64": "00033b2iq3aw5pvgm5nbh99sz8mj98rj32h1m6iw2xxwqaij06qw",
+    "version": "100.0.4896.12",
+    "sha256": "07jd3d5jhs659wwxnbxk6h93pz8zaynrw72b0y9l6l824lip6hl2",
+    "sha256bin64": "0fnxq0vjn00zai94p8jgx69bag30zzlfl2vzn0zb65pr10fpac87",
     "deps": {
       "gn": {
         "version": "2022-01-21",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "99.0.4844.27",
-    "sha256": "07srkycb92sajbxcjbwgjcj0xgb17k9i4b7cg50dvz3pwdvm7y8y",
-    "sha256bin64": "1a3a66kmcim3f8wvi19330m2iixxngsfiwv44g8zz51qk4rg4wx3",
+    "version": "99.0.4844.35",
+    "sha256": "085vsfp08y4vmv73z37ncynvax645qm302h883skx9xk4yyjkynj",
+    "sha256bin64": "18kys3f0zjkrp1x2vkcc9vx6vhj5yfrpb88lli7ql6q9b0ijjjn4",
     "deps": {
       "gn": {
         "version": "2022-01-10",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "99.0.4844.45",
-    "sha256": "1j6s9r2k6zyyjk3f74k2103zlih96wrr2a83bk79fwc582af9505",
-    "sha256bin64": "0lqps8lf7yg9nn5z2iy6hfrx2df59hif8vhf0camx2lfmrkgw8qa",
+    "version": "99.0.4844.51",
+    "sha256": "1qxsn8zvvvsnn0k7nn606rhaial8ikrlfh175msqpp50xibjxicp",
+    "sha256bin64": "1bayx03xf94ra0wid1jn10vysa6src4hmrdzdxf566rx9wcg29pk",
     "deps": {
       "gn": {
         "version": "2022-01-10",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,9 +32,9 @@
     }
   },
   "dev": {
-    "version": "100.0.4878.0",
-    "sha256": "0ac8fdbh3f66wq3y1l4s1i906zriajff84hpx9df9cwavj6r9svr",
-    "sha256bin64": "1q37q02v6aaqkxwyavljga0h60cclklxj8adr1jc1fqs0irks8a8",
+    "version": "100.0.4892.0",
+    "sha256": "03f003prk0vqxac7l0sp3nfhh3adlrdx60dklm74v504ykdw84yn",
+    "sha256bin64": "00033b2iq3aw5pvgm5nbh99sz8mj98rj32h1m6iw2xxwqaij06qw",
     "deps": {
       "gn": {
         "version": "2022-01-21",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "99.0.4844.16",
-    "sha256": "0xig6l1yx9glgb1a53idncnqc1imjvbszi5mrp39yvijarmx8s1f",
-    "sha256bin64": "18p2hqykizijb9w96dm8yxwgvpjx37vabyw6n9wc59l6wyhbjkkw",
+    "version": "100.0.4867.0",
+    "sha256": "1ay6p2aky90lf3gk3n87m4mrxyyhg4anr389kl648ijigsg6wlrd",
+    "sha256bin64": "11g8rlw5aahpn4cd2fl4b942g1giv05zcs10y0qrvirnwmp2i3ha",
     "deps": {
       "gn": {
-        "version": "2022-01-10",
+        "version": "2022-01-21",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "80a40b07305373617eba2d5878d353532af77da3",
-        "sha256": "1103lf38h7412949j6nrk48m2vv2rrxacn42sjg33lg88nyv7skv"
+        "rev": "0725d7827575b239594fbc8fd5192873a1d62f44",
+        "sha256": "1dzdvcn2r5c9giknvasf3y5y4901kav7igivjvrpww66ywsj8fzr"
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "99.0.4844.17",
-    "sha256": "18bhfy64rz4bilbzml33856azwzq4bhiisc2jlbncdnmk3x6n71s",
-    "sha256bin64": "1vaxcfgiww4skanny5ks431jyrnf0rgx7g850m29v8v49c3qflm8",
+    "version": "99.0.4844.27",
+    "sha256": "07srkycb92sajbxcjbwgjcj0xgb17k9i4b7cg50dvz3pwdvm7y8y",
+    "sha256bin64": "1a3a66kmcim3f8wvi19330m2iixxngsfiwv44g8zz51qk4rg4wx3",
     "deps": {
       "gn": {
         "version": "2022-01-10",

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "99.0.4844.35",
-    "sha256": "085vsfp08y4vmv73z37ncynvax645qm302h883skx9xk4yyjkynj",
-    "sha256bin64": "18kys3f0zjkrp1x2vkcc9vx6vhj5yfrpb88lli7ql6q9b0ijjjn4",
+    "version": "99.0.4844.45",
+    "sha256": "1j6s9r2k6zyyjk3f74k2103zlih96wrr2a83bk79fwc582af9505",
+    "sha256bin64": "0lqps8lf7yg9nn5z2iy6hfrx2df59hif8vhf0camx2lfmrkgw8qa",
     "deps": {
       "gn": {
         "version": "2022-01-10",

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, patchelf, makeWrapper
 
 # Linked dynamic libraries.
-, glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, gconf, nss, nspr
+, glib, fontconfig, freetype, pango, cairo, libX11, libXi, atk, nss, nspr
 , libXcursor, libXext, libXfixes, libXrender, libXScrnSaver, libXcomposite, libxcb
 , alsa-lib, libXdamage, libXtst, libXrandr, libxshmfence, expat, cups
 , dbus, gtk3, gdk-pixbuf, gcc-unwrapped, at-spi2-atk, at-spi2-core
@@ -57,7 +57,7 @@ let
   version = chromium.upstream-info.version;
 
   deps = [
-    glib fontconfig freetype pango cairo libX11 libXi atk gconf nss nspr
+    glib fontconfig freetype pango cairo libX11 libXi atk nss nspr
     libXcursor libXext libXfixes libXrender libXScrnSaver libXcomposite libxcb
     alsa-lib libXdamage libXtst libXrandr libxshmfence expat cups
     dbus gdk-pixbuf gcc-unwrapped.lib

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -118,6 +118,9 @@ in stdenv.mkDerivation {
     cp -a opt/* $out/share
     cp -a usr/share/* $out/share
 
+
+    substituteInPlace $out/share/google/$appname/google-$appname \
+      --replace 'CHROME_WRAPPER' 'WRAPPER'
     substituteInPlace $out/share/applications/google-$appname.desktop \
       --replace /usr/bin/google-chrome-$dist $exe
     substituteInPlace $out/share/gnome-control-center/default-apps/google-$appname.xml \
@@ -143,6 +146,7 @@ in stdenv.mkDerivation {
       --prefix LD_LIBRARY_PATH : "$rpath" \
       --prefix PATH            : "$binpath" \
       --prefix XDG_DATA_DIRS   : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH:${addOpenGLRunpath.driverLink}/share" \
+      --set CHROME_WRAPPER  "google-chrome-$dist" \
       --add-flags ${escapeShellArg commandLineArgs}
 
     for elf in $out/share/google/$appname/{chrome,chrome-sandbox,${crashpadHandlerBinary},nacl_helper}; do

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25664,7 +25664,7 @@ with pkgs;
 
   googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
-  google-chrome = callPackage ../applications/networking/browsers/google-chrome { gconf = gnome2.GConf; };
+  google-chrome = callPackage ../applications/networking/browsers/google-chrome { };
 
   google-chrome-beta = google-chrome.override { chromium = chromiumBeta; channel = "beta"; };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Also contains various bug fixes / improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
