### PR TITLE
wxwidgets: fix building 3.1 on darwin

### DIFF
--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -17,20 +17,26 @@
 , compat28 ? false
 , compat30 ? true
 , unicode ? true
-, withGtk2 ? true
+, withGtk2 ? (!stdenv.isDarwin)
 , withMesa ? lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms
-, withWebKit ? false, webkitgtk
-, darwin
+, withWebKit ? stdenv.isDarwin
+, webkitgtk
+, setfile
+, AGL
+, Carbon
+, Cocoa
+, Kernel
+, QTKit
+, AVFoundation
+, AVKit
+, WebKit
 }:
 
-assert withMesa -> libGLU != null && libGL != null;
-assert withWebKit -> webkitgtk != null;
+assert withWebKit -> stdenv.isDarwin;
 
 assert withGtk2 -> (!withWebKit);
 
 let
-  inherit (darwin.stubs) setfile;
-  inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   inherit (gnome2) GConf;
   inherit (gst_all_1) gst-plugins-base gstreamer;
   gtk = if withGtk2 then gtk2 else gtk3;
@@ -57,6 +63,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gst-plugins-base
     gstreamer
+  ]
+  ++ lib.optionals (!stdenv.isDarwin) [
     gtk
     libSM
     libXinerama
@@ -68,19 +76,25 @@ stdenv.mkDerivation rec {
     GConf
   ]
   ++ lib.optional withMesa libGLU
-  ++ lib.optional withWebKit webkitgtk
+  ++ lib.optional (withWebKit && !stdenv.isDarwin) webkitgtk
+  ++ lib.optional (withWebKit && stdenv.isDarwin) WebKit
   ++ lib.optionals stdenv.isDarwin [
+    setfile
     Carbon
     Cocoa
     Kernel
     QTKit
-    setfile
+    AVFoundation
+    AVKit
+    WebKit
   ];
 
   propagatedBuildInputs = lib.optional stdenv.isDarwin AGL;
 
   configureFlags = [
     "--disable-precomp-headers"
+    # This is the default option, but be explicit
+    "--disable-monolithic"
     "--enable-mediactrl"
     (if compat28 then "--enable-compat28" else "--disable-compat28")
     (if compat30 then "--enable-compat30" else "--disable-compat30")
@@ -88,10 +102,8 @@ stdenv.mkDerivation rec {
   ++ lib.optional unicode "--enable-unicode"
   ++ lib.optional withMesa "--with-opengl"
   ++ lib.optionals stdenv.isDarwin [
-    # allow building on 64-bit
-    "--enable-universal-binaries"
-    "--with-cocoa"
-    "--with-macosx-version-min=10.7"
+    "--with-osx_cocoa"
+    "--with-libiconv"
   ]
   ++ lib.optionals withWebKit [
     "--enable-webview"
@@ -139,7 +151,6 @@ stdenv.mkDerivation rec {
     license = licenses.wxWindows;
     maintainers = with maintainers; [ AndersonTorres tfmoraes ];
     platforms = platforms.unix;
-    badPlatforms = platforms.darwin; # ofBorg is failing, don't know if internal
   };
 
   passthru = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20727,7 +20727,10 @@ with pkgs;
 
   wxmac = callPackage ../development/libraries/wxwidgets/wxmac30.nix { };
 
-  wxGTK31 = callPackage ../development/libraries/wxwidgets/wxGTK31.nix { };
+  wxGTK31 = callPackage ../development/libraries/wxwidgets/wxGTK31.nix {
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit AVFoundation AVKit WebKit;
+  };
   wxGTK31-gtk2 = wxGTK31.override { withGtk2 = true; };
   wxGTK31-gtk3 = wxGTK31.override { withGtk2 = false; };
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Fix build failures on darwin by passing all the necessary dependencies and removing deprecated command line switches to configure.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
