### PR TITLE
vscode-extensions.kddejong.vscode-cfn-lint: init at 0.21.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -5,6 +5,7 @@
 , vscode-utils
 , asciidoctor
 , nodePackages
+, python3Packages
 , jdk
 , llvmPackages_8
 , nixpkgs-fmt
@@ -1297,6 +1298,33 @@ let
           homepage = "https://github.com/kamadorueda/alejandra";
           license = licenses.unlicense;
           maintainers = with maintainers; [ kamadorueda ];
+        };
+      };
+
+      kddejong.vscode-cfn-lint = let
+        inherit (python3Packages) cfn-lint;
+      in buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "vscode-cfn-lint";
+          publisher = "kddejong";
+          version = "0.21.0";
+          sha256 = "sha256-IueXiN+077tiecAsVCzgYksWYTs00mZv6XJVMtRJ/PQ=";
+        };
+
+        nativeBuildInputs = [ jq moreutils ];
+
+        buildInputs = [ cfn-lint ];
+
+        postInstall = ''
+          cd "$out/$installPrefix"
+          jq '.contributes.configuration.properties."cfnLint.path".default = "${cfn-lint}/bin/cfn-lint"' package.json | sponge package.json
+        '';
+
+        meta = with lib; {
+          description = "CloudFormation Linter IDE integration, autocompletion, and documentation";
+          homepage = "https://github.com/aws-cloudformation/cfn-lint-visual-studio-code";
+          license = lib.licenses.asl20;
+          maintainers = with maintainers; [ wolfangaukang ];
         };
       };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

The only thing not implemented is the usage of `pydot`/`pygraphviz` as somehow it is not being recognized. But the checks are being performed successfully after `cfn-lint` has been updated to 0.58.X (with version 0.56.X, it complained about a library missing `pbr`).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
