### PR TITLE
rmtoo: init at unstable-2021-11-09

### DIFF
--- a/pkgs/applications/science/engineering/rmtoo/default.nix
+++ b/pkgs/applications/science/engineering/rmtoo/default.nix
@@ -1,0 +1,132 @@
+{ lib
+, python3
+, fetchFromGitHub
+, substituteAll
+, git
+, graphviz
+, texlive
+, gnuplot
+}:
+
+let
+  python3Override = python3.override {
+    packageOverrides = self: super: {
+      gitdb = super.gitdb.overridePythonAttrs (oldAttrs: rec {
+        inherit (oldAttrs) pname;
+        version = "0.6.4";
+        disabled = "";
+        src = python3.pkgs.fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-o+u8J74DWi6HTtkE31FuNfSimneKdkOF3gneng8Tllg=";
+        };
+        postPatch = '''';
+      });
+
+      GitPython102 = super.GitPython.overridePythonAttrs (oldAttrs: rec {
+        inherit (oldAttrs) pname;
+        version = "1.0.2";
+        disabled = "";
+        src = fetchFromGitHub {
+          owner = "gitpython-developers";
+          repo = pname;
+          rev = version;
+          sha256 = "sha256-5IdI6yy3AtsrUkZWohcca7bJIWhMGpi/Go5EoK/4l54=";
+        };
+        patches = [ ];
+        postPatch = ''
+          substituteInPlace ./git/cmd.py --replace "\"git\""  "${git}/bin/git"
+          grep git ./git/cmd.py
+        '';
+      });
+
+      GitPython306 = super.GitPython.overridePythonAttrs (oldAttrs: rec {
+        inherit (oldAttrs) pname;
+        version = "3.0.6";
+        src = fetchFromGitHub {
+          owner = "gitpython-developers";
+          repo = pname;
+          rev = version;
+          sha256 = "sha256-tb+7UT3mxVzPxJpbIgylylUs4bpEeme55YDfzlUz4QY=";
+        };
+      });
+
+      odfpy134 = super.odfpy.overridePythonAttrs (oldAttrs: rec {
+        inherit (oldAttrs) pname;
+        version = "1.3.4";
+        src = python3.pkgs.fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-E+bXrs60nj29idoA1wD84+PwcXzQ2xu2+xbFTlebUfg=";
+        };
+        doCheck = false;
+        checkInputs = [ ];
+        checkPhase = ''
+          pushd tests
+          rm runtests
+          for file in test*.py; do
+            python  $file
+          done
+        '';
+      });
+    };
+  };
+in python3.pkgs.buildPythonApplication rec {
+  pname = "rmtoo";
+  version = "unstable-2021-11-09";
+  pythonVersion = "3.8";
+
+  src = fetchFromGitHub {
+    owner = "florath";
+    repo = pname;
+    rev = "6ffe08703451358dca24b232ee4380b1da23bcad";
+    sha256 = "sha256-0VpnfU/0gmEXnNVEUuZgj915glFX8OzPQ/4bW1G81go=";
+  };
+
+  buildInputs = [
+    graphviz
+    texlive.combined.scheme-basic
+  ];
+
+  propagatedBuildInputs = [
+    python3
+  ] ++ (with python3.pkgs; [
+    GitPython
+    flake8
+    future
+    gitdb
+    jinja2
+    numpy
+    odfpy
+    pylint
+    pyyaml
+    scipy
+    six
+    stevedore
+  ]);
+
+  postPatch = ''
+    substituteInPlace ./requirements.txt \
+      --replace "==" ">=" \
+      --replace "~" ">="
+    substituteInPlace ./setup.py --replace "==" ">="
+  '';
+
+  doCheck = true;
+
+  checkInputs = with python3.pkgs; [
+    pytestCheckHook
+    tox
+  ];
+
+  pythonImportsCheck = [ "rmtoo" ];
+
+  pytestFlagsArray = [ "rmtoo/tests/" ];
+
+  meta = with lib; {
+    description = "Requirements management tool";
+    homepage = "https://github.com/florath/rmtoo";
+    changelog = "https://github.com/florath/rmtoo/releases";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ yuu ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32847,6 +32847,8 @@ with pkgs;
 
   brmodelo = callPackage ../applications/science/engineering/brmodelo { };
 
+  rmtoo = callPackage ../applications/science/engineering/rmtoo { };
+
   ### SCIENCE / ELECTRONICS
 
   adms = callPackage ../applications/science/electronics/adms { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
Add requirements management tool https://github.com/florath/rmtoo.

Part of https://github.com/NixOS/nixpkgs/issues/164019

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
