### PR TITLE
polybar: 3.5.7 -> 3.6.0

### DIFF
--- a/pkgs/applications/misc/polybar/default.nix
+++ b/pkgs/applications/misc/polybar/default.nix
@@ -10,6 +10,7 @@
 , python3
 , python3Packages # sphinx-build
 , lib
+, libuv
 , stdenv
 , xcbproto
 , xcbutil
@@ -43,21 +44,24 @@
 
 stdenv.mkDerivation rec {
   pname = "polybar";
-  version = "3.5.7";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-h12VW3IY4do4cKz2Fd/QgVTBk+zJO+qXuRUCQUyO/x0=";
+    sha256 = "sha256-CgMXCo5YpnvuBNWSKZ8QdCcEb5bhnWx1DWBDy6fE1KI=";
     fetchSubmodules = true;
   };
+
+  cmakeFlags = ["-DBUILD_CONFIG=off"];
 
   nativeBuildInputs = [
     cmake
     pkg-config
     python3Packages.sphinx
     removeReferencesTo
+    libuv
   ] ++ lib.optional (i3Support || i3GapsSupport) makeWrapper;
 
   buildInputs = [


### PR DESCRIPTION
This was pretty straightforward. Two interesting things happened:

1. libuv is a new dependency. From https://github.com/polybar/polybar/releases/tag/3.6.0:
   > New dependency: libuv. At least version 1.3 is required.

2. Polybar now attempts to install a config file to
   `/etc/polybar/config.ini`. I don't know what the nix equivalent of
   that would be, so I just turned that setting off with
   `-DBUILD_CONFIG=off`. Here's what happens with that setting still
   enabled:

    ```
    $ nix-build
    ...
    -- Install configuration: "Release"
    -- Installing: /etc/polybar/config.ini
    CMake Error at cmake_install.cmake:54 (file):
    file INSTALL cannot copy file
    "/tmp/nix-build-polybar-3.6.0.drv-0/source/doc/config.ini" to
    "/etc/polybar/config.ini": Permission denied.

    make: *** [Makefile:100: install] Error 1
    error: builder for '/nix/store/gli9yhqd62i53jlsgw6hfz5p6qv6wvcp-polybar-3.6.0.drv' failed with exit code 2;
         last 10 log lines:
         > Install the project...
         > -- Install configuration: "Release"
         > -- Installing: /etc/polybar/config.ini
         > CMake Error at cmake_install.cmake:54 (file):
         >   file INSTALL cannot copy file
         >   "/tmp/nix-build-polybar-3.6.0.drv-0/source/doc/config.ini" to
         >   "/etc/polybar/config.ini": Permission denied.
         >
         >
         > make: *** [Makefile:100: install] Error 1
         For full logs, run 'nix log /nix/store/gli9yhqd62i53jlsgw6hfz5p6qv6wvcp-polybar-3.6.0.drv'.
    ```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
