### PR TITLE
discordchatexporter-cli: 2.32 -> 2.33.2

### DIFF
--- a/pkgs/tools/backup/discordchatexporter-cli/default.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/default.nix
@@ -1,20 +1,20 @@
 { lib
-, stdenv
 , buildDotnetModule
 , fetchFromGitHub
-, autoPatchelfHook
 , dotnetCorePackages
+, testVersion
+, discordchatexporter-cli
 }:
 
 buildDotnetModule rec {
   pname = "discordchatexporter-cli";
-  version = "2.32";
+  version = "2.33.2";
 
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
     rev = version;
-    sha256 = "xRoF/HJ4ekHL/Uk6ISQP+65nChRT+n9xLTYcZMJxyvo=";
+    sha256 = "wOSa6O3O4QlGL5ecnR14ldXPYV5mDoPDlJjcwN5Lrek=";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_6_0;
@@ -23,15 +23,24 @@ buildDotnetModule rec {
   projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
   nugetDeps = ./deps.nix;
 
-  nativeBuildInputs = [ autoPatchelfHook ];
-  buildInputs = [ stdenv.cc.cc.lib ];
+  postFixup = ''
+    ln -s $out/bin/DiscordChatExporter.Cli $out/bin/discordchatexporter-cli
+  '';
+
+  passthru = {
+    updateScript = ./updater.sh;
+    tests.version = testVersion {
+      package = discordchatexporter-cli;
+      version = "v${version}";
+    };
+  };
 
   meta = with lib; {
     description = "A tool to export Discord chat logs to a file";
     homepage = "https://github.com/Tyrrrz/DiscordChatExporter";
     license = licenses.gpl3Plus;
+    changelog = "https://github.com/Tyrrrz/DiscordChatExporter/blob/${version}/Changelog.md";
     maintainers = [ maintainers.ivar ];
     platforms = [ "x86_64-linux" ];
   };
-  passthru.updateScript = ./updater.sh;
 }

--- a/pkgs/tools/backup/discordchatexporter-cli/deps.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/deps.nix
@@ -1,6 +1,6 @@
 { fetchNuGet }: [
-  (fetchNuGet { pname = "CliFx"; version = "2.2.1"; sha256 = "1yxxl3jgl6sadar1g9175s62fag5f30lqpgrf58djll3509rbgw5"; })
-  (fetchNuGet { pname = "Gress"; version = "1.2.0"; sha256 = "0aidc9whi0718gh896j7xkyndki9x7rifd8n1n681afb2zbxw4bn"; })
+  (fetchNuGet { pname = "CliFx"; version = "2.2.2"; sha256 = "13g5xlrbyhnbwkyzic5jlhxl0kpvkfrdmb5h2rdf9yp4gp5p9mwg"; })
+  (fetchNuGet { pname = "Gress"; version = "2.0.1"; sha256 = "00xhyfkrlc38nbl6aymr7zwxc3kj0rxvx5gwk6fkfrvi1pzgq0wc"; })
   (fetchNuGet { pname = "JsonExtensions"; version = "1.2.0"; sha256 = "0g54hibabbqqfhxjlnxwv1rxagpali5agvnpymp2w3dk8h6q66xy"; })
   (fetchNuGet { pname = "MiniRazor.CodeGen"; version = "2.2.0"; sha256 = "1rbgkm1hsamqhviw2c62g6iafiwkxcnz66qbybpd32qgz1124cx4"; })
   (fetchNuGet { pname = "MiniRazor.Runtime"; version = "2.2.0"; sha256 = "0zm0l97jfbfy90zj0cbi7v3qbhxhfay1g8f2cw0gp829xz4yk9jr"; })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Removed `autoPatchelfHook` as it doesn't seem to be required anymore. 

Unfortunately we cannot run unit tests from upstream since they use the discord API which requires a token, so I've added `testVersion` to at least do a little bit of automated testing.

Supercedes #163099.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
