### PR TITLE
polybar: 3.5.7 -> 3.6.1

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -2004,6 +2004,24 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>polybar</literal> package has been updated from
+          3.5.7 to 3.6.2. See
+          <link xlink:href="https://github.com/polybar/polybar/releases/tag/3.6.0">the
+          changelog</link> for more details.
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              Breaking changes include changes to escaping rules in
+              configuration values, changes in behavior when
+              encountering invalid tag names, and changes to
+              inter-process-messaging (IPC).
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
           Renamed option
           <literal>services.openssh.challengeResponseAuthentication</literal>
           to

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -709,6 +709,9 @@ In addition to numerous new and upgraded packages, this release has the followin
   - The RPC protocol version was bumped; all zrepl daemons in a setup must be updated and restarted before replication can resume.
   - A bug involving encrypt-on-receive has been fixed. Read the [zrepl documentation](https://zrepl.github.io/configuration/sendrecvoptions.html#job-recv-options-placeholder) and check the output of `zfs get -r encryption,zrepl:placeholder PATH_TO_ROOTFS` on the receiver.
 
+- The `polybar` package has been updated from 3.5.7 to 3.6.2. See [the changelog](https://github.com/polybar/polybar/releases/tag/3.6.0) for more details.
+  - Breaking changes include changes to escaping rules in configuration values, changes in behavior when encountering invalid tag names, and changes to inter-process-messaging (IPC).
+
 - Renamed option `services.openssh.challengeResponseAuthentication` to `services.openssh.kbdInteractiveAuthentication`.
   Reason is that the old name has been deprecated upstream.
   Using the old option name will still work, but produce a warning.

--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -2,6 +2,7 @@
 , cairo
 , cmake
 , fetchFromGitHub
+, libuv
 , libXdmcp
 , libpthreadstubs
 , libxcb
@@ -43,13 +44,13 @@
 
 stdenv.mkDerivation rec {
   pname = "polybar";
-  version = "3.5.7";
+  version = "3.6.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-h12VW3IY4do4cKz2Fd/QgVTBk+zJO+qXuRUCQUyO/x0=";
+    hash = "sha256-mLAcA8afGLNhRRU/x/TngCMcSRXdEM5wKWoYZhezJqU=";
     fetchSubmodules = true;
   };
 
@@ -62,6 +63,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cairo
+    libuv
     libXdmcp
     libpthreadstubs
     libxcb
@@ -83,6 +85,14 @@ stdenv.mkDerivation rec {
   ++ lib.optional (i3Support || i3GapsSupport) jsoncpp
   ++ lib.optional i3Support i3
   ++ lib.optional i3GapsSupport i3-gaps;
+
+  patches = [ ./remove-hardcoded-etc.diff ];
+
+  # Replace hardcoded /etc when copying and reading the default config.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "/etc" $out
+    substituteAllInPlace src/utils/file.cpp
+  '';
 
   postInstall =
     if i3Support then ''

--- a/pkgs/applications/misc/polybar/remove-hardcoded-etc.diff
+++ b/pkgs/applications/misc/polybar/remove-hardcoded-etc.diff
@@ -1,0 +1,13 @@
+diff --git a/src/utils/file.cpp b/src/utils/file.cpp
+index 9511ad61..d3d82b99 100644
+--- a/src/utils/file.cpp
++++ b/src/utils/file.cpp
+@@ -322,7 +322,7 @@ namespace file_util {
+       possible_paths.push_back(xdg_config_dir + suffix + ".ini");
+     }
+ 
+-    possible_paths.push_back("/etc" + suffix + ".ini");
++    possible_paths.push_back("@out@" + suffix + ".ini");
+ 
+     for (const string& p : possible_paths) {
+       if (exists(p)) {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
changelog: https://github.com/polybar/polybar/releases/tag/3.6.0
see also: https://github.com/polybar/polybar/issues/1971#issuecomment-1055754773

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
