### PR TITLE
linux.configfile: fix alts containing "/m"

### DIFF
--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -81,7 +81,7 @@ sub runConfig {
                 my $question = $1; my $name = $2; my $alts = $3;
                 my $answer = "";
                 # Build everything as a module if possible.
-                $answer = "m" if $autoModules && $alts =~ /\/m/ && !($preferBuiltin && $alts =~ /Y/);
+                $answer = "m" if $autoModules && $alts =~ qr{\A(\w/)+m/(\w/)*\?\z} && !($preferBuiltin && $alts =~ /Y/);
                 $answer = $answers{$name} if defined $answers{$name};
                 print STDERR "QUESTION: $question, NAME: $name, ALTS: $alts, ANSWER: $answer\n" if $debug;
                 print OUT "$answer\n";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

generate-config.pl's auto modules feature answers "m" to any Kconfig question it thinks supports being a module.  It detected this by seeing if the help shown by make config (called "alts" by the script) contained the string "/m", which it would in the case of e.g a tristate option, where alts would be "N/m/y/?".

But then along came `CONFIG_MODPROBE_PATH `in Linux 5.13, with a default value, shown in the make config help, of "/sbin/modprobe". generate-config.pl would see the "/m" substring, and answer "m" to the question, meaning (I think) that the built kernel would expect the modprobe binary to be at /m.  This broke the (non-NixOS) VM images I build with Nix.  NixOS was unaffected because it uses a different mechanism to set the modprobe path.

With the current architecture, we can't 100% determine whether a Kconfig option is a string or a tristate, but we can get a lot closer by using a better regex.  My new regex only accepts single word characters, separated by slashes, with a "/?" at the end.  This is much less likely to ever end up as the default value of a string option.

Tested by building linux_latest.configfile before and after my changes, and checking the only difference is the correct default for `CONFIG_MODPROBE_PATH`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
