### PR TITLE
docbook_xml_dtd,docbook_xml_ebnf_dtd,xhtml1: replace name with pname&version

### DIFF
--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/default.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook-ebnf/default.nix
@@ -1,10 +1,11 @@
 {lib, stdenv, fetchurl}:
 
-stdenv.mkDerivation {
-  name = "docbook-xml-ebnf-1.2b1";
+stdenv.mkDerivation rec {
+  pname = "docbook-xml-ebnf";
+  version = "1.2b1";
 
   dtd = fetchurl {
-    url = "http://www.docbook.org/xml/ebnf/1.2b1/dbebnf.dtd";
+    url = "https://docbook.org/xml/ebnf/${version}/dbebnf.dtd";
     sha256 = "0min5dsc53my13b94g2yd65q1nkjcf4x1dak00bsc4ckf86mrx95";
   };
   catalog = ./docbook-ebnf.cat;

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.1.2.nix
@@ -1,27 +1,22 @@
 {lib, stdenv, fetchurl, unzip, findXMLCatalogs}:
 
 let
-
   # Urgh, DocBook 4.1.2 doesn't come with an XML catalog.  Use the one
   # from 4.2.
   docbook42catalog = fetchurl {
-    url = "http://www.docbook.org/xml/4.2/catalog.xml";
+    url = "https://docbook.org/xml/4.2/catalog.xml";
     sha256 = "18lhp6q2l0753s855r638shkbdwq9blm6akdjsc9nrik24k38j17";
   };
-
 in
 
 import ./generic.nix {
   inherit lib stdenv unzip findXMLCatalogs;
-  name = "docbook-xml-4.1.2";
+  version = "4.1.2";
   src = fetchurl {
-    url = "http://www.docbook.org/xml/4.1.2/docbkx412.zip";
+    url = "https://docbook.org/xml/4.1.2/docbkx412.zip";
     sha256 = "0wkp5rvnqj0ghxia0558mnn4c7s3n501j99q2isp3sp0ci069w1h";
   };
   postInstall = "
     sed 's|V4.2|V4.1.2|g' < ${docbook42catalog} > catalog.xml
   ";
-  meta = {
-    branch = "4.1.2";
-  };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.2.nix
@@ -2,12 +2,9 @@
 
 import ./generic.nix {
   inherit lib stdenv unzip findXMLCatalogs;
-  name = "docbook-xml-4.2";
+  version = "4.2";
   src = fetchurl {
-    url = "http://www.docbook.org/xml/4.2/docbook-xml-4.2.zip";
+    url = "https://docbook.org/xml/4.2/docbook-xml-4.2.zip";
     sha256 = "acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2";
-  };
-  meta = {
-    branch = "4.2";
   };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.3.nix
@@ -2,12 +2,9 @@
 
 import ./generic.nix {
   inherit lib stdenv unzip findXMLCatalogs;
-  name = "docbook-xml-4.3";
+  version = "4.3";
   src = fetchurl {
-    url = "http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip";
+    url = "https://docbook.org/xml/4.3/docbook-xml-4.3.zip";
     sha256 = "0r1l2if1z4wm2v664sqdizm4gak6db1kx9y50jq89m3gxaa8l1i3";
-  };
-  meta = {
-    branch = "4.3";
   };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.4.nix
@@ -2,12 +2,9 @@
 
 import ./generic.nix {
   inherit lib stdenv unzip findXMLCatalogs;
-  name = "docbook-xml-4.4";
+  version = "4.4";
   src = fetchurl {
-    url = "http://www.docbook.org/xml/4.4/docbook-xml-4.4.zip";
+    url = "https://docbook.org/xml/4.4/docbook-xml-4.4.zip";
     sha256 = "141h4zsyc71sfi2zzd89v4bb4qqq9ca1ri9ix2als9f4i3mmkw82";
-  };
-  meta = {
-    branch = "4.4";
   };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/4.5.nix
@@ -2,12 +2,9 @@
 
 import ./generic.nix {
   inherit lib stdenv unzip findXMLCatalogs;
-  name = "docbook-xml-4.5";
+  version = "4.5";
   src = fetchurl {
-    url = "http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip";
+    url = "https://docbook.org/xml/4.5/docbook-xml-4.5.zip";
     sha256 = "1d671lcjckjri28xfbf6dq7y3xnkppa910w1jin8rjc35dx06kjf";
-  };
-  meta = {
-    branch = "4.5";
   };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/docbook/generic.nix
@@ -1,9 +1,10 @@
-{ lib, stdenv, unzip, src, name, postInstall ? "true", meta ? {}, findXMLCatalogs }:
+{ lib, stdenv, unzip, src, version, postInstall ? "true", findXMLCatalogs }:
 
 stdenv.mkDerivation {
-  inherit src name postInstall;
+  inherit version src postInstall;
+  pname = "docbook-xml";
 
-  nativeBuildInputs = [unzip];
+  nativeBuildInputs = [ unzip ];
   propagatedNativeBuildInputs = [ findXMLCatalogs ];
 
   unpackPhase = ''
@@ -17,7 +18,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = meta // {
+  meta = {
+    branch = version;
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/data/sgml+xml/schemas/xml-dtd/xhtml1/default.nix
+++ b/pkgs/data/sgml+xml/schemas/xml-dtd/xhtml1/default.nix
@@ -1,10 +1,11 @@
 { lib, stdenv, fetchurl, libxml2 }:
 
 stdenv.mkDerivation {
-  name = "xhtml1-20020801";
+  pname = "xhtml1";
+  version = "unstable-2002-08-01";
 
   src = fetchurl {
-    url = "http://www.w3.org/TR/xhtml1/xhtml1.tgz";
+    url = "https://www.w3.org/TR/xhtml1/xhtml1.tgz";
     sha256 = "0rr0d89i0z75qvjbm8il93bippx09hbmjwy0y2sj44n9np69x3hl";
   };
 


### PR DESCRIPTION


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
#103997

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
