### PR TITLE
krunner-pass: pass-otp has been deprecated

### DIFF
--- a/pkgs/tools/security/krunner-pass/default.nix
+++ b/pkgs/tools/security/krunner-pass/default.nix
@@ -1,9 +1,17 @@
-{ mkDerivation, lib, fetchFromGitHub, fetchpatch, cmake, extra-cmake-modules
-, kauth, krunner
-, pass, pass-otp ? null }:
+{ mkDerivation
+, lib
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, extra-cmake-modules
+, kauth
+, krunner
+, pass
+}:
 
 mkDerivation rec {
   pname = "krunner-pass";
+  # when upgrading the version, check if cmakeFlags is still needed
   version = "1.3.0";
 
   src = fetchFromGitHub {
@@ -13,9 +21,10 @@ mkDerivation rec {
     sha256 = "032fs2174ls545kjixbhzyd65wgxkw4s5vg8b20irc5c9ak3pxm0";
   };
 
-  buildInputs  = [
-    kauth krunner
-    pass pass-otp
+  buildInputs = [
+    kauth
+    krunner
+    (pass.withExtensions (p: with p; [ pass-otp ]))
   ];
 
   nativeBuildInputs = [ cmake extra-cmake-modules ];
@@ -32,6 +41,9 @@ mkDerivation rec {
   CXXFLAGS = [
     ''-DNIXPKGS_PASS=\"${lib.getBin pass}/bin/pass\"''
   ];
+
+  # there are *lots* of pointless warnings in v1.3.0
+  cmakeFlags = [ "-Wno-dev" ];
 
   meta = with lib; {
     description = "Integrates krunner with pass the unix standard password manager (https://www.passwordstore.org/)";


### PR DESCRIPTION
###### Motivation for this change

`pass-otp` has been deprecated in favour of `pass.withExtensions`, so use that instead

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
