### PR TITLE
xxHash: Build with cmake and allow all platforms

### DIFF
--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -50,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Cyan4973/xxHash";
     license = with licenses; [ bsd2 gpl2 ];
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.unix;
+    platforms = platforms.all;
   };
 }

--- a/pkgs/development/libraries/xxHash/default.nix
+++ b/pkgs/development/libraries/xxHash/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, fetchurl
+}:
 
 stdenv.mkDerivation rec {
   pname = "xxHash";
@@ -11,21 +16,27 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2WoYCO6QRHWrbGP2mK04/sLNTyQLOuL3urVktilAwMA=";
   };
 
-  # Upstream Makefile does not anticipate that user may not want to
-  # build .so library.
-  postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
-    sed -i 's/lib: libxxhash.a libxxhash/lib: libxxhash.a/' Makefile
-    sed -i '/LIBXXH) $(DESTDIR/ d' Makefile
-  '';
+  patches = [
+    # Merged in https://github.com/Cyan4973/xxHash/pull/649
+    # Should be present in next release
+    (fetchurl {
+      name = "cmakeinstallfix.patch";
+      url = "https://github.com/Cyan4973/xxHash/commit/636f966ecc713c84ddd3b7ccfde2bfb2cc7492a0.patch";
+      hash = "sha256-fj+5V5mDhFgWGvrG1E4fEekL4eh7as0ouVvY4wnIHjs=";
+    })
+  ];
 
-  outputs = [ "out" "dev" ];
 
-  makeFlags = [ "PREFIX=$(dev)" "EXEC_PREFIX=$(out)" ];
+  nativeBuildInputs = [
+    cmake
+  ];
 
-  # pkgs/build-support/setup-hooks/compress-man-pages.sh hook fails
-  # to compress symlinked manpages. Avoid compressing manpages until
-  # it's fixed.
-  dontGzipMan = true;
+  # Using unofficial CMake build script to install CMake module files.
+  cmakeDir = "../cmake_unofficial";
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   meta = with lib; {
     description = "Extremely fast hash algorithm";


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Changed the build script such that it uses the cmake script in `cmake_unofficial` instead of the Makefile, allowing for using xxHash in other cmake scripts. This closes #155007.

Also add support for building to all platforms, since it works.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
