### PR TITLE
wails: init at 2.0.0-beta.33

### DIFF
--- a/pkgs/development/tools/wails/default.nix
+++ b/pkgs/development/tools/wails/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, makeWrapper
+, go
+, gcc
+, gtk3
+, webkitgtk
+, nodejs
+, upx
+, zlib
+}:
+
+buildGoModule rec {
+  pname = "wails";
+  version = "2.0.0-beta.33";
+
+  src = fetchFromGitHub {
+    owner = "wailsapp";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-efxOL/FllToum0P4JyAJt0fbrznTFYh7czTWpZu3uk0=";
+  } + "/v2";
+
+  vendorSha256 = "sha256-qPMVsvud2L7hpXUOfYYMiO32JXff8ZZC34EsxFoSJ0g=";
+
+  proxyVendor = true;
+
+  subPackages = [ "cmd/wails" ];
+
+  # These packages are needed to build wails
+  # and will also need to be used when building a wails app.
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  # Wails apps are built with Go, so we need to be able to
+  # add it in propagatedBuildInputs.
+  allowGoReference = true;
+
+  # Following packages are required when wails used as a builder.
+  propagatedBuildInputs = [
+    pkg-config
+    go
+    gcc
+    gtk3
+    webkitgtk
+    nodejs
+    upx
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # As Wails calls a compiler, certain apps and libraries need to be made available.
+  postFixup = ''
+    wrapProgram $out/bin/wails \
+      --prefix PATH : ${lib.makeBinPath [ pkg-config go gcc nodejs upx ]} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gtk3 webkitgtk ]} \
+      --set PKG_CONFIG_PATH "$PKG_CONFIG_PATH" \
+      --set CGO_LDFLAGS "-L${lib.makeLibraryPath [ zlib ]}"
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Build applications using Go + HTML + CSS + JS";
+    homepage = "https://wails.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ianmjones ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15882,6 +15882,8 @@ with pkgs;
 
   vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
 
+  wails = callPackage ../development/tools/wails { };
+
   whatsapp-for-linux = callPackage ../applications/networking/instant-messengers/whatsapp-for-linux { };
 
   whatstyle = callPackage ../development/tools/misc/whatstyle {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Add Wails to nixpkgs.

https://wails.io/

Build applications using Go + HTML + CSS + JS

Resolves #136707

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
