### PR TITLE
txt2tags: 2.6 -> 3.7

### DIFF
--- a/pkgs/tools/text/txt2tags/default.nix
+++ b/pkgs/tools/text/txt2tags/default.nix
@@ -1,34 +1,20 @@
-{ lib, stdenv, fetchurl, python2 }:
+{ lib, buildPythonApplication, fetchPypi, tox }:
 
-stdenv.mkDerivation rec {
-  version = "2.6";
+buildPythonApplication rec {
   pname = "txt2tags";
+  version = "3.7";
 
-  dontBuild = true;
-
-  # Python script, needs the interpreter
-  propagatedBuildInputs = [ python2 ];
-
-  installPhase = ''
-    mkdir -p "$out/bin"
-    mkdir -p "$out/share/doc"
-    mkdir -p "$out/share/man/man1/"
-    sed '1s|/usr/bin/env python|${python2}/bin/python|' < txt2tags > "$out/bin/txt2tags"
-    chmod +x "$out/bin/txt2tags"
-    gzip - < doc/manpage.man > "$out/share/man/man1/txt2tags.1.gz"
-    cp doc/userguide.pdf "$out/share/doc"
-    cp -r extras/ samples/ test/ "$out/share"
-  '';
-
-  src = fetchurl {
-    url = "http://txt2tags.googlecode.com/files/${pname}-${version}.tgz";
-    sha256 = "0p5hql559pk8v5dlzgm75yrcxwvz4z30f1q590yzng0ghvbnf530";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "12hpnvdy7dgarq6ini9jp7dp2zcmvpax04zbl3jb84kd423r75i7";
   };
+
+  checkInputs = [ tox ];
 
   meta = {
     homepage = "https://txt2tags.org/";
     description = "A KISS markup language";
-    license  = lib.licenses.gpl2;
+    license  = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ kovirobi ];
     platforms = with lib.platforms; unix;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10644,7 +10644,7 @@ with pkgs;
 
   txt2man = callPackage ../tools/misc/txt2man { };
 
-  txt2tags = callPackage ../tools/text/txt2tags { };
+  txt2tags = python3.pkgs.callPackage ../tools/text/txt2tags { };
 
   txtw = callPackage ../tools/misc/txtw { };
 


### PR DESCRIPTION
Tested by building a couple of packages that use this to generate their documentation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
