### PR TITLE
lib.types.package: only call toDerivation when necessary

### DIFF
--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -22,7 +22,8 @@ merging is handled.
 
 `types.package`
 
-:   A derivation or a store path.
+:   A top-level store path. This can be an attribute set pointing
+    to a store path, like a derivation or a flake input.
 
 `types.anything`
 

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -43,7 +43,9 @@
         </term>
         <listitem>
           <para>
-            A derivation or a store path.
+            A top-level store path. This can be an attribute set
+            pointing to a store path, like a derivation or a flake
+            input.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
I was trying to add flake inputs to `system.extraDependencies` to work around https://github.com/NixOS/nix/issues/3995:

```nix
{ inputs, ... }: {
  system.extraDependencies = [ inputs.foo ];
}
```

but got `error: 'builtins.storePath' is not allowed in pure evaluation mode`.

This is because the current logic for `types.package` assumes that everything that isn't a derivation is a store path and calls `toDerivation` on it, which uses `storePath`. In this case `inputs.foo` is neither a derivation nor a store path, and `toDerivation` is not needed.

Additional question: wouldn't `toDerivation = builtins.storePath` be enough? Why do we need a fake derivation?