### PR TITLE
devpi-client: add missing input, switch to pytestCheckHook

### DIFF
--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,26 +1,24 @@
 { lib
+, argon2-cffi-bindings
 , buildPythonApplication
-, fetchPypi
-# buildInputs
-, glibcLocales
-, pkginfo
 , check-manifest
-# propagatedBuildInputs
-, py
 , devpi-common
-, pluggy
-, setuptools
-# CheckInputs
-, pytest
-, pytest-flake8
-, webtest
-, mock
 , devpi-server
-, tox
-, sphinx
-, wheel
+, fetchPypi
 , git
+, glibcLocales
 , mercurial
+, mock
+, pkginfo
+, pluggy
+, py
+, pytestCheckHook
+, pytest-flake8
+, setuptools
+, sphinx
+, tox
+, webtest
+, wheel
 }:
 
 buildPythonApplication rec {
@@ -29,23 +27,44 @@ buildPythonApplication rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "362eb26e95136a792491861cc2728d14a6309a9d4c4f13a7b9c3e6fd39de58ec";
+    hash = "sha256-Ni6ybpUTankkkYYcwnKNFKYwmp1MTxOnucPm/TneWOw=";
   };
 
-  buildInputs = [ glibcLocales ];
-
-  propagatedBuildInputs = [ py devpi-common pluggy setuptools check-manifest pkginfo ];
-
-  checkInputs = [
-    pytest pytest-flake8 webtest mock
-    devpi-server tox
-    sphinx wheel git mercurial
+  buildInputs = [
+    glibcLocales
   ];
 
-  # --fast skips tests which try to start a devpi-server improperly
-  checkPhase = ''
-    HOME=$TMPDIR py.test --fast
+  propagatedBuildInputs = [
+    argon2-cffi-bindings
+    check-manifest
+    devpi-common
+    pkginfo
+    pluggy
+    py
+    setuptools
+  ];
+
+  checkInputs = [
+    devpi-server
+    git
+    mercurial
+    mock
+    pytestCheckHook
+    pytest-flake8
+    sphinx
+    tox
+    webtest
+    wheel
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d);
   '';
+
+  pytestFlagsArray = [
+    # --fast skips tests which try to start a devpi-server improperly
+    "--fast"
+  ];
 
   LC_ALL = "en_US.UTF-8";
 
@@ -57,5 +76,4 @@ buildPythonApplication rec {
     license = licenses.mit;
     maintainers = with maintainers; [ lewo makefu ];
   };
-
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Fix build (https://hydra.nixos.org/build/167846556)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
