### PR TITLE
ponyc: 0.44.0 -> 0.49.0, pony-corral: 0.5.4 -> 0.5.7

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,22 +3,13 @@
 
 stdenv.mkDerivation (rec {
   pname = "ponyc";
-  version = "0.44.0";
+  version = "0.49.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "0bzdkrrh6lvfqc61kdxvgz573dj32wwzhzwil53jvynhfcwp38ld";
-
-# Due to a bug in LLVM 9.x, ponyc has to include its own vendored patched
-# LLVM.  (The submodule is a specific tag in the LLVM source tree).
-#
-# The pony developers are currently working to get off 9.x as quickly
-# as possible so hopefully in a few revisions this package build will
-# become a lot simpler.
-#
-# https://reviews.llvm.org/rG9f4f237e29e7150dfcf04ae78fa287d2dc8d48e2
+    sha256 = "sha256-WS3/POC+2vdx6bA8314sjkdWCIWGu9lJG4kbKMWfnX8=";
 
     fetchSubmodules = true;
   };

--- a/pkgs/development/compilers/ponyc/disable-tests.patch
+++ b/pkgs/development/compilers/ponyc/disable-tests.patch
@@ -1,14 +1,16 @@
 diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index baf29e7..b63f368 100644
+index 9044dfb1..f0ea10f7 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -5,9 +5,6 @@ actor Main is TestList
-   new make() => None
+@@ -26,11 +26,6 @@ actor \nodoc\ Main is TestList
+       test(_TestTCPThrottle)
+     end
  
-   fun tag tests(test: PonyTest) =>
+-    // Tests below exclude osx and are listed alphabetically
 -    ifdef not osx then
 -      test(_TestBroadcast)
 -    end
-     test(_TestTCPWritev)
-     test(_TestTCPExpect)
-     test(_TestTCPMute)
+-
+ class \nodoc\ _TestPing is UDPNotify
+   let _h: TestHelper
+   let _ip: NetAddress

--- a/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
+++ b/pkgs/development/compilers/ponyc/make-safe-for-sandbox.patch
@@ -1,28 +1,33 @@
---- a/lib/CMakeLists.txt.orig	2021-10-01 13:04:00.867762912 -0400
-+++ a/lib/CMakeLists.txt	2021-10-01 13:06:21.220023453 -0400
-@@ -15,12 +15,12 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index dab2aaef..26b587b1 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -36,7 +36,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
  endif()
  
  ExternalProject_Add(gbenchmark
 -    URL ${PONYC_GBENCHMARK_URL}
 +    SOURCE_DIR gbenchmark-prefix/src/benchmark
-     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
+     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
  )
+ 
+@@ -46,7 +46,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+ endif()
  
  ExternalProject_Add(googletest
--    URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+-    URL ${PONYC_GOOGLETEST_URL}
 +    URL @googletest@
-     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=-fpic -Dgtest_force_shared_crt=ON --no-warn-unused-cli
+     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} -Dgtest_force_shared_crt=ON --no-warn-unused-cli
  )
  
-@@ -33,82 +33,6 @@
+@@ -59,82 +59,6 @@ install(TARGETS blake2
      COMPONENT library
  )
  
 -find_package(Git)
 -
--set(LLVM_DESIRED_HASH "fed41342a82f5a3a9201819a82bf7a48313e296b")
--set(PATCHES_DESIRED_HASH "3a655193262fd9b2e87340e096efcbd96726a07fe6dd42a263f3a4fc2dc0192e")
+-set(LLVM_DESIRED_HASH "75e33f71c2dae584b13a7d1186ae0a038ba98838")
+-set(PATCHES_DESIRED_HASH "a16f299fbfced16a2bbc628746db341f2a5af9ae8cc9c9ef4b1e9ca26de3c292")
 -
 -if(GIT_FOUND)
 -    if(EXISTS "${PROJECT_SOURCE_DIR}/../.git")
@@ -57,7 +62,7 @@
 -
 -    # check to see if the patch hashes match
 -    message("Checking patches ${PONY_LLVM_PATCHES}")
--    set(PATCHES_ACTUAL_HASH "")
+-    set(PATCHES_ACTUAL_HASH "needed_if_no_patches")
 -    foreach (PATCH ${PONY_LLVM_PATCHES})
 -        file(STRINGS ${PATCH} patch_file NEWLINE_CONSUME)
 -        string(REPLACE "\n" " " patch_file ${patch_file})
@@ -69,8 +74,8 @@
 -    string(SHA256 PATCHES_ACTUAL_HASH ${PATCHES_ACTUAL_HASH})
 -    # message("Desired hash ${PATCHES_DESIRED_HASH}")
 -    # message("Actual hash  ${PATCHES_ACTUAL_HASH}")
--    if(NOT PATCHES_ACTUAL_HASH EQUAL "${PATCHES_DESIRED_HASH}")
--        message(FATAL_ERROR "Patch hash actual ${PATCHES_ACTUAL_HASH} does not match desired ${PATCHES_DESIRED_HASH}")
+-    if(NOT PATCHES_ACTUAL_HASH MATCHES "${PATCHES_DESIRED_HASH}")
+-        message(FATAL_ERROR "Patch hash actual '${PATCHES_ACTUAL_HASH}' does not match desired '${PATCHES_DESIRED_HASH}'")
 -    endif()
 -
 -    foreach (PATCH ${PONY_LLVM_PATCHES})

--- a/pkgs/development/compilers/ponyc/pony-corral.nix
+++ b/pkgs/development/compilers/ponyc/pony-corral.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation ( rec {
   pname = "corral";
-  version = "0.5.4";
+  version = "0.5.7";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = pname;
     rev = version;
-    sha256 = "1chw56khx5akjxkq0vwrw9ryjpyc3fzdmksh496llc513l01hpkl";
+    sha256 = "sha256-OLA09C/6s2PyzreBvqFfzsoRDXiRMbdf3Jgnmawr7k4=";
   };
 
   buildInputs = [ ponyc ];


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Several upstream releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
