### PR TITLE
hydrus: 474 -> 477

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,18 +10,19 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "474";
+  version = "475";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "v${version}";
-    sha256 = "sha256-NeTHq8zlgBajw/eogwpabqeU0b7cp83Frqy6kisrths=";
+    sha256 = "sha256-RgsiREczdI+R4BcETqEpYa70s86m6BZLB0l0R2Py+Lk=";
   };
 
   nativeBuildInputs = [
     wrapQtAppsHook
+    python3Packages.mkdocs-material
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -85,6 +86,7 @@ python3Packages.buildPythonPackage rec {
     # Move the hydrus module and related directories
     mkdir -p $out/${python3Packages.python.sitePackages}
     mv {hydrus,static} $out/${python3Packages.python.sitePackages}
+    mkdocs build -d help
     mv help $out/doc/
 
     # install the hydrus binaries

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "476";
+  version = "477";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "v${version}";
-    sha256 = "sha256-hosLIKCuoQSpuDBvmghbn/edMU7O6tvjiZb983MgWJQ=";
+    sha256 = "sha256-/Gehlk+eMBPA+OT7xsTri6PDi2PBmzjckMVbqPGXT64=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "hydrus";
-  version = "475";
+  version = "476";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "hydrusnetwork";
     repo = "hydrus";
     rev = "v${version}";
-    sha256 = "sha256-RgsiREczdI+R4BcETqEpYa70s86m6BZLB0l0R2Py+Lk=";
+    sha256 = "sha256-hosLIKCuoQSpuDBvmghbn/edMU7O6tvjiZb983MgWJQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/mkdocs-material/default.nix
+++ b/pkgs/development/python-modules/mkdocs-material/default.nix
@@ -1,0 +1,41 @@
+{ lib, callPackage, buildPythonApplication, fetchFromGitHub
+, jinja2
+, markdown
+, mkdocs
+, mkdocs-material-extensions
+, pygments
+, pymdown-extensions
+}:
+
+buildPythonApplication rec {
+  pname = "mkdocs-material";
+  version = "8.2.5";
+
+  src = fetchFromGitHub {
+    owner = "squidfunk";
+    repo = pname;
+    rev = version;
+    sha256 = "0v30x2cgc5i307p0hsy5h58pfd8w6xpnvimsb75614xlmx3ycaqd";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    markdown
+    mkdocs
+    mkdocs-material-extensions
+    pygments
+    pymdown-extensions
+  ];
+
+  # No tests for python
+  doCheck = false;
+
+  pythonImportsCheck = [ "mkdocs" ];
+
+  meta = with lib; {
+    description = "Material for mkdocs";
+    homepage = "https://squidfunk.github.io/mkdocs-material/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
+++ b/pkgs/development/python-modules/mkdocs-material/mkdocs-material-extensions.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "mkdocs-material-extensions";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "facelessuser";
+    repo = pname;
+    rev = version;
+    sha256 = "1mvc13lz16apnli2qcqf0dvlm8mshy47jmz2vp72lja6x8jfq2p3";
+  };
+
+  doCheck = false; # Circular dependency
+
+  pythonImportsCheck = [ "materialx" ];
+
+  meta = with lib; {
+    description = "Markdown extension resources for MkDocs Material";
+    homepage = "https://github.com/facelessuser/mkdocs-material-extensions";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5157,6 +5157,8 @@ in {
   mizani = callPackage ../development/python-modules/mizani { };
 
   mkdocs = callPackage ../development/python-modules/mkdocs { };
+  mkdocs-material = callPackage ../development/python-modules/mkdocs-material { };
+  mkdocs-material-extensions = callPackage ../development/python-modules/mkdocs-material/mkdocs-material-extensions.nix { };
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Needed to package mkdocs-material for the new docs

Weekly update of hydrus,
Backported due to hydrus not supporting big leaps of upgrades and to maintain api compatability with the Public Tag Repository

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
