### PR TITLE
comitium: init at 1.8.1

### DIFF
--- a/pkgs/applications/networking/feedreaders/comitium/default.nix
+++ b/pkgs/applications/networking/feedreaders/comitium/default.nix
@@ -1,17 +1,25 @@
-{ buildGoModule, scdoc, fetchgit, lib }:
+{ buildGoModule, scdoc, fetchurl, lib }:
 
 buildGoModule rec {
   pname = "comitium";
   version = "1.8.1";
 
-  src = fetchgit {
-    url = "git://git.nytpu.com/comitium";
-    rev = "cf20f5877ef1fa258849f8a283dbd4080a96eb83";
-    sha256 = "01k09q9376lw8v2gh32anzf44139nym2acir11h8zpcsrb8ka9n5";
+  src = fetchurl {
+    url = "https://git.nytpu.com/${pname}/snapshot/${pname}-${version}.tar.bz2";
+    sha256 = "0xvnv8wmgpyl16vignnf8mfkah6agc5j83nnz04hk7kk1ai0y5j7";
   };
 
   nativeBuildInputs = [ scdoc ];
 
+  buildPhase = ''
+    make COMMIT=tarball
+  '';
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  doCheck = false;
   vendorSha256 = "sha256-6xtXTmSqaN2me0kyRk948ASNNtv7P5XBvtv9UWjNHoo=";
 
   meta = with lib; {

--- a/pkgs/applications/networking/feedreaders/comitium/default.nix
+++ b/pkgs/applications/networking/feedreaders/comitium/default.nix
@@ -1,0 +1,32 @@
+{ buildGoModule, scdoc, fetchurl, lib }:
+
+buildGoModule rec {
+  pname = "comitium";
+  version = "1.8.1";
+
+  src = fetchurl {
+    url = "https://git.nytpu.com/comitium/snapshot/${pname}-${version}.tar.bz2";
+    sha256 = "0xvnv8wmgpyl16vignnf8mfkah6agc5j83nnz04hk7kk1ai0y5j7";
+  };
+
+  nativeBuildInputs = [ scdoc ];
+
+  buildPhase = ''
+    make COMMIT=tarball
+  '';
+
+  installPhase = ''
+    make PREFIX=$out install
+  '';
+
+  doCheck = false;
+  vendorSha256 = "sha256-6xtXTmSqaN2me0kyRk948ASNNtv7P5XBvtv9UWjNHoo=";
+
+  meta = with lib; {
+    description = "Gemini feed aggregator that supports Atom, RSS and Gemini feeds";
+    homepage = "https://git.nytpu.com/comitium/";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ heph2 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/networking/feedreaders/comitium/default.nix
+++ b/pkgs/applications/networking/feedreaders/comitium/default.nix
@@ -1,25 +1,17 @@
-{ buildGoModule, scdoc, fetchurl, lib }:
+{ buildGoModule, scdoc, fetchgit, lib }:
 
 buildGoModule rec {
   pname = "comitium";
   version = "1.8.1";
 
-  src = fetchurl {
-    url = "https://git.nytpu.com/comitium/snapshot/${pname}-${version}.tar.bz2";
-    sha256 = "0xvnv8wmgpyl16vignnf8mfkah6agc5j83nnz04hk7kk1ai0y5j7";
+  src = fetchgit {
+    url = "git://git.nytpu.com/comitium";
+    rev = "cf20f5877ef1fa258849f8a283dbd4080a96eb83";
+    sha256 = "01k09q9376lw8v2gh32anzf44139nym2acir11h8zpcsrb8ka9n5";
   };
 
   nativeBuildInputs = [ scdoc ];
 
-  buildPhase = ''
-    make COMMIT=tarball
-  '';
-
-  installPhase = ''
-    make PREFIX=$out install
-  '';
-
-  doCheck = false;
   vendorSha256 = "sha256-6xtXTmSqaN2me0kyRk948ASNNtv7P5XBvtv9UWjNHoo=";
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -305,7 +305,7 @@ with pkgs;
 
   comedilib = callPackage ../development/libraries/comedilib {  };
 
-  comitium = callPackage ../pkgs/applications/networking/feedreaders/comitium { };
+  comitium = callPackage ../applications/networking/feedreaders/comitium {  };
 
   commitlint = nodePackages."@commitlint/cli";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -305,6 +305,8 @@ with pkgs;
 
   comedilib = callPackage ../development/libraries/comedilib {  };
 
+  comitium = callPackage ../pkgs/applications/networking/feedreaders/comitium { };
+
   commitlint = nodePackages."@commitlint/cli";
 
   commit-formatter = callPackage ../applications/version-management/commit-formatter { };


### PR DESCRIPTION
###### Motivation for this change
comitium is a Gemini, Gopher, and HTTP feed aggregator that supports Atom, RSS, JSON, and Gemini feeds
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
