### PR TITLE
checkov: 2.0.918 -> 2.0.921

### DIFF
--- a/pkgs/development/python-modules/bc-python-hcl2/default.nix
+++ b/pkgs/development/python-modules/bc-python-hcl2/default.nix
@@ -1,33 +1,21 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, lark
 , nose
 , pythonOlder
 }:
 
-let
-  lark-parser = buildPythonPackage rec {
-    pname = "lark-parser";
-    version = "0.10.1";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "15jr4c1falvgkq664xdgamykk6waklh1psy8v3wlrg0v59hngws2";
-    };
-
-    doCheck = true;
-  };
-in
 buildPythonPackage rec {
   pname = "bc-python-hcl2";
-  version = "0.3.30";
+  version = "0.3.33";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-wfcTIPKbMPa7xpXzkFtxnxG2ZRFzTw35EP7f4zwHxcs=";
+    hash = "sha256-tdsw9gf64VGH9tRWgYZZq3FNa5B5JNhN3k6wUHrU5zY=";
   };
 
   # Nose is required during build process, so can not use `checkInputs`.
@@ -36,7 +24,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    lark-parser
+    lark
   ];
 
   # This fork of python-hcl2 doesn't ship tests

--- a/pkgs/development/python-modules/pycep-parser/default.nix
+++ b/pkgs/development/python-modules/pycep-parser/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, assertpy
+, buildPythonPackage
+, fetchFromGitHub
+, lark
+, poetry-core
+, pytestCheckHook
+, pythonOlder
+, regex
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "pycep-parser";
+  version = "0.3.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "gruebel";
+    repo = "pycep";
+    rev = version;
+    hash = "sha256-S4jBqMgyreWrEp1SuR8J5RVFc+i1O0xbfgux1UvFP5k=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    lark
+    regex
+    typing-extensions
+  ];
+
+  checkInputs = [
+    assertpy
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'version = "0.3.1-alpha.1"' 'version = "${version}"' \
+      --replace 'regex = "^2022.3.2"' 'regex = "*"'
+  '';
+
+  pythonImportsCheck = [
+    "pycep"
+  ];
+
+  meta = with lib; {
+    description = "Python based Bicep parser";
+    homepage = "https://github.com/gruebel/pycep";
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/tools/analysis/checkov/default.nix
+++ b/pkgs/development/tools/analysis/checkov/default.nix
@@ -32,13 +32,13 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "checkov";
-  version = "2.0.918";
+  version = "2.0.921";
 
   src = fetchFromGitHub {
     owner = "bridgecrewio";
     repo = pname;
     rev = version;
-    hash = "sha256-8nhz32ugnheBH1W3YKKmjRvjjx4WcpSyLwBS0STvsPM=";
+    hash = "sha256-Bl9zwJGyZN5vJVpy63GeaCQ+4X0dYMTAV4FtT96L42U=";
   };
 
   nativeBuildInputs = with py.pkgs; [
@@ -71,6 +71,7 @@ buildPythonApplication rec {
     packaging
     policyuniverse
     prettytable
+    pycep-parser
     pyyaml
     semantic-version
     tabulate

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6717,6 +6717,8 @@ in {
 
   pycec = callPackage ../development/python-modules/pycec { };
 
+  pycep-parser = callPackage ../development/python-modules/pycep-parser { };
+
   pycfdns = callPackage ../development/python-modules/pycfdns { };
 
   pycflow2dot = callPackage ../development/python-modules/pycflow2dot {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
https://github.com/bridgecrewio/checkov/releases/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
