### PR TITLE
[Backport release-21.11] linuxPackages.rtl88x2bu: switch to the new, maintained repo

### DIFF
--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "rtl88x2bu";
-  version = "${kernel.version}-unstable-2021-11-04";
+  version = "${kernel.version}-unstable-2022-02-22";
 
   src = fetchFromGitHub {
     owner = "morrownr";
-    repo = "88x2bu";
-    rev = "745d134080b74b92389ffe59c03dcfd6658f8655";
-    sha256 = "0f1hsfdw3ar78kqzr4hi04kpp5wnx0hd29f9rm698k0drxaw1g44";
+    repo = "88x2bu-20210702";
+    rev = "6a5b7f005c071ffa179b6183ee034c98ed30db80";
+    sha256 = "sha256-BqTyJpICW3D4EfHHoN5svasteJnunu2Uz449u/CmNE0=";
   };
 
   hardeningDisable = [ "pic" ];
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Realtek rtl88x2bu driver";
-    homepage = "https://github.com/morrownr/88x2bu";
+    homepage = "https://github.com/morrownr/88x2bu-20210702";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
     maintainers = [ maintainers.ralith ];


### PR DESCRIPTION
This change was merged to master in PR #161698, but I didn't know I could add a label for automatic backport, so I'm backporting manually. As noted in that PR, I'm was already testing on 21.11.