### PR TITLE
README: white logo for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <p align="center">
-  <a href="https://nixos.org/nixos"><img src="https://nixos.org/logo/nixos-hires.png" width="500px" alt="NixOS logo" /></a>
+  <a href="https://nixos.org#gh-light-mode-only">
+    <img src="https://raw.githubusercontent.com/NixOS/nixos-homepage/master/logo/nixos-hires.png" width="500px" alt="NixOS logo"/>
+  </a>
+  <a href="https://nixos.org#gh-dark-mode-only">
+    <img src="https://raw.githubusercontent.com/NixOS/nixos-artwork/master/logo/nixos-white.png" width="500px" alt="NixOS logo"/>
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4804/157377833-055d2acd-9ba6-47bf-91cb-217482bfd16b.png)
![image](https://user-images.githubusercontent.com/4804/157377870-1f7e24d3-64eb-496a-8f46-8f1e96ae6be2.png)

After:
![image](https://user-images.githubusercontent.com/4804/157377956-a9d4f13a-e065-403a-824a-9466140adcaa.png)
![image](https://user-images.githubusercontent.com/4804/157377920-bda6eb22-9ffd-4819-b59c-e0f1fb8f11b4.png)


One unavoidable downside to this is the link to the image includes # anchors that are GitHub specific. Like https://nixos.org#gh-light-mode-only I think it is still worth the tradeoff of making it look good on dark mode. This thread may eventually contain information when GitHub improves this https://github.community/t/support-theme-context-for-images-in-light-vs-dark-mode/147981/97