### PR TITLE
LLVM 10,11,12,13,14: add enableZ3 argument

### DIFF
--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -22,7 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? true
-, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
+, enableZ3 ? false # TODO: if enabled, this flag is not safe to use when cross-compiling
 }:
 
 let

--- a/pkgs/development/compilers/llvm/10/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/10/llvm/default.nix
@@ -11,6 +11,7 @@
 , ncurses
 , version
 , release_version
+, z3
 , zlib
 , buildLlvmTools
 , debugVersion ? false
@@ -21,6 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? true
+, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
 }:
 
 let
@@ -52,7 +54,8 @@ in stdenv.mkDerivation (rec {
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
-    ++ optional enablePFM libpfm; # exegesis
+    ++ optional enablePFM libpfm # exegesis
+    ++ optional enableZ3 z3;
 
   propagatedBuildInputs = [ ncurses zlib ];
 
@@ -179,6 +182,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_Z3_SOLVER=${if enableZ3 then "ON" else "OFF"}"
   ] ++ optionals enableManpages [
     "-DLLVM_BUILD_DOCS=ON"
     "-DLLVM_ENABLE_SPHINX=ON"

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -22,7 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false # TODO should be on by default
-, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
+, enableZ3 ? false # TODO: if enabled, this flag is not safe to use when cross-compiling
 }:
 
 let

--- a/pkgs/development/compilers/llvm/11/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/11/llvm/default.nix
@@ -11,6 +11,7 @@
 , ncurses
 , version
 , release_version
+, z3
 , zlib
 , buildLlvmTools
 , debugVersion ? false
@@ -21,6 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false # TODO should be on by default
+, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
 }:
 
 let
@@ -52,7 +54,8 @@ in stdenv.mkDerivation (rec {
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
-    ++ optional enablePFM libpfm; # exegesis
+    ++ optional enablePFM libpfm # exegesis
+    ++ optional enableZ3 z3;
 
   propagatedBuildInputs = [ ncurses zlib ];
 
@@ -180,6 +183,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_Z3_SOLVER=${if enableZ3 then "ON" else "OFF"}"
   ] ++ optionals stdenv.hostPlatform.isStatic [
     # Disables building of shared libs, -fPIC is still injected by cc-wrapper
     "-DLLVM_ENABLE_PIC=OFF"

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -22,7 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
-, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
+, enableZ3 ? false # TODO: if enabled, this flag is not safe to use when cross-compiling
 }:
 
 let

--- a/pkgs/development/compilers/llvm/12/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/12/llvm/default.nix
@@ -11,6 +11,7 @@
 , ncurses
 , version
 , release_version
+, z3
 , zlib
 , buildLlvmTools
 , debugVersion ? false
@@ -21,6 +22,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
+, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
 }:
 
 let
@@ -52,7 +54,8 @@ in stdenv.mkDerivation (rec {
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
-    ++ optional enablePFM libpfm; # exegesis
+    ++ optional enablePFM libpfm # exegesis
+    ++ optional enableZ3 z3;
 
   propagatedBuildInputs = optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ ncurses ]
     ++ [ zlib ];
@@ -169,6 +172,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_Z3_SOLVER=${if enableZ3 then "ON" else "OFF"}"
   ] ++ optionals stdenv.hostPlatform.isStatic [
     # Disables building of shared libs, -fPIC is still injected by cc-wrapper
     "-DLLVM_ENABLE_PIC=OFF"

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -23,7 +23,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
-, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
+, enableZ3 ? false # TODO: if enabled, this flag is not safe to use when cross-compiling
 }:
 
 let

--- a/pkgs/development/compilers/llvm/13/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/13/llvm/default.nix
@@ -11,6 +11,7 @@
 , ncurses
 , version
 , release_version
+, z3
 , zlib
 , which
 , buildLlvmTools
@@ -22,6 +23,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
+, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
 }:
 
 let
@@ -44,7 +46,8 @@ in stdenv.mkDerivation (rec {
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
-    ++ optional enablePFM libpfm; # exegesis
+    ++ optional enablePFM libpfm # exegesis
+    ++ optional enableZ3 z3;
 
   propagatedBuildInputs = optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ ncurses ]
     ++ [ zlib ];
@@ -132,6 +135,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_Z3_SOLVER=${if enableZ3 then "ON" else "OFF"}"
   ] ++ optionals stdenv.hostPlatform.isStatic [
     # Disables building of shared libs, -fPIC is still injected by cc-wrapper
     "-DLLVM_ENABLE_PIC=OFF"

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -24,7 +24,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
-, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
+, enableZ3 ? false # TODO: if enabled, this flag is not safe to use when cross-compiling
 } @args:
 
 let

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -12,6 +12,7 @@
 , ncurses
 , version
 , release_version
+, z3
 , zlib
 , which
 , buildLlvmTools
@@ -23,6 +24,7 @@
   || stdenv.isAarch32 # broken for the armv7l builder
 )
 , enablePolly ? false
+, enableZ3 ? (stdenv.hostPlatform == stdenv.buildPlatform) # enable Z3 only if not cross-compiling
 } @args:
 
 let
@@ -53,7 +55,8 @@ in stdenv.mkDerivation (rec {
     ++ optionals enableManpages [ python3.pkgs.sphinx python3.pkgs.recommonmark ];
 
   buildInputs = [ libxml2 libffi ]
-    ++ optional enablePFM libpfm; # exegesis
+    ++ optional enablePFM libpfm # exegesis
+    ++ optional enableZ3 z3;
 
   propagatedBuildInputs = [ ncurses zlib ];
 
@@ -127,6 +130,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_ENABLE_DUMP=ON"
+    "-DLLVM_ENABLE_Z3_SOLVER=${if enableZ3 then "ON" else "OFF"}"
   ] ++ optionals stdenv.hostPlatform.isStatic [
     # Disables building of shared libs, -fPIC is still injected by cc-wrapper
     "-DLLVM_ENABLE_PIC=OFF"


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Added Z3 to the build inputs of LLVM versions 10-14 when not cross-compiling. Cross compiling needs further CMake variables I have not personally tested hence the test beforehand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
