### PR TITLE
kamid: init at 0.1

### DIFF
--- a/pkgs/servers/ftp/kamid/default.nix
+++ b/pkgs/servers/ftp/kamid/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.1";
 
   src = fetchurl {
-    url = "https://github.com/omar-polo/kamid/releases/download/0.1/${pname}-${version}.tar.gz";
+    url = "https://github.com/omar-polo/kamid/releases/download/${version}/${pname}-${version}.tar.gz";
     sha256 = "16gi82dgaxwy8fgg05hbam796pk51i6xlyrx8qhghi7ikxr5jd19";
   };
 

--- a/pkgs/servers/ftp/kamid/default.nix
+++ b/pkgs/servers/ftp/kamid/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, pkg-config
+, libevent
+, libressl
+, libbsd
+, fetchurl
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kamid";
+  version = "0.1";
+
+  src = fetchurl {
+    url = "https://github.com/omar-polo/kamid/releases/download/0.1/${pname}-${version}.tar.gz";
+    sha256 = "16gi82dgaxwy8fgg05hbam796pk51i6xlyrx8qhghi7ikxr5jd19";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libevent
+    libressl
+    readline
+    libbsd
+  ];
+
+  meta = with lib; {
+    description = "A FREE, easy-to-use and portable implementation of a 9p file server daemon for UNIX-like systems";
+    homepage = "https://kamid.omarpolo.com";
+    license = licenses.isc;
+    maintainers = with maintainers; [ heph2 ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15160,6 +15160,8 @@ with pkgs;
 
   kafka-delta-ingest = callPackage ../development/tools/kafka-delta-ingest { };
 
+  kamid = callPackage ../servers/ftp/kamid { };
+
   kati = callPackage ../development/tools/build-managers/kati { };
 
   kcat = callPackage ../development/tools/kcat { };


### PR DESCRIPTION
###### Motivation for this change
kamid is a FREE, easy-to-use and portable implementation of a 9p file server daemon for UNIX-like systems.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
