### PR TITLE
tor: 0.4.6.9 -> 0.4.6.10; fix updateScript

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -30,11 +30,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "tor";
-  version = "0.4.6.9";
+  version = "0.4.6.10";
 
   src = fetchurl {
     url = "https://dist.torproject.org/${pname}-${version}.tar.gz";
-    sha256 = "1ad99k4wysxrnlaprv7brxr2nc0h5zdnrh0rma10pqlck2037sf7";
+    sha256 = "lMzWDgTlWPM75zAyvITqJBZg+S9Yz7iHib2miTc54xw=";
   };
 
   outputs = [ "out" "geoip" ];

--- a/pkgs/tools/security/tor/update.nix
+++ b/pkgs/tools/security/tor/update.nix
@@ -15,14 +15,11 @@ with lib;
 let
   downloadPageUrl = "https://dist.torproject.org";
 
-  # See https://www.torproject.org/docs/signing-keys.html
+  # See https://support.torproject.org/little-t-tor/#fetching-the-tor-developers-key
   signingKeys = [
-    # Roger Dingledine
-    "B117 2656 DFF9 83C3 042B C699 EB5A 896A 2898 8BF5"
-    "F65C E37F 04BA 5B36 0AE6 EE17 C218 5258 19F7 8451"
-    # Nick Mathewson
-    "2133 BC60 0AB1 33E1 D826 D173 FE43 009C 4607 B1FB"
-    "B117 2656 DFF9 83C3 042B C699 EB5A 896A 2898 8BF5"
+    "514102454D0A87DB0767A1EBBE6A0531C18A9179" # Alexander Færøy
+    "B74417EDDF22AC9F9E90F49142E86A2A11F48D36" # David Goulet
+    "2133BC600AB133E1D826D173FE43009C4607B1FB" # Nick Mathewson
   ];
 in
 
@@ -52,20 +49,24 @@ srcName=''${srcBase/.tar.gz/}
 srcVers=(''${srcName//-/ })
 version=''${srcVers[1]}
 
-sigUrl=$srcUrl.asc
+checksumUrl=$srcUrl.sha256sum
+checksumFile=''${checksumUrl##*/}
+
+sigUrl=$checksumUrl.asc
 sigFile=''${sigUrl##*/}
 
 # upstream does not support byte ranges ...
 [[ -e "$srcFile" ]] || curl -L -o "$srcFile" -- "$srcUrl"
+[[ -e "$checksumFile" ]] || curl -L -o "$checksumFile" -- "$checksumUrl"
 [[ -e "$sigFile" ]] || curl -L -o "$sigFile" -- "$sigUrl"
 
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 
 gpg --batch --recv-keys ${concatStringsSep " " (map (x: "'${x}'") signingKeys)}
-gpg --batch --verify "$sigFile" "$srcFile"
+gpg --batch --verify "$sigFile" "$checksumFile"
 
-sha256=$(nix-hash --type sha256 --flat --base32 "$srcFile")
+sha256sum -c "$checksumFile"
 
-update-source-version tor "$version" "$sha256"
+update-source-version tor "$version" "$(cut -d ' ' "$checksumFile")"
 ''


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
