### PR TITLE
netbeans: 12.6 -> 13

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -3,7 +3,7 @@
 }:
 
 let
-  version = "12.6";
+  version = "13";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   inherit version;
   src = fetchurl {
     url = "mirror://apache/netbeans/netbeans/${version}/netbeans-${version}-bin.zip";
-    hash = "sha512-K0HjEO/yw9h+2+Y5CvxyYG1+kx+KH9NSn+QsKCsvh/rG/ilYLYyy93iZfx+wzwrgEfRtfMpZGtDAxd6nyUSnCA==";
+    hash = "sha512-Xnh2OhnHOo++gGPx1o/WmcTHV7KNVeeT6ut9xH2Zo0EFtt43GFi2+HLOXm3u/IcjAzWlbGvIp9+TVUnwDusDoA==";
   };
 
   buildCommand = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27895,7 +27895,7 @@ with pkgs;
   navipowm = callPackage ../applications/misc/navipowm { };
 
   netbeans = callPackage ../applications/editors/netbeans {
-    jdk = jdk11;
+    jdk = jdk17;
   };
 
   netcoredbg = callPackage ../development/tools/misc/netcoredbg { };


### PR DESCRIPTION
###### Motivation for this change
Update to latest release.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
 asbachb@nixos-t14s  ~/dev/src/nix/nixpkgs   update/netbeans  nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
these 3 paths will be fetched (7.14 MiB download, 51.97 MiB unpacked):
  /nix/store/irwhj97lkc2lhvdknl3sxy5f8a2mpigl-git-2.35.1
  /nix/store/zij1xxddp64y3yqcqr6sk5qmf884afyi-git-2.35.1-doc
  /nix/store/zqvbpdn0m8whacf73gdp7vc2rcajaqka-nixpkgs-review-2.6.4
copying path '/nix/store/zij1xxddp64y3yqcqr6sk5qmf884afyi-git-2.35.1-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/irwhj97lkc2lhvdknl3sxy5f8a2mpigl-git-2.35.1' from 'https://cache.nixos.org'...
copying path '/nix/store/zqvbpdn0m8whacf73gdp7vc2rcajaqka-nixpkgs-review-2.6.4' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (20/20), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 24 (delta 11), reused 6 (delta 6), pack-reused 4
Unpacking objects: 100% (24/24), 9.62 KiB | 820.00 KiB/s, done.
From https://github.com/NixOS/nixpkgs
   e976a7e860c..efff462fd30  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-89c922fdef1da418c5ad264794799fa4f8d8c9e8/nixpkgs efff462fd30a3c2d9a41e9e6186b3678a0527bc5
Preparing worktree (detached HEAD efff462fd30)
Updating files: 100% (29766/29766), done.
HEAD is now at efff462fd30 Merge pull request #162629 from r-ryantm/auto-update/exodus
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-89c922fdef1da418c5ad264794799fa4f8d8c9e8/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff 89c922fdef1da418c5ad264794799fa4f8d8c9e8
Auto-merging pkgs/top-level/all-packages.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-89c922fdef1da418c5ad264794799fa4f8d8c9e8/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
netbeans (12.6 → 13)

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-89c922fdef1da418c5ad264794799fa4f8d8c9e8/build.nix
1 package built:
netbeans

$ nix-shell /home/asbachb/.cache/nixpkgs-review/rev-89c922fdef1da418c5ad264794799fa4f8d8c9e8/shell.nix
```
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
