### PR TITLE
python3Packages.pulumi: init at 3.25.1

### DIFF
--- a/pkgs/development/python-modules/pulumi-aws/default.nix
+++ b/pkgs/development/python-modules/pulumi-aws/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, pulumi
+, parver
+, semver
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi-aws";
+  # version is independant of pulumi's.
+  version = "5.3.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-aws";
+    rev = "v${version}";
+    sha256 = "sha256-LrWiNYJeQQvXJDOxklRO86VSiaadvkOepQVPhh2BBkk=";
+  };
+
+  propagatedBuildInputs = [
+    pulumi
+    parver
+    semver
+  ];
+
+  postPatch = ''
+    cd sdk/python
+  '';
+
+  # checks require cloud resources
+  doCheck = false;
+  pythonImportsCheck = ["pulumi_aws"];
+
+  meta = with lib; {
+    description = "Pulumi python amazon web services provider";
+    homepage = "https://github.com/pulumi/pulumi-aws";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -11,6 +11,7 @@
 , pyyaml
 , six
 
+
 # for tests
 , tox
 , go
@@ -26,27 +27,20 @@
 
 , mypy
 }:
-
+let
+  data = import ./data.nix {};
+in
 buildPythonPackage rec {
   pname = "pulumi";
-  version = pulumi.version;
+  version = pulumi-bin.version;
   disabled = isPy27;
 
-  src = pulumi.src;
-
-  patches = [
-    # remove in next release
-    (fetchpatch {
-      url = "https://github.com/pulumi/pulumi/commit/d4b9d61d70972d22a344419fafc30aace58607f5.patch";
-      sha256 = "HEF7VWunFO+NCG18fZA7lbE2l8pc6Z3jcD+rSZ1Jsqg=";
-    }) ];
-
-  # src = fetchFromGitHub {
-  #   owner = "pulumi";
-  #   repo = "pulumi";
-  #   rev = "073e94a0b8b4ef0b1b856c63670a8dd88f6b6d02";
-  #   sha256 = "sha256-oyjQW/Z1NvsHpUwikX+bl1npfF4LESOua/o1qjqAgUs=";
-  # };
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi";
+    rev = "v${pulumi-bin.version}";
+    sha256 = "sha256-vqEZEHTpJV65a3leWwYhyi3dzAsN67BXOvk5hnTPeuI=";
+  };
 
   propagatedBuildInputs = [
     semver
@@ -64,7 +58,6 @@ buildPythonPackage rec {
     bash
     go
     tox
-    # pylint
     pytest
     pytest-timeout
     coverage
@@ -79,12 +72,6 @@ buildPythonPackage rec {
     cp README.md sdk/python/lib
     patchShebangs .
     cd sdk/python/lib
-    substituteInPlace ../Makefile \
-      --replace '$(shell cd ../../ && pulumictl get version)' '${pulumi-bin.version}' \
-      --replace '$(shell cd ../../ && pulumictl get version --language python)' '${version}'
-
-    substituteInPlace ../requirements.txt \
-      --replace 'pylint==2.10.2' 'pylint>=2.10.2'
 
     substituteInPlace setup.py \
       --replace "{VERSION}" "${version}"

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -1,0 +1,102 @@
+{ lib
+, buildPythonPackage
+, fetchpatch
+, fetchFromGitHub
+, protobuf
+, dill
+, grpcio
+, pulumi-bin
+, isPy27
+, semver
+, pyyaml
+, six
+
+# for tests
+, tox
+, go
+, pulumictl
+, bash
+, pylint
+, pytest
+, pytest-timeout
+, coverage
+, black
+, wheel
+, pytest-asyncio
+
+, mypy
+}:
+
+buildPythonPackage rec {
+  pname = "pulumi";
+  version = pulumi.version;
+  disabled = isPy27;
+
+  src = pulumi.src;
+
+  patches = [
+    # remove in next release
+    (fetchpatch {
+      url = "https://github.com/pulumi/pulumi/commit/d4b9d61d70972d22a344419fafc30aace58607f5.patch";
+      sha256 = "HEF7VWunFO+NCG18fZA7lbE2l8pc6Z3jcD+rSZ1Jsqg=";
+    }) ];
+
+  # src = fetchFromGitHub {
+  #   owner = "pulumi";
+  #   repo = "pulumi";
+  #   rev = "073e94a0b8b4ef0b1b856c63670a8dd88f6b6d02";
+  #   sha256 = "sha256-oyjQW/Z1NvsHpUwikX+bl1npfF4LESOua/o1qjqAgUs=";
+  # };
+
+  propagatedBuildInputs = [
+    semver
+    protobuf
+    dill
+    grpcio
+    pyyaml
+    six
+  ];
+
+  checkInputs = [
+    pulumi-bin
+    pulumictl
+    mypy
+    bash
+    go
+    tox
+    # pylint
+    pytest
+    pytest-timeout
+    coverage
+    pytest-asyncio
+    wheel
+    black
+  ];
+
+  pythonImportsCheck = ["pulumi"];
+
+  postPatch = ''
+    cp README.md sdk/python/lib
+    patchShebangs .
+    cd sdk/python/lib
+    substituteInPlace ../Makefile \
+      --replace '$(shell cd ../../ && pulumictl get version)' '${pulumi-bin.version}' \
+      --replace '$(shell cd ../../ && pulumictl get version --language python)' '${version}'
+
+    substituteInPlace ../requirements.txt \
+      --replace 'pylint==2.10.2' 'pylint>=2.10.2'
+
+    substituteInPlace setup.py \
+      --replace "{VERSION}" "${version}"
+  '';
+
+  # disabled because tests try to fetch go packages from the net
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Modern Infrastructure as Code. Any cloud, any language";
+    homepage = "https://github.com/pulumi/pulumi";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ teto ];
+  };
+}

--- a/pkgs/tools/admin/pulumi/update-pulumi-shell.nix
+++ b/pkgs/tools/admin/pulumi/update-pulumi-shell.nix
@@ -1,0 +1,8 @@
+{ nixpkgs ? import ../../../.. { } }:
+with nixpkgs;
+mkShell {
+  packages = [
+    pkgs.gh
+  ];
+}
+

--- a/pkgs/tools/admin/pulumi/update.sh
+++ b/pkgs/tools/admin/pulumi/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p gh
+#!nix-shell update-pulumi-shell.nix -i bash
 # shellcheck shell=bash
 # Bash 3 compatible for Darwin
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1103,6 +1103,8 @@ in {
 
   babelgladeextractor = callPackage ../development/python-modules/babelgladeextractor { };
 
+  pulumi = callPackage ../development/python-modules/pulumi { };
+
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1105,6 +1105,8 @@ in {
 
   pulumi = callPackage ../development/python-modules/pulumi { };
 
+  pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };
+
   backcall = callPackage ../development/python-modules/backcall { };
 
   backoff = callPackage ../development/python-modules/backoff { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

I've tried to enable tests, but ended up disabling it as it was starting some go process which I am unfamiliar with.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
