### PR TITLE
puddletag: 2.0.1 -> 2.1.1

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -2,25 +2,38 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "puddletag";
-  version = "2.0.1";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "keithgg";
+    owner = "puddletag";
     repo = "puddletag";
     rev = version;
-    sha256 = "sha256-9l8Pc77MX5zFkOqU00HFS8//3Bzd2OMnVV1brmWsNAQ=";
+    hash = "sha256-eilETaFvvPMopIbccV1uLbpD55kHX9KGTCcGVXaHPgM=";
   };
-
-  sourceRoot = "source/source";
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
   propagatedBuildInputs = [ chromaprint ] ++ (with python3Packages; [
+    python3Packages.chromaprint
     configobj
+    levenshtein
+    lxml
     mutagen
+    pyacoustid
     pyparsing
     pyqt5
   ]);
+
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "levenshtein==0.16.0" "levenshtein" \
+      --replace "pyparsing==3.0.7" "pyparsing" \
+      --replace "pyqt5==5.15.6" "pyqt5" \
+      --replace "pyqt5-sip==12.9.0" "pyqt5-sip" \
+      --replace "rapidfuzz==1.8.3" "rapidfuzz"
+    # According to PyPi, 'pyqt5-qt5' is a subset of 'pyqt5'.
+    sed -i '/pyqt5-qt5/d' requirements.txt
+  '';
 
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")

--- a/pkgs/development/python-modules/chromaprint/default.nix
+++ b/pkgs/development/python-modules/chromaprint/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+let
+  pname = "chromaprint";
+  version = "0.5";
+in
+python3.pkgs.buildPythonPackage rec {
+  inherit pname;
+  inherit version;
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname;
+    inherit version;
+    hash = "sha256-d4M+ieNQpIXcnEH1WyIWnTYZe3P+Y58W0uz1uYPwLQE=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [ m2r ];
+
+  meta = with lib; {
+    description = "Facilitate effortless color terminal output";
+    homepage = "https://pypi.org/project/${pname}/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dschrempf ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1607,6 +1607,8 @@ in {
 
   chispa = callPackage ../development/python-modules/chispa { };
 
+  chromaprint = callPackage ../development/python-modules/chromaprint { };
+
   ci-info = callPackage ../development/python-modules/ci-info { };
 
   ci-py = callPackage ../development/python-modules/ci-py { };


### PR DESCRIPTION
Puddletag has changed the versioning procedure. Exact dependencies are in the requirements.txt but those are not provided by Nixpkgs. I jailbrake those exact dependency requirements (Puddletag runs fine here, but of course: Is there a better/preferrable way to work around this?).

###### Things done
- Add `chromaprint` to Python packages (new dependency).
- Update `puddletag`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
