### PR TITLE
yuview: init at 2.12.1

### DIFF
--- a/pkgs/applications/video/yuview/default.nix
+++ b/pkgs/applications/video/yuview/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, qmake
+, wrapQtAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yuview";
+  version = "2.12.1";
+
+  src = fetchFromGitHub {
+    owner = "IENT";
+    repo = "YUView";
+    rev = "v${version}";
+    sha256 = "sha256-BQnlq6TBxGbwqn6lAZGBo4+2HeXdFYL33LKqKSXMvdY=";
+  };
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  patches = [ ./disable_version_check.patch ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://ient.github.io/YUView";
+    description = "YUV Viewer and Analysis Tool";
+    longDescription = ''
+      YUView is a Qt based YUV player with an advanced analytic toolset for
+      Linux, Windows and Mac. At its core, YUView is a powerful YUV player that
+      can open and show almost any YUV format. With its simple interface it is
+      easy to navigate through sequences and inspect details and a side by side
+      and comparison view can help to spot differences between two sequences. A
+      sophisticated statistics renderer can overlay the video with supplemental
+      information. More features include playlists, support for visual tests and
+      presentations, support of compressed formats (through libde265 and
+      FFmpeg), support for raw RGB files as well as image files and image
+      sequences, and many more. Further information can be found in the YUV help
+      in the application itself or in our wiki.
+    '';
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ leixb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/video/yuview/disable_version_check.patch
+++ b/pkgs/applications/video/yuview/disable_version_check.patch
@@ -1,0 +1,15 @@
+diff --git a/YUViewLib/src/common/Typedef.h b/YUViewLib/src/common/Typedef.h
+--- a/YUViewLib/src/common/Typedef.h
++++ b/YUViewLib/src/common/Typedef.h
+@@ -212,12 +212,7 @@ private:
+ #define YUVIEW_VERSION "Unknown"
+ #endif
+ 
+-#ifndef YUVIEW_HASH
+ #define VERSION_CHECK 0
+-#define YUVIEW_HASH 0
+-#else
+-#define VERSION_CHECK 1
+-#endif
+ 
+ #define MAX_RECENT_FILES 10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30181,6 +30181,8 @@ with pkgs;
 
   ytmdl = callPackage ../tools/misc/ytmdl { };
 
+  yuview = libsForQt5.yuview;
+
   zam-plugins = callPackage ../applications/audio/zam-plugins { };
 
   zammad = callPackage ../applications/networking/misc/zammad { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -226,4 +226,5 @@ in (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdParty // kdeGea
 
   soundkonverter = callPackage ../applications/audio/soundkonverter {};
 
+  yuview = callPackage ../applications/video/yuview { };
 })))


### PR DESCRIPTION
###### Motivation for this change

YUView is a Free and Open Source Cross Platform YUV Viewer with an advanced analytics toolset.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
