### PR TITLE
osrmt: init at 1.8, 1.8 -> unstable-04-24

### DIFF
--- a/pkgs/applications/science/engineering/osrmt/default.nix
+++ b/pkgs/applications/science/engineering/osrmt/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "osrmt";
-  version = "1.8";
+  version = "unstable-2020-04-24";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = version;
-    sha256 = "sha256-A+QkXH/XZEqQs+8jT1RA5rO6iKxRAsxRtQ7EPpbRtfo=";
+    rev = "b4909cd81e53244c15fe4e1a9218a91e37f2965a";
+    sha256 = "sha256-MS8CkuhXrwaQqJKcNL9tDybZ/YdNpINaR5mT35xRTFs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/science/engineering/osrmt/default.nix
+++ b/pkgs/applications/science/engineering/osrmt/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, ant
+, openjdk8
+, postgresqlSupport ? false
+, postgresql
+, libarchive
+, makeWrapper
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "osrmt";
+  version = "1.8";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-A+QkXH/XZEqQs+8jT1RA5rO6iKxRAsxRtQ7EPpbRtfo=";
+  };
+
+  nativeBuildInputs = [
+    ant
+    libarchive
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    openjdk8
+  ] ++ lib.optional postgresqlSupport postgresql;
+
+  patches = [
+    (fetchpatch {
+      name = "add-shebang.patch";
+      url = "https://github.com/yuuyins/osrmt/commit/6ef27fa22428873ce0890e469c33cb5167e2f832.patch";
+      sha256 = "sha256-psS1nUVKARsn0SDNAYczUDHEAz7obKXVz79arExODG8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace ./build-resources/appclient/resources/run.sh --replace "java" "${openjdk8}/bin/java"
+    substituteInPlace ./build-resources/appclient/resources/run3tier.sh --replace "java " "${openjdk8}/bin/java "
+    substituteInPlace ./build-resources/db-init/app-client/upgrade.sh --replace "java" "${openjdk8}/bin/java"
+  '';
+
+  buildPhase = ''
+    # Desktop application build.
+    # After build finishes assembling the application,
+    # OSRMT will be available in the 'dist' folder.
+    ant app.client.assemble
+  '';
+
+  installPhase = ''
+    install -d $out/bin $out/opt
+
+    bsdtar --extract --file $NIX_BUILD_TOP/${src.name}/dist/osrmt.desktop.zip --directory $out/opt
+    chmod +x $out/opt/run.sh $out/opt/run3tier.sh $out/opt/upgrade.sh
+    # ln -s $out/opt/run.sh $out/bin/osrmt
+
+    for jar in $out/opt/*.jar; do
+      classpath="''${classpath-}''${classpath:+:}''${jar}"
+    done
+
+    makeWrapper ${openjdk8}/bin/java $out/bin/osrmt \
+      --chdir $out/opt \
+      --prefix _JAVA_OPTIONS : "-Dawt.useSystemAAFontSettings=on" \
+      --add-flags "-Duser.dir=$out/opt -classpath \"$classpath\" com.osrmt.appclient.reqmanager.RequirementManagerController"
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "osrmt";
+      desktopName = "OSRMT";
+      genericName = "Open source requirements management tool";
+      exec = "osrmt";
+      icon = "osrmt";
+      comment = meta.description;
+      categories = [ "Development" "Education" "ComputerScience" "Engineering" "Java" ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "Requirements specification and management tool";
+    homepage = "https://github.com/osrmt/osrmt";
+    changelog = "https://github.com/osrmt/osrmt/releases";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ yuu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33329,6 +33329,8 @@ with pkgs;
 
   brmodelo = callPackage ../applications/science/engineering/brmodelo { };
 
+  osrmt = callPackage ../applications/science/engineering/osrmt { };
+
   ### SCIENCE / ELECTRONICS
 
   adms = callPackage ../applications/science/electronics/adms { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Add tool for specifying and managing software requirements https://github.com/osrmt/osrmt

Part of https://github.com/NixOS/nixpkgs/issues/164019

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Notes

it is trying to write to `/nix/store/<hash-name>/out` (current working directory) during runtime