### PR TITLE
gotktrix: init at 0.1.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
@@ -18,6 +18,7 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-9feKg/rnkWdJRolHBQ5WT6Rl3xTFe82M8HyxJK3VuN4=";
   };
+
   vendorSha256 = "sha256-eO/2MvWOVCeeCsiU2mSwgSEVlSbCXOp8qHyoG0lmk+Q=";
 
   buildInputs = [
@@ -30,6 +31,7 @@ buildGoModule rec {
 
   # Checking requires a working display
   doCheck = false;
+
   meta = with lib; {
     description = "Matrix client written in Go using GTK4";
     homepage = "https://github.com/diamondburned/gotktrix";

--- a/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gotktrix/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, gtk4
+, glib
+, gobject-introspection
+, pkg-config
+, go
+}:
+
+buildGoModule rec {
+  pname = "gotktrix";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "diamondburned";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-9feKg/rnkWdJRolHBQ5WT6Rl3xTFe82M8HyxJK3VuN4=";
+  };
+  vendorSha256 = "sha256-eO/2MvWOVCeeCsiU2mSwgSEVlSbCXOp8qHyoG0lmk+Q=";
+
+  buildInputs = [
+    gtk4
+    glib
+    gobject-introspection
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  # Checking requires a working display
+  doCheck = false;
+  meta = with lib; {
+    description = "Matrix client written in Go using GTK4";
+    homepage = "https://github.com/diamondburned/gotktrix";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ chuangzhu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1882,6 +1882,8 @@ with pkgs;
 
   gopacked = callPackage ../applications/misc/gopacked { };
 
+  gotktrix = callPackage ../applications/networking/instant-messengers/gotktrix { };
+
   gucci = callPackage ../tools/text/gucci { };
 
   guglielmo = libsForQt5.callPackage ../applications/radio/guglielmo { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add gotktrix, a Matrix client in Go and GTK4.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
