### PR TITLE
adguardhome: 0.107.4 - 0.107.5

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,19 +1,19 @@
 { fetchurl, fetchzip }:
 {
 "x86_64-darwin" = fetchzip {
-  sha256 = "sha256-mKCqFMkTei7n/eI9s3aiAKc4jdnRA121TOizRHON1ic==";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.4/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-bTbjkBHOjcI78+jyJJ1JGe/WrmTxXi5RRB1yQO2zuYw=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.5/AdGuardHome_darwin_amd64.zip";
 };
 "i686-linux" = fetchurl {
-  sha256 = "sha256-N+S2BWUskEHt5YjpncmiurdgQ6TN35TWN8Zv7bM3a5k=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.4/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-wdzj7P+Hhm65i5hY4l2Ty486W473coZyZnCbzx9Poro=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.5/AdGuardHome_linux_386.tar.gz";
 };
 "x86_64-linux" = fetchurl {
-  sha256 = "sha256-p665fB2lVSLpWIYlTNW+ZGOohpobdvOs0AIQ1l9BlmE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.4/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-sZQe8rNYD0gBSpNeXS+4hbqoT5nUFbkQSI3c6VuQOC8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.5/AdGuardHome_linux_amd64.tar.gz";
 };
 "aarch64-linux" = fetchurl {
-  sha256 = "sha256-oomkIHeQDTNDp6A6CcMv2s89PkuKpGVV4iLCxcj0Xsc=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.4/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-9JsGzFf03en2ClrodglREsYqrwr6j/vypsfEVaMzCTI=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.5/AdGuardHome_linux_arm64.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.4";
+  version = "0.107.5";
 
   src = (import ./bins.nix { inherit fetchurl fetchzip; }).${stdenv.hostPlatform.system};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
