### PR TITLE
factorio-experimental: 1.1.53 -> 1.1.56

### DIFF
--- a/pkgs/games/factorio/versions.json
+++ b/pkgs/games/factorio/versions.json
@@ -2,12 +2,12 @@
   "x86_64-linux": {
     "alpha": {
       "experimental": {
-        "name": "factorio_alpha_x64-1.1.53.tar.xz",
+        "name": "factorio_alpha_x64-1.1.56.tar.xz",
         "needsAuth": true,
-        "sha256": "1l5sk9rhf4pq9l87w5sv4a1ikqx8rpby5hf4xn7sdsm9mshd3wyw",
+        "sha256": "1i9mcq8m48ar0b3x53zgi5x9rsaddmlm2wqaphyf81xampl7ivcx",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.53/alpha/linux64",
-        "version": "1.1.53"
+        "url": "https://factorio.com/get-download/1.1.56/alpha/linux64",
+        "version": "1.1.56"
       },
       "stable": {
         "name": "factorio_alpha_x64-1.1.53.tar.xz",
@@ -20,12 +20,12 @@
     },
     "demo": {
       "experimental": {
-        "name": "factorio_demo_x64-1.1.53.tar.xz",
+        "name": "factorio_demo_x64-1.1.56.tar.xz",
         "needsAuth": false,
-        "sha256": "0m3mk296w4azma2v5z6pay1caqql2jfnlcyyd120laxl4rdg2k76",
+        "sha256": "0g1gphysh79h1frcjpfd5i3fpi05y8mq9gwmgnmalmr56w5n4qlz",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.53/demo/linux64",
-        "version": "1.1.53"
+        "url": "https://factorio.com/get-download/1.1.56/demo/linux64",
+        "version": "1.1.56"
       },
       "stable": {
         "name": "factorio_demo_x64-1.1.53.tar.xz",
@@ -38,12 +38,12 @@
     },
     "headless": {
       "experimental": {
-        "name": "factorio_headless_x64-1.1.53.tar.xz",
+        "name": "factorio_headless_x64-1.1.56.tar.xz",
         "needsAuth": false,
-        "sha256": "18ra52h32nhdqxz6vagp9nw3an5pgamariy0ny050xr2xpidw3v1",
+        "sha256": "174fvi9slpdp3y8j46w0w0ays7i7gy98il74xx5wxh7s94zb1b68",
         "tarDirectory": "x64",
-        "url": "https://factorio.com/get-download/1.1.53/headless/linux64",
-        "version": "1.1.53"
+        "url": "https://factorio.com/get-download/1.1.56/headless/linux64",
+        "version": "1.1.56"
       },
       "stable": {
         "name": "factorio_headless_x64-1.1.53.tar.xz",


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes

https://forums.factorio.com/viewtopic.php?p=563208

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
