### PR TITLE
pmacct: 1.7.6 -> 1.7.7

### DIFF
--- a/pkgs/tools/networking/pmacct/default.nix
+++ b/pkgs/tools/networking/pmacct/default.nix
@@ -11,19 +11,21 @@
 , withNflog ? true, libnetfilter_log
 , withSQLite ? true, sqlite
 , withPgSQL ? true, postgresql
-, withMysql ? true, libmysqlclient, zlib
+, withMysql ? true, libmysqlclient, zlib, numactl
 , gnutlsSupport ? false, gnutls
+, testVersion
+, pmacct
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.7.6";
+  version = "1.7.7";
   pname = "pmacct";
 
   src = fetchFromGitHub {
     owner = "pmacct";
     repo = "pmacct";
     rev = "v${version}";
-    sha256 = "0x1i75hwz44siqvn4i58jgji0zwrqgn6ayv89s9m9nh3b423nsiv";
+    sha256 = "1pjaa44qj3y5dfwsd1a9r7a4riy7afza8phx2npcsyyarssxc63w";
   };
 
   nativeBuildInputs = [
@@ -38,7 +40,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional withNflog libnetfilter_log
   ++ lib.optional withSQLite sqlite
   ++ lib.optional withPgSQL postgresql
-  ++ lib.optionals withMysql [ libmysqlclient zlib ]
+  ++ lib.optionals withMysql [ libmysqlclient zlib numactl ]
   ++ lib.optional gnutlsSupport gnutls;
 
   MYSQL_CONFIG = lib.optionalString withMysql "${lib.getDev libmysqlclient}/bin/mysql_config";
@@ -52,6 +54,10 @@ stdenv.mkDerivation rec {
   ++ lib.optional withMysql "--enable-mysql"
   ++ lib.optional gnutlsSupport "--enable-gnutls";
 
+  passthru.tests = {
+    version = testVersion { package = pmacct; command = "pmacct -V"; };
+  };
+
   meta = with lib; {
     description = "A small set of multi-purpose passive network monitoring tools";
     longDescription = ''
@@ -59,6 +65,7 @@ stdenv.mkDerivation rec {
       [NetFlow IPFIX sFlow libpcap BGP BMP RPKI IGP Streaming Telemetry]
     '';
     homepage = "http://www.pmacct.net/";
+    changelog = "https://github.com/pmacct/pmacct/blob/v${version}/ChangeLog";
     license = licenses.gpl2;
     maintainers = with maintainers; [ _0x4A6F ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Upgrade to [1.7.7](https://github.com/pmacct/pmacct/releases/tag/v1.7.7) incorporating these [changes](https://github.com/pmacct/pmacct/compare/v1.7.6...v1.7.7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
