### PR TITLE
sonar-scanner-cli: 4.5.0.2216 -> 4.7.0.2747

### DIFF
--- a/pkgs/tools/security/sonar-scanner-cli/default.nix
+++ b/pkgs/tools/security/sonar-scanner-cli/default.nix
@@ -2,16 +2,16 @@
 
 let
 
-  version = "4.5.0.2216";
+  version = "4.7.0.2747";
 
   sonarScannerArchPackage = {
     "x86_64-linux" = {
       url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-linux.zip";
-      sha256 = "sha256-rmvDb5l2BGV8j94Uhu2kJXwoDAHA3VncAahqGvLY3I0=";
+      sha256 = "0qy97lcn9nfwg0x32v9x5kh5jswnjyw3wpvxj45z7cddlj2is4iy";
     };
     "x86_64-darwin" = {
       url = "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${version}-macosx.zip";
-      sha256 = "1g3lldpkrjlvwld9h82hlwclyplxpbk4q3nq59ylw4dhp26kb993";
+      sha256 = "0f8km7wqkw09g01l03kcrjgvq7b6xclzpvb5r64ymsmrc39p0ylp";
     };
   };
 


### PR DESCRIPTION
###### Description of changes

Update sonar-scanner-cli package to 4.7.0.2747 (2022-02-22).

- Page w/ download links and brief changelog: https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/
- Full Changelog: https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=11230&version=17288

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
