### PR TITLE
driftctl: 0.20.0 -> 0.23.0

### DIFF
--- a/pkgs/applications/networking/cluster/driftctl/default.nix
+++ b/pkgs/applications/networking/cluster/driftctl/default.nix
@@ -1,56 +1,56 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "driftctl";
-  version = "0.20.0";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
-    owner = "cloudskiff";
+    owner = "snyk";
     repo = "driftctl";
     rev = "v${version}";
-    sha256 = "sha256-8egkz1wXvdNoTkbhOdvoP4hrBPmuiUvd2QaD6tPH2xU=";
+    sha256 = "sha256-TUwTvCsWB+n+shVU1hTzLYROG9Wp4ySzJwAnappK7TY=";
   };
 
-  vendorSha256 = "sha256-lftOTcob8l9dUZkH2MMxzD6FZzLOR/PXEXFVdOaguK4=";
+  vendorSha256 = "sha256-I0OCRhUvuaF4k5qqPaV6R24mrd9AG5GgQCCF6yodK0E=";
 
-  postUnpack = ''
-    # Without this, tests fail to locate aws/3.19.0.json
-    for prefix in /                        \
-                  /pkg                     \
-                  /pkg/analyser            \
-                  /pkg/alerter             \
-                  /pkg/remote              \
-                  /pkg/middlewares         \
-                  /pkg/cmd/scan/output     \
-                  /pkg/iac/terraform/state \
-                  /pkg/iac/supplier ; do
-      mkdir -p ./source/$prefix/github.com/cloudskiff
-      ln -sf $PWD/source ./source/$prefix/github.com/cloudskiff/driftctl
-    done
+  nativeBuildInputs = [ installShellFiles ];
 
-    # Disable check for latest version and telemetry, which are opt-out.
-    # Making it out-in is quite a job, and why bother?
-    find -name '*.go' \
-      | xargs sed -i 's,https://2lvzgmrf2e.execute-api.eu-west-3.amazonaws.com/,https://0.0.0.0/,g'
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/snyk/driftctl/pkg/version.version=v${version}"
+    "-X github.com/snyk/driftctl/build.env=release"
+    "-X github.com/snyk/driftctl/build.enableUsageReporting=false"
+  ];
 
-    # and remove corresponding flags from --help, so things look tidy.
-    find -name driftctl.go | \
-      xargs sed -i -e '/("no-version-check"/ d'  -e '/("disable-telemetry"/ d'
+  postInstall = ''
+    installShellCompletion --cmd driftctl \
+      --bash <($out/bin/driftctl completion bash) \
+      --fish <($out/bin/driftctl completion fish) \
+      --zsh <($out/bin/driftctl completion zsh)
+  '';
 
-    # Presumably it can be done with ldflags, but I failed to find incantation
-    # that would work, we here we go old-school.
-    find -name version.go | xargs sed -i -e 's/"dev"/"${version}"/'
-    find -name build.go | xargs sed -i -e 's/"dev"/"release"/'
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
 
-    # Fix the tests that checks for dev-dev.
-    find -name version_test.go | xargs sed -i -e 's/"dev-dev/"${version}/'
-    find -name driftctl_test.go | xargs sed -i -e 's/"dev-dev/"${version}/'
+    $out/bin/driftctl --help
+    $out/bin/driftctl version | grep "v${version}"
+    # check there's no telemetry flag
+    $out/bin/driftctl --help | grep -vz "telemetry"
+
+    runHook postInstallCheck
   '';
 
   meta = with lib; {
-    description = "Tool to track infrastructure drift";
-    homepage = "https://github.com/cloudskiff/driftctl";
+    homepage = "https://driftctl.com/";
+    changelog = "https://github.com/snyk/driftctl/releases/tag/v${version}";
+    description = "Detect, track and alert on infrastructure drift";
+    longDescription = ''
+      driftctl is a free and open-source CLI that warns of infrastructure drift
+      and fills in the missing piece in your DevSecOps toolbox.
+    '';
     license = licenses.asl20;
-    maintainers = with maintainers; [ kaction ];
+    maintainers = with maintainers; [ kaction jk ];
   };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump driftctl to `0.23.0`

- added ldflags for stripping, version, and telemetry
- added shell completions
- added some install checks
- updated meta
- added myself as a maintainer

cc: @kaction

Closes #162308
Closes #147896

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
