### PR TITLE
irpf: init at 2022-1.0

### DIFF
--- a/pkgs/applications/finance/irpf/default.nix
+++ b/pkgs/applications/finance/irpf/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenvNoCC
+, fetchzip
+, copyDesktopItems
+, jdk11
+, makeDesktopItem
+, makeWrapper
+, unzip
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "irpf";
+  version = "2022-1.0";
+
+  src = let
+    year = lib.head (lib.splitVersion version);
+  in fetchzip {
+    url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${version}.zip";
+    sha256 = "0h8f51ilvg7m6hlx0y5mpxhac90p32ksbrffw0hxdqbilgjz1s68";
+  };
+
+  nativeBuildInputs = [ unzip makeWrapper copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = pname;
+      exec = pname;
+      icon = "rfb64";
+      desktopName = "Imposto de Renda Pessoa Física";
+      comment = "Programa Oficial da Receita para elaboração do IRPF";
+      categories = [ "Office" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    BASEDIR="$out/share/${pname}"
+    mkdir -p "$BASEDIR"
+
+    cp -r help lib lib-modulos "$BASEDIR"
+
+    install -Dm755 irpf.jar "$BASEDIR/${pname}.jar"
+    install -Dm644 Leia-me.htm offline.png online.png pgd-updater.jar "$BASEDIR"
+
+    makeWrapper ${jdk11}/bin/java $out/bin/${pname} \
+      --add-flags "-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "-Dswing.aatext=true" \
+      --add-flags "-jar $BASEDIR/${pname}.jar" \
+      --set _JAVA_AWT_WM_NONREPARENTING 1 \
+      --set AWT_TOOLKIT MToolkit
+
+    mkdir -p $out/share/pixmaps
+    unzip -j lib/ppgd-icones-4.0.jar icones/rfb64.png -d $out/share/pixmaps
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Programa Oficial da Receita para elaboração do IRPF";
+    homepage = "https://www.gov.br/receitafederal/pt-br";
+    license = licenses.unfree;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3373,6 +3373,8 @@ with pkgs;
 
   iotools = callPackage ../tools/misc/iotools { };
 
+  irpf = callPackage ../applications/finance/irpf { };
+
   jellycli = callPackage ../applications/audio/jellycli { };
 
   jellyfin = callPackage ../servers/jellyfin { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

I wrote this derivation to be able to use the software to write and submit  income tax reports officially in my country, Brazil. I hope it can help my nix maniacs compatriots.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
