### PR TITLE
yandex-browser: 21.6.2.817-1 -> 22.1.3.856-1

### DIFF
--- a/pkgs/applications/networking/browsers/yandex-browser/default.nix
+++ b/pkgs/applications/networking/browsers/yandex-browser/default.nix
@@ -50,11 +50,11 @@
 
 stdenv.mkDerivation rec {
   pname = "yandex-browser";
-  version = "21.6.2.817-1";
+  version = "22.1.3.856-1";
 
   src = fetchurl {
     url = "http://repo.yandex.ru/yandex-browser/deb/pool/main/y/${pname}-beta/${pname}-beta_${version}_amd64.deb";
-    sha256 = "sha256-xeZkQzVPPNABxa3/YBLoZl1obbFdzxdqIgLyoA4PN8U=";
+    sha256 = "sha256-+xxyV8dBnfu2hQ/ykkp7wFSaojhlPLVvMmZdh/hyaoE=";
   };
 
   nativeBuildInputs = [
@@ -109,21 +109,22 @@ stdenv.mkDerivation rec {
   ];
 
   unpackPhase = ''
-    mkdir -p $TMP/ya $out/bin
-    cp $src $TMP/ya.deb
-    ar vx ya.deb
+    mkdir $TMP/ya/ $out/bin/ -p
+    ar vx $src
     tar --no-overwrite-dir -xvf data.tar.xz -C $TMP/ya/
   '';
 
   installPhase = ''
-    cp -R $TMP/ya/opt $out/
+    cp $TMP/ya/{usr/share,opt} $out/ -R
+    substituteInPlace $out/share/applications/yandex-browser-beta.desktop --replace /usr/ $out/
     ln -sf $out/opt/yandex/browser-beta/yandex_browser $out/bin/yandex-browser
   '';
 
-  runtimeDependencies = [
-    libpulseaudio.out
-    (lib.getLib systemd)
-  ];
+  runtimeDependencies = map lib.getLib [
+    libpulseaudio
+    curl
+    systemd
+  ] ++ buildInputs;
 
   meta = with lib; {
     description = "Yandex Web Browser";
@@ -131,6 +132,5 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ dan4ik605743 ];
     platforms = [ "x86_64-linux" ];
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
