### PR TITLE
keep-presence: init at 1.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8568,6 +8568,12 @@
     githubId = 772914;
     name = "Mikael Voss";
   };
+  mwdomino = {
+    email = "matt@dominey.io";
+    github = "mwdomino";
+    githubId = 46284538;
+    name = "Matt Dominey";
+  };
   maxwilson = {
     email = "nixpkgs@maxwilson.dev";
     github = "mwilsoncoding";

--- a/pkgs/tools/misc/keep-presence/default.nix
+++ b/pkgs/tools/misc/keep-presence/default.nix
@@ -24,10 +24,10 @@ let
       # to carrot69's (original author) repo to see if they would like
       # to merge.
       src = fetchFromGitHub {
-        owner = "mwdomino";
-        repo = "keep-presence-1";
-        rev = "1c65b84525c290c2633992028073ade45081361e";
-        sha256 = "0hha6z2ljh4ggks2d31wksxzk908wwqrm39y5j900kbg5x3aabz6";
+        owner = "carrot69";
+        repo = "keep-presence";
+        rev = "f55ba91bf78681e4e99e39ed63be4810c81e28c6";
+        sha256 = "1a4r35pbdmd73767x3g41c3chjxjwqf3y4n3dhmh31s1lx7cahmv";
       } + /src;
 
       propagatedBuildInputs = with pythonPkgs; [ setuptools pynput ];

--- a/pkgs/tools/misc/keep-presence/default.nix
+++ b/pkgs/tools/misc/keep-presence/default.nix
@@ -1,0 +1,47 @@
+{ nixpkgs ? import <nixpkgs> {}, pythonPkgs ? nixpkgs.pkgs.python3Packages }:
+
+let
+  inherit (nixpkgs) pkgs lib fetchFromGitHub;
+  inherit pythonPkgs;
+
+  f = { buildPythonPackage, setuptools, pynput }:
+    buildPythonPackage rec {
+      name = "keep-presence";
+      version = "1.0.5";
+
+      meta = with lib; {
+        description = ''
+          This program moves the mouse or press a key when it detects that you are away.
+          It won't do anything if you are using your computer.
+          Useful to trick your machine to think you are still working with it.
+        '';
+        homepage = https://github.com/carrot69/keep-presence;
+        license = licenses.cc0;
+        platforms = platforms.unix;
+      };
+
+      # Using a fork with proper shebangs and setup.py added, will open PR
+      # to carrot69's (original author) repo to see if they would like
+      # to merge.
+      src = fetchFromGitHub {
+        owner = "mwdomino";
+        repo = "keep-presence-1";
+        rev = "1c65b84525c290c2633992028073ade45081361e";
+        sha256 = "0hha6z2ljh4ggks2d31wksxzk908wwqrm39y5j900kbg5x3aabz6";
+      } + /src;
+
+      propagatedBuildInputs = with pythonPkgs; [ setuptools pynput ];
+
+      doCheck = false;
+
+      postInstall = ''
+        mv -v $out/bin/keep-presence.py $out/bin/keep-presence
+        patchShebangs $out/bin/keep-presence
+        chmod +x $out/bin/keep-presence
+      '';
+    };
+
+  drv = pythonPkgs.callPackage f {};
+
+in
+if pkgs.lib.inNixShell then drv.env else drv

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34734,4 +34734,6 @@ with pkgs;
   honeytail = callPackage ../servers/tracing/honeycomb/honeytail { };
 
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
+
+  keep-presence = callPackage ../tools/misc/keep-presence { };
 }


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
This is my first contribution to `nixpkgs` so please let me know if I've missed anything!

###### Description of changes
This adds a new package `keep-presence` from https://github.com/carrot69/keep-presence.

keep-presence is a simple python script to move your mouse and keep your computer active. Can be used to prevent sleep or to keep yourself 'active' on the current chat app of choice.

~~I'll be opening a PR to the repo above to see if the maintainer is interested in integrating the changes. If so, I will update this package at that time to use the primary repo instead of my fork.~~ The original author has merged the PR so I've updated this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
