### PR TITLE
kde/gear: 21.12.2 -> 21.12.3

### DIFF
--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/release-service/21.12.2/src -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/release-service/21.12.3/src -A '*.tar.xz' )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -4,1843 +4,1843 @@
 
 {
   akonadi = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-21.12.2.tar.xz";
-      sha256 = "1i1q8zda3hl564w02478wyqv35wj8npkqayy7b13shkq9b9j3nj8";
-      name = "akonadi-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-21.12.3.tar.xz";
+      sha256 = "026srxk7da20vfhbj7jh8aip3sylpm61czwblj3wxxps0vbxxs2g";
+      name = "akonadi-21.12.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-calendar-21.12.2.tar.xz";
-      sha256 = "001ndvgqn6x70s7gdya1f1vr080mfkypam3k6z0i2ivlpymc3wly";
-      name = "akonadi-calendar-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-calendar-21.12.3.tar.xz";
+      sha256 = "0hzy6y9pxa06k0pp5yr84i0sv15qgzjn7nrlmsylm6iy7fspqqbq";
+      name = "akonadi-calendar-21.12.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-calendar-tools-21.12.2.tar.xz";
-      sha256 = "0f0l6wj3h2afbmvnq60cg0x03a412849dg4l9dwgdn8yxvnxkhw6";
-      name = "akonadi-calendar-tools-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-calendar-tools-21.12.3.tar.xz";
+      sha256 = "1idh6kf8h9158rgw3b5lld7z9mvvif00jrvpz891cziblvr19p4a";
+      name = "akonadi-calendar-tools-21.12.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-contacts-21.12.2.tar.xz";
-      sha256 = "1aq81569kz529n66dl5jjzamy6kxw0xk5bcmjfvb3wpxznhiigqm";
-      name = "akonadi-contacts-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-contacts-21.12.3.tar.xz";
+      sha256 = "04ixj09s27q8pbmfrb1475bc0h84sb5ikfxzpc4i5b3whx40g9dm";
+      name = "akonadi-contacts-21.12.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-import-wizard-21.12.2.tar.xz";
-      sha256 = "0b4mphxbqzf3akhafxc4fvil83l3z4qcf8xnblw23ficqqs8s0di";
-      name = "akonadi-import-wizard-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-import-wizard-21.12.3.tar.xz";
+      sha256 = "1fbxx53zdcqp98mzdx45ccncppnxqfhc7j9qwwxcik0ygrmg9wcj";
+      name = "akonadi-import-wizard-21.12.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-mime-21.12.2.tar.xz";
-      sha256 = "1nd6bf26lb5wfhzh4kn37iwmb6savcq9wsaph5c7jg6m0bdix1fn";
-      name = "akonadi-mime-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-mime-21.12.3.tar.xz";
+      sha256 = "1bcrbf5z9175p206cvm5s6zq882nb32cf9akdcbnadqiibrpxkxv";
+      name = "akonadi-mime-21.12.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-notes-21.12.2.tar.xz";
-      sha256 = "1s3bxnqsjnlgsnia0nvqyc3m1ppzanzna9598lgwbmz053rgn7ck";
-      name = "akonadi-notes-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-notes-21.12.3.tar.xz";
+      sha256 = "0xkcw9izgxfzglciig2i4wiz6iflzjg0d6dp1nq6p1kwxwc899sb";
+      name = "akonadi-notes-21.12.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadi-search-21.12.2.tar.xz";
-      sha256 = "1hp2x8y59azl59znrqhrjn4n1bs2iqnkdsldv1f2k1ima6z5f4qy";
-      name = "akonadi-search-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadi-search-21.12.3.tar.xz";
+      sha256 = "1id6zzjxc9zvpz1ryj2zn1yff5ak04r1mlk9cklbj99frzf0wv6p";
+      name = "akonadi-search-21.12.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akonadiconsole-21.12.2.tar.xz";
-      sha256 = "1rqfmhi1mzh6yzjg7jf6adf1xqvpbhcxgld2pp4rd9g5mi9rlxlk";
-      name = "akonadiconsole-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akonadiconsole-21.12.3.tar.xz";
+      sha256 = "1chb0ars9w05pq6ij2l8qfj1ac7pmzwg2mq1i4z8syhdklyryir1";
+      name = "akonadiconsole-21.12.3.tar.xz";
     };
   };
   akregator = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/akregator-21.12.2.tar.xz";
-      sha256 = "1srsm25qvbww0hl7r878n32b71g0p222zxyys7chzrg8izrh12b8";
-      name = "akregator-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/akregator-21.12.3.tar.xz";
+      sha256 = "1yy5c29zxpli4cddknmdvjkgii3j7pvw6lhwqfrqjc8jh83gm8f8";
+      name = "akregator-21.12.3.tar.xz";
     };
   };
   analitza = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/analitza-21.12.2.tar.xz";
-      sha256 = "1ak2wyfx67cwx85d5053f6flxwas973mhnm25mf4jw0qll72vid4";
-      name = "analitza-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/analitza-21.12.3.tar.xz";
+      sha256 = "0rgims4c80nficibg3lh764csh0kjsfnf7h303kyfd9yk59xa3in";
+      name = "analitza-21.12.3.tar.xz";
     };
   };
   ark = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ark-21.12.2.tar.xz";
-      sha256 = "1g05lyv8ll85myw0i62bxr4kmfd3dhldvmbgpgym9r1rgan12q90";
-      name = "ark-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ark-21.12.3.tar.xz";
+      sha256 = "1p30bgnb3aw0f2jnaksz7jfqqcz45b2x3bjrri0w5w580204a5s8";
+      name = "ark-21.12.3.tar.xz";
     };
   };
   artikulate = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/artikulate-21.12.2.tar.xz";
-      sha256 = "1g0h0dqqsf3x8q292hfhrizl9dlqzm8gjynzcyrzx0gvbfadj2l1";
-      name = "artikulate-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/artikulate-21.12.3.tar.xz";
+      sha256 = "0fbgmd3yfyv1pzz24874a0v7cl4yk6wlfryn8sn21smi054wqz6z";
+      name = "artikulate-21.12.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/audiocd-kio-21.12.2.tar.xz";
-      sha256 = "07nk060vkyn94ihs9v054zhsckfwpn8z911gy3hnyf1wdmnpfh2n";
-      name = "audiocd-kio-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/audiocd-kio-21.12.3.tar.xz";
+      sha256 = "1alyn7w0v1by3fkb6xfnwj0hayjrrnmwnajnrnpvn8skbqsbzlgc";
+      name = "audiocd-kio-21.12.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/baloo-widgets-21.12.2.tar.xz";
-      sha256 = "1ax7pak9qb60yzdca8frkb8qs4khs6f2wbkwyb48s7zmdxqyw1bj";
-      name = "baloo-widgets-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/baloo-widgets-21.12.3.tar.xz";
+      sha256 = "0cfcfmsgbaxi53a3r0f013lskm5yll7zaxw98nlj6r8fsq2slrhv";
+      name = "baloo-widgets-21.12.3.tar.xz";
     };
   };
   blinken = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/blinken-21.12.2.tar.xz";
-      sha256 = "0h0nw79zr891f54y2r3d3n837bzn24pfvkxsab1f0a228kjakw09";
-      name = "blinken-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/blinken-21.12.3.tar.xz";
+      sha256 = "1pbwb7q4p705k31kd62gira0x9qccjsn07d6h1w44wydc3lfdjnc";
+      name = "blinken-21.12.3.tar.xz";
     };
   };
   bomber = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/bomber-21.12.2.tar.xz";
-      sha256 = "1348mdiykfg1c3gr5fkcf71mxf7lyapwg5ym3jqp9vyc56vhwfjs";
-      name = "bomber-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/bomber-21.12.3.tar.xz";
+      sha256 = "1mlxs2dbsycq7mw9g1hl2l17gl0z33mrry5r0zmz74i67nfijg8w";
+      name = "bomber-21.12.3.tar.xz";
     };
   };
   bovo = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/bovo-21.12.2.tar.xz";
-      sha256 = "0i2i5ici9v402lrh83mhfsrxmqi0fs75rkfvhsbza3wab7b165kc";
-      name = "bovo-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/bovo-21.12.3.tar.xz";
+      sha256 = "1jzvazqy5vcwkyhnbzw7sh8ngff5clclq98vbbhzd9dmnacirdbq";
+      name = "bovo-21.12.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/calendarsupport-21.12.2.tar.xz";
-      sha256 = "021rr06ln7l0v2xjzsij4r71jwpy1w1r761bjad0ywprwkdc93bm";
-      name = "calendarsupport-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/calendarsupport-21.12.3.tar.xz";
+      sha256 = "0annni037cp1ga2lj2gkjxlkygnaxna4fs095lbaqp5zljz3g8vp";
+      name = "calendarsupport-21.12.3.tar.xz";
     };
   };
   cantor = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/cantor-21.12.2.tar.xz";
-      sha256 = "0vq8yvdglf43y5r2f9bvamm9bp82q92hw9sr8xmgb5hqz5mkap78";
-      name = "cantor-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/cantor-21.12.3.tar.xz";
+      sha256 = "0v0xcgaz3rag044wmpiq8gs7pp6n7wcca0q1hzav7i651pgqjjks";
+      name = "cantor-21.12.3.tar.xz";
     };
   };
   cervisia = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/cervisia-21.12.2.tar.xz";
-      sha256 = "1vpm3cjknpa4s9mjdfngpvidqihfh5sb427yhnydr1q2dmllr9nn";
-      name = "cervisia-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/cervisia-21.12.3.tar.xz";
+      sha256 = "106x0xrscc6xvgijmqy892r1hrirjh32nj8lqhc7g7dzjaa7lhsj";
+      name = "cervisia-21.12.3.tar.xz";
     };
   };
   dolphin = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/dolphin-21.12.2.tar.xz";
-      sha256 = "0c0gk1djgl1d1qzibw5f1w29cnlxl6kan8pkg0izaqvnbmmx53wn";
-      name = "dolphin-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/dolphin-21.12.3.tar.xz";
+      sha256 = "0m5nqa8j0mcsrx9wxfcf8z39kxas51k03lschr721vm4x65j64jq";
+      name = "dolphin-21.12.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/dolphin-plugins-21.12.2.tar.xz";
-      sha256 = "1mrsampq1zq5rri1kx77dz0afz4a6s8pvb1255q0pl7imgxhiaqc";
-      name = "dolphin-plugins-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/dolphin-plugins-21.12.3.tar.xz";
+      sha256 = "0rbz6fw98c71h10ry1xjc0pgzvphajmj18lnjm4hf7bbrizsmdb5";
+      name = "dolphin-plugins-21.12.3.tar.xz";
     };
   };
   dragon = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/dragon-21.12.2.tar.xz";
-      sha256 = "07zn4ishffh9g8hvkpfgm7j9cimw3plcabzk9p157nhgxr62z4sb";
-      name = "dragon-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/dragon-21.12.3.tar.xz";
+      sha256 = "09iwwlbv4jmxs92dz20z9fqg1sfnqih54izz8459ibl8vydfgfp1";
+      name = "dragon-21.12.3.tar.xz";
     };
   };
   elisa = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/elisa-21.12.2.tar.xz";
-      sha256 = "0zwy0bi4s25y6adgjhrhw992i2c1kjwpgvp9yg902h8zpsdynwh5";
-      name = "elisa-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/elisa-21.12.3.tar.xz";
+      sha256 = "0cg9v438fclqnv1rgx2k86mzfp5ggfcp7d5kr8xh4kjbmy17rzca";
+      name = "elisa-21.12.3.tar.xz";
     };
   };
   eventviews = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/eventviews-21.12.2.tar.xz";
-      sha256 = "1v3bpd0b3ph7v0kg8pyp4rr4j8cxy7y4csym5dlqn6l81db7d3gr";
-      name = "eventviews-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/eventviews-21.12.3.tar.xz";
+      sha256 = "01x9ccwspn1dwkmcxcr8p6pazj6w31pxhx0bzlfr6bgpccicp2w2";
+      name = "eventviews-21.12.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ffmpegthumbs-21.12.2.tar.xz";
-      sha256 = "17cyrimlnf1npffmxinnj3q5ynqg3agx35b55iqnw3xixrz4snzr";
-      name = "ffmpegthumbs-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ffmpegthumbs-21.12.3.tar.xz";
+      sha256 = "0x2gpx30azkz61p3xj1nm7hckyrmyh0qhs29ah30z6a5xw7336ws";
+      name = "ffmpegthumbs-21.12.3.tar.xz";
     };
   };
   filelight = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/filelight-21.12.2.tar.xz";
-      sha256 = "0khhwnms2ysy9ijpmmagm68w1zixmxs7svaaldd30xb3w52f78v2";
-      name = "filelight-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/filelight-21.12.3.tar.xz";
+      sha256 = "1w3q0l9p5ry2crwdzcyb1d4ms2y4gp3y0a3j5drpy8clmxn0gz18";
+      name = "filelight-21.12.3.tar.xz";
     };
   };
   granatier = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/granatier-21.12.2.tar.xz";
-      sha256 = "0j7yizbljqx1a4wd4prmb3463r67f3lk5gv5x8j1yx2zmiaq0qki";
-      name = "granatier-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/granatier-21.12.3.tar.xz";
+      sha256 = "16yriharl66frglmdy6750nixczh0l4c19nnr6dav15m8qfb3g6b";
+      name = "granatier-21.12.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/grantlee-editor-21.12.2.tar.xz";
-      sha256 = "0wxkg56s83i61i17cb2y6ziminaq2gammynrwm5jvkpi5vqwvi2s";
-      name = "grantlee-editor-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/grantlee-editor-21.12.3.tar.xz";
+      sha256 = "00qy1ncgwylc995g051x5l679s16wjpcj7il62ck7d0j02rah0n2";
+      name = "grantlee-editor-21.12.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/grantleetheme-21.12.2.tar.xz";
-      sha256 = "0z1p0s7fakfbscppmrgp1irf3dm2ayadyd3yb5zdsr9xahs0b9md";
-      name = "grantleetheme-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/grantleetheme-21.12.3.tar.xz";
+      sha256 = "1w83slbkj2y1wk78srq2k95ybs66sb4mbaa0zm7fl9pkwhqxbnb7";
+      name = "grantleetheme-21.12.3.tar.xz";
     };
   };
   gwenview = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/gwenview-21.12.2.tar.xz";
-      sha256 = "1jkv34llga981dq08npk8alrg9h27prdpffcxkm368i77mvp9hv6";
-      name = "gwenview-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/gwenview-21.12.3.tar.xz";
+      sha256 = "0zbsyrwlwbc9zmdxcgk02dvcb0f8izhlcbbzqw8cgr4l2c90xl98";
+      name = "gwenview-21.12.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/incidenceeditor-21.12.2.tar.xz";
-      sha256 = "151jhn84d5amv3abvp6cd2q10mf4mmv3q5hn0inqrmapy3v6bn8i";
-      name = "incidenceeditor-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/incidenceeditor-21.12.3.tar.xz";
+      sha256 = "1sbflfggpqhwhg3iw46462z3p83sjhlx6f1fvgz251m020vqq9xa";
+      name = "incidenceeditor-21.12.3.tar.xz";
     };
   };
   itinerary = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/itinerary-21.12.2.tar.xz";
-      sha256 = "02w6696kdzgz2r9677nr1jyhd9mfhc2zhmasy70nblz0jn22bcq7";
-      name = "itinerary-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/itinerary-21.12.3.tar.xz";
+      sha256 = "0gvkhwnxichvpwrsb6wjiv5q80v8k2yqvgpvfdapxnd7sx6qp7fp";
+      name = "itinerary-21.12.3.tar.xz";
     };
   };
   juk = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/juk-21.12.2.tar.xz";
-      sha256 = "1qgxpy1ksrgvdik69vppzdl1crscn69284q4wvwc5qh9v6rhv1xn";
-      name = "juk-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/juk-21.12.3.tar.xz";
+      sha256 = "1ipzx031996h83f9w3fzbx5vf5nnskq9kf71a6aypqckk65vcqcs";
+      name = "juk-21.12.3.tar.xz";
     };
   };
   k3b = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/k3b-21.12.2.tar.xz";
-      sha256 = "0rjg3zs85gw62r3z3msp438jnf0ghc6y577br59ig19m10x33rz9";
-      name = "k3b-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/k3b-21.12.3.tar.xz";
+      sha256 = "0igqb6zw76j2hl9xclcwfny2831phdg9s2msa1y87zyc3c7g9nxc";
+      name = "k3b-21.12.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kaccounts-integration-21.12.2.tar.xz";
-      sha256 = "0c4yxrhbas0wsmrxr0pwkpgw9gzdvvf5r5nxd15f656bwwhmqlwy";
-      name = "kaccounts-integration-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kaccounts-integration-21.12.3.tar.xz";
+      sha256 = "13q4d7ln98vdpb6ryk49zakx5bysdnjxifi7cma10fgk9gcqqhpb";
+      name = "kaccounts-integration-21.12.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kaccounts-providers-21.12.2.tar.xz";
-      sha256 = "1srz43xf6kz7xfz8np94pdnhmvashk7y2f2a275rwpnlrl0yw1yd";
-      name = "kaccounts-providers-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kaccounts-providers-21.12.3.tar.xz";
+      sha256 = "0kcyvpa0b872q7s4amagqcrzpl8cxlb91nwc9yg91wg56mmfv7m0";
+      name = "kaccounts-providers-21.12.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kaddressbook-21.12.2.tar.xz";
-      sha256 = "04ac5z9603lxylc6x55chnc0w59mx3z92nyvfnvjvp1ga77si36b";
-      name = "kaddressbook-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kaddressbook-21.12.3.tar.xz";
+      sha256 = "1hzq0fdy99l1kqw14d582l0s56gvrw86abihib6k4az4c6g3c0md";
+      name = "kaddressbook-21.12.3.tar.xz";
     };
   };
   kajongg = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kajongg-21.12.2.tar.xz";
-      sha256 = "04s3f8nj0rh1zy7sfa5kq0smbfsyylz9w3lxm2z69g7x5sb08k53";
-      name = "kajongg-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kajongg-21.12.3.tar.xz";
+      sha256 = "1sffssfpzsd83ippkwpmqdx8rfh9cpd7i22nsv8asnaylylvy3zd";
+      name = "kajongg-21.12.3.tar.xz";
     };
   };
   kalarm = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kalarm-21.12.2.tar.xz";
-      sha256 = "0f3hcsql20lim9nqb0ha5lpsrbh131rwcla9i6aax5sgw4m6nyfh";
-      name = "kalarm-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kalarm-21.12.3.tar.xz";
+      sha256 = "1miwcxim46hiabp2rbs874np544ip4x5nl1dc62h9li9784a9k3i";
+      name = "kalarm-21.12.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kalarmcal-21.12.2.tar.xz";
-      sha256 = "15l893iv4smlppk7k682m9hwrph84p5chx5mgxixjxl28c1blcc8";
-      name = "kalarmcal-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kalarmcal-21.12.3.tar.xz";
+      sha256 = "160pmr702b68hys9l02azvrv6pagy1r2whw0zp3jlf6863p9fkqr";
+      name = "kalarmcal-21.12.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kalgebra-21.12.2.tar.xz";
-      sha256 = "0w1h3as6dip4hrp2ay61sz9gixf4s887jp42v7zjajwwhjs6xs1m";
-      name = "kalgebra-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kalgebra-21.12.3.tar.xz";
+      sha256 = "0870kdqha0nk2cm8hq8d9l2fqfw6hn0rx2qc9f9w8l4014rcn127";
+      name = "kalgebra-21.12.3.tar.xz";
     };
   };
   kalzium = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kalzium-21.12.2.tar.xz";
-      sha256 = "0kvrmvd2vgl6fklxq9sr46p6nnh0fk0l6licj9b5q9rz82xwbr50";
-      name = "kalzium-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kalzium-21.12.3.tar.xz";
+      sha256 = "1qha1dh638ms785j1b73j19pj8y3c7v1n4jd1m93026a292m8jll";
+      name = "kalzium-21.12.3.tar.xz";
     };
   };
   kamera = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kamera-21.12.2.tar.xz";
-      sha256 = "07n1xlmg7m6p5ca0i4hjjyv564cqrn4p6h5yqx4pw3pcq8nizqfz";
-      name = "kamera-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kamera-21.12.3.tar.xz";
+      sha256 = "1xwxmlnra9qdhvf1hhy04v72ar02pqxkg0l16a53809ilyss2wrm";
+      name = "kamera-21.12.3.tar.xz";
     };
   };
   kamoso = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kamoso-21.12.2.tar.xz";
-      sha256 = "09qn1px0mmcjhw9ikaz8xcjbdabh657ij3sa4ps37jbfzyyv45fb";
-      name = "kamoso-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kamoso-21.12.3.tar.xz";
+      sha256 = "1q98f6ni4p19pk0svbfw4mbfwnc9i5p9csms2aj76mp2dn78xpib";
+      name = "kamoso-21.12.3.tar.xz";
     };
   };
   kanagram = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kanagram-21.12.2.tar.xz";
-      sha256 = "1l4j2fy8mwdywp0prswng1f06rpwkfi54dc8z5z02b13p47hz5cy";
-      name = "kanagram-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kanagram-21.12.3.tar.xz";
+      sha256 = "131flw9pjvin4w1m36qkwgzna3llvxp1vq0ynzwfnvhs49i3g5gc";
+      name = "kanagram-21.12.3.tar.xz";
     };
   };
   kapman = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kapman-21.12.2.tar.xz";
-      sha256 = "0n1iz9jfgzpcpavb4ijfqp3hym7z53wzp5a5hiad8i6nws408grn";
-      name = "kapman-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kapman-21.12.3.tar.xz";
+      sha256 = "1974z7g3ylvf48xh3xhf3gr7iphgmj83ir9hss1a2ba0hpgg463k";
+      name = "kapman-21.12.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kapptemplate-21.12.2.tar.xz";
-      sha256 = "1sjyji533x9ph9l63zf0llsb0m5fzb1lka03h5blm7fdyw570bad";
-      name = "kapptemplate-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kapptemplate-21.12.3.tar.xz";
+      sha256 = "16jgybcq3ixqwi7wli11ns7w4zdlj8rgw4chzsjcqxn6c0sqy8zq";
+      name = "kapptemplate-21.12.3.tar.xz";
     };
   };
   kate = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kate-21.12.2.tar.xz";
-      sha256 = "0r59rfyrbs50w9brl4rrq1wdfmrr3sz7plw2pqlc5xpzngrdlhs1";
-      name = "kate-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kate-21.12.3.tar.xz";
+      sha256 = "1pp0k00kvih0xkkv1q1gha4na2bwqc7dhyyrla7c2vvln8gi99dg";
+      name = "kate-21.12.3.tar.xz";
     };
   };
   katomic = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/katomic-21.12.2.tar.xz";
-      sha256 = "123ls2p6az9bpy741xg85azs0p1qbssgcg4fh8cqazkz0kgzr0hf";
-      name = "katomic-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/katomic-21.12.3.tar.xz";
+      sha256 = "1y4mnvkd6ajk0m0j2xph5zbw3a14clm2sswc4y8c9r4ipk3hqsgh";
+      name = "katomic-21.12.3.tar.xz";
     };
   };
   kbackup = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kbackup-21.12.2.tar.xz";
-      sha256 = "1yadxlqfz2a4lirxf2xmivggvdpbjiaw5zn7aw72jb3yjs7x6j03";
-      name = "kbackup-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kbackup-21.12.3.tar.xz";
+      sha256 = "0r1cqkfzpdqpwv5pds8l0p7lxlwpv0mr7rjys1icsp8gl4hbpv60";
+      name = "kbackup-21.12.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kblackbox-21.12.2.tar.xz";
-      sha256 = "1y5l5l5p3s2gf69rih3mjdv42h9ydfk66v10ad5na3b4sqbi2qi7";
-      name = "kblackbox-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kblackbox-21.12.3.tar.xz";
+      sha256 = "10j8rnpr3gjaqspx4mxqj9cncqj6v2jn5rkldr46bv7yxgjb5rw3";
+      name = "kblackbox-21.12.3.tar.xz";
     };
   };
   kblocks = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kblocks-21.12.2.tar.xz";
-      sha256 = "13anvyy3br7ybl74jcrnjmw5qjfyk4z6s7ncziw8l37ggg4k7n91";
-      name = "kblocks-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kblocks-21.12.3.tar.xz";
+      sha256 = "1n3jc96ws8078gk1il61dc96p3pzvj3z9brnwi274pk4cif63bli";
+      name = "kblocks-21.12.3.tar.xz";
     };
   };
   kbounce = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kbounce-21.12.2.tar.xz";
-      sha256 = "07k5vmfkh9l4b4sb4an5qlnq0b9hmhh6dax0bjgia0ng9vxd011q";
-      name = "kbounce-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kbounce-21.12.3.tar.xz";
+      sha256 = "1am4j11cjzlmav2zh5802kasy0kdcx78slycadnf96bmhxs8hvyv";
+      name = "kbounce-21.12.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kbreakout-21.12.2.tar.xz";
-      sha256 = "08rykfi82hgzg5l2bhs8nvh8si06nisy60653n6r7m8g327yyn1m";
-      name = "kbreakout-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kbreakout-21.12.3.tar.xz";
+      sha256 = "0vqlxaggzvvrb439ybsvd5kr9j2jzpwk4xy3yni83y830h1mmhhc";
+      name = "kbreakout-21.12.3.tar.xz";
     };
   };
   kbruch = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kbruch-21.12.2.tar.xz";
-      sha256 = "0vvl2rk636zpg27hj2jly1awg4z3fm6mk75qrda3hl6gm8rddw1v";
-      name = "kbruch-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kbruch-21.12.3.tar.xz";
+      sha256 = "1kcwbpa5lawkqqwn40r6d7savwvi7kkdgdxfxqxkviwnif2qkssx";
+      name = "kbruch-21.12.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcachegrind-21.12.2.tar.xz";
-      sha256 = "1fg7fn8a3bjbjr6bi298gqr4mr838v96bz9773pd7rnhffvvip8z";
-      name = "kcachegrind-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcachegrind-21.12.3.tar.xz";
+      sha256 = "1cssjywnhfbnsvly4mralpx3af2pqkmhg1jj2q3cjiqx44i3gkyx";
+      name = "kcachegrind-21.12.3.tar.xz";
     };
   };
   kcalc = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcalc-21.12.2.tar.xz";
-      sha256 = "037xk57gjfbjpw1q4gm9k1xkc3x5xxjr4d8xmnrnc6ni090648q4";
-      name = "kcalc-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcalc-21.12.3.tar.xz";
+      sha256 = "15yqzhrlzcix8wvgaah8wf12msylgzyqwk58f58k5agxh97ahv4q";
+      name = "kcalc-21.12.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcalutils-21.12.2.tar.xz";
-      sha256 = "0i474by8pyv64b7i807kym2q4wkhnyyn21vn56dbgp1awpi198i8";
-      name = "kcalutils-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcalutils-21.12.3.tar.xz";
+      sha256 = "006sfkjzyid8byl2mmyn1is4nra9wjqh21ksd5g1kv948hf1jdcs";
+      name = "kcalutils-21.12.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcharselect-21.12.2.tar.xz";
-      sha256 = "1czkni7wrl2l5v0zpvxfwdaqd5i0x6knzbjhzh8shdg3h19sgqrm";
-      name = "kcharselect-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcharselect-21.12.3.tar.xz";
+      sha256 = "1aaiz9f9y2fmf284617pfnncgxjjjyfvdv08h900sc0bdlfmh4y7";
+      name = "kcharselect-21.12.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcolorchooser-21.12.2.tar.xz";
-      sha256 = "12s2vfa3i7b5dh8c10xbqsy1xi9pq13vdj2xcpm5chkgw22595hv";
-      name = "kcolorchooser-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcolorchooser-21.12.3.tar.xz";
+      sha256 = "0jnnbwaj9xb0ifcc95xay8yc4bx9f29wqkj3h4kffzdlwvw3vp7s";
+      name = "kcolorchooser-21.12.3.tar.xz";
     };
   };
   kcron = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kcron-21.12.2.tar.xz";
-      sha256 = "0ddgl61vw4mj8sa6zg1m4s6qagwygdkvw9pjmfs8fsa1anhlillk";
-      name = "kcron-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kcron-21.12.3.tar.xz";
+      sha256 = "0ffc71inp1kyd4xh39x6vbfggz0kpipd6r6vabfn187lpnpwcmpm";
+      name = "kcron-21.12.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kde-dev-scripts-21.12.2.tar.xz";
-      sha256 = "1vdssqwyi25j3saz5cw8n40y2i6bhq5l0rxbarh8m3iwcvx4ki3c";
-      name = "kde-dev-scripts-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kde-dev-scripts-21.12.3.tar.xz";
+      sha256 = "04w4kk7vpfkjj2fzylmq590kk7xskw3a0id3wndw8066pfafsfg3";
+      name = "kde-dev-scripts-21.12.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kde-dev-utils-21.12.2.tar.xz";
-      sha256 = "0flzc0kl252imng2mpg9mp71k8jrxc3yy7dzqlfdnpjz36dwpaqf";
-      name = "kde-dev-utils-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kde-dev-utils-21.12.3.tar.xz";
+      sha256 = "1jdqv5zdigwazh3m580rmnylr6h6a6l5g2cpxy54v9sdvh3qb1yr";
+      name = "kde-dev-utils-21.12.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdebugsettings-21.12.2.tar.xz";
-      sha256 = "0cimipq45c36nwk3alg738jl93zxja3xi77zjqk0k28ffn6qn7c2";
-      name = "kdebugsettings-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdebugsettings-21.12.3.tar.xz";
+      sha256 = "19ng7hvqpyh3kh0pahrknh89c113mqx1kxjq4r26xbww1ypkz8zq";
+      name = "kdebugsettings-21.12.3.tar.xz";
     };
   };
   kdeconnect-kde = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdeconnect-kde-21.12.2.tar.xz";
-      sha256 = "0crw0navhdsix0rpsya4vhffj35vlascpcflrs04vyws3v8xr026";
-      name = "kdeconnect-kde-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdeconnect-kde-21.12.3.tar.xz";
+      sha256 = "1n9km7czif19cvrsdfcjbb02i1xgpa1z4ycn20d3g8azmli4zj4g";
+      name = "kdeconnect-kde-21.12.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdeedu-data-21.12.2.tar.xz";
-      sha256 = "1cpbi5gkbq7xrv276vm0jlcjc5y9x1kw8l8x0z7syy06s4s3pvg9";
-      name = "kdeedu-data-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdeedu-data-21.12.3.tar.xz";
+      sha256 = "11mxxcca6jxz4qcmba12p6xbv845xa16b8ag529409f3276w4915";
+      name = "kdeedu-data-21.12.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdegraphics-mobipocket-21.12.2.tar.xz";
-      sha256 = "0zbiz47mqa176gcina8v03fw2qqrc5v1l8mg2fcpnl5dxc9d56c4";
-      name = "kdegraphics-mobipocket-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdegraphics-mobipocket-21.12.3.tar.xz";
+      sha256 = "091ix343p9vs4iyj8abq6mw9lbm1fx5167gykhm4g8bjk5vdri2q";
+      name = "kdegraphics-mobipocket-21.12.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdegraphics-thumbnailers-21.12.2.tar.xz";
-      sha256 = "09adinkdfbn5hfic92zbdhq9ldxpnbgf9pybsp4ibpw2097l2k5f";
-      name = "kdegraphics-thumbnailers-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdegraphics-thumbnailers-21.12.3.tar.xz";
+      sha256 = "0shdrl6n1724i8jrkmy8z6ayhflg93401jia87mcc1apaw9s8y83";
+      name = "kdegraphics-thumbnailers-21.12.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdenetwork-filesharing-21.12.2.tar.xz";
-      sha256 = "0q7gndwvki3r9vhkxmwr8xzc54cjpk9nzhk2665wsk1msfp3xqw6";
-      name = "kdenetwork-filesharing-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdenetwork-filesharing-21.12.3.tar.xz";
+      sha256 = "1y6sa22j2165j3x6ql1cfm30vv9ifb94mczbqbcjzmhqsypp5pw2";
+      name = "kdenetwork-filesharing-21.12.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdenlive-21.12.2.tar.xz";
-      sha256 = "1h668q91pcq3km7pq75krgq06x8gglmp8al52b0imyc9g9wy28z6";
-      name = "kdenlive-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdenlive-21.12.3.tar.xz";
+      sha256 = "1hamdi2v3rx5zjmvpx1bximdppmzgsk9gbjxwgr691lkybkgx8vs";
+      name = "kdenlive-21.12.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdepim-addons-21.12.2.tar.xz";
-      sha256 = "00j67rvkvm1sri6ij5ziqjh340cmpsyfwwmw8hr1dsi3vlva4gk1";
-      name = "kdepim-addons-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdepim-addons-21.12.3.tar.xz";
+      sha256 = "1pv780z29ccx05z12l2w5zdmby9d1q993jr0cyzvpapnmck9146h";
+      name = "kdepim-addons-21.12.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdepim-runtime-21.12.2.tar.xz";
-      sha256 = "0y1hgab16h9ypqh9isabbb4km2907vzdydfkd1m5b63vfbambz0j";
-      name = "kdepim-runtime-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdepim-runtime-21.12.3.tar.xz";
+      sha256 = "1ahrnnc9vn0556s4nrsjgc9vbf5rb6yby7fn33p3jjnpgja0mc7m";
+      name = "kdepim-runtime-21.12.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdesdk-kioslaves-21.12.2.tar.xz";
-      sha256 = "0vz6dk5an0bhnyglyqdgf3lqxdlc61k4vsbh8a4fky1zpvpwya84";
-      name = "kdesdk-kioslaves-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdesdk-kioslaves-21.12.3.tar.xz";
+      sha256 = "1nhsvx5pznm3adf0scrcqqb2ibl52a241ki2gbwvxk2qpwwwx6jd";
+      name = "kdesdk-kioslaves-21.12.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdesdk-thumbnailers-21.12.2.tar.xz";
-      sha256 = "1w90zjnwnqh1a47kgmijr8xp6z096f6ij250qfcl3bwvhxqmsrb0";
-      name = "kdesdk-thumbnailers-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdesdk-thumbnailers-21.12.3.tar.xz";
+      sha256 = "0337rhgil42wychi5anq2v61xq8mbcvma4gb50smapcrjfl7fkdy";
+      name = "kdesdk-thumbnailers-21.12.3.tar.xz";
     };
   };
   kdev-php = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdev-php-21.12.2.tar.xz";
-      sha256 = "0ghxfllh8pkyrvsaz4iwc9bm98mkq6z3wr558w4wjykgjp69r08j";
-      name = "kdev-php-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdev-php-21.12.3.tar.xz";
+      sha256 = "0z5iqgsh7w0hw0pw2522zlh5sd88zlplrxm3vjp3yvmza65471aa";
+      name = "kdev-php-21.12.3.tar.xz";
     };
   };
   kdev-python = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdev-python-21.12.2.tar.xz";
-      sha256 = "05jj7q7agkgpbrxzwh0n2ipc854cgm8skjyjkqmxp2kdf3fdm8lj";
-      name = "kdev-python-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdev-python-21.12.3.tar.xz";
+      sha256 = "1iyg1cfldf5mk62anw8schiw3ii0gp20qwg6ljk1r9hv583iwrq6";
+      name = "kdev-python-21.12.3.tar.xz";
     };
   };
   kdevelop = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdevelop-21.12.2.tar.xz";
-      sha256 = "13kgkxvbjcb60ckapqrcr4m0y5kyag948xx6gwrvzhrhn46ynfgz";
-      name = "kdevelop-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdevelop-21.12.3.tar.xz";
+      sha256 = "1shp8zlxr7iyysn1c8d3fp6rg6g2krj2v3zw5apalxcnal16bww6";
+      name = "kdevelop-21.12.3.tar.xz";
     };
   };
   kdf = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdf-21.12.2.tar.xz";
-      sha256 = "1fs8bab6q7imfpqqgasvr98k57nm68ignfch2i76rdcywhx3q268";
-      name = "kdf-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdf-21.12.3.tar.xz";
+      sha256 = "179ygy4kxkapfyxqj8h5xlvp1160vd72af34vd0a4r5az7wfd1m7";
+      name = "kdf-21.12.3.tar.xz";
     };
   };
   kdialog = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdialog-21.12.2.tar.xz";
-      sha256 = "1k6zlh1gbpj0y40h1i8pan28d8chqjsnhd6pvsvr95b91d0pj2xn";
-      name = "kdialog-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdialog-21.12.3.tar.xz";
+      sha256 = "04d1dqc5f02s867lllx1ix0nc55xw9hrpg7jxiy3v4c8vlzg0w53";
+      name = "kdialog-21.12.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kdiamond-21.12.2.tar.xz";
-      sha256 = "08b2a13bmxw3h6rhip619jvzgjrjgpz2v83i2azbqccfynisjnyh";
-      name = "kdiamond-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kdiamond-21.12.3.tar.xz";
+      sha256 = "1d3c4pckddnri9i19g2pi2ygpqakllrgy6azgvnh5hn20kgsw7d9";
+      name = "kdiamond-21.12.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/keditbookmarks-21.12.2.tar.xz";
-      sha256 = "1fxm0mm3sqp2frk2fcs2jw86wjxb2j5z9vyb34x7g80k5j17j57m";
-      name = "keditbookmarks-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/keditbookmarks-21.12.3.tar.xz";
+      sha256 = "0wfb7j1lhhdfw2x03p692mglmy9i9qys8mn4f3gxlb5imrd2hmnk";
+      name = "keditbookmarks-21.12.3.tar.xz";
     };
   };
   kfind = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kfind-21.12.2.tar.xz";
-      sha256 = "0kx6p4hyyalx5i8g4aq81aj30c9ac0380xvia9130g95pgkzd96c";
-      name = "kfind-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kfind-21.12.3.tar.xz";
+      sha256 = "1v1yxsbmzv4q5m5rbvl9n095d9fq0b1zphnl6vrzff5r8i53pzx0";
+      name = "kfind-21.12.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kfloppy-21.12.2.tar.xz";
-      sha256 = "10245c87379576n11xcjkll3rkvzv815qsavr4alsj1jr8w6zyg8";
-      name = "kfloppy-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kfloppy-21.12.3.tar.xz";
+      sha256 = "1phkigxd6bkwlcjrsfhlhn44ra9imfq0flcvp4vmza6c9ylsx6m8";
+      name = "kfloppy-21.12.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kfourinline-21.12.2.tar.xz";
-      sha256 = "1kz7ff31h8lvz7snqmjs6cma9i3py7dyd91i6ik2pwiar80sin1x";
-      name = "kfourinline-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kfourinline-21.12.3.tar.xz";
+      sha256 = "0rb5jcmmf19bidwywj56dn0wfrnrfi5kc75c20d7mxnlgygfdnkg";
+      name = "kfourinline-21.12.3.tar.xz";
     };
   };
   kgeography = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kgeography-21.12.2.tar.xz";
-      sha256 = "09h5zp8pxzr47s7j50l6xfssvk9zk56cqgnsjx75yh1n077z1d0j";
-      name = "kgeography-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kgeography-21.12.3.tar.xz";
+      sha256 = "1s1xyfffqkhmf4n74a4ksjz62rdiyl1fk1v57s9gnr6qw71wqql0";
+      name = "kgeography-21.12.3.tar.xz";
     };
   };
   kget = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kget-21.12.2.tar.xz";
-      sha256 = "0jmy2yxzrgq592dq075k7gp7ynk42i899jsbw0gbn79x69cxlkmv";
-      name = "kget-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kget-21.12.3.tar.xz";
+      sha256 = "1w249gvzz47ac7n1mnxxf20d9l7jmbh18m5dijy55ck61s4zcq4l";
+      name = "kget-21.12.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kgoldrunner-21.12.2.tar.xz";
-      sha256 = "0by6cq31jsls3qaqn4agrdhvd9jqg84plm6nbgh3rc85pnj5h22p";
-      name = "kgoldrunner-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kgoldrunner-21.12.3.tar.xz";
+      sha256 = "0gzz58407zjmk311kyyj5l2c1ciczcq9i8ckpwbd341dvwaww27q";
+      name = "kgoldrunner-21.12.3.tar.xz";
     };
   };
   kgpg = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kgpg-21.12.2.tar.xz";
-      sha256 = "1f193fyn1azwhm7b8gd5ffyb11acg1269mh1d2ly60ax83qjs48c";
-      name = "kgpg-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kgpg-21.12.3.tar.xz";
+      sha256 = "1mzq3g4xwg459k0mp9xvg8bhilizadbh4gck1764wq69bxlcyav3";
+      name = "kgpg-21.12.3.tar.xz";
     };
   };
   khangman = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/khangman-21.12.2.tar.xz";
-      sha256 = "0xih54w33vigvm3x2xp5lf29k4aga4yil0qv263965nxn9djnlaw";
-      name = "khangman-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/khangman-21.12.3.tar.xz";
+      sha256 = "000vn11pp4hwfh2689rmnwrrssrmrhx5569k02h4ynswkiykvbv6";
+      name = "khangman-21.12.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/khelpcenter-21.12.2.tar.xz";
-      sha256 = "09ddkc7kiayx852mpgdmv04l19vrrc0yrf30hnyzkci58kbavvcq";
-      name = "khelpcenter-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/khelpcenter-21.12.3.tar.xz";
+      sha256 = "1fj1c57bqs009rx9db4ifvfmhhl4b35r5sfly3wvbfr4dapjqfqr";
+      name = "khelpcenter-21.12.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kidentitymanagement-21.12.2.tar.xz";
-      sha256 = "00fwjax3kfvr8jsy04hp1jyihvskvprbg83z2avhcy6lvr7g25kk";
-      name = "kidentitymanagement-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kidentitymanagement-21.12.3.tar.xz";
+      sha256 = "18xwvlmqhih5jmig2mj3a6mc5awlxdv8f81da6cgm123imhrirk4";
+      name = "kidentitymanagement-21.12.3.tar.xz";
     };
   };
   kig = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kig-21.12.2.tar.xz";
-      sha256 = "100ds4728lfnb6r6c52rdzk2n4rcpc5jiv35q5qd7d6cszmxvhvx";
-      name = "kig-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kig-21.12.3.tar.xz";
+      sha256 = "0rl0z1djsf9ha0q94v0cnj5qm4ij6yjsil2s57r3v666h64yradn";
+      name = "kig-21.12.3.tar.xz";
     };
   };
   kigo = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kigo-21.12.2.tar.xz";
-      sha256 = "0g1sl7bw9aln7fm2786sgh0m44da6vfxc9g0rizw31ff8papnyb8";
-      name = "kigo-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kigo-21.12.3.tar.xz";
+      sha256 = "14pp73b9mbf0ny75b90vs7z9l61m7zp8cll7hl4bplqh1kig1szf";
+      name = "kigo-21.12.3.tar.xz";
     };
   };
   killbots = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/killbots-21.12.2.tar.xz";
-      sha256 = "1qryy2g2i6iqc6rsw8jz4c14x67glpm3zvcx2dghyll6q9hns43z";
-      name = "killbots-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/killbots-21.12.3.tar.xz";
+      sha256 = "1ncr55xq04vrx6bss1ahk86c3l9ckhv4zjbc6gq4krhjw0lkdfiv";
+      name = "killbots-21.12.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kimagemapeditor-21.12.2.tar.xz";
-      sha256 = "11j55jvfxdpam3gkfv7355av9d6mz8z6djhplhmfd56llkmvw4n2";
-      name = "kimagemapeditor-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kimagemapeditor-21.12.3.tar.xz";
+      sha256 = "0qdmyrlf0jp3737p7x31wk428676xv77lx0mgyd9h2hdl0ipnbvr";
+      name = "kimagemapeditor-21.12.3.tar.xz";
     };
   };
   kimap = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kimap-21.12.2.tar.xz";
-      sha256 = "0sdas8knk6wa8hhgc3w62famdpq6pcxfhl4vmpw0r3aqskaci4q3";
-      name = "kimap-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kimap-21.12.3.tar.xz";
+      sha256 = "11jd9zkvflfh3gqs36fhj8mla3k44xf7zdb0z4nl9sk5nhhgm5px";
+      name = "kimap-21.12.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kio-extras-21.12.2.tar.xz";
-      sha256 = "0133cww4k2svn7cvw0fbdcwwv0zg09d27gz59gkpfswjmpsxdqj4";
-      name = "kio-extras-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kio-extras-21.12.3.tar.xz";
+      sha256 = "11zpnjdri7z4sz6zx26d9iv52aj4vf5lr9c114gg4pvz2l4h4h5i";
+      name = "kio-extras-21.12.3.tar.xz";
     };
   };
   kio-gdrive = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kio-gdrive-21.12.2.tar.xz";
-      sha256 = "1n3khrx5fczffwzg4bzxjhzy2kxf72dmb7fqs9hqfn1qkaahfv49";
-      name = "kio-gdrive-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kio-gdrive-21.12.3.tar.xz";
+      sha256 = "0bm3c7g6q7z2ydnha2x5c456x9wlgachi9453mlrd2zcsc7c5h87";
+      name = "kio-gdrive-21.12.3.tar.xz";
     };
   };
   kipi-plugins = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kipi-plugins-21.12.2.tar.xz";
-      sha256 = "11f3qmgqxdlzvv2zldjawn7a3kdigj5pb535rc9v9a8fp8mjvk88";
-      name = "kipi-plugins-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kipi-plugins-21.12.3.tar.xz";
+      sha256 = "1h6107d2a6jcyjsd191cg2ykgwm580j7wr0blg328ff6wwk1aizy";
+      name = "kipi-plugins-21.12.3.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kirigami-gallery-21.12.2.tar.xz";
-      sha256 = "0rg9lg4iqxycfbhs62qs4ms4qadz1ii1dcv3ykkgn3w2brx77wad";
-      name = "kirigami-gallery-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kirigami-gallery-21.12.3.tar.xz";
+      sha256 = "0pjd9bq965v9x433p8rbhd7w3fj0808qd7x4c11ziyhy4cg9gwml";
+      name = "kirigami-gallery-21.12.3.tar.xz";
     };
   };
   kiriki = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kiriki-21.12.2.tar.xz";
-      sha256 = "1blj3vl87jdrr8qv2cyng20nr4d54gbk7w72z9rl02l62c9gkw5j";
-      name = "kiriki-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kiriki-21.12.3.tar.xz";
+      sha256 = "0qbm0zjjqnbcdm39zi8h240nblpa1pa7g1ls9mghzbqrdrh7n3a0";
+      name = "kiriki-21.12.3.tar.xz";
     };
   };
   kiten = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kiten-21.12.2.tar.xz";
-      sha256 = "18kxqrhfgch32583ra4422h7csd5ajijf9989bxz9hwi9mn3r2vl";
-      name = "kiten-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kiten-21.12.3.tar.xz";
+      sha256 = "0z0haqxxkh7m2510b5qfwbx8s45vcahbk503jp1x0bwz03mrwflw";
+      name = "kiten-21.12.3.tar.xz";
     };
   };
   kitinerary = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kitinerary-21.12.2.tar.xz";
-      sha256 = "0g7z6408nhrv54h6xxd2rd9wj2hmwzc3lg5risyqbg2zii9j0sp2";
-      name = "kitinerary-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kitinerary-21.12.3.tar.xz";
+      sha256 = "0kccrjiyib2zljr6rnc89y29jgi8cnhwfh1yq8psyzmca2n8lpxi";
+      name = "kitinerary-21.12.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kjumpingcube-21.12.2.tar.xz";
-      sha256 = "1abv3yi716n88b19rmimhw0vnnwyw28ab6fbcy9g1lgpbi69g5ax";
-      name = "kjumpingcube-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kjumpingcube-21.12.3.tar.xz";
+      sha256 = "1wlk6my6pawmdv3zgcpnyyzpjwz0wii0h8i1z0gxhbpg9nc8iy1r";
+      name = "kjumpingcube-21.12.3.tar.xz";
     };
   };
   kldap = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kldap-21.12.2.tar.xz";
-      sha256 = "1xda42f1q5ih3hdhmcbdz0fx2nchirlwips3gq0jb6lfzi5dbqpl";
-      name = "kldap-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kldap-21.12.3.tar.xz";
+      sha256 = "13llsfhx9lfvhf90a3vmpkyh02fjg5sp4fmrwrqyx9hjrbmy1g0a";
+      name = "kldap-21.12.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kleopatra-21.12.2.tar.xz";
-      sha256 = "1b2nq823gq1v20dnh3hm298fva7cmbn9hh0kmbq22kh98kv8chhh";
-      name = "kleopatra-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kleopatra-21.12.3.tar.xz";
+      sha256 = "10f61m0qrs0qipn94jd32gibyj8pcvprs8j7gmac0mym0b3djjls";
+      name = "kleopatra-21.12.3.tar.xz";
     };
   };
   klettres = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/klettres-21.12.2.tar.xz";
-      sha256 = "1wi1byr36x7z9scsy1gffna36m8x9vyfcqzndvx6042i2y0smhwz";
-      name = "klettres-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/klettres-21.12.3.tar.xz";
+      sha256 = "0l4zgfqd6l2bk67s2a0zldbcy8v7nwbv7yahvnyw4jf4jyv9q9rv";
+      name = "klettres-21.12.3.tar.xz";
     };
   };
   klickety = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/klickety-21.12.2.tar.xz";
-      sha256 = "19rn9p7cbxhn471b65nhwhpnfnhykjwj6n5lrsd431391dyhvshc";
-      name = "klickety-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/klickety-21.12.3.tar.xz";
+      sha256 = "03liv3fax764ngfkwp3ga96irn8qb509b08ljnhz5aw5v9yrssnk";
+      name = "klickety-21.12.3.tar.xz";
     };
   };
   klines = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/klines-21.12.2.tar.xz";
-      sha256 = "1r004rsy98lxh5vd3r4bc0l4d7ymija13barg9xglj53xzbyij3k";
-      name = "klines-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/klines-21.12.3.tar.xz";
+      sha256 = "1ypi64wdsw1zsj03wcxj02v27y1by113v89as8dyk9wr0pfmbpqf";
+      name = "klines-21.12.3.tar.xz";
     };
   };
   kmag = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmag-21.12.2.tar.xz";
-      sha256 = "03kzahsr80wnbx6ky112ka3zm01pnc5h85l28a4186617swx344l";
-      name = "kmag-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmag-21.12.3.tar.xz";
+      sha256 = "067x65gmip89rdgii2nwnxn7zi96cf7vfbhqzg0499pd2d69p3sl";
+      name = "kmag-21.12.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmahjongg-21.12.2.tar.xz";
-      sha256 = "1w8v6fchrkvsbyvnx8vvs801cvg52pr78ihvdjv6c0vpd0q7z9rz";
-      name = "kmahjongg-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmahjongg-21.12.3.tar.xz";
+      sha256 = "02yvvpwkk5gbj445zv5xhfragk8220rlx0pkxf32pj0jsv7dnz1x";
+      name = "kmahjongg-21.12.3.tar.xz";
     };
   };
   kmail = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmail-21.12.2.tar.xz";
-      sha256 = "003bnp00figa09qcp2hl45sivdk3d0j3amxdidyrn47q9vy40554";
-      name = "kmail-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmail-21.12.3.tar.xz";
+      sha256 = "1knh6cf72hidc6jyiw250b708b410fla0c5w83zaavmwv37ah8z0";
+      name = "kmail-21.12.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmail-account-wizard-21.12.2.tar.xz";
-      sha256 = "1nmg8qns3iglcc4l4g5nffnji1vgg43a9fa9rz1hacvlkarm98m4";
-      name = "kmail-account-wizard-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmail-account-wizard-21.12.3.tar.xz";
+      sha256 = "0ar2rm6viissfipbak07fxivrgqgsdfilsprsqmvab44inw2g4pg";
+      name = "kmail-account-wizard-21.12.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmailtransport-21.12.2.tar.xz";
-      sha256 = "0rs6qihzy8q2n204zkhakgnjxwqy9pz9i0kv1j3amw2xv3f51rvw";
-      name = "kmailtransport-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmailtransport-21.12.3.tar.xz";
+      sha256 = "0l3pgs781a6is937i0bkz9ykr40l36rwlrirsr4g8wh0gkc3ifi6";
+      name = "kmailtransport-21.12.3.tar.xz";
     };
   };
   kmbox = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmbox-21.12.2.tar.xz";
-      sha256 = "1mfwaw4d480kbb60wb0kvl5z35ly2hn6h73kx9wdb5y7mz05rvn1";
-      name = "kmbox-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmbox-21.12.3.tar.xz";
+      sha256 = "04cl2khj3a7n81nlmxsg8kgszrl22qm6s2kvbrhz39yfzi31cwqr";
+      name = "kmbox-21.12.3.tar.xz";
     };
   };
   kmime = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmime-21.12.2.tar.xz";
-      sha256 = "0qxb0gf4pqfa0540fsbnf24nh9qwiamwl65q7vaanb80b211qp2g";
-      name = "kmime-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmime-21.12.3.tar.xz";
+      sha256 = "03s7l4lywdvp97h4qjgq06qqcclvnhy83qsrfzv0w2wcl631nnpw";
+      name = "kmime-21.12.3.tar.xz";
     };
   };
   kmines = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmines-21.12.2.tar.xz";
-      sha256 = "0dsqlqmbaggab38zzjyhnx318sn2mw6y51k52c7blm2l53a8zp3j";
-      name = "kmines-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmines-21.12.3.tar.xz";
+      sha256 = "1wxy0cyz733wvnxfjhirqf41wnda4f6aqdiqmb5r1ngzzllgbglc";
+      name = "kmines-21.12.3.tar.xz";
     };
   };
   kmix = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmix-21.12.2.tar.xz";
-      sha256 = "0fyjzzv6x9xf0g222jjsvrywnm3blhbzm2zwhxagrfkjvjpb2cvk";
-      name = "kmix-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmix-21.12.3.tar.xz";
+      sha256 = "1zk2xljis1pv3m4vs5zr6wza6iv5y6wmh1csx3rn8ylfkrpk7h8k";
+      name = "kmix-21.12.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmousetool-21.12.2.tar.xz";
-      sha256 = "1hh7sql04hpwvb8hbi7snvh2d6922a2yraah9hd1jiwniv3cv175";
-      name = "kmousetool-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmousetool-21.12.3.tar.xz";
+      sha256 = "013qr1md3gbin7hcahnv14y9i2cg35r433s2w81fvgcakd38qvkj";
+      name = "kmousetool-21.12.3.tar.xz";
     };
   };
   kmouth = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmouth-21.12.2.tar.xz";
-      sha256 = "0vxssxchh23bl237qw9pznbrkwyqx1bhbnp2fq9baw1bn88d18i5";
-      name = "kmouth-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmouth-21.12.3.tar.xz";
+      sha256 = "0xvkp2pm2szbgzdsfmwrykma8npmlwmx2pb1iakbx3x1wyyjsbim";
+      name = "kmouth-21.12.3.tar.xz";
     };
   };
   kmplot = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kmplot-21.12.2.tar.xz";
-      sha256 = "025n51s7i5nr63knsd78pg48wfs4cldhplr68jmwv2k8pb5w9kxs";
-      name = "kmplot-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kmplot-21.12.3.tar.xz";
+      sha256 = "1vmrzfcdyaxgvyp9la2gvy3h5fhksmn24lsnrpvr6alj880mh8bq";
+      name = "kmplot-21.12.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/knavalbattle-21.12.2.tar.xz";
-      sha256 = "1z1qqr5jjinm49p7rhr0pzf8ir2nvdq157zqxnnr6i11xqk2mnkj";
-      name = "knavalbattle-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/knavalbattle-21.12.3.tar.xz";
+      sha256 = "1mpj1783za6b7a7cjawy4v0z24dvcd34gdb25qch4gi9cx1lc28z";
+      name = "knavalbattle-21.12.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/knetwalk-21.12.2.tar.xz";
-      sha256 = "1gnir7h1iam51frdajp4h6xw4biz545nljdfcck17jiw6ad9py4j";
-      name = "knetwalk-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/knetwalk-21.12.3.tar.xz";
+      sha256 = "0ahms3imvkdknp1z2h6j42k9g1i20ygd2633icjv37d2cbij128m";
+      name = "knetwalk-21.12.3.tar.xz";
     };
   };
   knights = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/knights-21.12.2.tar.xz";
-      sha256 = "0k9hqgz3zw7vhrgbwnmy0v3j9kflz6wx8wavckg1i2l4qadprc1y";
-      name = "knights-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/knights-21.12.3.tar.xz";
+      sha256 = "1m2big16rdw3w347m5vi0qhypnb2rgz6804kkxs7ln0yx658y4x4";
+      name = "knights-21.12.3.tar.xz";
     };
   };
   knotes = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/knotes-21.12.2.tar.xz";
-      sha256 = "0f8ra6nkgndgkfnw194y5976kkrm7qdj1w7l27znwalzaydnxvjg";
-      name = "knotes-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/knotes-21.12.3.tar.xz";
+      sha256 = "07pj0aqwsy1xi5mx7x0h3zmxfg0n4afgjax9a9ihc553xs6k48d7";
+      name = "knotes-21.12.3.tar.xz";
     };
   };
   kolf = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kolf-21.12.2.tar.xz";
-      sha256 = "0as18rc45daak3xsmwn6k789yni46nsdkv83bfmbj3jcjhzv9x5k";
-      name = "kolf-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kolf-21.12.3.tar.xz";
+      sha256 = "00dhjy82d9964z94nn4vkkwynql3bfa6djwrgsq93f9d7grgkd7g";
+      name = "kolf-21.12.3.tar.xz";
     };
   };
   kollision = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kollision-21.12.2.tar.xz";
-      sha256 = "1ycim9gjn9p6w6yyzsipqn7zpvi946s287mp4br35zavsf25gzn0";
-      name = "kollision-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kollision-21.12.3.tar.xz";
+      sha256 = "0avin6s1lglfps6qlvz19i27nb0x0hgrl4q2brpq4kax7azs1nc3";
+      name = "kollision-21.12.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kolourpaint-21.12.2.tar.xz";
-      sha256 = "0z53hp31sq4ksarvpzqmx9f3gac8ygrcj0ncppgbwwjkq63wr6v1";
-      name = "kolourpaint-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kolourpaint-21.12.3.tar.xz";
+      sha256 = "0kbz8jz33bk4zr7kk6mb1y42mdq6nykdfqm2cs08sxldd3nrs6fj";
+      name = "kolourpaint-21.12.3.tar.xz";
     };
   };
   kompare = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kompare-21.12.2.tar.xz";
-      sha256 = "0ps6ng77kzcqf6b2sh8xmqh5d4jwkmj3qnbyxh4v4xxjbwy0mrwm";
-      name = "kompare-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kompare-21.12.3.tar.xz";
+      sha256 = "097aawmziplsndj42bdjf3x3smal1fy67c2y7cik9p1qw9wgn24h";
+      name = "kompare-21.12.3.tar.xz";
     };
   };
   konqueror = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/konqueror-21.12.2.tar.xz";
-      sha256 = "0ia8qqas9x261ixa6jzih273ypqhdv5hijk042bcdmqd1z1s4n55";
-      name = "konqueror-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/konqueror-21.12.3.tar.xz";
+      sha256 = "0z3zq71n0lnpx5ggfg835zbmgf2ly4zsmz01yyyxn9n9d9b6d3px";
+      name = "konqueror-21.12.3.tar.xz";
     };
   };
   konquest = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/konquest-21.12.2.tar.xz";
-      sha256 = "1arxp4x8pcmv8yqg1xy5b23avh5a7x660vvh6kaviimysad5wmc5";
-      name = "konquest-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/konquest-21.12.3.tar.xz";
+      sha256 = "0lrahq9s70rx24dw4cgpvchr4s6pcl565vh343ggg24s1rd3ly80";
+      name = "konquest-21.12.3.tar.xz";
     };
   };
   konsole = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/konsole-21.12.2.tar.xz";
-      sha256 = "00gyzhcacd3467sv5ijihqva7pnvcy1chywfpy8qh2hcdkkvyfxa";
-      name = "konsole-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/konsole-21.12.3.tar.xz";
+      sha256 = "06sqm2xmairicrdcxnf7imvyvw0wyknrrym334scx2w7mfhjg5qs";
+      name = "konsole-21.12.3.tar.xz";
     };
   };
   kontact = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kontact-21.12.2.tar.xz";
-      sha256 = "16ld08sx5lvrm9r0ync7r8bpd540gxsssvhxj5p43chq6b9hr5lm";
-      name = "kontact-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kontact-21.12.3.tar.xz";
+      sha256 = "16p17b4llral0g48l3s9yg838x6hhc4dprlcpd00b8sy58c27f90";
+      name = "kontact-21.12.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kontactinterface-21.12.2.tar.xz";
-      sha256 = "1qvjm27v797hcdqbr6jwdkwn3vpsy3f1i92slrwks03zj498ydlj";
-      name = "kontactinterface-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kontactinterface-21.12.3.tar.xz";
+      sha256 = "1qwx0q4bbk3d720ij37wbd54g9alw6ispjl1mq19hkk3gs5l1c78";
+      name = "kontactinterface-21.12.3.tar.xz";
     };
   };
   kontrast = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kontrast-21.12.2.tar.xz";
-      sha256 = "0mk2i2x1yz0ykbnqvdbdpi9kplyzjxlwhhsvl4rbq0726g3q6pas";
-      name = "kontrast-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kontrast-21.12.3.tar.xz";
+      sha256 = "1rp279mfq18p5kzw3788m8w6kkj8w7zfdv97rnl3n5jir4j94yxl";
+      name = "kontrast-21.12.3.tar.xz";
     };
   };
   konversation = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/konversation-21.12.2.tar.xz";
-      sha256 = "0lpkah6z12c4f77z6r5z31q5np3xwyb3y6xnsv1iq1rdzj0daxch";
-      name = "konversation-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/konversation-21.12.3.tar.xz";
+      sha256 = "05dxzkpadz29b5fm6pf225xqq0gaz9w50paz9341kzz4k3rnzq80";
+      name = "konversation-21.12.3.tar.xz";
     };
   };
   kopeninghours = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kopeninghours-21.12.2.tar.xz";
-      sha256 = "1s4wcnk7p0vjqdhyf8131l3s6bn86gfkwl45zwpi7lpyacwgdf6k";
-      name = "kopeninghours-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kopeninghours-21.12.3.tar.xz";
+      sha256 = "0pfkrns576ll6wc33c8i6pgzd9wf543w2isbvh393zyb1rr3bzgd";
+      name = "kopeninghours-21.12.3.tar.xz";
     };
   };
   kopete = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kopete-21.12.2.tar.xz";
-      sha256 = "1py45nk6bv5x2hnfzh5srq17lprkqrmpqr2h0fpmkmffx66njz5q";
-      name = "kopete-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kopete-21.12.3.tar.xz";
+      sha256 = "1v519sw2lzlap6xci3j55k8c48755sc9p3mgvj566b6jjq64xi5k";
+      name = "kopete-21.12.3.tar.xz";
     };
   };
   korganizer = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/korganizer-21.12.2.tar.xz";
-      sha256 = "1kablp0x65jmdz5n3y19rgplcvvmq8vxz0ljw7lkrwr3pvvhyv3q";
-      name = "korganizer-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/korganizer-21.12.3.tar.xz";
+      sha256 = "072pyzs38dv07mwi4hlfb4rh9jx40dpxac3ywy7kj6nyvbfjmh0r";
+      name = "korganizer-21.12.3.tar.xz";
     };
   };
   kosmindoormap = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kosmindoormap-21.12.2.tar.xz";
-      sha256 = "0max3mfwd5x8m3kqybnkrb4v93rdk1r007xw31l52j2rq2gh8pj2";
-      name = "kosmindoormap-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kosmindoormap-21.12.3.tar.xz";
+      sha256 = "06i616c873lkkpy2iwdjcgwnm6adjrr6rcain2rrb1j4pgzmmbvw";
+      name = "kosmindoormap-21.12.3.tar.xz";
     };
   };
   kpat = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kpat-21.12.2.tar.xz";
-      sha256 = "0vra8n9xsba67as0ybmbjy235v3s7dmrwlf18avnb3ygxy0h8swf";
-      name = "kpat-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kpat-21.12.3.tar.xz";
+      sha256 = "1jd9457hf15d2l6njkfyj9a7lfyabcm80vz3zjb2cykm16x3sdb8";
+      name = "kpat-21.12.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kpimtextedit-21.12.2.tar.xz";
-      sha256 = "06d42k433dvkfrnzfdx0b1qarrnmhnb4gyq7vgy6251ah8smild8";
-      name = "kpimtextedit-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kpimtextedit-21.12.3.tar.xz";
+      sha256 = "19hrqbjcmpi81vmnggrkrv0fcc9inhz5aa5klx0141aylnzfgwsl";
+      name = "kpimtextedit-21.12.3.tar.xz";
     };
   };
   kpkpass = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kpkpass-21.12.2.tar.xz";
-      sha256 = "0p2l1z4blfq1iz3x9cnwwx2p9cs6bb4vw1csj29s09i6237ippzx";
-      name = "kpkpass-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kpkpass-21.12.3.tar.xz";
+      sha256 = "05f88hlqxfak94jy8afiv91dgzxd9qgrkarnqi9rv1f5a3j7k3k7";
+      name = "kpkpass-21.12.3.tar.xz";
     };
   };
   kpmcore = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kpmcore-21.12.2.tar.xz";
-      sha256 = "1iyirvf04br0r8vclcpx0qrlm8wgqm9ww6xds3h9qjyqj1w8ng41";
-      name = "kpmcore-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kpmcore-21.12.3.tar.xz";
+      sha256 = "19h0ag54xzv4hwh950hshjghd4fb9xkdg8rlx6lvqa0w9b8admva";
+      name = "kpmcore-21.12.3.tar.xz";
     };
   };
   kpublictransport = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kpublictransport-21.12.2.tar.xz";
-      sha256 = "02ffpgki4mdyczxa5bqb9wmg2c6anwxnsmlfdn1k47ry7ny2k9sl";
-      name = "kpublictransport-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kpublictransport-21.12.3.tar.xz";
+      sha256 = "1jcba5bq320afzfs5ly3vyyicdix8fprpr02x67v8p7mdzg58cq6";
+      name = "kpublictransport-21.12.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kqtquickcharts-21.12.2.tar.xz";
-      sha256 = "1sjm1vaksvp73866w09xadd1d0lakh00fwiic498siws4dvhhpif";
-      name = "kqtquickcharts-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kqtquickcharts-21.12.3.tar.xz";
+      sha256 = "0gl9c8zfn440202l82y4nfng0hyhivby8a4hf91rphi8f1xfxxmr";
+      name = "kqtquickcharts-21.12.3.tar.xz";
     };
   };
   krdc = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/krdc-21.12.2.tar.xz";
-      sha256 = "005i3a7l9aq63nxsivj28kzjy2zdl759snwm56cgwq9rgc6sc003";
-      name = "krdc-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/krdc-21.12.3.tar.xz";
+      sha256 = "09np9clvmdll7v2p9aswnlhz4cgsnly82za7k3k9fs66h5c8q20j";
+      name = "krdc-21.12.3.tar.xz";
     };
   };
   kreversi = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kreversi-21.12.2.tar.xz";
-      sha256 = "03b4c28297dzdzplmg818r27r9gpqj48rha9884h22fz9davgmhw";
-      name = "kreversi-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kreversi-21.12.3.tar.xz";
+      sha256 = "0lbypkh6lc5af43c2p19gs2c53icxd26abxf5rhs2c8182gr39b8";
+      name = "kreversi-21.12.3.tar.xz";
     };
   };
   krfb = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/krfb-21.12.2.tar.xz";
-      sha256 = "1989q0mig516hz0lbq2m8p85x8ikpyrhj36cvq4c32sd2nasxkvc";
-      name = "krfb-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/krfb-21.12.3.tar.xz";
+      sha256 = "1r8lvvh2z8xi0l3pizlpl12nm4fnbpgiwqmx18w8i51x4j27dv0n";
+      name = "krfb-21.12.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kross-interpreters-21.12.2.tar.xz";
-      sha256 = "14j7z6lwl0j7zdz29c1kjyhw0my6qfgnyxibwn9z87paxl8nv6z0";
-      name = "kross-interpreters-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kross-interpreters-21.12.3.tar.xz";
+      sha256 = "0wyr3xwdkb2fiadzh5lhjli1g0mbxjw353q7k1vbi2wxg5b9042g";
+      name = "kross-interpreters-21.12.3.tar.xz";
     };
   };
   kruler = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kruler-21.12.2.tar.xz";
-      sha256 = "1w5dw3qda69d4ycbiaj18gfn6w28dj2lc37x2d86kx5skv8adxbw";
-      name = "kruler-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kruler-21.12.3.tar.xz";
+      sha256 = "0jmb3a907jx0s80865lmd7in8ggdf30gdbgykpalzfrv7nkjamzr";
+      name = "kruler-21.12.3.tar.xz";
     };
   };
   kshisen = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kshisen-21.12.2.tar.xz";
-      sha256 = "0wjr9fnkmbylfq13zy3hifr4byj4y46f8cwh0w61ypgc0wjxnhhg";
-      name = "kshisen-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kshisen-21.12.3.tar.xz";
+      sha256 = "1i11gh87gfza58rpdd44pjb423an9a44cls117ba9gznxm67cph5";
+      name = "kshisen-21.12.3.tar.xz";
     };
   };
   ksirk = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksirk-21.12.2.tar.xz";
-      sha256 = "1lif8n8n2pj4vaf7zifqj7mjv5dbhki75wbwjd4q061wpr434vfj";
-      name = "ksirk-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksirk-21.12.3.tar.xz";
+      sha256 = "1ipnkg2mgj37g5s5ihlys176kn2c11f3d57xr9zhqf8fvkvrkfm0";
+      name = "ksirk-21.12.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksmtp-21.12.2.tar.xz";
-      sha256 = "0hg5g401map67kjcgrd1a07iwyss5jnryhpsajffwz19sra855jp";
-      name = "ksmtp-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksmtp-21.12.3.tar.xz";
+      sha256 = "0kdy5gsg1sgccvdk1fpf866xl9m8v8z034jpgf6s7n2pr5r5mni2";
+      name = "ksmtp-21.12.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksnakeduel-21.12.2.tar.xz";
-      sha256 = "0rdbsyfd3bink5cb0k5l713jw4syhz82kchn95cbg5zgc2iclfw4";
-      name = "ksnakeduel-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksnakeduel-21.12.3.tar.xz";
+      sha256 = "06rill73xhhxra7kmbvwwriv9vbi91641z334ry1m4rr1qm2cdd6";
+      name = "ksnakeduel-21.12.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kspaceduel-21.12.2.tar.xz";
-      sha256 = "1kmwn55a4555g5m21jcr88k3f9aj87yifgrab6sx6gcw5q51d7vz";
-      name = "kspaceduel-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kspaceduel-21.12.3.tar.xz";
+      sha256 = "0dv539jlpkj8hr4cz0ncqm3scg6ja3s41p37bpqd94zicfvzxw84";
+      name = "kspaceduel-21.12.3.tar.xz";
     };
   };
   ksquares = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksquares-21.12.2.tar.xz";
-      sha256 = "12k09lasxyaxq4bp4fhczj8bpi8l6h1gn4nj6ka3zbc4mxxz34yc";
-      name = "ksquares-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksquares-21.12.3.tar.xz";
+      sha256 = "1wbrakq1wnwp558y140j9vbid3g0k332rwbilky7z11c0giiv76x";
+      name = "ksquares-21.12.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksudoku-21.12.2.tar.xz";
-      sha256 = "1din2i3d9lhca5kw06ivixgk2prh1kfy8ikm0byl8qaqj4v89lji";
-      name = "ksudoku-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksudoku-21.12.3.tar.xz";
+      sha256 = "1gw0ybwhvg1z8pcs72f73y52jvzvrw367g275axf2rw50iik6jwv";
+      name = "ksudoku-21.12.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ksystemlog-21.12.2.tar.xz";
-      sha256 = "0cvx13859bm4kfz75iia3chzi5pbbv70lkmspvjpa6cpsn05zy53";
-      name = "ksystemlog-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ksystemlog-21.12.3.tar.xz";
+      sha256 = "0jkd0rx0xlzwsxa3s40sp5x4r19a9rg1x9klpnjfw0b326vgf2m9";
+      name = "ksystemlog-21.12.3.tar.xz";
     };
   };
   kteatime = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kteatime-21.12.2.tar.xz";
-      sha256 = "1m7ni3w82lqykgs5qfi0a43p9973244k8lr6rk30x7w551rc7yyw";
-      name = "kteatime-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kteatime-21.12.3.tar.xz";
+      sha256 = "0i3ps1a8y8crmxf1631q4zjfa0zglqhq1rk6id5v2xx8f10rkh54";
+      name = "kteatime-21.12.3.tar.xz";
     };
   };
   ktimer = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktimer-21.12.2.tar.xz";
-      sha256 = "0jprayxn54pw7brrcb1b70y5sal9j6pfpwrphd2nyw5rkb2a484l";
-      name = "ktimer-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktimer-21.12.3.tar.xz";
+      sha256 = "0s6zbygxnk69dciyz1iv1d6whfcv637licsd07n7fc8bsygqjl5p";
+      name = "ktimer-21.12.3.tar.xz";
     };
   };
   ktnef = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktnef-21.12.2.tar.xz";
-      sha256 = "0cl589z0v6h1z3aszk4160y99gpihpk203rn73dmb7c6qsk11cbl";
-      name = "ktnef-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktnef-21.12.3.tar.xz";
+      sha256 = "1in991n8alkxf40p0wvkr7gdaaz8w4kdw1rsq6sbjil6cs4cr5nl";
+      name = "ktnef-21.12.3.tar.xz";
     };
   };
   ktorrent = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktorrent-21.12.2.tar.xz";
-      sha256 = "1zwakqp5j2795j4pln4sq595bc2zlw8cy8qdzwj365clfbpcbyc3";
-      name = "ktorrent-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktorrent-21.12.3.tar.xz";
+      sha256 = "021x6qcbk4kdh5ay5mqmf92129s42j2rhrs0q350b0wcnpad55zd";
+      name = "ktorrent-21.12.3.tar.xz";
     };
   };
   ktouch = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktouch-21.12.2.tar.xz";
-      sha256 = "1rq2n8395sb17rqd295axv2pbwzhqs8ikjqx5ryn4lv1713alabl";
-      name = "ktouch-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktouch-21.12.3.tar.xz";
+      sha256 = "0wi01gr85sxs4qhvnwkkp1230wnvz7gdr74zar03rc3wzwgv22nd";
+      name = "ktouch-21.12.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-accounts-kcm-21.12.2.tar.xz";
-      sha256 = "14niidb9kza6sms9rhhnvrba6rdwhc890b5inmlhdllnqbdrrcbl";
-      name = "ktp-accounts-kcm-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-accounts-kcm-21.12.3.tar.xz";
+      sha256 = "1ydsfiw67avgwswvpy85s3siggyi4w610yqz5dyl535i6my1kl5n";
+      name = "ktp-accounts-kcm-21.12.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-approver-21.12.2.tar.xz";
-      sha256 = "11scv978silxrprkyd66b4xkdww05xpgk8kvrknlwp33rmhm05sn";
-      name = "ktp-approver-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-approver-21.12.3.tar.xz";
+      sha256 = "0mvczpc0dy2m0dn25r2h2js3hw7s0qr8zl3syvqbyqqs51s59xnl";
+      name = "ktp-approver-21.12.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-auth-handler-21.12.2.tar.xz";
-      sha256 = "006an8bva8zawnirv3ai3kjb59ffgany124ip546r5wg06zkk069";
-      name = "ktp-auth-handler-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-auth-handler-21.12.3.tar.xz";
+      sha256 = "0lgg0ify9mbsd8has8ingkq3m0g91r9gvfq85s2xf90cwc1s429c";
+      name = "ktp-auth-handler-21.12.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-call-ui-21.12.2.tar.xz";
-      sha256 = "0n8yirlsig37839rl73azg8vf8ppdxlf1dqgkf5bz8g3jcs92gcm";
-      name = "ktp-call-ui-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-call-ui-21.12.3.tar.xz";
+      sha256 = "1npr8qbpxx25pm9mky9sd0qngc5wphmy5blvl6qy7nvs2rqszgam";
+      name = "ktp-call-ui-21.12.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-common-internals-21.12.2.tar.xz";
-      sha256 = "0c7kfrgf8bqm7q9hp9fd8q49vakiihzl0dgdklpvgly48zfa2yan";
-      name = "ktp-common-internals-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-common-internals-21.12.3.tar.xz";
+      sha256 = "0spr2gs5d561agvipkipwcxk2zjlhzvp6swdh8rcv23qr6igqjq6";
+      name = "ktp-common-internals-21.12.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-contact-list-21.12.2.tar.xz";
-      sha256 = "0pw5kl0lh0ph3y9hyws7h7phh475lw07gydxxjsfxsd4nb70hkz8";
-      name = "ktp-contact-list-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-contact-list-21.12.3.tar.xz";
+      sha256 = "1qn3bmwl4kvm5ikbr0ycy2znm4c2yv4m5863d4vakr8xhhappamp";
+      name = "ktp-contact-list-21.12.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-contact-runner-21.12.2.tar.xz";
-      sha256 = "0as41gba7ra65i6ml8j8fqh70x165cnmp9ry13ijrdf9vx21a45k";
-      name = "ktp-contact-runner-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-contact-runner-21.12.3.tar.xz";
+      sha256 = "0bwi0j733jnwiqlxv8nik1whdvk4aggfayy2bcwwpj5zdzr3mbga";
+      name = "ktp-contact-runner-21.12.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-desktop-applets-21.12.2.tar.xz";
-      sha256 = "0675hlcjq6xyzl1sz3a45inc3g69z5ilxyhhicxns8by3ydmb82x";
-      name = "ktp-desktop-applets-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-desktop-applets-21.12.3.tar.xz";
+      sha256 = "01h26jsdb7mkw8isxpy4sfpdn11q209xqhhpnk7xvchs8fpl5fni";
+      name = "ktp-desktop-applets-21.12.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-filetransfer-handler-21.12.2.tar.xz";
-      sha256 = "1cw2y06zcdfm9vixw99gbipgkl63vpkf73giq5ibal2g2yq9c2r5";
-      name = "ktp-filetransfer-handler-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-filetransfer-handler-21.12.3.tar.xz";
+      sha256 = "0aq5ii7b2kk0qan4qph9glapp81sgqm2zzbdknggxz7vkhj5y6lk";
+      name = "ktp-filetransfer-handler-21.12.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-kded-module-21.12.2.tar.xz";
-      sha256 = "1mwmdnr2c6ilhhjlq8bwd7gwvjmiq1k3lph5vlb5hy8nrp9x2p1r";
-      name = "ktp-kded-module-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-kded-module-21.12.3.tar.xz";
+      sha256 = "0921lahpqjx094ngk68pphkv306ajgxbp6yb0hkckmlic4f2hm37";
+      name = "ktp-kded-module-21.12.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-send-file-21.12.2.tar.xz";
-      sha256 = "0083z5al3jgl1szmzddzkjln9ci37906mmnrcy9f0yxfq5v2gr44";
-      name = "ktp-send-file-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-send-file-21.12.3.tar.xz";
+      sha256 = "0vvg0qz2zxckqqwfibsl88w0mpa7a0lzskwhzbvzir03x14rwjlc";
+      name = "ktp-send-file-21.12.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktp-text-ui-21.12.2.tar.xz";
-      sha256 = "0lhbsmhp23sil3rckk51156qhz15hjyp943mgh4s3w49lwxgjpc8";
-      name = "ktp-text-ui-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktp-text-ui-21.12.3.tar.xz";
+      sha256 = "046611abkdn7qqh6n4v8ssdzg10q4g14rji7klypmccfng0px2xg";
+      name = "ktp-text-ui-21.12.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/ktuberling-21.12.2.tar.xz";
-      sha256 = "0w9gx0i895vd0gi8wgd6hqikqjz5ir4li14i15k4akc7i7niy46r";
-      name = "ktuberling-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/ktuberling-21.12.3.tar.xz";
+      sha256 = "1awsn285j9nggyypkra9ladgi46w2m7m09d8364w5d0sygpzmgsg";
+      name = "ktuberling-21.12.3.tar.xz";
     };
   };
   kturtle = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kturtle-21.12.2.tar.xz";
-      sha256 = "0xkl12albs66vnsbilkwpnw5qaqx2ss8wldsnigmf0x5d5hd554k";
-      name = "kturtle-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kturtle-21.12.3.tar.xz";
+      sha256 = "1689skwk2dwm4mrl2mrakb1cn74nyxd6xa8ipxsip5zhjgkkvg23";
+      name = "kturtle-21.12.3.tar.xz";
     };
   };
   kubrick = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kubrick-21.12.2.tar.xz";
-      sha256 = "1sd8biyndnc7y4d3zsy4bmi409js9viyd4q5ql6fd2wcz656y1im";
-      name = "kubrick-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kubrick-21.12.3.tar.xz";
+      sha256 = "0hx81cp1lql74c9067dw7mi78c6sp6p1a035j2nzjn9drpxal6p2";
+      name = "kubrick-21.12.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kwalletmanager-21.12.2.tar.xz";
-      sha256 = "0d2ma7dzn0nc25fj7lwaysfjfgqfl5nsisc01lp42n9k1bg0s0i5";
-      name = "kwalletmanager-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kwalletmanager-21.12.3.tar.xz";
+      sha256 = "01xif44iz1ik32swlrzzjycizy4hjlis1f336qc9p7affjyv2797";
+      name = "kwalletmanager-21.12.3.tar.xz";
     };
   };
   kwave = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kwave-21.12.2.tar.xz";
-      sha256 = "01bjsm3aj7m1mq3nr6iwmcxswq8sxdxhhdyc5zlgffifpym53dc5";
-      name = "kwave-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kwave-21.12.3.tar.xz";
+      sha256 = "07xbbii5gpllbpmkxfv5kwxawd390zp0angh94xjk0yq71lvdav2";
+      name = "kwave-21.12.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/kwordquiz-21.12.2.tar.xz";
-      sha256 = "1na113adrd9djxk016riz3ajwrn9rbpc0ib34adfvp6nw48d9snp";
-      name = "kwordquiz-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/kwordquiz-21.12.3.tar.xz";
+      sha256 = "1p06ki75zy4il6k9siavqddpr9j02z3lbnd14pxwk42fhfmbx057";
+      name = "kwordquiz-21.12.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libgravatar-21.12.2.tar.xz";
-      sha256 = "0xj3v0cknkvr8ac5iipxpz1azr0hk42zgaaip5ivn7qjfhp0zvv0";
-      name = "libgravatar-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libgravatar-21.12.3.tar.xz";
+      sha256 = "1bihy3dfagwc7aday40myqjbn555mkzzaaq7c14ywkmhh99dhvh7";
+      name = "libgravatar-21.12.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkcddb-21.12.2.tar.xz";
-      sha256 = "07bcbmf3z5l0v5b6ra1h36yvbjpim1kzz1npd2h30iq09ibx6dr8";
-      name = "libkcddb-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkcddb-21.12.3.tar.xz";
+      sha256 = "14f1mzsfm0vyqzsyja0p8ln1105sw5dr6fssj25j0qw4rnf9yw32";
+      name = "libkcddb-21.12.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkcompactdisc-21.12.2.tar.xz";
-      sha256 = "08abnybd0fa0vvpaixi18ljfz0s8a5pmbblzpcc8rvwzdjc7az6q";
-      name = "libkcompactdisc-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkcompactdisc-21.12.3.tar.xz";
+      sha256 = "1vmaf3b41sj0sm4k9zdliy5ba4ps5z0cwabggfish152wzw34kgn";
+      name = "libkcompactdisc-21.12.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkdcraw-21.12.2.tar.xz";
-      sha256 = "0mzq0nha7mq5v3lb03xbspc0y2a7mg1mzlwbp3706ph6jp4m7mwa";
-      name = "libkdcraw-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkdcraw-21.12.3.tar.xz";
+      sha256 = "1pyqsaaficwxbg6hk8xg8srq79i6xdxvghkn2rf54zj1435d9kva";
+      name = "libkdcraw-21.12.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkdegames-21.12.2.tar.xz";
-      sha256 = "1m1qz59fb82bsj9ri3b8a1ph2ihgs97wlqq91pbgqw0kgvyvka1j";
-      name = "libkdegames-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkdegames-21.12.3.tar.xz";
+      sha256 = "0x5mw25c8hmnxhcxc2xm19xmgdxfbx89nrxfl6mzfrh8myr3ybsb";
+      name = "libkdegames-21.12.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkdepim-21.12.2.tar.xz";
-      sha256 = "0qqz9b17fz3kgh3gcyq30ds8fq7zkm14k85g4mywsn3lnn8bj6z9";
-      name = "libkdepim-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkdepim-21.12.3.tar.xz";
+      sha256 = "0g9jx6z5jf9yqn01xc1k038b4ljr9sil7bwvifc64s38qxl9wmww";
+      name = "libkdepim-21.12.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkeduvocdocument-21.12.2.tar.xz";
-      sha256 = "16vh1bycq92bh47phv7nk62r5vjaiv1p8fvq5p5idsz9ipzb1wzp";
-      name = "libkeduvocdocument-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkeduvocdocument-21.12.3.tar.xz";
+      sha256 = "16kk7ij2qxy5abgv9hgk1ycbx0f2gnpc9lxqbhl5sq9vxd4nblv0";
+      name = "libkeduvocdocument-21.12.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkexiv2-21.12.2.tar.xz";
-      sha256 = "1j1p1pw2l32q7lk8kp6r0nz9mzjdw6mxr2gi0p770k3k0arrsg87";
-      name = "libkexiv2-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkexiv2-21.12.3.tar.xz";
+      sha256 = "0r2m6d9rw0r6rm6xqpj1i3w0hplhivy8h90zggqynfzvfyr9c529";
+      name = "libkexiv2-21.12.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkgapi-21.12.2.tar.xz";
-      sha256 = "0n6x0vdirv5qbi9qmd8956i307dz0lp80bw5cqxgk4gr4f8hzi8w";
-      name = "libkgapi-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkgapi-21.12.3.tar.xz";
+      sha256 = "1vbk8786mk1irm94bsm97270gnd149nz7w0zqnvwz499f72d21jx";
+      name = "libkgapi-21.12.3.tar.xz";
     };
   };
   libkipi = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkipi-21.12.2.tar.xz";
-      sha256 = "0zlga9gy45cs3icx56gvq2nab7i3z5ydrmisa46vpca63w8swmys";
-      name = "libkipi-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkipi-21.12.3.tar.xz";
+      sha256 = "0w2kwi6djwp8mhmpfrr16v8fgmwjmsc89rcwpfhgii1p68xia8gc";
+      name = "libkipi-21.12.3.tar.xz";
     };
   };
   libkleo = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkleo-21.12.2.tar.xz";
-      sha256 = "0vqgycmj2v91car7ckksnjxbq3b5nzk31p4x3577dgck9jmi30zd";
-      name = "libkleo-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkleo-21.12.3.tar.xz";
+      sha256 = "19q128ldi0aspy7vc03r54vrf7wz7l1181x9pbmax8340nbnaz7l";
+      name = "libkleo-21.12.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkmahjongg-21.12.2.tar.xz";
-      sha256 = "10fgk8nhcr3rbdnh8az46jvl6w6xankdxzw4djj3qs4dpkl52vk4";
-      name = "libkmahjongg-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkmahjongg-21.12.3.tar.xz";
+      sha256 = "114viyqq7zlwsdnm96iyyvj8ma4p06m69hs641yv42xlbkspwbal";
+      name = "libkmahjongg-21.12.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libkomparediff2-21.12.2.tar.xz";
-      sha256 = "07yzzc6ns1yx92gpcvhnxw0xna6ly1j4l4lx1rbw3d94z796694z";
-      name = "libkomparediff2-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libkomparediff2-21.12.3.tar.xz";
+      sha256 = "1j93lf9adyw581a9i8kc1pj6vadscibw49wvwfs750f0kxn5p0d2";
+      name = "libkomparediff2-21.12.3.tar.xz";
     };
   };
   libksane = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libksane-21.12.2.tar.xz";
-      sha256 = "1iksfjwkibn1i8n541nngalrp8krc94qy9in801q10d291clwz9i";
-      name = "libksane-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libksane-21.12.3.tar.xz";
+      sha256 = "0ci2284ysh4q8sbhqcg5bis2v02bp5x64h8n0qik14yy24x852zg";
+      name = "libksane-21.12.3.tar.xz";
     };
   };
   libksieve = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libksieve-21.12.2.tar.xz";
-      sha256 = "03aaqqb5g9iv49crrf7zbmsri8jjszn5wfvmcw559swalmmyzb4i";
-      name = "libksieve-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libksieve-21.12.3.tar.xz";
+      sha256 = "1li9cc5y6xbn4m4qa21qmsjd4xzshp67mxwh2nvr17mfs8ray7vd";
+      name = "libksieve-21.12.3.tar.xz";
     };
   };
   libktorrent = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/libktorrent-21.12.2.tar.xz";
-      sha256 = "06ak3bsy5x6a0r3l9hbfih9m41y3l357rpd42x8qp08djbs11xbf";
-      name = "libktorrent-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/libktorrent-21.12.3.tar.xz";
+      sha256 = "0i976al9bsc3gbplqbxkxr03sdhxv3yzjlfkdaghga8fkihzkkl0";
+      name = "libktorrent-21.12.3.tar.xz";
     };
   };
   lokalize = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/lokalize-21.12.2.tar.xz";
-      sha256 = "1x6sb1fw0fqvk3vg299xvih1v2xm9hviv5h1b624maasw071nfyy";
-      name = "lokalize-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/lokalize-21.12.3.tar.xz";
+      sha256 = "1gzfiajy377kx0iar85z72zqxh7y9vhp1hs03zzqymazawm9lqnn";
+      name = "lokalize-21.12.3.tar.xz";
     };
   };
   lskat = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/lskat-21.12.2.tar.xz";
-      sha256 = "0v16rg6d2l41xgkrkj8ibh5a0zjyb4jn7am6rbgl6k9g9mfqwdx7";
-      name = "lskat-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/lskat-21.12.3.tar.xz";
+      sha256 = "1cfs1lfwgxwpn2g56y7jb2c6ijd81bi8ba8ap0yyx6nhv6na072b";
+      name = "lskat-21.12.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/mailcommon-21.12.2.tar.xz";
-      sha256 = "01kirl4lk1xq7y474438jv0av3ccg18krlchllcigd9c0vcp67qj";
-      name = "mailcommon-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/mailcommon-21.12.3.tar.xz";
+      sha256 = "1zi8zkhv9g4vsylqzjm2wr9v6b20irfxhf4q467cmpqqrqpcp3af";
+      name = "mailcommon-21.12.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/mailimporter-21.12.2.tar.xz";
-      sha256 = "1ng8w4byq4iiwfzh4acl2glndlr7r9hr62qpj10kpn4fi0qblakb";
-      name = "mailimporter-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/mailimporter-21.12.3.tar.xz";
+      sha256 = "0lcr9zzdf16f82spr9x33jnzr23sx7xk2zvfpzdki3b5jxvapnsk";
+      name = "mailimporter-21.12.3.tar.xz";
     };
   };
   marble = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/marble-21.12.2.tar.xz";
-      sha256 = "093drig77dyxwfavx30h2nzdqkn52h6pjn54j7fnwygz4742qv7n";
-      name = "marble-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/marble-21.12.3.tar.xz";
+      sha256 = "0v6qd9cl6g8k55mjq2lswsfcxzf88w33nlm1193ps3ac0awjaaa4";
+      name = "marble-21.12.3.tar.xz";
     };
   };
   markdownpart = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/markdownpart-21.12.2.tar.xz";
-      sha256 = "0g7j15s15blqr0lfagmhvxxggdplvmnkf8g2b9ysjkrr49lgk7b6";
-      name = "markdownpart-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/markdownpart-21.12.3.tar.xz";
+      sha256 = "1drvjrvmd2c36xj3x7kxb7lvk23cmaw8mi976pdfnxn5pdamv6wl";
+      name = "markdownpart-21.12.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/mbox-importer-21.12.2.tar.xz";
-      sha256 = "0qakmg86978zjm2m98602zbaiyiryrmlx2vk93yyv5xg352gphjb";
-      name = "mbox-importer-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/mbox-importer-21.12.3.tar.xz";
+      sha256 = "01bh0yzv23vkicc7lj217rp8c36kyyjlxmkwylss3hakr4b3afan";
+      name = "mbox-importer-21.12.3.tar.xz";
     };
   };
   messagelib = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/messagelib-21.12.2.tar.xz";
-      sha256 = "0ln473gdwsscjpsh50h2cbazxbc8qy1mmll9lsfngfw1qq49dwsp";
-      name = "messagelib-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/messagelib-21.12.3.tar.xz";
+      sha256 = "0xrhnkahqirsz37lbvx505ll7bfhr25lbq89yqq81bxbzkbvamsw";
+      name = "messagelib-21.12.3.tar.xz";
     };
   };
   minuet = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/minuet-21.12.2.tar.xz";
-      sha256 = "050pmw3srfb800h91x6pqn1vz7s6458w94r2innwc1j04pr8jaxv";
-      name = "minuet-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/minuet-21.12.3.tar.xz";
+      sha256 = "0r68z3j0j2gbwzj77wvsx1idrfkagj0pjai9j7fbqa0r6q833flr";
+      name = "minuet-21.12.3.tar.xz";
     };
   };
   okular = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/okular-21.12.2.tar.xz";
-      sha256 = "1k0bwyhk73gshc7f0j6mply2m9ykfd07mhkxwnzj874sby5rxhv9";
-      name = "okular-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/okular-21.12.3.tar.xz";
+      sha256 = "054rzdqsqkjx2sncyfcnfdvm9bp45sdw3rycmpzicnwpn5j4hcb3";
+      name = "okular-21.12.3.tar.xz";
     };
   };
   palapeli = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/palapeli-21.12.2.tar.xz";
-      sha256 = "0v5456hm56c7f9d49l5zjql6f4ap72wmkf8in8s95lqmpn42dl17";
-      name = "palapeli-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/palapeli-21.12.3.tar.xz";
+      sha256 = "076igql89sx55hfxjb79248ih4cjbkr1s1jnz46y3dk793rscm8g";
+      name = "palapeli-21.12.3.tar.xz";
     };
   };
   parley = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/parley-21.12.2.tar.xz";
-      sha256 = "1cwnlv57yqjm52i0jwl33pz4h9h448h0ljrg598ghby8p3b2i5w7";
-      name = "parley-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/parley-21.12.3.tar.xz";
+      sha256 = "10hv885l0gz5aymf72f42bhkncfarj768nb12q9fxqk4x5rviiw0";
+      name = "parley-21.12.3.tar.xz";
     };
   };
   partitionmanager = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/partitionmanager-21.12.2.tar.xz";
-      sha256 = "0rr7ic2ivm7lp3lj20b8rfbx1sr91s24fzxfzfwnw9znl9vj410q";
-      name = "partitionmanager-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/partitionmanager-21.12.3.tar.xz";
+      sha256 = "0x0k3vsbngcb7kvcgqj2w025fn9xvfd2232lx51xfar5r3jb7h1p";
+      name = "partitionmanager-21.12.3.tar.xz";
     };
   };
   picmi = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/picmi-21.12.2.tar.xz";
-      sha256 = "0qp8b1di3qnv4xrnpcmyi6myrrwzdlijhvxmacx4ijv7b7wlg4r7";
-      name = "picmi-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/picmi-21.12.3.tar.xz";
+      sha256 = "0gk1yq5ac55k6lxbxszxpd393fb9k6yphisb71lx2zv9gchl44n6";
+      name = "picmi-21.12.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/pim-data-exporter-21.12.2.tar.xz";
-      sha256 = "0m4dq3x5kbncnvixjigb85j6siws6q600piw53qabiwd6w6rp1xy";
-      name = "pim-data-exporter-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/pim-data-exporter-21.12.3.tar.xz";
+      sha256 = "0qcwsbb4zsjgc15fhq9pp341wwm35y9v1lq8gnpjdsvfq2pczq5q";
+      name = "pim-data-exporter-21.12.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/pim-sieve-editor-21.12.2.tar.xz";
-      sha256 = "1cpazs6q6hv15ib6isif5syvpywxfdi7d3w8vc4pnfj94wkcq3gm";
-      name = "pim-sieve-editor-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/pim-sieve-editor-21.12.3.tar.xz";
+      sha256 = "1gp4gpagv6pfiy6gyfh14z1rb16iqm1npmngw6ybjlhh6d424n90";
+      name = "pim-sieve-editor-21.12.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/pimcommon-21.12.2.tar.xz";
-      sha256 = "1pnhjhnjx98wdc3dg71qgjjj3dsncl56d86cagkk2spicv901p69";
-      name = "pimcommon-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/pimcommon-21.12.3.tar.xz";
+      sha256 = "1k1d100lr277lgwyzn2ssxsx9x2yd9nfd5657r95vmdnkh2qs517";
+      name = "pimcommon-21.12.3.tar.xz";
     };
   };
   poxml = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/poxml-21.12.2.tar.xz";
-      sha256 = "1zzw9jwwd5nx12ma2ihffj6nhr3zlpahnj8k0r8mxcyn99j51kyn";
-      name = "poxml-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/poxml-21.12.3.tar.xz";
+      sha256 = "19hrb75fbh102fw8ajflj4777s7hq7vxv6kbwjir6wzsvdfanwdb";
+      name = "poxml-21.12.3.tar.xz";
     };
   };
   print-manager = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/print-manager-21.12.2.tar.xz";
-      sha256 = "0xqv7f9p27maa0p20nc92g6240qkcin9s3dldr5b5q944hkkxizq";
-      name = "print-manager-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/print-manager-21.12.3.tar.xz";
+      sha256 = "1q9vv5v9hivm583hcx8qa7xik9yv4zicrd02abcsn6hvgwmdav8b";
+      name = "print-manager-21.12.3.tar.xz";
     };
   };
   rocs = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/rocs-21.12.2.tar.xz";
-      sha256 = "1mjrgh0vfc1kvici5m1dx23s1c7qpvfx1br91yglgll1biajzqlq";
-      name = "rocs-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/rocs-21.12.3.tar.xz";
+      sha256 = "1fgjap71qnaydar9q155is7vwjlkpa8wi1162dsqxr5ywy464wrg";
+      name = "rocs-21.12.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/signon-kwallet-extension-21.12.2.tar.xz";
-      sha256 = "0qfim8ahklwkixpxcm9sj1w49cmb0wz5r8np6ga3r2rh4vlqdxbf";
-      name = "signon-kwallet-extension-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/signon-kwallet-extension-21.12.3.tar.xz";
+      sha256 = "0sv0g50bxxd442ia7wzk2lkqwr8lsjxk5wm3zsskxhql851y0ybm";
+      name = "signon-kwallet-extension-21.12.3.tar.xz";
     };
   };
   skanlite = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/skanlite-21.12.2.tar.xz";
-      sha256 = "1fvdrzyvps0iqb9irnpdn81gmlmfhgfsfb5mg4i259sms6rq3h8m";
-      name = "skanlite-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/skanlite-21.12.3.tar.xz";
+      sha256 = "06dwmdjrss7cqqigg4rwsy5dya35577qwdaxj2jbvs2pkzp9rq3p";
+      name = "skanlite-21.12.3.tar.xz";
     };
   };
   spectacle = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/spectacle-21.12.2.tar.xz";
-      sha256 = "1966ynfdkaya1iydi2hfmcr13adk7agjr9ndz2hjrwgjagd29pyr";
-      name = "spectacle-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/spectacle-21.12.3.tar.xz";
+      sha256 = "155xin26lkjr0swb281afha906nqy2821lf2spmzzxa3xalzq3sv";
+      name = "spectacle-21.12.3.tar.xz";
     };
   };
   step = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/step-21.12.2.tar.xz";
-      sha256 = "1paq5wpya82s92zwacwbjf96nj52gy1sydk0gndyqi8jdplhlnps";
-      name = "step-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/step-21.12.3.tar.xz";
+      sha256 = "0j3w63bxj3b4lrfb0mnchlvsr987v5zwwjw5jrgvqidrhv1rh7dc";
+      name = "step-21.12.3.tar.xz";
     };
   };
   svgpart = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/svgpart-21.12.2.tar.xz";
-      sha256 = "15624gfcn85xkh6lypkw73iidnclprhqhpxrjggbng1x22jg2iwc";
-      name = "svgpart-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/svgpart-21.12.3.tar.xz";
+      sha256 = "0yg8sn1z9zfb7a6y61nw7vya516sfaydkgxh7cfwiz7sljl87z8j";
+      name = "svgpart-21.12.3.tar.xz";
     };
   };
   sweeper = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/sweeper-21.12.2.tar.xz";
-      sha256 = "07rqshzjjzqgmm5z0fn1hjd09prcwlnyilp3s61nl5fciby6m8fh";
-      name = "sweeper-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/sweeper-21.12.3.tar.xz";
+      sha256 = "1l4ag2nhy0da9z4nlf7fmjrim7pmwpm3m4v4y50jlpdv73f63246";
+      name = "sweeper-21.12.3.tar.xz";
     };
   };
   umbrello = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/umbrello-21.12.2.tar.xz";
-      sha256 = "07bp3rf31x5c1vag6pw0lal9b6zmvsqa8wg8a30kj7k9wabvjprb";
-      name = "umbrello-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/umbrello-21.12.3.tar.xz";
+      sha256 = "1i94l5hnn8hl0dgdq8sj5xm2vk372zfcnch9qvf9gcvhg08gdif6";
+      name = "umbrello-21.12.3.tar.xz";
     };
   };
   yakuake = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/yakuake-21.12.2.tar.xz";
-      sha256 = "1xkdyn944ga1xvwbbblnffvlnwgypspr909yvdy6xf5j0qaldsdk";
-      name = "yakuake-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/yakuake-21.12.3.tar.xz";
+      sha256 = "10mkr8svkjf2s023mf21cil2c5v986s5b2yp1hm0fzdgmawpwrh9";
+      name = "yakuake-21.12.3.tar.xz";
     };
   };
   zanshin = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/zanshin-21.12.2.tar.xz";
-      sha256 = "1ilgswm4jbjk1mbvcrdi451f1w4vwx3ah6y32a3y5a9blbh9bh6c";
-      name = "zanshin-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/zanshin-21.12.3.tar.xz";
+      sha256 = "1cwawpmx5hc60zkdkyh484lp3bwiipn6c3yh164gzw769vz9zr71";
+      name = "zanshin-21.12.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "21.12.2";
+    version = "21.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/release-service/21.12.2/src/zeroconf-ioslave-21.12.2.tar.xz";
-      sha256 = "0b59npqhmf3yvp9x0jm29bwzlyl0vm9l56jlsgwgiq7pwis5njwd";
-      name = "zeroconf-ioslave-21.12.2.tar.xz";
+      url = "${mirror}/stable/release-service/21.12.3/src/zeroconf-ioslave-21.12.3.tar.xz";
+      sha256 = "09jmf233njbqam1swzvpzfgdplpjzdx48vjy6kcpmjvg2qlm7i2l";
+      name = "zeroconf-ioslave-21.12.3.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Bump/update KDE Gear / Applications to 21.12.3, relaased in 2 March 2022.

The number of reported recompilations should be inflated, because of several branches are usually broken on this build, and the actual number should allow it to be merged to `master` instead of `staging`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
