### PR TITLE
seabios: 1.15.0 -> 1.16.0

### DIFF
--- a/pkgs/applications/virtualization/seabios/default.nix
+++ b/pkgs/applications/virtualization/seabios/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchurl, acpica-tools, python3 }:
+{ lib, stdenv, fetchgit, acpica-tools, python3 }:
 
 stdenv.mkDerivation rec {
 
   pname = "seabios";
-  version = "1.15.0";
+  version = "1.16.0";
 
-  src = fetchurl {
-    url = "https://www.seabios.org/downloads/${pname}-${version}.tar.gz";
-    sha256 = "sha256-YownF8mUMmtFMlFXPRBZ4qOhEtSqSIds4nyz8d4ZiPg=";
+  src = fetchgit {
+    url = "https://git.seabios.org/seabios.git";
+    rev = "rel-${version}";
+    sha256 = "0acal1rr7sya86wlhw2mgimabwhjnr0y1pl5zxwb79j8k1w1r8sh";
   };
 
   nativeBuildInputs = [ python3 ];
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://www.seabios.org";
     license = licenses.lgpl3;
-    maintainers = [ maintainers.tstrobel ];
+    maintainers = with maintainers; [ tstrobel ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Update SeaBIOS to version 1.16.0. Also, use the git repository as
source, since the release was tagged and announced, but no release
tarball was published.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
