### PR TITLE
prometheus-gitlab-ci-pipelines-exporter: 0.4.9 -> 0.5.3

### DIFF
--- a/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
@@ -24,7 +24,6 @@ buildGoModule rec {
     description = "Prometheus / OpenMetrics exporter for GitLab CI pipelines insights";
     homepage = "https://github.com/mvisonneau/gitlab-ci-pipelines-exporter";
     license = licenses.asl20;
-    platforms = platforms.unix ++ platforms.darwin;
     maintainers = with maintainers; [ mmahut mvisonneau ];
   };
 }

--- a/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/gitlab-ci-pipelines-exporter.nix
@@ -2,23 +2,29 @@
 
 buildGoModule rec {
   pname = "gitlab-ci-pipelines-exporter";
-  version = "0.4.9";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "mvisonneau";
     repo = pname;
     rev = "v${version}";
-    sha256 = "13zs8140n4z56i0xkl6jvvmwy80l07dxyb23wxzd5avbdm8knypz";
+    sha256 = "1i0ry93w2pk8m7i4fbdn1xvsmvjn83d6lr6l7yywid9d0kmkjz13";
   };
 
-  vendorSha256 = "1k620r3d1swhj7cfmqjh5n08da2a6w87fwrsajl0y324iyw2chsa";
+  subPackages = [ "cmd/${pname}" ];
 
+  ldflags = [
+    "-X main.version=v${version}"
+  ];
+
+  vendorSha256 = "UszZaxql5sO4DSDVD/UIjeeDojCQEPF+ATL7O9MaTG8=";
   doCheck = true;
 
   meta = with lib; {
     description = "Prometheus / OpenMetrics exporter for GitLab CI pipelines insights";
     homepage = "https://github.com/mvisonneau/gitlab-ci-pipelines-exporter";
     license = licenses.asl20;
+    platforms = platforms.unix ++ platforms.darwin;
     maintainers = with maintainers; [ mmahut mvisonneau ];
   };
 }


### PR DESCRIPTION
###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
