### PR TITLE
tela-circle-icon-theme: 2022-02-08 -> 2022-03-07

### DIFF
--- a/pkgs/data/icons/tela-circle-icon-theme/default.nix
+++ b/pkgs/data/icons/tela-circle-icon-theme/default.nix
@@ -4,6 +4,7 @@
 , gtk3
 , hicolor-icon-theme
 , jdupes
+, gitUpdater
 , allColorVariants ? false
 , circularFolder ? false
 , colorVariants ? [] # default is standard
@@ -16,13 +17,13 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "black" "blue" "brow
 
 stdenvNoCC.mkDerivation rec {
   inherit pname;
-  version = "2022-02-08";
+  version = "2022-03-07";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
     repo = pname;
     rev = version;
-    sha256 = "08a1jhirvn2x9hhjr0lqqqayhsf446cddapprxpsnsn9q6x2j2gp";
+    sha256 = "vQeWGZmurvT/UQJ1dx6t+ZeKdJ1Oq9TdHBADw64x18g=";
   };
 
   nativeBuildInputs = [
@@ -50,16 +51,18 @@ stdenvNoCC.mkDerivation rec {
       ${lib.optionalString circularFolder "-c"} \
       ${if allColorVariants then "-a" else builtins.toString colorVariants}
 
-    jdupes -L -r $out/share/icons
+    jdupes --link-soft --recurse $out/share
 
     runHook postInstall
   '';
+
+  passthru.updateScript = gitUpdater {inherit pname version; };
 
   meta = with lib; {
     description = "Flat and colorful personality icon theme";
     homepage = "https://github.com/vinceliuice/Tela-circle-icon-theme";
     license = licenses.gpl3Only;
-    platforms = platforms.unix;
+    platforms = platforms.linux; # darwin use case-insensitive filesystems that cause hash mismatches
     maintainers = with maintainers; [ romildo ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
- Update to version [2022-03-07](https://github.com/vinceliuice/Tela-circle-icon-theme/releases/tag/2022-03-07)
- Use symbolic links instead of hard links in jdupes
- Add update script
- Restrict platforms to linux, as darwin systems use case-insensitive filesystems that cause hash mismatches _(edited)_

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
