### PR TITLE
faircamp: init at unstable-2022-01-19

### DIFF
--- a/pkgs/applications/misc/faircamp/default.nix
+++ b/pkgs/applications/misc/faircamp/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, rustPlatform
+, fetchgit
+, makeWrapper
+, ffmpeg
+, callPackage
+, unstableGitUpdater
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "faircamp";
+  version = "unstable-2022-01-19";
+
+  # TODO when switching to a stable release, use fetchFromGitea and add a
+  # version test. Meanwhile, fetchgit is used to make unstableGitUpdater work.
+  src = fetchgit {
+    url = "https://codeberg.org/simonrepp/faircamp.git";
+    rev = "f8ffc7a35a12251b83966b35c63f72b4912f75a9";
+    sha256 = "sha256-9t42+813IPLUChbLkcwzoCr7FXSL1g+ZG6I3d+7pmec=";
+  };
+
+  cargoHash = "sha256-24ALBede3W8rjlBRdtL0aazRyK1RmNLdHF/bt5i4S5Y=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/faircamp \
+      --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}
+  '';
+
+  passthru.tests.wav = callPackage ./test-wav.nix { };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "A self-hostable, statically generated bandcamp alternative";
+    longDescription = ''
+      Faircamp takes a directory on your disk - your Catalog - and from it
+      produces a fancy-looking (and technically simple and completely static)
+      website, which presents your music in a way similar to how popular
+      commercial service bandcamp does it.
+
+      You can upload the files faircamp generates to any webspace - no database
+      and no programming language support (PHP or such) is required. If your
+      webspace supports SSH access, faircamp can be configured to upload your
+      website for you automatically, otherwise you can use FTP or whichever
+      means you prefer to do that manually.
+    '';
+    homepage = "https://codeberg.org/simonrepp/faircamp";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/misc/faircamp/test-wav.nix
+++ b/pkgs/applications/misc/faircamp/test-wav.nix
@@ -1,0 +1,14 @@
+{ stdenv
+, faircamp
+, ffmpeg
+}:
+
+stdenv.mkDerivation {
+  name = "faircamp-test-wav";
+  meta.timeout = 60;
+  buildCommand = ''
+    mkdir album
+    ${ffmpeg}/bin/ffmpeg -f lavfi -i "sine=frequency=440:duration=1" album/track.wav
+    ${faircamp}/bin/faircamp --build-dir $out
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25449,6 +25449,8 @@ with pkgs;
 
   f1viewer = callPackage ../applications/video/f1viewer {};
 
+  faircamp = callPackage ../applications/misc/faircamp { };
+
   fasttext = callPackage ../applications/science/machine-learning/fasttext { };
 
   fbmenugen = callPackage ../applications/misc/fbmenugen { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
