### PR TITLE
steam: actually remove nativeOnly packages

### DIFF
--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -105,6 +105,7 @@ in buildFHSUserEnv rec {
     gtk3
     dbus
     zlib
+    glib
     atk
     cairo
     freetype
@@ -130,6 +131,9 @@ in buildFHSUserEnv rec {
     openssl_1_1
     rtmpdump
 
+    # needed by getcap for vr startup
+    libcap
+
     # dependencies for mesa drivers, needed inside pressure-vessel
     mesa.drivers
     mesa.llvmPackages.llvm.lib
@@ -141,69 +145,6 @@ in buildFHSUserEnv rec {
     xorg.libxshmfence
     xorg.libXxf86vm
     libelf
-
-    # Required
-    glib
-    gtk2
-    bzip2
-
-    # Without these it silently fails
-    xorg.libXinerama
-    xorg.libXcursor
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libXi
-    xorg.libSM
-    xorg.libICE
-    gnome2.GConf
-    (curl.override { gnutlsSupport = true; opensslSupport = false; })
-    nspr
-    nss
-    cups
-    libcap
-    SDL2
-    libusb1
-    dbus-glib
-    ffmpeg
-    # Only libraries are needed from those two
-    libudev0-shim
-    networkmanager098
-
-    # Verified games requirements
-    xorg.libXt
-    xorg.libXmu
-    libogg
-    libvorbis
-    SDL
-    SDL2_image
-    glew110
-    libidn
-    tbb
-
-    # Other things from runtime
-    flac
-    freeglut
-    libjpeg
-    libpng12
-    libsamplerate
-    libmikmod
-    libtheora
-    libtiff
-    pixman
-    speex
-    SDL_image
-    SDL_ttf
-    SDL_mixer
-    SDL2_ttf
-    SDL2_mixer
-    libappindicator-gtk2
-    libcaca
-    libcanberra
-    libgcrypt
-    libvpx
-    librsvg
-    xorg.libXft
-    libvdpau
   ]
   ++ steamPackages.steam-runtime-wrapped.overridePkgs
   ++ extraLibraries pkgs;


### PR DESCRIPTION
fae860361ee35e1e7cefa6c93857ce2fc3cc3500 missed an important if statement which
guarded all of these behind nativeOnly

glib and libcap are non-nativeOnly requirements that were deduplicated away with
the nativeOnly requirements, so we need to bring those back

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
