### PR TITLE
copyDesktopItems: Use bin output

### DIFF
--- a/pkgs/build-support/setup-hooks/copy-desktop-items.sh
+++ b/pkgs/build-support/setup-hooks/copy-desktop-items.sh
@@ -28,16 +28,15 @@ copyDesktopItems() {
         return
     fi
 
+    applications="${!outputBin}/share/applications"
     for desktopItem in $desktopItems; do
         if [[ -f "$desktopItem" ]]; then
-            echo \
-              "Copying '$desktopItem' into '${!outputBin}/share/applications'"
-            install -D -m 444 -t "${!outputBin}"/share/applications \
-              "$desktopItem"
+            echo "Copying '$desktopItem' into '${applications}'"
+            install -D -m 444 -t "${applications}" "$desktopItem"
         else
             for f in "$desktopItem"/share/applications/*.desktop; do
-                echo "Copying '$f' into '${!outputBin}/share/applications'"
-                install -D -m 444 -t "${!outputBin}"/share/applications "$f"
+                echo "Copying '$f' into '${applications}'"
+                install -D -m 444 -t "${applications}" "$f"
             done
         fi
     done

--- a/pkgs/build-support/setup-hooks/copy-desktop-items.sh
+++ b/pkgs/build-support/setup-hooks/copy-desktop-items.sh
@@ -30,12 +30,14 @@ copyDesktopItems() {
 
     for desktopItem in $desktopItems; do
         if [[ -f "$desktopItem" ]]; then
-            echo "Copying '$desktopItem' into '$out/share/applications'"
-            install -D -m 444 -t "$out"/share/applications "$desktopItem"
+            echo \
+              "Copying '$desktopItem' into '${!outputBin}/share/applications'"
+            install -D -m 444 -t "${!outputBin}"/share/applications \
+              "$desktopItem"
         else
             for f in "$desktopItem"/share/applications/*.desktop; do
-                echo "Copying '$f' into '$out/share/applications'"
-                install -D -m 444 -t "$out"/share/applications "$f"
+                echo "Copying '$f' into '${!outputBin}/share/applications'"
+                install -D -m 444 -t "${!outputBin}"/share/applications "$f"
             done
         fi
     done


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Desktop files are only useful when accompanied by the binaries specify. So it makes more sense to put them next to the binaries than `$out` which only usually contains the binaries.

This may affect packages that have worked around this behavior by manually copying things to `$out/share` rather than next to the binaries. Not sure what the best way is to smoke these out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
