### PR TITLE
SPIRV-LLVM-Translator: Add llvm-spirv tool; libclc: 11.0.1 -> 12.0.1

### DIFF
--- a/pkgs/development/compilers/spirv-llvm-translator/default.nix
+++ b/pkgs/development/compilers/spirv-llvm-translator/default.nix
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
   # FIXME: CMake tries to run "/llvm-lit" which of course doesn't exist
   doCheck = false;
 
+  makeFlags = [ "all" "llvm-spirv" ];
+
+  postInstall = ''
+    install -D tools/llvm-spirv/llvm-spirv $out/bin/llvm-spirv
+  '';
+
   meta = with lib; {
     homepage    = "https://github.com/KhronosGroup/SPIRV-LLVM-Translator";
     description = "A tool and a library for bi-directional translation between SPIR-V and LLVM IR";

--- a/pkgs/development/libraries/libclc/default.nix
+++ b/pkgs/development/libraries/libclc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, ninja, cmake, python3, llvmPackages }:
+{ lib, stdenv, fetchFromGitHub, ninja, cmake, python3, llvmPackages, spirv-llvm-translator }:
 
 let
   llvm = llvmPackages.llvm;
@@ -7,13 +7,13 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libclc";
-  version = "11.0.1";
+  version = "12.0.1";
 
   src = fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
     rev = "llvmorg-${version}";
-    sha256 = "0bxh43hp1vl4axl3s9n2nb2ii8x1cbq98xz9c996f8rl5jy84ags";
+    sha256 = "08s5w2db9imb2yaqsvxs6pg21csi1cf6wa35rf8x6q07mam7j8qv";
   };
   sourceRoot = "source/libclc";
 
@@ -21,10 +21,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace 'find_program( LLVM_CLANG clang PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
-                'find_program( LLVM_CLANG clang PATHS "${clang-unwrapped}/bin" NO_DEFAULT_PATH )'
+                'find_program( LLVM_CLANG clang PATHS "${clang-unwrapped}/bin" NO_DEFAULT_PATH )' \
+      --replace 'find_program( LLVM_SPIRV llvm-spirv PATHS ''${LLVM_BINDIR} NO_DEFAULT_PATH )' \
+                'find_program( LLVM_SPIRV llvm-spirv PATHS "${spirv-llvm-translator}/bin" NO_DEFAULT_PATH )'
   '';
 
-  nativeBuildInputs = [ cmake ninja python3 ];
+  nativeBuildInputs = [ cmake ninja python3 spirv-llvm-translator ];
   buildInputs = [ llvm clang-unwrapped ];
   strictDeps = true;
   cmakeFlags = [


### PR DESCRIPTION
The SPIRV-LLVM-Translator is updated to install the llvm-spirv tool. Unfortunately this tool is not installed as part of the normal 'make install' process so I added `postBuild` and `postInstall`.

libclc is upgraded from 11.0.1 to 12.0.1. In 12.0.0, libclc started using the llvm-spirv tool to create to spv files:

* spirv64-mesa3d-.spv
* spirv-mesa3d-.spv

###### Motivation for this change

The Mesa project is starting to make use of these SPIR-V libraries. It can be used by some drivers for opencl now, and potentially in the future for Vulkan ray-tracing support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - `llvm-spirv` was used by the libclc 12 build process
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
