### PR TITLE
brave: enable native wayland support with NIXOS_OZONE_WL

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -37,6 +37,7 @@
 , pango
 , pipewire
 , udev
+, wayland
 , xorg
 , zlib
 , xdg-utils
@@ -82,6 +83,7 @@ rpath = lib.makeLibraryPath [
   pango
   pipewire
   udev
+  wayland
   xdg-utils
   xorg.libxcb
   zlib
@@ -160,6 +162,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     # Add command line args to wrapGApp.
     gappsWrapperArgs+=(--add-flags ${lib.escapeShellArg commandLineArgs})
+    gappsWrapperArgs+=(--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland}}")
   '';
 
   installCheckPhase = ''


### PR DESCRIPTION
###### Motivation for this change
Right now brave doesn't support wayland native.

This PR adds wayland support & fixes https://github.com/NixOS/nixpkgs/issues/133331. It follows usage of NIXOS_OZONE_WL introduced here: https://github.com/NixOS/nixpkgs/pull/147557 


###### Things done
Added wayland dependency (didn't run without it) and enabled wayland support for brave.
Didn't add `--enable-features=UseOzonePlatform` as is not required as mentioned here: https://github.com/NixOS/nixpkgs/pull/160234 



- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
