### PR TITLE
layan-kde: init at 2022-02-13

### DIFF
--- a/pkgs/data/themes/layan-kde/default.nix
+++ b/pkgs/data/themes/layan-kde/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+}:
+
+stdenv.mkDerivation rec {
+  pname = "layan-kde";
+  version = "2022-02-13";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = pname;
+    rev = version;
+    sha256 = "09z90g13l26v23nwr8n5bapwldp3hhdrdikynvm4vvb7qsvb4vrp";
+  };
+
+  postPatch = ''
+    patchShebangs install.sh
+
+    substituteInPlace install.sh \
+      --replace '$HOME/.local' $out \
+      --replace '$HOME/.config' $out/share
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    name= ./install.sh --dest $out/share/themes
+
+    mkdir -p $out/share/sddm/themes
+    cp -a sddm/Layan* $out/share/sddm/themes/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater {inherit pname version; };
+
+  meta = with lib; {
+    description = "A flat Design theme for KDE Plasma desktop";
+    homepage = "https://github.com/vinceliuice/Layan-kde";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23843,6 +23843,8 @@ with pkgs;
 
   layan-gtk-theme = callPackage ../data/themes/layan-gtk-theme { };
 
+  layan-kde = callPackage ../data/themes/layan-kde { };
+
   lato = callPackage ../data/fonts/lato {};
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Add [layan-kde](https://github.com/vinceliuice/Layan-kde).

Fixes https://github.com/NixOS/nixpkgs/issues/163262

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
