### PR TITLE
python3Packages.desktop-notifier: 3.3.2 -> 3.3.5

### DIFF
--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "desktop-notifier";
-  version = "3.3.4";
+  version = "3.3.5";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-X0tizMD/2hfYKBk+zGqfyU5yYjqM4cQiS/uI6GuVmew=";
+    sha256 = "sha256-tXvA1EddTrOcTupQqZrX58jXiAqB5gMJP+OE3fZxGJI=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -11,6 +11,7 @@
 buildPythonPackage rec {
   pname = "desktop-notifier";
   version = "3.3.5";
+  format = "pyproject";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -27,8 +28,6 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isLinux [
     dbus-next
   ];
-
-  format = "pyproject";
 
   # no tests available, do the imports check instead
   doCheck = false;

--- a/pkgs/development/python-modules/desktop-notifier/default.nix
+++ b/pkgs/development/python-modules/desktop-notifier/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "desktop-notifier";
-  version = "3.3.2";
+  version = "3.3.4";
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
     owner = "SamSchott";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-h7an/Fm9pNnThCHXg9PAKG822dqXE/CUuW8lDJlwMfw=";
+    sha256 = "sha256-X0tizMD/2hfYKBk+zGqfyU5yYjqM4cQiS/uI6GuVmew=";
   };
 
   propagatedBuildInputs = [
@@ -27,6 +27,8 @@ buildPythonPackage rec {
   ] ++ lib.optionals stdenv.isLinux [
     dbus-next
   ];
+
+  format = "pyproject";
 
   # no tests available, do the imports check instead
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Upstream update.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
