### PR TITLE
eos-installer: init at 4.0.3

### DIFF
--- a/pkgs/applications/misc/eos-installer/default.nix
+++ b/pkgs/applications/misc/eos-installer/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitHub
+, autoconf, autoconf-archive, automake, glib, intltool, libtool, pkg-config
+, gnome, gnupg, gtk3, udisks
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eos-installer";
+  version = "4.0.3";
+
+  src = fetchFromGitHub {
+    owner = "endlessm";
+    repo = "eos-installer";
+    rev = "Release_${version}";
+    sha256 = "1nl6vim5dd83kvskmf13xp9d6zx39fayz4z0wqwf7xf4nwl07gwz";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    autoconf autoconf-archive automake glib intltool libtool pkg-config
+  ];
+  buildInputs = [ gnome.gnome-desktop gtk3 udisks ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--libexecdir=${placeholder "out"}/bin"
+    "--localstatedir=/var"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  # These are for runtime, so can't be discovered from PATH, which
+  # is constructed from nativeBuildInputs.
+  GPG_PATH = "${gnupg}/bin/gpg";
+  GPGCONF_PATH = "${gnupg}/bin/gpgconf";
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/endlessm/eos-installer";
+    description = "Installer UI which writes images to disk";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ qyliss ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25369,6 +25369,8 @@ with pkgs;
 
   eolie = callPackage ../applications/networking/browsers/eolie { };
 
+  eos-installer = callPackage ../applications/misc/eos-installer { };
+
   epdfview = callPackage ../applications/misc/epdfview { };
 
   epeg = callPackage ../applications/graphics/epeg { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change

eos-installer is a GUI Linux image installer program.  It was designed
to install Endless OS but is becoming more generic over time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
