### PR TITLE
cc-wrapper-test: support cross compilers

### DIFF
--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -71,7 +71,7 @@ in stdenv.mkDerivation {
     ${lib.optionalString sanitizersWorking ''
       printf "checking whether sanitizers are fully functional... ">&2
       $CC -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
-      ${emulator} ./sanitizers
+      ASAN_OPTIONS=use_sigaltstack=0 ${emulator} ./sanitizers
     ''}
 
     touch $out

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, glibc }:
+{ lib, stdenv, glibc, buildPackages }:
 
 let
   # Sanitizers are not supported on Darwin.
@@ -8,6 +8,7 @@ let
     || (stdenv.cc.isGNU && stdenv.isLinux)
   );
   staticLibc = lib.optionalString (stdenv.hostPlatform.libc == "glibc") "-L ${glibc.static}/lib";
+  emulator = stdenv.hostPlatform.emulator buildPackages;
 in stdenv.mkDerivation {
   name = "cc-wrapper-test";
 
@@ -17,28 +18,28 @@ in stdenv.mkDerivation {
 
     printf "checking whether compiler builds valid C binaries... " >&2
     $CC -o cc-check ${./cc-main.c}
-    ./cc-check
+    ${emulator} ./cc-check
 
     printf "checking whether compiler builds valid C++ binaries... " >&2
     $CXX -o cxx-check ${./cxx-main.cc}
-    ./cxx-check
+    ${emulator} ./cxx-check
 
     ${lib.optionalString (stdenv.isDarwin && stdenv.cc.isClang) ''
       printf "checking whether compiler can build with CoreFoundation.framework... " >&2
       mkdir -p foo/lib
       $CC -framework CoreFoundation -o core-foundation-check ${./core-foundation-main.c}
-      ./core-foundation-check
+      ${emulator} ./core-foundation-check
     ''}
 
 
     ${lib.optionalString (!stdenv.isDarwin) ''
       printf "checking whether compiler builds valid static C binaries... " >&2
       $CC ${staticLibc} -static -o cc-static ${./cc-main.c}
-      ./cc-static
+      ${emulator} ./cc-static
       ${lib.optionalString (stdenv.cc.isGNU && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "8.0.0") ''
         printf "checking whether compiler builds valid static pie C binaries... " >&2
         $CC ${staticLibc} -static-pie -o cc-static-pie ${./cc-main.c}
-        ./cc-static-pie
+        ${emulator} ./cc-static-pie
       ''}
     ''}
 
@@ -46,7 +47,7 @@ in stdenv.mkDerivation {
     mkdir -p foo/include
     cp ${./foo.c} foo/include/foo.h
     NIX_CFLAGS_COMPILE="-Ifoo/include -DVALUE=42" $CC -o cflags-check ${./cflags-main.c}
-    ./cflags-check
+    ${emulator} ./cflags-check
 
     printf "checking whether compiler uses NIX_LDFLAGS... " >&2
     mkdir -p foo/lib
@@ -57,20 +58,20 @@ in stdenv.mkDerivation {
       ${./foo.c}
 
     NIX_LDFLAGS="-L$NIX_BUILD_TOP/foo/lib -rpath $NIX_BUILD_TOP/foo/lib" $CC -lfoo -o ldflags-check ${./ldflags-main.c}
-    ./ldflags-check
+    ${emulator} ./ldflags-check
 
     printf "Check whether -nostdinc and -nostdinc++ is handled correctly" >&2
     mkdir -p std-include
     cp ${./stdio.h} std-include/stdio.h
     NIX_DEBUG=1 $CC -I std-include -nostdinc -o nostdinc-main ${./nostdinc-main.c}
-    ./nostdinc-main
+    ${emulator} ./nostdinc-main
     $CXX -I std-include -nostdinc++ -o nostdinc-main++ ${./nostdinc-main.c}
-    ./nostdinc-main++
+    ${emulator} ./nostdinc-main++
 
     ${lib.optionalString sanitizersWorking ''
       printf "checking whether sanitizers are fully functional... ">&2
       $CC -o sanitizers -fsanitize=address,undefined ${./sanitizers.c}
-      ./sanitizers
+      ${emulator} ./sanitizers
     ''}
 
     touch $out

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersWorking = !stdenv.isDarwin && !stdenv.hostPlatform.isMusl && (
+  sanitizersWorking = (stdenv.buildPlatform == stdenv.hostPlatform) && !stdenv.isDarwin && !stdenv.hostPlatform.isMusl && (
     (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "5.0.0")
     || (stdenv.cc.isGNU && stdenv.isLinux)
   );

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -3,7 +3,7 @@
 let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
-  sanitizersWorking = !stdenv.hostPlatform.isMusl && (
+  sanitizersWorking = !stdenv.isDarwin && !stdenv.hostPlatform.isMusl && (
     (stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion stdenv.cc.name) "5.0.0")
     || (stdenv.cc.isGNU && stdenv.isLinux)
   );


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
Run compiled check programs under an emulator, in order to make cc-wrapper tests work with cross compilers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] riscv64-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
