### PR TITLE
tuxpaint: 0.9.24 -> 0.9.27 + other fixes and updates

### DIFF
--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
 
   # stamps
   stamps = fetchurl {
-    url = "mirror://sourceforge/project/tuxpaint/tuxpaint-stamps/2014-08-23/tuxpaint-stamps-2014.08.23.tar.gz";
-    sha256 = "0rhlwrjz44wp269v3rid4p8pi0i615pzifm1ym6va64gn1bms06q";
+    url = "mirror://sourceforge/project/tuxpaint/tuxpaint-stamps/2021-11-25/tuxpaint-stamps-2021.11.25.tar.gz";
+    sha256 = "sha256-y1XuIbLSW0QO4has+rC7jZBq8cma28d+jbEe7DBYnVI=";
   };
 
   postInstall = ''
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
     # Install stamps
     tar xzf $stamps
-    cd tuxpaint-stamps-2014.08.23
+    cd tuxpaint-stamps-*
     make install-all PREFIX=$out
     rm -rf $out/share/tuxpaint/stamps/military
   '';

--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -1,17 +1,21 @@
-{ lib, stdenv, fetchurl, SDL, SDL_image, SDL_ttf, SDL_mixer, libpng,
-  cairo, librsvg, gettext, libpaper, fribidi, pkg-config, gperf, imagemagick }:
+{ lib, stdenv, fetchurl, SDL, SDL_gfx, SDL_image, SDL_ttf, SDL_mixer, libpng
+, libimagequant, cairo, librsvg, gettext, libpaper, fribidi, pkg-config, gperf
+, imagemagick
+}:
 
 stdenv.mkDerivation rec {
-  version = "0.9.24";
+  version = "0.9.27";
   pname = "tuxpaint";
 
   src = fetchurl {
     url = "mirror://sourceforge/tuxpaint/${version}/${pname}-${version}.tar.gz";
-    sha256 = "06m1lg2pikfkmassfvvrbwqffwgixcmjh1li6akaldgkalpmfql7";
+    sha256 = "sha256-qyuA6J34gijNDsCmyQtJ1UPLFXqjj7kMvTop8AFAVXo=";
   };
 
-  nativeBuildInputs = [ SDL SDL_image SDL_ttf SDL_mixer libpng cairo
-    librsvg gettext libpaper fribidi pkg-config gperf imagemagick ];
+  nativeBuildInputs = [
+    SDL SDL_gfx SDL_image SDL_ttf SDL_mixer libpng cairo libimagequant librsvg
+    gettext libpaper fribidi pkg-config gperf imagemagick
+  ];
   hardeningDisable = [ "format" ];
   makeFlags = [ "GPERF=${gperf}/bin/gperf"
                 "PREFIX=$$out"
@@ -45,7 +49,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Open Source Drawing Software for Children";
     homepage = "http://www.tuxpaint.org/";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ woffs ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -46,6 +46,8 @@ stdenv.mkDerivation rec {
     rm -rf $out/share/tuxpaint/stamps/military
   '';
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "Open Source Drawing Software for Children";
     homepage = "http://www.tuxpaint.org/";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
