### PR TITLE
fontforge: 20201107 -> 20220308

### DIFF
--- a/pkgs/tools/misc/fontforge/default.nix
+++ b/pkgs/tools/misc/fontforge/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchpatch, fetchFromGitHub, lib
 , cmake, perl, uthash, pkg-config, gettext
 , python, freetype, zlib, glib, giflib, libpng, libjpeg, libtiff, libxml2, cairo, pango
-, readline, woff2, zeromq, libuninameslist
+, readline, woff2, zeromq
 , withSpiro ? false, libspiro
 , withGTK ? false, gtk3
 , withGUI ? withGTK
@@ -14,13 +14,13 @@ assert withGTK -> withGUI;
 
 stdenv.mkDerivation rec {
   pname = "fontforge";
-  version = "20201107";
+  version = "20220308";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-Rl/5lbXaPgIndANaD0IakaDus6T53FjiBb45FIuGrvc=";
+    sha256 = "sha256-q+71PDPODl5fEEy3d1icRl+rBGY7AhH+2dMUKeBWGgI=";
   };
 
   patches = [
@@ -28,13 +28,11 @@ stdenv.mkDerivation rec {
     # Taken from https://salsa.debian.org/fonts-team/fontforge/-/blob/master/debian/patches/0001-add-extra-cmake-install-rules.patch
     (fetchpatch {
       url = "https://salsa.debian.org/fonts-team/fontforge/raw/76bffe6ccf8ab20a0c81476a80a87ad245e2fd1c/debian/patches/0001-add-extra-cmake-install-rules.patch";
-      sha256 = "u3D9od2xLECNEHhZ+8dkuv9818tPkdP6y/Tvd9CADJg=";
-    })
-    # Fix segmentation fault with some fonts.
-    # This is merged and should be present in the next release.
-    (fetchpatch {
-      url = "https://github.com/fontforge/fontforge/commit/69e263b2aff29ad22f97f13935cfa97a1eabf207.patch";
-      sha256 = "06yyf90605aq6ppfiz83mqkdmnaq5418axp9jgsjyjq78b00xb29";
+      excludes = [
+        # Already handled upstream: https://github.com/fontforge/fontforge/commit/f97a2cd7b344ec8fcb9f8bfb908e1b6f36326d20
+        "contrib/cidmap/CMakeLists.txt"
+      ];
+      sha256 = "iQwaGeBHUais979hGVbU2NxKozQSQkpYXjApxPuLI/4=";
     })
   ];
 
@@ -52,7 +50,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config cmake ];
   buildInputs = [
-    readline uthash woff2 zeromq libuninameslist
+    readline uthash woff2 zeromq
     python freetype zlib glib giflib libpng libjpeg libtiff libxml2
   ]
     ++ lib.optionals withSpiro [ libspiro ]


### PR DESCRIPTION
###### Description of changes

https://github.com/fontforge/fontforge/releases/tag/20220308

###### Things done

updated the package
removed the upstreamed patch
edited the debian patch so it applies again
  still seems required to get the extra binaries

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - not attempted, `rebuild-amount.sh` estimates 9633 packages affected, turns out a lot of stuff uses fonts...
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - not all, but the fontforge GUI seems to work
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
