### PR TITLE
nixos/gnome: be pipewire by default

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1067,6 +1067,14 @@
       </listitem>
       <listitem>
         <para>
+          GNOME now defaults to using pipewire only, whereas before the
+          default configuration would lead to both pulseaudio and
+          pipewire being enabled. This should fix some issues that arose
+          due to the two being enabled before.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>services.mbpfan</literal> module was converted to
           a
           <link xlink:href="https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md">RFC

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -344,6 +344,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - It is now possible to specify wordlists to include as handy to access environment variables using the `config.environment.wordlist` configuration options.
 
+- GNOME now defaults to using pipewire only, whereas before the default configuration would lead to both pulseaudio and pipewire being enabled. This should fix some issues that arose due to the two being enabled before.
+
 - The `services.mbpfan` module was converted to a [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md) configuration.
 
 - The default value for `programs.spacefm.settings.graphical_su` got unset. It previously pointed to `gksu` which has been removed.

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -166,7 +166,7 @@ in
         # Enable CUPS to print documents.
         # services.printing.enable = true;
 
-        # Enable sound.
+        # Enable sound (may be already enabled by a desktop manager like gnome).
         # sound.enable = true;
         # hardware.pulseaudio.enable = true;
 

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -351,7 +351,6 @@ in
 
     (mkIf serviceCfg.core-os-services.enable {
       hardware.bluetooth.enable = mkDefault true;
-      hardware.pulseaudio.enable = mkDefault true;
       programs.dconf.enable = true;
       security.polkit.enable = true;
       services.accounts-daemon.enable = true;
@@ -367,6 +366,9 @@ in
       services.gnome.tracker.enable = mkDefault true;
       services.hardware.bolt.enable = mkDefault true;
       services.packagekit.enable = mkDefault true;
+      services.pipewire.enable = mkDefault true;
+      services.pipewire.pulse.enable = mkDefault true;
+      services.pipewire.alsa.enable = mkDefault true;
       services.udisks2.enable = true;
       services.upower.enable = config.powerManagement.enable;
       services.xserver.libinput.enable = mkDefault true; # for controlling touchpad settings via gnome control center


### PR DESCRIPTION
Without that, gnome enables both pipewire and pulseaudio by default;
which leads to issues with eg. bluetooth headsets as the gnome settings
command go to pulseaudio but the headset is connected to pipewire (and
correctly has sound but thus can't be reconfigured)

Fixes https://github.com/NixOS/nixpkgs/issues/163399

### nixpkgs-check report

**version:** `nixpkgs-check v0.1.0` on NixOS 21.11, sandbox = "true"
**packages declared changed:** {"nixosTests.gnome", "nixosTests.gnome-xorg"}
**manual tests declared performed:**
 * 😢 not built on NixOS
 * 😢 not built on MacOS
 * 😢 not built on Other Linux distributions
 * manually overridden these configuration parameters in my config, rebooted and checked the bluetooth headset now works properly

**complies with contributing.md:** ✔ yes
**package nixosTests.gnome:** ✔ continued building
**package nixosTests.gnome-xorg:** ✔ continued building
**closure size for nixosTests.gnome:** ✔ increased by 112 B, from 34.6 KB to 34.7 KB
**tests of nixosTests.gnome:** 😢 there are no tests

**closure size for nixosTests.gnome-xorg:** ✔ increased by 608 B, from 28.4 KB to 29.0 KB
**tests of nixosTests.gnome-xorg:** 😢 there are no tests