### PR TITLE
iosevka-bin: Fix meta attributes

### DIFF
--- a/pkgs/data/fonts/iosevka/bin.nix
+++ b/pkgs/data/fonts/iosevka/bin.nix
@@ -30,7 +30,8 @@ in stdenv.mkDerivation rec {
     unzip -d $out/share/fonts/truetype $src
   '';
 
-  meta = iosevka.meta // {
+  meta = {
+    inherit (iosevka.meta) homepage downloadPage description license platforms;
     maintainers = with lib.maintainers; [
       cstrahan
     ];


### PR DESCRIPTION
###### Description of changes

Joining the entire `iosevka.meta` set seemed to cause some attributes to not be set as expected. For example `iosevka-bin.meta.name` was `iosevka-14.0.1` instead of `iosevka-bin-10.1.0`, and `iosevka-bin.meta.position` also pointed to `iosevka/default.nix` instead of `iosevka/bin.nix`.

Before this PR (notice how `name` and `position` match the `iosevka` attributes):
```text
nix-repl> pkgs.iosevka.meta
{ available = true; broken = false; description = "Slender monospace sans-serif and slab-serif typeface inspired by Pragmata\nPro, M+ and PF DIN Mono, designed to be the ideal font for programming.\n"; downloadPage = "https://github.com/be5invis/Iosevka/releases"; homepage = "https://be5invis.github.io/Iosevka"; insecure = false; license = { ... }; maintainers = [ ... ]; name = "iosevka-14.0.1"; outputsToInstall = [ ... ]; platforms = [ ... ]; position = "/nix/store/qld4041snpbwi1d1vqs64hrvnb0ic71f-nixos/nixos/pkgs/data/fonts/iosevka/default.nix:124"; unfree = false; unsupported = false; }

nix-repl> pkgs.iosevka-bin.meta
{ available = true; broken = false; description = "Slender monospace sans-serif and slab-serif typeface inspired by Pragmata\nPro, M+ and PF DIN Mono, designed to be the ideal font for programming.\n"; downloadPage = "https://github.com/be5invis/Iosevka/releases"; homepage = "https://be5invis.github.io/Iosevka"; insecure = false; license = { ... }; maintainers = [ ... ]; name = "iosevka-14.0.1"; outputsToInstall = [ ... ]; platforms = [ ... ]; position = "/nix/store/qld4041snpbwi1d1vqs64hrvnb0ic71f-nixos/nixos/pkgs/data/fonts/iosevka/default.nix:124"; unfree = false; unsupported = false; }
```

After this PR:
```text
nix-repl> pkgs.iosevka-bin.meta
{ available = true; broken = false; description = "Slender monospace sans-serif and slab-serif typeface inspired by Pragmata\nPro, M+ and PF DIN Mono, designed to be the ideal font for programming.\n"; downloadPage = "https://github.com/be5invis/Iosevka/releases"; homepage = "https://be5invis.github.io/Iosevka"; insecure = false; license = { ... }; maintainers = [ ... ]; name = "iosevka-bin-10.1.0"; outputsToInstall = [ ... ]; platforms = [ ... ]; position = "/home/stephane/src/nixpkgs/pkgs/data/fonts/iosevka/bin.nix:34"; unfree = false; unsupported = false; }
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
