### PR TITLE
gPodder: 3.10.17 -> 3.10.21

### DIFF
--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -5,14 +5,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gpodder";
-  version = "3.10.17";
+  version = "3.10.21";
   format = "other";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "0wrk8d4q6ricbcjzlhk10vrk1qg9hi323kgyyd0c8nmh7a82h8pd";
+    sha256 = "0n73jm5ypsj962gpr0dk10lqh83giqsczm63wchyhmrkyf1wgga1";
   };
 
   patches = [
@@ -42,7 +42,10 @@ python3Packages.buildPythonApplication rec {
   ];
 
   checkInputs = with python3Packages; [
-    coverage minimock
+    minimock
+    pytest
+    pytest-httpserver
+    pytest-cov
   ];
 
   doCheck = true;
@@ -51,6 +54,7 @@ python3Packages.buildPythonApplication rec {
     feedparser
     dbus-python
     mygpoclient
+    requests
     pygobject3
     eyeD3
     podcastparser
@@ -69,7 +73,8 @@ python3Packages.buildPythonApplication rec {
   '';
 
   installCheckPhase = ''
-    LC_ALL=C PYTHONPATH=./src:$PYTHONPATH python3 -m gpodder.unittests
+    LC_ALL=C PYTHONPATH=src/:$PYTHONPATH pytest --ignore=tests --ignore=src/gpodder/utilwin32ctypes.py --doctest-modules src/gpodder/util.py src/gpodder/jsonconfig.py
+    LC_ALL=C PYTHONPATH=src/:$PYTHONPATH pytest tests --ignore=src/gpodder/utilwin32ctypes.py --ignore=src/mygpoclient --cov=gpodder
   '';
 
   meta = with lib; {

--- a/pkgs/applications/audio/gpodder/disable-autoupdate.patch
+++ b/pkgs/applications/audio/gpodder/disable-autoupdate.patch
@@ -11,41 +11,20 @@
      </section>
      <section>
        <item>
-@@ -201,4 +197,4 @@
-     </submenu>
-   </menu>
- </interface>
--<!-- :noTabs=true:tabSize=2:indentSize=2: -->
-\ No newline at end of file
-+<!-- :noTabs=true:tabSize=2:indentSize=2: -->
 --- a/src/gpodder/config.py
 +++ b/src/gpodder/config.py
-@@ -91,13 +91,6 @@
-         'retries': 3,  # number of retries when downloads time out
-     },
+@@ -94,7 +94,7 @@
  
--    # Software updates from gpodder.org
--    'software_update': {
+     # Software updates from gpodder.org
+     'software_update': {
 -        'check_on_startup': True,  # check for updates on start
--        'last_check': 0,  # unix timestamp of last update check
--        'interval': 5,  # interval (in days) to check for updates
--    },
--
-     'ui': {
-         # Settings for the Command-Line Interface
-         'cli': {
++       'check_on_startup': False,  # check for updates on start
+         'last_check': 0,  # unix timestamp of last update check
+         'interval': 5,  # interval (in days) to check for updates
+     },
 --- a/src/gpodder/gtkui/main.py
 +++ b/src/gpodder/gtkui/main.py
-@@ -224,7 +224,7 @@
-             util.idle_add(self.subscribe_to_url, self.options.subscribe)
-         elif not self.channels:
-             self.on_itemUpdate_activate()
--        elif self.config.software_update.check_on_startup:
-+        elif False and self.config.software_update.check_on_startup:
-             # Check for software updates from gpodder.org
-             diff = time.time() - self.config.software_update.last_check
-             if diff > (60 * 60 * 24) * self.config.software_update.interval:
-@@ -3288,6 +3288,7 @@
+@@ -3445,6 +3445,7 @@
          If silent=False, a message will be shown even if no updates are
          available (set silent=False when the check is manually triggered).
          """


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Many bugfixes and improvements. See https://github.com/gpodder/gpodder/releases
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
