### PR TITLE
xk6: init at 0.6.1

### DIFF
--- a/pkgs/development/tools/k6/xk6.nix
+++ b/pkgs/development/tools/k6/xk6.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, go }:
+
+buildGoModule rec {
+  pname = "xk6";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-3jA4e7EL/7wMETjX15JMmTMLCb+b+4MW6XhHeyj+dO8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  subPackages = [ "./cmd/xk6" ];
+
+  vendorSha256 = null;
+
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/xk6 --prefix PATH : ${lib.makeBinPath [ go ]}
+  '';
+
+  meta = with lib; {
+    description = "Build k6 with extensions";
+    homepage = "https://k6.io/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sagikazarmark ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7078,6 +7078,10 @@ with pkgs;
 
   k6 = callPackage ../development/tools/k6 { };
 
+  xk6 = callPackage ../development/tools/k6/xk6.nix {
+      go = go_1_17;
+  };
+
   l2md = callPackage ../tools/text/l2md { };
 
   lab = callPackage ../applications/version-management/git-and-tools/lab { };


### PR DESCRIPTION
Signed-off-by: Mark Sagi-Kazar <mark.sagikazar@gmail.com>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
k6 is a great load testing tool, but the core version does not contain all available extensions. xk6 is a tool that allows building custom versions of k6.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
