### PR TITLE
treesheets: adjust output directories

### DIFF
--- a/pkgs/applications/office/treesheets/default.nix
+++ b/pkgs/applications/office/treesheets/default.nix
@@ -17,24 +17,24 @@ stdenv.mkDerivation rec {
   preConfigure = "cd src";
 
   postInstall = ''
-    mkdir "$out/share" -p
-    cp -av ../TS "$out/share/libexec"
+    mkdir -p "$out/libexec"
+    cp -av ../TS "$out/libexec/treesheets"
 
-    mkdir "$out/bin" -p
-    makeWrapper "$out/share/libexec/treesheets" "$out/bin/treesheets"
+    mkdir -p "$out/bin"
+    makeWrapper "$out/libexec/treesheets/treesheets" "$out/bin/treesheets"
 
-    mkdir "$out/share/doc" -p
+    mkdir -p "$out/share/doc/treesheets"
 
     for f in readme.html docs examples
     do
-      mv -v "$out/share/libexec/$f" "$out/share/doc"
-      ln -sv "$out/share/doc/$f" "$out/share/libexec/$f"
+      mv -v "$out/libexec/treesheets/$f" "$out/share/doc/treesheets"
+      ln -sv "$out/share/doc/treesheets/$f" "$out/libexec/treesheets/$f"
     done
 
     mkdir "$out/share/applications" -p
-    mv -v "$out/share/libexec/treesheets.desktop" "$out/share/applications"
+    mv -v "$out/libexec/treesheets/treesheets.desktop" "$out/share/applications"
     substituteInPlace "$out/share/applications/treesheets.desktop" \
-      --replace "Icon=images/treesheets.svg" "Icon=$out/share/libexec/images/treesheets.svg"
+      --replace "Icon=images/treesheets.svg" "Icon=$out/libexec/treesheets/images/treesheets.svg"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Right now, the treesheets derivation outputs docs to `$out/share/doc/` This is undesirable, because if you install Treesheets into, say, your profile, you end up with its readme under `~/.nix-profile/share/doc/readme.html`. This patch moves Treesheets docs to `$out/share/doc/treesheets/` instead. 

Also, I've moved `$out/share/libexec` to `$out/libexec`; this seems to be the common Nixpkgs convention.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
