### PR TITLE
crowdsec: init at 1.3.1

### DIFF
--- a/pkgs/tools/security/crowdsec/default.nix
+++ b/pkgs/tools/security/crowdsec/default.nix
@@ -1,0 +1,86 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, installShellFiles, jq, fetchpatch }:
+
+buildGoModule rec {
+  pname = "crowdsec";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "crowdsecurity";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-EbwvNRzd28pVUk/obOqyIAcaTEafczJ62TTJAOw5QEA=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      # 0000-00-00_00:00:00
+      date -u -d "@$(git log -1 --pretty=%ct)" "+%Y-%m-%d_%H:%M:%S" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/crowdsecurity/crowdsec/pull/1302/commits/07f2b64f63ed339bc7f7664192452060929ccd2b.patch";
+      sha256 = "sha256-bTfJt3ZfHUsLRPGF6mHnaEsGNoMCvWS0sA4Ylw/o5ao=";
+    })
+  ];
+
+  vendorSha256 = "sha256-fZj+gViuyu6oapj18aGQxWsrLeTlPo+SZdbDPrPSpFA=";
+
+  nativeBuildInputs = [ installShellFiles jq ];
+
+  subPackages = [ "cmd/crowdsec-cli" "cmd/crowdsec" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/crowdsecurity/crowdsec/pkg/cwversion.Version=v${version}"
+  ];
+
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Tag=$(cat COMMIT)"
+    ldflags+=" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.BuildDate=$(cat SOURCE_DATE_EPOCH)"
+    ldflags+=" -X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=$(jq -r .CodeName < RELEASE.json)"
+  '';
+
+  postBuild = ''
+    mv $GOPATH/bin/{crowdsec-cli,cscli}
+  '';
+
+  # many failing tests due to expecting files such as /etc/shadow and services such as docker
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/crowdsec
+    cp -r ./config $out/share/crowdsec/
+
+    # --config since it fails if the file doesn't exist or look like real config
+    # luckily there's some config in ./config
+    installShellCompletion --cmd cscli \
+      --bash <($out/bin/cscli completion --config ./config/config.yaml bash) \
+      --zsh <($out/bin/cscli completion --config ./config/config.yaml zsh)
+  '';
+
+  meta = with lib; {
+    homepage = "https://crowdsec.net/";
+    changelog = "https://github.com/crowdsecurity/crowdsec/releases/tag/v${version}";
+    description = "CrowdSec is a free, open-source and collaborative IPS";
+    longDescription = ''
+      CrowdSec is a free, modern & collaborative behavior detection engine,
+      coupled with a global IP reputation network. It stacks on fail2ban's
+      philosophy but is IPV6 compatible and 60x faster (Go vs Python), uses Grok
+      patterns to parse logs and YAML scenario to identify behaviors. CrowdSec
+      is engineered for modern Cloud/Containers/VM based infrastructures (by
+      decoupling detection and remediation). Once detected you can remedy
+      threats with various bouncers (firewall block, nginx http 403, Captchas,
+      etc.) while the aggressive IP can be sent to CrowdSec for curation before
+      being shared among all users to further improve everyone's security.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2796,6 +2796,8 @@ with pkgs;
 
   crosvm = callPackage ../applications/virtualization/crosvm { };
 
+  crowdsec = callPackage ../tools/security/crowdsec { };
+
   crunch = callPackage ../tools/security/crunch { };
 
   crudini = callPackage ../tools/misc/crudini { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Resolves #155822 

Package crowdsec `1.3.1` for nix

I'll keep this draft while I investigate the other components such as:

config
patterns
bouncers
etc

I'll probably save nixos module(s) for another PR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
