### PR TITLE
abuild: 3.7.0 -> 3.9.0

### DIFF
--- a/pkgs/development/tools/abuild/default.nix
+++ b/pkgs/development/tools/abuild/default.nix
@@ -1,32 +1,48 @@
 { lib
 , stdenv
 , fetchFromGitLab
+, makeWrapper
 , pkg-config
+, file
+, scdoc
 , openssl
 , zlib
 , busybox
+, apk-tools
+, perl
 }:
 
 stdenv.mkDerivation rec {
   pname = "abuild";
-  version = "3.7.0";
+  version = "3.9.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.alpinelinux.org";
     owner = "alpine";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1xsik9hyzzq861bi922sb5r8c6r4wpnpxz5kd30i9f20vvfpp5jx";
+    rev = version;
+    sha256 = "1zs8slaqiv8q8bim8mwfy08ymar78rqpkgqksw8y1lsjrj49fqy4";
   };
 
   buildInputs = [
     openssl
     zlib
     busybox
+    # for $out/bin/apkbuild-cpan and $out/bin/apkbuild-pypi
+    (perl.withPackages (ps: with ps; [
+      LWP
+      JSON
+      ModuleBuildTiny
+      LWPProtocolHttps
+      IPCSystemSimple
+    ]))
   ];
 
   nativeBuildInputs = [
     pkg-config
+    scdoc
+    makeWrapper
+    file
   ];
 
   patchPhase = ''
@@ -42,6 +58,24 @@ stdenv.mkDerivation rec {
   installFlags = [
     "sysconfdir=${placeholder "out"}/etc"
   ];
+
+  postInstall = ''
+    # this script requires unpackaged 'augeas' rubygem, no reason
+    # to ship it if we can't provide the dependencies for it
+    rm -f ${placeholder "out"}/bin/apkbuild-gem-resolver
+
+    # Find all executables that are not compiled binaries and wrap
+    # them, make `apk-tools` available in their PATH and also the
+    # $out directory since many of the binaries provided call into
+    # other binaries
+    for prog in \
+      $(find ${placeholder "out"}/bin -type f -exec ${file}/bin/file -i '{}' + \
+      | grep -v x-executable | cut -d : -f1); do
+      wrapProgram $prog \
+        --prefix PATH : "${lib.makeBinPath [ apk-tools ]}" \
+        --prefix PATH : "${placeholder "out"}/bin"
+    done
+  '';
 
   meta = with lib; {
     description = "Alpine Linux build tools";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

There is no changelog but the [commit log](https://gitlab.alpinelinux.org/alpine/abuild/-/commits/master) should be enough

most importantly this fixes a serious bug in `abuild checksum` that causes it to create a new `sha512sums=` entry instead of updating the already existing one.

see this [commit](https://gitlab.alpinelinux.org/alpine/aports/-/commit/e541d20d5e86dfd53f96e2f1c58359bd03c2570f) for an example.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

1. updated version from `3.7.0` to `3.9.0`
2. updated `rev` to use `version` directly instead of `v${version}`
3. added `scdoc` to `nativeBuildInputs`
5. added `makeWrapper` to `nativeBuildInputs`
6. wrapped all shellscripts to add `apk-tools` to their `PATH`
7. added `perl` to `buildInputs` chained with `.withPackages` to get all the packages needed by the scripts

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
