### PR TITLE
ssr: refactor

### DIFF
--- a/pkgs/applications/audio/soundscape-renderer/default.nix
+++ b/pkgs/applications/audio/soundscape-renderer/default.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv
-, fetchgit
+{ lib
+, stdenv
+, fetchFromGitHub
 , autoreconfHook
 , help2man
 , pkg-config
@@ -11,24 +12,25 @@
 , boost
 , ecasound
 , glibcLocales
-, libGLU, libGL # Needed because help2man basically does a ./ssr-binaural  --help and ssr-binaural needs libGL
+, libGLU
+, libGL # Needed because help2man basically does a ./ssr-binaural  --help and ssr-binaural needs libGL
 }:
 
 stdenv.mkDerivation {
-  pname = "soundscape-renderer-unstable";
+  pname = "soundscape-renderer";
+  version = "unstable-2016-11-03";
 
-  version = "2016-11-03";
-
-  src = fetchgit {
-    url = "https://github.com/SoundScapeRenderer/ssr";
+  src = fetchFromGitHub {
+    owner = "SoundScapeRenderer";
+    repo = "ssr";
     rev = "0dd0136dd24e47b63d8a4e05de467f5c7b047ec9";
-    sha256 = "095x2spv9bmg6pi71mpajnghbqj58ziflg16f9854awx0qp9d8x7";
+    sha256 = "sha256-9s+Elaxz9kX+Nle1CqBU/9r0hdI4dhsJ6GrNqvP5HIs=";
   };
 
   # Without it doesn't find all of the boost libraries.
-  BOOST_LIB_DIR="${boost}/lib";
+  BOOST_LIB_DIR = "${boost}/lib";
   # uses the deprecated get_generic_category() in boost_system
-  NIX_CFLAGS_COMPILE="-DBOOST_SYSTEM_ENABLE_DEPRECATED=1";
+  NIX_CFLAGS_COMPILE = "-DBOOST_SYSTEM_ENABLE_DEPRECATED=1";
 
   LC_ALL = "en_US.UTF-8";
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
switch to fetchFromGitHub and formated

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
