### PR TITLE
postgresqlPackages.rum: init at 1.3.9

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/rum.nix
+++ b/pkgs/servers/sql/postgresql/ext/rum.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "rum";
+  version = "1.3.9";
+
+  src = fetchFromGitHub {
+    owner = "postgrespro";
+    repo = "rum";
+    rev = version;
+    sha256 = "sha256-xdCj9hzBg7VtAIHpIFpeeaK6U4aRrCsoQrPKdABSl+Y=";
+  };
+
+  buildInputs = [ postgresql ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out/lib *.so
+    install -D -t $out/share/postgresql/extension *.control
+    install -D -t $out/share/postgresql/extension *.sql
+  '';
+
+  meta = with lib; {
+    description = "Full text search index method for PostgreSQL";
+    homepage = "https://github.com/postgrespro/rum";
+    license = licenses.postgresql;
+    platforms = postgresql.meta.platforms;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -61,4 +61,6 @@ self: super: {
     pg_safeupdate = super.callPackage ./ext/pg_safeupdate.nix { };
 
     repmgr = super.callPackage ./ext/repmgr.nix { };
+
+    rum = super.callPackage ./ext/rum.nix { };
 }


### PR DESCRIPTION
###### Description of changes

https://github.com/postgrespro/rum

This is a PostgreSQL extension providing RUM indexes, intended to be an improvement over PostgreSQL's built-in GIN indexes, useful for full text search.  

Tested this with PostgreSQL 13 and 14 on NixOS

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
