### PR TITLE
skytemple: 1.3.2 -> 1.3.10

### DIFF
--- a/pkgs/applications/misc/skytemple/default.nix
+++ b/pkgs/applications/misc/skytemple/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "skytemple";
-  version = "1.3.2";
+  version = "1.3.10";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "1sx2rib0la3mifvh84ia3jnnq4qw9jxc13vxyidsdkp6x82nbvcg";
+    sha256 = "sha256-CyYGTXdQsGpDR/gpqViEQO1xUPHaXTES592nRJixa1o=";
   };
 
   buildInputs = [
@@ -26,7 +26,10 @@ python3Packages.buildPythonApplication rec {
     packaging
     pycairo
     pygal
+    psutil
+    gbulb
     pypresence
+    sentry-sdk
     setuptools
     skytemple-dtef
     skytemple-eventserver

--- a/pkgs/development/python-modules/dungeon-eos/default.nix
+++ b/pkgs/development/python-modules/dungeon-eos/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "dungeon-eos";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "0hxygjk9i4qlwsxnxr52cxhqy3i62pc373z1x5sh2pas5ag59bvl";
+    sha256 = "sha256-Z1fGtslXP8zcZmVeWjRrbcM2ZJsfbrWjpLWZ49uSCRY=";
   };
 
   doCheck = false; # there are no tests

--- a/pkgs/development/python-modules/gbulb/default.nix
+++ b/pkgs/development/python-modules/gbulb/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pygobject3
+, pytestCheckHook
+, gtk3
+, gobject-introspection
+}:
+
+buildPythonPackage rec {
+  pname = "gbulb";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "beeware";
+    repo = "gbulb";
+    rev = "v${version}";
+    sha256 = "sha256-QNpZf1zfe6r6MtmYMWSrXPsXm5iX36oMx4GnXiTYPaQ=";
+  };
+
+  propagatedBuildInputs = [
+    pygobject3
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+    gtk3
+    gobject-introspection
+  ];
+
+  disabledTests = [
+    "test_glib_events.TestBaseGLibEventLoop" # Somtimes fail due to imprecise timing
+  ];
+
+  pythonImportsCheck = [ "gbulb" ];
+
+  meta = with lib; {
+    description = "GLib implementation of PEP 3156";
+    homepage = "https://github.com/beeware/gbulb";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ marius851000 ];
+  };
+}

--- a/pkgs/development/python-modules/py-desmume/default.nix
+++ b/pkgs/development/python-modules/py-desmume/default.nix
@@ -3,28 +3,17 @@
 , alsa-lib, soundtouch, openal
 }:
 
-let
-  desmume = fetchFromGitHub {
-    owner = "SkyTemple";
-    repo = "desmume";
-    rev = "8e7af8ada883b7e91344985236f7c7c04ee795d7";
-    sha256 = "0svmv2rch9q347gbpbws4agymas8n014gh1ssaf91wx7jwn53842";
-  };
-in
 buildPythonPackage rec {
   pname = "py-desmume";
-  version = "0.0.3.post2";
+  version = "0.0.4.post2";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "1chsg70k8kqnlasn88b04ww3yl0lay1bjxvz6lhp6s2cvsxv03x1";
+    sha256 = "sha256-a819+K/Ovnz53ViDKpUGGjeblWvrAO5ozt/tizdLKCY=";
+    fetchSubmodules = true;
   };
-
-  postPatch = ''
-    cp -R --no-preserve=mode ${desmume} __build_desmume
-  '';
 
   buildInputs = [ GitPython libpcap SDL2 alsa-lib soundtouch openal ];
   nativeBuildInputs = [ meson ninja pkg-config ];

--- a/pkgs/development/python-modules/skytemple-files/default.nix
+++ b/pkgs/development/python-modules/skytemple-files/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "skytemple-files";
-  version = "1.3.3";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "01j6khn60mdmz32xkpqrzwdqibmpdpi2wvwzxgdnaim9sq0fdqws";
+    sha256 = "sha256-Z/jbr9o0WKPjkAsfZzxuwAKKdwYV3rLGkUMlMgyC5s0=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -2,23 +2,25 @@
 
 buildPythonPackage rec {
   pname = "skytemple-rust";
-  version = "unstable-2021-08-11";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
-    rev = "e306e5edc096cb3fef25585d9ca5a2817543f1cd";
-    sha256 = "0ja231gsy9i1z6jsaywawz93rnyjhldngi5i787nhnf88zrwx9ml";
+    rev = version;
+    sha256 = "sha256-rC7KA79va8gZpMKJQ7s3xYdbopNqmWdRYDCbaWaxsR0=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    sha256 = "0gjvfblyv72m0nqv90m7qvbdnazsh5ind1pxwqz83vm4zjh9a873";
+    sha256 = "sha256-lXPCxRbaqUC5EfyeBPtJDuGADYOA+DWMaOZRwXppP8E=";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
   nativeBuildInputs = [ setuptools-rust ] ++ (with rustPlatform; [ cargoSetupHook rust.cargo rust.rustc ]);
+
+  GETTEXT_SYSTEM = true;
 
   doCheck = false; # there are no tests
   pythonImportsCheck = [ "skytemple_rust" ];

--- a/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-debugger/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "skytemple-ssb-debugger";
-  version = "1.3.0";
+  version = "1.3.8.post2";
 
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = pname;
     rev = version;
-    sha256 = "12v0071125m8xjcp2hxm9qvs0qw4hdhkx8r3gbl0plm22vl3fk0d";
+    sha256 = "sha256-dd0qsSNBwxuSopjz2PLqEFddZpvMgeJIjBXY5P6OAow=";
   };
 
   buildInputs = [ gobject-introspection gtk3 gtksourceview3 ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3255,6 +3255,8 @@ in {
 
   gbinder-python = callPackage ../development/python-modules/gbinder-python { };
 
+  gbulb = callPackage ../development/python-modules/gbulb { };
+
   gcovr = callPackage ../development/python-modules/gcovr { };
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
A new version was released, including an important (for me), as well as some other interesting feature.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

As I needed to recompile basically everything, I didn't tested it with webgitgtk (disabled this input locally)

Also disabled a flaky test in a depency. It refused to build on the first try, but succeded in the second, with no change in library code.

Target staging due to using function stabilized in rust 1.59

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Ping @xfix 