### PR TITLE
 thunderbird, thunderbird-bin: 91.6.1 -> 91.6.2 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.6.1";
+  version = "91.6.2";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/af/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/af/thunderbird-91.6.2.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "b0d36d12bb29897b4502fe28fd5d05117b8cf3c6f2a8f9a0a88542b915587cda";
+      sha256 = "12677fdd95e2e39554b588d17520805490cf0155dcc0ba46a342fdf1f1203c2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ar/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ar/thunderbird-91.6.2.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "26c86b4a73085d1b2b08e73a9adb1a2e8148fce1c8b27f3b1f9566fb72269361";
+      sha256 = "9117f12de36b8823208d1513f19f7aa97d212d757f89a160391d0174452929fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ast/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ast/thunderbird-91.6.2.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "f0ffeb6273b2c748cdeb2b6e73e17848c6c1b583ee0dfae1ec7eda8b295bef09";
+      sha256 = "0d4af76bfacf63bcffc05df23632ad8253706cab6733672e1da63d9f16ad3adf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/be/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/be/thunderbird-91.6.2.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "b55b54e87b28329d717023397d42d162299bf89dc47b6db5910b57263b377645";
+      sha256 = "6f5797eae430340d6a36d4ed62a14a3e4e872150e089e7cd333e94df93ca3c65";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/bg/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/bg/thunderbird-91.6.2.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "93d99a4eebf65152ffede2b86f94f0bb4a626c0a0b0925514e529785b717ec21";
+      sha256 = "750dce93e9e87a43a61c6a64165e1a2cb22875a758676af13827578bf2988766";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/br/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/br/thunderbird-91.6.2.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "944395c06dbc26d14add54d6e9e990496179ee0e956d585d84246e90d3a5a058";
+      sha256 = "d58fed791e98b711416605cff2629fe0eb1babde72210e17a21058f8bb44b9f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ca/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ca/thunderbird-91.6.2.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "426f1f2b8c3849e60e1e88e74f33c1bc51f8de3007fbbf9d58c0c477e7c4d0f2";
+      sha256 = "58841064da94416897a4fc0cf3bb5cc3379523d4500ce1e95d65509c34ad7aeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/cak/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cak/thunderbird-91.6.2.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "04baa09f4f28e62057cb4a62981f916c820a82be5c7418367be67a5f1f180dff";
+      sha256 = "5edb25818fd16d959bf28f98e107d433bd55e26ba63b3a813d31ceeb3524d3dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/cs/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cs/thunderbird-91.6.2.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "d724b84ac07ec0dd8f81b790f4baf58c2d81f9d1e8aa121fe379aa968fd7c78a";
+      sha256 = "efedce066919a150637821ca72c173057beb6283b3059dc862c4be8361e9a87f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/cy/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cy/thunderbird-91.6.2.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bde7231dda570182a0c4e73645025aad818be321bea0c0425dddb275b28d438c";
+      sha256 = "9cf0e5b52277d5c3cf863617a61854422c44301d8edfc97966570c3f9ccfbce6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/da/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/da/thunderbird-91.6.2.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "b671d892a013f551ce32c3ee98d956227561a9ad9f168095521f8be1899bd1fe";
+      sha256 = "af73b4ce45e9f7570986ef01e82e31a717c2717b146a6dc9815a8352b18f3ff0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/de/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/de/thunderbird-91.6.2.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "cca775ff187ab71db985c031ff08d906fcfba2aa2aa25ad204f1223c94ee1fd8";
+      sha256 = "2be5afaf377e61290a8e7bbfc274ca1dae4f9d1e54188b85677425ad067b6f35";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/dsb/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/dsb/thunderbird-91.6.2.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "19bd301bb47874abaece776961e85b277ae02cfe772c11f62b731d19c3d87b39";
+      sha256 = "ca44c469fae35a4e388017c172eb9610ddc6057b7768860806dac4a86527829b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/el/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/el/thunderbird-91.6.2.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "40f279167634c0903f60297a76ce483a34233110c34d50d01fdd976f65337e41";
+      sha256 = "8c7b1071d9b0d911f0d714f9e5aee2fd7e256178255fb721562c649f0aa776c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/en-CA/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-CA/thunderbird-91.6.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "41ac7d58a099e68cf87f604d77e8fa844e48264b52409b9f8637fc777d15bdad";
+      sha256 = "85709ee24b0c18f39c843c500d15d04f90ebe1c3ed70c54ebc5a47e7cb2ead01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/en-GB/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-GB/thunderbird-91.6.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "e20e547b074816931fce3cffe04eb7b9690439f047b2154d2f0d36b7eda9071e";
+      sha256 = "ff3a7fe7eef034ae215c3d4cd7e735419bd5aaaa05d15bf025a98643c6fadc64";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/en-US/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-US/thunderbird-91.6.2.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "08e963292b4e63be2dad7a24eb125bca484107b05856dcebf98ceddaf47f1e87";
+      sha256 = "319d173d06ccecc820080f92f2bd9348566457f46c08a328db15dc921cbc055f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/es-AR/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/es-AR/thunderbird-91.6.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "23775b4446630146d6e6c34760cbb9c155a21bfa759d6b18135fe28e80459c7f";
+      sha256 = "c14bcb2b168397145cf5cd5a81d8cd6b2881678759886016b5915f93cd8761fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/es-ES/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/es-ES/thunderbird-91.6.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "0ba964ad2cc0d86b12e8498ccfd374931d0e26fb163994704aae622a420bffe8";
+      sha256 = "9f85fa21ce05846a795f0282bb3216d0559b4cbff189ba0e1867220a7c4f0cfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/et/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/et/thunderbird-91.6.2.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "94a73f46e5e2e9672a0c54a4a445c5a24a60924e45d57218a0c5a3eda7437091";
+      sha256 = "39fa22da95ad03f31eaa2eb548f53e6bfb8e8e7fea424fda2b5432c1f12547f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/eu/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/eu/thunderbird-91.6.2.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3fed5e7cc72572e7a71f2916ac1750b40c0896d7786bfb76a49679d15ac07031";
+      sha256 = "7a7c1517f5cc132b0c0d71d993bd8e816a0f72679799276c87eb57ca348dc523";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/fi/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fi/thunderbird-91.6.2.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "b7e233e744afd3569748013d091f57fbb8339e1cefd328d1808cccd0abd9f7c7";
+      sha256 = "703e0287c5b39b875abdb47b971d0c884df5ed6376ea2f541c7d26b2be532180";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/fr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fr/thunderbird-91.6.2.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "1066814d16f3de8e0a6b0aad4ecbc078bc4e76a5daad8173d7a0af1986fc49ba";
+      sha256 = "278263e42d1ae302682986591d42bb2cb35efd25d1a91935b030d0ef8b3232fa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/fy-NL/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fy-NL/thunderbird-91.6.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "eeb7f557ac32ab426c5843061c1fa394671328794f9b0d5313351768ea020fa1";
+      sha256 = "57099abb0727c46862835235dc0a6065766e4284f7b672722957cfc6de555b01";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ga-IE/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ga-IE/thunderbird-91.6.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "8c1adead3a4c715cd2e6ebd7d23a086a6bb5308cb8620e35aeef151c3a25ad40";
+      sha256 = "077c2618862b042aa85117f0352d2d510b58f6d0e011ee82341ae1431a93f148";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/gd/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/gd/thunderbird-91.6.2.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "23db6bd6aded7d7424c2c0b5a5c9da938b504b517297b535d0eee907c20ff921";
+      sha256 = "54890fdb2eb00bb2678230b1e1ec3dbbec93ee17b56b1373a2d1c53aecdaa8bc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/gl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/gl/thunderbird-91.6.2.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "10483ac92240dd7f1a4cc25dfae74291ef3546ff36b51205bcb3fa2af2e97489";
+      sha256 = "91423a9ebf11e08f66c743199a28a7e201981fb63f108e960d3afbd5b2a459be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/he/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/he/thunderbird-91.6.2.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "211c4f58cd5553da8933386c4b1a7847f61df83212228f3ec4ef807a2115f220";
+      sha256 = "d314d468c11715589b4023367fbcf5c75d86f3988d475b4c5e9ada28906d92ce";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/hr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hr/thunderbird-91.6.2.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "3b71a6ab9df2a45c15342f241cb63f323170f692d204e9a98f9772f6e50809f4";
+      sha256 = "a60f4a5b486341d1df0ec1eb3f7c57a823aa2a8a6f1d7903d44e6a5b7a932bd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/hsb/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hsb/thunderbird-91.6.2.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "0603f34c825bee5e813fb63c5f1060e5de31ab89d12abe4259f5f2c56f880e65";
+      sha256 = "7678c9a81d2174030e32fd658337d4145c30e459aa8f22469ec7feea8c352572";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/hu/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hu/thunderbird-91.6.2.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "64db18fb3477198f696cbf8d100b45abb2cf74abc960c90143abad224fe56e48";
+      sha256 = "6dbf4defe558fa4be7402b783dd1f6854111edbb2f8937ccebb59dd8a451351c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/hy-AM/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hy-AM/thunderbird-91.6.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ec3064d387558c56e80965fc87a73c19ae530802ffff3f0cd35e7026f76655e3";
+      sha256 = "e611665c2790dd32544c073e89a62794e0bb3fd663341f43ca8fca219500d45f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/id/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/id/thunderbird-91.6.2.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "a7635897857f1c4bc86b9208ecbfa983a80a889a24274ce2c41d1fd401163230";
+      sha256 = "42d4b227700df923b9250a798d919429e0542cfc98db3c380fbfebf640e491ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/is/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/is/thunderbird-91.6.2.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "310cae89c6a62b5a9cf19a81622395b1d9d2de1670dfb9542d8465fd2bebe3a6";
+      sha256 = "61b3cb9f32c1f3241d0441ba2b5a08af4453f7ecf0a752a579fd6c3d002fd196";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/it/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/it/thunderbird-91.6.2.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "826223383cfd0ed931f0df19100ec24e22c5ed6eabb71ebee2663a4199368fd5";
+      sha256 = "15006b56087f9459d201d3ba882ddda6619abe67810133acf47ffa40a688cd4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ja/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ja/thunderbird-91.6.2.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "a62b2d76c228d54a00dcb81931a010369ab5cb5f7e5d5601fa74076431ec39c9";
+      sha256 = "290c013ffc6269754ff0d1bd5cfa29e6a847644e5508f769cc0e9bf7159583b8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ka/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ka/thunderbird-91.6.2.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "2e7b571096baa8d4d68eec97f25197b7504ef0e196bb711344180f4324b260e9";
+      sha256 = "5cb5d34ee7898f611c2cde2ddb328d3538f9be8f594364133a9e6b8de9912baf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/kab/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/kab/thunderbird-91.6.2.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "378de38b2393987fcbd22057c64c581365ddff6239d8055ac631df9903df4ed4";
+      sha256 = "211e8129ae2d8f69c7582dd86d5c5f3176a36aa79e66493f0e214a10d8c39d31";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/kk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/kk/thunderbird-91.6.2.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "51e8c5d832f8deb27d962ef175cd2bf6ea66fd8c0a24b7c647d4d98d524c3bef";
+      sha256 = "cbba1424eff7f98af28893a97d84ce77df18e4d7a11c25085d11e6b04e3ac48f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ko/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ko/thunderbird-91.6.2.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "a63cf39f84cab3c6a6164a6c62ace5aab948ab71d8934f5869cd2290851c17ac";
+      sha256 = "1fd8858f58d51145534baf36a6cc65785e97f27c2288b42fa2be678b9cb53c6d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/lt/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/lt/thunderbird-91.6.2.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "1d44efdae4a299d57c1ab4769fccc5326e85b95cb2078332aadde3a3d0d72c7a";
+      sha256 = "41c50eaa92f3197c54f3ad26645c3ba6c68ea8a43123e10a9b5f8b6c9948aefc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/lv/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/lv/thunderbird-91.6.2.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "cc8e4b043ae003d43240df52eed2b3b3a16cc09e963c6bc768d672e6dcb59022";
+      sha256 = "9ce05e78b63ab688fb696f6f246a9673ee27a5c353e2b0cdb3cb8007b716c080";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ms/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ms/thunderbird-91.6.2.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "8b64d50a219467347cbe02e237fc1f5473a9d86d8b29fa0cfaa5c423c7265db3";
+      sha256 = "020034bbb08295558c313e8fddb0a9566df789fe6458b8f6af48afcd7b13faf6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/nb-NO/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nb-NO/thunderbird-91.6.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "71256fe14843fc5c3026dc17d39d9f10b0dcb5ebe0d1769740397db45164e8fe";
+      sha256 = "6d68c19f302bc285dcc9791a62fbeb43c212d00250b55671ea6f1120eb3832d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/nl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nl/thunderbird-91.6.2.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "6cc1efd14f8fdfde047ac8245fcbd42cc6829d4973fadad43e5113d95c2334af";
+      sha256 = "ad16ce405e3afdeb476c2b77d4cbbe07e804f7f24c6ed309904991142dca5833";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/nn-NO/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nn-NO/thunderbird-91.6.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "efcf3519eed57080c022d8ea3e45bb50cb302d6eead93b2e50d3e6d69635b1db";
+      sha256 = "a978d79422012ec000ab47568bc9eaa3cc6aa6eae2c81546ecb6d6638dbdc9be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/pa-IN/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pa-IN/thunderbird-91.6.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "69e27e7a1e7534b6903f3e6a1248b8d62617dbeda0051453f78ebe68bd0e978c";
+      sha256 = "ce38914fd910829414ae6cfbaf16d0b87b94c9bbd8c5ff6f1207e56a65cb69e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/pl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pl/thunderbird-91.6.2.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "8903c2302e4ec1a77076cf51a770861738793d4f5ec87faa87da922f1be2d620";
+      sha256 = "f4c98014363d6cabde1c482b92f144316d15d3add07c62897d22c0609d30945b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/pt-BR/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pt-BR/thunderbird-91.6.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "558adf768654a03738f755b765a2c6c3aad514ffbe532b4e47c0d94cd9dfd262";
+      sha256 = "852ab5784791248bf47fb10256cef4182bc1aab9ecea614042ac633302e4a5df";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/pt-PT/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pt-PT/thunderbird-91.6.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2fb3c682ee289e2bdf1263b5c32f38e31090d742b108b373befb3f093d655e30";
+      sha256 = "31db0fed5d7fd611f010c98504fb3e93d4cc176331eaf0620ad72aeb3cdba074";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/rm/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/rm/thunderbird-91.6.2.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "9e489ce3861ee17a2ee145ed5edb1c0b2c0c3f1446f6fb64081ac623f381ef1d";
+      sha256 = "cde517205596b4de4871af82fa1fd3ac7573569e7f20e4f09200cd89c0c44209";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ro/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ro/thunderbird-91.6.2.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "4bf6b617ea7d4a2ebe81a73c09e24cd1e1bb360ca501a4f139c99a84d1492005";
+      sha256 = "6d8a7c29be04853b412f17e58542b0bd9041a501381eea8480f9f801f31c67ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/ru/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ru/thunderbird-91.6.2.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "fd88dd41fd4c93d829c6e44d2d88092652827ed08121c6ba25cd410082cf4991";
+      sha256 = "b57efd432369dcf8dd5e0c372bf9e4c2126384319bca00068f5e48b38f028353";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/sk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sk/thunderbird-91.6.2.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "53b6fa462a3057e9eec72f75d698631486514839bdf30f6388f9749848846462";
+      sha256 = "89d011a751e74584e327aa27dc240a1e1a55c41203f27f04d19e3207efa00ece";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/sl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sl/thunderbird-91.6.2.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "cebe056640e0589c8f4ff029aa74f1666b1a0faeb742f356b74e07b2b0998e39";
+      sha256 = "8ab24ed74c8647cdf560c8617a141b7288040aecbdbcaa24535d9893395edae4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/sq/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sq/thunderbird-91.6.2.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "9f1bf49edf710455bcf23cd6c14618518ae4b07a75d259e2cc821d5c85c0e0aa";
+      sha256 = "fef5737faa9c619405198d1e544e1a463b83359f8fc948d4a6b7829aae66addd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/sr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sr/thunderbird-91.6.2.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "f287d6abde4537dffa599c54910bda7e0f90596f931d88921d0d3248c941166a";
+      sha256 = "37027ae2e80d562e8487cbf8f74583ad8615697529a48286f3d720c936d449cb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/sv-SE/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sv-SE/thunderbird-91.6.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "02952a1f2d47394b4a8ce06af67a1058822c47660f69d606e719f215205709d8";
+      sha256 = "e733a4043b75d198e39b17370ffd1271a395742130c9b9448405f6ca6c4fde1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/th/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/th/thunderbird-91.6.2.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "8cec77f0fd16e9ab2b316ba884c26f35dbe15694e22e02ecd27d3caec68970bc";
+      sha256 = "da5c57c69d4663b19818af4542fcd01daa49709c3fca89866d3036fbcf39a40a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/tr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/tr/thunderbird-91.6.2.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "aa66efd16a8e5328e20052676d0e06f3ede903a88262c4b01ff0a78ec013f9cb";
+      sha256 = "34ca81f38b37948ef31ba91e69eafc3d2d3de3c8d957d4f8b108b5317a3ea69c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/uk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/uk/thunderbird-91.6.2.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "23d654a7755a846b2354c392a6d86f0794f126425e64a19af7c1f047bd758cae";
+      sha256 = "3c21631ede559d1956632967910d10a7efecfe7dd10e5abe2c7a3a2299304c4f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/uz/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/uz/thunderbird-91.6.2.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "c97b2d05e7043ba438f313569bb6165fd106b9f2351478549a6de5467f980280";
+      sha256 = "21ff155db506ec20e7eb65dacf1bfb410cbca19dea0e9c1009abfdaffa9d10e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/vi/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/vi/thunderbird-91.6.2.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "0c4341944eeb0d6724dbabda5dc68796cf40034dffed1d0af2d942af5eb242f2";
+      sha256 = "145f4b4be96928ea84076dedb8d5a693a6570091e88a60711d3353eb8d61183e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/zh-CN/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/zh-CN/thunderbird-91.6.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "86bb80438e4e729faaf57a3b5651b936647ec6ff58c78e263011e242d7e41fbe";
+      sha256 = "6551815d957d568850bf87a68cd68b2c8f244806b7485a9f3e40267d7132e80f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-x86_64/zh-TW/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/zh-TW/thunderbird-91.6.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "733ec3383204fff674456bdda36f7088e32914fceaa62fa6a98768e9ecbef321";
+      sha256 = "5a9c213bbfecaad06ef74ca6a3469325010780f1c0020d75a4a1b282aef75206";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/af/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/af/thunderbird-91.6.2.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "3c8f1f172919ef3c5327bf337a49ed428f6581e3dc6f3ed69c7f6268cf8f4fea";
+      sha256 = "e0238ea69c1b04426bf9f100dcf804bb2e521c909fcff3e8c71b991d7e516afa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ar/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ar/thunderbird-91.6.2.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e938549a5be6c8f1dff66e330cc9e059a352ed9b539145a812838aeec2668bdf";
+      sha256 = "3cc3c94ce260f3d51a1d8f94190d7dcb3355345feb00dd46dde87445a7c96103";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ast/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ast/thunderbird-91.6.2.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "a0d93d9f8c9ed659409f971ebecdd6134db8a4b954db9638b7a440c898adb0b3";
+      sha256 = "10c77a2690c83f85a437068ca1090ea727f499bcfe9cccea3db7a437c4eadbf8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/be/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/be/thunderbird-91.6.2.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "741da67fb46ef6e73196dec3f0c71ce1024e282421c6a8e111ffb9ba2a2a5014";
+      sha256 = "176b3e2480cb9524b6b988649312557e0d6c92a910540517e2a64bceacc318dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/bg/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/bg/thunderbird-91.6.2.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "afb8fac75b94957f60686c170bec9af438d04c4f42d259e80c07bb446c875aff";
+      sha256 = "453320d2bb60676b54b5ec4db932be5c48b0d611e24dec0d383c6038cf116350";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/br/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/br/thunderbird-91.6.2.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "474656d25e48718b303b2d4463465bb7a272cadcabf6360adfaa7dd23c808c2b";
+      sha256 = "04b9839b0f8b9ec5378a2bcd938cdda5ba06beac4ee15d9244db44fa79ce4082";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ca/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ca/thunderbird-91.6.2.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c2b4e38ea9810f10455c78de2d68a76655eb855ea8e3d55c895e6f8d5df84066";
+      sha256 = "292ab4580a1d5d0b9c210b5e17404c4b694ba1a6083372e7a2fa116762304bc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/cak/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cak/thunderbird-91.6.2.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "1da916a640b36c8e2f84e733dfa6b1cd4a7e90dc2367e56522ad3525d646712d";
+      sha256 = "632312be72925ad593c34e6f7244d264e85ecb2d11226438b8a73e46ad803bcd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/cs/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cs/thunderbird-91.6.2.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "f0ff0220167566300fb0913f58056ff81c5b70f2835830d325c1235caa468a99";
+      sha256 = "7c791ce5591fbd961e13518e7cb79ad4564e3e1ebd2020e4e3eee5b3c705373e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/cy/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cy/thunderbird-91.6.2.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "1b8e7ae9b27dab0872443a2b26733888d569765e6e72cfaea775d157273c8344";
+      sha256 = "81a74d583402e8260e269c4e04c9493b651c20cce7a3cdb7a6eff1f079afd798";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/da/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/da/thunderbird-91.6.2.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "79ae2ac91c0540e76578556c82bec7340baee79758ef0e157155aed8f1d68b3b";
+      sha256 = "33da64a7f4bcbcb916ec96605c99775d040a82f6fd993b56465db5cd5358813d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/de/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/de/thunderbird-91.6.2.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "cf5096d178152abfcc5fbe7cd109722875d8d11575b526577e713a4efd28d226";
+      sha256 = "7cbd8da69bc78f8f69c38776f9ccb13f710ab78dc63f33e882869f34dbcc27d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/dsb/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/dsb/thunderbird-91.6.2.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "a650eda884498dd7d0e3dbd73cb1e9b020f10e690ce26d77ed654c0202f1d915";
+      sha256 = "50ddf1a1f53daaa9652b2b21b9fb0ac364c22dd1a504e112892814196029f647";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/el/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/el/thunderbird-91.6.2.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "be65c035956efd25246265fa102f934fc14794457fc110d815b140165c81fed9";
+      sha256 = "b23178543705c768d0ae361bc9c24d4323a903d95a1386f5f190acab3ac6c358";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/en-CA/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-CA/thunderbird-91.6.2.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "dc906637f397a2ad86b72d8c4636b511263255327b3a92da5adc9d3444117311";
+      sha256 = "bc2e2f127cc53297e11d36b4de86453e397fc7a19dfe85b456e1973f2185c3da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/en-GB/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-GB/thunderbird-91.6.2.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "0f028e97594448ab058b839e3a4ab2f3aaefe79732512a4f193c53dc75c59e3c";
+      sha256 = "8c1a29f1a35ed8360eb8c064dafea875aab15186c7f7125e1ff21550afa68ee7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/en-US/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-US/thunderbird-91.6.2.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "5f24ac86a2e91f4568d179529caf5254c3aff65593b3a79d25ef96d03211d0c0";
+      sha256 = "436f46c5d235ffee2fac9e36a256c95e9d842e6712192972f784e8b02159c0aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/es-AR/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/es-AR/thunderbird-91.6.2.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "5c5a93460f61d7e8a7168c14a46ff24fdecbf67c06da0aab2b30602bd1a1ef51";
+      sha256 = "2eeb70ef1733d7204ac04421ac4dacdb8828c859e9b0207f45a8ecbefb649718";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/es-ES/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/es-ES/thunderbird-91.6.2.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "8ecf33158eda96155604583c57dccc55c7168abd8dc161e8801da0e7c7d24b40";
+      sha256 = "980a281ad7e1f0b137bf12022c2a2b103dd3022607bae77311a2dc6fb0db6b97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/et/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/et/thunderbird-91.6.2.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a0e3b7c8c095dd8c116630fec01f50fca6b07d83902a7a004d2f4b52b02536e2";
+      sha256 = "a91f7e379fb911e84fa9a1a77f5d8b15c7123533a39ad0db7923bd6451571b93";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/eu/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/eu/thunderbird-91.6.2.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "e18f1f105a7e7a88410e749ed9e6e51685cbd6d9fd44f37c8146d333ba405274";
+      sha256 = "c3ad75fcb81f86dc7df237c1517ee0e9fcea74e09c5bea69e934a5e55f23d47d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/fi/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fi/thunderbird-91.6.2.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "984c5d69ef752ae62b08e6615ca19384ff9b2a46167d17ad01e71bec48dd7996";
+      sha256 = "df15bb410f85783f8c4e77dddd91b75801ccb3b7cbae800b558e4e484d7ed22a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/fr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fr/thunderbird-91.6.2.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "ae2fabdf55e587f3b57849ddd518bfac0035f5c0e1eaed585713f022fb50fcab";
+      sha256 = "eec2b42190741d90464fa4c96e6c567e785de3c7cfa417a6c001c027ac547129";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/fy-NL/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fy-NL/thunderbird-91.6.2.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "a4abcd89e36fbdad7f2102142b0790f1223116b5a016bce6cffd59f5547b26e7";
+      sha256 = "93b7eec77754a039fbae93075b28a912e0bf5c5553db5f055801a792b7649219";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ga-IE/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ga-IE/thunderbird-91.6.2.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "eff63f42237deb6ecaa60b940ec877e88827769346e14d55624ce3044fac1860";
+      sha256 = "7bdfeadd23365a1a077d952bad918f1b84ebc18d6f0ddc791fccba7ff37fac55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/gd/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/gd/thunderbird-91.6.2.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "4399f90f6e28be1bfd68ef3273a4b11cb3a912394033a4ba4f0f722eceeb916e";
+      sha256 = "bc598051782aad08cab0edb0c4fc7288f3d0d0a58f4bbca6ea15c399af8780e3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/gl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/gl/thunderbird-91.6.2.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "be6a01476604cf120131724e0e5afc1951421baf489c231fd10115b947a56f41";
+      sha256 = "fcdf50a161f485eeea7c94fde63abfee5085234e6a2495af655f6e69fb9f262e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/he/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/he/thunderbird-91.6.2.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "fd3548a80dc4983b264f5a2062d87bd9956c681fc191d35246bac2248c61c429";
+      sha256 = "d12d9fdcd6904de941059b369e5000e116725e8d440a80aefd590f6942250120";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/hr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hr/thunderbird-91.6.2.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "e149a9a469ef013264ffbcf10051e1476f946f52ad4eae8f734643394f6f74c8";
+      sha256 = "d3c55c9171263f254899cf47e2051fab0c2c45e96512bd82349de7313fb4a454";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/hsb/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hsb/thunderbird-91.6.2.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "77baab4a6d3ba3339cc32475fdd654034eb57e61d2c51258e38eba6c14aa2f89";
+      sha256 = "e06c1178134628bdaf16f57d72433ee0e0ed21d1d7d3ddc9e8b72c861922c29a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/hu/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hu/thunderbird-91.6.2.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "c796ac09b0e4033f1ab9d1e6da4b78e540f1b731bfbcda040743e409164ea2f1";
+      sha256 = "8111a674ec2b7bd0f124d61fbf1ec426fdd0c86fbc4d923dbf62c8c1d903fbca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/hy-AM/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hy-AM/thunderbird-91.6.2.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "c6023895e3e26e7b52c277640702a821bf4a562287ba7d8e632a59774a6757ee";
+      sha256 = "25b55c080f5f039379127271b8bff72440bd79297b88e96d0b93b7d529050612";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/id/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/id/thunderbird-91.6.2.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "a76f567644ef6092168e2c526839bc0901a18533f08ac525381e74f77e9fcb7d";
+      sha256 = "029b2928a8acf2977be19fed3f7aba57b5a8bb0ab70d01c5d83f27bdf48183bd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/is/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/is/thunderbird-91.6.2.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a023e32837355ab83583bcf504e9ff3210f3a68d30c73477ec158ef1162df4eb";
+      sha256 = "ae74117ec005cdcba771e7de0077a982e0d5d29debd5ccc4de9bd3183ed2606f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/it/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/it/thunderbird-91.6.2.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "459aec2da31a3159f0d81cb0876686e63d9b1e72ad36e967472d1ce98c380983";
+      sha256 = "85d772c2de86ef7fec4c17de19fd99b013f7df8765922df46f16d870be6c6781";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ja/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ja/thunderbird-91.6.2.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "307faf7556594072ab83121c1774005392bc556396c5234a2467ef6843a490f9";
+      sha256 = "c6234cc2222d1522adef42df8c3cc1d5da947f8475031901300f927804d60152";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ka/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ka/thunderbird-91.6.2.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "42cd7f10453541b23099631f402ff70103131025ef868de06fe2e82430bb7eb3";
+      sha256 = "22c342874a82fc083dc74f29d2852c40d1d60f718cd35e9d7c76cef35de4ab8f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/kab/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/kab/thunderbird-91.6.2.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "cc62b8ce7bea99dd9e9cf660f5dcaac4b9a44746b7b4cccf84612ef844df9e7e";
+      sha256 = "455c17b71f216f5071fd32b9c7b96c464ee5bfe1d3c18964afdd230bcaf86afc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/kk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/kk/thunderbird-91.6.2.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "ee9e74534c1d7716ea80e2874007b4f9778942bcae559effc830477e614341ee";
+      sha256 = "f5556480e9121dd335e286ae0b9233376ced197371d14b181aec8d8311cfc706";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ko/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ko/thunderbird-91.6.2.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "12106fad7493ce63c189b0a7e92c9828c7b2d46d7f5cd9ecadbc90be041e6bbd";
+      sha256 = "badf2b99ba059e60d3f33c714b172f8276adabcd043461c11354eb463aaf3306";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/lt/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/lt/thunderbird-91.6.2.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ead9b5e035f2fcd1213aba5e63c8898b96bf0bfaefde7709228014aadf608420";
+      sha256 = "ff701d1181b44b5277f2c8743da2069549b4d13f417c16f839af4796dd305baa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/lv/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/lv/thunderbird-91.6.2.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "72980d6c676a269b9d3220a171cffd67ebc1dc0759bef5ac15db76725aac86cc";
+      sha256 = "bbfdb1ae9395dcc76f4bb7a6c9317add2ebeaa63541340f8b6de0d8f020c3a6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ms/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ms/thunderbird-91.6.2.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "dfd0cfceee31c31a300ebe37fe99690008f5a21992e7188680b319fe5b5d0207";
+      sha256 = "83ba8a72bef318bcd450171a325702fe2996c471944a777fd460b325119c8cfa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/nb-NO/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nb-NO/thunderbird-91.6.2.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "7610a56f57d4753f6fd7a55147d7a22157453b47548fe807b5fdbc1ef166eda0";
+      sha256 = "fa08cca82864940a7b7ea7e9835761b4c6ceb5c2bcb0310c6b347d62ab301ff2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/nl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nl/thunderbird-91.6.2.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "6a470f707e9838937c67e2ce7c2da216e23964bab94c4590d20cedb4b337d18d";
+      sha256 = "8bfe89776537bb81584dee98fbfbc248ab6ff0d6ea245938bb0c6be4b9c1431f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/nn-NO/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nn-NO/thunderbird-91.6.2.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "e393dfbd10ae6ce910ed594ca6d314d048d57e98a1a01d53be82788d6a3988d2";
+      sha256 = "1b74509b54c3f3394188891c2def0100b9b3c43be4bc603558a23c48d260d498";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/pa-IN/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pa-IN/thunderbird-91.6.2.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "ddc8558e84531478a4295fe1a3b09f95df458e1f1ecec89b0e1ee19e0dea6e5c";
+      sha256 = "4f45285252db5e7a648b3b68ce0854d3c3a63a38aeec2ff5fec5a032eed32247";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/pl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pl/thunderbird-91.6.2.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "015e25da0565942bbad23a9e0a345cbec4b24676c21286bbce3cf85938031ca2";
+      sha256 = "8ced6cbaea784c7f0c0b2139831f35b7200ebbd677538080a3c5e7abc1f2eebc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/pt-BR/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pt-BR/thunderbird-91.6.2.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2966875426c08658dcc5aec7e91305e40342bb7318b8ba19482b036d6f1efc9e";
+      sha256 = "8a24f7027af15dadc69d695460288604a2c4647cf31e953087d179ade207c533";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/pt-PT/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pt-PT/thunderbird-91.6.2.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "c3ee66dff637e75aaa4a8e3d40c85176e152c19464e7afcbd40cc1e3108a1d91";
+      sha256 = "09ea567cb7584cc3f4fe016419e00b0e609f73a2d50c77eada148494ec028764";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/rm/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/rm/thunderbird-91.6.2.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c320c05190b160ad807528e9be6604ac5f79958fad9a4de32c55842a94db20fd";
+      sha256 = "c3d36020692139774e0cf1b93c7985eff3afe8c5295e3401b220185b11830068";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ro/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ro/thunderbird-91.6.2.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "90547a8965aec3db8d4150c0e232bdf6e623df1850cb206a9cbca43432a3cd35";
+      sha256 = "5cbfc9fc4544289c3cd5f13404ae3990501c65fab43b041b115ab6d0f13839cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/ru/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ru/thunderbird-91.6.2.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "1dbaf198232b519711c90646c05d77b16bdad20054aaa7f313255ac15e773dec";
+      sha256 = "5eebb3c3c133e6a7df15f919df3bcb408833978d52fb17df9b556a47aca6cbc2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/sk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sk/thunderbird-91.6.2.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "8d92baafe787bdd054cf7c76a7135a6075da0bd573237f28dcb379fb6e1f7c49";
+      sha256 = "0d96ae0d24560028c9294dca7f22579eb2f9a7b953f6a7a108c1d69bf25d4b14";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/sl/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sl/thunderbird-91.6.2.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "f6ba6c8a7c7aacd28959c85adf708ad1661b4921c82035a1c954c6f6264d101a";
+      sha256 = "99aa913065720bc00e6818f5c05c752a8509f41602ad4dd239a51ff55484f9b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/sq/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sq/thunderbird-91.6.2.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e4fe39206253ab53000e5d5265e2cf3183f8c15900f1f0e5ba23cbe141145e20";
+      sha256 = "583599470bb612ca4d3cf7327d2f327e1d8bb3f9c3c0c201cc6babd3ec1ebff1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/sr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sr/thunderbird-91.6.2.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "469cda2fad3873e8de320ee7a68c45c4da6cad5e6d9904242d2c489a1e5b829e";
+      sha256 = "e9417477f1ba60bb59afc14abf95fd6f32628c9c37313659a9ac5c177e2d389f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/sv-SE/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sv-SE/thunderbird-91.6.2.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "0303bb0290c84ede66d657ac88795e879611c42815e5eaec98beb235d7764922";
+      sha256 = "80c858fa06feb45012ba9d65c2ca205185633f89f0b2e8c1ed89632e725c851f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/th/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/th/thunderbird-91.6.2.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "5915739123b4c14d72f919fdb193a65e3a15ef472e563d21d7e1e872858f3364";
+      sha256 = "8ffa993488ce3fd25875a5ba008eab546efec0e51c18a167542f4a3971b01049";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/tr/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/tr/thunderbird-91.6.2.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "8cf4a385c861d5905b742a0366df783666a05e154b4e0f23e65f883c81b2bfd9";
+      sha256 = "a76ac267c21b9dae3696e1a1f24f0e1cab88dd9ebc2a7b9f3e3e8bc17c6c1be3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/uk/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/uk/thunderbird-91.6.2.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "7e1a14c20e1ef7aa923bdb8d09a3a513dedd653388721d8537f42354c0cf386d";
+      sha256 = "3b2b760292535779565584aa2cb5048b8945cefcfe61755b8c6508dbcaec889d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/uz/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/uz/thunderbird-91.6.2.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "8f129954fcccf19fe4e46cb66f35fa298ef396d5327f647d1e7b813345dc7ecf";
+      sha256 = "e5684d4b52097287e9576bf300ecbc557bfcddfe626baa0a939119001da83f92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/vi/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/vi/thunderbird-91.6.2.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "ab232199fe149938019dd3e8a242630875be9529e32050f94add2419d2690726";
+      sha256 = "1a3091986a4f52f61318a95d82a3c205fccb4b11aef5fba88659dc053eb92d49";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/zh-CN/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/zh-CN/thunderbird-91.6.2.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "cb58b53ffb9eb1d05ff3ae856a80f8f504f86e8cdaa2075ff5b5bfcc27712b97";
+      sha256 = "50a2976f5ed463559e54468d53ae52a0e01e2c5ab4c16a88432d248c100c4e0f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.1/linux-i686/zh-TW/thunderbird-91.6.1.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/zh-TW/thunderbird-91.6.2.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "441a2fc15f7d4efeb7f76cef1166c694cd7713b12f75aab0ceae161f3e77f934";
+      sha256 = "227030569512d3cd69567d63d63d02f1db927578d99f07fd517215e3eb0458f2";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -10,12 +10,12 @@ in
 rec {
   thunderbird = common rec {
     pname = "thunderbird";
-    version = "91.6.1";
+    version = "91.6.2";
     application = "comm/mail";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "a74d9489bbd2d62916eac8214c6c3a54dfa0c03b56ad471750724315f8bdd96b6ee1079687ac973264ba0f70bdfbf2f183f359c33f7fcda9a9e48914636b1ab2";
+      sha512 = "eb1cb06390694872e37830991e16d1e0bd3259cd1fedfed86fd24901f190bc9c274fc1a85cfbba01a0c9cac0d422b62a9b1062d8ba1770fd25bf99528f6df9e0";
     };
     patches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

- Security fixes
- Other fix

https://www.thunderbird.net/en-US/thunderbird/91.6.2/releasenotes/

The Security Advisories is not updated yet.
https://www.mozilla.org/en-US/security/known-vulnerabilities/thunderbird/#thunderbird91.6.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
