### PR TITLE
firefox-bin: 97.0.2 -> 98.0; firefox-esr: 91.6.1esr -> 91.7.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "97.0.2";
+  version = "98.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ach/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ach/firefox-98.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "06103fa79feea876422843439c9d806634dcec91cc75288659df2597ce3a94ac";
+      sha256 = "92fe50154b763faba3d923ba19be737a7e6c48c04652275da2727489c0f3b14f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/af/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/af/firefox-98.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "1c1694e6a7b9460c009395fe69a388e38180fad1e772a3b25167bf883aad4977";
+      sha256 = "f086d9cf3142c7adebff590702f497e1f99d74ccb69b7001851e1b0329b9ff7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/an/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/an/firefox-98.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "2209fc5aa9f128a04efc54c1f87ba7e29bb20410810d37cd7585896dad209400";
+      sha256 = "5e7e8fa95293bf2921596ecddd10217f10682e4a576b3f0f8c70021ee785afb2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ar/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ar/firefox-98.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "540b8871c713288704eb50c3e6ccad4aa4633a6733e3a9bd7e6392bc37325a90";
+      sha256 = "cf7e5bfe6fcc19e0e6ac6b2646118e25b471cffc025d1de85ac62b0569582285";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ast/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ast/firefox-98.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "79791936785b296e9d6313616f0186ae4e1f79b0346cd2565315f55c6c43127e";
+      sha256 = "54c694772844caf3946520aa624d8a5c8d2d21ab29c64bc1c438011ad830d001";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/az/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/az/firefox-98.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "d853989cef9482473e20bfd45ca58028b1607cdb4892fc5d89c495d0f4aa3518";
+      sha256 = "0e342f5bc920684c2b7ae988a983e27e0bdf130b6f1e210952139edee2ea9827";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/be/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/be/firefox-98.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "8d0916765b3daef73af89d594155ab99cbec6d2c555bf2b98d77906cb7fdf02c";
+      sha256 = "89973f6718cfb63e43713594089618355e5c8323b3912a7a67d4d0fdfbe1cfd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/bg/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/bg/firefox-98.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "3a11ce5379ee46890cd4dbd870d3076848ce5ad842303798b577bb2ad9d06dea";
+      sha256 = "b7ea5573feb114ba63e5f0b516f36d134b4015a262c2e7f824dcce5cf31d7058";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/bn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/bn/firefox-98.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "0092a295b61df555e4f217e13a8d2549c23931673cb811d0bf6dd970ee2dc5df";
+      sha256 = "bc4837219822c224b556c826f83bc913f9454da7aa9b26ff3a44119e5284b63d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/br/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/br/firefox-98.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "77093f532db755d9b12c8b325fd152229223cbe552708749b5c67a74caa2f0ee";
+      sha256 = "36d61c43e4aaf323763676ca5ac5be3e4c23af46b4aeb00409ca7391cdf60143";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/bs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/bs/firefox-98.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "07e863a6cb8776af8142c03cddd9d88e7b9cc9f58d196c47a45a6e4026489b61";
+      sha256 = "6215685be94ad53ea827a6366673a14c327d2e4fc94fca51918b6cb2a8fb5897";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ca-valencia/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ca-valencia/firefox-98.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "a7c30b0f7c167a1b9ef11f1677355b98e88ec2ca5dbe029c1a61bdabf580aab5";
+      sha256 = "15220b2edf948b6027d391bf0140becb69f529565094f5f10a65b090456cc295";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ca/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ca/firefox-98.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "91435687d154908d07fac68a2a916cdd21a31a50aab4c6427e5d00458137d5c2";
+      sha256 = "1060f9d8a46d078b3a1234116a2b963537213084e74dec8fc6b2598a8e863196";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/cak/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/cak/firefox-98.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "3a204dc9e8da4bfd7f9e5310c23cd0ae52ce4c4a7f3c1175ce6c76d0972ab0cc";
+      sha256 = "03a302fe8bea3dd231b204946cd843850526652ffd2b77b4110c97ddcd6b4f54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/cs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/cs/firefox-98.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "dba92bf8ba406c2626422481a2dddc220d74a239b57ee40372d09aa4e7f513fe";
+      sha256 = "6815701642c6a76a3ee5f75433aa91d8e0e23b8a68c3f2204862703a4426fede";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/cy/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/cy/firefox-98.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "15f83a6eb972193a25f382d500ea2e01a88b11e43a981c7e0d49396750c19e6d";
+      sha256 = "f68a21a0dd833f51a9d8e66e0c5d970b5d704472728e3585512d07fcbd28c470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/da/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/da/firefox-98.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "0db23e6b132998e974749fc195043a457ae860163707b1bf0517a00aa1e57237";
+      sha256 = "66689f2a8ebdce69f3f83edf2e626017c51dfd823340a946e23550d93cbcfc80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/de/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/de/firefox-98.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "6481bfe00c9ab3de1f6b374610ffe285bb58501ffa0b0779859759f76bb10bf3";
+      sha256 = "183b0453e691f33ea7844a8a0b4fe91cacfca64b07375d85a84dc58aa95fdc5b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/dsb/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/dsb/firefox-98.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "2e717c2b79dbe0dc3cd5f76f9a119638964b8fe08820b490252f5e2c5df16e42";
+      sha256 = "b129086ca18bf18ab583015c2602710e7164a53bb262c8e3ecdc62092d88eed5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/el/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/el/firefox-98.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "9f185015367acf57ea80bd4ab3ce93cd468884b5995341adfd890ad7a8f79dd7";
+      sha256 = "46f9fc4b9cabb2e9fbee8a6453b7e5cccbed4dc7529717e917e4c3be3bb7fc54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/en-CA/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/en-CA/firefox-98.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "51605d1fbc4644ee6b13ca000cb04248e8ae0c63ccdafd3db5ed24e518f42cad";
+      sha256 = "5f7f255b6d210709f716920989f835f4908bdf02a5a2c1f9c12a393e03da6a8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/en-GB/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/en-GB/firefox-98.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "2eac6e8c38348c508958940f9bb76dbd7c9de1426f3fb46d0ecfe9ed3de3e9cc";
+      sha256 = "a940242819cf79b1bd834520358e0aaea24e682cd5019668f356460a6815e4c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/en-US/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/en-US/firefox-98.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "ad296c84895b006ba555ab2cf88bdbe5c38f759dc3de3285160851a951017c70";
+      sha256 = "1a3d68e5e449faec50a427f709b98078bb57aee8209743a0beac978a4a72a05e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/eo/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/eo/firefox-98.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "c7cfb29ad0e7ff34a5b7ca9df77a430133cc0e23ab343b81648b3cefc91929ed";
+      sha256 = "d070191b8184943b55c4a68a3b523712ab04b0781ac835ec1f31de5aa170782a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/es-AR/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/es-AR/firefox-98.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "1778407785e942b56767a5d44ceba1e64a6ba7610f2e37ce1b3c0d9006e8770a";
+      sha256 = "d5a3c016b4090b926710c184729f2a59af3c257ec8ba48dcadb6367f67976192";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/es-CL/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/es-CL/firefox-98.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "0980c00a7e3dd353fd62b0265c930219a0377b369d02223589451a950a5449fe";
+      sha256 = "c22546ecc83739731783c6090172b1a8ca9082415881d62c691a97ed27b0813f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/es-ES/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/es-ES/firefox-98.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "e3d0a16e79302b06dd4c5d5bca684481a4a8e23a41ac57b5599fdebb80cd28e4";
+      sha256 = "33a424c76e44d1ee73e360da08a5aca42ab30bdcc3ad2524c0c209be37121978";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/es-MX/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/es-MX/firefox-98.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "fac81aadfc0b53d4ee796369ab5f3d20195b902ac3712ac23afce07f252c81c9";
+      sha256 = "5ee32de772d925389210cd210c326f3aec85e9ad45b8041a373cf8456008b7eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/et/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/et/firefox-98.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5e5136778ac41a749ecc2c3b3d9600f52a7384731d1210745baed8a2dd609b01";
+      sha256 = "3bfdba6becdc20002d267ed8d695b72915f4d59073f0c0c5c5858bd383189017";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/eu/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/eu/firefox-98.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "0454dbe09d19df75d96f494c83ddc64a09ee56914edfcb9604f5bed1cc082dcb";
+      sha256 = "2c0669ed569b7676e10330d034802d9ffd24ca85ef38cff0208a7a02cba53d22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/fa/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/fa/firefox-98.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "4adeb426f43ab52e388d20e47de344da7e4b9510f54b6c35249154bad90396d8";
+      sha256 = "c7c8242892426c9cd1f0f60c3235de6dc7d9e77b3b341630c9d6887e34ff2761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ff/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ff/firefox-98.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "59595e382c31d74b76436a0e9db60e2d387d0ecfa79e957cd9fa5105d01ac43b";
+      sha256 = "4a7352a86887d5200106ad725e7a41aab1d353547da2c1891fc399424112ba20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/fi/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/fi/firefox-98.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "79878a6fcc291dcebb3bbf73ddec2592b9037ab41daae5260eadc5da8450a13d";
+      sha256 = "a696aa3e201f6b776610195e8e0130791015229a66082e3f1240d925210db6db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/fr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/fr/firefox-98.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "370622eb7a2a1d35f7564e118884ec9897a0af8bce74925f8185923ca2e3fa82";
+      sha256 = "67022f4ed56749d968780a97e1efc14d272a38a96aaf4bc55584e6fe423d48ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/fy-NL/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/fy-NL/firefox-98.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "18b08369f2808970c48a7a2bb83562431ec983d1d8cc87238d67595475e91f99";
+      sha256 = "1718465d4a46d4e8b0fba79b9e0fdadb241183745ad158fa65a3f8d17212d7eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ga-IE/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ga-IE/firefox-98.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "82b9eb2e68d832f2494d95b583db9eefa0cb926843cd27ea26acb18f4d996f13";
+      sha256 = "65ea67422e9816b20be8259b5771f3db7f4c414e52cbc9975612a533ad4d6009";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/gd/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/gd/firefox-98.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "2a95b87a4779f6f978d86bc4e1b62b6e26c384dcefd591a9fc67de62dbc743bc";
+      sha256 = "5ba3f664ee375bf22255c5d9776c8da83747f52aea566a4436d29b91b34afb7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/gl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/gl/firefox-98.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "337be7c5c81988f2d14d455c9a2f1df9d70dbf6748f0e0935ab8c8adf478d320";
+      sha256 = "58edc93a8885ae6c2686a8c8f67b93b19fc99376155770b4e72e821d762be0a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/gn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/gn/firefox-98.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "798c829b199f19a94a2133d1bd90d1f89d9250a5e48eddd48517964e7fe2511a";
+      sha256 = "c5c08869c3390a95de8e490af4e69783bba03fe8d55a1c2b344339cab9fbc4f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/gu-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/gu-IN/firefox-98.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "48eae1301e522a180b8e3cf522c1da4716dc98ac6199358141254c93d2e32229";
+      sha256 = "35f29f0b0574ccbb02cf08d4714e2827ce364876ad7751ba7f1cc24e9f9861c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/he/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/he/firefox-98.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "ba205d1076d9a95333e4472f3f2fd904a523838adb2db8d9e1b35da9c3bc27c7";
+      sha256 = "27c5343c95f53dced72958155d7f8af100e3cdb8aabfebc3189f1a9c2550428c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/hi-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/hi-IN/firefox-98.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "813cf75f2362e0b482073591529eed3ecf53c96868c677a0b8643197725d6a69";
+      sha256 = "f8d7111c208a529c8f461284249d1c77f88e8d644c27f398aabdd414a7309802";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/hr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/hr/firefox-98.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "36fcc3a5a40132658c8df595887875f84d10020b95fd45ae04ec7e5335625c88";
+      sha256 = "721b61beae502b2b7039e29b959c2b4b8cde84260b601aa29bbcf80c73a633f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/hsb/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/hsb/firefox-98.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "656d24f9b2c771f6faaa0595d67c1cac40a997248b13291ec5f1f7cf578c9448";
+      sha256 = "4eb192a2d3942e0c80ec2f3ba805a19824ab4c1d85e1ada9050409cf0cfd4ef2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/hu/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/hu/firefox-98.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "0c29e97498fd60955c02cd231acefc9411b52c3d10ae736f4f6cda447cd3e08b";
+      sha256 = "70b9a67a51d3e61242c1ece908a81d0ce4b407bfdd9d3592a7025242cfb0ecce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/hy-AM/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/hy-AM/firefox-98.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "0ce2b30421133e682058d38d61145839477f268f9b896d9c57d0355edcacaf84";
+      sha256 = "1135df2ba82e8834a8d38e436df2debab2601884c02a9ed876a64044dec9170e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ia/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ia/firefox-98.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "017d78f171e756108d4b19c620380f093b33cf6b963e3551e22ebfc89d3e3045";
+      sha256 = "0e8b652231ae2962c61a90466d1e8278c11ca3b4ce70432dd3a3541a7bd55760";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/id/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/id/firefox-98.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "034e4f54181adaf70a6732fe568c8e8e775a171bdda9bbc70002a0a23f49b9e1";
+      sha256 = "5c35d191e9010e7a0e97844b38573b6fde93ec57e13c1fcb85f3bbe595257bd1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/is/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/is/firefox-98.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b87b498b95ac5c54df7acb746518d74c7de7f66cbae0a186d20a433ad84ca756";
+      sha256 = "297aebec277c01bcc5dc0fcccc44946181991192e3f485ec4bc0555131f132ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/it/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/it/firefox-98.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "b90d484ab42c02f5f151f242dc36e4b83d1ebde15b87e2d41e809138a8f921f0";
+      sha256 = "7d0c7162f4c3c264d5394814c99881e2a39f9fd406e7a32fb5319bf63c3fe344";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ja/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ja/firefox-98.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "06167f6cd79dd32e4292e2ac1269386119478abc9c0d8689d8a4ab4785bc2ac5";
+      sha256 = "eb260c766f1c82d45393d5c7f3c3c945166f837ba02f061691bcb1b3f9d11b90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ka/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ka/firefox-98.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "9b1bddd0afcd3b562c48838027ca22741f03f4ee8bea2a619bdd1a086de6a1e4";
+      sha256 = "ce8f6ee46fe3c8b836fd694b2642be066a81191a9011e33c0853396dea625880";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/kab/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/kab/firefox-98.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "82490f5055e81a243172397fd370a9787aec2a034f73dabc8c0a607dd9650293";
+      sha256 = "05a282afed3bb3e573c4250368b3ff1edc4c322dfa81d30e8f8f3447199fe9c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/kk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/kk/firefox-98.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "b2637ef860d818be2e4fe94f520a4051813a0a72ab9c18888f7ff46d6f572eeb";
+      sha256 = "558a35d13332976880b0cacb69d45f25d72e34d4ef43e7c92260621dc1287ff3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/km/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/km/firefox-98.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "00377371bf242b579a38832d14bc0cb005a085b65bb1cbcaed95bea1bdf6e885";
+      sha256 = "a3d3f64dc5e55e9b3168e18a64b2bda9d238e10bbc295d7ce7f4c1d964b6553e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/kn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/kn/firefox-98.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "79462373ac45c47ec74fd73ce6cb67124f2b30ae1536c3d089adc160809d4ef6";
+      sha256 = "b06d52db9c0e2984c8a652278595cbd0530512b9bb8e6d5ec5d3015620225bab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ko/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ko/firefox-98.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "6e68582fcbee036e815de250c3758d6f5f64f05a522263505372a71efa9b6a29";
+      sha256 = "f1edc7483429824478a9a4d2f4f3a03a9adf23e9ae364ce8c50da8d97fb55052";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/lij/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/lij/firefox-98.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "e4c65f4dc771b0b82626db51388e048ce1685d0141e0602bb03b257a6c7e8a6f";
+      sha256 = "e441db0a47d1265d1280a60c592b4b2ddd33751c1e9b38bd71afc2f25edfe469";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/lt/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/lt/firefox-98.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "5d27f70cd772512268f0b2e0375732899dba624aa06b8fdf7991870e960323cf";
+      sha256 = "989c66160ac78aec5a4d543a519e11cad772cbbeb6b5bd30832b04751217d621";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/lv/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/lv/firefox-98.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "3481e2f2d6eeaac8104a42557bbf81099e83fa1f6fae83faec7d98c54def051d";
+      sha256 = "764a3821b57384676d1236e9553007a78583fd277d27174bf4970750ecbcf9e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/mk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/mk/firefox-98.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "876eb0ee59161f1ddb72510373f7050883cce63d99ce167039f2d6da6f4bfd16";
+      sha256 = "104b650e57a1d521951086fcd337a21fb3133358dce8842c434089454a389f12";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/mr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/mr/firefox-98.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "213f2fba8f6e9421c1b818b32f9da7608545de2c9a375497583cb7f3fd7bb021";
+      sha256 = "396359e41e9fbbc03a548e6f77c1a607af0e3c09044d6b57e2cb01fb80fab94a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ms/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ms/firefox-98.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "f55c1c63518f027202d12e9631980b8592ab7dc9bf69bedaac615d21bc54c93c";
+      sha256 = "e8dcb2af15e9fbedb0e3ebdfabdda5f596fd469b6b20e4b6c5eaedc177e6c7bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/my/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/my/firefox-98.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "7d280b786459220037395d140dd248da4c5efb6b7ddf5dd995e15c190103160b";
+      sha256 = "89e64cb715720dafacbebc7ddd72a5c6cbd69995113f1b7d1e68805b09591df7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/nb-NO/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/nb-NO/firefox-98.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "4826da52357f84c1880964c0c387a83a178fad365e427a80e14452a8914116a2";
+      sha256 = "640c4b9f4e23d08df22d67e915cae12ba07aea80ef392658f693bd5a14a23572";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ne-NP/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ne-NP/firefox-98.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "d1f51d93f6fa8d0d467ea85331e4ddbd3b485b6e4629c26a9a3e4347db957a6b";
+      sha256 = "efe07ad3079a3295744b8739d3718374137ee98d39622c0056f079196175dfed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/nl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/nl/firefox-98.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "a6092114a7d6b58c66874ff1c77c155d2c248c8574de210cf4111587a4c1e21a";
+      sha256 = "d979a5e416109251b0f27a50e5d2831ae2fbf3da6ed3d3e34b52adf2c19221ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/nn-NO/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/nn-NO/firefox-98.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "22bed8fd59c3138be2e0c32bacf3ea4c270c911bb13b269903689c6b44b92f24";
+      sha256 = "cdffc971080f506d083b7c4fb1edb769046a6b56ad5c6851fd3a09b48d401bfa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/oc/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/oc/firefox-98.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "4f932b1ef1689f4c3733b47176d5f1b4ff7ae3ef0e9448821be5ba545a3bd80f";
+      sha256 = "7d4206e9e73132f13f5ac5377eb619c796ab1088f8a91958dd13789b0b309995";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/pa-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/pa-IN/firefox-98.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ee8ed5b62a3af8693bd9bffcdd371e214f1d8e8d8f027021fe0dd0ced7febbc1";
+      sha256 = "f46a2e85222e39c03019373cfd539ae5354c608e60783151f15bbdd1a8be3b62";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/pl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/pl/firefox-98.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "1030e47fbe9b56d411aa7479645467a2d7d69d2547785723ed6eeb71287de855";
+      sha256 = "1853fb827d238af7122e9edb0d7553aab00196f5523addc641f93b3f26b02b0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/pt-BR/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/pt-BR/firefox-98.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "677c9c2320e5c76b906bf45af9af6dc06ab6643d708842d5ec53be7879e410f1";
+      sha256 = "a5f4e7c3f0b187bc86c4b085536a8dddd9c2fff6f746db77ed186b6ccc4efb97";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/pt-PT/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/pt-PT/firefox-98.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "713454c171d909cb25e32ba5e2a9a5402b268462440d3d1c6af6c381aed81dcc";
+      sha256 = "88dd8f0332d88ccd38ba119acdaeaad4fa3692b45759762871fba67a110af9b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/rm/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/rm/firefox-98.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "e5f32064d6466cc063f42ca2a8aa71bad1c8416296e43aab51ef26483cf99e36";
+      sha256 = "7e901202cb7b29f04c481df5bb330faa92e48d41dfe49ab614f089c4787ac36c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ro/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ro/firefox-98.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "029254291c06bdfebef637336f3e369d1225698890deb1d3a8f1c22af8af96bc";
+      sha256 = "149b39e24f83bd14c9befc52ef92639ad02ac2059a247d8521a8e5f8659b0983";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ru/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ru/firefox-98.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "cbba6fbd7badc80ea6c027567197931c1ff0d0954bae7afcfebe1aba8ad1a5c3";
+      sha256 = "5739758546b279d77101391edd7cfe236ddbf69434ea89dea6c5d4f857a016e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sco/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sco/firefox-98.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "42c7008ea400a4d0459dc640d62ffcd53ff7fb9cab4ddd2d256fd5d904e7a9d1";
+      sha256 = "cbb408a2be5d3c15ba7f9e865c02228f65c9ce59d2c29dd081638515404da03a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/si/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/si/firefox-98.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "2a1f68f377b399effa9ce5bef552999961f65bc9811e348e67df8219b1f8f674";
+      sha256 = "b96e1604af6e1e828230a1a3652f83bdf28247dbcb9961b233d18a9bcc829da9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sk/firefox-98.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "1b8a84779f43505eba914c8200bbd081fc9f8733349b1a1a111e841143a17b59";
+      sha256 = "ebe0774a5872e8e9f3ed3c894d10dd9aebcbce1539e56febcbbb7ee97c3ee358";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sl/firefox-98.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "4bb3560dfbfeddffe123daef7feaf2cca07fefd61165b73500e10fc8b5b19725";
+      sha256 = "2b3e38e812508438768d4f12e545d96f1b7e160d53edd26481ff70510d89388d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/son/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/son/firefox-98.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "7e34dc2ba0ffa089f2a33e9a03876233aa229c3dd196a13d386fa2809a75f0cf";
+      sha256 = "df1bc20d146bdb2d1491cb040c4eaac1a70d4af024a00863539b218b6e1098ef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sq/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sq/firefox-98.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "b463cf0e58785d24e1afe41ddbcac913fb8c6d1183d0a42fdebe4c3372c1ff77";
+      sha256 = "9b40353c9c9911522fa495d35f19764b220e2c40488205050719c951911dac11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sr/firefox-98.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "293679d7963bbbcd56388076eafa71a8642094826cbd0852c127ff2f6f1af6e6";
+      sha256 = "d2ba0fe06528af4fed9907870bd72290df1c433c02bafad8b7b834a24b9a1427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/sv-SE/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/sv-SE/firefox-98.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "76ea065441b99bf4fd9e19063161f46d553720353a301e207dd2f2a4aec68d8c";
+      sha256 = "44fa731f57d2f0639d1e3595eebeb2491cd3dfff7ff8144eac663e966ffa8f6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/szl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/szl/firefox-98.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "8098c6ebc375223a64b377555634581d9674e8122e8fb35ffbce4d168e7d2cc1";
+      sha256 = "37523769babf48c7c942d878c8c55bc0bd761a0e4df8a0d562416ccff46f8cb6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ta/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ta/firefox-98.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "65a9903767a0af7315bdba205c4f5958b6a8b62667b47c461776a42327034f25";
+      sha256 = "3aa9dc19988fb6663ac95b6c3b79d03313cd78cb4e80700708ac92c3939d513f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/te/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/te/firefox-98.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "c472245fc0fadc10317f6cdbbfb16007241ac88629f89fc0140ef13d86a34823";
+      sha256 = "bd7a1af00c7aaf49c5ba667e7e85bac5672384b68f5f7cb96e4670f7363ff063";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/th/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/th/firefox-98.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "45bbe61e8dc4c14845348d9d27c1b9936d6457ae2f8d3e469bf89d948571a54a";
+      sha256 = "962c9e428f1ab3d3d143920a503dcf6d5335489e7e691a4447c32ddfad0b55d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/tl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/tl/firefox-98.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "8eab5ba98fd9009016063c72e6bb2697a35144057216d783f68f25bc7b2cd95f";
+      sha256 = "6ae919a932170ccc3891f0805949e29cd403f6a2e6efed38b76c7817c9533cef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/tr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/tr/firefox-98.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "3353d52fbb87f2153b47bc0b7418b59c7a69c9fc485317c798dfb46c22576b25";
+      sha256 = "27127d6261975f62185966a8d2a9c4e686c92212b8f4e06a36b47d16434413aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/trs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/trs/firefox-98.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "128592aeea8f05a45de19775694c6328348c6e9c379c87f74d3e128f6d2f24c0";
+      sha256 = "a005665c64968a82221d6332ed20aa6702f197ec31960fd4a4a78871a947586c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/uk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/uk/firefox-98.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "8b6dc07b28938823bad837c4afe35974162269b18603558922e5cdbfb8803e77";
+      sha256 = "866021efaa23457b203bb2700b8f24649222855d7ac1f71bf05ee98469f8c7ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/ur/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/ur/firefox-98.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "55cd1f091e19393e20286c841391276518f5052ca276212f7fcee131cb8afb8c";
+      sha256 = "d34a0c4f6937d8f6375c5d056cb615db37673917dfafec7d1f5201c38359a1c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/uz/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/uz/firefox-98.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "2e047e036591bb43e402bac8f2fb4c201ca20c98954516899a05a1f81fdcfc99";
+      sha256 = "a5098a02bf4a8c983e81b2863afae1cccc007c69556d69432577928a9eed89d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/vi/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/vi/firefox-98.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "5f7f76c7c18697154b42de673d73536c5f464c31400c40d63ab21fe63b0a3f3e";
+      sha256 = "ec7c91879c348fdccbe73b498757d1ad7bb1461df530829012c33c706c023aa0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/xh/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/xh/firefox-98.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "9242eda24dc7f713e271c2d510ff0b5b6b9b4245f52c61c854ce9027ddf0aaf4";
+      sha256 = "0b8bb8c5eaf45faa1f128c08a8d47d7f1388f37e09f73f3ee9b0e77044aa83a6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/zh-CN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/zh-CN/firefox-98.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "d6747951a775d94628e132ac6ae4d42be832db68b8acd37e88a6704265f96492";
+      sha256 = "4cbe5d68f610f3778be063d132271fca35ad9c7a7914aa32459527b4c1800948";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-x86_64/zh-TW/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-x86_64/zh-TW/firefox-98.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "0696bf38ecfc74515125bae5e78488d3791c96d278e13a945c8fc4ef22f29795";
+      sha256 = "80d4bc113d203fdba00f6af11ef1fd7b9184204b1788124e66049ca5ec13b3c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ach/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ach/firefox-98.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "2192bc876e5d20d07dd7bce8b1cec0a7de9fbc2792bcda0cda56f4e6094f0780";
+      sha256 = "98a4025d0771980dbd3d06511ba15de71d7df7311c7e683039d315bce7dcb590";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/af/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/af/firefox-98.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "cbe1617bc50bad32cdb5d509ddbdcc06ee29446b4aebf9f7ff43b76a3c397c80";
+      sha256 = "8519234c67e0f8b4e13df38ca98589d0a618f607eb940cf1f686f540a3dad527";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/an/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/an/firefox-98.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "cf8fd1eb1381e799c691bc29e7ffff12d7b680fa3e581e74450c4299b96c1f12";
+      sha256 = "61bcf050289a12e11c6a2b308f3323f39558aceaaa7b18cd95dd19609065a66f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ar/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ar/firefox-98.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "e9c2a210cfd311a4150e2b669f28e2cd402f90e3188a0025a6c10784ecb599e0";
+      sha256 = "961d7585e36e387d7a0f01bec3cb8359704a0716124211f2a24f5c046d49d338";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ast/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ast/firefox-98.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "46f6fad024ae9f936e87817ef8c412b5cfcec136bc20b81711999f3d0fd80f1e";
+      sha256 = "bb104056866e6518bb0ab94ba179b525105ddba09fc969065dc48d15f70de5cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/az/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/az/firefox-98.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "e949fee909684137ecf11d708d7792d567dd2626ca85aa65553aab798ee22158";
+      sha256 = "897fe5ebfd497eadda7858701217d6a0cf0bbf2a74389ffdfc46ddc8a5706480";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/be/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/be/firefox-98.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "c722c2207d3c517d3990b9c391279c8edf64c8d2580a9aaabbeaeda068187bbe";
+      sha256 = "6e4122643e4bd368c7adeb640554c7a5252562b767093aeb0e9cd63c9a533b25";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/bg/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/bg/firefox-98.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "9d160390573d2fbe8bee16fbf02e5aef8b39cdddb29b4659d62d8c4cb3b7ca9b";
+      sha256 = "481a3cc57cdd62d1ad23ef9f8f0c15087ff20335ab57bc28729dd74975460370";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/bn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/bn/firefox-98.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "07b43530c11a8c9dd17d2add98e969543e3de5641480d8598c8622a30b8d0c9d";
+      sha256 = "d56c44b8c5103072605b9fd3e5cec63ef613698bad3198543e67958c7ae2c97c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/br/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/br/firefox-98.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "d4fc63b59f15a19f1a8096321f97250e2c62c545e1ab4376e00dd37bf926358b";
+      sha256 = "2f25b1130142faa0efe08413512353319dd341d31221fd463f198ff8ec776b4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/bs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/bs/firefox-98.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "2926112d25fb8b539c64150182c871925442624588214428c3404e172408db65";
+      sha256 = "a0a33294d9eed0867463b56bd0e02e58836c5eae91718ba918160dc98eb7ac42";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ca-valencia/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ca-valencia/firefox-98.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "84aa8decb3de692e7bb0d0ee81776e97d17ca5e5d7acb26e40974864edd97749";
+      sha256 = "fed1ba8e292c72cff4c28ce3c5e59f58fd20f25624444084394f7b1cd61446e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ca/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ca/firefox-98.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "c3d5e497af8a54aecf3759577a84d0f3653f7a23482373e76c7357216dcf91ab";
+      sha256 = "f2cff173d6c5f6d12f8b29f07b3ee0d51dc523d508f340a65a99404953e1cb74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/cak/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/cak/firefox-98.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "a6c9ca50b2736f938c083f77256e535f0292c1185f9953de4b85f96e38319cbb";
+      sha256 = "c48e7d51d10b4d398a3a737faf204cd695091da360a70f3fb6dcf8b5ddcc265d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/cs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/cs/firefox-98.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "09d99e99bf9de31352331fc8785b0b3d3780a2bb3b204040796cf97e5d122d89";
+      sha256 = "1a223fcfa992f1f58e61f9c4903253e51adbf8a73380d09e9b38eda8f713c31d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/cy/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/cy/firefox-98.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "49e60a72cfe50cf5ab611b3ad8f138591450160846af4463932786885af84d6a";
+      sha256 = "3f26e158ac5870fecd94d2b5a07f7116577fb0cacae5a98f456aa64b66eac64f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/da/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/da/firefox-98.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "0ee8afceb0cbeaf073ef55c11ba689a150c22b3d0c2f195cb229faa8a9b5b649";
+      sha256 = "1ad6bd99e003d2c8a2d3dfb15360f52800b8e2b0c6ce586f1857ab491763a27c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/de/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/de/firefox-98.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "e26b2d1eef2534cf70d4f179fd0588d5154499a8a24103b214ac12c0b5a8c8cd";
+      sha256 = "1f433c261278469c96f239c595ccaeaab2d735b461847b2a6f0770cb618e13d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/dsb/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/dsb/firefox-98.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "aa18dd0dd29922806a9cb5898b4c96288cbab93f167e811a9dd3c74932078a08";
+      sha256 = "c0aa0c513549ddcf73243d7b0fec5110d547be0536b79d2763714447cd80460f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/el/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/el/firefox-98.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "c716a804e8b2742e9c429605239857243776aa659c401faadee69768bd0291ab";
+      sha256 = "0e341f6e22862bc0d92efce71243e64cde6e9324ac33bb1fbfed59b84fb4fb89";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/en-CA/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/en-CA/firefox-98.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "eccbac7e72e1e71e09836e029d898e8f01edf38d32cbfaf40012891cca7c22f5";
+      sha256 = "5dedc5db801b0f7c7bc42a2373e8558895a1fc757cb1f39f99b355729eff7e4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/en-GB/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/en-GB/firefox-98.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "9373ba9afc767b7d52e3f7183250fa315315a6e845b9700019509d2f623f1341";
+      sha256 = "05d2a3ed1e9b2d7693062758183187d0a8a4524d6644532029aadb1d2d1b9548";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/en-US/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/en-US/firefox-98.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "6d2457c5d25ca4be784d189deb3134421c2072881412a24f732d2853b86e0bef";
+      sha256 = "01e9e15b89299cac4ec8931e84f11ed63ff3ee5e70cb73be4cb6f6f5d817cfb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/eo/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/eo/firefox-98.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "4d0e02741eb10eccdb9300b0ff6f13674a74bed47139cd786e9bd7e4315970b7";
+      sha256 = "121a736e78d12f984270cea37b14915fe65a52c3dfd29e155f20a09707d69c58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/es-AR/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/es-AR/firefox-98.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "6a8c963e0860d89a829aa27acc32fd2f79bf89cf87534c837bdcdcd9fb5e0157";
+      sha256 = "a051af8c255954d2c025cb9d3a0ad2d1ad6bbfbc1bf69436abe8ec6674277ece";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/es-CL/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/es-CL/firefox-98.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "8472ac2735d2142bc8d465749c247413362637a81d57d68bbd15851fbe05cc2f";
+      sha256 = "17a2fa85675f5fbf532da3485099315de98397e5286e2fa5a0b1c8b468a9c974";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/es-ES/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/es-ES/firefox-98.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "922d5e41d37b98226a2969ee51079d7ab584c9522234188a97c9aee1feb31f27";
+      sha256 = "ffa84eba0ac4cd45fa385de6fba23b8bc69efbee1a3bc39b7e1fb95cf6e6581d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/es-MX/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/es-MX/firefox-98.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "082db8cff7aa39fead4764f497ea27eb43f761928d5ab6602032feabae599a74";
+      sha256 = "f73059f6dfa6df82282ce8cf5068fc5fdbc6320d2e73c981ff6571afba8b3959";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/et/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/et/firefox-98.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "22b7484208ab90ab3c145e22688f945764d7d2c3321577a8eae339f6a385dc09";
+      sha256 = "250eb95ef69fa4e61fb6fff0c10c7f884684ca428318b1feed366a2b49809993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/eu/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/eu/firefox-98.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "25ffb27b43aa19b0bbf7cb8205a26744804d9ad995c05121c946bbbf5a9cd426";
+      sha256 = "6a709d754542a74104539e8e043f1b07652e007a1c062e067af4123d46c46071";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/fa/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/fa/firefox-98.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "65b842820b27d8c721d00b20fe349b7143dcf512743ef24792346be2945196a3";
+      sha256 = "5435ad7aff621091454b61f2261e72ef1ba2fcd2b89d32148f8ffde0635e237e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ff/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ff/firefox-98.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "c48993b690dee9cf52cbfbc1e9dbe050a7a09cd31a0351727e761232f51af521";
+      sha256 = "627f8970b92f5a96d8023406ca14c46471be457147d282e15e71db0163822a66";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/fi/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/fi/firefox-98.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "b2b019f93bd46e7fda9f9bb587bac5b6fa6933a8a438a56651c1b357a1422ead";
+      sha256 = "ef7912a562f3d01e20ee54dd505859ec6da549c8daba04c5003a8b618af722d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/fr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/fr/firefox-98.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "55f34a1298704c4e35bf3bbb6bfe5ecd723a2266cfa326440a53dce7800fa4b5";
+      sha256 = "da5b3dd660ff8ac8f10f5419d0d848503a74948d76ebe45fbf88470703b24831";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/fy-NL/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/fy-NL/firefox-98.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b24917d24a66762f190bd3de0fc4c3063bea6b8367bbe0cb7179a0403dfd34aa";
+      sha256 = "5d58c3ef8e75c22db07e82131d6773f8af8930d46a3ea9667bae07a59dd6b8bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ga-IE/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ga-IE/firefox-98.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "8b492d36f0031705cea67d6862991f1a78ed2678df96f7862b97f13f30b4f7ed";
+      sha256 = "05a3402a6be754390c79a66160510696acf866002225a5d242d2f178e3c63dc6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/gd/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/gd/firefox-98.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "3ddece6e94a6ef0c26f2204cc5442a00f5bc4aacd3bd87b2f4085aae5cf6d519";
+      sha256 = "6832439565a3a18ec623c5a6d0c36e429b2ef291bc8c0152da6934a108ca32a3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/gl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/gl/firefox-98.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "e0aa1ea385d06324b174eb534744e16293e9e2a9ec67448500f5f85c1e78cad2";
+      sha256 = "2e55dcaf24d4fb028ff5dcba94fac38499897bbb7cecca79d6fafc0b83e21a9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/gn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/gn/firefox-98.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "e36c9a22f3bf6047cb8d697b5e1e9cf23b9074d916dc7743653d9126c9315eda";
+      sha256 = "c25a77b99c022c3de29cea922e926db9e738771cd146acc6d71545cf8f1acdaf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/gu-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/gu-IN/firefox-98.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "ee328a70d051a7abd6c2d9ec7654eeb6b53dc0f30d109e1690020b246c7802e8";
+      sha256 = "e41991d388c6fecf9b22416c5f840e8f96d032d3be793101c9133ef7cc545850";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/he/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/he/firefox-98.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "93598f5edcc207eb20796c52629eab98a9422f24c2788a65dd45c92498352123";
+      sha256 = "55125f1e56fa6d8f5af4aba206e3ede2bb80f39414563a541f07eebc568de993";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/hi-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/hi-IN/firefox-98.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "9c86333eaa06e03cdfcb3b5e2b7feb5f740825fc59a1b115b7a9180c5cdf71af";
+      sha256 = "4ebdde0d91f94399607c127953e738855a17463cea34a4360b630ce0e6add5c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/hr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/hr/firefox-98.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "1b067012f8b23c0ecbf0dea390b8cfe7665a584abd3d5b2dd5706d45de2960c1";
+      sha256 = "11f2449791c1613394764d36e1661cb05a83e2582904eb00ade9f09f58d4147d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/hsb/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/hsb/firefox-98.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "1b0c71e9822b6a61704118bbd20111f3350389d8a12d52b3932383bf85f133ff";
+      sha256 = "d7138688ce4edd030bb51d7eb68626a4055ef18dfaf30045d872c03b187b4ed8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/hu/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/hu/firefox-98.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "039aec5700c4c43583637f331dcf18ffd7be59884804908a7cfe85c29030d626";
+      sha256 = "693e08538b19f9d1aaab399e8d4b582e557e34ba5d2cae7de6c7e048b175dd3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/hy-AM/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/hy-AM/firefox-98.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "0edb9c11fa2e1f4c0f73c259d8943120e7f7ffa88b31bfcb796543b7b9e1cfa0";
+      sha256 = "1e78ed371f092f9e1ec9ec7c43b16da6b5a277056983ea810af568e250c9d588";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ia/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ia/firefox-98.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "53da2a2c4b3c952ffe14915fd984342d023e0a01f348d41bf747f2e338b05798";
+      sha256 = "a02a62a042cc51d7b6389366114816daf10cead0ce51a716ff58485fd7b856e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/id/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/id/firefox-98.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "18b9041709dcbf3209e1527a5d5bc0067ad8eee6031dd76ea40d4b88908fcc1c";
+      sha256 = "e548a304acb9075e6110c276482a1759cfb06b6cbd4edf2b7aa633f6762b91d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/is/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/is/firefox-98.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "037eb31ed338a220054b223f875f58c020178da7b06dc93c89e836010a5ac5cb";
+      sha256 = "c43167df2a3739d7d9e7c8013cbe4a9ed5e18a060d06667ebf36102ad7a0587c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/it/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/it/firefox-98.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "f224b94d31507276f2bd220cdc3bb476dd6aff5f50afac5c57c0b1d42525f08a";
+      sha256 = "4eba45221ef34d71353b3d442e8cc5a565fe79cad1a21b4de27129da92f165fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ja/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ja/firefox-98.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "4856c05bb62ecb086b2be18236917554f0145374782bf03ee32e13ceb669664d";
+      sha256 = "173c3f7afc252f495e9553c6b7a1afdd5090de2578a477e15307ccbecad937f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ka/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ka/firefox-98.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "bf42c9959f08650090525624cfa6e301c8c08bfc3f112ab39362b7729ddc12bd";
+      sha256 = "de14be28830076b11610a8824cf20e161cb4e7c0e527d160caf7d214f41ba9a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/kab/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/kab/firefox-98.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "8529eb80d70cb5a76482ac742ef3336c754e733d9c9b7cb80c6b9193e4a26983";
+      sha256 = "385dfe3ea1c1aafd4e0f3c4176bf2498876b34d7fee5195ba5fa5884203ae338";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/kk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/kk/firefox-98.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "9a4148fee4ef601129d0d76733d94efba0e1fb69daf75f12243ff687852425bb";
+      sha256 = "c9b2f1fe4cdce853ec155a4b99d44279dc64c266706e58274413b0b37cf71317";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/km/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/km/firefox-98.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "4106ef9adb0ad0333a551c57c24a5a1a1c13d912d8ba4524ac0bc95e87ecfbf8";
+      sha256 = "adc84f8768a71d7f2ed314dad0347a346b3592d47bb7ef621301deb2b72f7f56";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/kn/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/kn/firefox-98.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "5f6d6d22ba1ac0e0a9e74fc2299e8fc0f0329fcc9a814dc5807fa80e6870fe5f";
+      sha256 = "c0579f13e76c62e402065069ab7dcbddd7cfbea8e428b5bf2e77d42550d18557";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ko/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ko/firefox-98.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "e03e8c645a98277d8a7d9e49dea8ee35bf574e331909ddb3f47a113834e0fd63";
+      sha256 = "bfc610608666e626715000bc4fa48dccd43ce0036ee0111e926f92b75034a0f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/lij/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/lij/firefox-98.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "40f5caa8e5393c6832632fa8539c3c8859c05b96bcebfd7b098e81020bf14c6c";
+      sha256 = "fb1afb37bd4d47aae8de6ff8b1a2dc34d41903ae4ead5a2671baeeb6ef3b3196";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/lt/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/lt/firefox-98.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "5750105121d1f2c3192407c9859c5bba10fbae70b79b4dafd03a5fadd7a582e8";
+      sha256 = "0197a8c4ddf84ac38aba0533a84b4a57e783d3542b48e221b3317b39e9decddc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/lv/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/lv/firefox-98.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "201027627af36b8062352d790255952cb3244a6d4ec50c40e70375fcd754fa6c";
+      sha256 = "a7631d6bfc46a140c226cd1914074084ac1bba0104c7811305d40291e015c2c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/mk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/mk/firefox-98.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "fc67d3f4524c50ccea04ef1d28d1850c8ce732df6fd80208f3b95d0f5bc97b13";
+      sha256 = "78be93a5ef3ec79c9b7b8ed4134b25fd66db74e4160235e1ff57f87f7ecf7f71";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/mr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/mr/firefox-98.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "a966671ec7ff2f880557f4847bd652ba98aaa08ed787755ce88ea1e80f2ed06e";
+      sha256 = "3890be73f978299ebbd3c7ef0919a6d5f916729528ee90f7d1ef86b088fb748d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ms/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ms/firefox-98.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "82c4358c9df915d6757fb2935289218d88083bae677881c883d6b626aa3b2ca8";
+      sha256 = "5bbded06e5eb3c4f628df573ca10aed952d72125ca1f96f74643e28210121e47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/my/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/my/firefox-98.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "91d6c81aaed53c8d218a1fea1c440aec8850926c53a994b7e4efcafb061daccb";
+      sha256 = "2a8ea9468c6fa4a4a303c4b5b1a9306898ed8f2fd60a3e8c9915ae549baefa09";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/nb-NO/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/nb-NO/firefox-98.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d8773597a84212cb0fdd6555fd358dcf6dec7d97db9a6b646c083055b13765b0";
+      sha256 = "c7fb5c534a03afe15bc2c439b679dbf3316aea92d23d154b6902893633fa9b32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ne-NP/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ne-NP/firefox-98.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "1027a001f4586cf6dffc85e8fd7b9e8e7f70eacef30198b8a6bc8c5b70d1fcf8";
+      sha256 = "d2b2731732202c4501e0989fdd95a68cca01aa4b13a02ca035247a1de7a7f299";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/nl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/nl/firefox-98.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "0add3e6e26b51bd8363b577f7ed09395710304dc44c9e584af2267d855d4584b";
+      sha256 = "2947d1783e0cc8126c086bb9a1ed139de735ddf2bcb4f104e9efb6d68d844503";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/nn-NO/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/nn-NO/firefox-98.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "1c666a04b8ec8dad7d56d9390a565e9a95d3668687e348cd83a4e9c61d76ab46";
+      sha256 = "1aad31043951d9b81f707cd9c6259d6c215ae20f55776719c2553148dc3bb589";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/oc/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/oc/firefox-98.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "c1ccfcd6bd1f5e9cd5713cc70eaa852f111311c4e6b2fdafb081d21c5cfad8ef";
+      sha256 = "c237cab50aba2e059224d80ebddda67f13f8737899a29d6246418dcb09c486de";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/pa-IN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/pa-IN/firefox-98.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "17d4aa8cbd8915ebb36f5e33a61c21ac20c1a22804ebbde9af1e23bfb97bc8f4";
+      sha256 = "e487db05bc46eae01509b5ac3a9f4aa6e3cd8bd0970366d9501c1a74653f3110";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/pl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/pl/firefox-98.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "045e39e9b4b5a8267ffa61aa61035fd9b8072cb5abe1c3bf55b5962ee5c187ad";
+      sha256 = "a84f34fd417855acfeb89926fdacc8c4fdcb870251d3b43095e04d2392a6637f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/pt-BR/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/pt-BR/firefox-98.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "2fedcba08ee5bea1e3b96c2f505f6c8005858db7b3cab323c1af116da6d6baf0";
+      sha256 = "5a4e35c0efdb79e83d535b62d57c26d5021d20c26d2654b98f6078ebbf4b6094";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/pt-PT/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/pt-PT/firefox-98.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "8eb62212fe9dfe210106d4cb294c9483f8beeefbb1a71043bea0d615e164a0de";
+      sha256 = "f61b70f911e708f4964f4592e9b46c8e70a730f778aaa6e320ee7c0d3647253d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/rm/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/rm/firefox-98.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "251a08a9662aa199df492c6f8301e888ec49bba30b36dfb4e55d03080796c69d";
+      sha256 = "3b602a6d897e2311f1521a36ffc4be4c6b84705605aa1bf321b684010c02d59e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ro/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ro/firefox-98.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "72255f3acdaf1f519c2dbb644c3b6ad3686391884bca4babf5d16e3f42664b5b";
+      sha256 = "94ff92349315c126c3c1294e9d468914b7f81ef8a0597c5fd039fe66bcad271e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ru/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ru/firefox-98.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "47cc1e7e044be8c8e23d5398932770352482468eef09a7981de792bf63d5636a";
+      sha256 = "1f24d74427e79b7c78ffcdfbe1a40c5e767ed0854a870babdf1f4956ddaa17bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sco/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sco/firefox-98.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "d95ff1e2a6ed5dae1bc86b54109d32cb70997fd67a5d2509918acf162ad0f575";
+      sha256 = "2b11f6b4b380143ffb07764c6fb6fb139da7aaab0ea5bdad826b1c14eea09a3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/si/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/si/firefox-98.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "1babc4d0daf943eb83bd0b6cec67f5fd82fa9014efbd1d828c7ef89055645220";
+      sha256 = "f644c5fcc35bb8e4a2d4ba1d7210cacfa498ca9aaed79174ac4f973021dbac63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sk/firefox-98.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "fc0984f13d0a01ccd17830855ef2c14344dc0d51d60c7660dcb25c4d8cc6c9ce";
+      sha256 = "859bfb3a177429a24e585e6ad11fdf9220d5d0a2751ab861aa33e3e553a3fa2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sl/firefox-98.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "4978ff29f97455bca143b1b69c1da4edfb4740734853c51ed040621bd04d7fd1";
+      sha256 = "e5ba078d2f83df37b8211f8423dc549358b9d1c508a9607d1d5e735501ca9845";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/son/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/son/firefox-98.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "e391df473e4711ff30c26fc3a6069f93ba7ebba7681350ba932c2af443052b60";
+      sha256 = "07f902640b9742954ac03b737fd402d1024e647d4cfc096ceff2ef5329853235";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sq/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sq/firefox-98.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "d2cb665ebda69305e9294e7f59c8321bdbf6995ca12ee0cf9730ae832191b6d6";
+      sha256 = "2dc1cdc47fabf4d212745f326dea7ad202527fa8dee9d90908812a3f7b152840";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sr/firefox-98.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "bebc7b77b5b3a4f68d0a65f0901f4fe3eab30c9d0c17511de1c4c16224ce89ad";
+      sha256 = "d84a3a521ed43b9ce70a6984f6afb35bb02da5b4b9372cfdd47607151dbfdce5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/sv-SE/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/sv-SE/firefox-98.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "6f70d748dacb0847197dd4b513a41056db6b9cdfa09cf05c85407f54c73bcffc";
+      sha256 = "5c313719484370ac42a46cda464ef5096e866a93d821fd88d8cadc3fe483b8be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/szl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/szl/firefox-98.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "691d0d47a0eeee2ead1b4ad6d68c30f57f716606081747c8e318fc6d124f52a7";
+      sha256 = "6933fcc3ca447d2c530bc4d5a3fac65351359de13ca8415c17034611d343e4d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ta/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ta/firefox-98.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "799399db843a096b0a26f916662b774347559fc1e22f2763b89a409f346d859f";
+      sha256 = "a1d11f11350ad8a1aca420774896721a71db6640e78798bd5d0e9563fa215350";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/te/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/te/firefox-98.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "9470f20496f2abc22da792dfd2dceeffc1fcc5a7cb94c63478f784ef3ffe4718";
+      sha256 = "a09332149b4d4daf758cc75a0b50c793207e6dfa7f487f04864f8c41e2f7c2c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/th/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/th/firefox-98.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "9efeeb40b74356e5c6a9c44b702fead83c29eea0782964024a8884f22216d055";
+      sha256 = "615300bf23c3903079601c5e4d9509bc3a7d5fa1e94a01aff09559f3c2994306";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/tl/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/tl/firefox-98.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "eee74ab0114e6d43a92d081048d8b4a560bc6534cc40dc1f6986472cf1f55089";
+      sha256 = "f323e7204e86b91cce656780e65bfb4166bd0e27d1ba84ede5e8b87ab6c4e122";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/tr/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/tr/firefox-98.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "bd085cf744b30adade22ebf1a3483468154798c457968cf28b2b6466dfd3942b";
+      sha256 = "cf36e947181fc7750186b75edb0998df3219097ed94e4617435cff2690f626d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/trs/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/trs/firefox-98.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b62b22cae2b433b417d986f0e6dadb1cc9e18756e6dc5add12f3b4ebc579905a";
+      sha256 = "137270152321a9922decfbfcad4643ce9d3b127498d91ef7a4d60069d249632e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/uk/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/uk/firefox-98.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "039a1cb867a67776f5895ff5fe30fba423f90349dc3d414ffac38a1e9ada8555";
+      sha256 = "4571eb45952e27756ba8332cd62673c3cd21d58b85662d6eae7a43afc5aa9613";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/ur/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/ur/firefox-98.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "4395013e4a95c1c558b7b56c3c5a0ad91e1dd71ebe63a4e3ffe059e55d0c265c";
+      sha256 = "77d60ba1a7bf22d7fb690ec1c22dd35b84b3e59891d07c129335894d3c47e8fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/uz/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/uz/firefox-98.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "05597062b24868b0dca7869afd2254f66963e1e36976d995d061cd4451514026";
+      sha256 = "a716e77dae132d1741366836c9fb59320477f623cef47713e93ff7ea6c712d49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/vi/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/vi/firefox-98.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "15aef2b0666f6c2eb9b673e880551c1fe80976fd22c6462e52500bf87afe076c";
+      sha256 = "90d8f9ae57521d77e4f9db4166aa7124f4b935f3f1531639058cecd7cf96be36";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/xh/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/xh/firefox-98.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "404d67957ac6ad847ba8983928285789d8d76bc39c4ca2864ea7ce61f4e610fe";
+      sha256 = "ede2ab7f812aeef2f4f07ceac4df1edcdeca35c1b8d1d64053a7250fd781187e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/zh-CN/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/zh-CN/firefox-98.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "1572fa6528616efbadf7475c587b163780d5b8ac2c186179ae9161b3557a5f9c";
+      sha256 = "02c61d1b1bb6e966444a800a319eb69fa36ce913614369d0c8f95388e4bdd14d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/97.0.2/linux-i686/zh-TW/firefox-97.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0/linux-i686/zh-TW/firefox-98.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "da300411ebae5ada6030d116f989d5d8f1808c31ede8d7eeaf4b851330001f9d";
+      sha256 = "5c347fe33e423b8300fd6f2a0a3026896ac6c74af7bbdfead40f72874e65b0c2";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -16,7 +16,7 @@ rec {
     meta = {
       description = "A web browser built from Firefox source tree";
       homepage = "http://www.mozilla.com/en-US/firefox/";
-      maintainers = with lib.maintainers; [ eelco lovesegfault hexa ];
+      maintainers = with lib.maintainers; [ lovesegfault hexa ];
       platforms = lib.platforms.unix;
       badPlatforms = lib.platforms.darwin;
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr-91 = common rec {
     pname = "firefox-esr";
-    version = "91.6.1esr";
+    version = "91.7.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "e72ff7114e251ec3558f47bb45e4017fe4c665a95e0a108d5818c628b3de44c92f57cfb3dd9f5a25b7abad889be228f89dda838bc20fc9617c90655694184ed5";
+      sha512 = "925811989d8a91d826ba356bd46ac54be8153288ec0319c28d2bfbe89191e62e107691159dd7ca247253e2a4952eb59a5b9613e3feea3f5351238d4822e26301";
     };
 
     meta = {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
https://www.mozilla.org/en-US/firefox/98.0/releasenotes/
https://www.mozilla.org/en-US/firefox/91.7.0/releasenotes/

Firefox 98.0 source build blocked by NSS 3.75 being stuck in #161366, extracted into #163197

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
