### PR TITLE
Add libraries for codecs of the ogg family to ocamlPackages

### DIFF
--- a/pkgs/development/ocaml-modules/flac/default.nix
+++ b/pkgs/development/ocaml-modules/flac/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, ogg, flac }:
+
+buildDunePackage rec {
+  pname = "flac";
+  version = "0.3.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-flac";
+    rev = "v${version}";
+    sha256 = "06gfbrp30sdxigzkix83y1b610ljzik6rrxmbl3ppmpx4dqlwnxa";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ogg flac.dev ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-flac";
+    description = "Bindings for flac";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ogg/default.nix
+++ b/pkgs/development/ocaml-modules/ogg/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, libogg }:
+
+buildDunePackage rec {
+  pname = "ogg";
+  version = "0.7.1";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-ogg";
+    rev = "v${version}";
+    sha256 = "0z3z0816rxq8wdjw51plzn8lmilic621ilk4x9wpnr0axmnl3wqb";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ libogg ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-ogg";
+    description = "Bindings to libogg";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opus/default.nix
+++ b/pkgs/development/ocaml-modules/opus/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, pkg-config, ogg, libopus }:
+
+buildDunePackage rec {
+  pname = "opus";
+  version = "0.2.1";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-opus";
+    rev = "v${version}";
+    sha256 = "09mgnprhhs1adqm25c0qjhknswbh6va3jknq06fnp1jszszcjf4s";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ogg libopus.dev ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-opus";
+    description = "Bindings to libopus";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/speex/default.nix
+++ b/pkgs/development/ocaml-modules/speex/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ogg, speex }:
+
+buildDunePackage rec {
+  pname = "speex";
+  version = "0.4.1";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-speex";
+    rev = "v${version}";
+    sha256 = "0p4ip37kihlz9qy604llak2kzd00g45ix1yiihnrri2nm01scfab";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ogg speex.dev ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-speex";
+    description = "Bindings to libspeex";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/theora/default.nix
+++ b/pkgs/development/ocaml-modules/theora/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ogg, libtheora }:
+
+buildDunePackage rec {
+  pname = "theora";
+  version = "0.4.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-theora";
+    rev = "v${version}";
+    sha256 = "1sggjmlrx4idkih1ddfk98cgpasq60haj4ykyqbfs22cmii5gpal";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ogg libtheora ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-theora";
+    description = "Bindings to libtheora";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/vorbis/default.nix
+++ b/pkgs/development/ocaml-modules/vorbis/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ogg, libvorbis }:
+
+buildDunePackage rec {
+  pname = "vorbis";
+  version = "0.8.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-vorbis";
+    rev = "v${version}";
+    sha256 = "1acy7yvf2y5dggzxw4vmrpdipakr98si3pw5kxw0mh7livn08al8";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ogg libvorbis ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-vorbis";
+    description = "Bindings to libvorbis";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1133,6 +1133,8 @@ let
 
     ocurl = callPackage ../development/ocaml-modules/ocurl { };
 
+    ogg = callPackage ../development/ocaml-modules/ogg { };
+
     parany = callPackage ../development/ocaml-modules/parany { };
 
     pipebang = callPackage ../development/ocaml-modules/pipebang { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1408,6 +1408,8 @@ let
 
     vlq = callPackage ../development/ocaml-modules/vlq { };
 
+    vorbis = callPackage ../development/ocaml-modules/vorbis { };
+
     visitors = callPackage ../development/ocaml-modules/visitors { };
 
     wasm = callPackage ../development/ocaml-modules/wasm { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1005,6 +1005,8 @@ let
 
     optint = callPackage ../development/ocaml-modules/optint { };
 
+    opus = callPackage ../development/ocaml-modules/opus { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otoml = callPackage ../development/ocaml-modules/otoml { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1361,6 +1361,8 @@ let
     tezos-version = callPackage ../development/ocaml-modules/tezos/version.nix { };
     tezos-workers = callPackage ../development/ocaml-modules/tezos/workers.nix { };
 
+    theora = callPackage ../development/ocaml-modules/theora { };
+
     toml = callPackage ../development/ocaml-modules/toml { };
 
     topkg = callPackage ../development/ocaml-modules/topkg { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1091,6 +1091,10 @@ let
 
     spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };
 
+    speex = callPackage ../development/ocaml-modules/speex {
+      inherit (pkgs) speex;
+    };
+
     tar-unix = callPackage ../development/ocaml-modules/tar/unix.nix { };
 
     tar = callPackage ../development/ocaml-modules/tar { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -398,6 +398,10 @@ let
 
     fix = callPackage ../development/ocaml-modules/fix { };
 
+    flac = callPackage ../development/ocaml-modules/flac {
+      inherit (pkgs) flac;
+    };
+
     fmt = callPackage ../development/ocaml-modules/fmt { };
 
     fontconfig = callPackage ../development/ocaml-modules/fontconfig {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Part of splitting out #140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
