### PR TITLE
vk-messenger: 5.2.3 -> 5.3.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
+++ b/pkgs/applications/networking/instant-messengers/vk-messenger/default.nix
@@ -4,20 +4,20 @@
 
 let
   pname = "vk-messenger";
-  version = "5.2.3";
+  version = "5.3.2";
 
   src = {
     i686-linux = fetchurl {
       url = "https://desktop.userapi.com/rpm/master/vk-${version}.i686.rpm";
-      sha256 = "09zi2rzsank6lhw1z9yar1rp634y6qskvr2i0rvqg2fij7cy6w19";
+      sha256 = "L0nE0zW4LP8udcE8uPy+cH9lLuQsUSq7cF13Gv7w2rI=";
     };
     x86_64-linux = fetchurl {
       url = "https://desktop.userapi.com/rpm/master/vk-${version}.x86_64.rpm";
-      sha256 = "1m6saanpv1k5wc5s58jpf0wsgjsj7haabx8nycm1fjyhky1chirb";
+      sha256 = "spDw9cfDSlIuCwOqREsqXC19tx62TiAz9fjIS9lYjSQ=";
     };
     x86_64-darwin = fetchurl {
-      url = "https://web.archive.org/web/20210310071550/https://desktop.userapi.com/mac/master/vk.dmg";
-      sha256 = "0j5qsr0fyl55d0x46xm4h2ykwr4y9z1dsllhqx5lnc15nc051s9b";
+      url = "https://web.archive.org/web/20220302083827/https://desktop.userapi.com/mac/master/vk.dmg";
+      sha256 = "hxK8I9sF6njfCxSs1KBCHfnG81JGKUgHKAeFLtuCNe0=";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 


### PR DESCRIPTION
###### Motivation for this change
`vk-messenger: 5.2.3 -> 5.3.2`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
