### PR TITLE
modemmanager: add modemManagerFlags option

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -395,6 +395,12 @@ in {
           for more details.
         '';
       };
+
+      modemManagerFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Flags to be passed to the ModemManager daemon.";
+      };
     };
   };
 
@@ -517,7 +523,13 @@ in {
       wantedBy = [ "network-online.target" ];
     };
 
-    systemd.services.ModemManager.aliases = [ "dbus-org.freedesktop.ModemManager1.service" ];
+    systemd.services.ModemManager = {
+      serviceConfig.ExecStart = [
+        "" # clear ExecStart from upstream unit file.
+        "${pkgs.modemmanager}/sbin/ModemManager ${toString cfg.modemManagerFlags}"
+      ];
+      aliases = [ "dbus-org.freedesktop.ModemManager1.service" ];
+    };
 
     systemd.services.NetworkManager-dispatcher = {
       wantedBy = [ "network.target" ];


### PR DESCRIPTION
###### Motivation for this change
Allow users to provide flags to ModemManager, e.g. `--test-quick-suspend-resume` as described in https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/blob/main/NEWS . This is particularly useful for PinePhone users, to support quick resume when accepting calls.

I've tested this by setting `modemManagerFlags` and seeing that the daemon has that flag:

```
$ systemctl status ModemManager.service 
[...]
             ├─ 851 /nix/store/a1wbkyyfr17an789bx046mmpbjmfhn14-modemmanager-1.18.4/sbin/ModemManager --test-quick-suspend-resume
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
