### PR TITLE
bzip2: add symlink libbz2.so.1.0

### DIFF
--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
-    ln -s libbz2.so.1.0.* $out/lib/libbz2.so.1.0
+    ln -s $out/lib/libbz2.so.1.0.* $out/lib/libbz2.so.1.0
   '';
 
   meta = with lib; {

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   postInstall = ''
-    ln -s libbz2.so.1.0.6 $out/lib/libbz2.so.1.0
+    ln -s libbz2.so.1.0.* $out/lib/libbz2.so.1.0
   '';
 
   meta = with lib; {

--- a/pkgs/tools/compression/bzip2/default.nix
+++ b/pkgs/tools/compression/bzip2/default.nix
@@ -44,6 +44,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  postInstall = ''
+    ln -s libbz2.so.1.0.6 $out/lib/libbz2.so.1.0
+  '';
+
   meta = with lib; {
     description = "High-quality data compression program";
     homepage = "https://www.sourceware.org/bzip2";


### PR DESCRIPTION
###### Description of changes

```diff
 $ ls -l /nix/store/nsgg55q1kh1ala68pas78hzfxsb3bnjk-bzip2-1.0.6.0.2/lib/
 -r-xr-xr-x 1 root root   950  1. Jan 1970  libbz2.la
 lrwxrwxrwx 1 root root    15  1. Jan 1970  libbz2.so -> libbz2.so.1.0.6
 lrwxrwxrwx 1 root root    15  1. Jan 1970  libbz2.so.1 -> libbz2.so.1.0.6
+lrwxrwxrwx 1 root root    15  1. Jan 1970  libbz2.so.1.0 -> libbz2.so.1.0.6
 -r-xr-xr-x 1 root root 78960  1. Jan 1970  libbz2.so.1.0.6
```

why? help `autoPatchelfHook` to resolve `libbz2.so.1.0`

alternative? fix `autoPatchelfHook` to resolve `libbz2.so.1.0` to `libbz2.so.1.0.*`
= fuzzy matching by major version number
= general solution, avoid fixing "all the packages"

alternative 2:

```nix
{
  nativeBuildInputs = [ autoPatchelfHook ];
  postInstall = ''
    patchelf --replace-needed libbz2.so.1.0 libbz2.so.1.0.6 $out/lib/somelib.so
  '';
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
