### PR TITLE
dcpj315w{lpr, -cupswrapper}: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5637,6 +5637,16 @@
     githubId = 9425955;
     name = "Jean-François Labonté";
   };
+  jensac = {
+    email = "jens.schneider.ac@posteo.de";
+    github = "jensac";
+    githubId = 17930863;
+    name = "Jens Schneider";
+    keys = [{
+      longkeyid = "rsa4096/0x955C9CF126CE94C3";
+      fingerprint = "B6CB 48B1 8625 6F28 B29F  1E22 955C 9CF1 26CE 94C3";
+    }];
+  };
   jensbin = {
     email = "jensbin+git@pm.me";
     github = "jensbin";

--- a/pkgs/misc/cups/drivers/brother/dcpj315w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcpj315w/default.nix
@@ -35,7 +35,7 @@ rec {
     installPhase = ''
       substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter${model} \
       --replace /opt "$out/opt"
- 
+
       substituteInPlace $out/opt/brother/Printers/${model}/inf/brdcpj315wrc \
       --replace "Letter" "A4"
 

--- a/pkgs/misc/cups/drivers/brother/dcpj315w/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcpj315w/default.nix
@@ -1,0 +1,102 @@
+{ lib
+, stdenv
+, fetchurl
+, cups
+, dpkg
+, gnused
+, makeWrapper
+, ghostscript
+, file
+, a2ps
+, coreutils
+, gnugrep
+, which
+, gawk
+}:
+
+let
+  version = "1.1.3";
+  model = "dcpj315w";
+in
+rec {
+  driver = stdenv.mkDerivation {
+    pname = "${model}-lpr";
+    inherit version;
+
+    src = fetchurl {
+      url= "https://download.brother.com/welcome/dlf005591/dcpj315wlpr-${version}-1.i386.deb";
+      sha256 = "1myc6jrbkk6rbx1ynhac24l3hlkz7dmic557rz6q69fc54m69zmi";
+    };
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+    buildInputs = [ cups ghostscript a2ps gawk ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter${model} \
+      --replace /opt "$out/opt"
+ 
+      substituteInPlace $out/opt/brother/Printers/${model}/inf/brdcpj315wrc \
+      --replace "Letter" "A4"
+
+      patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/opt/brother/Printers/${model}/lpd/br${model}filter
+
+      mkdir -p $out/lib/cups/filter/
+      ln -s $out/opt/brother/Printers/${model}/lpd/filter${model} $out/lib/cups/filter/brlpdwrapper${model}
+
+      wrapProgram $out/opt/brother/Printers/${model}/lpd/filter${model} \
+        --prefix PATH ":" ${lib.makeBinPath [
+          gawk
+          ghostscript
+          a2ps
+          file
+          gnused
+          gnugrep
+          coreutils
+          which
+        ]}
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer driver";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=as_ot&lang=en&prod=${model}_eu&os=128";
+      maintainers = with maintainers; [ jensac ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation {
+    pname = "${model}-cupswrapper";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://download.brother.com/welcome/dlf005593/dcpj315wcupswrapper-${version}-1.i386.deb";
+      sha256 = "0xvcav8wzairdd35cw9wn0mcji9lzq8aqp6pfddizjcnnfnzwxxk";
+    };
+
+    nativeBuildInputs = [ dpkg makeWrapper ];
+    buildInputs = [ cups ghostscript a2ps gawk ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      for f in $out/opt/brother/Printers/${model}/cupswrapper/cupswrapper${model}; do
+        wrapProgram $f --prefix PATH : ${lib.makeBinPath [ coreutils ghostscript gnugrep gnused ]}
+      done
+
+      mkdir -p $out/share/cups/model
+      ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/
+    '';
+
+    meta = with lib; {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer CUPS wrapper driver";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=as_ot&lang=en&prod=${model}_eu&os=128";
+      maintainers = with maintainers; [ jensac ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33028,6 +33028,10 @@ with pkgs;
 
   cups-bjnp = callPackage ../misc/cups/drivers/cups-bjnp { };
 
+  dcpj315wlpr = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcpj315w { }).driver;
+
+  dcpj315w-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcpj315w { }).cupswrapper;
+
   dcp9020cdwlpr = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).driver;
 
   dcp9020cdw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).cupswrapper;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add drivers for brother dcpj315w on NixOS. For me this enabled printing and I hope it can do so for others, too :printer: 
Moreover, I added myself as maintainer. As long as my dcpj315w is alive a can take care for the package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
