### PR TITLE
sam-ba: 2.16 -> 3.5

### DIFF
--- a/pkgs/tools/misc/sam-ba/default.nix
+++ b/pkgs/tools/misc/sam-ba/default.nix
@@ -1,40 +1,35 @@
-{ lib, stdenv, fetchzip, libX11, libXScrnSaver, libXext, libXft, libXrender
-, freetype, zlib, fontconfig
-}:
+{ lib, stdenv, fetchzip, glib, zlib, libglvnd, python3, autoPatchelfHook }:
 
-let
-  maybe64 = if stdenv.isx86_64 then "_64" else "";
-  libPath = lib.makeLibraryPath
-    [ stdenv.cc.cc.lib libX11 libXScrnSaver libXext libXft libXrender freetype
-      zlib fontconfig
-    ];
-in
 stdenv.mkDerivation rec {
-  version = "2.16";
+  version = "3.5";
   pname = "sam-ba";
 
   src = fetchzip {
-    url = "http://www.atmel.com/dyn/resources/prod_documents/sam-ba_${version}_linux.zip";
-    sha256 = "18lsi4747900cazq3bf0a87n3pc7751j5papj9sxarjymcz9vks4";
+    url = "https://ww1.microchip.com/downloads/en/DeviceDoc/sam-ba_${version}-linux_x86_64.tar.gz";
+    sha256 = "1k0nbgyc98z94nphm2q7s82b274clfnayf4a2kv93l5594rzdbp1";
   };
 
-  # Pre-built binary package. Install everything to /opt/sam-ba to not mess up
-  # the internal directory structure. Then create wrapper in /bin. Attemts to
-  # use "patchelf --set-rpath" instead of setting LD_PRELOAD_PATH failed.
+  buildInputs = [
+    glib
+    libglvnd
+    zlib
+
+    (python3.withPackages (ps: [ps.pyserial]))
+  ];
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
   installPhase = ''
+    runHook preInstall
+
     mkdir -p "$out/bin/" \
              "$out/opt/sam-ba/"
     cp -a . "$out/opt/sam-ba/"
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out/opt/sam-ba/sam-ba${maybe64}"
-    cat > "$out/bin/sam-ba" << EOF
-    export LD_LIBRARY_PATH="${libPath}"
-    exec "$out/opt/sam-ba/sam-ba${maybe64}"
-    EOF
-    chmod +x "$out/bin/sam-ba"
-  '';
+    ln -sr "$out/opt/sam-ba/sam-ba" "$out/bin/"
+    ln -sr "$out/opt/sam-ba/multi_sam-ba.py" "$out/bin/"
 
-  # Do our own thing
-  dontPatchELF = true;
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Programming tools for Atmel SAM3/7/9 ARM-based microcontrollers";
@@ -42,10 +37,10 @@ stdenv.mkDerivation rec {
       Atmel SAM-BA software provides an open set of tools for programming the
       Atmel SAM3, SAM7 and SAM9 ARM-based microcontrollers.
     '';
+    # Alternatively: https://www.microchip.com/en-us/development-tool/SAM-BA-In-system-Programmer
     homepage = "http://www.at91.com/linux4sam/bin/view/Linux4SAM/SoftwareTools";
-    # License in <source>/doc/readme.txt
-    license = "BSD-like (partly binary-only)";  # according to Buildroot
-    platforms = [ "x86_64-linux" ];  # patchelf fails on i686-linux
+    license = lib.licenses.gpl2Only;
+    platforms = [ "x86_64-linux" ];
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I noticed this package was quite outdated.

I'm unable to test it with hardware, but all runtime dependencies seem satisfied.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
