### PR TITLE
dottrace: init at 2021.3.3

### DIFF
--- a/pkgs/development/tools/dottrace/default.nix
+++ b/pkgs/development/tools/dottrace/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchurl, dotnet-runtime }:
+
+with lib;
+stdenv.mkDerivation rec {
+  pname = "dottrace";
+  version = "2021.3.3";
+
+  src = fetchurl {
+    url = "https://download.jetbrains.com/resharper/dotUltimate.${version}/JetBrains.dotTrace.CommandLineTools.linux-x64.${version}.tar.gz";
+    sha256 = "sha256-PcJX0IO/P0i3Am3MEZuauX9FQeX9ojxzWCnxIDekPNo=";
+  };
+
+  unpackPhase = ''
+    mkdir dist
+    cd dist
+    tar -xzf ${src}
+  '';
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/dist
+    mkdir -p $out/bin
+    cp -r ./ $out/dist
+    rm -rf $out/dist/dotnet #removing bundled dotnet
+    ln -s $out/dist/dottrace $out/bin/dottrace
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/dist/runtime-dotnet.sh --replace 'dotnet="$root/$platform-$architecture/dotnet"' 'dotnet=${dotnet-runtime}'
+    substituteInPlace $out/bin/dottrace --replace 'root=$(dirname "$0")' 'root=$(dirname "$0")/../dist'
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/dottrace | grep ${version}
+  '';
+
+  meta = {
+    description = ".NET Performance Profiler CLI";
+    homepage = "https://www.jetbrains.com/profiler/";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.gbtb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -334,6 +334,8 @@ with pkgs;
 
   deadnix = callPackage ../development/tools/deadnix { };
 
+  dottrace = callPackage ../development/tools/dottrace { };
+
   each = callPackage ../tools/text/each { };
 
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };


### PR DESCRIPTION
###### Description of changes

Created package for JetBrains dotTrace CLI tool

###### Things done

dotTrace CLI is a dotnet application, so packaging it was not hard. There was only one problem - archive structure, which has multiple top level folders, therefore I've had to do manual unpack.
Also In addition to automatic patching and binary rewriting I've had to rewrite couple of paths in provided scripts. And I was able to replace bundled dotnet with nixpkgs dotnet-runtime.  Also I've added simple smoke test which checks default help output.

In theory dotTrace supports macos and arm64 linux as well, but I don't have machines to test it, so I've set platform to 64bit linux only.
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
