### PR TITLE
roundcubePlugins.custom_from: init at 1.6.6

### DIFF
--- a/pkgs/servers/roundcube/plugins/custom_from/default.nix
+++ b/pkgs/servers/roundcube/plugins/custom_from/default.nix
@@ -1,0 +1,11 @@
+{ roundcubePlugin, fetchzip }:
+
+roundcubePlugin rec {
+  pname = "custom_from";
+  version = "1.6.6";
+
+  src = fetchzip {
+    url = "https://github.com/r3c/custom_from/archive/refs/tags/${version}.zip";
+    hash = "sha256-QvMYwFWY0BZOkzhDtW7XJ77i5mVkDNAiN4JBdsCuUy0=";
+  };
+}

--- a/pkgs/servers/roundcube/plugins/plugins.nix
+++ b/pkgs/servers/roundcube/plugins/plugins.nix
@@ -7,6 +7,7 @@
 
   carddav = callPackage ./carddav { };
   contextmenu = callPackage ./contextmenu { };
+  custom_from = callPackage ./custom_from { };
   persistent_login = callPackage ./persistent_login { };
   thunderbird_labels = callPackage ./thunderbird_labels { };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Add the [custom_from plugin](https://github.com/r3c/custom_from) for roundcube. Tested working on nixos-21.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
