### PR TITLE
makeDesktopItem: improve error messages

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -36,7 +36,7 @@
 let
   # FIXME: workaround until https://github.com/NixOS/nixpkgs/pull/162246 lands
   cleanName = if lib.hasInfix " " name
-                then throw "Name must not contain spaces!"
+                then throw "makeDesktopItem: name must not contain spaces!"
                 else name;
 
   # There are multiple places in the FDO spec that make "boolean" values actually tristate,
@@ -45,13 +45,13 @@ let
   boolOrNullToString = value:
     if value == null then null
     else if builtins.isBool value then lib.boolToString value
-    else throw "Value must be a boolean or null!";
+    else throw "makeDesktopItem: value must be a boolean or null!";
 
   # Multiple values are represented as one string, joined by semicolons.
   # Technically, it's possible to escape semicolons in values with \;, but this is currently not implemented.
-  renderList = value:
-    if !builtins.isList value then throw "Value must be a list!"
-    else if builtins.any (item: lib.hasInfix ";" item) value then throw "Values in list must not contain semicolons!"
+  renderList = key: value:
+    if !builtins.isList value then throw "makeDesktopItem: value for ${key} must be a list!"
+    else if builtins.any (item: lib.hasInfix ";" item) value then throw "makeDesktopItem: values in ${key} list must not contain semicolons!"
     else if value == [] then null
     else builtins.concatStringsSep ";" value;
 
@@ -65,18 +65,18 @@ let
     "NoDisplay" = boolOrNullToString noDisplay;
     "Comment" = comment;
     "Icon" = icon;
-    "OnlyShowIn" = renderList onlyShowIn;
-    "NotShowIn" = renderList notShowIn;
+    "OnlyShowIn" = renderList "onlyShowIn" onlyShowIn;
+    "NotShowIn" = renderList "notShowIn" notShowIn;
     "DBusActivatable" = boolOrNullToString dbusActivatable;
     "TryExec" = tryExec;
     "Exec" = exec;
     "Path" = path;
     "Terminal" = boolOrNullToString terminal;
-    "Actions" = renderList (builtins.attrNames actions);
-    "MimeType" = renderList mimeTypes;
-    "Categories" = renderList categories;
-    "Implements" = renderList implements;
-    "Keywords" = renderList keywords;
+    "Actions" = renderList "actions" (builtins.attrNames actions);
+    "MimeType" = renderList "mimeTypes" mimeTypes;
+    "Categories" = renderList "categories" categories;
+    "Implements" = renderList "implements" implements;
+    "Keywords" = renderList "keywords" keywords;
     "StartupNotify" = boolOrNullToString startupNotify;
     "StartupWMClass" = startupWMClass;
     "URL" = url;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
