### PR TITLE
haskell-updates fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -995,6 +995,7 @@ self: super: {
   # dontCheck: https://github.com/haskell-servant/servant-auth/issues/113
   # doJailbreak: waiting on revision 1 to hit hackage
   servant-auth-client = doJailbreak (dontCheck super.servant-auth-client);
+  servant-auth-server = doJailbreak super.servant-auth-server;
 
   # Generate cli completions for dhall.
   dhall = generateOptparseApplicativeCompletion "dhall" super.dhall;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2322,6 +2322,9 @@ self: super: {
     ./patches/regex-compat-tdfa-ghc-9.0.patch
   ] super.regex-compat-tdfa;
 
+  # https://github.com/kowainik/validation-selective/issues/64
+  validation-selective = doJailbreak super.validation-selective;
+
   # aws upstream seems to lack the necessary maintenance at the moment, luckily
   # Joey Hess seems to have already looked into building git-annex with aeson 2.0
   # https://github.com/aristidb/aws/issues/275

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -289,4 +289,7 @@ self: super: ({
 
   # https://github.com/fpco/inline-c/issues/127
   inline-c-cpp = dontCheck super.inline-c-cpp;
+
+  # https://github.com/haskell-crypto/cryptonite/issues/360
+  cryptonite = appendPatch ./patches/cryptonite-remove-argon2.patch super.cryptonite;
 })

--- a/pkgs/development/haskell-modules/patches/cryptonite-remove-argon2.patch
+++ b/pkgs/development/haskell-modules/patches/cryptonite-remove-argon2.patch
@@ -1,0 +1,69 @@
+diff --git a/Crypto/KDF/Argon2.hs b/Crypto/KDF/Argon2.hs
+index 044ba00..31dc6f1 100644
+--- a/Crypto/KDF/Argon2.hs
++++ b/Crypto/KDF/Argon2.hs
+@@ -12,6 +12,7 @@
+ -- File started from Argon2.hs, from Oliver Charles
+ -- at https://github.com/ocharles/argon2
+ --
++{-# LANGUAGE DataKinds #-}
+ module Crypto.KDF.Argon2
+     (
+       Options(..)
+@@ -32,6 +33,7 @@ import           Control.Monad (when)
+ import           Data.Word
+ import           Foreign.C
+ import           Foreign.Ptr
++import           Data.Proxy
+ 
+ -- | Which variant of Argon2 to use. You should choose the variant that is most
+ -- applicable to your intention to hash inputs.
+@@ -100,33 +102,12 @@ defaultOptions =
+             }
+ 
+ hash :: (ByteArrayAccess password, ByteArrayAccess salt, ByteArray out)
+-     => Options
++     => [Proxy "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360"]
+      -> password
+      -> salt
+      -> Int
+      -> CryptoFailable out
+-hash options password salt outLen
+-    | saltLen < saltMinLength  = CryptoFailed CryptoError_SaltTooSmall
+-    | outLen < outputMinLength = CryptoFailed CryptoError_OutputLengthTooSmall
+-    | outLen > outputMaxLength = CryptoFailed CryptoError_OutputLengthTooBig
+-    | otherwise                = CryptoPassed $ B.allocAndFreeze outLen $ \out -> do
+-        res <- B.withByteArray password $ \pPass ->
+-               B.withByteArray salt     $ \pSalt ->
+-                    argon2_hash (iterations options)
+-                                (memory options)
+-                                (parallelism options)
+-                                pPass
+-                                (csizeOfInt passwordLen)
+-                                pSalt
+-                                (csizeOfInt saltLen)
+-                                out
+-                                (csizeOfInt outLen)
+-                                (cOfVariant $ variant options)
+-                                (cOfVersion $ version options)
+-        when (res /= 0) $ error "argon2: hash: internal error"
+-  where
+-    saltLen = B.length salt
+-    passwordLen = B.length password
++hash options password salt outLen = error "cryptonite:Crypto.KDF.Argon2.hash is known to be broken on this architecture. See https://github.com/haskell-crypto/cryptonite/issues/360"
+ 
+ data Pass
+ data Salt
+diff --git a/tests/KAT_Argon2.hs b/tests/KAT_Argon2.hs
+index a347fc5..fdba079 100644
+--- a/tests/KAT_Argon2.hs
++++ b/tests/KAT_Argon2.hs
+@@ -32,7 +32,7 @@ kdfTests = zipWith toKDFTest is vectors
+   where
+     toKDFTest i v =
+         testCase (show i)
+-            (CryptoPassed (kdfResult v) @=? Argon2.hash (kdfOptions v) (kdfPass v) (kdfSalt v) (B.length $ kdfResult v))
++            (pure ())
+ 
+     is :: [Int]
+     is = [1..]


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Partially fix `cryptonite` to make `cabal2nix` build on `aarch64-darwin`. Refs https://github.com/haskell-crypto/cryptonite/issues/360

Make `validation-selective` build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
