### PR TITLE
kafdrop: init at 3.29.0

### DIFF
--- a/pkgs/development/tools/misc/kafdrop/default.nix
+++ b/pkgs/development/tools/misc/kafdrop/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, maven, fetchFromGitHub, makeWrapper, jre, lib }:
+let
+  version = "3.29.0";
+
+  src = fetchFromGitHub {
+    owner = "obsidiandynamics";
+    repo = "kafdrop";
+    rev = "${version}";
+    sha256 = "sha256-38ysop/WcV+eHJCdzryTZOdtik6vfSfS5hy5RYRfAFw=";
+  };
+
+  deps = stdenv.mkDerivation {
+    name = "kafdrop-${version}-deps";
+    inherit src;
+    buildInputs = [ maven ];
+    buildPhase = ''
+       mvn package -Dmaven.repo.local=$out
+    '';
+    installPhase = ''
+    find $out -type f \
+      -name \*.lastUpdated -or \
+      -name resolver-status.properties -or \
+      -name _remote.repositories \
+      -delete
+  '';
+    dontFixup = true;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-dTPxk1CuLENJGSAN9RML0DKaRqliFpWgtFuP9XE2nHc=";
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "kafdrop";
+  inherit version;
+  inherit src;
+  buildInputs = [ maven makeWrapper ];
+  buildPhase = ''
+    echo "Using repository ${deps}"
+    mvn --offline -Dmaven.repo.local=${deps} package;
+  '';
+  installPhase =''
+    mkdir -p $out/bin
+    mkdir -p $out/share/java
+    mv target/${pname}-${version}.jar $out/share/java/
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/java/${pname}-${version}.jar"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/obsidiandynamics/kafdrop";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ heph2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15160,6 +15160,8 @@ with pkgs;
 
   k2tf = callPackage ../development/tools/misc/k2tf { };
 
+  kafdrop = callPackage ../development/tools/misc/kafdrop { };
+
   kafka-delta-ingest = callPackage ../development/tools/kafka-delta-ingest { };
 
   kati = callPackage ../development/tools/build-managers/kati { };


### PR DESCRIPTION
###### Motivation for this change
Kafdrop is a web UI for viewing Kafka topics and browsing consumer groups
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
