### PR TITLE
puddletag: 2.0.1 -> 2.1.1

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -1,26 +1,62 @@
-{ lib, fetchFromGitHub, python3Packages, wrapQtAppsHook, chromaprint }:
+{ lib, fetchFromGitHub, python3Packages, wrapQtAppsHook }:
 
+# As of 2.1, puddletag has started pinning versions of all dependencies that it
+# was built against which is an issue as the chances of us having the exact same
+# versions in nixpkgs are slim to none.
+#
+# There is a difference between explicit and implicit version requirements and
+# we should be able to safely ignore the latter. Therefore use requirements.in
+# which contains just the explicit version dependencies instead of
+# requirements.txt.
+#
+# Additionally, we do need to override some of the explicit requirements through
+# `overrideVersions`. While we technically run the risk of breaking something by
+# ignoring the pinned versions, it's just something we will have to accept
+# unless we want to vendor those versions.
+
+let
+  # NOTE: check if we can drop any of these overrides when bumping the version
+  overrideVersions = [
+    "pyparsing"
+    "pyqt5"
+  ];
+
+in
 python3Packages.buildPythonApplication rec {
   pname = "puddletag";
-  version = "2.0.1";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "keithgg";
+    owner = "puddletag";
     repo = "puddletag";
     rev = version;
-    sha256 = "sha256-9l8Pc77MX5zFkOqU00HFS8//3Bzd2OMnVV1brmWsNAQ=";
+    hash = "sha256-eilETaFvvPMopIbccV1uLbpD55kHX9KGTCcGVXaHPgM=";
   };
 
-  sourceRoot = "source/source";
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace share/pixmaps share/icons
+
+    cp requirements.in requirements.txt
+  '' + lib.concatMapStringsSep "\n"
+    (e: ''
+      sed -i requirements.txt -e 's/^${e}.*/${e}/'
+    '')
+    overrideVersions;
 
   nativeBuildInputs = [ wrapQtAppsHook ];
 
-  propagatedBuildInputs = [ chromaprint ] ++ (with python3Packages; [
+  propagatedBuildInputs = with python3Packages; [
+    pyacoustid
+    chromaprint
     configobj
+    levenshtein
+    lxml
     mutagen
     pyparsing
     pyqt5
-  ]);
+    rapidfuzz
+  ];
 
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
@@ -33,8 +69,8 @@ python3Packages.buildPythonApplication rec {
   meta = with lib; {
     description = "An audio tag editor similar to the Windows program, Mp3tag";
     homepage = "https://docs.puddletag.net";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ peterhoeg ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ peterhoeg dschrempf ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/chromaprint/default.nix
+++ b/pkgs/development/python-modules/chromaprint/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy27
+, m2r
+}:
+
+buildPythonPackage rec {
+  pname = "chromaprint";
+  version = "0.5";
+
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-d4M+ieNQpIXcnEH1WyIWnTYZe3P+Y58W0uz1uYPwLQE=";
+  };
+
+  buildInputs = [ m2r ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "chromaprint" ];
+
+  meta = with lib; {
+    description = "Facilitate effortless color terminal output";
+    homepage = "https://pypi.org/project/${pname}/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dschrempf peterhoeg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1607,6 +1607,8 @@ in {
 
   chispa = callPackage ../development/python-modules/chispa { };
 
+  chromaprint = callPackage ../development/python-modules/chromaprint { };
+
   ci-info = callPackage ../development/python-modules/ci-info { };
 
   ci-py = callPackage ../development/python-modules/ci-py { };


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

- pythonPackages.chromaprint: init at 0.5.0
- puddletag: 2.0.1 -> 2.1.1

Supercedes #163331

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
