### PR TITLE
redis-plus-plus: init at 1.3.3

### DIFF
--- a/pkgs/development/libraries/redis-plus-plus/default.nix
+++ b/pkgs/development/libraries/redis-plus-plus/default.nix
@@ -1,0 +1,38 @@
+{ lib, stdenv, fetchFromGitHub, cmake, hiredis
+, enableShared ? !stdenv.hostPlatform.isStatic
+, enableStatic ? stdenv.hostPlatform.isStatic
+}:
+
+# You must build at one type of library
+assert enableShared || enableStatic;
+
+stdenv.mkDerivation rec {
+  pname = "redis-plus-plus";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    owner = "sewenew";
+    repo = "redis-plus-plus";
+    rev = version;
+    sha256 = "sha256-k4q5YbbbKKHXcL0nndzJPshzXS20ARz4Tdy5cBg7kMc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ hiredis ];
+
+  cmakeFlags = [
+    "-DREDIS_PLUS_PLUS_BUILD_TEST=OFF"
+  ] ++ lib.optional (!enableShared) [
+    "-DREDIS_PLUS_PLUS_BUILD_SHARED=OFF"
+  ] ++ lib.optional (!enableStatic) [
+    "-DREDIS_PLUS_PLUS_BUILD_STATIC=OFF"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/sewenew/redis-plus-plus";
+    description = "Redis client written in C++";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ wheelsandmetal ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15506,6 +15506,8 @@ with pkgs;
 
   redis-dump = callPackage ../development/tools/redis-dump { };
 
+  redis-plus-plus = callPackage ../development/libraries/redis-plus-plus { };
+
   redo = callPackage ../development/tools/build-managers/redo { };
 
   redo-apenwarr = callPackage ../development/tools/build-managers/redo-apenwarr { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add redis++ c++ library

https://github.com/sewenew/redis-plus-plus

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
