### PR TITLE
ocamlPackages.ffmpeg: init at 1.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/ffmpeg/base.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/base.nix
@@ -1,0 +1,21 @@
+{ lib, fetchFromGitHub }:
+
+rec {
+  version = "1.1.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-ffmpeg";
+    rev = "v${version}";
+    sha256 = "13rc3d0n963a28my5ahv78r82rh450hvbsc74mb6ld0r9v210r0p";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-ffmpeg";
+    description = "Bindings for the ffmpeg libraries";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/default.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildDunePackage, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil
+, ffmpeg-avcodec
+, ffmpeg-avfilter
+, ffmpeg-swscale
+, ffmpeg-swresample
+, ffmpeg-av
+, ffmpeg-avdevice
+}:
+
+buildDunePackage {
+  pname = "ffmpeg";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  propagatedBuildInputs = [
+    ffmpeg-avutil
+    ffmpeg-avcodec
+    ffmpeg-avfilter
+    ffmpeg-swscale
+    ffmpeg-swresample
+    ffmpeg-av
+    ffmpeg-avdevice
+  ];
+
+  # The tests fail
+  doCheck = false;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg libraries";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil, ffmpeg-avcodec, ffmpeg }:
+
+buildDunePackage {
+  pname = "ffmpeg-av";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-avutil ffmpeg-avcodec ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg libraries -- top-level helpers";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-avcodec";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg avcodec library";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-av, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-avdevice";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-av ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg avdevice library";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-avfilter";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg avfilter library";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-avutil";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg avutil libraries";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
@@ -1,0 +1,23 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil, ffmpeg-avcodec, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-swresample";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-avutil ffmpeg-avcodec ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg swresample library";
+  };
+
+}

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
@@ -1,0 +1,22 @@
+{ lib, buildDunePackage, dune-configurator, pkg-config, fetchFromGitHub, callPackage
+, ffmpeg-base ? callPackage ./base.nix { }
+, ffmpeg-avutil, ffmpeg
+}:
+
+buildDunePackage {
+  pname = "ffmpeg-swscale";
+
+  minimalOCamlVersion = "4.08";
+
+  inherit (ffmpeg-base) version src useDune2;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ffmpeg-avutil ffmpeg.dev ];
+
+  doCheck = true;
+
+  meta = ffmpeg-base.meta // {
+    description = "Bindings for the ffmpeg swscale library";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -390,6 +390,29 @@ let
     ff-pbt = callPackage ../development/ocaml-modules/ff/pbt.nix { };
     ff-sig = callPackage ../development/ocaml-modules/ff/sig.nix { };
 
+    ffmpeg = callPackage ../development/ocaml-modules/ffmpeg { };
+    ffmpeg-avutil = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-avcodec = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-avfilter = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-swscale = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-swresample = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-av = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-av.nix {
+      inherit (pkgs) ffmpeg;
+    };
+    ffmpeg-avdevice = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix {
+      inherit (pkgs) ffmpeg;
+    };
+
     fiat-p256 = callPackage ../development/ocaml-modules/fiat-p256 { };
 
     fileutils = callPackage ../development/ocaml-modules/fileutils { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Part of splitting out #140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
