### PR TITLE
nixos/mmsd-tng: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -136,6 +136,14 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://gitlab.com/kop316/mmsd">mmsd-tng</link>,
+          a service for sending and receiving MMS through the
+          ModemManager or ofono stack. Available as
+          <link xlink:href="options.html#opt-services.mmsd-tng.enable">services.mmsd-tng</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/ngoduykhanh/PowerDNS-Admin">PowerDNS-Admin</link>,
           a web interface for the PowerDNS server. Available at
           <link xlink:href="options.html#opt-services.powerdns-admin.enable">services.powerdns-admin</link>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -41,6 +41,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [ergochat](https://ergo.chat), a modern IRC with IRCv3 features. Available as [services.ergochat](options.html#opt-services.ergochat.enable).
 
+- [mmsd-tng](https://gitlab.com/kop316/mmsd), a service for sending and receiving MMS through the ModemManager or ofono stack. Available as [services.mmsd-tng](options.html#opt-services.mmsd-tng.enable).
+
 - [PowerDNS-Admin](https://github.com/ngoduykhanh/PowerDNS-Admin), a web interface for the PowerDNS server. Available at [services.powerdns-admin](options.html#opt-services.powerdns-admin.enable).
 
 - [pgadmin4](https://github.com/postgres/pgadmin4), an admin interface for the PostgreSQL database. Available at [services.pgadmin](options.html#opt-services.pgadmin.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -803,6 +803,7 @@
   ./services/networking/mjpg-streamer.nix
   ./services/networking/minidlna.nix
   ./services/networking/miniupnpd.nix
+  ./services/networking/mmsd-tng.nix
   ./services/networking/mosquitto.nix
   ./services/networking/monero.nix
   ./services/networking/morty.nix

--- a/nixos/modules/services/networking/mmsd-tng.nix
+++ b/nixos/modules/services/networking/mmsd-tng.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mmsd-tng;
+
+  dbusServiceFile = pkgs.writeTextFile rec {
+    name = "org.ofono.mms.service";
+    destination = "/share/dbus-1/services/${name}";
+    text = ''
+      [D-BUS Service]
+      Name=org.ofono.mms
+      Exec=${pkgs.mmsd-tng}/bin/mmsdtng
+      SystemdService=mmsd-tng.service
+    '';
+  };
+in
+{
+  options = {
+    services.mmsd-tng = {
+      enable = mkEnableOption "Multimedia Messaging Service Daemon - The Next Generation (mmsd-tng)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.mmsd-tng = {
+      description = "Multimedia Messaging Service Daemon - The Next Generation";
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.ofono.mms";
+        ExecStart = "${pkgs.mmsd-tng}/bin/mmsdtng";
+      };
+    };
+
+    services.dbus.packages = [ dbusServiceFile ];
+  };
+}

--- a/pkgs/tools/networking/mmsd-tng/default.nix
+++ b/pkgs/tools/networking/mmsd-tng/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, pkg-config
+, ninja
+, dbus
+, glib
+, modemmanager
+, libsoup
+, c-ares
+, protobuf
+, libphonenumber
+, mobile-broadband-provider-info
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mmsd-tng";
+  version = "1.9";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.com";
+    owner = "kop316";
+    repo = "mmsd";
+    rev = version;
+    sha256 = "1l2wy4fg4k9rh4wbsa0m9nzwckfabinqxwzr1bl0478azd9wrb90";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+
+  buildInputs = [
+    dbus
+    glib
+    modemmanager
+    libsoup
+    c-ares
+    protobuf
+    libphonenumber
+    mobile-broadband-provider-info
+  ];
+
+  meta = with lib; {
+    description = "Transmits and receives MMMSes through ModemManager";
+    homepage = "https://gitlab.com/kop316/mmsd";
+    license = with licenses; [ gpl2Plus ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ noneucat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27435,6 +27435,8 @@ with pkgs;
 
   mmsd = callPackage ../tools/networking/mmsd { };
 
+  mmsd-tng = callPackage ../tools/networking/mmsd-tng { };
+
   mmtc = callPackage ../applications/audio/mmtc { };
 
   mnamer = callPackage ../applications/misc/mnamer { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`mmsd-tng` facilitates the sending and receiving of MMS messages through ModemManager and ofono stacks. It currently works with the `chatty` messaging application through the `org.ofono.mms` DBus service name. This PR adds a package for `mmsd-tng`, as well as a module that adds a DBus service definition and a user service.

Tested with `chatty` on a PinePhone Pro with mobile-nixos.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
