### PR TITLE
networkmanager: 1.34.0 -> 1.36.2

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -54,11 +54,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.34.0";
+  version = "1.36.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-gZeV0ImQdiBPVnJCGljxsdnjk1Nu6Hu4RLkR5iQ78L0=";
+    sha256 = "1aqc8z8zv1sds439ilihwqczwg9iqzki0f007fd2x0s17fz5r1db";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/data/84-nm-drivers.rules b/data/84-nm-drivers.rules
-index e398cb9f2f..a43d61864f 100644
+index 148acade5c..6395fbfbe5 100644
 --- a/data/84-nm-drivers.rules
 +++ b/data/84-nm-drivers.rules
-@@ -7,6 +7,6 @@ ACTION!="add|change", GOTO="nm_drivers_end"
+@@ -7,6 +7,6 @@ ACTION!="add|change|move", GOTO="nm_drivers_end"
  # Determine ID_NET_DRIVER if there's no ID_NET_DRIVER or DRIVERS (old udev?)
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
@@ -24,19 +24,19 @@ index e23b3a5282..c7246a3b61 100644
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index 21863b9533..c9b709659d 100644
+index a11486d54b..de8e9022c6 100644
 --- a/src/core/devices/nm-device.c
 +++ b/src/core/devices/nm-device.c
-@@ -13994,14 +13994,14 @@ nm_device_start_ip_check(NMDevice *self)
-             gw = nm_ip4_config_best_default_route_get(priv->ip_config_4);
+@@ -13571,14 +13571,14 @@ nm_device_start_ip_check(NMDevice *self)
+             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
              if (gw) {
                  _nm_utils_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
 -                ping_binary = nm_utils_find_helper("ping", "/usr/bin/ping", NULL);
 +                ping_binary = "@iputils@/bin/ping";
                  log_domain  = LOGD_IP4;
              }
-         } else if (priv->ip_config_6 && priv->ip_state_6 == NM_DEVICE_IP_STATE_DONE) {
-             gw = nm_ip6_config_best_default_route_get(priv->ip_config_6);
+         } else if (priv->ip_data_6.state == NM_DEVICE_IP_STATE_READY) {
+             gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET6);
              if (gw) {
                  _nm_utils_inet6_ntop(&NMP_OBJECT_CAST_IP6_ROUTE(gw)->gateway, buf);
 -                ping_binary = nm_utils_find_helper("ping6", "/usr/bin/ping6", NULL);
@@ -65,10 +65,10 @@ index 21a01e0b04..091c98428f 100644
        '--lib-path', meson.current_build_dir(),
        '--gir', '@INPUT@',
 diff --git a/src/libnm-platform/nm-platform-utils.c b/src/libnm-platform/nm-platform-utils.c
-index 6435dcc482..214d01194e 100644
+index 9ad030df76..8d800fb1c0 100644
 --- a/src/libnm-platform/nm-platform-utils.c
 +++ b/src/libnm-platform/nm-platform-utils.c
-@@ -2097,7 +2097,7 @@ nmp_utils_modprobe(GError **error, gboolean suppress_error_logging, const char *
+@@ -2207,7 +2207,7 @@ nmp_utils_modprobe(GError **error, gboolean suppress_error_logging, const char *
  
      /* construct the argument list */
      argv = g_ptr_array_sized_new(4);
@@ -78,13 +78,13 @@ index 6435dcc482..214d01194e 100644
      g_ptr_array_add(argv, (char *) arg1);
  
 diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
-index 72691e34c2..95495b6585 100644
+index e2c0c394bd..1a507aa0d4 100644
 --- a/src/libnmc-base/nm-vpn-helpers.c
 +++ b/src/libnmc-base/nm-vpn-helpers.c
 @@ -198,25 +198,8 @@ nm_vpn_openconnect_authenticate_helper(const char *host,
      gs_free const char **output_v = NULL;
-     const char *const *  iter;
-     const char *         path;
+     const char *const   *iter;
+     const char          *path;
 -    const char *const    DEFAULT_PATHS[] = {
 -        "/sbin/",
 -        "/usr/sbin/",


### PR DESCRIPTION
Tested on my system.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
