### PR TITLE
nixos-rebuild: add --no-flake switch

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -92,6 +92,10 @@
    </arg>
 
    <arg>
+    <option>--no-flake</option>
+   </arg>
+
+   <arg>
     <option>--override-input</option> <replaceable>input-name</replaceable> <replaceable>flake-uri</replaceable>
    </arg>
 
@@ -590,6 +594,20 @@
       <literal>nixosConfigurations.<replaceable>name</replaceable></literal>. If
       <replaceable>name</replaceable> is omitted, it default to the
       current host name.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term>
+     <option>--no-flake</option>
+    </term>
+    <listitem>
+     <para>
+      Do not imply <option>--flake</option> if
+      <filename>/etc/nixos/flake.nix</filename> exists. With this
+      option, it is possible to build non-flake NixOS configurations
+      even if the current NixOS systems uses flakes.
      </para>
     </listitem>
    </varlistentry>

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -32,6 +32,7 @@ buildHost=localhost
 targetHost=
 remoteSudo=
 verboseScript=
+noFlake=
 # comma separated list of vars to preserve when using sudo
 preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
 
@@ -114,6 +115,9 @@ while [ "$#" -gt 0 ]; do
         flake="$1"
         flakeFlags=(--extra-experimental-features 'nix-command flakes')
         shift 1
+        ;;
+      --no-flake)
+        noFlake=1
         ;;
       --recreate-lock-file|--no-update-lock-file|--no-write-lock-file|--no-registries|--commit-lock-file)
         lockFlags+=("$i")
@@ -339,7 +343,7 @@ fi
 
 # Use /etc/nixos/flake.nix if it exists. It can be a symlink to the
 # actual flake.
-if [[ -z $flake && -e /etc/nixos/flake.nix ]]; then
+if [[ -z $flake && -e /etc/nixos/flake.nix && -z $noFlake ]]; then
     flake="$(dirname "$(readlink -f /etc/nixos/flake.nix)")"
 fi
 


### PR DESCRIPTION
When a NixOS system uses flakes, i.e., `/etc/nixos/flake.nix exists`, it is impossible to use `nixos-rebuild` to build a pre-flake `configuration.nix`. Of course, one can directly use `nix` command to build the configuration, but not everybody remembers the correct nix options to do that.

With the new option, it is possible to build a pre-flake configuration with command like this:

    nixos-rebuild build-vm -I nixos-config=./vm.nix --no-flake

The option might be useful for people following older pre-flake tutorials on a flake-based system.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
