### PR TITLE
crystalline: init at 0.7.0

### DIFF
--- a/pkgs/development/tools/crystalline/default.nix
+++ b/pkgs/development/tools/crystalline/default.nix
@@ -1,0 +1,35 @@
+{ lib, fetchFromGitHub, crystal, }:
+
+crystal.buildCrystalPackage rec {
+  version = "0.7.0";
+  pname = "crystalline";
+
+  src = fetchFromGitHub {
+    ownerr = "elbywan";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "";
+  };
+
+  postPatch = ''
+    export HOME=$TMP
+  '';
+
+  format = "shards";
+
+  # Update with
+  #   nix-shell -p crystal2nix --run
+  # with crystalline's shard.lock file in the current directory
+  shardsFile = ./shards.nix;
+
+  crystalBinaries.pname.src = "src/${pname}.cr";
+
+  meta = with lib; {
+    description = "A Language Server for Crystal";
+    homepage = "https://github.com/elbywan/crystalline";
+    license = licenses.mit;
+    maintainers = with maintainers; [ annaaurora ];
+    platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+    #broken = lib.versionOlder crystal.version "1.0";
+  };
+}

--- a/pkgs/development/tools/crystalline/shards.nix
+++ b/pkgs/development/tools/crystalline/shards.nix
@@ -1,0 +1,22 @@
+{
+  bisect = {
+    url = "https://github.com/spider-gazelle/bisect.git";
+    rev = "v1.2.1";
+    sha256 = "1ddz7fag1l65m6g0vw6xa96yv00rdwjj2z69k26rvyz37qk9ccqg";
+  };
+  priority-queue = {
+    url = "https://github.com/spider-gazelle/priority-queue.git";
+    rev = "v1.0.1";
+    sha256 = "1rkppd8win4yalxcvsxikqcq6sw0npdqjajqbj57m78bzlxpyjv6";
+  };
+  sentry = {
+    url = "https://github.com/samueleaton/sentry.git";
+    rev = "cd86128f94567594da9ddff78cc428c697754d88";
+    sha256 = "0sralc92wckmbf825mw8gsds8515qccaip8knkilzi8naap7yn3a";
+  };
+  version_from_shard = {
+    url = "https://github.com/hugopl/version_from_shard.git";
+    rev = "v1.2.4";
+    sha256 = "0y684h29ca4fld5mz9jfvvb3kla87w6daskw4vzaic0qxxj869g8";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13431,6 +13431,8 @@ with pkgs;
 
   crystal2nix = callPackage ../development/compilers/crystal2nix { };
 
+  crystalline = callPackage ../development/tools/crystalline/default.nix { };
+
   icr = callPackage ../development/tools/icr { };
 
   scry = callPackage ../development/tools/scry { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/129002

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
