### PR TITLE
onlykey: 5.3.3 -> 5.3.4, onlykey-cli: 1.2.5 -> 1.2.6, onlykey-agent: 1.1.11 -> 1.1.12

### DIFF
--- a/pkgs/tools/security/onlykey-agent/default.nix
+++ b/pkgs/tools/security/onlykey-agent/default.nix
@@ -6,11 +6,11 @@
 let
   # onlykey requires a patched version of libagent
   lib-agent = with python3Packages; libagent.overridePythonAttrs (oa: rec{
-    version = "1.0.2";
+    version = "1.0.3";
     src = fetchPypi {
       inherit version;
       pname = "lib-agent";
-      sha256 = "sha256-NAimivO3m4UUPM4JgLWGq2FbXOaXdQEL/DqZAcy+kEw=";
+      sha256 = "sha256-hFaT6FQMZNU6xsUxt0nVqJMlz0a0skhgxE1pvuyreR8=";
     };
     propagatedBuildInputs = oa.propagatedBuildInputs or [ ] ++ [
       pynacl
@@ -32,11 +32,11 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "onlykey-agent";
-  version = "1.1.11";
+  version = "1.1.12";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "sha256-YH/cqQOVy5s6dTp2JwxM3s4xRTXgwhOr00whtHAwZZI=";
+    sha256 = "sha256-vD+jWC0XmOI+w1Qoi36AhQHJY4xBekuVCDodeC/8BpU=";
   };
 
   propagatedBuildInputs = with python3Packages; [ lib-agent onlykey-cli ];

--- a/pkgs/tools/security/onlykey-cli/default.nix
+++ b/pkgs/tools/security/onlykey-cli/default.nix
@@ -2,12 +2,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "onlykey-cli";
-  version = "1.2.5";
+  version = "1.2.6";
 
   src = python3Packages.fetchPypi {
     inherit version;
     pname = "onlykey";
-    sha256 = "sha256-7Pr1gXaPF5mctGxDciKKj0YDDQVFFi1+t6QztoKqpAA=";
+    sha256 = "sha256-Uf4FASugl5r5n2G6pZQ8W1PmbON+KombwlIzi00XANc=";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/security/onlykey/node-packages.nix
+++ b/pkgs/tools/security/onlykey/node-packages.nix
@@ -4,31 +4,31 @@
 
 let
   sources = {
-    "@babel/code-frame-7.14.5" = {
+    "@babel/code-frame-7.16.7" = {
       name = "_at_babel_slash_code-frame";
       packageName = "@babel/code-frame";
-      version = "7.14.5";
+      version = "7.16.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz";
-        sha512 = "9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==";
+        url = "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz";
+        sha512 = "iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==";
       };
     };
-    "@babel/helper-validator-identifier-7.14.9" = {
+    "@babel/helper-validator-identifier-7.16.7" = {
       name = "_at_babel_slash_helper-validator-identifier";
       packageName = "@babel/helper-validator-identifier";
-      version = "7.14.9";
+      version = "7.16.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz";
-        sha512 = "pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==";
+        url = "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz";
+        sha512 = "hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==";
       };
     };
-    "@babel/highlight-7.14.5" = {
+    "@babel/highlight-7.16.10" = {
       name = "_at_babel_slash_highlight";
       packageName = "@babel/highlight";
-      version = "7.14.5";
+      version = "7.16.10";
       src = fetchurl {
-        url = "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz";
-        sha512 = "qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==";
+        url = "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz";
+        sha512 = "5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==";
       };
     };
     "@gulp-sourcemaps/identity-map-1.0.2" = {
@@ -157,13 +157,13 @@ let
         sha512 = "1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==";
       };
     };
-    "ansi-regex-5.0.0" = {
+    "ansi-regex-5.0.1" = {
       name = "ansi-regex";
       packageName = "ansi-regex";
-      version = "5.0.0";
+      version = "5.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz";
-        sha512 = "bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==";
+        url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz";
+        sha512 = "quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
       };
     };
     "ansi-styles-2.2.1" = {
@@ -391,13 +391,13 @@ let
         sha1 = "a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428";
       };
     };
-    "asn1-0.2.4" = {
+    "asn1-0.2.6" = {
       name = "asn1";
       packageName = "asn1";
-      version = "0.2.4";
+      version = "0.2.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz";
-        sha512 = "jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==";
+        url = "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz";
+        sha512 = "ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==";
       };
     };
     "assert-plus-1.0.0" = {
@@ -706,15 +706,6 @@ let
         sha512 = "E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==";
       };
     };
-    "buffer-to-vinyl-1.1.0" = {
-      name = "buffer-to-vinyl";
-      packageName = "buffer-to-vinyl";
-      version = "1.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz";
-        sha1 = "00f15faee3ab7a1dda2cde6d9121bffdd07b2262";
-      };
-    };
     "buffers-0.1.1" = {
       name = "buffers";
       packageName = "buffers";
@@ -769,13 +760,13 @@ let
         sha1 = "32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a";
       };
     };
-    "camelcase-6.2.0" = {
+    "camelcase-6.3.0" = {
       name = "camelcase";
       packageName = "camelcase";
-      version = "6.2.0";
+      version = "6.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz";
-        sha512 = "c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==";
+        url = "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz";
+        sha512 = "Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==";
       };
     };
     "capture-stack-trace-1.0.1" = {
@@ -805,13 +796,13 @@ let
         sha512 = "Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==";
       };
     };
-    "chai-4.3.4" = {
+    "chai-4.3.6" = {
       name = "chai";
       packageName = "chai";
-      version = "4.3.4";
+      version = "4.3.6";
       src = fetchurl {
-        url = "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz";
-        sha512 = "yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==";
+        url = "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz";
+        sha512 = "bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==";
       };
     };
     "chai-as-promised-7.1.1" = {
@@ -866,15 +857,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz";
         sha512 = "mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==";
-      };
-    };
-    "charm-0.1.2" = {
-      name = "charm";
-      packageName = "charm";
-      version = "0.1.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz";
-        sha1 = "06c21eed1a1b06aeb67553cdc53e23274bac2296";
       };
     };
     "check-error-1.0.2" = {
@@ -958,24 +940,6 @@ let
         sha512 = "OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==";
       };
     };
-    "clone-0.2.0" = {
-      name = "clone";
-      packageName = "clone";
-      version = "0.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz";
-        sha1 = "c6126a90ad4f72dbf5acdb243cc37724fe93fc1f";
-      };
-    };
-    "clone-1.0.4" = {
-      name = "clone";
-      packageName = "clone";
-      version = "1.0.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz";
-        sha1 = "da309cc263df15994c688ca902179ca3c7cd7c7e";
-      };
-    };
     "clone-2.1.2" = {
       name = "clone";
       packageName = "clone";
@@ -992,15 +956,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz";
         sha1 = "e3e25b207ac4e701af721e2cb5a16792cac3dc58";
-      };
-    };
-    "clone-stats-0.0.1" = {
-      name = "clone-stats";
-      packageName = "clone-stats";
-      version = "0.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz";
-        sha1 = "b88f94a82cf38b8791d58046ea4029ad88ca99d1";
       };
     };
     "clone-stats-1.0.0" = {
@@ -1183,6 +1138,15 @@ let
         sha1 = "b5fd54220aa2bc5ab57aab7140c940754503c1a7";
       };
     };
+    "core-util-is-1.0.3" = {
+      name = "core-util-is";
+      packageName = "core-util-is";
+      version = "1.0.3";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz";
+        sha512 = "ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==";
+      };
+    };
     "create-error-class-3.0.2" = {
       name = "create-error-class";
       packageName = "create-error-class";
@@ -1264,13 +1228,13 @@ let
         sha512 = "doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==";
       };
     };
-    "debug-4.3.2" = {
+    "debug-4.3.3" = {
       name = "debug";
       packageName = "debug";
-      version = "4.3.2";
+      version = "4.3.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz";
-        sha512 = "mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==";
+        url = "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz";
+        sha512 = "/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==";
       };
     };
     "debug-fabulous-1.1.0" = {
@@ -1309,15 +1273,6 @@ let
         sha1 = "eb3913333458775cb84cd1a1fae062106bb87545";
       };
     };
-    "decompress-3.0.0" = {
-      name = "decompress";
-      packageName = "decompress";
-      version = "3.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz";
-        sha1 = "af1dd50d06e3bfc432461d37de11b38c0d991bed";
-      };
-    };
     "decompress-4.2.1" = {
       name = "decompress";
       packageName = "decompress";
@@ -1325,15 +1280,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz";
         sha512 = "e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==";
-      };
-    };
-    "decompress-tar-3.1.0" = {
-      name = "decompress-tar";
-      packageName = "decompress-tar";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz";
-        sha1 = "217c789f9b94450efaadc5c5e537978fc333c466";
       };
     };
     "decompress-tar-4.1.1" = {
@@ -1345,15 +1291,6 @@ let
         sha512 = "JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==";
       };
     };
-    "decompress-tarbz2-3.1.0" = {
-      name = "decompress-tarbz2";
-      packageName = "decompress-tarbz2";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz";
-        sha1 = "8b23935681355f9f189d87256a0f8bdd96d9666d";
-      };
-    };
     "decompress-tarbz2-4.1.1" = {
       name = "decompress-tarbz2";
       packageName = "decompress-tarbz2";
@@ -1363,15 +1300,6 @@ let
         sha512 = "s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==";
       };
     };
-    "decompress-targz-3.1.0" = {
-      name = "decompress-targz";
-      packageName = "decompress-targz";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz";
-        sha1 = "b2c13df98166268991b715d6447f642e9696f5a0";
-      };
-    };
     "decompress-targz-4.1.1" = {
       name = "decompress-targz";
       packageName = "decompress-targz";
@@ -1379,15 +1307,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz";
         sha512 = "4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==";
-      };
-    };
-    "decompress-unzip-3.4.0" = {
-      name = "decompress-unzip";
-      packageName = "decompress-unzip";
-      version = "3.4.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz";
-        sha1 = "61475b4152066bbe3fee12f9d629d15fe6478eeb";
       };
     };
     "decompress-unzip-4.0.1" = {
@@ -1417,13 +1336,13 @@ let
         sha512 = "+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==";
       };
     };
-    "deep-is-0.1.3" = {
+    "deep-is-0.1.4" = {
       name = "deep-is";
       packageName = "deep-is";
-      version = "0.1.3";
+      version = "0.1.4";
       src = fetchurl {
-        url = "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz";
-        sha1 = "b369d6fb5dbc13eecf524f91b070feedc357cf34";
+        url = "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz";
+        sha512 = "oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==";
       };
     };
     "default-compare-1.0.0" = {
@@ -1532,15 +1451,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/download/-/download-5.0.3.tgz";
         sha1 = "63537f977f99266a30eb8a2a2fbd1f20b8000f7a";
-      };
-    };
-    "duplexer2-0.1.4" = {
-      name = "duplexer2";
-      packageName = "duplexer2";
-      version = "0.1.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz";
-        sha1 = "8b12dab878c0d69e3e7891051662a32fc6bddcc1";
       };
     };
     "duplexer3-0.1.4" = {
@@ -1759,13 +1669,13 @@ let
         sha512 = "39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==";
       };
     };
-    "estraverse-5.2.0" = {
+    "estraverse-5.3.0" = {
       name = "estraverse";
       packageName = "estraverse";
-      version = "5.2.0";
+      version = "5.3.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz";
-        sha512 = "BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==";
+        url = "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz";
+        sha512 = "MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==";
       };
     };
     "esutils-2.0.3" = {
@@ -1822,13 +1732,13 @@ let
         sha1 = "97e801aa052df02454de46b02bf621642cdc8502";
       };
     };
-    "ext-1.4.0" = {
+    "ext-1.6.0" = {
       name = "ext";
       packageName = "ext";
-      version = "1.4.0";
+      version = "1.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz";
-        sha512 = "Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==";
+        url = "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz";
+        sha512 = "sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==";
       };
     };
     "extend-3.0.2" = {
@@ -2110,15 +2020,6 @@ let
         sha512 = "ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==";
       };
     };
-    "first-chunk-stream-1.0.0" = {
-      name = "first-chunk-stream";
-      packageName = "first-chunk-stream";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz";
-        sha1 = "59bfb50cd905f60d7c394cd3d9acaab4e6ad934e";
-      };
-    };
     "flagged-respawn-1.0.1" = {
       name = "flagged-respawn";
       packageName = "flagged-respawn";
@@ -2236,13 +2137,13 @@ let
         sha512 = "YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==";
       };
     };
-    "fs-jetpack-4.1.1" = {
+    "fs-jetpack-4.3.1" = {
       name = "fs-jetpack";
       packageName = "fs-jetpack";
-      version = "4.1.1";
+      version = "4.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.1.1.tgz";
-        sha512 = "BSZ+f6VjrMInpA6neNnUhQNFPPdf3M+I8v8M9dBRrbmExd8GNRbTJIq1tjNh86FQ4a+EoMtPcp1oemwY5ghGBw==";
+        url = "https://registry.npmjs.org/fs-jetpack/-/fs-jetpack-4.3.1.tgz";
+        sha512 = "dbeOK84F6BiQzk2yqqCVwCPWTxAvVGJ3fMQc6E2wuEohS28mR6yHngbrKuVCK1KHRx/ccByDylqu4H5PCP2urQ==";
       };
     };
     "fs-mkdirp-stream-1.0.0" = {
@@ -2344,15 +2245,6 @@ let
         sha512 = "zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==";
       };
     };
-    "get-stdin-4.0.1" = {
-      name = "get-stdin";
-      packageName = "get-stdin";
-      version = "4.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz";
-        sha1 = "b968c6b0a04384324902e8bf1a5df32579a450fe";
-      };
-    };
     "get-stream-2.3.1" = {
       name = "get-stream";
       packageName = "get-stream";
@@ -2389,15 +2281,6 @@ let
         sha1 = "5eff8e3e684d569ae4cb2b1282604e8ba62149fa";
       };
     };
-    "glob-5.0.15" = {
-      name = "glob";
-      packageName = "glob";
-      version = "5.0.15";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz";
-        sha1 = "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1";
-      };
-    };
     "glob-7.1.6" = {
       name = "glob";
       packageName = "glob";
@@ -2407,13 +2290,13 @@ let
         sha512 = "LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==";
       };
     };
-    "glob-7.1.7" = {
+    "glob-7.2.0" = {
       name = "glob";
       packageName = "glob";
-      version = "7.1.7";
+      version = "7.2.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz";
-        sha512 = "OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==";
+        url = "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz";
+        sha512 = "lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==";
       };
     };
     "glob-base-0.3.0" = {
@@ -2450,15 +2333,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz";
         sha512 = "AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==";
-      };
-    };
-    "glob-stream-5.3.5" = {
-      name = "glob-stream";
-      packageName = "glob-stream";
-      version = "5.3.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz";
-        sha1 = "a55665a9a8ccdc41915a87c701e32d4e016fad22";
       };
     };
     "glob-stream-6.1.0" = {
@@ -2524,13 +2398,13 @@ let
         sha1 = "240cd05785a9a18e561dc1b44b41c763ef1e8db0";
       };
     };
-    "graceful-fs-4.2.8" = {
+    "graceful-fs-4.2.9" = {
       name = "graceful-fs";
       packageName = "graceful-fs";
-      version = "4.2.8";
+      version = "4.2.9";
       src = fetchurl {
-        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz";
-        sha512 = "qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==";
+        url = "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz";
+        sha512 = "NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==";
       };
     };
     "growl-1.10.5" = {
@@ -2558,15 +2432,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz";
         sha512 = "zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==";
-      };
-    };
-    "gulp-sourcemaps-1.6.0" = {
-      name = "gulp-sourcemaps";
-      packageName = "gulp-sourcemaps";
-      version = "1.6.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz";
-        sha1 = "b86ff349d801ceb56e1d9e7dc7bbcb4b7dee600c";
       };
     };
     "gulp-sourcemaps-2.6.5" = {
@@ -2650,13 +2515,13 @@ let
         sha512 = "3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==";
       };
     };
-    "has-symbols-1.0.2" = {
+    "has-symbols-1.0.3" = {
       name = "has-symbols";
       packageName = "has-symbols";
-      version = "1.0.2";
+      version = "1.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz";
-        sha512 = "chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==";
+        url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz";
+        sha512 = "l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==";
       };
     };
     "has-to-string-tag-x-1.4.1" = {
@@ -2848,15 +2713,6 @@ let
         sha1 = "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6";
       };
     };
-    "is-absolute-0.1.7" = {
-      name = "is-absolute";
-      packageName = "is-absolute";
-      version = "0.1.7";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz";
-        sha1 = "847491119fccb5fb436217cc737f7faad50f603f";
-      };
-    };
     "is-absolute-1.0.0" = {
       name = "is-absolute";
       packageName = "is-absolute";
@@ -2920,22 +2776,13 @@ let
         sha512 = "NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==";
       };
     };
-    "is-bzip2-1.0.0" = {
-      name = "is-bzip2";
-      packageName = "is-bzip2";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz";
-        sha1 = "5ee58eaa5a2e9c80e21407bedf23ae5ac091b3fc";
-      };
-    };
-    "is-core-module-2.6.0" = {
+    "is-core-module-2.8.1" = {
       name = "is-core-module";
       packageName = "is-core-module";
-      version = "2.6.0";
+      version = "2.8.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz";
-        sha512 = "wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==";
+        url = "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz";
+        sha512 = "SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==";
       };
     };
     "is-data-descriptor-0.1.4" = {
@@ -3073,31 +2920,13 @@ let
         sha1 = "7ba5ae24217804ac70707b96922567486cc3e84a";
       };
     };
-    "is-glob-4.0.1" = {
+    "is-glob-4.0.3" = {
       name = "is-glob";
       packageName = "is-glob";
-      version = "4.0.1";
+      version = "4.0.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz";
-        sha512 = "5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==";
-      };
-    };
-    "is-gzip-1.0.0" = {
-      name = "is-gzip";
-      packageName = "is-gzip";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz";
-        sha1 = "6ca8b07b99c77998025900e555ced8ed80879a83";
-      };
-    };
-    "is-natural-number-2.1.1" = {
-      name = "is-natural-number";
-      packageName = "is-natural-number";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz";
-        sha1 = "7d4c5728377ef386c3e194a9911bf57c6dc335e7";
+        url = "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz";
+        sha512 = "xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==";
       };
     };
     "is-natural-number-4.0.1" = {
@@ -3226,15 +3055,6 @@ let
         sha1 = "1d03dded53bd8db0f30c26e4f95d36fc7c87dc24";
       };
     };
-    "is-relative-0.1.3" = {
-      name = "is-relative";
-      packageName = "is-relative";
-      version = "0.1.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz";
-        sha1 = "905fee8ae86f45b3ec614bc3c15c869df0876e82";
-      };
-    };
     "is-relative-1.0.0" = {
       name = "is-relative";
       packageName = "is-relative";
@@ -3260,15 +3080,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz";
         sha1 = "12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44";
-      };
-    };
-    "is-tar-1.0.0" = {
-      name = "is-tar";
-      packageName = "is-tar";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz";
-        sha1 = "2f6b2e1792c1f5bb36519acaa9d65c0d26fe853d";
       };
     };
     "is-typedarray-1.0.0" = {
@@ -3298,15 +3109,6 @@ let
         sha1 = "4b0da1442104d1b336340e80797e865cf39f7d72";
       };
     };
-    "is-valid-glob-0.3.0" = {
-      name = "is-valid-glob";
-      packageName = "is-valid-glob";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz";
-        sha1 = "d4b55c69f51886f9b65c70d6c2622d37e29f48fe";
-      };
-    };
     "is-valid-glob-1.0.0" = {
       name = "is-valid-glob";
       packageName = "is-valid-glob";
@@ -3323,15 +3125,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz";
         sha512 = "eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==";
-      };
-    };
-    "is-zip-1.0.0" = {
-      name = "is-zip";
-      packageName = "is-zip";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz";
-        sha1 = "47b0a8ff4d38a76431ccfd99a8e15a4c86ba2325";
       };
     };
     "isarray-0.0.1" = {
@@ -3397,6 +3190,15 @@ let
         sha512 = "1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==";
       };
     };
+    "js-sha256-0.9.0" = {
+      name = "js-sha256";
+      packageName = "js-sha256";
+      version = "0.9.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz";
+        sha512 = "sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==";
+      };
+    };
     "js-tokens-4.0.0" = {
       name = "js-tokens";
       packageName = "js-tokens";
@@ -3442,13 +3244,13 @@ let
         sha512 = "iK7tAZtpoghibjdB1ncCWykeBMmke3JThUe+rnkD4qkZaglOIQ70Pw7r5UJ4lyUT+7gnw7ehmmLUHDuhqzQD+g==";
       };
     };
-    "json-schema-0.2.3" = {
+    "json-schema-0.4.0" = {
       name = "json-schema";
       packageName = "json-schema";
-      version = "0.2.3";
+      version = "0.4.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz";
-        sha1 = "b480c892e59a2f05954ce727bd3f2a4e882f9e13";
+        url = "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz";
+        sha512 = "es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==";
       };
     };
     "json-schema-traverse-0.4.1" = {
@@ -3487,13 +3289,13 @@ let
         sha1 = "8771aae0799b64076b76640fca058f9c10e33ecb";
       };
     };
-    "jsprim-1.4.1" = {
+    "jsprim-1.4.2" = {
       name = "jsprim";
       packageName = "jsprim";
-      version = "1.4.1";
+      version = "1.4.2";
       src = fetchurl {
-        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz";
-        sha1 = "313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2";
+        url = "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz";
+        sha512 = "P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==";
       };
     };
     "jszip-3.7.1" = {
@@ -3559,13 +3361,13 @@ let
         sha1 = "45b96942c17b1c79c772198259ba943bebf8ca5b";
       };
     };
-    "lazystream-1.0.0" = {
+    "lazystream-1.0.1" = {
       name = "lazystream";
       packageName = "lazystream";
-      version = "1.0.0";
+      version = "1.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz";
-        sha1 = "f6995fe0f820392f61396be89462407bb77168e4";
+        url = "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz";
+        sha512 = "b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==";
       };
     };
     "lcid-1.0.0" = {
@@ -3640,15 +3442,6 @@ let
         sha512 = "v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==";
       };
     };
-    "lodash.isequal-4.5.0" = {
-      name = "lodash.isequal";
-      packageName = "lodash.isequal";
-      version = "4.5.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz";
-        sha1 = "415c4478f2bcc30120c22ce10ed3226f7d3e18e0";
-      };
-    };
     "log-symbols-4.0.0" = {
       name = "log-symbols";
       packageName = "log-symbols";
@@ -3656,6 +3449,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz";
         sha512 = "FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==";
+      };
+    };
+    "loupe-2.3.4" = {
+      name = "loupe";
+      packageName = "loupe";
+      version = "2.3.4";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz";
+        sha512 = "OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==";
       };
     };
     "lowercase-keys-1.0.1" = {
@@ -3748,15 +3550,6 @@ let
         sha512 = "VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==";
       };
     };
-    "merge-stream-1.0.1" = {
-      name = "merge-stream";
-      packageName = "merge-stream";
-      version = "1.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz";
-        sha1 = "4041202d508a342ba00174008df0c251b8c135e1";
-      };
-    };
     "micromatch-2.3.11" = {
       name = "micromatch";
       packageName = "micromatch";
@@ -3775,22 +3568,22 @@ let
         sha512 = "MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==";
       };
     };
-    "mime-db-1.49.0" = {
+    "mime-db-1.51.0" = {
       name = "mime-db";
       packageName = "mime-db";
-      version = "1.49.0";
+      version = "1.51.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz";
-        sha512 = "CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz";
+        sha512 = "5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==";
       };
     };
-    "mime-types-2.1.32" = {
+    "mime-types-2.1.34" = {
       name = "mime-types";
       packageName = "mime-types";
-      version = "2.1.32";
+      version = "2.1.34";
       src = fetchurl {
-        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz";
-        sha512 = "hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz";
+        sha512 = "6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==";
       };
     };
     "mimic-fn-2.1.0" = {
@@ -3809,6 +3602,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz";
         sha512 = "yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==";
+      };
+    };
+    "minimatch-3.1.2" = {
+      name = "minimatch";
+      packageName = "minimatch";
+      version = "3.1.2";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz";
+        sha512 = "J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==";
       };
     };
     "minimist-1.2.5" = {
@@ -3881,15 +3683,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
         sha512 = "6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
-      };
-    };
-    "multimeter-0.1.1" = {
-      name = "multimeter";
-      packageName = "multimeter";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/multimeter/-/multimeter-0.1.1.tgz";
-        sha1 = "f856c80fc3cf0f1d4ad8eb36ad68735e3ed5b3ea";
       };
     };
     "mute-stdout-1.0.1" = {
@@ -4045,13 +3838,13 @@ let
         sha1 = "097b602b53422a522c1afb8790318336941a011d";
       };
     };
-    "nw-0.36.4" = {
+    "nw-0.55.0" = {
       name = "nw";
       packageName = "nw";
-      version = "0.36.4";
+      version = "0.55.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/nw/-/nw-0.36.4.tgz";
-        sha512 = "/8z60bdfI4AeBAWdZxOtvVpdpxUrwcAm+1PxOAmoLnJyKG0aXQYSsX9fZPNcJvubX9hy9GkqFEEd0rXn4n/Ryg==";
+        url = "https://registry.npmjs.org/nw/-/nw-0.55.0.tgz";
+        sha512 = "/EYsT55LJraJCZeSCpJoXnftsLtR+8lbhEXABlhye/n+0//F+v9kYsGLbnC+SS3JN7NQksnv/WcnoLVjL1WXcg==";
       };
     };
     "nw-autoupdater-1.1.11" = {
@@ -4079,15 +3872,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz";
         sha512 = "fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==";
-      };
-    };
-    "object-assign-2.1.1" = {
-      name = "object-assign";
-      packageName = "object-assign";
-      version = "2.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz";
-        sha1 = "43c36e5d569ff8e4816c4efa8be02d26967c18aa";
       };
     };
     "object-assign-4.1.1" = {
@@ -4205,15 +3989,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz";
         sha512 = "+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==";
-      };
-    };
-    "ordered-read-streams-0.3.0" = {
-      name = "ordered-read-streams";
-      packageName = "ordered-read-streams";
-      version = "0.3.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz";
-        sha1 = "7137e69b3298bb342247a1bbee3881c80e2fd78b";
       };
     };
     "ordered-read-streams-1.0.1" = {
@@ -4441,13 +4216,13 @@ let
         sha1 = "6309f4e0e5fa913ec1c69307ae364b4b377c9e7b";
       };
     };
-    "picomatch-2.3.0" = {
+    "picomatch-2.3.1" = {
       name = "picomatch";
       packageName = "picomatch";
-      version = "2.3.0";
+      version = "2.3.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz";
-        sha512 = "lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==";
+        url = "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz";
+        sha512 = "JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==";
       };
     };
     "pify-2.3.0" = {
@@ -4603,13 +4378,13 @@ let
         sha1 = "7e32f75b41381291d04611f1bf14109ac00651d7";
       };
     };
-    "qs-6.5.2" = {
+    "qs-6.5.3" = {
       name = "qs";
       packageName = "qs";
-      version = "6.5.2";
+      version = "6.5.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz";
-        sha512 = "N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==";
+        url = "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz";
+        sha512 = "qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==";
       };
     };
     "randomatic-3.1.1" = {
@@ -4630,15 +4405,6 @@ let
         sha512 = "vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==";
       };
     };
-    "read-all-stream-3.1.0" = {
-      name = "read-all-stream";
-      packageName = "read-all-stream";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz";
-        sha1 = "35c3e177f2078ef789ee4bfafa4373074eaef4fa";
-      };
-    };
     "read-pkg-1.1.0" = {
       name = "read-pkg";
       packageName = "read-pkg";
@@ -4655,15 +4421,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz";
         sha1 = "9d63c13276c065918d57f002a57f40a1b643fb02";
-      };
-    };
-    "readable-stream-1.0.34" = {
-      name = "readable-stream";
-      packageName = "readable-stream";
-      version = "1.0.34";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz";
-        sha1 = "125820e34bc842d2f2aaafafe4c2916ee32c157c";
       };
     };
     "readable-stream-1.1.14" = {
@@ -4783,15 +4540,6 @@ let
         sha1 = "8dcae470e1c88abc2d600fff4a776286da75e637";
       };
     };
-    "replace-ext-0.0.1" = {
-      name = "replace-ext";
-      packageName = "replace-ext";
-      version = "0.0.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz";
-        sha1 = "29bbd92078a739f0bcce2b4ee41e837953522924";
-      };
-    };
     "replace-ext-1.0.1" = {
       name = "replace-ext";
       packageName = "replace-ext";
@@ -4837,13 +4585,13 @@ let
         sha1 = "97f717b69d48784f5f526a6c5aa8ffdda055a4d1";
       };
     };
-    "resolve-1.20.0" = {
+    "resolve-1.22.0" = {
       name = "resolve";
       packageName = "resolve";
-      version = "1.20.0";
+      version = "1.22.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz";
-        sha512 = "wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==";
+        url = "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz";
+        sha512 = "Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==";
       };
     };
     "resolve-dir-1.0.1" = {
@@ -4943,6 +4691,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz";
         sha512 = "Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==";
+      };
+    };
+    "safe-buffer-5.2.1" = {
+      name = "safe-buffer";
+      packageName = "safe-buffer";
+      version = "5.2.1";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz";
+        sha512 = "rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
       };
     };
     "safe-regex-1.1.0" = {
@@ -5071,13 +4828,13 @@ let
         sha1 = "da42f49740c0b42db2ca9728571cb190c98efea3";
       };
     };
-    "signal-exit-3.0.3" = {
+    "signal-exit-3.0.7" = {
       name = "signal-exit";
       packageName = "signal-exit";
-      version = "3.0.3";
+      version = "3.0.7";
       src = fetchurl {
-        url = "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz";
-        sha512 = "VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==";
+        url = "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz";
+        sha512 = "wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==";
       };
     };
     "slice-ansi-2.1.0" = {
@@ -5188,13 +4945,13 @@ let
         sha512 = "cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==";
       };
     };
-    "spdx-license-ids-3.0.10" = {
+    "spdx-license-ids-3.0.11" = {
       name = "spdx-license-ids";
       packageName = "spdx-license-ids";
-      version = "3.0.10";
+      version = "3.0.11";
       src = fetchurl {
-        url = "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz";
-        sha512 = "oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==";
+        url = "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz";
+        sha512 = "Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==";
       };
     };
     "split-string-3.1.0" = {
@@ -5215,13 +4972,13 @@ let
         sha1 = "04e6926f662895354f3dd015203633b857297e2c";
       };
     };
-    "sshpk-1.16.1" = {
+    "sshpk-1.17.0" = {
       name = "sshpk";
       packageName = "sshpk";
-      version = "1.16.1";
+      version = "1.17.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz";
-        sha512 = "HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==";
+        url = "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz";
+        sha512 = "/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==";
       };
     };
     "stack-trace-0.0.10" = {
@@ -5233,15 +4990,6 @@ let
         sha1 = "547c70b347e8d32b4e108ea1a2a159e5fdde19c0";
       };
     };
-    "stat-mode-0.2.2" = {
-      name = "stat-mode";
-      packageName = "stat-mode";
-      version = "0.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz";
-        sha1 = "e6c80b623123d7d80cf132ce538f346289072502";
-      };
-    };
     "static-extend-0.1.2" = {
       name = "static-extend";
       packageName = "static-extend";
@@ -5249,15 +4997,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz";
         sha1 = "60809c39cbff55337226fd5e0b520f341f1fb5c6";
-      };
-    };
-    "stream-combiner2-1.1.1" = {
-      name = "stream-combiner2";
-      packageName = "stream-combiner2";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz";
-        sha1 = "fb4d8a1420ea362764e21ad4780397bebcb41cbe";
       };
     };
     "stream-exhaust-1.0.2" = {
@@ -5296,13 +5035,13 @@ let
         sha512 = "vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==";
       };
     };
-    "string-width-4.2.2" = {
+    "string-width-4.2.3" = {
       name = "string-width";
       packageName = "string-width";
-      version = "4.2.2";
+      version = "4.2.3";
       src = fetchurl {
-        url = "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz";
-        sha512 = "XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==";
+        url = "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz";
+        sha512 = "wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==";
       };
     };
     "string_decoder-0.10.31" = {
@@ -5341,13 +5080,13 @@ let
         sha512 = "DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==";
       };
     };
-    "strip-ansi-6.0.0" = {
+    "strip-ansi-6.0.1" = {
       name = "strip-ansi";
       packageName = "strip-ansi";
-      version = "6.0.0";
+      version = "6.0.1";
       src = fetchurl {
-        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz";
-        sha512 = "AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==";
+        url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz";
+        sha512 = "Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==";
       };
     };
     "strip-bom-2.0.0" = {
@@ -5359,15 +5098,6 @@ let
         sha1 = "6219a85616520491f35788bdbf1447a99c7e6b0e";
       };
     };
-    "strip-bom-stream-1.0.0" = {
-      name = "strip-bom-stream";
-      packageName = "strip-bom-stream";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz";
-        sha1 = "e7144398577d51a6bed0fa1994fa05f43fd988ee";
-      };
-    };
     "strip-bom-string-1.0.0" = {
       name = "strip-bom-string";
       packageName = "strip-bom-string";
@@ -5375,15 +5105,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz";
         sha1 = "e5211e9224369fbb81d633a2f00044dc8cedad92";
-      };
-    };
-    "strip-dirs-1.1.1" = {
-      name = "strip-dirs";
-      packageName = "strip-dirs";
-      version = "1.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz";
-        sha1 = "960bbd1287844f3975a4558aa103a8255e2456a0";
       };
     };
     "strip-dirs-2.1.0" = {
@@ -5411,15 +5132,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz";
         sha512 = "k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==";
-      };
-    };
-    "sum-up-1.0.3" = {
-      name = "sum-up";
-      packageName = "sum-up";
-      version = "1.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz";
-        sha1 = "1c661f667057f63bcb7875aa1438bc162525156e";
       };
     };
     "supports-color-2.0.0" = {
@@ -5456,6 +5168,15 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz";
         sha512 = "MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==";
+      };
+    };
+    "supports-preserve-symlinks-flag-1.0.0" = {
+      name = "supports-preserve-symlinks-flag";
+      packageName = "supports-preserve-symlinks-flag";
+      version = "1.0.0";
+      src = fetchurl {
+        url = "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz";
+        sha512 = "ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==";
       };
     };
     "sver-compat-1.5.0" = {
@@ -5503,15 +5224,6 @@ let
         sha1 = "0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5";
       };
     };
-    "through2-0.6.5" = {
-      name = "through2";
-      packageName = "through2";
-      version = "0.6.5";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz";
-        sha1 = "41ab9c67b29d57209071410e1d7a7a968cd3ad48";
-      };
-    };
     "through2-2.0.5" = {
       name = "through2";
       packageName = "through2";
@@ -5519,15 +5231,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz";
         sha512 = "/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==";
-      };
-    };
-    "through2-filter-2.0.0" = {
-      name = "through2-filter";
-      packageName = "through2-filter";
-      version = "2.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz";
-        sha1 = "60bc55a0dacb76085db1f9dae99ab43f83d622ec";
       };
     };
     "through2-filter-3.0.0" = {
@@ -5582,15 +5285,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz";
         sha512 = "jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==";
-      };
-    };
-    "to-absolute-glob-0.1.1" = {
-      name = "to-absolute-glob";
-      packageName = "to-absolute-glob";
-      version = "0.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz";
-        sha1 = "1cdfa472a9ef50c239ee66999b662ca0eb39937f";
       };
     };
     "to-absolute-glob-2.0.2" = {
@@ -5737,13 +5431,13 @@ let
         sha512 = "+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==";
       };
     };
-    "type-2.5.0" = {
+    "type-2.6.0" = {
       name = "type";
       packageName = "type";
-      version = "2.5.0";
+      version = "2.6.0";
       src = fetchurl {
-        url = "https://registry.npmjs.org/type/-/type-2.5.0.tgz";
-        sha512 = "180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==";
+        url = "https://registry.npmjs.org/type/-/type-2.6.0.tgz";
+        sha512 = "eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==";
       };
     };
     "type-check-0.3.2" = {
@@ -5944,15 +5638,6 @@ let
         sha1 = "450d4dc9fa70de732762fbd2d4a28981419a0ccf";
       };
     };
-    "uuid-2.0.3" = {
-      name = "uuid";
-      packageName = "uuid";
-      version = "2.0.3";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz";
-        sha1 = "67e2e863797215530dff318e5bf9dcebfd47b21a";
-      };
-    };
     "uuid-3.4.0" = {
       name = "uuid";
       packageName = "uuid";
@@ -5978,15 +5663,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz";
         sha512 = "mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==";
-      };
-    };
-    "vali-date-1.0.0" = {
-      name = "vali-date";
-      packageName = "vali-date";
-      version = "1.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz";
-        sha1 = "1b904a59609fb328ef078138420934f6b86709a6";
       };
     };
     "validate-npm-package-license-3.0.4" = {
@@ -6016,24 +5692,6 @@ let
         sha1 = "3a105ca17053af55d6e270c1f8288682e18da400";
       };
     };
-    "vinyl-0.4.6" = {
-      name = "vinyl";
-      packageName = "vinyl";
-      version = "0.4.6";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz";
-        sha1 = "2f356c87a550a255461f36bbeb2a5ba8bf784847";
-      };
-    };
-    "vinyl-1.2.0" = {
-      name = "vinyl";
-      packageName = "vinyl";
-      version = "1.2.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz";
-        sha1 = "5c88036cf565e5df05558bfc911f8656df218884";
-      };
-    };
     "vinyl-2.2.1" = {
       name = "vinyl";
       packageName = "vinyl";
@@ -6041,24 +5699,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz";
         sha512 = "LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==";
-      };
-    };
-    "vinyl-assign-1.2.1" = {
-      name = "vinyl-assign";
-      packageName = "vinyl-assign";
-      version = "1.2.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz";
-        sha1 = "4d198891b5515911d771a8cd9c5480a46a074a45";
-      };
-    };
-    "vinyl-fs-2.4.4" = {
-      name = "vinyl-fs";
-      packageName = "vinyl-fs";
-      version = "2.4.4";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz";
-        sha1 = "be6ff3270cb55dfd7d3063640de81f25d7532239";
       };
     };
     "vinyl-fs-3.0.3" = {
@@ -6316,19 +5956,19 @@ let
   };
 in
 {
-  "onlykey-git://github.com/trustcrypto/OnlyKey-App.git#v5.3.3" = nodeEnv.buildNodePackage {
+  "onlykey-git://github.com/trustcrypto/OnlyKey-App.git#v5.3.4" = nodeEnv.buildNodePackage {
     name = "OnlyKey";
     packageName = "OnlyKey";
-    version = "5.3.3";
+    version = "5.3.4";
     src = fetchgit {
       url = "git://github.com/trustcrypto/OnlyKey-App.git";
-      rev = "0bd08ef5828d9493cd4c5f4909e9a4fc4c59a494";
-      sha256 = "d2386369fd9d9b7d5ea5d389434848c33fa34e26d713d439e8e2f2e447237bb0";
+      rev = "da67e5088514c919a3a0a885ed68ca19a904da13";
+      sha256 = "9e3f434932483a8709227ce6b51a746f38a647b53ef6b1ee5b85b68855c412a7";
     };
     dependencies = [
-      sources."@babel/code-frame-7.14.5"
-      sources."@babel/helper-validator-identifier-7.14.9"
-      (sources."@babel/highlight-7.14.5" // {
+      sources."@babel/code-frame-7.16.7"
+      sources."@babel/helper-validator-identifier-7.16.7"
+      (sources."@babel/highlight-7.16.10" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
           sources."chalk-2.4.2"
@@ -6338,13 +5978,13 @@ in
       (sources."@gulp-sourcemaps/identity-map-1.0.2" // {
         dependencies = [
           sources."acorn-5.7.4"
+          sources."normalize-path-2.1.1"
           sources."source-map-0.6.1"
-          sources."through2-2.0.5"
         ];
       })
       (sources."@gulp-sourcemaps/map-sources-1.0.0" // {
         dependencies = [
-          sources."through2-2.0.5"
+          sources."normalize-path-2.1.1"
         ];
       })
       sources."@ungap/promise-all-settled-1.1.2"
@@ -6364,66 +6004,14 @@ in
       sources."ansi-wrap-0.1.0"
       (sources."anymatch-2.0.0" // {
         dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          (sources."braces-2.3.2" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          sources."debug-2.6.9"
-          (sources."expand-brackets-2.1.4" // {
-            dependencies = [
-              sources."define-property-0.2.5"
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          sources."extend-shallow-3.0.2"
-          (sources."extglob-2.0.4" // {
-            dependencies = [
-              sources."define-property-1.0.0"
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          (sources."fill-range-4.0.0" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."is-extendable-1.0.1"
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."isobject-3.0.1"
-          sources."kind-of-6.0.3"
-          sources."micromatch-3.1.10"
-          sources."ms-2.0.0"
+          sources."normalize-path-2.1.1"
         ];
       })
       sources."append-buffer-1.0.2"
       sources."applescript-1.0.0"
       sources."archy-1.0.0"
       sources."argparse-1.0.10"
-      sources."arr-diff-2.0.0"
+      sources."arr-diff-4.0.0"
       sources."arr-filter-1.1.2"
       sources."arr-flatten-1.1.0"
       sources."arr-map-2.0.2"
@@ -6445,8 +6033,8 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."array-unique-0.2.1"
-      sources."asn1-0.2.4"
+      sources."array-unique-0.3.2"
+      sources."asn1-0.2.6"
       sources."assert-plus-1.0.0"
       sources."assertion-error-1.1.0"
       sources."assign-symbols-1.0.0"
@@ -6464,7 +6052,6 @@ in
       (sources."base-0.11.2" // {
         dependencies = [
           sources."define-property-1.0.0"
-          sources."isobject-3.0.1"
         ];
       })
       sources."base64-js-1.5.1"
@@ -6474,7 +6061,11 @@ in
       sources."bindings-1.5.0"
       sources."bl-1.2.3"
       sources."brace-expansion-1.1.11"
-      sources."braces-1.8.5"
+      (sources."braces-2.3.2" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
       sources."browser-stdout-1.3.1"
       sources."buffer-5.7.1"
       sources."buffer-alloc-1.2.0"
@@ -6483,35 +6074,27 @@ in
       sources."buffer-equal-1.0.0"
       sources."buffer-fill-1.0.0"
       sources."buffer-from-1.1.2"
-      sources."buffer-to-vinyl-1.1.0"
       sources."buffers-0.1.1"
-      (sources."cache-base-1.0.1" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."cache-base-1.0.1"
       sources."call-bind-1.0.2"
       sources."callsites-3.1.0"
       sources."camelcase-2.1.1"
       sources."capture-stack-trace-1.0.1"
       sources."caseless-0.12.0"
       sources."caw-2.0.1"
-      sources."chai-4.3.4"
+      sources."chai-4.3.6"
       sources."chai-as-promised-7.1.1"
       sources."chainsaw-0.1.0"
       sources."chalk-1.1.3"
       sources."chardet-0.7.0"
-      sources."charm-0.1.2"
       sources."check-error-1.0.2"
       (sources."chokidar-2.1.8" // {
         dependencies = [
-          sources."array-unique-0.3.2"
-          sources."braces-2.3.2"
-          sources."fill-range-4.0.0"
-          sources."is-glob-4.0.1"
-          sources."is-number-3.0.0"
-          sources."isobject-3.0.1"
-          sources."normalize-path-3.0.0"
+          (sources."glob-parent-3.1.0" // {
+            dependencies = [
+              sources."is-glob-3.1.0"
+            ];
+          })
         ];
       })
       (sources."class-utils-0.3.6" // {
@@ -6528,23 +6111,18 @@ in
             ];
           })
           sources."is-descriptor-0.1.6"
-          sources."isobject-3.0.1"
           sources."kind-of-5.1.0"
         ];
       })
       sources."cli-cursor-3.1.0"
       sources."cli-width-3.0.0"
       sources."cliui-3.2.0"
-      sources."clone-1.0.4"
+      sources."clone-2.1.2"
       sources."clone-buffer-1.0.0"
-      sources."clone-stats-0.0.1"
+      sources."clone-stats-1.0.0"
       sources."cloneable-readable-1.1.3"
       sources."code-point-at-1.1.0"
-      (sources."collection-map-1.0.0" // {
-        dependencies = [
-          sources."for-own-1.0.0"
-        ];
-      })
+      sources."collection-map-1.0.0"
       sources."collection-visit-1.0.0"
       sources."color-convert-1.9.3"
       sources."color-name-1.1.3"
@@ -6555,14 +6133,18 @@ in
       sources."concat-map-0.0.1"
       sources."concat-stream-1.6.2"
       sources."config-chain-1.1.13"
-      sources."convert-source-map-1.8.0"
+      (sources."convert-source-map-1.8.0" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."copy-descriptor-0.1.1"
       (sources."copy-props-2.0.5" // {
         dependencies = [
           sources."is-plain-object-5.0.0"
         ];
       })
-      sources."core-util-is-1.0.2"
+      sources."core-util-is-1.0.3"
       sources."create-error-class-3.0.2"
       sources."cross-spawn-6.0.5"
       (sources."css-2.2.4" // {
@@ -6573,37 +6155,25 @@ in
       sources."d-1.0.1"
       sources."dashdash-1.14.1"
       sources."debounce-1.2.1"
-      sources."debug-4.3.2"
+      sources."debug-4.3.3"
       (sources."debug-fabulous-1.1.0" // {
         dependencies = [
           sources."debug-3.2.7"
-          sources."object-assign-4.1.1"
         ];
       })
       sources."decamelize-1.2.0"
       sources."decode-uri-component-0.2.0"
-      sources."decompress-3.0.0"
-      (sources."decompress-tar-3.1.0" // {
+      sources."decompress-4.2.1"
+      sources."decompress-tar-4.1.1"
+      (sources."decompress-tarbz2-4.1.1" // {
         dependencies = [
-          sources."clone-0.2.0"
-          sources."vinyl-0.4.6"
+          sources."file-type-6.2.0"
         ];
       })
-      (sources."decompress-tarbz2-3.1.0" // {
+      sources."decompress-targz-4.1.1"
+      (sources."decompress-unzip-4.0.1" // {
         dependencies = [
-          sources."clone-0.2.0"
-          sources."vinyl-0.4.6"
-        ];
-      })
-      (sources."decompress-targz-3.1.0" // {
-        dependencies = [
-          sources."clone-0.2.0"
-          sources."vinyl-0.4.6"
-        ];
-      })
-      (sources."decompress-unzip-3.4.0" // {
-        dependencies = [
-          sources."through2-2.0.5"
+          sources."file-type-3.9.0"
         ];
       })
       (sources."decompress-zip-0.3.3" // {
@@ -6614,7 +6184,7 @@ in
         ];
       })
       sources."deep-eql-3.0.1"
-      sources."deep-is-0.1.3"
+      sources."deep-is-0.1.4"
       (sources."default-compare-1.0.0" // {
         dependencies = [
           sources."kind-of-5.1.0"
@@ -6622,11 +6192,7 @@ in
       })
       sources."default-resolution-2.0.0"
       sources."define-properties-1.1.3"
-      (sources."define-property-2.0.2" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."define-property-2.0.2"
       sources."delayed-stream-1.0.0"
       sources."detect-file-1.0.0"
       sources."detect-newline-2.1.0"
@@ -6634,27 +6200,9 @@ in
       sources."doctrine-3.0.0"
       (sources."download-5.0.3" // {
         dependencies = [
-          sources."decompress-4.2.1"
-          sources."decompress-tar-4.1.1"
-          (sources."decompress-tarbz2-4.1.1" // {
-            dependencies = [
-              sources."file-type-6.2.0"
-            ];
-          })
-          sources."decompress-targz-4.1.1"
-          (sources."decompress-unzip-4.0.1" // {
-            dependencies = [
-              sources."file-type-3.9.0"
-              sources."get-stream-2.3.1"
-            ];
-          })
-          sources."file-type-5.2.0"
-          sources."is-natural-number-4.0.1"
-          sources."object-assign-4.1.1"
-          sources."strip-dirs-2.1.0"
+          sources."get-stream-3.0.0"
         ];
       })
-      sources."duplexer2-0.1.4"
       sources."duplexer3-0.1.4"
       sources."duplexify-3.7.1"
       sources."each-props-1.3.2"
@@ -6673,8 +6221,6 @@ in
           sources."ansi-regex-4.1.0"
           sources."ansi-styles-3.2.1"
           sources."chalk-2.4.2"
-          sources."glob-parent-5.1.2"
-          sources."is-glob-4.0.1"
           sources."semver-6.3.0"
           sources."strip-ansi-5.2.0"
           sources."supports-color-5.5.0"
@@ -6687,31 +6233,62 @@ in
       sources."esprima-4.0.1"
       (sources."esquery-1.4.0" // {
         dependencies = [
-          sources."estraverse-5.2.0"
+          sources."estraverse-5.3.0"
         ];
       })
       (sources."esrecurse-4.3.0" // {
         dependencies = [
-          sources."estraverse-5.2.0"
+          sources."estraverse-5.3.0"
         ];
       })
       sources."estraverse-4.3.0"
       sources."esutils-2.0.3"
       sources."event-emitter-0.3.5"
-      sources."expand-brackets-0.1.5"
-      sources."expand-range-1.8.2"
-      sources."expand-tilde-2.0.2"
-      (sources."ext-1.4.0" // {
+      (sources."expand-brackets-2.1.4" // {
         dependencies = [
-          sources."type-2.5.0"
+          sources."debug-2.6.9"
+          sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
+          (sources."is-accessor-descriptor-0.1.6" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          (sources."is-data-descriptor-0.1.4" // {
+            dependencies = [
+              sources."kind-of-3.2.2"
+            ];
+          })
+          sources."is-descriptor-0.1.6"
+          sources."kind-of-5.1.0"
+          sources."ms-2.0.0"
+        ];
+      })
+      (sources."expand-range-1.8.2" // {
+        dependencies = [
+          sources."fill-range-2.2.4"
+          sources."is-number-2.1.0"
+          sources."isobject-2.1.0"
+          sources."kind-of-3.2.2"
+        ];
+      })
+      sources."expand-tilde-2.0.2"
+      (sources."ext-1.6.0" // {
+        dependencies = [
+          sources."type-2.6.0"
         ];
       })
       sources."extend-3.0.2"
-      sources."extend-shallow-2.0.1"
-      sources."external-editor-3.1.0"
-      (sources."extglob-0.3.2" // {
+      (sources."extend-shallow-3.0.2" // {
         dependencies = [
-          sources."is-extglob-1.0.0"
+          sources."is-extendable-1.0.1"
+        ];
+      })
+      sources."external-editor-3.1.0"
+      (sources."extglob-2.0.4" // {
+        dependencies = [
+          sources."define-property-1.0.0"
+          sources."extend-shallow-2.0.1"
         ];
       })
       sources."extsprintf-1.3.0"
@@ -6723,96 +6300,37 @@ in
       sources."figures-3.2.0"
       sources."file-entry-cache-5.0.1"
       sources."file-exists-2.0.0"
-      sources."file-type-3.9.0"
+      sources."file-type-5.2.0"
       sources."file-uri-to-path-1.0.0"
       sources."filename-regex-2.0.1"
       sources."filename-reserved-regex-2.0.0"
       sources."filenamify-2.1.0"
-      sources."fill-range-2.2.4"
-      sources."find-up-1.1.2"
-      (sources."findup-sync-3.0.0" // {
+      (sources."fill-range-4.0.0" // {
         dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          (sources."braces-2.3.2" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          sources."debug-2.6.9"
-          sources."define-property-1.0.0"
-          (sources."expand-brackets-2.1.4" // {
-            dependencies = [
-              sources."define-property-0.2.5"
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          sources."extend-shallow-3.0.2"
-          (sources."extglob-2.0.4" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          (sources."fill-range-4.0.0" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."is-extendable-1.0.1"
-          sources."is-glob-4.0.1"
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."isobject-3.0.1"
-          sources."kind-of-6.0.3"
-          sources."micromatch-3.1.10"
-          sources."ms-2.0.0"
+          sources."extend-shallow-2.0.1"
         ];
       })
+      sources."find-up-1.1.2"
+      sources."findup-sync-3.0.0"
       sources."fined-1.2.0"
-      sources."first-chunk-stream-1.0.0"
       sources."flagged-respawn-1.0.1"
       sources."flat-5.0.2"
       (sources."flat-cache-2.0.1" // {
         dependencies = [
-          sources."glob-7.1.7"
           sources."rimraf-2.6.3"
         ];
       })
       sources."flatted-2.0.2"
       sources."flush-write-stream-1.1.1"
       sources."for-in-1.0.2"
-      sources."for-own-0.1.5"
+      sources."for-own-1.0.0"
       sources."forever-agent-0.6.1"
       sources."form-data-2.3.3"
       sources."fragment-cache-0.2.1"
       sources."fs-constants-1.0.0"
       sources."fs-extra-7.0.1"
-      sources."fs-jetpack-4.1.1"
-      (sources."fs-mkdirp-stream-1.0.0" // {
-        dependencies = [
-          sources."through2-2.0.5"
-        ];
-      })
+      sources."fs-jetpack-4.3.1"
+      sources."fs-mkdirp-stream-1.0.0"
       sources."fs.realpath-1.0.0"
       sources."fsevents-1.2.13"
       sources."function-bind-1.1.1"
@@ -6821,11 +6339,10 @@ in
       sources."get-func-name-2.0.0"
       sources."get-intrinsic-1.1.1"
       sources."get-proxy-2.1.0"
-      sources."get-stdin-4.0.1"
-      sources."get-stream-3.0.0"
+      sources."get-stream-2.3.1"
       sources."get-value-2.0.6"
       sources."getpass-0.1.7"
-      sources."glob-5.0.15"
+      sources."glob-7.2.0"
       (sources."glob-base-0.3.0" // {
         dependencies = [
           sources."glob-parent-2.0.0"
@@ -6833,41 +6350,29 @@ in
           sources."is-glob-2.0.1"
         ];
       })
-      sources."glob-parent-3.1.0"
-      sources."glob-stream-5.3.5"
-      (sources."glob-watcher-5.0.5" // {
+      sources."glob-parent-5.1.2"
+      (sources."glob-stream-6.1.0" // {
         dependencies = [
-          sources."normalize-path-3.0.0"
+          sources."glob-parent-3.1.0"
+          sources."is-glob-3.1.0"
         ];
       })
+      sources."glob-watcher-5.0.5"
       sources."global-modules-1.0.0"
       sources."global-prefix-1.0.2"
       sources."globals-12.4.0"
       sources."glogg-1.0.2"
-      sources."got-6.7.1"
-      sources."graceful-fs-4.2.8"
-      sources."growl-1.10.5"
-      (sources."gulp-4.0.2" // {
+      (sources."got-6.7.1" // {
         dependencies = [
-          sources."clone-2.1.2"
-          sources."clone-stats-1.0.0"
-          sources."glob-7.1.7"
-          sources."glob-stream-6.1.0"
-          sources."is-absolute-1.0.0"
-          sources."is-relative-1.0.0"
-          sources."is-valid-glob-1.0.0"
-          sources."ordered-read-streams-1.0.1"
-          sources."replace-ext-1.0.1"
-          sources."through2-2.0.5"
-          sources."to-absolute-glob-2.0.2"
-          sources."vinyl-2.2.1"
-          sources."vinyl-fs-3.0.3"
+          sources."get-stream-3.0.0"
         ];
       })
+      sources."graceful-fs-4.2.9"
+      sources."growl-1.10.5"
+      sources."gulp-4.0.2"
       (sources."gulp-cli-2.3.0" // {
         dependencies = [
           sources."camelcase-3.0.0"
-          sources."isobject-3.0.1"
           sources."yargs-7.1.2"
         ];
       })
@@ -6875,7 +6380,6 @@ in
         dependencies = [
           sources."acorn-5.7.4"
           sources."source-map-0.6.1"
-          sources."through2-2.0.5"
         ];
       })
       sources."gulplog-1.0.0"
@@ -6885,20 +6389,11 @@ in
       sources."has-ansi-2.0.0"
       sources."has-flag-3.0.0"
       sources."has-symbol-support-x-1.4.2"
-      sources."has-symbols-1.0.2"
+      sources."has-symbols-1.0.3"
       sources."has-to-string-tag-x-1.4.1"
-      (sources."has-value-1.0.0" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."has-value-1.0.0"
       (sources."has-values-1.0.0" // {
         dependencies = [
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
           sources."kind-of-4.0.0"
         ];
       })
@@ -6917,92 +6412,77 @@ in
       sources."ini-1.3.8"
       (sources."inquirer-7.3.3" // {
         dependencies = [
-          sources."ansi-regex-5.0.0"
+          sources."ansi-regex-5.0.1"
           sources."ansi-styles-4.3.0"
           sources."chalk-4.1.2"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."has-flag-4.0.0"
           sources."is-fullwidth-code-point-3.0.0"
-          sources."string-width-4.2.2"
-          sources."strip-ansi-6.0.0"
+          sources."string-width-4.2.3"
+          sources."strip-ansi-6.0.1"
           sources."supports-color-7.2.0"
         ];
       })
       sources."interpret-1.4.0"
       sources."invert-kv-1.0.0"
-      sources."is-absolute-0.1.7"
-      (sources."is-accessor-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.3"
-        ];
-      })
+      sources."is-absolute-1.0.0"
+      sources."is-accessor-descriptor-1.0.0"
       sources."is-arrayish-0.2.1"
       sources."is-binary-path-1.0.1"
       sources."is-buffer-1.1.6"
-      sources."is-bzip2-1.0.0"
-      sources."is-core-module-2.6.0"
-      (sources."is-data-descriptor-1.0.0" // {
-        dependencies = [
-          sources."kind-of-6.0.3"
-        ];
-      })
-      (sources."is-descriptor-1.0.2" // {
-        dependencies = [
-          sources."kind-of-6.0.3"
-        ];
-      })
+      sources."is-core-module-2.8.1"
+      sources."is-data-descriptor-1.0.0"
+      sources."is-descriptor-1.0.2"
       sources."is-dotfile-1.0.3"
       sources."is-equal-shallow-0.1.3"
       sources."is-extendable-0.1.1"
       sources."is-extglob-2.1.1"
       sources."is-fullwidth-code-point-1.0.0"
-      sources."is-glob-3.1.0"
-      sources."is-gzip-1.0.0"
-      sources."is-natural-number-2.1.1"
+      sources."is-glob-4.0.3"
+      sources."is-natural-number-4.0.1"
       sources."is-negated-glob-1.0.0"
-      sources."is-number-2.1.0"
-      sources."is-object-1.0.2"
-      sources."is-plain-obj-2.1.0"
-      (sources."is-plain-object-2.0.4" // {
+      (sources."is-number-3.0.0" // {
         dependencies = [
-          sources."isobject-3.0.1"
+          sources."kind-of-3.2.2"
         ];
       })
+      sources."is-object-1.0.2"
+      sources."is-plain-obj-2.1.0"
+      sources."is-plain-object-2.0.4"
       sources."is-posix-bracket-0.1.1"
       sources."is-primitive-2.0.0"
       sources."is-promise-2.2.2"
       sources."is-redirect-1.0.0"
-      sources."is-relative-0.1.3"
+      sources."is-relative-1.0.0"
       sources."is-retry-allowed-1.2.0"
       sources."is-stream-1.1.0"
-      sources."is-tar-1.0.0"
       sources."is-typedarray-1.0.0"
       sources."is-unc-path-1.0.0"
       sources."is-utf8-0.2.1"
-      sources."is-valid-glob-0.3.0"
+      sources."is-valid-glob-1.0.0"
       sources."is-windows-1.0.2"
-      sources."is-zip-1.0.0"
       sources."isarray-1.0.0"
       sources."isexe-2.0.0"
-      sources."isobject-2.1.0"
+      sources."isobject-3.0.1"
       sources."isstream-0.1.2"
       sources."isurl-1.0.0"
+      sources."js-sha256-0.9.0"
       sources."js-tokens-4.0.0"
       sources."js-yaml-3.14.1"
       sources."jsbn-0.1.1"
       sources."json-10.0.0"
-      sources."json-schema-0.2.3"
+      sources."json-schema-0.4.0"
       sources."json-schema-traverse-0.4.1"
       sources."json-stable-stringify-without-jsonify-1.0.1"
       sources."json-stringify-safe-5.0.1"
       sources."jsonfile-4.0.0"
-      sources."jsprim-1.4.1"
+      sources."jsprim-1.4.2"
       sources."jszip-3.7.1"
       sources."just-debounce-1.1.0"
-      sources."kind-of-3.2.2"
+      sources."kind-of-6.0.3"
       sources."last-run-1.1.1"
-      sources."lazystream-1.0.0"
+      sources."lazystream-1.0.1"
       sources."lcid-1.0.0"
       sources."lead-1.0.0"
       sources."levn-0.3.0"
@@ -7011,7 +6491,6 @@ in
       sources."load-json-file-1.1.0"
       sources."locate-path-6.0.0"
       sources."lodash-4.17.21"
-      sources."lodash.isequal-4.5.0"
       (sources."log-symbols-4.0.0" // {
         dependencies = [
           sources."ansi-styles-4.3.0"
@@ -7022,6 +6501,7 @@ in
           sources."supports-color-7.2.0"
         ];
       })
+      sources."loupe-2.3.4"
       sources."lowercase-keys-1.0.1"
       sources."lru-queue-0.1.0"
       (sources."make-dir-1.3.0" // {
@@ -7029,69 +6509,13 @@ in
           sources."pify-3.0.0"
         ];
       })
-      (sources."make-iterator-1.0.1" // {
-        dependencies = [
-          sources."kind-of-6.0.3"
-        ];
-      })
+      sources."make-iterator-1.0.1"
       sources."map-cache-0.2.2"
       sources."map-visit-1.0.0"
       (sources."matchdep-2.0.0" // {
         dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          (sources."braces-2.3.2" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          sources."debug-2.6.9"
-          sources."define-property-1.0.0"
-          (sources."expand-brackets-2.1.4" // {
-            dependencies = [
-              sources."define-property-0.2.5"
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          sources."extend-shallow-3.0.2"
-          (sources."extglob-2.0.4" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          (sources."fill-range-4.0.0" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
           sources."findup-sync-2.0.0"
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."is-extendable-1.0.1"
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."isobject-3.0.1"
-          sources."kind-of-6.0.3"
-          sources."micromatch-3.1.10"
-          sources."ms-2.0.0"
+          sources."is-glob-3.1.0"
         ];
       })
       sources."math-random-1.0.4"
@@ -7101,17 +6525,11 @@ in
         ];
       })
       sources."merge-1.2.1"
-      sources."merge-stream-1.0.1"
-      (sources."micromatch-2.3.11" // {
-        dependencies = [
-          sources."is-extglob-1.0.0"
-          sources."is-glob-2.0.1"
-        ];
-      })
-      sources."mime-db-1.49.0"
-      sources."mime-types-2.1.32"
+      sources."micromatch-3.1.10"
+      sources."mime-db-1.51.0"
+      sources."mime-types-2.1.34"
       sources."mimic-fn-2.1.0"
-      sources."minimatch-3.0.4"
+      sources."minimatch-3.1.2"
       sources."minimist-1.2.5"
       (sources."mixin-deep-1.3.2" // {
         dependencies = [
@@ -7138,14 +6556,12 @@ in
           sources."find-up-5.0.0"
           sources."fsevents-2.3.2"
           sources."glob-7.1.6"
-          sources."glob-parent-5.1.2"
           sources."has-flag-4.0.0"
           sources."is-binary-path-2.1.0"
-          sources."is-glob-4.0.1"
           sources."is-number-7.0.0"
           sources."js-yaml-4.0.0"
+          sources."minimatch-3.0.4"
           sources."ms-2.1.3"
-          sources."normalize-path-3.0.0"
           sources."path-exists-4.0.0"
           sources."readdirp-3.5.0"
           sources."supports-color-8.1.1"
@@ -7155,26 +6571,17 @@ in
         ];
       })
       sources."ms-2.1.2"
-      sources."multimeter-0.1.1"
       sources."mute-stdout-1.0.1"
       sources."mute-stream-0.0.8"
       sources."nan-2.15.0"
       sources."nanoid-3.1.20"
-      (sources."nanomatch-1.2.13" // {
-        dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          sources."extend-shallow-3.0.2"
-          sources."is-extendable-1.0.1"
-          sources."kind-of-6.0.3"
-        ];
-      })
+      sources."nanomatch-1.2.13"
       sources."natural-compare-1.4.0"
       sources."next-tick-1.0.0"
       sources."nice-try-1.0.5"
       sources."nopt-3.0.6"
       sources."normalize-package-data-2.5.0"
-      sources."normalize-path-2.1.1"
+      sources."normalize-path-3.0.0"
       sources."now-and-later-2.0.1"
       (sources."npm-conf-1.1.3" // {
         dependencies = [
@@ -7182,44 +6589,31 @@ in
         ];
       })
       sources."number-is-nan-1.0.1"
-      (sources."nw-0.36.4" // {
+      (sources."nw-0.55.0" // {
         dependencies = [
           sources."yargs-3.32.0"
         ];
       })
-      (sources."nw-autoupdater-1.1.11" // {
-        dependencies = [
-          sources."decompress-4.2.1"
-          sources."decompress-tar-4.1.1"
-          (sources."decompress-tarbz2-4.1.1" // {
-            dependencies = [
-              sources."file-type-6.2.0"
-            ];
-          })
-          sources."decompress-targz-4.1.1"
-          (sources."decompress-unzip-4.0.1" // {
-            dependencies = [
-              sources."file-type-3.9.0"
-            ];
-          })
-          sources."file-type-5.2.0"
-          sources."get-stream-2.3.1"
-          sources."is-natural-number-4.0.1"
-          sources."object-assign-4.1.1"
-          sources."strip-dirs-2.1.0"
-        ];
-      })
+      sources."nw-autoupdater-1.1.11"
       (sources."nw-dev-3.0.1" // {
         dependencies = [
           sources."anymatch-1.3.2"
+          sources."arr-diff-2.0.0"
+          sources."array-unique-0.2.1"
+          sources."braces-1.8.5"
           sources."chokidar-1.7.0"
+          sources."expand-brackets-0.1.5"
+          sources."extglob-0.3.2"
           sources."glob-parent-2.0.0"
           sources."is-extglob-1.0.0"
           sources."is-glob-2.0.1"
+          sources."kind-of-3.2.2"
+          sources."micromatch-2.3.11"
+          sources."normalize-path-2.1.1"
         ];
       })
       sources."oauth-sign-0.9.0"
-      sources."object-assign-2.1.1"
+      sources."object-assign-4.1.1"
       (sources."object-copy-0.1.0" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -7230,53 +6624,32 @@ in
               sources."kind-of-5.1.0"
             ];
           })
+          sources."kind-of-3.2.2"
         ];
       })
       sources."object-keys-1.1.1"
-      (sources."object-visit-1.0.1" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
+      sources."object-visit-1.0.1"
       sources."object.assign-4.1.2"
-      (sources."object.defaults-1.1.0" // {
+      sources."object.defaults-1.1.0"
+      sources."object.map-1.0.1"
+      (sources."object.omit-2.0.1" // {
         dependencies = [
-          sources."for-own-1.0.0"
-          sources."isobject-3.0.1"
+          sources."for-own-0.1.5"
         ];
       })
-      (sources."object.map-1.0.1" // {
-        dependencies = [
-          sources."for-own-1.0.0"
-        ];
-      })
-      sources."object.omit-2.0.1"
-      (sources."object.pick-1.3.0" // {
-        dependencies = [
-          sources."isobject-3.0.1"
-        ];
-      })
-      (sources."object.reduce-1.0.1" // {
-        dependencies = [
-          sources."for-own-1.0.0"
-        ];
-      })
+      sources."object.pick-1.3.0"
+      sources."object.reduce-1.0.1"
       sources."once-1.4.0"
       sources."onetime-5.1.2"
       sources."optionator-0.8.3"
-      sources."ordered-read-streams-0.3.0"
+      sources."ordered-read-streams-1.0.1"
       sources."os-locale-1.4.0"
       sources."os-tmpdir-1.0.2"
       sources."p-limit-3.1.0"
       sources."p-locate-5.0.0"
       sources."pako-1.0.11"
       sources."parent-module-1.0.1"
-      (sources."parse-filepath-1.0.2" // {
-        dependencies = [
-          sources."is-absolute-1.0.0"
-          sources."is-relative-1.0.0"
-        ];
-      })
+      sources."parse-filepath-1.0.2"
       (sources."parse-glob-3.0.4" // {
         dependencies = [
           sources."is-extglob-1.0.0"
@@ -7298,7 +6671,7 @@ in
       sources."pathval-1.1.1"
       sources."pend-1.2.0"
       sources."performance-now-2.1.0"
-      sources."picomatch-2.3.0"
+      sources."picomatch-2.3.1"
       sources."pify-2.3.0"
       sources."pinkie-2.0.4"
       sources."pinkie-promise-2.0.1"
@@ -7315,122 +6688,46 @@ in
       sources."pumpify-1.5.1"
       sources."punycode-2.1.1"
       sources."q-1.5.1"
-      sources."qs-6.5.2"
+      sources."qs-6.5.3"
       (sources."randomatic-3.1.1" // {
         dependencies = [
           sources."is-number-4.0.0"
-          sources."kind-of-6.0.3"
         ];
       })
       sources."randombytes-2.1.0"
-      sources."read-all-stream-3.1.0"
       sources."read-pkg-1.1.0"
       sources."read-pkg-up-1.0.1"
-      sources."readable-stream-2.3.7"
-      (sources."readdirp-2.2.1" // {
+      (sources."readable-stream-2.3.7" // {
         dependencies = [
-          sources."arr-diff-4.0.0"
-          sources."array-unique-0.3.2"
-          (sources."braces-2.3.2" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          sources."debug-2.6.9"
-          sources."define-property-1.0.0"
-          (sources."expand-brackets-2.1.4" // {
-            dependencies = [
-              sources."define-property-0.2.5"
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          sources."extend-shallow-3.0.2"
-          (sources."extglob-2.0.4" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-              sources."is-extendable-0.1.1"
-            ];
-          })
-          (sources."fill-range-4.0.0" // {
-            dependencies = [
-              sources."extend-shallow-2.0.1"
-            ];
-          })
-          (sources."is-accessor-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-data-descriptor-0.1.4" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          (sources."is-descriptor-0.1.6" // {
-            dependencies = [
-              sources."kind-of-5.1.0"
-            ];
-          })
-          sources."is-extendable-1.0.1"
-          (sources."is-number-3.0.0" // {
-            dependencies = [
-              sources."kind-of-3.2.2"
-            ];
-          })
-          sources."isobject-3.0.1"
-          sources."kind-of-6.0.3"
-          sources."micromatch-3.1.10"
-          sources."ms-2.0.0"
+          sources."safe-buffer-5.1.2"
         ];
       })
+      sources."readdirp-2.2.1"
       sources."rechoir-0.6.2"
       sources."regex-cache-0.4.4"
-      (sources."regex-not-1.0.2" // {
-        dependencies = [
-          sources."extend-shallow-3.0.2"
-          sources."is-extendable-1.0.1"
-        ];
-      })
+      sources."regex-not-1.0.2"
       sources."regexpp-2.0.1"
       sources."remove-bom-buffer-3.0.0"
-      (sources."remove-bom-stream-1.2.0" // {
-        dependencies = [
-          sources."through2-2.0.5"
-        ];
-      })
+      sources."remove-bom-stream-1.2.0"
       sources."remove-trailing-separator-1.1.0"
       sources."repeat-element-1.1.4"
       sources."repeat-string-1.6.1"
-      sources."replace-ext-0.0.1"
-      (sources."replace-homedir-1.0.0" // {
-        dependencies = [
-          sources."is-absolute-1.0.0"
-          sources."is-relative-1.0.0"
-        ];
-      })
-      (sources."request-2.88.2" // {
-        dependencies = [
-          sources."uuid-3.4.0"
-        ];
-      })
+      sources."replace-ext-1.0.1"
+      sources."replace-homedir-1.0.0"
+      sources."request-2.88.2"
       sources."require-directory-2.1.1"
       sources."require-main-filename-1.0.1"
-      sources."resolve-1.20.0"
+      sources."resolve-1.22.0"
       sources."resolve-dir-1.0.1"
       sources."resolve-from-4.0.0"
       sources."resolve-options-1.1.0"
       sources."resolve-url-0.2.1"
       sources."restore-cursor-3.1.0"
       sources."ret-0.1.15"
-      (sources."rimraf-2.7.1" // {
-        dependencies = [
-          sources."glob-7.1.7"
-        ];
-      })
+      sources."rimraf-2.7.1"
       sources."run-async-2.4.1"
       sources."rxjs-6.6.7"
-      sources."safe-buffer-5.1.2"
+      sources."safe-buffer-5.2.1"
       sources."safe-regex-1.1.0"
       sources."safer-buffer-2.1.2"
       sources."sax-1.2.4"
@@ -7445,10 +6742,14 @@ in
       sources."serialize-javascript-5.0.1"
       sources."set-blocking-2.0.0"
       sources."set-immediate-shim-1.0.1"
-      sources."set-value-2.0.1"
+      (sources."set-value-2.0.1" // {
+        dependencies = [
+          sources."extend-shallow-2.0.1"
+        ];
+      })
       sources."shebang-command-1.2.0"
       sources."shebang-regex-1.0.0"
-      sources."signal-exit-3.0.3"
+      sources."signal-exit-3.0.7"
       (sources."slice-ansi-2.1.0" // {
         dependencies = [
           sources."ansi-styles-3.2.1"
@@ -7459,6 +6760,7 @@ in
         dependencies = [
           sources."debug-2.6.9"
           sources."define-property-0.2.5"
+          sources."extend-shallow-2.0.1"
           (sources."is-accessor-descriptor-0.1.6" // {
             dependencies = [
               sources."kind-of-3.2.2"
@@ -7477,10 +6779,13 @@ in
       (sources."snapdragon-node-2.1.1" // {
         dependencies = [
           sources."define-property-1.0.0"
-          sources."isobject-3.0.1"
         ];
       })
-      sources."snapdragon-util-3.0.1"
+      (sources."snapdragon-util-3.0.1" // {
+        dependencies = [
+          sources."kind-of-3.2.2"
+        ];
+      })
       sources."source-map-0.5.7"
       sources."source-map-resolve-0.5.3"
       sources."source-map-url-0.4.1"
@@ -7488,17 +6793,11 @@ in
       sources."spdx-correct-3.1.1"
       sources."spdx-exceptions-2.3.0"
       sources."spdx-expression-parse-3.0.1"
-      sources."spdx-license-ids-3.0.10"
-      (sources."split-string-3.1.0" // {
-        dependencies = [
-          sources."extend-shallow-3.0.2"
-          sources."is-extendable-1.0.1"
-        ];
-      })
+      sources."spdx-license-ids-3.0.11"
+      sources."split-string-3.1.0"
       sources."sprintf-js-1.0.3"
-      sources."sshpk-1.16.1"
+      sources."sshpk-1.17.0"
       sources."stack-trace-0.0.10"
-      sources."stat-mode-0.2.2"
       (sources."static-extend-0.1.2" // {
         dependencies = [
           sources."define-property-0.2.5"
@@ -7516,20 +6815,22 @@ in
           sources."kind-of-5.1.0"
         ];
       })
-      sources."stream-combiner2-1.1.1"
       sources."stream-exhaust-1.0.2"
       sources."stream-shift-1.0.1"
       sources."string-width-1.0.2"
-      sources."string_decoder-1.1.1"
+      (sources."string_decoder-1.1.1" // {
+        dependencies = [
+          sources."safe-buffer-5.1.2"
+        ];
+      })
       sources."strip-ansi-3.0.1"
       sources."strip-bom-2.0.0"
-      sources."strip-bom-stream-1.0.0"
       sources."strip-bom-string-1.0.0"
-      sources."strip-dirs-1.1.1"
+      sources."strip-dirs-2.1.0"
       sources."strip-json-comments-3.1.1"
       sources."strip-outer-1.0.1"
-      sources."sum-up-1.0.3"
       sources."supports-color-2.0.0"
+      sources."supports-preserve-symlinks-flag-1.0.0"
       sources."sver-compat-1.5.0"
       (sources."table-5.4.6" // {
         dependencies = [
@@ -7543,41 +6844,22 @@ in
       sources."tar-stream-1.6.2"
       sources."text-table-0.2.0"
       sources."through-2.3.8"
-      (sources."through2-0.6.5" // {
-        dependencies = [
-          sources."isarray-0.0.1"
-          sources."readable-stream-1.0.34"
-          sources."string_decoder-0.10.31"
-        ];
-      })
-      (sources."through2-filter-2.0.0" // {
-        dependencies = [
-          sources."through2-2.0.5"
-        ];
-      })
+      sources."through2-2.0.5"
+      sources."through2-filter-3.0.0"
       sources."time-stamp-1.1.0"
       sources."timed-out-4.0.1"
       sources."timers-ext-0.1.7"
       sources."tmp-0.0.33"
-      sources."to-absolute-glob-0.1.1"
+      sources."to-absolute-glob-2.0.2"
       sources."to-buffer-1.1.1"
-      sources."to-object-path-0.3.0"
-      (sources."to-regex-3.0.2" // {
+      (sources."to-object-path-0.3.0" // {
         dependencies = [
-          sources."extend-shallow-3.0.2"
-          sources."is-extendable-1.0.1"
+          sources."kind-of-3.2.2"
         ];
       })
-      (sources."to-regex-range-2.1.1" // {
-        dependencies = [
-          sources."is-number-3.0.0"
-        ];
-      })
-      (sources."to-through-2.0.0" // {
-        dependencies = [
-          sources."through2-2.0.5"
-        ];
-      })
+      sources."to-regex-3.0.2"
+      sources."to-regex-range-2.1.1"
+      sources."to-through-2.0.0"
       (sources."touch-0.0.3" // {
         dependencies = [
           sources."nopt-1.0.10"
@@ -7604,12 +6886,7 @@ in
       })
       sources."undertaker-registry-1.0.1"
       sources."union-value-1.0.1"
-      (sources."unique-stream-2.3.1" // {
-        dependencies = [
-          sources."through2-2.0.5"
-          sources."through2-filter-3.0.0"
-        ];
-      })
+      sources."unique-stream-2.3.1"
       sources."universalify-0.1.2"
       (sources."unset-value-1.0.0" // {
         dependencies = [
@@ -7619,7 +6896,6 @@ in
             ];
           })
           sources."has-values-0.1.4"
-          sources."isobject-3.0.1"
         ];
       })
       sources."untildify-3.0.3"
@@ -7631,32 +6907,21 @@ in
       sources."url-to-options-1.0.1"
       sources."use-3.1.1"
       sources."util-deprecate-1.0.2"
-      sources."uuid-2.0.3"
+      sources."uuid-3.4.0"
       sources."v8-compile-cache-2.3.0"
       sources."v8flags-3.2.0"
-      sources."vali-date-1.0.0"
       sources."validate-npm-package-license-3.0.4"
       sources."value-or-function-3.0.0"
-      sources."verror-1.10.0"
-      sources."vinyl-1.2.0"
-      (sources."vinyl-assign-1.2.1" // {
+      (sources."verror-1.10.0" // {
         dependencies = [
-          sources."object-assign-4.1.1"
+          sources."core-util-is-1.0.2"
         ];
       })
-      (sources."vinyl-fs-2.4.4" // {
-        dependencies = [
-          sources."gulp-sourcemaps-1.6.0"
-          sources."object-assign-4.1.1"
-          sources."through2-2.0.5"
-        ];
-      })
+      sources."vinyl-2.2.1"
+      sources."vinyl-fs-3.0.3"
       (sources."vinyl-sourcemap-1.1.0" // {
         dependencies = [
-          sources."clone-2.1.2"
-          sources."clone-stats-1.0.0"
-          sources."replace-ext-1.0.1"
-          sources."vinyl-2.2.1"
+          sources."normalize-path-2.1.1"
         ];
       })
       sources."which-1.3.1"
@@ -7675,15 +6940,15 @@ in
       sources."y18n-3.2.2"
       (sources."yargs-16.2.0" // {
         dependencies = [
-          sources."ansi-regex-5.0.0"
+          sources."ansi-regex-5.0.1"
           sources."ansi-styles-4.3.0"
           sources."cliui-7.0.4"
           sources."color-convert-2.0.1"
           sources."color-name-1.1.4"
           sources."get-caller-file-2.0.5"
           sources."is-fullwidth-code-point-3.0.0"
-          sources."string-width-4.2.2"
-          sources."strip-ansi-6.0.0"
+          sources."string-width-4.2.3"
+          sources."strip-ansi-6.0.1"
           sources."wrap-ansi-7.0.0"
           sources."y18n-5.0.8"
           sources."yargs-parser-20.2.9"
@@ -7696,7 +6961,7 @@ in
       })
       (sources."yargs-unparser-2.0.0" // {
         dependencies = [
-          sources."camelcase-6.2.0"
+          sources."camelcase-6.3.0"
           sources."decamelize-4.0.0"
         ];
       })

--- a/pkgs/tools/security/onlykey/package.json
+++ b/pkgs/tools/security/onlykey/package.json
@@ -1,3 +1,3 @@
 [
-  {"onlykey": "git://github.com/trustcrypto/OnlyKey-App.git#v5.3.3"}
+  {"onlykey": "git://github.com/trustcrypto/OnlyKey-App.git#v5.3.4"}
 ]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

https://github.com/trustcrypto/OnlyKey-App/releases/tag/v5.3.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
