### PR TITLE
talosctl: 0.14.2 -> 0.14.3

### DIFF
--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,11 +1,11 @@
 { lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 let
   # look for GO_LDFLAGS getting set in the Makefile
-  version = "0.14.2";
-  sha256 = "sha256-sQtry94T5cDO+836D/p/8ptQi3WYKDBLr1QZyEXdLQI=";
-  vendorSha256 = "sha256-cd2iNMxWmkSWqqkPLYocUG+fCUXoeUXEuGQxjUWQnXk=";
-  pkgsVersion = "0.9.0-4-gc875fbe";
-  extrasVersion = "0.7.0-2-gb4c9d21";
+  version = "0.14.3";
+  sha256 = "sha256-toEbWUZxnJkUe9jkZRdJrcPXu+CIh62fUKyX38OkXxU=";
+  vendorSha256 = "sha256-Pj1918TIOGfhkRiFEKkURL4xMFgWroiNsNU6yWzT8yk=";
+  pkgsVersion = "v0.9.0-6-gbfcc795";
+  extrasVersion = "v0.7.0-2-gb4c9d21";
 in
 buildGoModule rec {
   pname = "talosctl";
@@ -29,8 +29,8 @@ buildGoModule rec {
       "-X ${versionPkg}.Name=Talos"
       "-X ${versionPkg}.SHA=${src.rev}" # should be the hash, but as we build from tags, this needs to do
       "-X ${versionPkg}.Tag=${src.rev}"
-      "-X ${versionPkg}.PkgsVersion=v${pkgsVersion}" # PKGS
-      "-X ${versionPkg}.ExtrasVersion=v${extrasVersion}" # EXTRAS
+      "-X ${versionPkg}.PkgsVersion=${pkgsVersion}" # PKGS
+      "-X ${versionPkg}.ExtrasVersion=${extrasVersion}" # EXTRAS
       "-X ${imagesPkgs}.Username=talos-systems" # USERNAME
       "-X ${imagesPkgs}.Registry=ghcr.io" # REGISTRY
       "-X ${mgmtHelpersPkg}.ArtifactsPath=_out" # ARTIFACTS


### PR DESCRIPTION
###### Motivation for this change
New release!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
