### PR TITLE
ocamlPackages: fix broken packages

### DIFF
--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, num, ounit
+{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocamlbuild, qtest, qcheck, num, ounit
 , doCheck ? lib.versionAtLeast ocaml.version "4.08" && !stdenv.isAarch64
 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild ];
-  checkInputs = [ qtest ounit ];
+  checkInputs = [ qtest ounit qcheck ];
   propagatedBuildInputs = [ num ];
 
   strictDeps = !doCheck;

--- a/pkgs/development/ocaml-modules/conduit/default.nix
+++ b/pkgs/development/ocaml-modules/conduit/default.nix
@@ -15,8 +15,7 @@ buildDunePackage rec {
     sha256 = "2a37ffaa352a1e145ef3d80ac28661213c69a741b238623e59f29e3d5a12c537";
   };
 
-  buildInputs = [ ppx_sexp_conv ];
-  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri logs ];
+  propagatedBuildInputs = [ astring ipaddr ipaddr-sexp sexplib uri logs ppx_sexp_conv ];
 
   meta = {
     description = "A network connection establishment library";

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -8,9 +8,9 @@ stdenv.mkDerivation rec {
     sha256 = "1nymykskq1yx87y4xl6hl9i4q6kv0qaq25rniqgl1bfn883p1ysc";
   };
 
-  nativeBuildInputs = [ perl ocaml findlib ];
+  nativeBuildInputs = [ perl ocaml findlib camlidl ];
 
-  propagatedBuildInputs = [ apron camlidl gmp mpfr ];
+  propagatedBuildInputs = [ apron gmp mpfr ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/facile/default.nix
+++ b/pkgs/development/ocaml-modules/facile/default.nix
@@ -1,10 +1,8 @@
-{ lib, fetchurl, buildDunePackage }:
+{ lib, fetchurl, buildDunePackage, ocaml }:
 
 buildDunePackage rec {
   pname = "facile";
   version = "1.1.4";
-
-  useDune2 = false;
 
   src = fetchurl {
     url = "https://github.com/Emmanuel-PLF/facile/releases/download/${version}/facile-${version}.tbz";
@@ -12,6 +10,9 @@ buildDunePackage rec {
   };
 
   doCheck = true;
+
+  useDune2 = lib.versionAtLeast ocaml.version "4.12";
+  postPatch = lib.optionalString useDune2 "dune upgrade";
 
   meta = {
     homepage = "http://opti.recherche.enac.fr/facile/";

--- a/pkgs/development/ocaml-modules/gmetadom/default.nix
+++ b/pkgs/development/ocaml-modules/gmetadom/default.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ pkg-config ocaml findlib ];
-  buildInputs = [ gdome2 libxslt];
-  propagatedBuildInputs = [gdome2];
+  buildInputs = [ libxslt ];
+  propagatedBuildInputs = [ gdome2 ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/hack_parallel/default.nix
+++ b/pkgs/development/ocaml-modules/hack_parallel/default.nix
@@ -15,7 +15,7 @@ buildDunePackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ core core_kernel sqlite ];
+  propagatedBuildInputs = [ core core_kernel sqlite ];
 
   meta = {
     description =

--- a/pkgs/development/ocaml-modules/mccs/default.nix
+++ b/pkgs/development/ocaml-modules/mccs/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  buildInputs = [
+  propagatedBuildInputs = [
     cudf
   ];
 

--- a/pkgs/development/ocaml-modules/mirage-logs/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-logs/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchurl, buildDunePackage
 , logs, lwt, mirage-clock, mirage-profile, ptime
-, alcotest
+, alcotest, stdlib-shims
 }:
 
 buildDunePackage rec {
@@ -14,7 +14,7 @@ buildDunePackage rec {
     sha256 = "0h0amzjxy067jljscib7fvw5q8k0adqa8m86affha9hq5jsh07a1";
   };
 
-  propagatedBuildInputs = [ logs lwt mirage-clock mirage-profile ptime ];
+  propagatedBuildInputs = [ logs lwt mirage-clock mirage-profile ptime stdlib-shims ];
 
   doCheck = true;
   checkInputs = [ alcotest ];

--- a/pkgs/development/ocaml-modules/mirage-profile/default.nix
+++ b/pkgs/development/ocaml-modules/mirage-profile/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, buildDunePackage
-, ppx_cstruct
+, ppx_cstruct, stdlib-shims
 , cstruct, lwt
 }:
 
@@ -15,7 +15,7 @@ buildDunePackage rec {
   };
 
   buildInputs = [ ppx_cstruct ];
-  propagatedBuildInputs = [ cstruct lwt ];
+  propagatedBuildInputs = [ cstruct lwt stdlib-shims ];
 
   meta = with lib; {
     description = "Collect runtime profiling information in CTF format";

--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "17xqiclaqs4hmnb92p9z6z9a1xfr31vcn8nlnj8ykk57by31vfza";
   };
 
-  nativeBuildInputs = [ perl ocaml findlib mpfr camlidl ];
+  nativeBuildInputs = [ perl ocaml findlib camlidl ];
   buildInputs = [ gmp mpfr ];
 
   strictDeps = true;
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   postConfigure = ''
-    sed -i Makefile \
-      -e 's|/bin/rm|rm|'
+    substituteInPlace Makefile --replace "/bin/rm" "rm"
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
   '';
 

--- a/pkgs/development/ocaml-modules/nonstd/default.nix
+++ b/pkgs/development/ocaml-modules/nonstd/default.nix
@@ -1,10 +1,8 @@
-{ lib, fetchzip, buildDunePackage }:
+{ lib, fetchzip, buildDunePackage, ocaml }:
 
 buildDunePackage rec {
   pname = "nonstd";
   version = "0.0.3";
-
-  useDune2 = false;
 
   minimalOCamlVersion = "4.02";
 
@@ -13,6 +11,8 @@ buildDunePackage rec {
     sha256 = "0ccjwcriwm8fv29ij1cnbc9win054kb6pfga3ygzdbjpjb778j46";
   };
 
+  useDune2 = lib.versionAtLeast ocaml.version "4.12";
+  postPatch = lib.optionalString useDune2 "dune upgrade";
   doCheck = true;
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/odoc-parser/default.nix
+++ b/pkgs/development/ocaml-modules/odoc-parser/default.nix
@@ -23,7 +23,7 @@ buildDunePackage rec {
 
   useDune2 = true;
 
-  buildInputs = [ astring result ];
+  propagatedBuildInputs = [ astring result ];
 
   meta = {
     description = "Parser for Ocaml documentation comments";

--- a/pkgs/development/ocaml-modules/opium_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/opium_kernel/default.nix
@@ -9,6 +9,7 @@
 , ezjsonm
 , hmap
 , sexplib
+, fieldslib
 }:
 
 buildDunePackage rec {
@@ -31,7 +32,7 @@ buildDunePackage rec {
   ];
 
   propagatedBuildInputs = [
-    hmap cohttp-lwt ezjsonm sexplib
+    hmap cohttp-lwt ezjsonm sexplib fieldslib
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/pcap-format/default.nix
+++ b/pkgs/development/ocaml-modules/pcap-format/default.nix
@@ -1,6 +1,6 @@
 { lib, buildDunePackage, fetchurl
 , ppx_cstruct, ppx_tools
-, cstruct, ounit, mmap
+, cstruct, ounit, mmap, stdlib-shims
 }:
 
 buildDunePackage rec {
@@ -24,6 +24,7 @@ buildDunePackage rec {
 
   propagatedBuildInputs = [
     cstruct
+    stdlib-shims
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/pipebang/default.nix
+++ b/pkgs/development/ocaml-modules/pipebang/default.nix
@@ -15,7 +15,7 @@ buildOcaml rec {
 
   strictDeps = true;
 
-  buildInputs = [ camlp4 ];
+  propagatedBuildInputs = [ camlp4 ];
 
   meta = with lib; {
     homepage = "https://github.com/janestreet/pipebang";

--- a/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
+++ b/pkgs/development/ocaml-modules/piqi-ocaml/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, piqi, stdlib-shims }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ocaml, findlib, piqi, stdlib-shims, num }:
 
 stdenv.mkDerivation rec {
   version = "0.7.7";
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ ocaml findlib ];
   buildInputs = [ piqi stdlib-shims ];
+
+  checkInputs  = [ num ];
 
   strictDeps = true;
 

--- a/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_cstubs/default.nix
@@ -27,17 +27,19 @@ buildDunePackage rec {
     sha256 = "15cjb9ygnvp2kv85rrb7ncz7yalifyl7wd2hp2cl8r1qrpgi1d0w";
   };
 
-  nativeBuildInputs = [ cppo ];
+  nativeBuildInputs = [ cppo findlib ];
 
   buildInputs = [
     bigarray-compat
     containers
-    ctypes
     integers
     num
     ppxlib
     re
-    findlib
+  ];
+
+  propagatedBuildInputs = [
+    ctypes
   ];
 
   strictDeps = true;

--- a/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_protobuf/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchurl, buildDunePackage, cppo, ppx_deriving
-, ppxlib
+, ppxlib, dune-configurator
 }:
 
 buildDunePackage rec {
@@ -13,7 +13,9 @@ buildDunePackage rec {
     sha256 = "1dc1vxnkd0cnrgac5v3zbaj2lq1d2w8118mp1cmsdxylp06yz1sj";
   };
 
-  buildInputs = [ cppo ppxlib ppx_deriving ];
+  nativeBuildInputs = [ cppo ];
+  buildInputs = [ ppxlib dune-configurator ];
+  propagatedBuildInputs = [ ppx_deriving ];
 
   meta = with lib; {
     homepage = "https://github.com/ocaml-ppx/ppx_deriving_protobuf";

--- a/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
+++ b/pkgs/development/ocaml-modules/shared-memory-ring/default.nix
@@ -5,6 +5,7 @@
 , mirage-profile
 , cstruct
 , ounit
+, stdlib-shims
 }:
 
 buildDunePackage rec {
@@ -25,6 +26,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     mirage-profile
     cstruct
+    stdlib-shims
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/ulex/default.nix
+++ b/pkgs/development/ocaml-modules/ulex/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   createFindlibDestdir = true;
 
   nativeBuildInputs = [ ocaml findlib ocamlbuild camlp4 ];
+  propagatedBuildInputs = [ camlp4 ];
 
   strictDeps = true;
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fix a lot of packages broken by #161344 and some extras I found along the way. The commits are structured so that we don't have to squash the commits if we don't want to.

ppx_deriving was intentionally left out of this since there's another open PR for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
