### PR TITLE
astc-encoder: 3.3 -> 3.4

### DIFF
--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -46,6 +46,12 @@ gccStdenv.mkDerivation rec {
     "-DCMAKE_BUILD_TYPE=Release"
   ];
 
+  # Set a fixed build year to display within help output (otherwise, it would be 1980)
+  postPatch = ''
+    substituteInPlace Source/cmake_core.cmake \
+      --replace 'string(TIMESTAMP astcencoder_YEAR "%Y")' 'set(astcencoder_YEAR "2022")'
+  '';
+
   # Link binaries into environment and provide 'astcenc' link
   postInstall = ''
     mv $out/astcenc $out/bin

--- a/pkgs/tools/graphics/astc-encoder/default.nix
+++ b/pkgs/tools/graphics/astc-encoder/default.nix
@@ -31,13 +31,13 @@ with rec {
 
 gccStdenv.mkDerivation rec {
   pname = "astc-encoder";
-  version = "3.3";
+  version = "3.4";
 
   src = fetchFromGitHub {
     owner = "ARM-software";
     repo = "astc-encoder";
     rev = version;
-    sha256 = "sha256-5E26QzphF5HwVTH+92S4rT3IUAp9ravT/wxsmaH9IAM=";
+    sha256 = "sha256-blOfc/H64UErjPjkdZQNp2H/Hw57RbQRFBcUo/C2b0Q=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Description of changes

Update to version 3.4 and fix to year in console output. 

Version release notes: https://github.com/ARM-software/astc-encoder/releases/tag/3.4

This is an alternative PR to #162133. 
The sources are the same, but I added the patch suggested by @bobby285271 to fix the year that is part of the console output.

Closes #162133

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
