### PR TITLE
hdrmerge: fix desktop entry file, install icons

### DIFF
--- a/pkgs/applications/graphics/hdrmerge/default.nix
+++ b/pkgs/applications/graphics/hdrmerge/default.nix
@@ -55,17 +55,15 @@ mkDerivation rec {
       desktopName = "HDRMerge";
       comment = meta.description;
       icon = "hdrmerge";
-      exec = "@out@/bin/hdrmerge -F";
+      exec = "hdrmerge %F";
       categories = [ "Graphics" ];
       mimeTypes = [ "image/x-dcraw" "image/x-adobe-dng" ];
       terminal = false;
     })
   ];
 
-  postInstallPhase = ''
-    # Make a desktop item
-    mkdir -p $out/share/icons/ $out/share/applications/
-    cp ../data/images/logo.png $out/share/icons/hdrmerge.png
+  postInstall = ''
+    install -Dm444 ../data/images/icon.png $out/share/icons/hicolor/128x128/apps/hdrmerge.png
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
We had an `@out@` in the `Exec` line of the desktop entry file, but did no env substitution on it, so it just output the `@out@` verbatim. I think we can drop the absolute path and rely on the binary being in PATH.

Also, we want `%F` for "one or more files" as an [Exec variable](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables)

Tested this with the Plasma menu, and it looks fine. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
