### PR TITLE
ftxui: unstable-2021-08-13 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/ftxui/default.nix
+++ b/pkgs/development/libraries/ftxui/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ftxui";
-  version = "unstable-2021-08-13";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "ArthurSonzogni";
     repo = pname;
-    rev = "69b0c9e53e523ac43a303964fc9c5bc0da7d5d61";
-    sha256 = "0cbljksgy1ckw34h0mq70s8sma0p16sznn4z9r4hwv76y530m0ww";
+    rev = "v${version}";
+    sha256 = "sha256-BfNUk2DbBpKMBEu1tQWl85tgjB/4NAh86VVSS9zAjKo=";
   };
 
   nativeBuildInputs = [
@@ -23,9 +23,13 @@ stdenv.mkDerivation rec {
     graphviz
   ];
 
+  # gtest and gbenchmark don't seem to generate any binaries
+  doCheck = false;
+
   meta = with lib; {
     homepage = "https://github.com/ArthurSonzogni/FTXUI";
-    description = "Functional Terminal User Interface for C++";
+    changelog = "https://github.com/ArthurSonzogni/FTXUI/blob/v${version}/CHANGELOG.md";
+    description = "Functional Terminal User Interface library for C++";
     license = licenses.mit;
     maintainers = [ maintainers.ivar ];
     platforms = platforms.unix;


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
See [the changelog](https://github.com/ArthurSonzogni/FTXUI/blob/v2.0.0/CHANGELOG.md) for more information.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
