### PR TITLE
mujoco: init at 2.1.1

### DIFF
--- a/pkgs/development/libraries/mujoco/default.nix
+++ b/pkgs/development/libraries/mujoco/default.nix
@@ -1,0 +1,63 @@
+{ fetchurl
+, stdenv
+, lib
+, libGLU
+, mesa
+, libX11
+, mesa_drivers
+, autoPatchelfHook
+}:
+let
+  # TODO: Maybe Darwin could be supported
+  tags = {
+    "x86_64-linux" = {
+      arch = "linux-x86_64";
+      sha256 = "d422720fc53f161992b264847d6173eabbe3a3710aa0045d68738ee942f3246e";
+    };
+    "aarch64-linux" = {
+      arch = "linux-aarch64";
+      sha256 = "83949d7d159b3b958153efcd62d3c7c9b160917b37a19cacda95c2cb1f0dda19";
+    };
+  };
+
+  download = tags.${stdenv.system} or (builtins.abort "${stdenv.system} is currently unsupported !");
+in
+stdenv.mkDerivation rec {
+  pname = "mujoco";
+  version = "2.1.1";
+
+  src = fetchurl {
+    inherit (download) sha256;
+    url = "https://github.com/deepmind/mujoco/releases/download/${version}/mujoco-${version}-${download.arch}.tar.gz";
+  };
+
+  noBuildPhase = true;
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r ./* $out/
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  # Techincally `libOSMesa.so.6` is not satsified, but it seems to work anyway
+  autoPatchelfIgnoreMissingDeps = true;
+
+  buildInputs = [
+    libGLU.dev
+    mesa
+    libX11
+    mesa_drivers.osmesa
+  ];
+
+  meta = {
+    description = "Multi-Joint dynamics with Contact. A general purpose physics simulator.";
+    longDescription = ''
+      MuJoCo is a physics engine that aims to facilitate research and development in robotics, biomechanics, graphics and animation, and other areas where fast and accurate simulation is needed
+    '';
+    homepage = "https://mujoco.org/";
+    maintainers = [ lib.maintainers.mazurel ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1176,6 +1176,8 @@ with pkgs;
 
   mrxvt = callPackage ../applications/terminal-emulators/mrxvt { };
 
+  mujoco = callPackage ../development/libraries/mujoco { };
+
   nimmm = callPackage ../applications/terminal-emulators/nimmm { };
 
   roxterm = callPackage ../applications/terminal-emulators/roxterm { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

MuJoCo is a physics engine that aims to facilitate research and development in robotics, biomechanics, graphics and animation, and other areas where fast and accurate simulation is needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
