### PR TITLE
lib.licenses: add SPDX license exceptions identifiers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -155,7 +155,7 @@
 /pkgs/applications/editors/jetbrains @edwtjo
 
 # Licenses
-/lib/licenses.nix @alyssais
+/lib/licenses.nix @alyssais @c0bw3b
 
 # Qt / KDE
 /pkgs/applications/kde @ttuegel

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -404,16 +404,6 @@ in mkLicense lset) ({
     fullName = "GNU General Public License v2.0 only";
   };
 
-  gpl2Classpath = {
-    spdxId = "GPL-2.0-with-classpath-exception";
-    fullName = "GNU General Public License v2.0 only (with Classpath exception)";
-  };
-
-  gpl2ClasspathPlus = {
-    fullName = "GNU General Public License v2.0 or later (with Classpath exception)";
-    url = "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception";
-  };
-
   gpl2Oss = {
     fullName = "GNU General Public License version 2 only (with OSI approved licenses linking exception)";
     url = "https://www.mysql.com/about/legal/licensing/foss-exception";
@@ -432,11 +422,6 @@ in mkLicense lset) ({
   gpl3Plus = {
     spdxId = "GPL-3.0-or-later";
     fullName = "GNU General Public License v3.0 or later";
-  };
-
-  gpl3ClasspathPlus = {
-    fullName = "GNU General Public License v3.0 or later (with Classpath exception)";
-    url = "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception";
   };
 
   hpnd = {
@@ -563,11 +548,6 @@ in mkLicense lset) ({
   llgpl21 = {
     fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
     url = "https://opensource.franz.com/preamble.html";
-  };
-
-  llvm-exception = {
-    spdxId = "LLVM-exception";
-    fullName = "LLVM Exception"; # LLVM exceptions to the Apache 2.0 License
   };
 
   lppl12 = {
@@ -743,11 +723,6 @@ in mkLicense lset) ({
     fullName = "Q Public License 1.0";
   };
 
-  qwt = {
-    fullName = "Qwt License, Version 1.0";
-    url = "https://qwt.sourceforge.io/qwtlicense.html";
-  };
-
   ruby = {
     spdxId = "Ruby";
     fullName = "Ruby License";
@@ -875,11 +850,6 @@ in mkLicense lset) ({
     fullName = "Do What The F*ck You Want To Public License";
   };
 
-  wxWindows = {
-    spdxId = "wxWindows";
-    fullName = "wxWindows Library Licence, Version 3.1";
-  };
-
   xfig = {
     fullName = "xfig";
     url = "http://mcj.sourceforge.net/authors.html#xfig"; # https is broken
@@ -899,8 +869,178 @@ in mkLicense lset) ({
     spdxId = "ZPL-2.1";
     fullName = "Zope Public License 2.1";
   };
+
 } // {
-  # TODO: remove legacy aliases
+  /*
+    Below is the list of known license exceptions introduced with SPDX 2.0
+    https://spdx.org/licenses/exceptions-index.html
+  */
+
+  autoconf-exception2 = {
+    spdxId = "Autoconf-exception-2.0"; # Typically used with GPL-2.0
+    fullName = "Autoconf exception 2.0";
+  };
+
+  autoconf-exception3 = {
+    spdxId = "Autoconf-exception-3.0"; # Typically used with GPL-3.0
+    fullName = "Autoconf exception 3.0";
+  };
+
+  bison-exception = {
+    spdxId = "Bison-exception-2.2"; # Typically used with GPL-2.0 or GPL-3.0
+    fullName = "Bison exception 2.2";
+  };
+
+  classpath-exception = {
+    spdxId = "Classpath-exception-2.0"; # Applies to GPL-2.0 / GPL-3.0
+    fullName = "Classpath exception 2.0";
+  };
+
+  clisp-exception = {
+    spdxId = "CLISP-exception-2.0"; # Typically used with GPL-2.0
+    fullName = "CLISP exception 2.0";
+  };
+
+  fltk-exception = {
+    spdxId = "FLTK-exception"; # Applies to LGPL-2.0-only
+    fullName = "FLTK exception";
+  };
+
+  font-exception = {
+    spdxId = "Font-exception-2.0"; # Typically used with GPL-2.0-or-later
+    fullName = "Font exception 2.0";
+  };
+
+  gcc-exception2 = {
+    spdxId = "GCC-exception-2.0"; # Typically used with GPL-2.0-or-later
+    fullName = "GCC Runtime Library exception 2.0";
+  };
+
+  gcc-exception31 = {
+    spdxId = "GCC-exception-3.1"; # Typically used with GPL-3.0
+    fullName = "GCC Runtime Library exception 3.1";
+  };
+
+  gpl3-linking-exception = {
+    spdxId = "GPL-3.0-linking-exception"; # Applies to GPL-3.0
+    fullName = "GPL-3.0 Linking Exception";
+  };
+
+  gpl3-linking-source-exception = {
+    spdxId = "GPL-3.0-linking-source-exception"; # Applies to GPL-3.0
+    fullName = "GPL-3.0 Linking Exception (with Corresponding Source)";
+  };
+
+  gplcc-exception = {
+    spdxId = "GPL-CC-1.0"; # Applies to GPL-2.0 / LGPL-2.0 / LGPL-2.1
+    fullName = "GPL Cooperation Commitment 1.0";
+  };
+
+  i2p-exception = {
+    spdxId = "i2p-gpl-java-exception"; # Typically used with GPL-2.0-or-later
+    fullName = "i2p GPL+Java Exception";
+  };
+
+  javamail-exception = {
+    spdxId = "gnu-javamail-exception"; # Typically used with GPL (any version)
+    fullName = "GNU JavaMail exception";
+  };
+
+  lgpl3-linking-exception = {
+    spdxId = "LGPL-3.0-linking-exception"; # Applies to LGPL-3.0
+    fullName = "LGPL-3.0 Linking Exception";
+  };
+
+  libtool-exception = {
+    spdxId = "Libtool-exception"; # Applies to GPL-2.0-or-later
+    fullName = "Libtool Exception";
+  };
+
+  linux-syscall-exception = {
+    spdxId = "Linux-syscall-note"; # Applies to GPL-2.0-only
+    fullName = "Linux Syscall Note";
+  };
+
+  llvm-exception = {
+    spdxId = "LLVM-exception"; # Applies to Apache-2.0
+    fullName = "LLVM Exception"; # LLVM exceptions to the Apache 2.0 License
+  };
+
+  lzma-exception = {
+    spdxId = "LZMA-exception"; # Applies to CPL-1.0
+    fullName = "LZMA exception";
+  };
+
+  mif-exception = {
+    spdxId = "mif-exception"; # Typically used with GPL-2.0
+    fullName = "Macros and Inline Functions Exception";
+  };
+
+  ocaml-exception = {
+    spdxId = "OCaml-LGPL-linking-exception"; # Applies to LGPL-2.0-or-later
+    fullName = "OCaml LGPL Linking Exception";
+  };
+
+  opencascade-exception = {
+    spdxId = "OCCT-exception-1.0"; # Applies to LGPL-2.1
+    fullName = "Open CASCADE Exception 1.0";
+  };
+
+  openjdk-assembly-exception = {
+    spdxId = "OpenJDK-assembly-exception-1.0"; # Applies to GPL-2.0-only
+    fullName = "OpenJDK Assembly exception 1.0";
+  };
+
+  openvpn-openssl-exception = {
+    spdxId = "openvpn-openssl-exception"; # Typically used with GPL 2.0
+    fullName = "OpenVPN OpenSSL Exception";
+  };
+
+  pspdf-exception = {
+    spdxId = "PS-or-PDF-font-exception-20170817"; # Applies to AGPL-3.0
+    fullName = "PS/PDF font exception (2017-08-17)";
+  };
+
+  qtgpl-exception = {
+    spdxId = "Qt-GPL-exception-1.0"; # Typically used with the GPL-3.0
+    fullName = "Qt GPL exception 1.0";
+  };
+
+  qtlgpl-exception = {
+    spdxId = "Qt-LGPL-exception-1.1"; # Applies to LGPL-2.1
+    fullName = "Qt LGPL exception 1.1";
+  };
+
+  qwt-exception = {
+    spdxId = "Qwt-exception-1.0"; # Applies to LGPL-2.1
+    fullName = "Qwt exception 1.0";
+  };
+
+  swift-exception = {
+    spdxId = "Swift-exception"; # Applies to Apache-2.0
+    fullName = "Swift Exception";
+  };
+
+  uboot-exception = {
+    spdxId = "u-boot-exception-2.0"; # Typically used with GPL-2.0-or-later
+    fullName = "U-Boot exception 2.0";
+  };
+
+  unifoss-exception = {
+    spdxId = "Universal-FOSS-exception-1.0";
+    fullName = "Universal FOSS Exception, Version 1.0";
+  };
+
+  wx-exception = {
+    spdxId = "WxWindows-exception-3.1"; # Typically used with LGPL-2.0-or-later
+    fullName = "WxWindows Library Exception 3.1";
+  };
+
+} // {
+  /*
+    Below are old SPDX identifiers that were deprecated with SPDX 3.0
+    TODO: remove legacy aliases
+  */
   agpl3 = {
     spdxId = "AGPL-3.0";
     fullName = "GNU Affero General Public License v3.0";
@@ -931,9 +1071,24 @@ in mkLicense lset) ({
     fullName = "GNU General Public License v2.0";
     deprecated = true;
   };
+  gpl2Classpath = {
+    spdxId = "GPL-2.0-with-classpath-exception";
+    fullName = "GNU General Public License v2.0 only (with Classpath exception)";
+    deprecated = true;
+  };
+  gpl2ClasspathPlus = {
+    fullName = "GNU General Public License v2.0 or later (with Classpath exception)";
+    url = "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception";
+    deprecated = true;
+  };
   gpl3 = {
     spdxId = "GPL-3.0";
     fullName = "GNU General Public License v3.0";
+    deprecated = true;
+  };
+  gpl3ClasspathPlus = {
+    fullName = "GNU General Public License v3.0 or later (with Classpath exception)";
+    url = "https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception";
     deprecated = true;
   };
   lgpl2 = {
@@ -949,6 +1104,16 @@ in mkLicense lset) ({
   lgpl3 = {
     spdxId = "LGPL-3.0";
     fullName = "GNU Lesser General Public License v3.0";
+    deprecated = true;
+  };
+  qwt = {
+    fullName = "Qwt License, Version 1.0";
+    url = "https://qwt.sourceforge.io/qwtlicense.html";
+    deprecated = true;
+  };
+  wxWindows = {
+    spdxId = "wxWindows";
+    fullName = "wxWindows Library Licence, Version 3.1";
     deprecated = true;
   };
 })

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -700,6 +700,7 @@ in mkLicense lset) ({
 
   publicDomain = {
     fullName = "Public Domain";
+    url = "https://opensource.org/faq#public-domain";
   };
 
   purdueBsd = {

--- a/pkgs/applications/editors/bluej/default.nix
+++ b/pkgs/applications/editors/bluej/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple integrated development environment for Java";
     homepage = "https://www.bluej.org/";
-    license = licenses.gpl2ClasspathPlus;
+    license = with licenses; [ gpl2Plus /* WITH */ classpath-exception ];
     maintainers = [ maintainers.chvp ];
     platforms = platforms.unix;
   };

--- a/pkgs/applications/editors/greenfoot/default.nix
+++ b/pkgs/applications/editors/greenfoot/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A simple integrated development environment for Java";
     homepage = "https://www.greenfoot.org/";
-    license = licenses.gpl2ClasspathPlus;
+    license = with licenses; [ gpl2Plus /* WITH */ classpath-exception ];
     maintainers = [ maintainers.chvp ];
     platforms = platforms.unix;
   };

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix
@@ -54,7 +54,7 @@ let cpuName = stdenv.hostPlatform.parsed.cpu.name;
   passthru.home = result;
 
   meta = with lib; {
-    license = licenses.gpl2Classpath;
+    license = with licenses; [ gpl2Only /* WITH */ classpath-exception ];
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
     platforms = [ "x86_64-darwin" ]; # some inherit jre.meta.platforms
     maintainers = with lib.maintainers; [ taku0 ];

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -111,7 +111,7 @@ let result = stdenv.mkDerivation rec {
   passthru.home = result;
 
   meta = with lib; {
-    license = licenses.gpl2Classpath;
+    license = with licenses; [ gpl2Only /* WITH */ classpath-exception ];
     description = "AdoptOpenJDK, prebuilt OpenJDK binary";
     platforms = lib.mapAttrsToList (arch: _: arch + "-linux") sourcePerArch; # some inherit jre.meta.platforms
     maintainers = with lib.maintainers; [ taku0 ];

--- a/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
+++ b/pkgs/development/compilers/graalvm/community-edition/mkGraal.nix
@@ -318,7 +318,9 @@ let
       inherit platforms;
       homepage = "https://www.graalvm.org/";
       description = "High-Performance Polyglot VM";
-      license = with licenses; [ upl gpl2Classpath bsd3 ];
+      license = with licenses; [
+        upl /* AND */ gpl2Only /* WITH */ classpath-exception /* AND */ bsd3
+      ];
       maintainers = with maintainers; [
         bandresen
         volth

--- a/pkgs/development/libraries/qwt/6.nix
+++ b/pkgs/development/libraries/qwt/6.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     description = "Qt widgets for technical applications";
     homepage = "http://qwt.sourceforge.net/";
     # LGPL 2.1 plus a few exceptions (more liberal)
-    license = lib.licenses.qwt;
+    license = with licenses; [ lgpl21Only /* WITH */ qwt-exception ];
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
     branch = "6";

--- a/pkgs/development/libraries/qwt/6_qt4.nix
+++ b/pkgs/development/libraries/qwt/6_qt4.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "Qt widgets for technical applications";
     homepage = "http://qwt.sourceforge.net/";
     # LGPL 2.1 plus a few exceptions (more liberal)
-    license = lib.licenses.qwt;
+    license = with licenses; [ lgpl21Only /* WITH */ qwt-exception ];
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
     branch = "6";

--- a/pkgs/development/libraries/qwt/default.nix
+++ b/pkgs/development/libraries/qwt/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     description = "Qt widgets for technical applications";
     homepage = "http://qwt.sourceforge.net/";
     # LGPL 2.1 plus a few exceptions (more liberal)
-    license = lib.licenses.qwt;
+    license = with licenses; [ lgpl21Only /* WITH */ qwt-exception ];
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };

--- a/pkgs/development/libraries/wasilibc/default.nix
+++ b/pkgs/development/libraries/wasilibc/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation {
     homepage    = "https://wasi.dev";
     platforms   = platforms.wasi;
     maintainers = [ maintainers.matthewbauer ];
-    license = with licenses; [ asl20 mit llvm-exception ];
+    license = with licenses; [ asl20 /* WITH */ llvm-exception /* AND */ mit ];
   };
 }

--- a/pkgs/development/libraries/wxwidgets/2.8/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.8/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
       multithreading, image loading and saving in a variety of popular formats,
       database support, HTML viewing and printing, and much more.
     '';
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/wxwidgets/2.9/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.9/default.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
       multithreading, image loading and saving in a variety of popular formats,
       database support, HTML viewing and printing, and much more.
     '';
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     maintainers = with maintainers; [ ];
     platforms = platforms.darwin ++ platforms.linux;
     badPlatforms = [ "x86_64-darwin" ];

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation rec {
       multithreading, image loading and saving in a variety of popular formats,
       database support, HTML viewing and printing, and much more.
     '';
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     maintainers = with maintainers; [ ];
     platforms = platforms.linux ++ platforms.darwin;
     badPlatforms = [ "x86_64-darwin" ];

--- a/pkgs/development/libraries/wxwidgets/3.0/mac.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/mac.nix
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
       multithreading, image loading and saving in a variety of popular formats,
       database support, HTML viewing and printing, and much more.
     '';
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     maintainers = with maintainers; [ lnl7 ];
     platforms = platforms.darwin;
   };

--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     platforms = with platforms; darwin ++ linux;
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     homepage = "https://www.wxwidgets.org/";
     description = "A C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
     longDescription = ''

--- a/pkgs/development/python-modules/wxPython/4.0.nix
+++ b/pkgs/development/python-modules/wxPython/4.0.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
   meta = {
     description = "Cross platform GUI toolkit for Python, Phoenix version";
     homepage = "http://wxpython.org/";
-    license = lib.licenses.wxWindows;
+    license = with lib.licenses; [ lgpl2Plus /* WITH */ wx-exception ];
   };
 
 }

--- a/pkgs/development/python-modules/wxPython/4.1.nix
+++ b/pkgs/development/python-modules/wxPython/4.1.nix
@@ -94,7 +94,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Cross platform GUI toolkit for Python, Phoenix version";
     homepage = "http://wxpython.org/";
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     maintainers = with maintainers; [ tfmoraes ];
   };
 }

--- a/pkgs/development/tools/java/visualvm/default.nix
+++ b/pkgs/development/tools/java/visualvm/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       SE platform.
     '';
     homepage = "https://visualvm.github.io";
-    license = licenses.gpl2ClasspathPlus;
+    license = with licenses; [ gpl2Plus /* WITH */ classpath-exception ];
     platforms = platforms.all;
     maintainers = with maintainers; [ michalrus moaxcp ];
   };

--- a/pkgs/tools/X11/virtualgl/lib.nix
+++ b/pkgs/tools/X11/virtualgl/lib.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.virtualgl.org/";
     description = "X11 GL rendering in a remote computer with full 3D hw acceleration";
-    license = licenses.wxWindows;
+    license = with licenses; [ lgpl2Plus /* WITH */ wx-exception ];
     platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
   };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

To move away from some deprecated SPDX license identifier we need to have the license exceptions available in our stdlib.
A typical example is the former `GPL-2.0-with-classpath-exception` that should now be expressed as `GPL-2.0-only` with `Classpath-exception-2.0`.

This adds most of the SPDX exceptions (ignoring a handful that shouldn't be too useful) as a separate section/set in `licenses.nix` since upstream [publishes it as its own distinct list](https://spdx.org/licenses/exceptions-index.html).

Also updated accordingly all instances of:
* `gpl[2,3]Classpath` -> now expressed as GPL-[2,3] with classpath exception
* `qwt` -> now LGPL-2.1 with Qwt exception
* `wxWindows` -> now LGPL-2.0 with WxWindows exception

Also added a link explaining what public domain is in a simple way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
