### PR TITLE
init shine, and ocamlPackages.shine

### DIFF
--- a/pkgs/development/libraries/shine/default.nix
+++ b/pkgs/development/libraries/shine/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  pname = "shine";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "toots";
+    repo = "shine";
+    rev = version;
+    sha256 = "06nwylqqji0i1isdprm2m5qsdj4qiywcgnp69c5b55pnw43f07qg";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  meta = with lib; {
+    description = "Fast fixed-point mp3 encoding library";
+    homepage = "https://github.com/toots/shine";
+    license = licenses.lgpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/development/ocaml-modules/shine/default.nix
+++ b/pkgs/development/ocaml-modules/shine/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, shine }:
+
+buildDunePackage rec {
+  pname = "shine";
+  version = "0.2.2";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-shine";
+    rev = "2e1de686ea031f1056df389161ea2b721bfdb39e";
+    sha256 = "0v6i4ym5zijki6ffkp2qkp00lk4fysjhmg690xscj23gwz4zx8ir";
+  };
+
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ shine ];
+
+  meta = with lib; {
+    homepage = "https://github.com/savonet/ocaml-shine";
+    description = "Bindings to the fixed-point mp3 encoding library shine";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ dandellion ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20012,6 +20012,8 @@ with pkgs;
 
   shhopt = callPackage ../development/libraries/shhopt { };
 
+  shine = callPackage ../development/libraries/shine { };
+
   graphite2 = callPackage ../development/libraries/silgraphite/graphite2.nix {};
 
   s2n-tls = callPackage ../development/libraries/s2n-tls { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1104,6 +1104,10 @@ let
 
     seq = callPackage ../development/ocaml-modules/seq { };
 
+    shine = callPackage ../development/ocaml-modules/shine {
+      inherit (pkgs) shine;
+    };
+
     sosa = callPackage ../development/ocaml-modules/sosa { };
 
     spacetime_lib = callPackage ../development/ocaml-modules/spacetime_lib { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Part of splitting up #140777 for easier review

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
