### PR TITLE
tcl: 8.5.18 -> 8.5.19, 8.6.11 -> 8.6.12

### DIFF
--- a/pkgs/development/interpreters/tcl/8.5.nix
+++ b/pkgs/development/interpreters/tcl/8.5.nix
@@ -2,12 +2,12 @@
 
 callPackage ./generic.nix (args // rec {
   release = "8.5";
-  version = "${release}.18";
+  version = "${release}.19";
 
   # Note: when updating, the hash in pkgs/development/libraries/tk/8.5.nix must also be updated!
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
-    sha256 = "1jfkqp2fr0xh6xvaqx134hkfa5kh7agaqbxm6lhjbpvvc1xfaaq3";
+    sha256 = "066vlr9k5f44w9gl9382hlxnryq00d5p6c7w5vq1fgc7v9b49w6k";
   };
 })

--- a/pkgs/development/interpreters/tcl/8.6.nix
+++ b/pkgs/development/interpreters/tcl/8.6.nix
@@ -2,12 +2,12 @@
 
 callPackage ./generic.nix (args // rec {
   release = "8.6";
-  version = "${release}.11";
+  version = "${release}.12";
 
   # Note: when updating, the hash in pkgs/development/libraries/tk/8.6.nix must also be updated!
 
   src = fetchurl {
     url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
-    sha256 = "0n4211j80mxr6ql0xx52rig8r885rcbminfpjdb2qrw6hmk8c14c";
+    sha256 = "19n1wk6ypx19p26gywvibwbhqs2zapp93n3136qlhzhn1zfrbj96";
   };
 })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
