### PR TITLE
dosfstools: 4.1 -> 4.2

### DIFF
--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -1,18 +1,24 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libiconv }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libiconv, gettext }:
 
 stdenv.mkDerivation rec {
   pname = "dosfstools";
-  version = "4.1";
+  version = "4.2";
 
   src = fetchFromGitHub {
     owner = "dosfstools";
     repo = "dosfstools";
     rev = "v${version}";
-    sha256 = "1a2zn1655d5f1m6jp9vpn3bp8yfxhcmxx3mx23ai9hmxiydiykr1";
+    sha256 = "sha256-2gxB0lQixiHOHw8uTetHekaM57fvUd9zOzSxWnvUz/c=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config ]
     ++ lib.optional stdenv.isDarwin libiconv;
+
+  # configure.ac:75: error: required file './config.rpath' not found
+  # https://github.com/dosfstools/dosfstools/blob/master/autogen.sh
+  postPatch = ''
+    cp ${gettext}/share/gettext/config.rpath config.rpath
+  '';
 
   configureFlags = [ "--enable-compat-symlinks" ];
 

--- a/pkgs/tools/filesystems/dosfstools/default.nix
+++ b/pkgs/tools/filesystems/dosfstools/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libiconv, gettext }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, libiconv, gettext, xxd }:
 
 stdenv.mkDerivation rec {
   pname = "dosfstools";
@@ -21,6 +21,9 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags = [ "--enable-compat-symlinks" ];
+
+  checkInputs = [ xxd ];
+  doCheck = true;
 
   meta = {
     description = "Utilities for creating and checking FAT and VFAT file systems";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
