### PR TITLE
python39Packages.oci: 2.56.0 -> 2.60.0, oci-cli: 3.5.0 -> 3.6.0, lexicon: 3.9.0 -> 3.9.4

### DIFF
--- a/pkgs/development/python-modules/oci/default.nix
+++ b/pkgs/development/python-modules/oci/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "oci";
-  version = "2.56.0";
+  version = "2.60.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "oracle";
     repo = "oci-python-sdk";
     rev = "v${version}";
-    hash = "sha256-olrWv4c2DoZ7ddm58Wpb5jZntw8WEKJ6IzAND11tdjk=";
+    hash = "sha256-fXeea4MftVSJWzanHeAuERRiQLBp8l1l1Cw2lG3uz24=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/admin/lexicon/default.nix
+++ b/pkgs/tools/admin/lexicon/default.nix
@@ -3,42 +3,18 @@
 , fetchFromGitHub
 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-      # until https://github.com/ags-slc/localzone/issues/1 gets resolved
-      dnspython = super.dnspython.overridePythonAttrs(oldAttrs: rec {
-        pname = "dnspython";
-        version = "1.16.0";
-        # since name is defined from the previous derivation, need to override
-        # name explicity for correct version to show in drvName
-        name = "${pname}-${version}";
-
-        src = super.fetchPypi {
-          inherit pname version;
-          extension = "zip";
-          sha256 = "00cfamn97w2vhq3id87f10mjna8ag5yz5dw0cy5s0sa3ipiyii9n";
-        };
-      });
-
-      localzone = super.localzone.overridePythonAttrs(oldAttrs: rec {
-        meta = oldAttrs.meta // { broken = false; };
-      });
-    };
-  };
-in
-  with py.pkgs;
+with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "lexicon";
-  version = "3.9.0";
+  version = "3.9.4";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AnalogJ";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-qJFHwFzFjZVdQv4YfrlR2cMQHsEtpQbvg/DMo6C5/z0=";
+    hash = "sha256-TySgIxBEl2RolndAkEN4vCIDKaI48vrh2ocd+CTn7Ow=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/admin/oci-cli/default.nix
+++ b/pkgs/tools/admin/oci-cli/default.nix
@@ -23,14 +23,14 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "oci-cli";
-  version = "3.5.0";
+  version = "3.6.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "oci-cli";
     rev = "v${version}";
-    hash = "sha256-udvYfYFUulGfnc1gzjG3UxOc68JuecpPJ1/s57qvX0k=";
+    hash = "sha256-ADjHPRG3QzSWR7FvcTIJdcBYmzZK+SWipdY1giNtaME=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
