### PR TITLE
expat: 2.4.6 -> 2.4.7

### DIFF
--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "expat";
-  version = "2.4.6";
+  version = "2.4.7";
 
   src = fetchurl {
     url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-3lV5S3qbwhSFL9wHW+quzYVO/hNhWX5iaO6HlGlRKJs=";
+    sha256 = "0zbss0dssn17mjmvk17qfi5cmvm0lcyzs62cwvqr219hhl864xcq";
   };
 
   outputs = [ "out" "dev" ]; # TODO: fix referrers

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     inherit python3;
+    inherit (python3.pkgs) xmltodict;
     inherit (haskellPackages) hexpat;
     inherit (perlPackages) XMLSAXExpat XMLParser;
     inherit (luaPackages) luaexpat;

--- a/pkgs/development/python-modules/xmltodict/default.nix
+++ b/pkgs/development/python-modules/xmltodict/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , coverage
-, pytestCheckHook
+, nose
 }:
 
 buildPythonPackage rec {
@@ -14,13 +14,11 @@ buildPythonPackage rec {
     sha256 = "50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21";
   };
 
-  checkInputs = [ coverage pytestCheckHook ];
+  checkInputs = [ coverage nose ];
 
-  disabledTests = [
-    # incompatibilities with security fixes: https://github.com/martinblech/xmltodict/issues/289
-    "test_namespace_collapse"
-    "test_namespace_support"
-  ];
+  checkPhase = ''
+    nosetests
+  '';
 
   meta = {
     description = "Makes working with XML feel like you are working with JSON";

--- a/pkgs/development/python-modules/xmltodict/default.nix
+++ b/pkgs/development/python-modules/xmltodict/default.nix
@@ -1,28 +1,27 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, coverage
-, nose
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "xmltodict";
   version = "0.12.0";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21";
   };
 
-  checkInputs = [ coverage nose ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  checkPhase = ''
-    nosetests
-  '';
-
-  meta = {
+  meta = with lib; {
     description = "Makes working with XML feel like you are working with JSON";
     homepage = "https://github.com/martinblech/xmltodict";
-    license = lib.licenses.mit;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
This primarily fixes regressions in various other packages after the expat security fixes.

I'm unsure if this should go to `staging-next` (current iteration) or the next one (`staging` branch).  It rebuilds stdenv on all platforms, but it also fixes some regressions from the expat security update.  Note that the commits are based in a way to allow easy merging to either/both branches.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
