### PR TITLE
mat2: support darwin

### DIFF
--- a/pkgs/applications/misc/metadata-cleaner/default.nix
+++ b/pkgs/applications/misc/metadata-cleaner/default.nix
@@ -18,7 +18,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "metadata-cleaner";
-  version = "2.1.4";
+  version = "2.1.5";
 
   format = "other";
 
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "rmnvgr";
     repo = "metadata-cleaner";
     rev = "v${version}";
-    hash = "sha256-46J0iLXzZX5tww4CK8WhrADql023rauO0fpW7Asn5ZY=";
+    hash = "sha256-G7Azeh8+OQILoYEmlIeacoDzN0NRt5NTGavYM9CH8WA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/mat2/bubblewrap-path.patch
+++ b/pkgs/development/python-modules/mat2/bubblewrap-path.patch
@@ -1,0 +1,35 @@
+diff --git a/libmat2/bubblewrap.py b/libmat2/bubblewrap.py
+index 970d5dd..5d3c0b7 100644
+--- a/libmat2/bubblewrap.py
++++ b/libmat2/bubblewrap.py
+@@ -22,11 +22,7 @@ CalledProcessError = subprocess.CalledProcessError
+ 
+ 
+ def _get_bwrap_path() -> str:
+-    which_path = shutil.which('bwrap')
+-    if which_path:
+-        return which_path
+-
+-    raise RuntimeError("Unable to find bwrap")  # pragma: no cover
++    return '@bwrap@'
+ 
+ 
+ def _get_bwrap_args(tempdir: str,
+@@ -37,16 +33,11 @@ def _get_bwrap_args(tempdir: str,
+ 
+     # XXX: use --ro-bind-try once all supported platforms
+     # have a bubblewrap recent enough to support it.
+-    ro_bind_dirs = ['/usr', '/lib', '/lib64', '/bin', '/sbin', '/etc/alternatives', cwd]
++    ro_bind_dirs = ['/nix/store', cwd]
+     for bind_dir in ro_bind_dirs:
+         if os.path.isdir(bind_dir):  # pragma: no cover
+             ro_bind_args.extend(['--ro-bind', bind_dir, bind_dir])
+ 
+-    ro_bind_files = ['/etc/ld.so.cache']
+-    for bind_file in ro_bind_files:
+-        if os.path.isfile(bind_file):  # pragma: no cover
+-            ro_bind_args.extend(['--ro-bind', bind_file, bind_file])
+-
+     args = ro_bind_args + \
+         ['--dev', '/dev',
+          '--proc', '/proc',

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , python
 , pythonOlder
@@ -37,7 +38,6 @@ buildPythonPackage rec {
     # hardcode paths to some binaries
     (substituteAll ({
       src = ./paths.patch;
-      bwrap = "${bubblewrap}/bin/bwrap";
       exiftool = "${exiftool}/bin/exiftool";
       ffmpeg = "${ffmpeg}/bin/ffmpeg";
     } // lib.optionalAttrs dolphinIntegration {
@@ -51,6 +51,11 @@ buildPythonPackage rec {
     (substituteAll {
       src = ./fix_poppler.patch;
       poppler_path = "${poppler_gi}/lib/girepository-1.0";
+    })
+  ] ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+    (substituteAll {
+      src = ./bubblewrap-path.patch;
+      bwrap = "${bubblewrap}/bin/bwrap";
     })
   ];
 

--- a/pkgs/development/python-modules/mat2/paths.patch
+++ b/pkgs/development/python-modules/mat2/paths.patch
@@ -12,41 +12,6 @@ index 41c8de4..11df258 100644
 +Icon=@mat2svg@
 +Exec=@kdialog@ --yesno  "$( @mat2@ -s %F )" --title "Clean Metadata?" && @mat2@ %U
 +Exec[de]=@kdialog@ --yesno  "$( @mat2@ -s %F )" --title "Metadaten löschen?" && @mat2@ %U
-diff --git a/libmat2/bubblewrap.py b/libmat2/bubblewrap.py
-index 970d5dd..5d3c0b7 100644
---- a/libmat2/bubblewrap.py
-+++ b/libmat2/bubblewrap.py
-@@ -22,11 +22,7 @@ CalledProcessError = subprocess.CalledProcessError
- 
- 
- def _get_bwrap_path() -> str:
--    which_path = shutil.which('bwrap')
--    if which_path:
--        return which_path
--
--    raise RuntimeError("Unable to find bwrap")  # pragma: no cover
-+    return '@bwrap@'
- 
- 
- def _get_bwrap_args(tempdir: str,
-@@ -37,16 +33,11 @@ def _get_bwrap_args(tempdir: str,
- 
-     # XXX: use --ro-bind-try once all supported platforms
-     # have a bubblewrap recent enough to support it.
--    ro_bind_dirs = ['/usr', '/lib', '/lib64', '/bin', '/sbin', '/etc/alternatives', cwd]
-+    ro_bind_dirs = ['/nix/store', cwd]
-     for bind_dir in ro_bind_dirs:
-         if os.path.isdir(bind_dir):  # pragma: no cover
-             ro_bind_args.extend(['--ro-bind', bind_dir, bind_dir])
- 
--    ro_bind_files = ['/etc/ld.so.cache']
--    for bind_file in ro_bind_files:
--        if os.path.isfile(bind_file):  # pragma: no cover
--            ro_bind_args.extend(['--ro-bind', bind_file, bind_file])
--
-     args = ro_bind_args + \
-         ['--dev', '/dev',
-          '--proc', '/proc',
 diff --git a/libmat2/exiftool.py b/libmat2/exiftool.py
 index eb65b2a..51a0fa1 100644
 --- a/libmat2/exiftool.py

--- a/pkgs/tools/admin/bubblewrap/default.nix
+++ b/pkgs/tools/admin/bubblewrap/default.nix
@@ -1,21 +1,54 @@
-{ lib, stdenv, fetchurl, libxslt, docbook_xsl, libcap }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, docbook_xsl
+, libxslt
+, meson
+, ninja
+, pkg-config
+, bash-completion
+, libcap
+, libselinux
+}:
 
 stdenv.mkDerivation rec {
   pname = "bubblewrap";
-  version = "0.5.0";
+  version = "0.6.1";
 
-  src = fetchurl {
-    url = "https://github.com/containers/bubblewrap/releases/download/v${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-Fv2vM3mdYxBONH4BM/kJGW/pDQxQUV0BC8tCLrWgCBg=";
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "bubblewrap";
+    rev = "v${version}";
+    sha256 = "sha256-YmK/Tq9/JTJr5gLNKEH5t6TvvXlNSTDz5Ui7d3ewv2s=";
   };
 
-  nativeBuildInputs = [ libxslt docbook_xsl ];
-  buildInputs = [ libcap ];
+  postPatch = ''
+    substituteInPlace tests/libtest.sh \
+      --replace "/var/tmp" "$TMPDIR"
+  '';
+
+  nativeBuildInputs = [
+    docbook_xsl
+    libxslt
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    bash-completion
+    libcap
+    libselinux
+  ];
+
+  # incompatible with Nix sandbox
+  doCheck = false;
 
   meta = with lib; {
     description = "Unprivileged sandboxing tool";
     homepage = "https://github.com/containers/bubblewrap";
     license = licenses.lgpl2Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ dotlambda ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation
https://github.com/NixOS/nixpkgs/pull/155170#issuecomment-1061213501

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @habere-et-dispertire