### PR TITLE
wl-gammactl: init at unstable-2021-09-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7217,6 +7217,12 @@
     githubId = 1267527;
     name = "Daniel Firth";
   };
+  lodi = {
+    email = "anthony.lodi@gmail.com";
+    github = "lodi";
+    githubId = 918448;
+    name = "Anthony Lodi";
+  };
   lopsided98 = {
     email = "benwolsieffer@gmail.com";
     github = "lopsided98";

--- a/pkgs/tools/wayland/wl-gammactl/default.nix
+++ b/pkgs/tools/wayland/wl-gammactl/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchFromGitHub
+, meson, pkg-config, ninja
+, wayland, wayland-scanner, wlroots, wlr-protocols, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wl-gammactl";
+  version = "unstable-2021-09-13";
+
+  src = fetchFromGitHub {
+    owner = "mischw";
+    repo = pname;
+    rev = "e2385950d97a3baf1b6e2f064dd419ccec179586";
+    sha256 = "8iMJK4O/sNIGPOBZQEfK47K6OjT6sxYFe19O2r/VSr8=";
+  };
+
+  nativeBuildInputs = [ meson pkg-config ninja ];
+  buildInputs = [ wayland wlroots gtk3 ];
+
+  postUnpack = ''
+    rmdir source/wlr-protocols
+    ln -s ${wlr-protocols}/share/wlr-protocols source
+  '';
+
+  postPatch = ''
+    substituteInPlace meson.build --replace "git = find_program('git')" "git = 'false'"
+  '';
+
+  meta = with lib; {
+    description = "Contrast, brightness, and gamma adjustments for Wayland";
+    longDescription = ''
+      Small GTK GUI application to set contrast, brightness, and gamma for wayland compositors which
+      support the wlr-gamma-control protocol extension.
+    '';
+    homepage = "https://github.com/mischw/wl-gammactl";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lodi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2726,6 +2726,8 @@ with pkgs;
 
   wlsunset = callPackage ../tools/wayland/wlsunset { };
 
+  wl-gammactl = callPackage ../tools/wayland/wl-gammactl { };
+
   wluma = callPackage ../tools/wayland/wluma {  };
 
   wob = callPackage ../tools/wayland/wob { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Packaged mischw/[wl-gammactl](https://github.com/mischw/wl-gammactl) for contrast/brightness/gamma adjustment on Wayland compositors.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
