### PR TITLE
nfstream: init at 6.3.5

### DIFF
--- a/pkgs/development/python-modules/nfstream/default.nix
+++ b/pkgs/development/python-modules/nfstream/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, buildPythonApplication
+, psutil
+, numpy
+, dpkt
+, cffi
+, pandas
+}:
+
+buildPythonPackage rec {
+  pname = "nfstream";
+  version = "6.3.5";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    sha256 = "1wqcz4vavay56gf8nn55s67wp61rmyw8s1mzki3b3zbbzwl1zbvy";
+    abi = "cp39";
+    python = "cp39";
+    platform = "manylinux1_x86_64";
+  };
+
+  propagatedBuildInputs = [ psutil numpy dpkt cffi pandas ];
+
+  meta = with lib; {
+    description = "Python Framework for network data analytics";
+    homepage = "https://github.com/nfstream/nfstream";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ heph2 ];
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

NFStream is a multiplatform Python framework providing fast, flexible, and expressive data structures designed to make working with online or offline network data both easy and intuitive. It aims to be the fundamental high-level building block for doing practical, real world network data analysis in Python. Additionally, it has the broader goal of becoming a common network data analytics framework for researchers providing data reproducibility across experiments.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
