### PR TITLE
git-series: 0.9.1 -> unstable-2019-10-15

### DIFF
--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -1,54 +1,36 @@
-{ lib, fetchFromGitHub, fetchpatch, rustPlatform
-, openssl, cmake, perl, pkg-config, zlib, curl, libgit2, libssh2
+{ lib, rustPlatform, fetchFromGitHub
+, pkg-config, openssl, zlib, curl, libgit2, libssh2
 }:
 
-with rustPlatform;
-
-buildRustPackage rec {
-  version = "0.9.1";
+rustPlatform.buildRustPackage rec {
   pname = "git-series";
+  version = "unstable-2019-10-15";
 
   src = fetchFromGitHub {
     owner = "git-series";
     repo = "git-series";
-    rev = version;
-    sha256 = "07mgq5h6r1gf3jflbv2khcz32bdazw7z1s8xcsafdarnm13ps014";
+    rev = "c570a015e15214be46a7fd06ba08526622738e20";
+    sha256 = "1i0m2b7ma6xvkg95k57gaj1wpc1rfvka6h8jr5hglxmqqbz6cb6w";
   };
 
-  cargoSha256 = "0870f4rd98fbmyl8524ivfg3xf4qpzb1x68q1idnl47mmf68pyx8";
+  cargoSha256 = "1hmx14z3098c98achgii0jkcm4474iw762rmib77amcsxj73zzdh";
 
-  cargoPatches = [
-    (fetchpatch {
-      url = "https://github.com/Mic92/git-series/commit/3aa30a47d74ebf90b444dccdf8c153f07f119483.patch";
-      sha256 = "06v8br9skvy75kcw2zgbswxyk82sqzc8smkbqpzmivxlc2i9rnh0";
-    })
-    # Update Cargo.lock to allow using OpenSSL 1.1
-    (fetchpatch {
-      url = "https://github.com/edef1c/git-series/commit/11fe70ffcc18200e5f2a159c36aab070e8ff4228.patch";
-      sha256 = "0clwllf9mrhq86dhzyyhkw1q2ggpgqpw7s05dvp3gj9zhfsyya4s";
-    })
-    # Cargo.lock: Update url, which fixes incompatibility with NLL
-    (fetchpatch {
-      url = "https://github.com/edef1c/git-series/commit/27ff2ecf2d615dae1113709eca0e43596de12ac4.patch";
-      sha256 = "1byjbdcx56nd0bbwz078bl340rk334mb34cvaa58h76byvhpkw10";
-    })
-  ];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl zlib curl libgit2 libssh2 ];
 
   LIBGIT2_SYS_USE_PKG_CONFIG = true;
   LIBSSH2_SYS_USE_PKG_CONFIG = true;
-  nativeBuildInputs = [ cmake pkg-config perl ];
-  buildInputs = [ openssl zlib curl libgit2 libssh2 ];
 
-  postBuild = ''
+  postInstall = ''
     install -D "$src/git-series.1" "$out/man/man1/git-series.1"
   '';
 
   meta = with lib; {
     description = "A tool to help with formatting git patches for review on mailing lists";
     longDescription = ''
-          git series tracks changes to a patch series over time. git
-          series also tracks a cover letter for the patch series,
-          formats the series for email, and prepares pull requests.
+      git series tracks changes to a patch series over time. git
+      series also tracks a cover letter for the patch series,
+      formats the series for email, and prepares pull requests.
     '';
     homepage = "https://github.com/git-series/git-series";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Fixes this inscrutable error when `git-series(1)` is used in a repository with no prior `series` state:

```
[0/-1] an unknown error occurred
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
