### PR TITLE
Backport KNewStuff/Discover cache expiration patches

### DIFF
--- a/pkgs/desktops/plasma-5/discover.nix
+++ b/pkgs/desktops/plasma-5/discover.nix
@@ -1,5 +1,6 @@
 { mkDerivation
 , lib
+, fetchpatch
 , extra-cmake-modules
 , gettext
 , kdoctools
@@ -60,5 +61,14 @@ mkDerivation {
     kwindowsystem
     kxmlgui
     plasma-framework
+  ];
+  patches = [
+    # The following patch mitigates a cache expiration bug. Upstream requested
+    # we backport this patch to reduce load on KDE infrastructure:
+    # https://mail.kde.org/pipermail/distributions/2022-February/001140.html
+    (fetchpatch {
+      url = "https://invent.kde.org/plasma/discover/-/commit/6257e21c313e21afd80d101d24c78d66621236b1.patch";
+      sha256 = "1sss2wk0qnyk4cv475k1fjkkcd6nskz3hfy5y9nnrxpnw51xai38";
+    })
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff/default.nix
@@ -1,5 +1,5 @@
 {
-  mkDerivation, fetchpatch,
+  mkDerivation, lib, fetchpatch,
   extra-cmake-modules,
   attica, karchive, kcompletion, kconfig, kcoreaddons, ki18n, kiconthemes,
   kio, kitemviews, kpackage, kservice, ktextwidgets, kwidgetsaddons, kxmlgui, qtbase,
@@ -17,5 +17,13 @@ mkDerivation {
   propagatedBuildInputs = [ attica kservice kxmlgui ];
   patches = [
     ./0001-Delay-resolving-knsrcdir.patch
+    # The following two patches mitigate a cache expiration bug. Upstream
+    # requested we backport these patches to reduce load on KDE infrastructure:
+    # https://mail.kde.org/pipermail/distributions/2022-February/001140.html
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/knewstuff/-/commit/c8165b7a0d622e318b3353ccf257a8f229dd12c9.patch";
+      sha256 = "1b6cbxzfqnnym6gkb8vkhgffibyk560bfcvx0znsnlx03ahavdmf";
+    })
+    ./knewstuff-httpworker-cache-expiry.patch
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/knewstuff/knewstuff-httpworker-cache-expiry.patch
+++ b/pkgs/development/libraries/kde-frameworks/knewstuff/knewstuff-httpworker-cache-expiry.patch
@@ -1,0 +1,30 @@
+diff --git a/src/core/jobs/httpworker.cpp b/src/core/jobs/httpworker.cpp
+index b81edd2d..82f12e38 100644
+--- a/src/core/jobs/httpworker.cpp
++++ b/src/core/jobs/httpworker.cpp
+@@ -41,7 +41,6 @@ public:
+         return nam.get(request);
+     }
+ 
+-private:
+     QNetworkDiskCache cache;
+ };
+ 
+@@ -102,6 +101,17 @@ static void addUserAgent(QNetworkRequest &request)
+         agentHeader += QStringLiteral("-%1/%2").arg(QCoreApplication::instance()->applicationName(), QCoreApplication::instance()->applicationVersion());
+     }
+     request.setHeader(QNetworkRequest::UserAgentHeader, agentHeader);
++
++    // Assume that no cache expiration time will be longer than a week, but otherwise prefer the cache
++    // This is mildly hacky, but if we don't do this, we end up with infinite cache expirations in some
++    // cases, which of course isn't really acceptable... See ed62ee20 for a situation where that happened.
++    QNetworkCacheMetaData cacheMeta{s_httpWorkerNAM->cache.metaData(request.url())};
++    if (cacheMeta.isValid()) {
++        const QDateTime nextWeek{QDateTime::currentDateTime().addDays(7)};
++        if (cacheMeta.expirationDate().isValid() && cacheMeta.expirationDate() < nextWeek) {
++            request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
++        }
++    }
+ }
+ 
+ void HTTPWorker::startRequest()


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

Upstream [requests](https://mail.kde.org/pipermail/distributions/2022-February/001140.html) that we backport these patches for KNewStuff and Discover to mitigate the effect of a cache expiration bug on the KDE servers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
