### PR TITLE
dotnet: add setup hook with required env vars

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -129,9 +129,6 @@ in stdenvNoCC.mkDerivation (args // {
   # gappsWrapperArgs gets included when wrapping for dotnet, as to avoid double wrapping
   dontWrapGApps = args.dontWrapGApps or true;
 
-  DOTNET_NOLOGO = args.DOTNET_NOLOGO or true; # This disables the welcome message.
-  DOTNET_CLI_TELEMETRY_OPTOUT = args.DOTNET_CLI_TELEMETRY_OPTOUT or true;
-
   passthru = {
     fetch-deps = writeScript "fetch-${pname}-deps" ''
       set -euo pipefail

--- a/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hooks/dotnet-configure-hook.sh
@@ -9,8 +9,6 @@ dotnetConfigureHook() {
         parallelFlag="--disable-parallel"
     fi
 
-    export HOME=$(mktemp -d)
-
     for project in ${projectFile[@]} ${testProjectFile[@]}; do
         env \
             dotnet restore "$project" \

--- a/pkgs/development/compilers/dotnet/build-dotnet.nix
+++ b/pkgs/development/compilers/dotnet/build-dotnet.nix
@@ -4,9 +4,11 @@
 }:
 
 assert builtins.elem type [ "aspnetcore" "runtime" "sdk"];
+
 { lib
 , stdenv
 , fetchurl
+, writeText
 , libunwind
 , openssl
 , icu
@@ -85,6 +87,13 @@ in stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/dotnet --info
+  '';
+
+  setupHook = writeText "dotnet-setup-hook" ''
+    export HOME=$(mktemp -d) # Dotnet expects a writable home directory for its configuration files
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 # Dont try to expand NuGetFallbackFolder to disk
+    export DOTNET_NOLOGO=1 # Disables the welcome message
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -102,11 +102,6 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     runHook preConfigure
 
-    # Set up Nuget dependencies
-    export HOME=$(mktemp -d)
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_NOLOGO=1
-
     # Never use nuget.org
     nuget sources Disable -Name "nuget.org"
 

--- a/pkgs/development/tools/misc/netcoredbg/default.nix
+++ b/pkgs/development/tools/misc/netcoredbg/default.nix
@@ -24,14 +24,7 @@ let
   unmanaged = clangStdenv.mkDerivation rec {
     inherit src pname version;
 
-    nativeBuildInputs = [ cmake ];
-
-    # Building the "unmanaged part" still involves compiling C# code.
-    preBuild = ''
-      export HOME=$(mktemp -d)
-      export DOTNET_CLI_TELEMETRY_OPTOUT=1
-      export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-    '';
+    nativeBuildInputs = [ cmake dotnet-sdk ];
 
     hardeningDisable = [ "strictoverflow" ];
 

--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -70,11 +70,6 @@ stdenv.mkDerivation rec {
   configurePhase = ''
     runHook preConfigure
 
-    export HOME=$(mktemp -d)
-
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_NOLOGO=1
-
     nuget sources Add -Name nixos -Source "$PWD/nixos"
     nuget init "$nugetDeps" "$PWD/nixos"
 

--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -43,10 +43,6 @@ stdenv.mkDerivation rec {
   '';
 
   buildPhase = ''
-    mkdir home
-    export HOME=$PWD/home
-    export DOTNET_CLI_TELEMETRY_OPTOUT=1
-    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
     export FrameworkPathOverride=${mono}/lib/mono/4.7.1-api
 
     # disable default-source so nuget does not try to download from online-repo


### PR DESCRIPTION
###### Motivation for this change
This adds a setup hook with all the environment variables `dotnet` needs to run. About time, manually specifying this was getting a bit annoying :sweat_smile: 

~~We still need to do that for the (many) `buildDotnetModule` update scripts since setup hooks don't get propagated from a `nix-shell`, which these scripts use. But that's an issue for another day.~~ 
It turns out I was wrong, setup hooks do get propagated from `nix-shell`'s.

cc @kuznero @prusnak 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
