### PR TITLE
openjdk8: 8u272-b10 -> 8u322-ga

### DIFF
--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -32,7 +32,6 @@ let
       rev = "jdk${version}";
       sha256 = "sha256-e39Yv+NDQG7z6fGmpKEnkKd5MoHZ50SXlq/Q7lzWcDA=";
     };
-
     outputs = [ "out" "jre" ];
 
     nativeBuildInputs = [ pkg-config lndir unzip ];

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, pkg-config, lndir, bash, cpio, file, which, unzip, zip
+{ stdenv, lib, fetchFromGitHub, pkg-config, lndir, bash, cpio, file, which, unzip, zip
 , cups, freetype, alsa-lib, cacert, perl, liberation_ttf, fontconfig, zlib
 , libX11, libICE, libXrender, libXext, libXt, libXtst, libXi, libXinerama, libXcursor, libXrandr
 , libjpeg, giflib
@@ -19,67 +19,19 @@ let
     aarch64-linux = "aarch64";
   }.${stdenv.system} or (throw "Unsupported platform");
 
-  update = "272";
-  build = if stdenv.isAarch64 then "b10" else "b10";
-  baseurl = if stdenv.isAarch64 then "https://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah"
-            else "https://hg.openjdk.java.net/jdk8u/jdk8u";
-  repover = lib.optionalString stdenv.isAarch64 "aarch64-shenandoah-"
-            + "jdk8u${update}-${build}";
+  update = "322";
+  build = "ga";
 
-  jdk8 = fetchurl {
-             name = "jdk8-${repover}.tar.gz";
-             url = "${baseurl}/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "db98897d6fddce85996a9b0daf4352abce4578be0b51eada41702ee1469dd415"
-                      else "8f0e8324d3500432e8ed642b4cc7dff90a617dbb2a18a94c07c1020d32f93b7a";
-          };
-  langtools = fetchurl {
-             name = "langtools-${repover}.tar.gz";
-             url = "${baseurl}/langtools/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "6544c1cc455844bbbb3d2914ffc716b1cee7f19e6aa223764d41a7cddc41322c"
-                      else "632417b0b067c929eda6958341352e29c5810056a5fec138641eb3503f9635b7";
-          };
-  hotspot = fetchurl {
-             name = "hotspot-${repover}.tar.gz";
-             url = "${baseurl}/hotspot/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "37abb89e66641607dc6f372946bfc6bd413f23fec0b9c3baf75f41ce517e21d8"
-                      else "2142f3b769800a955613b51ffe192551bab1db95b0c219900cf34febc6f20245";
-          };
-  corba = fetchurl {
-             name = "corba-${repover}.tar.gz";
-             url = "${baseurl}/corba/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "5da82f7b4aceff32e02d2f559033e3b62b9509d79f1a6891af871502e1d125b1"
-                      else "320098d64c843c1ff2ae62579817f9fb4a81772bc0313a543ce68976ad7a6d98";
-          };
-  jdk = fetchurl {
-             name = "jdk-${repover}.tar.gz";
-             url = "${baseurl}/jdk/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "ee613296d823605dcd1a0fe2f89b4c7393bdb8ae5f2659f48f5cbc0012bb1a47"
-                      else "957c24fc58ac723c8cd808ab60c77d7853710148944c8b9a59f470c4c809e1a0";
-          };
-  jaxws = fetchurl {
-             name = "jaxws-${repover}.tar.gz";
-             url = "${baseurl}/jaxws/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "7c426b85f0d378125fa46e6d1b25ddc27ad29d93514d38c5935c84fc540b26ce"
-                      else "4efb0ee143dfe86c8ee06db2429fb81a0c8c65af9ea8fc18daa05148c8a1162f";
-          };
-  jaxp = fetchurl {
-             name = "jaxp-${repover}.tar.gz";
-             url = "${baseurl}/jaxp/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "928e363877afa7e0ad0c350bb18be6ab056b23708c0624a0bd7f01c4106c2a14"
-                      else "25a651c670d5b036042f7244617a3eb11fec80c07745c1c8181a1cdebeda3d8e";
-          };
-  nashorn = fetchurl {
-             name = "nashorn-${repover}.tar.gz";
-             url = "${baseurl}/nashorn/archive/${repover}.tar.gz";
-             sha256 = if stdenv.isAarch64 then "f060e08c5924457d4f5047c02ad6a987bdbdcd1cea53d2208322073ba4f398c3"
-                      else "a28b41d86f0c87ceacd2b686dd31c9bf391d851b1b5187a49ef5e565fc2cbc84";
-          };
-  openjdk8 = stdenv.mkDerivation {
+  openjdk8 = stdenv.mkDerivation rec {
     pname = "openjdk" + lib.optionalString headless "-headless";
     version = "8u${update}-${build}";
 
-    srcs = [ jdk8 langtools hotspot corba jdk jaxws jaxp nashorn ];
-    sourceRoot = ".";
+    src = fetchFromGitHub {
+      owner = "openjdk";
+      repo = "jdk8u";
+      rev = "jdk${version}";
+      sha256 = "sha256-e39Yv+NDQG7z6fGmpKEnkKd5MoHZ50SXlq/Q7lzWcDA=";
+    };
 
     outputs = [ "out" "jre" ];
 
@@ -91,16 +43,6 @@ let
     ] ++ lib.optionals (!headless && enableGnome2) [
       gtk2 gnome_vfs GConf glib
     ];
-
-    # move the seven other source dirs under the main jdk8u directory,
-    # with version suffixes removed, as the remainder of the build will expect
-    prePatch = ''
-      mainDir=$(find . -maxdepth 1 -name jdk8u\*);
-      find . -maxdepth 1 -name \*jdk\* -not -name jdk8u\* | awk -F- '{print $1}' | while read p; do
-        mv $p-* $mainDir/$p
-      done
-      cd $mainDir
-    '';
 
     patches = [
       ./fix-java-home-jdk8.patch


### PR DESCRIPTION
###### Motivation for this change
The OpenJDK 8 version in Nix has not been updated for nearing two years and is missing security fixes. Also with 322 they finally moved to a monorepo on GitHub making this derivation much smaller and easier to maintain.

###### Things done
Switched to the new upstream Monorepo as source and bumped to Update 322. I removed using aarch64-shenandoah for aarch64 as x86_64 doesn't have Shenandoah either. IMO we should either use the Shenandoah branch for both (just by using the `shenandoah-jdk8u` repo instead of the `jdk8u`) or neither.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
