### PR TITLE
tree-sitter-hcl: init

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/default.nix
@@ -34,6 +34,7 @@
   tree-sitter-gomod = lib.importJSON ./tree-sitter-gomod.json;
   tree-sitter-graphql = lib.importJSON ./tree-sitter-graphql.json;
   tree-sitter-haskell = lib.importJSON ./tree-sitter-haskell.json;
+  tree-sitter-hcl = lib.importJSON ./tree-sitter-hcl.json;
   tree-sitter-heex = lib.importJSON ./tree-sitter-heex.json;
   tree-sitter-hjson = lib.importJSON ./tree-sitter-hjson.json;
   tree-sitter-html = lib.importJSON ./tree-sitter-html.json;

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-hcl.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://github.com/MichaHoffmann/tree-sitter-hcl",
+  "rev": "3cb7fc28247efbcb2973b97e71c78838ad98a583",
+  "date": "2021-09-20T21:50:41+02:00",
+  "path": "/nix/store/rgd0p162smlfn90ggyq3y6y4q9sgybwh-tree-sitter-hcl",
+  "sha256": "0hg7w3hsvxjwz1rb1izknn46msm4mkjx2cnq603lzn7i9mb1pbyr",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/pkgs/development/tools/parsing/tree-sitter/update.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/update.nix
@@ -308,6 +308,10 @@ let
       orga = "milisims";
       repo = "tree-sitter-org";
     };
+    "tree-sitter-hcl" = {
+      orga = "MichaHoffmann";
+      repo = "tree-sitter-hcl";
+    };
   };
 
   allGrammars =


### PR DESCRIPTION
###### Motivation for this change

Adds HCL support to tree-sitter, which is the configuration language used by several Hashicorp products like Terraform and Packer.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
