### PR TITLE
zeal: bump git rev

### DIFF
--- a/pkgs/data/documentation/zeal/default.nix
+++ b/pkgs/data/documentation/zeal/default.nix
@@ -9,8 +9,8 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zealdocs";
     repo = "zeal";
-    rev = "1ce0e2e446232e7647c5588c1f603f1dd88e0f67";
-    sha256 = "0gj5qcm7ck8m5zfmiabay2f7wbxldmrkw8m3xi7v9i8y8hx0jkxr";
+    rev = "763edca12ccd6c67e51f10891d1ced8b2510904f";
+    sha256 = "sha256-1/wQXkRWvpRia8UDvvvmzHinPG8q2Tz9Uoeegej9uC8=";
   };
 
   # we only need this if we are using a version that hasn't been released. We


### PR DESCRIPTION
###### Motivation for this change

2020-07-03 -> 2021-12-25

https://github.com/zealdocs/zeal/compare/1ce0e2e446232e7647c5588c1f603f1dd88e0f67...763edca12ccd6c67e51f10891d1ced8b2510904f

Mostly for the fixes w.r.t crashing.

Version/.git bits in build system were touched, looks like if we drop the snippet substituting in our version string it reports itself as v0.6.2-dev.  Leaving this as it was for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).