### PR TITLE
QtRvSim: init at 0.9.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5619,6 +5619,12 @@
     github = "jduan";
     githubId = 452450;
   };
+  jdupak = {
+    name = "Jakub Dupak";
+    email = "dev@jakubdupak.com";
+    github = "jdupak";
+    githubId = 22683640;
+  };
   jecaro = {
     email = "jeancharles.quillet@gmail.com";
     github = "jecaro";

--- a/pkgs/applications/science/computer-architecture/qtrvsim/default.nix
+++ b/pkgs/applications/science/computer-architecture/qtrvsim/default.nix
@@ -1,0 +1,25 @@
+{ lib, stdenv, fetchFromGitHub, cmake, wrapQtAppsHook, qtbase }:
+stdenv.mkDerivation rec {
+  pname = "QtRVSim";
+  version = "0.9.1";
+  src = fetchFromGitHub {
+    owner = "cvut";
+    repo = "qtrvsim";
+    rev = "refs/tags/v${version}";
+    sha256 = "AOksVS0drIBnK4RCxZw40yVxf4E8GjG9kU0rIZsY9gA=";
+  };
+  nativeBuildInputs = [ cmake wrapQtAppsHook ];
+  buildInputs = [ qtbase ];
+  meta = with lib; {
+    description = "RISC-V CPU simulator for education purposes";
+    longDescription = ''
+      RISC-V CPU simulator for education purposes with pipeline and cache visualization.
+      Developed at FEE CTU for computer architecture classes.
+    '';
+    homepage = "https://github.com/cvut/qtrvsim";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ jdupak ];
+    mainProgram = "qtrvsim_gui";
+  };
+}

--- a/pkgs/applications/science/computer-architecture/qtrvsim/default.nix
+++ b/pkgs/applications/science/computer-architecture/qtrvsim/default.nix
@@ -1,15 +1,20 @@
 { lib, stdenv, fetchFromGitHub, cmake, wrapQtAppsHook, qtbase }:
+
 stdenv.mkDerivation rec {
   pname = "QtRVSim";
   version = "0.9.1";
+
   src = fetchFromGitHub {
     owner = "cvut";
     repo = "qtrvsim";
     rev = "refs/tags/v${version}";
     sha256 = "AOksVS0drIBnK4RCxZw40yVxf4E8GjG9kU0rIZsY9gA=";
   };
+
   nativeBuildInputs = [ cmake wrapQtAppsHook ];
+
   buildInputs = [ qtbase ];
+
   meta = with lib; {
     description = "RISC-V CPU simulator for education purposes";
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33734,6 +33734,8 @@ with pkgs;
 
   qMasterPassword = libsForQt5.callPackage ../applications/misc/qMasterPassword { };
 
+  qtrvsim = libsForQt5.callPackage ../applications/science/computer-architecture/qtrvsim { };
+
   py-wmi-client = callPackage ../tools/networking/py-wmi-client { };
 
   qdl = callPackage ../tools/misc/qdl { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

Packaging of a new application developed for educational purposes at the Czech Technical University to make it easily available to students, visitors of Embedded World Conference 2022 (where it will be presented) and other users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS** test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] **New package, nothing depends**: Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes) **New package, none applicable.**
  - [] (Package updates) Added a release notes entry if the change is major or breaking
  - [] (Module updates) Added a release notes entry if the change is significant
  - [] (Module addition) Added a release notes entry if adding a new NixOS module
  - [] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
