### PR TITLE
home-assistant: 2022.2.9 -> 2022.3.1

### DIFF
--- a/nixos/tests/home-assistant.nix
+++ b/nixos/tests/home-assistant.nix
@@ -2,26 +2,12 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
 
 let
   configDir = "/var/lib/foobar";
-  mqttUsername = "homeassistant";
-  mqttPassword = "secret";
 in {
   name = "home-assistant";
   meta.maintainers = lib.teams.home-assistant.members;
 
   nodes.hass = { pkgs, ... }: {
     environment.systemPackages = with pkgs; [ mosquitto ];
-
-    services.mosquitto = {
-      enable = true;
-      listeners = [ {
-        users = {
-          "${mqttUsername}" = {
-            acl = [ "readwrite #" ];
-            password = mqttPassword;
-          };
-        };
-      } ];
-    };
 
     services.postgresql = {
       enable = true;
@@ -76,23 +62,6 @@ in {
         # https://www.home-assistant.io/integrations/frontend/
         frontend = {};
 
-        # configure an mqtt broker connection
-        # https://www.home-assistant.io/integrations/mqtt
-        mqtt = {
-          broker = "127.0.0.1";
-          username = mqttUsername;
-          password = mqttPassword;
-        };
-
-        # create a mqtt sensor that syncs state with its mqtt topic
-        # https://www.home-assistant.io/integrations/sensor.mqtt/
-        binary_sensor = [ {
-          platform = "mqtt";
-          state_topic = "home-assistant/test";
-          payload_on = "let_there_be_light";
-          payload_off = "off";
-        } ];
-
         # set up a wake-on-lan switch to test capset capability required
         # for the ping suid wrapper
         # https://www.home-assistant.io/integrations/wake_on_lan/
@@ -109,11 +78,9 @@ in {
           listen_port = 80;
         };
 
-        # show mqtt interaction in the log
         # https://www.home-assistant.io/integrations/logger/
         logger = {
           default = "info";
-          logs."homeassistant.components.mqtt" = "debug";
         };
       };
 
@@ -167,12 +134,6 @@ in {
         hass.wait_for_open_port(8123)
         hass.succeed("curl --fail http://localhost:8123/lovelace")
 
-    with subtest("Toggle a binary sensor using MQTT"):
-        hass.wait_for_open_port(1883)
-        hass.succeed(
-            "mosquitto_pub -V mqttv5 -t home-assistant/test -u ${mqttUsername} -P '${mqttPassword}' -m let_there_be_light"
-        )
-
     with subtest("Check that capabilities are passed for emulated_hue to bind to port 80"):
         hass.wait_for_open_port(80)
         hass.succeed("curl --fail http://localhost:80/description.xml")
@@ -187,10 +148,6 @@ in {
 
     with subtest("Check that no errors were logged"):
         assert "ERROR" not in output_log
-
-    # example line: 2020-06-20 10:01:32 DEBUG (MainThread) [homeassistant.components.mqtt] Received message on home-assistant/test: b'let_there_be_light'
-    with subtest("Check we received the mosquitto message"):
-        assert "let_there_be_light" in output_log
 
     with subtest("Check systemd unit hardening"):
         hass.log(hass.succeed("systemctl cat home-assistant.service"))

--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "1.4.7";
+  version = "1.4.8";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-NtiShZpPFl+elYNPLaKAg6uV8pDJv0pyR+NTUiFoMm0=";
+    sha256 = "sha256-ts3PnL1ePWJHHaLuC0eQKqBOt+HeEeAayeVBAIhnUWs=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiohomekit/default.nix
+++ b/pkgs/development/python-modules/aiohomekit/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "aiohomekit";
-  version = "0.6.11";
+  version = "0.7.15";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "Jc2k";
     repo = pname;
     rev = version;
-    sha256 = "1rrdzzb2gcl3lc8l5vb99hy2lmdj5723fds2q78n4sf83y93czw7";
+    sha256 = "sha256-na94H1ll9aZz/mQ4/y3b2vhSaOgo4OjtIsAfW6zGYyI=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,8 @@ buildPythonPackage rec {
     cryptography
     zeroconf
   ];
+
+  doCheck = lib.versionAtLeast pytest-aiohttp.version "1.0.0";
 
   checkInputs = [
     pytest-aiohttp

--- a/pkgs/development/python-modules/aiohue/default.nix
+++ b/pkgs/development/python-modules/aiohue/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "aiohue";
-  version = "4.2.1";
+  version = "4.3.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-bcSCYNJt9xYBMmuZYM6s+PWV0TAUFOn3ibHE0KRX+iw=";
+    hash = "sha256-PslmDeG/o9WAOc0FhidUNaISrlXa3rba3UEuvPVN/+A=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/aiopvpc/default.nix
+++ b/pkgs/development/python-modules/aiopvpc/default.nix
@@ -46,6 +46,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # Failures seem related to changes in holidays-0.13, https://github.com/azogue/aiopvpc/issues/44
+    "test_number_of_national_holidays"
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml --replace \
       " --cov --cov-report term --cov-report html" ""

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "1.0.10";
+  version = "1.0.11";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    hash = "sha256-YHdHh7uC9QF+dj+SI2Y4rEkBq+gGalNBmuWFVgq7XOM=";
+    hash = "sha256-N+8vmB41AUu4aTUTBYX6SPVsW1PARaq5mCOdhg9h0/g=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/asyncsleepiq/default.nix
+++ b/pkgs/development/python-modules/asyncsleepiq/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, aiohttp
+}:
+
+buildPythonPackage rec {
+  pname = "asyncsleepiq";
+  version = "1.1.0";
+
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "93c944ff84fd23832b188320b10681a3b1caf935dd584cdd4e508a9bcc8fec1b";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "asyncsleepiq" ];
+
+  meta = with lib; {
+    description = "Async interface to SleepIQ API";
+    homepage = "https://github.com/kbickar/asyncsleepiq";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/elkm1-lib/default.nix
+++ b/pkgs/development/python-modules/elkm1-lib/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "elkm1-lib";
-  version = "1.0.0";
+  version = "1.2.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "gwww";
     repo = "elkm1";
     rev = version;
-    sha256 = "04xidix6l5d9rqfwp6cmj6wvais04nlvz5ynp0zwgyjp9sh2nhp6";
+    hash = "sha256-+rFW7qFpay/ebUz9EEB8nn0kuqVtVmG5ZHOWG2bMPts=";
   };
 
   nativeBuildInputs = [
@@ -34,15 +34,6 @@ buildPythonPackage rec {
   checkInputs = [
     pytest-asyncio
     pytestCheckHook
-  ];
-
-  patches = [
-    # Switch to poetry-core, https://github.com/gwww/elkm1/pull/45
-    (fetchpatch {
-      name = "switch-to-poetry-core.patch";
-      url = "https://github.com/gwww/elkm1/commit/807a17268498298908bf82af4933b158b37c8f32.patch";
-      sha256 = "1539g8wsxppqj6dm6w81ps05frb8vrfaxahxn2cqs76zdhvly3p9";
-    })
   ];
 
   pythonImportsCheck = [ "elkm1_lib" ];

--- a/pkgs/development/python-modules/gridnet/default.nix
+++ b/pkgs/development/python-modules/gridnet/default.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, aiohttp
+, yarl
+, aresponses
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "gridnet";
+  version = "4.0.0";
+
+  disabled = pythonOlder "3.9";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "klaasnicolaas";
+    repo = "python-gridnet";
+    rev = "v${version}";
+    hash = "sha256-Ihs8qUx50tAUcRBsVArRhzoLcQUi1vbYh8sPyK75AEk=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}" \
+      --replace "--cov" ""
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    yarl
+  ];
+
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "gridnet" ];
+
+  meta = with lib; {
+    description = "Asynchronous Python client for NET2GRID devices";
+    homepage = "https://github.com/klaasnicolaas/python-gridnet";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "hass-nabucasa";
-  version = "0.52.0";
+  version = "0.54.0";
 
   src = fetchFromGitHub {
     owner = "nabucasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-mTbNuER26BPQIjcmlpkdFNeBcNF1vTldaNpoEla0XbM=";
+    sha256 = "sha256-UL7HPmii65p+WO22y0qv8zq3yICKarRORqE+FK1u7OE=";
   };
 
   postPatch = ''
@@ -40,6 +40,8 @@ buildPythonPackage rec {
     snitun
     warrant
   ];
+
+  doCheck = lib.versionAtLeast pytest-aiohttp.version "1.0.0";
 
   checkInputs = [
     asynctest

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.12";
+  version = "0.13";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d99f2b6ddc5bfab7b7f8bbed457a82104f8980122a04b982bfc0e4f8820a1d46";
+    sha256 = "sha256-xvfDq4ralIBnAtqTHZTTfNYbz6kstNOdNRtqnFIQZ1w=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pydeconz/default.nix
+++ b/pkgs/development/python-modules/pydeconz/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "pydeconz";
-  version = "86";
+  version = "87";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "Kane610";
     repo = "deconz";
     rev = "v${version}";
-    sha256 = "sha256-NqNXbF5rGMCbugzZY+AQPPHYmQx/RrSwqtnoF1shSSU=";
+    sha256 = "sha256-scNTHbUL8TOhkUJyib4cgL8A4gZ73asmFLi8aGw3sX8=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyefergy/default.nix
+++ b/pkgs/development/python-modules/pyefergy/default.nix
@@ -1,15 +1,18 @@
 { lib
 , aiohttp
+, aresponses
 , buildPythonPackage
 , fetchFromGitHub
 , iso4217
+, pytest-asyncio
+, pytestCheckHook
 , pythonOlder
 , pytz
 }:
 
 buildPythonPackage rec {
   pname = "pyefergy";
-  version = "0.1.5";
+  version = "22.1.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -18,7 +21,7 @@ buildPythonPackage rec {
     owner = "tkdrob";
     repo = pname;
     rev = version;
-    sha256 = "sha256-8xcKgsZ6buaQdrKD8Qn7jB5IlQ0NkR0nZGuFk+Dd8Q8=";
+    sha256 = "sha256-AdoM+PcVoajxhnEfkyN9UuNufChu8XGmZDLNC3mjrps=";
   };
 
   propagatedBuildInputs = [
@@ -27,10 +30,15 @@ buildPythonPackage rec {
     pytz
   ];
 
-  # Project has no tests
-  doCheck = false;
+  checkInputs = [
+    aresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
 
-  pythonImportsCheck = [ "pyefergy" ];
+  pythonImportsCheck = [
+    "pyefergy"
+  ];
 
   meta = with lib; {
     description = "Python API library for Efergy energy meters";

--- a/pkgs/development/python-modules/pynina/default.nix
+++ b/pkgs/development/python-modules/pynina/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pynina";
-  version = "0.1.4";
+  version = "0.1.7";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "PyNINA";
     inherit version;
-    sha256 = "1q382b70ydzzbqb9sa5y5w7039rp6q0wyffarrsdw916kbc4zyqd";
+    sha256 = "sha256-7sceYmzOmXJMKaIdGmXMuCAum0aJeVTxx1w/jZy5Eig=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/radios/default.nix
+++ b/pkgs/development/python-modules/radios/default.nix
@@ -1,0 +1,67 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, poetry-core
+, aiodns
+, aiohttp
+, awesomeversion
+, backoff
+, cachetools
+, pycountry
+, pydantic
+, yarl
+, pytest-asyncio
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "radios";
+  version = "0.1.0";
+
+  disabled = pythonOlder "3.9";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "frenck";
+    repo = "python-radios";
+    rev = "v${version}";
+    hash = "sha256-3xRtOGY9DYnZN0g95213vWDbO3/XZZ5+s7A9sqNmO/w=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}" \
+      --replace "--cov" ""
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    aiodns
+    aiohttp
+    awesomeversion
+    backoff
+    cachetools
+    pycountry
+    pydantic
+    yarl
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "radios" ];
+
+  meta = with lib; {
+    description = "Asynchronous Python client for the Radio Browser API";
+    homepage = "https://github.com/frenck/python-radios";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "snitun";
-  version = "0.30.0";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "NabuCasa";
     repo = pname;
     rev = version;
-    sha256 = "sha256-IjdgxX6ed9IWMFaMXIXQWZWoODrZBzXtMAcMOIhPFVQ=";
+    sha256 = "sha256-Ehafb35H462Ffn6omGh/MDJKQX5qJJZeiIBO3n0IGlA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.66";
+  version = "0.0.67";
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zha-device-handlers";
     rev = version;
-    sha256 = "18g0i6b60ndfmbvdsx5pniq56fyc5k39ylp3sjhrfjcj434wvbvc";
+    sha256 = "sha256-qkXXrwqMEtfafHsXtlyy6HFwuo/8sOZuQ9SvGRJkGtA=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/zwave-js-server-python/default.nix
+++ b/pkgs/development/python-modules/zwave-js-server-python/default.nix
@@ -2,6 +2,7 @@
 , aiohttp
 , buildPythonPackage
 , fetchFromGitHub
+, pydantic
 , pytest-aiohttp
 , pytestCheckHook
 , pythonOlder
@@ -9,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "zwave-js-server-python";
-  version = "0.34.0";
+  version = "0.35.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
@@ -18,12 +19,15 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = pname;
     rev = version;
-    sha256 = "sha256-hqq/CYlM9ZahDiH3iFLFzfE22CB19WQnFIDt+gCrEXU=";
+    sha256 = "sha256-WmpXQttcQ3Z/SFkNPfmvPWPGzWectQBoI9+bL2QYeaY=";
   };
 
   propagatedBuildInputs = [
     aiohttp
+    pydantic
   ];
+
+  doCheck = lib.versionAtLeast pytest-aiohttp.version "1.0.0";
 
   checkInputs = [
     pytest-aiohttp

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.3.0";
+  version = "2022.3.1";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2022.2.9";
+  version = "2022.3.0";
   components = {
     "abode" = ps: with ps; [ abodepy ];
     "accuweather" = ps: with ps; [ accuweather ];
@@ -44,7 +44,6 @@
     "apache_kafka" = ps: with ps; [ aiokafka ];
     "apcupsd" = ps: with ps; [ apcaccess ];
     "api" = ps: with ps; [ aiohttp-cors ];
-    "apns" = ps: with ps; [ ]; # missing inputs: apns2
     "apple_tv" = ps: with ps; [ aiohttp-cors ifaddr pyatv zeroconf ];
     "apprise" = ps: with ps; [ apprise ];
     "aprs" = ps: with ps; [ aprslib geopy ];
@@ -166,7 +165,7 @@
     "deconz" = ps: with ps; [ pydeconz ];
     "decora" = ps: with ps; [ bluepy ]; # missing inputs: decora
     "decora_wifi" = ps: with ps; [ ]; # missing inputs: decora_wifi
-    "default_config" = ps: with ps; [ pynacl pyturbojpeg aiodiscover aiohttp-cors async-upnp-client emoji hass-nabucasa home-assistant-frontend ifaddr pillow pyserial pyudev scapy sqlalchemy zeroconf ];
+    "default_config" = ps: with ps; [ pynacl pyturbojpeg aiodiscover aiohttp-cors async-upnp-client hass-nabucasa home-assistant-frontend ifaddr pillow pyserial pyudev scapy sqlalchemy zeroconf ];
     "delijn" = ps: with ps; [ pydelijn ];
     "deluge" = ps: with ps; [ deluge-client ];
     "demo" = ps: with ps; [ aiohttp-cors sqlalchemy ];
@@ -188,12 +187,13 @@
     "digitalloggers" = ps: with ps; [ ]; # missing inputs: dlipower
     "directv" = ps: with ps; [ directv ];
     "discogs" = ps: with ps; [ discogs-client ];
-    "discord" = ps: with ps; [ discordpy ];
+    "discord" = ps: with ps; [ nextcord ];
     "discovery" = ps: with ps; [ aiohttp-cors ifaddr netdisco zeroconf ];
     "dlib_face_detect" = ps: with ps; [ face_recognition ];
     "dlib_face_identify" = ps: with ps; [ face_recognition ];
     "dlink" = ps: with ps; [ ]; # missing inputs: pyW215
     "dlna_dmr" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr zeroconf ];
+    "dlna_dms" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr zeroconf ];
     "dnsip" = ps: with ps; [ aiodns ];
     "dominos" = ps: with ps; [ aiohttp-cors ]; # missing inputs: pizzapi
     "doods" = ps: with ps; [ pillow pydoods ];
@@ -224,7 +224,7 @@
     "eight_sleep" = ps: with ps; [ pyeight ];
     "elgato" = ps: with ps; [ elgato ];
     "eliqonline" = ps: with ps; [ eliqonline ];
-    "elkm1" = ps: with ps; [ elkm1-lib ];
+    "elkm1" = ps: with ps; [ aiohttp-cors elkm1-lib ifaddr ];
     "elmax" = ps: with ps; [ elmax-api ];
     "elv" = ps: with ps; [ pypca ];
     "emby" = ps: with ps; [ pyemby ];
@@ -273,6 +273,7 @@
     "fireservicerota" = ps: with ps; [ pyfireservicerota ];
     "firmata" = ps: with ps; [ pymata-express ];
     "fitbit" = ps: with ps; [ aiohttp-cors fitbit ];
+    "fivem" = ps: with ps; [ ]; # missing inputs: fivem-api
     "fixer" = ps: with ps; [ fixerio ];
     "fjaraskupan" = ps: with ps; [ fjaraskupan ];
     "fleetgo" = ps: with ps; [ ritassist ];
@@ -324,7 +325,6 @@
     "gitlab_ci" = ps: with ps; [ python-gitlab ];
     "gitter" = ps: with ps; [ ]; # missing inputs: gitterpy
     "glances" = ps: with ps; [ glances-api ];
-    "gntp" = ps: with ps; [ gntp ];
     "goalfeed" = ps: with ps; [ ]; # missing inputs: pysher
     "goalzero" = ps: with ps; [ goalzero ];
     "gogogate2" = ps: with ps; [ ismartgate ];
@@ -446,7 +446,7 @@
     "kiwi" = ps: with ps; [ ]; # missing inputs: kiwiki-client
     "kmtronic" = ps: with ps; [ pykmtronic ];
     "knx" = ps: with ps; [ xknx ];
-    "kodi" = ps: with ps; [ pykodi ];
+    "kodi" = ps: with ps; [ aiohttp-cors pykodi ];
     "konnected" = ps: with ps; [ aiohttp-cors konnected ];
     "kostal_plenticore" = ps: with ps; [ ]; # missing inputs: kostal_plenticore
     "kraken" = ps: with ps; [ krakenex pykrakenapi ];
@@ -532,11 +532,12 @@
     "minio" = ps: with ps; [ minio ];
     "mitemp_bt" = ps: with ps; [ ]; # missing inputs: mitemp_bt
     "mjpeg" = ps: with ps; [ ];
-    "mobile_app" = ps: with ps; [ pynacl pyturbojpeg aiohttp-cors emoji hass-nabucasa pillow ];
+    "mobile_app" = ps: with ps; [ pynacl pyturbojpeg aiohttp-cors hass-nabucasa pillow ];
     "mochad" = ps: with ps; [ ]; # missing inputs: pymochad
     "modbus" = ps: with ps; [ pymodbus ];
     "modem_callerid" = ps: with ps; [ aiohttp-cors phone-modem pyserial pyudev ];
     "modern_forms" = ps: with ps; [ aiomodernforms ];
+    "moehlenhoff_alpha2" = ps: with ps; [ ]; # missing inputs: moehlenhoff-alpha2
     "mold_indicator" = ps: with ps; [ ];
     "monoprice" = ps: with ps; [ ]; # missing inputs: pymonoprice
     "moon" = ps: with ps; [ ];
@@ -680,6 +681,7 @@
     "proxy" = ps: with ps; [ pillow ];
     "ps4" = ps: with ps; [ ]; # missing inputs: pyps4-2ndscreen
     "pulseaudio_loopback" = ps: with ps; [ pulsectl ];
+    "pure_energie" = ps: with ps; [ gridnet ];
     "push" = ps: with ps; [ aiohttp-cors ];
     "pushbullet" = ps: with ps; [ pushbullet ];
     "pushover" = ps: with ps; [ pushover-complete ];
@@ -697,6 +699,7 @@
     "qwikswitch" = ps: with ps; [ ]; # missing inputs: pyqwikswitch
     "rachio" = ps: with ps; [ pyturbojpeg aiohttp-cors hass-nabucasa rachiopy ];
     "radarr" = ps: with ps; [ ];
+    "radio_browser" = ps: with ps; [ radios ];
     "radiotherm" = ps: with ps; [ radiotherm ];
     "rainbird" = ps: with ps; [ ]; # missing inputs: pyrainbird
     "raincloud" = ps: with ps; [ ]; # missing inputs: raincloudy
@@ -791,7 +794,7 @@
     "skybeacon" = ps: with ps; [ pygatt ];
     "skybell" = ps: with ps; [ skybellpy ];
     "slack" = ps: with ps; [ slackclient ];
-    "sleepiq" = ps: with ps; [ sleepyq ];
+    "sleepiq" = ps: with ps; [ asyncsleepiq ];
     "slide" = ps: with ps; [ ]; # missing inputs: goslide-api
     "sma" = ps: with ps; [ pysma ];
     "smappee" = ps: with ps; [ aiohttp-cors pysmappee ];
@@ -814,7 +817,7 @@
     "soma" = ps: with ps; [ pysoma ];
     "somfy" = ps: with ps; [ aiohttp-cors pymfy ];
     "somfy_mylink" = ps: with ps; [ somfy-mylink-synergy ];
-    "sonarr" = ps: with ps; [ sonarr ];
+    "sonarr" = ps: with ps; [ aiopyarr ];
     "songpal" = ps: with ps; [ python-songpal ];
     "sonos" = ps: with ps; [ aiohttp-cors async-upnp-client ifaddr plexapi plexauth plexwebsocket soco spotipy zeroconf ];
     "sony_projector" = ps: with ps; [ pysdcp ];
@@ -924,7 +927,7 @@
     "twilio_call" = ps: with ps; [ aiohttp-cors twilio ];
     "twilio_sms" = ps: with ps; [ aiohttp-cors twilio ];
     "twinkly" = ps: with ps; [ ttls ];
-    "twitch" = ps: with ps; [ python-twitch-client ];
+    "twitch" = ps: with ps; [ twitchapi ];
     "twitter" = ps: with ps; [ twitterapi ];
     "ubus" = ps: with ps; [ openwrt-ubus-rpc ];
     "ue_smart_radio" = ps: with ps; [ ];
@@ -990,6 +993,7 @@
     "wilight" = ps: with ps; [ pywilight ];
     "wirelesstag" = ps: with ps; [ ]; # missing inputs: wirelesstagpy
     "withings" = ps: with ps; [ aiohttp-cors ]; # missing inputs: withings-api
+    "wiz" = ps: with ps; [ aiohttp-cors ifaddr pywizlight ];
     "wled" = ps: with ps; [ wled ];
     "wolflink" = ps: with ps; [ ]; # missing inputs: wolf_smartset
     "workday" = ps: with ps; [ holidays ];
@@ -998,7 +1002,6 @@
     "worxlandroid" = ps: with ps; [ ];
     "wsdot" = ps: with ps; [ ];
     "x10" = ps: with ps; [ ];
-    "xbee" = ps: with ps; [ ]; # missing inputs: xbee-helper
     "xbox" = ps: with ps; [ aiohttp-cors xbox-webapi ];
     "xbox_live" = ps: with ps; [ xboxapi ];
     "xeoma" = ps: with ps; [ pyxeoma ];
@@ -1031,6 +1034,7 @@
     "zoneminder" = ps: with ps; [ zm-py ];
     "zwave" = ps: with ps; [ homeassistant-pyozw pydispatcher ];
     "zwave_js" = ps: with ps; [ aiohttp-cors pyserial pyudev zwave-js-server-python ];
+    "zwave_me" = ps: with ps; [ aiohttp-cors ifaddr url-normalize zeroconf ]; # missing inputs: zwave_me_ws
   };
   # components listed in tests/components for which all dependencies are packaged
   supportedComponentsWithTests = [
@@ -1143,6 +1147,7 @@
     "directv"
     "discovery"
     "dlna_dmr"
+    "dlna_dms"
     "dnsip"
     "doorbird"
     "dsmr"
@@ -1343,6 +1348,7 @@
     "min_max"
     "minecraft_server"
     "minio"
+    "mjpeg"
     "mobile_app"
     "modbus"
     "modem_callerid"
@@ -1423,6 +1429,7 @@
     "prometheus"
     "prosegur"
     "proximity"
+    "pure_energie"
     "push"
     "pushbullet"
     "pvoutput"
@@ -1431,6 +1438,7 @@
     "qld_bushfire"
     "rachio"
     "radarr"
+    "radio_browser"
     "rainforest_eagle"
     "rainmachine"
     "random"
@@ -1459,6 +1467,7 @@
     "safe_mode"
     "samsungtv"
     "scene"
+    "scrape"
     "screenlogic"
     "script"
     "search"
@@ -1605,6 +1614,7 @@
     "whois"
     "wiffi"
     "wilight"
+    "wiz"
     "wled"
     "workday"
     "worldclock"

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -138,7 +138,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.2.9";
+  hassVersion = "2022.3.0";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -156,7 +156,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-So/MAKyFVa1TchrVE4ego1fRbgOXCoXR3w/rJLFSBqI=";
+    hash = "sha256-ms5ZKOGhpCHHIMWBXtpNgaGhVPPJDoJKsFXbTfP7ApE=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -31,6 +31,26 @@ let
     # Override the version of some packages pinned in Home Assistant's setup.py and requirements_all.txt
     (mkOverride "python-slugify" "4.0.1" "69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270")
 
+    # pytest-aiohttp>0.3.0 breaks home-assistant tests
+    (self: super: {
+      pytest-aiohttp = super.pytest-aiohttp.overridePythonAttrs (oldAttrs: rec {
+        version = "0.3.0";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0kx4mbs9bflycd8x9af0idcjhdgnzri3nw1qb0vpfyb3751qaaf9";
+        };
+      });
+      aiohomekit = super.aiohomekit.overridePythonAttrs (oldAttrs: {
+        doCheck = false; # requires aiohttp>=1.0.0
+      });
+      hass-nabucasa = super.hass-nabucasa.overridePythonAttrs (oldAttrs: {
+        doCheck = false; # requires aiohttp>=1.0.0
+      });
+      zwave-js-server-python = super.zwave-js-server-python.overridePythonAttrs (oldAttrs: {
+        doCheck = false; # requires aiohttp>=1.0.0
+      });
+    })
+
     (self: super: {
       huawei-lte-api = super.huawei-lte-api.overridePythonAttrs (oldAttrs: rec {
         version = "1.4.18";

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -158,7 +158,7 @@ let
   extraPackagesFile = writeText "home-assistant-packages" (lib.concatMapStringsSep "\n" (pkg: pkg.pname) extraBuildInputs);
 
   # Don't forget to run parse-requirements.py after updating
-  hassVersion = "2022.3.0";
+  hassVersion = "2022.3.1";
 
 in python.pkgs.buildPythonApplication rec {
   pname = "homeassistant";
@@ -176,7 +176,7 @@ in python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     rev = version;
-    hash = "sha256-ms5ZKOGhpCHHIMWBXtpNgaGhVPPJDoJKsFXbTfP7ApE=";
+    hash = "sha256-bihb6DL8hQuRnJZp39Lh2qfTXr0tFxn7FHFZewttNOc=";
   };
 
   # leave this in, so users don't have to constantly update their downstream patch handling
@@ -237,6 +237,8 @@ in python.pkgs.buildPythonApplication rec {
     yarl
     # Not in setup.py, but used in homeassistant/util/package.py
     setuptools
+    # Not in setup.py, but uncounditionally imported via tests/conftest.py
+    paho-mqtt
   ] ++ componentBuildInputs ++ extraBuildInputs;
 
   makeWrapperArgs = lib.optional skipPip "--add-flags --skip-pip";

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -4,7 +4,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20220203.1";
+  version = "20220301.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -12,7 +12,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    sha256 = "sha256-6+TzBhHo9+eo6Hlk8RF+BAt4O0i759iAN+dKAPDmTNY=";
+    sha256 = "sha256-Gshw8GIiZfFHmldvxBhUKZ5NFWuBIA6ug7m7eEfQ+ao=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -11,8 +11,9 @@ let
     config = [ pydispatcher ];
     generic = [ ha-av ];
     google_translate = [ mutagen ];
+    lovelace = [ PyChromecast ];
     nest = [ ha-av ];
-    onboarding = [ pymetno rpi-bad-power ];
+    onboarding = [ pymetno radios rpi-bad-power ];
     version = [ aioaseko ];
     voicerss = [ mutagen ];
     yandextts = [ mutagen ];
@@ -25,6 +26,13 @@ let
       # tado/test_{climate,water_heater}.py: Tries to connect to my.tado.com
       "tests/components/tado/test_climate.py"
       "tests/components/tado/test_water_heater.py"
+    ];
+  };
+
+  extraDisabledTests = {
+    roku = [
+      # homeassistant.components.roku.media_player:media_player.py:428 Media type music is not supported with format None (mime: audio/x-matroska)
+      "test_services_play_media_audio"
     ];
   };
 
@@ -45,6 +53,7 @@ in lib.listToAttrs (map (component: lib.nameValuePair component (
       ++ home-assistant.getPackages component home-assistant.python.pkgs
       ++ extraCheckInputs.${component} or [ ];
 
+    disabledTests = old.disabledTests ++ extraDisabledTests.${component} or [];
     disabledTestPaths = old.disabledTestPaths ++ extraDisabledTestPaths.${component} or [ ];
 
     pytestFlagsArray = lib.remove "tests" old.pytestFlagsArray
@@ -59,6 +68,7 @@ in lib.listToAttrs (map (component: lib.nameValuePair component (
       broken = lib.elem component [
         "airtouch4"
         "dnsip"
+        "zwave"
       ];
       # upstream only tests on Linux, so do we.
       platforms = lib.platforms.linux;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -714,6 +714,8 @@ in {
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
+  asyncsleepiq = callPackage ../development/python-modules/asyncsleepiq { };
+
   asyncssh = callPackage ../development/python-modules/asyncssh { };
 
   asyncstdlib = callPackage ../development/python-modules/asyncstdlib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8571,6 +8571,8 @@ in {
 
   radio_beam = callPackage ../development/python-modules/radio_beam { };
 
+  radios = callPackage ../development/python-modules/radios { };
+
   radiotherm = callPackage ../development/python-modules/radiotherm { };
 
   radish-bdd = callPackage ../development/python-modules/radish-bdd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3579,6 +3579,8 @@ in {
 
   growattserver = callPackage ../development/python-modules/growattserver { };
 
+  gridnet = callPackage ../development/python-modules/gridnet { };
+
   grip = callPackage ../development/python-modules/grip { };
 
   groestlcoin_hash = callPackage ../development/python-modules/groestlcoin_hash { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://www.home-assistant.io/blog/2022/03/02/release-20223/

Still a mess, I need to figure out what broke teardown of the tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
