### PR TITLE
minidlna: 1.3.0 -> 1.3.1

### DIFF
--- a/nixos/tests/minidlna.nix
+++ b/nixos/tests/minidlna.nix
@@ -33,7 +33,9 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     server.succeed("mkdir -p /tmp/stuff && chown minidlna: /tmp/stuff")
     server.wait_for_unit("minidlna")
     server.wait_for_open_port("8200")
-    server.succeed("curl --fail http://localhost:8200/")
-    client.succeed("curl --fail http://server:8200/")
+    # requests must be made *by IP* to avoid triggering minidlna's
+    # DNS-rebinding protection
+    server.succeed("curl --fail http://$(getent ahostsv4 localhost | head -n1 | cut -f 1 -d ' '):8200/")
+    client.succeed("curl --fail http://$(getent ahostsv4 server | head -n1 | cut -f 1 -d ' '):8200/")
   '';
 })

--- a/pkgs/tools/networking/minidlna/default.nix
+++ b/pkgs/tools/networking/minidlna/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, autoreconfHook, ffmpeg, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext }:
+{ lib, stdenv, fetchgit, autoreconfHook, ffmpeg, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext, nixosTests }:
 
 let
   pname = "minidlna";
@@ -27,6 +27,8 @@ stdenv.mkDerivation {
     cp minidlna.conf.5 $out/share/man/man5
     cp minidlnad.8 $out/share/man/man8
   '';
+
+  passthru.tests = { inherit (nixosTests) minidlna; };
 
   meta = with lib; {
     description = "Media server software";

--- a/pkgs/tools/networking/minidlna/default.nix
+++ b/pkgs/tools/networking/minidlna/default.nix
@@ -1,19 +1,24 @@
-{ lib, stdenv, fetchurl, ffmpeg, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext }:
+{ lib, stdenv, fetchgit, autoreconfHook, ffmpeg, flac, libvorbis, libogg, libid3tag, libexif, libjpeg, sqlite, gettext }:
 
-let version = "1.3.0"; in
-
-stdenv.mkDerivation {
+let
   pname = "minidlna";
-  inherit version;
+  version = "1.3.1";
+in
+stdenv.mkDerivation {
+  inherit pname version;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/minidlna/minidlna/${version}/minidlna-${version}.tar.gz";
-    sha256 = "0qrw5ny82p5ybccw4pp9jma8nwl28z927v0j2561m0289imv1na7";
+  # tarball for 1.3.1 is missing
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/${pname}/git";
+    rev = "v${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-nbvz/QHSZBTZEqX/utOoOF5vorhrxGqIBA9qfpIZzyU=";
   };
 
   preConfigure = ''
     export makeFlags="INSTALLPREFIX=$out"
   '';
+
+  nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ ffmpeg flac libvorbis libogg libid3tag libexif libjpeg sqlite gettext ];
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Prevents DNS rebinding attacks through malicious remote web servers.

https://www.openwall.com/lists/oss-security/2022/03/03/1

Fixes: CVE-2022-26505

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
