### PR TITLE
[21.11] i2pd: 2.39.0 -> 2.41.0

### DIFF
--- a/pkgs/tools/networking/i2pd/default.nix
+++ b/pkgs/tools/networking/i2pd/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub
+, installShellFiles
 , boost, zlib, openssl
 , upnpSupport ? true, miniupnpc ? null
 , aesniSupport ? stdenv.hostPlatform.aesSupport
@@ -21,6 +22,10 @@ stdenv.mkDerivation rec {
   buildInputs = with lib; [ boost zlib openssl ]
     ++ optional upnpSupport miniupnpc;
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   makeFlags =
     let ynf = a: b: a + "=" + (if b then "yes" else "no"); in
     [ (ynf "USE_AESNI" aesniSupport)
@@ -32,6 +37,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -D i2pd $out/bin/i2pd
+    install --mode=444 -D 'contrib/i2pd.service' "$out/etc/systemd/system/i2pd.service"
+    installManPage 'debian/i2pd.1'
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/i2pd/default.nix
+++ b/pkgs/tools/networking/i2pd/default.nix
@@ -9,13 +9,13 @@ assert upnpSupport -> miniupnpc != null;
 
 stdenv.mkDerivation rec {
   pname = "i2pd";
-  version = "2.39.0";
+  version = "2.40.0";
 
   src = fetchFromGitHub {
     owner = "PurpleI2P";
     repo = pname;
     rev = version;
-    sha256 = "sha256-j8kHuX5Ca90ODjmF94HpGvjSpocDSuSxfVmvbIYRAKo=";
+    sha256 = "sha256-Cld5TP2YoLzm73q7uP/pwqEeUsT5uMPAUx9HABOVeZA=";
   };
 
   buildInputs = with lib; [ boost zlib openssl ]

--- a/pkgs/tools/networking/i2pd/default.nix
+++ b/pkgs/tools/networking/i2pd/default.nix
@@ -10,13 +10,13 @@ assert upnpSupport -> miniupnpc != null;
 
 stdenv.mkDerivation rec {
   pname = "i2pd";
-  version = "2.40.0";
+  version = "2.41.0";
 
   src = fetchFromGitHub {
     owner = "PurpleI2P";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Cld5TP2YoLzm73q7uP/pwqEeUsT5uMPAUx9HABOVeZA=";
+    sha256 = "sha256-fQqbZYb0brGmGf7Yc/2Zd5BZ+YOkGYC3o9uhShYdAE4=";
   };
 
   buildInputs = with lib; [ boost zlib openssl ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

`i2pd` is crashing for R21.11 users.
See https://github.com/NixOS/nixpkgs/pull/161204#issuecomment-1055772753

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
