### PR TITLE
nix-output-monitor: 1.0.5.0 -> 1.1.1.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -700,11 +700,6 @@ self: super: builtins.intersectAttrs super {
     testToolDepends = [ pkgs.git pkgs.mercurial ] ++ drv.testToolDepends or [];
   }) super.retrie_1_2_0_0;
 
-  nix-output-monitor = overrideCabal {
-    # Can't ran the golden-tests with nix, because they call nix
-    testTarget = "unit-tests";
-  } super.nix-output-monitor;
-
   haskell-language-server = overrideCabal (drv: {
     # starting with 1.6.1.1 haskell-language-server wants to be linked dynamically
     # by default. Unless we reflect this in the generic builder, GHC is going to

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,32 +1,145 @@
-{ mkDerivation, ansi-terminal, async, attoparsec, base, containers
-, cassava, directory, HUnit, mtl, nix-derivation, process, relude, lib
-, stm, terminal-size, text, time, unix, wcwidth, fetchFromGitHub
-, lock-file, data-default, expect, runtimeShell
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh"
+{
+  mkDerivation,
+  ansi-terminal,
+  async,
+  attoparsec,
+  base,
+  cassava,
+  containers,
+  data-default,
+  directory,
+  expect,
+  extra,
+  fetchzip,
+  filepath,
+  generic-optics,
+  HUnit,
+  lib,
+  lock-file,
+  MemoTrie,
+  mtl,
+  nix-derivation,
+  optics,
+  process,
+  random,
+  relude,
+  runtimeShell,
+  safe,
+  stm,
+  streamly,
+  terminal-size,
+  text,
+  time,
+  unix,
+  vector,
+  wcwidth,
 }:
-mkDerivation rec {
+mkDerivation {
   pname = "nix-output-monitor";
-  version = "1.0.5.0";
-  src = fetchFromGitHub {
-    owner = "maralorn";
-    repo = "nix-output-monitor";
-    hash = "sha256-7vjGE/MfRlFplGQBkhYwqMWjiFfky7J9aI8Tt5FycBo=";
-    rev = "v${version}";
+  version = "1.1.1.0";
+  src = fetchzip {
+    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.1.0.tar.gz";
+    sha256 = "1zw7x1snyycl1bp5w7jh8wwnynqvw3g4glr293bnzi5jyirj5wlg";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal async attoparsec base cassava containers directory mtl
-    nix-derivation relude stm terminal-size text time unix wcwidth lock-file
+    ansi-terminal
+    async
+    attoparsec
+    base
+    cassava
+    containers
     data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
   ];
   executableHaskellDepends = [
-    ansi-terminal async attoparsec base containers directory mtl
-    nix-derivation relude stm text time unix
+    ansi-terminal
+    async
+    attoparsec
+    base
+    cassava
+    containers
+    data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
   ];
   testHaskellDepends = [
-    ansi-terminal async attoparsec base containers directory HUnit mtl
-    nix-derivation process relude stm text time unix
+    ansi-terminal
+    async
+    attoparsec
+    base
+    cassava
+    containers
+    data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    HUnit
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    process
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
   ];
+  homepage = "https://github.com/maralorn/nix-output-monitor";
+  description = "Parses output of nix-build to show additional information";
+  license = lib.licenses.agpl3Plus;
+  maintainers = with lib.maintainers; [maralorn];
+  passthru.updateScript = ./update.sh;
+  testTarget = "unit-tests";
   postInstall = ''
     cat > $out/bin/nom-build << EOF
     #!${runtimeShell}
@@ -34,8 +147,4 @@ mkDerivation rec {
     EOF
     chmod a+x $out/bin/nom-build
   '';
-  homepage = "https://github.com/maralorn/nix-output-monitor";
-  description = "Parses output of nix-build to show additional information";
-  license = lib.licenses.agpl3Plus;
-  maintainers = [ lib.maintainers.maralorn ];
 }

--- a/pkgs/tools/nix/nix-output-monitor/update.sh
+++ b/pkgs/tools/nix/nix-output-monitor/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix curl jq alejandra
+#
+# This script will update the nix-output-monitor derivation to the latest version using
+# cabal2nix.
+
+set -eo pipefail
+
+# This is the directory of this update.sh script.
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+derivation_file="${script_dir}/default.nix"
+
+# This is the latest released version of nix-output-monitor on GitHub.
+new_version=$(curl --silent "https://api.github.com/repos/maralorn/nix-output-monitor/releases" | jq '.[0].tag_name' --raw-output)
+
+echo "Updating nix-output-monitor to version $new_version."
+echo "Running cabal2nix and outputting to ${derivation_file}..."
+
+cat > "$derivation_file" << EOF
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh"
+EOF
+cabal2nix --extra-arguments expect --extra-arguments runtimeShell --maintainer maralorn "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/${new_version}.tar.gz" | head -n-1 >> "$derivation_file"
+cat >> "$derivation_file" << EOF
+    passthru.updateScript = ./update.sh;
+    testTarget = "unit-tests";
+    postInstall = ''
+        cat > \$out/bin/nom-build << EOF
+        #!\${runtimeShell}
+        \${expect}/bin/unbuffer nix-build "\\\$@" 2>&1 | exec \$out/bin/nom
+        EOF
+        chmod a+x \$out/bin/nom-build
+    '';
+}
+EOF
+
+alejandra "${derivation_file}" | cat
+
+echo "Finished."


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

This is a major new release. Introducing the new dependency graph. 

See https://github.com/maralorn/nix-output-monitor/blob/master/CHANGELOG.md
and the updated https://github.com/maralorn/nix-output-monitor/blob/master/README.md if you’re curious.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
