### PR TITLE
brave: 1.35.103 -> 1.36.109

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,11 +91,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.35.103";
+  version = "1.36.109";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "UgperKruN2quKdFTf/iTa+dd2GB57nt+mu6KBe4VvYk=";
+    sha256 = "KKoMpMagq5lVoRFyWNs92LdPwNIlmAjfwqxfOArIFeo=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#136109

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).