### PR TITLE
sway-launcher-desktop: init at 1.5.4

### DIFF
--- a/pkgs/applications/misc/sway-launcher-desktop/default.nix
+++ b/pkgs/applications/misc/sway-launcher-desktop/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, lib, pkgs, fzf, gawk, fetchFromGitHub, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "sway-launcher-desktop";
+  version = "1.5.4";
+
+  src = fetchFromGitHub {
+    owner = "Biont";
+    repo = "sway-launcher-desktop";
+    rev = "v${version}";
+    sha256 = "0i19igj30jyszqb63ibq0b0zxzvjw3z1zikn9pbk44ig1c0v61aa";
+  };
+
+  postPatch = ''
+    patchShebangs ${pname}.sh
+  '';
+
+  buildInputs = [ fzf gawk ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -d $out/bin
+    install ${pname}.sh $out/bin/${pname}
+    wrapProgram $out/bin/${pname} \
+      --prefix PATH : ${lib.makeBinPath [ gawk fzf ]}
+  '';
+
+  meta = with lib; {
+    description = "TUI Application launcher with Desktop Entry support.";
+    longDescription = ''
+      This is a TUI-based launcher menu made with bash and the amazing fzf.
+      Despite its name, it does not (read: no longer) depend on the Sway window manager
+      in any way and can be used with just about any WM.
+    '';
+    homepage = "https://github.com/Biont/sway-launcher-desktop";
+    changelog = "https://github.com/Biont/sway-launcher-desktop/releases/tag/v${version}";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mrhedgehog ];
+    mainProgram = "${pname}";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28880,6 +28880,8 @@ with pkgs;
 
   styx = callPackage ../applications/misc/styx { };
 
+  sway-launcher-desktop = callPackage ../applications/misc/sway-launcher-desktop { };
+
   tecoc = callPackage ../applications/editors/tecoc { };
 
   viber = callPackage ../applications/networking/instant-messengers/viber { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change
`sway-launcher-desktop` is a TUI application launcher with desktop entry support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
