### PR TITLE
gg-scm: 1.2.1 -> 1.3.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/gg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gg/default.nix
@@ -10,8 +10,8 @@
 }:
 
 let
-  version = "1.2.1";
-  commit = "eed9dc7c82c5a7fbc13fd9b496e1faaec3f20d57";
+  version = "1.3.0";
+  commit = "5bfe79b3632f15c442e8dc51ec206ab76354487f";
 in buildGoModule {
   pname = "gg-scm";
   inherit version;
@@ -20,7 +20,7 @@ in buildGoModule {
     owner = "gg-scm";
     repo = "gg";
     rev = "v${version}";
-    sha256 = "770c807403f5d99cea6450f889d268800e1c2563f0cd6142936741c40b29cc95";
+    sha256 = "e628aeddb94d2470de860df09ef65499f8c5493fb336bf3df8502842ee02487f";
   };
   postPatch = ''
     substituteInPlace cmd/gg/editor_unix.go \


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
