### PR TITLE
coqPackages.metacoq: create package

### DIFF
--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -36,7 +36,7 @@ let
       derivation = mkCoqDerivation ({
         inherit version pname defaultVersion release releaseRev repo owner;
 
-        nativeBuildInputs = [ which ];
+        extraNativeBuildInputs = [ which ];
         mlPlugin = true;
         extraBuildInputs = [ equations coq.ocamlPackages.zarith ];
         propagatedBuildInputs = metacoq-deps;

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -13,7 +13,7 @@ let
     ] null;
   release = {
     "1.0-beta2-8.11".sha256 = "sha256-I9YNk5Di6Udvq5/xpLSNflfjRyRH8fMnRzbo3uhpXNs=";
-    "1.0-beta2-8.12".sha256 = "sha256-I9YNk5Di6Udvq5/xpLSNflfjRyRH8fMnRzbo3uhpXNs=";
+    "1.0-beta2-8.12".sha256 = "sha256-I8gpmU9rUQJh0qfp5KOgDNscVvCybm5zX4TINxO1TVA=";
     "1.0-beta2-8.13".sha256 = "sha256-IC56/lEDaAylUbMCfG/3cqOBZniEQk8jmI053DBO5l8=";
   };
   releaseRev = v: "v${v}";

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -46,10 +46,10 @@ let
           patchShebangs ./template-coq/update_plugin.sh
           patchShebangs ./template-coq/gen-src/to-lower.sh
           patchShebangs ./pcuic/clean_extraction.sh
-          patchShebangs ./pcuic/theories/replace.sh
           patchShebangs ./safechecker/clean_extraction.sh
           patchShebangs ./erasure/clean_extraction.sh
           echo "CAMLFLAGS+=-w -60 # Unused module" >> ./safechecker/Makefile.plugin.local
+          sed -i -e 's/mv $i $newi;/mv $i tmp; mv tmp $newi;/' ./template-coq/gen-src/to-lower.sh ./pcuic/clean_extraction.sh ./safechecker/clean_extraction.sh ./erasure/clean_extraction.sh
         '' ;
 
         configurePhase = optionalString (package == "all") pkgallMake + ''

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -1,0 +1,76 @@
+{ lib, which, fetchzip,
+  mkCoqDerivation, recurseIntoAttrs,  single ? false,
+  coqPackages, coq, equations, version ? null }@args:
+with builtins // lib;
+let
+  repo  = "metacoq";
+  owner = "MetaCoq";
+  defaultVersion = with versions; switch coq.coq-version [
+      { case = "8.11"; out = "1.0-beta2-8.11"; }
+      { case = "8.12"; out = "1.0-beta2-8.12"; }
+      # Do not provide 8.13 because it does not compile with equations 1.3 provided by default (only 1.2.3)
+      # { case = "8.13"; out = "1.0-beta2-8.13"; }
+    ] null;
+  release = {
+    "1.0-beta2-8.11".sha256 = "sha256-I9YNk5Di6Udvq5/xpLSNflfjRyRH8fMnRzbo3uhpXNs=";
+    "1.0-beta2-8.12".sha256 = "sha256-I9YNk5Di6Udvq5/xpLSNflfjRyRH8fMnRzbo3uhpXNs=";
+    "1.0-beta2-8.13".sha256 = "sha256-IC56/lEDaAylUbMCfG/3cqOBZniEQk8jmI053DBO5l8=";
+  };
+  releaseRev = v: "v${v}";
+
+  # list of core metacoq packages sorted by dependency order
+  packages = [ "template-coq" "pcuic" "safechecker" "erasure" "all" ];
+
+  template-coq = metacoq_ "template-coq";
+
+  metacoq_ = package: let
+      metacoq-deps = if package == "single" then []
+        else map metacoq_ (head (splitList (pred.equal package) packages));
+      pkgpath = if package == "single" then "./" else "./${package}";
+      pname = if package == "all" then "metacoq" else "metacoq-${package}";
+      pkgallMake = ''
+          mkdir all
+          echo "all:" > all/Makefile
+          echo "install:" >> all/Makefile
+        '' ;
+      derivation = mkCoqDerivation ({
+        inherit version pname defaultVersion release releaseRev repo owner;
+
+        nativeBuildInputs = [ which ];
+        mlPlugin = true;
+        extraBuildInputs = [ equations coq.ocamlPackages.zarith ];
+        propagatedBuildInputs = metacoq-deps;
+
+        patchPhase =  ''
+          patchShebangs ./configure.sh
+          patchShebangs ./template-coq/update_plugin.sh
+          patchShebangs ./template-coq/gen-src/to-lower.sh
+          patchShebangs ./pcuic/clean_extraction.sh
+          patchShebangs ./pcuic/theories/replace.sh
+          patchShebangs ./safechecker/clean_extraction.sh
+          patchShebangs ./erasure/clean_extraction.sh
+          echo "CAMLFLAGS+=-w -60 # Unused module" >> ./safechecker/Makefile.plugin.local
+        '' ;
+
+        configurePhase = optionalString (package == "all") pkgallMake + ''
+          touch ${pkgpath}/metacoq-config
+        '' + optionalString (elem package ["safechecker" "erasure"]) ''
+          echo  "-I ${template-coq}/lib/coq/${coq.coq-version}/user-contrib/MetaCoq/Template/" > ${pkgpath}/metacoq-config
+        '' + optionalString (package == "single") ''
+          ./configure.sh local
+        '';
+
+        preBuild = ''
+          cd ${pkgpath}
+        '' ;
+
+        meta = {
+          homepage    = "https://metacoq.github.io/";
+          license     = licenses.mit;
+          maintainers = with maintainers; [ cohencyril ];
+        };
+      } // optionalAttrs (package != "single")
+        { passthru = genAttrs packages metacoq_; });
+    in derivation;
+in
+metacoq_ (if single then "single" else "all")

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -38,8 +38,8 @@ let
 
         extraNativeBuildInputs = [ which ];
         mlPlugin = true;
-        extraBuildInputs = [ equations coq.ocamlPackages.zarith ];
-        propagatedBuildInputs = metacoq-deps;
+        extraBuildInputs = [ coq.ocamlPackages.zarith ];
+        propagatedBuildInputs = [ equations ] ++ metacoq-deps;
 
         patchPhase =  ''
           patchShebangs ./configure.sh

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -77,6 +77,7 @@ let
       mathcomp-word = callPackage ../development/coq-modules/mathcomp-word {};
       mathcomp-zify = callPackage ../development/coq-modules/mathcomp-zify {};
       mathcomp-tarjan = callPackage ../development/coq-modules/mathcomp-tarjan {};
+      metacoq = callPackage ../development/coq-modules/metacoq { };
       metalib = callPackage ../development/coq-modules/metalib { };
       multinomials = callPackage ../development/coq-modules/multinomials {};
       odd-order = callPackage ../development/coq-modules/odd-order { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Adds a nix derivation for MetaCoq as a coq package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
