### PR TITLE
river: copy wayland-session from contrib

### DIFF
--- a/pkgs/applications/window-managers/river/default.nix
+++ b/pkgs/applications/window-managers/river/default.nix
@@ -61,6 +61,17 @@ stdenv.mkDerivation rec {
   */
   installFlags = [ "DESTDIR=$(out)" ];
 
+  postInstall = ''
+    mkdir -p $out/share/wayland-sessions
+    cp contrib/river.desktop $out/share/wayland-sessions/
+  '';
+
+  passthru = {
+    providedSessions = [
+     "river"
+    ];
+  };
+
   meta = with lib; {
     homepage = "https://github.com/ifreund/river";
     description = "A dynamic tiling wayland compositor";


### PR DESCRIPTION
###### Description of changes

Copies contrib/sway.desktop to share/wayland-sessions/ and declares a providedSession for NixOS. This should allow starting river from eg lightdm by adding the river package to `services.xserver.displayManager.sessionPackages`.