### PR TITLE
python3Packages.volvooncall: 0.9.2 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -5,7 +5,6 @@
 , setuptools
 , geopy
 , docopt
-, pyyaml
 , certifi
 , amqtt
 , websockets
@@ -17,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "volvooncall";
-  version = "0.9.2";
+  version = "0.10.0";
 
   disabled = pythonOlder "3.8";
 
@@ -27,24 +26,30 @@ buildPythonPackage rec {
     owner = "molobrakos";
     repo = "volvooncall";
     rev = "v${version}";
-    hash = "sha256-OTs282z7qzILl/xxM3whaxiQr8FZOfgceO2EY3NJKbA=";
+    hash = "sha256-HLSanXJs1yPSgYo4oX0zJtrV5sKkxV2yLPhc2dVRHY8=";
   };
 
   propagatedBuildInputs = [
-    geopy
-    docopt
-    pyyaml
-    certifi
-    amqtt
-    websockets
     aiohttp
   ];
 
+  passthru.extras-require = {
+    console = [
+      certifi
+      docopt
+      geopy
+    ];
+    mqtt = [
+      amqtt
+      certifi
+    ];
+  };
+
   checkInputs = [
-    pytestCheckHook
     asynctest
     pytest-asyncio
-  ];
+    pytestCheckHook
+  ] ++ passthru.extras-require.mqtt;
 
   pythonImportsCheck = [ "volvooncall" ];
 


### PR DESCRIPTION

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Description of changes
https://github.com/molobrakos/volvooncall/releases/tag/v0.10.0

> Console & MQTT specific dependencies have been moved to extras_require to avoid bringing those dependencies in for basic API or Home Assistant use cases.

Should we use `passthru.extra-require`?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


