### PR TITLE
 thunderbird, thunderbird-bin: 91.6.2 -> 91.7.0 [High security fixes]

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,655 +1,655 @@
 {
-  version = "91.6.2";
+  version = "91.7.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/af/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/af/thunderbird-91.7.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "12677fdd95e2e39554b588d17520805490cf0155dcc0ba46a342fdf1f1203c2a";
+      sha256 = "bcc9a123b3de4d442836820d3eff52a37ff513b063850493e58c2132ad0ec029";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ar/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ar/thunderbird-91.7.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "9117f12de36b8823208d1513f19f7aa97d212d757f89a160391d0174452929fa";
+      sha256 = "4800a0be829e654d6917271b4944a5be3a8688e75eed58a4a5bae3643d2bce4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ast/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ast/thunderbird-91.7.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "0d4af76bfacf63bcffc05df23632ad8253706cab6733672e1da63d9f16ad3adf";
+      sha256 = "779bf2732f89a82f36449d75d14ec4f8cbceb79c7f2d590f0407f4261fd9a5f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/be/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/be/thunderbird-91.7.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "6f5797eae430340d6a36d4ed62a14a3e4e872150e089e7cd333e94df93ca3c65";
+      sha256 = "e1f033cf11d1d18828771ca81e90e6851a1b96971f0d3d81665ca6aebb6c737c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/bg/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/bg/thunderbird-91.7.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "750dce93e9e87a43a61c6a64165e1a2cb22875a758676af13827578bf2988766";
+      sha256 = "293917397d1d52415bab86a1d27e9442b5bafb989e65cb3cbee0ba601970bc2d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/br/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/br/thunderbird-91.7.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "d58fed791e98b711416605cff2629fe0eb1babde72210e17a21058f8bb44b9f8";
+      sha256 = "317883e2764505713e4507fffeaf1528f685fc774b99dc5b802164cdd1473292";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ca/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ca/thunderbird-91.7.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "58841064da94416897a4fc0cf3bb5cc3379523d4500ce1e95d65509c34ad7aeb";
+      sha256 = "cdfcbddc1697b46a85b67382d7b4a9d64d1ffc31d5faeb8e0edd21f4868a6008";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cak/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/cak/thunderbird-91.7.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "5edb25818fd16d959bf28f98e107d433bd55e26ba63b3a813d31ceeb3524d3dd";
+      sha256 = "8c1d1dff29b7631d5aad6384d02269b5c058bd1c37d85de0c92fd74e2a08e37c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cs/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/cs/thunderbird-91.7.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "efedce066919a150637821ca72c173057beb6283b3059dc862c4be8361e9a87f";
+      sha256 = "3d1818c6d067552a7f7c62fc9dfae7370c309c9604f20ba1f1f4723020f04c7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/cy/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/cy/thunderbird-91.7.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9cf0e5b52277d5c3cf863617a61854422c44301d8edfc97966570c3f9ccfbce6";
+      sha256 = "d339d87800e4060120468314544b34b4dfc355a5369363d6df826a6f10682afc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/da/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/da/thunderbird-91.7.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "af73b4ce45e9f7570986ef01e82e31a717c2717b146a6dc9815a8352b18f3ff0";
+      sha256 = "e00bb159fa9d113272866986eb8f9c3e6c3f29748cc7240cc736c00ed3eb1927";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/de/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/de/thunderbird-91.7.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "2be5afaf377e61290a8e7bbfc274ca1dae4f9d1e54188b85677425ad067b6f35";
+      sha256 = "af8365195927f75f6aac52fd91904193172f5e3b7bc09a7e52a94840ede1a6aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/dsb/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/dsb/thunderbird-91.7.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "ca44c469fae35a4e388017c172eb9610ddc6057b7768860806dac4a86527829b";
+      sha256 = "96bdb60659052126bca84a64a1f2fdd26654875d74feacd4b9d50cf66b90c3d9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/el/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/el/thunderbird-91.7.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "8c7b1071d9b0d911f0d714f9e5aee2fd7e256178255fb721562c649f0aa776c9";
+      sha256 = "af0101f1d999947cb02b3cf7c92eadab0f360b64f64788a3ea2ecbb6e8628c9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-CA/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/en-CA/thunderbird-91.7.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "85709ee24b0c18f39c843c500d15d04f90ebe1c3ed70c54ebc5a47e7cb2ead01";
+      sha256 = "3537bfe2ffe474e587df4549a243ace7fb02236e8a424fac9c9e23ea74978969";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-GB/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/en-GB/thunderbird-91.7.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "ff3a7fe7eef034ae215c3d4cd7e735419bd5aaaa05d15bf025a98643c6fadc64";
+      sha256 = "ff0daecd9a50d9bb060750d822bd0da409ac838f9280faf71ed6f146f1bd928d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/en-US/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/en-US/thunderbird-91.7.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "319d173d06ccecc820080f92f2bd9348566457f46c08a328db15dc921cbc055f";
+      sha256 = "f4da2a0627b042e61b8f25eb57396ab71d862c728abd9cc82e9eb102b27d26f5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/es-AR/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/es-AR/thunderbird-91.7.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "c14bcb2b168397145cf5cd5a81d8cd6b2881678759886016b5915f93cd8761fb";
+      sha256 = "a052ed75f7b3aaa2fea27b7eaa658a0d75e03c5d8e51214e9207e79c8c656489";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/es-ES/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/es-ES/thunderbird-91.7.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "9f85fa21ce05846a795f0282bb3216d0559b4cbff189ba0e1867220a7c4f0cfb";
+      sha256 = "312b2eb38ec895a77a10cbd41cf861f03520d9ce7ff6cc0b2fd9e282c1a85743";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/et/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/et/thunderbird-91.7.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "39fa22da95ad03f31eaa2eb548f53e6bfb8e8e7fea424fda2b5432c1f12547f8";
+      sha256 = "257137eab9877c8c6663cfa9200707f5ff5ff30076c72952f43db9eeb3fc334b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/eu/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/eu/thunderbird-91.7.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "7a7c1517f5cc132b0c0d71d993bd8e816a0f72679799276c87eb57ca348dc523";
+      sha256 = "69e426d23b3d29aa625d3fcc18080befe5ea717279a4d17a798c987819ce9f0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fi/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/fi/thunderbird-91.7.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "703e0287c5b39b875abdb47b971d0c884df5ed6376ea2f541c7d26b2be532180";
+      sha256 = "2acb1d75cf32c65ca281ee353a79973bda5b96cfb1b8c6d55f91f5051ad9b720";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/fr/thunderbird-91.7.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "278263e42d1ae302682986591d42bb2cb35efd25d1a91935b030d0ef8b3232fa";
+      sha256 = "979a4ab6ae26ed9fe2320bc0baf828588ee96899d9aa04781aa5e3f7e1e4e35a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/fy-NL/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/fy-NL/thunderbird-91.7.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "57099abb0727c46862835235dc0a6065766e4284f7b672722957cfc6de555b01";
+      sha256 = "2cad6ddf73676bedc04d18afec2fce7f8085fe10400b514d5091113dbd1ccd39";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ga-IE/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ga-IE/thunderbird-91.7.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "077c2618862b042aa85117f0352d2d510b58f6d0e011ee82341ae1431a93f148";
+      sha256 = "6a8b5f6f413bf2d9122b90865131f1b2e3d1f528a2c0c54b0c3118b16948ef6f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/gd/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/gd/thunderbird-91.7.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "54890fdb2eb00bb2678230b1e1ec3dbbec93ee17b56b1373a2d1c53aecdaa8bc";
+      sha256 = "e739fdbcd525b1ec9a6415a1fc2b4f982895bc07e503324f8ee7cb9c44e30bf1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/gl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/gl/thunderbird-91.7.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "91423a9ebf11e08f66c743199a28a7e201981fb63f108e960d3afbd5b2a459be";
+      sha256 = "b8b87d0c8d200264e7aab95fc2f1a59b3ffd1b0a6143409cb947df6acce2711b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/he/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/he/thunderbird-91.7.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "d314d468c11715589b4023367fbcf5c75d86f3988d475b4c5e9ada28906d92ce";
+      sha256 = "3d8048e55eb538414b436387419d0ed2b4589a6846d55c49665af2741082bd03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/hr/thunderbird-91.7.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "a60f4a5b486341d1df0ec1eb3f7c57a823aa2a8a6f1d7903d44e6a5b7a932bd9";
+      sha256 = "e3eb72e83138d593046db8c72a09538b3b83abdef9b1534b9cf757751f172f78";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hsb/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/hsb/thunderbird-91.7.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "7678c9a81d2174030e32fd658337d4145c30e459aa8f22469ec7feea8c352572";
+      sha256 = "e110bd72de8a035ba2de4f849b09e60d11db161b09dda2bd4ba01ee7e42c0075";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hu/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/hu/thunderbird-91.7.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "6dbf4defe558fa4be7402b783dd1f6854111edbb2f8937ccebb59dd8a451351c";
+      sha256 = "2fc4d4e970257aff81352132dd73fc365cc7df822b70aef9716082cb455bbc6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/hy-AM/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/hy-AM/thunderbird-91.7.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e611665c2790dd32544c073e89a62794e0bb3fd663341f43ca8fca219500d45f";
+      sha256 = "ff5d16b7712f6975e68305f4d50e3c97846238021a4ffeb87526a5db0eb76db3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/id/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/id/thunderbird-91.7.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "42d4b227700df923b9250a798d919429e0542cfc98db3c380fbfebf640e491ba";
+      sha256 = "5063b921fbe8ea8273441868f1cda6e0e32a8fe00b2b866dd4f91c9f12f15011";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/is/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/is/thunderbird-91.7.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "61b3cb9f32c1f3241d0441ba2b5a08af4453f7ecf0a752a579fd6c3d002fd196";
+      sha256 = "55d42de9dea45c13ad4288144b544d61b789d94d85976525b18c6dd32a75d210";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/it/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/it/thunderbird-91.7.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "15006b56087f9459d201d3ba882ddda6619abe67810133acf47ffa40a688cd4e";
+      sha256 = "7a6774106b689e6f829f8f74b03d23a85d79b9f8304d9a60d3fd172188e1bc26";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ja/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ja/thunderbird-91.7.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "290c013ffc6269754ff0d1bd5cfa29e6a847644e5508f769cc0e9bf7159583b8";
+      sha256 = "b557c29aa992758dd4f92d3dab71cdac764b82b66359b75f2695de4fa052f918";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ka/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ka/thunderbird-91.7.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "5cb5d34ee7898f611c2cde2ddb328d3538f9be8f594364133a9e6b8de9912baf";
+      sha256 = "681430faee4d1e6512ca4a68142b6c3314f26e2944c7de04016404c60bae735e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/kab/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/kab/thunderbird-91.7.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "211e8129ae2d8f69c7582dd86d5c5f3176a36aa79e66493f0e214a10d8c39d31";
+      sha256 = "5b45b128a48395300ed63e033ea09562b368276c7e6a9ea7801db74b8db13e97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/kk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/kk/thunderbird-91.7.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "cbba1424eff7f98af28893a97d84ce77df18e4d7a11c25085d11e6b04e3ac48f";
+      sha256 = "a44dfb8259cd9e8c694e8c842cf5b691f2bfe5d9c5176dcc65bcfa9a316e78d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ko/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ko/thunderbird-91.7.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "1fd8858f58d51145534baf36a6cc65785e97f27c2288b42fa2be678b9cb53c6d";
+      sha256 = "e04ab8d19264afe6207875ea08b878993041ca84b613c4184d608a4f8bbedcba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/lt/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/lt/thunderbird-91.7.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "41c50eaa92f3197c54f3ad26645c3ba6c68ea8a43123e10a9b5f8b6c9948aefc";
+      sha256 = "4cc3797ed91e6edfe994821bca011f20a64a7d1f6bc13634c1a31c877b161b2c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/lv/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/lv/thunderbird-91.7.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "9ce05e78b63ab688fb696f6f246a9673ee27a5c353e2b0cdb3cb8007b716c080";
+      sha256 = "011867f9ee77187f02b6ce0040ab9c2d4babd6d2bbbb4c174094cc5f35eca65d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ms/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ms/thunderbird-91.7.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "020034bbb08295558c313e8fddb0a9566df789fe6458b8f6af48afcd7b13faf6";
+      sha256 = "8f9bd1f1d5052a8259f1096b38fef693f5a74e81b8a2bb69477fc1cfa7461796";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nb-NO/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/nb-NO/thunderbird-91.7.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "6d68c19f302bc285dcc9791a62fbeb43c212d00250b55671ea6f1120eb3832d8";
+      sha256 = "7bc57e4bc1373b5b484eb98f9775b85bbe9c6564e246af157b51314f74a20c67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/nl/thunderbird-91.7.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "ad16ce405e3afdeb476c2b77d4cbbe07e804f7f24c6ed309904991142dca5833";
+      sha256 = "bff24b619fa4282cc6341828528798d0d256213b43f1bcb4b36070e370bd2ba6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/nn-NO/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/nn-NO/thunderbird-91.7.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "a978d79422012ec000ab47568bc9eaa3cc6aa6eae2c81546ecb6d6638dbdc9be";
+      sha256 = "4286c9c093aacb233874bb1439e8b7880d7f3e81dc1bdeb24dd0096075d34b7d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pa-IN/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/pa-IN/thunderbird-91.7.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "ce38914fd910829414ae6cfbaf16d0b87b94c9bbd8c5ff6f1207e56a65cb69e7";
+      sha256 = "6ae5d50b4296201996b6ddf9ab2614534ec5fa3ed903c8e9d36c3254af820862";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/pl/thunderbird-91.7.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "f4c98014363d6cabde1c482b92f144316d15d3add07c62897d22c0609d30945b";
+      sha256 = "ac2fb293885f0a37d0ec6903cb72ca0d2126e18540a8e542ebf89e15748ed9e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pt-BR/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/pt-BR/thunderbird-91.7.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "852ab5784791248bf47fb10256cef4182bc1aab9ecea614042ac633302e4a5df";
+      sha256 = "7d31e4ea4f14cf1b3c2c2c7dc9af2d0c2e97d397a6748cb53f8fc0ded21c3d5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/pt-PT/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/pt-PT/thunderbird-91.7.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "31db0fed5d7fd611f010c98504fb3e93d4cc176331eaf0620ad72aeb3cdba074";
+      sha256 = "7eedd322ea310df8b308a075c995cb530892be67348b66bac82096cc3d7da035";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/rm/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/rm/thunderbird-91.7.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "cde517205596b4de4871af82fa1fd3ac7573569e7f20e4f09200cd89c0c44209";
+      sha256 = "606b4d58bc6afd7fe67be985d3eac5ad2c734c0037bd5e6380e9b0993579d762";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ro/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ro/thunderbird-91.7.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "6d8a7c29be04853b412f17e58542b0bd9041a501381eea8480f9f801f31c67ec";
+      sha256 = "a189258f7986e540edec1c0cb35f84f58924a079cce2da2332ad80a323c63241";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/ru/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/ru/thunderbird-91.7.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b57efd432369dcf8dd5e0c372bf9e4c2126384319bca00068f5e48b38f028353";
+      sha256 = "2677c5d98c13ad6cdf3698b644b38ea9c94e94e46eec9ef307036d5bd3d32c9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/sk/thunderbird-91.7.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "89d011a751e74584e327aa27dc240a1e1a55c41203f27f04d19e3207efa00ece";
+      sha256 = "f3d630189c20ff6d4246f4f67173f60ff89bc4643267e6fd27cc37a25437b6d6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/sl/thunderbird-91.7.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "8ab24ed74c8647cdf560c8617a141b7288040aecbdbcaa24535d9893395edae4";
+      sha256 = "d2020220b3c54b9bbc114ff367c10818541bd070f5e0e0d4c56fdbb027bd8d85";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sq/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/sq/thunderbird-91.7.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "fef5737faa9c619405198d1e544e1a463b83359f8fc948d4a6b7829aae66addd";
+      sha256 = "91cc13d2a69372b619273feeabb961ae4e27dda6973b64cbb316db7207760c27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/sr/thunderbird-91.7.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "37027ae2e80d562e8487cbf8f74583ad8615697529a48286f3d720c936d449cb";
+      sha256 = "7b4c459eb200c9d407acfbcc451290a5f43c6b9f0aa4dac6d4536c267b6afadf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/sv-SE/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/sv-SE/thunderbird-91.7.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e733a4043b75d198e39b17370ffd1271a395742130c9b9448405f6ca6c4fde1b";
+      sha256 = "be920ab8279dfe412f5e12082a7709d0e24ea7869f5a86d36e65962430a5798e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/th/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/th/thunderbird-91.7.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "da5c57c69d4663b19818af4542fcd01daa49709c3fca89866d3036fbcf39a40a";
+      sha256 = "2a6d558efee3c0d02e4695b77b1f9dbaacf673f499a4ef28e3763358bb61346f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/tr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/tr/thunderbird-91.7.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "34ca81f38b37948ef31ba91e69eafc3d2d3de3c8d957d4f8b108b5317a3ea69c";
+      sha256 = "0cb0bb5991481cdb80d729f1c59276f4e1e12fac48b820fe5e352d63a44ff8ea";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/uk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/uk/thunderbird-91.7.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "3c21631ede559d1956632967910d10a7efecfe7dd10e5abe2c7a3a2299304c4f";
+      sha256 = "056a958ad687e5b3a0c707379d15ba2b23e17a5c11f113edebcecaf5ab229ada";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/uz/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/uz/thunderbird-91.7.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "21ff155db506ec20e7eb65dacf1bfb410cbca19dea0e9c1009abfdaffa9d10e9";
+      sha256 = "31bf50803722d1b8017861da34237c41d725649a5884b33a15a3bc35738adb94";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/vi/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/vi/thunderbird-91.7.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "145f4b4be96928ea84076dedb8d5a693a6570091e88a60711d3353eb8d61183e";
+      sha256 = "55b5d7c9c3ce8b02d58cb371b58afeff39f08e8b45b1d8875aaa267273ff65b0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/zh-CN/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/zh-CN/thunderbird-91.7.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "6551815d957d568850bf87a68cd68b2c8f244806b7485a9f3e40267d7132e80f";
+      sha256 = "39983db7492adfd30f7c281f7de16f5538e65dfffd86579cc6abd91936c420b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-x86_64/zh-TW/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-x86_64/zh-TW/thunderbird-91.7.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "5a9c213bbfecaad06ef74ca6a3469325010780f1c0020d75a4a1b282aef75206";
+      sha256 = "0b0dbff293c33ed286904f798153c64e8ee631430e9293bc384ca1f1368c44f8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/af/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/af/thunderbird-91.7.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "e0238ea69c1b04426bf9f100dcf804bb2e521c909fcff3e8c71b991d7e516afa";
+      sha256 = "dd662bf17307215d0ffab8ea10852bf1a742b5dc0564b07b1f3583239169fccb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ar/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ar/thunderbird-91.7.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "3cc3c94ce260f3d51a1d8f94190d7dcb3355345feb00dd46dde87445a7c96103";
+      sha256 = "b3ea9d805c423c3ae2b7bdf74bcc3bc3cda88467c28c3eb02c5cf9f42bcee801";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ast/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ast/thunderbird-91.7.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "10c77a2690c83f85a437068ca1090ea727f499bcfe9cccea3db7a437c4eadbf8";
+      sha256 = "5853f37ec0ac021ace8ee23b2255bc680c2ac5a8c81a4023a98235d3fa2b53d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/be/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/be/thunderbird-91.7.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "176b3e2480cb9524b6b988649312557e0d6c92a910540517e2a64bceacc318dc";
+      sha256 = "ef0149c8c758a487cfd748f0a0cd114ee01d3fe63605952e3f5cb02c0fe2e351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/bg/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/bg/thunderbird-91.7.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "453320d2bb60676b54b5ec4db932be5c48b0d611e24dec0d383c6038cf116350";
+      sha256 = "9ce3b7ee2fae34af3e272d1a0a24a086901e032e589169005a4b75ca1dff6051";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/br/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/br/thunderbird-91.7.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "04b9839b0f8b9ec5378a2bcd938cdda5ba06beac4ee15d9244db44fa79ce4082";
+      sha256 = "6bb10ee9209b264889fd5338be11a6ed0295c4480eae1b0ca35ca8cd5e173066";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ca/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ca/thunderbird-91.7.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "292ab4580a1d5d0b9c210b5e17404c4b694ba1a6083372e7a2fa116762304bc2";
+      sha256 = "8b2cbcce416213c2628656722f2d6f4a8de47b8f601e6da665c99ba2710e3ae5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cak/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/cak/thunderbird-91.7.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "632312be72925ad593c34e6f7244d264e85ecb2d11226438b8a73e46ad803bcd";
+      sha256 = "140658bf9d5d0e7d8cdf7a6ecd987fd9d18a789d92a7ccc9fe64200fa531c0b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cs/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/cs/thunderbird-91.7.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "7c791ce5591fbd961e13518e7cb79ad4564e3e1ebd2020e4e3eee5b3c705373e";
+      sha256 = "5c4dffc7b3f672edbaf6906e487fc6636ab25fcc8dc9e3697b2b8d2a90ba24da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/cy/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/cy/thunderbird-91.7.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "81a74d583402e8260e269c4e04c9493b651c20cce7a3cdb7a6eff1f079afd798";
+      sha256 = "b248ee575f00f1b4de3ac4be15886f270366b1073ad6dd84f4807ecc7fbd9a9f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/da/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/da/thunderbird-91.7.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "33da64a7f4bcbcb916ec96605c99775d040a82f6fd993b56465db5cd5358813d";
+      sha256 = "e2c03805474f8c39467217cd26a08133fd3cba61de35d4a2515b1d535bea6d0b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/de/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/de/thunderbird-91.7.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "7cbd8da69bc78f8f69c38776f9ccb13f710ab78dc63f33e882869f34dbcc27d2";
+      sha256 = "5de15b1da2b90eac08889791178a2d8b304b97bb4377c2478a0142ad0dc166f0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/dsb/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/dsb/thunderbird-91.7.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "50ddf1a1f53daaa9652b2b21b9fb0ac364c22dd1a504e112892814196029f647";
+      sha256 = "20c2c5e9a57440eb046b35ce7f549d846e17afd26cf4883d7ee9de2223bce0d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/el/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/el/thunderbird-91.7.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b23178543705c768d0ae361bc9c24d4323a903d95a1386f5f190acab3ac6c358";
+      sha256 = "3c5c3462455517f391ef0aa194a39522397d971e8d5ab2113a47cde1bea3b7b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-CA/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/en-CA/thunderbird-91.7.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "bc2e2f127cc53297e11d36b4de86453e397fc7a19dfe85b456e1973f2185c3da";
+      sha256 = "adee07c4cc48bcd3595d32c881bedabf3410df9c3517c3f8f6feeb237552451d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-GB/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/en-GB/thunderbird-91.7.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "8c1a29f1a35ed8360eb8c064dafea875aab15186c7f7125e1ff21550afa68ee7";
+      sha256 = "b9eaf0f03ac73e961a160017bfc3f4537592d6d6d63239c3a8249fdb08a5f232";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/en-US/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/en-US/thunderbird-91.7.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "436f46c5d235ffee2fac9e36a256c95e9d842e6712192972f784e8b02159c0aa";
+      sha256 = "50783e08cf7bcb904bcca66270b55570a961390d078dae9998fcf8e527f92d3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/es-AR/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/es-AR/thunderbird-91.7.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "2eeb70ef1733d7204ac04421ac4dacdb8828c859e9b0207f45a8ecbefb649718";
+      sha256 = "e43babb45d6bffed8e2f27b7a21c211306322cec480b928124118b6bf999b6f9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/es-ES/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/es-ES/thunderbird-91.7.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "980a281ad7e1f0b137bf12022c2a2b103dd3022607bae77311a2dc6fb0db6b97";
+      sha256 = "eead62cde35d787634bb1b6e6e8a96458f05e68d0bb9cd66c3926350d890c5a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/et/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/et/thunderbird-91.7.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "a91f7e379fb911e84fa9a1a77f5d8b15c7123533a39ad0db7923bd6451571b93";
+      sha256 = "c3b4d1ebdc325e6ecd6f35012634ea5f4ffd620de7c30589a8999b128b986d59";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/eu/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/eu/thunderbird-91.7.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "c3ad75fcb81f86dc7df237c1517ee0e9fcea74e09c5bea69e934a5e55f23d47d";
+      sha256 = "b23c783109a22c71bd5b337e2633bf2d17f8ee7b580faa43164b2ce7d70d5c45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fi/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/fi/thunderbird-91.7.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "df15bb410f85783f8c4e77dddd91b75801ccb3b7cbae800b558e4e484d7ed22a";
+      sha256 = "a34afada49c57d6816cfc472681b100366df881fdd343495b959df44dcc8bf5b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/fr/thunderbird-91.7.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "eec2b42190741d90464fa4c96e6c567e785de3c7cfa417a6c001c027ac547129";
+      sha256 = "85c5472de95eb357bba1eb697b17b309ec586717ef09a735cc94b3d7ee069ce3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/fy-NL/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/fy-NL/thunderbird-91.7.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "93b7eec77754a039fbae93075b28a912e0bf5c5553db5f055801a792b7649219";
+      sha256 = "e654bd29cd2a4a99a09d0d7feca2af89cd308d8d9fca6ad1069e5b026e04cee2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ga-IE/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ga-IE/thunderbird-91.7.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "7bdfeadd23365a1a077d952bad918f1b84ebc18d6f0ddc791fccba7ff37fac55";
+      sha256 = "ae2e865abb044bb61f51f46636f84054f87ef0e2d46b0c4d85d990bcb05d45da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/gd/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/gd/thunderbird-91.7.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "bc598051782aad08cab0edb0c4fc7288f3d0d0a58f4bbca6ea15c399af8780e3";
+      sha256 = "54b117bb7ba110de0c3fb5e9c4d2743d54a49b941c273ed7f8c11dae30c1517e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/gl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/gl/thunderbird-91.7.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "fcdf50a161f485eeea7c94fde63abfee5085234e6a2495af655f6e69fb9f262e";
+      sha256 = "bcec6b86c99fd463cbb16974e43fb232bc93e5ff2b1b08b18332000b274eaa67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/he/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/he/thunderbird-91.7.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "d12d9fdcd6904de941059b369e5000e116725e8d440a80aefd590f6942250120";
+      sha256 = "9ab72a7b9a87a75b113421ceef891b3e546a056e48c039f7af20e85a1b17b598";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/hr/thunderbird-91.7.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "d3c55c9171263f254899cf47e2051fab0c2c45e96512bd82349de7313fb4a454";
+      sha256 = "b8ec76e30180214f2c4d2743686e8de374207fbad8677d5801eb941174217834";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hsb/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/hsb/thunderbird-91.7.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "e06c1178134628bdaf16f57d72433ee0e0ed21d1d7d3ddc9e8b72c861922c29a";
+      sha256 = "5d35c9c51d1d94c55cf72901866ce0896770d8939fbbefe234f312f1b18c6b17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hu/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/hu/thunderbird-91.7.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "8111a674ec2b7bd0f124d61fbf1ec426fdd0c86fbc4d923dbf62c8c1d903fbca";
+      sha256 = "dc34328fd070973dd230158679bc34ba79075eaf8c62b4c3d67fc9daa8fd04a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/hy-AM/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/hy-AM/thunderbird-91.7.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "25b55c080f5f039379127271b8bff72440bd79297b88e96d0b93b7d529050612";
+      sha256 = "6e94dca126ef9f60dc8f6086b4396548fbf3db4cd85feba332ee9cdc5c5546e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/id/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/id/thunderbird-91.7.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "029b2928a8acf2977be19fed3f7aba57b5a8bb0ab70d01c5d83f27bdf48183bd";
+      sha256 = "7ef09c4636f141fc19ca67e0787d1a04d4b6856d6bfc57732f1eacc31fe6b437";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/is/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/is/thunderbird-91.7.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "ae74117ec005cdcba771e7de0077a982e0d5d29debd5ccc4de9bd3183ed2606f";
+      sha256 = "8644c28c791152e6de4bf932417328afbcb3ff1832e85ded577d88a045071ceb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/it/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/it/thunderbird-91.7.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "85d772c2de86ef7fec4c17de19fd99b013f7df8765922df46f16d870be6c6781";
+      sha256 = "a17c80fdb39ff828ab0b7d8fb2274a2f9c1dafb4d8657c510e894697f72e6941";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ja/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ja/thunderbird-91.7.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "c6234cc2222d1522adef42df8c3cc1d5da947f8475031901300f927804d60152";
+      sha256 = "50f48c0bb455132ee1a8e7f2a98a7e01688c0517c134dbf706538432615f44ec";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ka/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ka/thunderbird-91.7.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "22c342874a82fc083dc74f29d2852c40d1d60f718cd35e9d7c76cef35de4ab8f";
+      sha256 = "16b4cdc1dda75f62f664f5d0780e4dd9e65c91414fa3c6e546ed9ae39a5f251b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/kab/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/kab/thunderbird-91.7.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "455c17b71f216f5071fd32b9c7b96c464ee5bfe1d3c18964afdd230bcaf86afc";
+      sha256 = "ef2db45999395216684c0cdee16fbaa9ad8a665088d529bcb80df72d442b433b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/kk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/kk/thunderbird-91.7.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "f5556480e9121dd335e286ae0b9233376ced197371d14b181aec8d8311cfc706";
+      sha256 = "fb1e05654c70c6b4361892799bf5e2b2035183407db9cae5307b4191548c3bd9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ko/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ko/thunderbird-91.7.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "badf2b99ba059e60d3f33c714b172f8276adabcd043461c11354eb463aaf3306";
+      sha256 = "ca29bff1b2276510bba6bdaf280ea8a198fc36c77b325e60a4c1f5207a16a7e2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/lt/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/lt/thunderbird-91.7.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "ff701d1181b44b5277f2c8743da2069549b4d13f417c16f839af4796dd305baa";
+      sha256 = "7551bc85a46fa13c4fd7d72b31d34bda108bf5c7831825b7906c153542918f86";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/lv/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/lv/thunderbird-91.7.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "bbfdb1ae9395dcc76f4bb7a6c9317add2ebeaa63541340f8b6de0d8f020c3a6f";
+      sha256 = "a6fd175e80f8f14431500cd272f7a277ab7b210b6d81c4b80c333e34e13260f7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ms/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ms/thunderbird-91.7.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "83ba8a72bef318bcd450171a325702fe2996c471944a777fd460b325119c8cfa";
+      sha256 = "5fcb5b9a0a04957192a40fda0b097a1f781a98d9b18e6165810bbfad96cf188a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nb-NO/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/nb-NO/thunderbird-91.7.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "fa08cca82864940a7b7ea7e9835761b4c6ceb5c2bcb0310c6b347d62ab301ff2";
+      sha256 = "50d5e767ea3c826d3c924d5a50bce2db2eff9b5ada8c2fd10b4bd8c85061e9da";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/nl/thunderbird-91.7.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "8bfe89776537bb81584dee98fbfbc248ab6ff0d6ea245938bb0c6be4b9c1431f";
+      sha256 = "c44d23adedd33715a38aa6a704de273de1034dbf0964698224463a2eb3a22fde";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/nn-NO/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/nn-NO/thunderbird-91.7.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "1b74509b54c3f3394188891c2def0100b9b3c43be4bc603558a23c48d260d498";
+      sha256 = "c2081d7dc420cf97cbfc38901af9e3654bdd00610ad27cfc0a006afb7de003c5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pa-IN/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/pa-IN/thunderbird-91.7.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "4f45285252db5e7a648b3b68ce0854d3c3a63a38aeec2ff5fec5a032eed32247";
+      sha256 = "426e6b686e8cfa660dadda666b7bfdc0a70ccb5db4134e4960cf7c408e88c9e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/pl/thunderbird-91.7.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "8ced6cbaea784c7f0c0b2139831f35b7200ebbd677538080a3c5e7abc1f2eebc";
+      sha256 = "c667bddefd1b82dd4945ca3a4a392f60b27ab7ab56e1b9fece0cac0dc4eb4971";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pt-BR/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/pt-BR/thunderbird-91.7.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "8a24f7027af15dadc69d695460288604a2c4647cf31e953087d179ade207c533";
+      sha256 = "ea24bf62001fa225ed08a05a34f8e5b0579de6c6b79fa08bd28760f41607ffd2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/pt-PT/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/pt-PT/thunderbird-91.7.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "09ea567cb7584cc3f4fe016419e00b0e609f73a2d50c77eada148494ec028764";
+      sha256 = "8676b8fcd019099ede4973fa1e949e63ea06bd5dc599cc6dcc836dc49fdf4470";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/rm/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/rm/thunderbird-91.7.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "c3d36020692139774e0cf1b93c7985eff3afe8c5295e3401b220185b11830068";
+      sha256 = "4aa9681f172a62d5be35c5c4e3ba500253541ef4f8e38eaf37fcb41dac7989c2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ro/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ro/thunderbird-91.7.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "5cbfc9fc4544289c3cd5f13404ae3990501c65fab43b041b115ab6d0f13839cd";
+      sha256 = "12c57824de26d6bfde6e9de1c3d5b5b1481213ce939fc4860c2fc86aaf8d64a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/ru/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/ru/thunderbird-91.7.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "5eebb3c3c133e6a7df15f919df3bcb408833978d52fb17df9b556a47aca6cbc2";
+      sha256 = "3afa7da7eacf0a3479b92a72c3d1f503d62961a9683c9cf5a538da90e5a3bae8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/sk/thunderbird-91.7.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "0d96ae0d24560028c9294dca7f22579eb2f9a7b953f6a7a108c1d69bf25d4b14";
+      sha256 = "1f5b0a28de82f795eb54daf44b8b807fdd30a7bff9dc5d1565adb001d38bd354";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sl/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/sl/thunderbird-91.7.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "99aa913065720bc00e6818f5c05c752a8509f41602ad4dd239a51ff55484f9b6";
+      sha256 = "340026146fd09e3ed7a49a7123898b3d005a147d4988bc2df2c86b173fa088fb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sq/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/sq/thunderbird-91.7.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "583599470bb612ca4d3cf7327d2f327e1d8bb3f9c3c0c201cc6babd3ec1ebff1";
+      sha256 = "64a9d0d4652d2d709aed3aa1e2a09bcf17ce936c0c4c950a27f8784e0a89d995";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/sr/thunderbird-91.7.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "e9417477f1ba60bb59afc14abf95fd6f32628c9c37313659a9ac5c177e2d389f";
+      sha256 = "eb59bc42ef366a5ecf98f20f53113e69cc2f6591008bcccf592bc76dab636945";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/sv-SE/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/sv-SE/thunderbird-91.7.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "80c858fa06feb45012ba9d65c2ca205185633f89f0b2e8c1ed89632e725c851f";
+      sha256 = "0f833b8b7a83b06b2f3cab5bffe94bfe28cbfc043543f73102f6789fdce95e61";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/th/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/th/thunderbird-91.7.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "8ffa993488ce3fd25875a5ba008eab546efec0e51c18a167542f4a3971b01049";
+      sha256 = "149d88dbb883e9eb04584d080d5e746a0165fa9cecc100e1af875414bd2c1154";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/tr/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/tr/thunderbird-91.7.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "a76ac267c21b9dae3696e1a1f24f0e1cab88dd9ebc2a7b9f3e3e8bc17c6c1be3";
+      sha256 = "7b92aa7c7ace49f7e7d0489b5c69a2c1282fc267b3650aec765e194413b6e9e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/uk/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/uk/thunderbird-91.7.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "3b2b760292535779565584aa2cb5048b8945cefcfe61755b8c6508dbcaec889d";
+      sha256 = "217e921fb8d0fb6773ec7b4dabcb9a29293b15d2024353a4b542c8660f93e924";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/uz/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/uz/thunderbird-91.7.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "e5684d4b52097287e9576bf300ecbc557bfcddfe626baa0a939119001da83f92";
+      sha256 = "9428919a2d99f2ae953e50d148ab27200a3d9d8d02e5a8f5615a804468867922";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/vi/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/vi/thunderbird-91.7.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "1a3091986a4f52f61318a95d82a3c205fccb4b11aef5fba88659dc053eb92d49";
+      sha256 = "2ee2b69190e6a5640b378d8a4b1dbe78aff7cae1db131aa162e23ee6626ee215";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/zh-CN/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/zh-CN/thunderbird-91.7.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "50a2976f5ed463559e54468d53ae52a0e01e2c5ab4c16a88432d248c100c4e0f";
+      sha256 = "e0537b6f509428a3721bac1ab4ff4567568d9854ece675a68a7bc2c058176e7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.6.2/linux-i686/zh-TW/thunderbird-91.6.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/91.7.0/linux-i686/zh-TW/thunderbird-91.7.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "227030569512d3cd69567d63d63d02f1db927578d99f07fd517215e3eb0458f2";
+      sha256 = "ec7aec372154e7e7281fd1b2d84068140c50577d8e1f3ad30006092fefc61766";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -10,12 +10,12 @@ in
 rec {
   thunderbird = common rec {
     pname = "thunderbird";
-    version = "91.6.2";
+    version = "91.7.0";
     application = "comm/mail";
     binaryName = pname;
     src = fetchurl {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-      sha512 = "eb1cb06390694872e37830991e16d1e0bd3259cd1fedfed86fd24901f190bc9c274fc1a85cfbba01a0c9cac0d422b62a9b1062d8ba1770fd25bf99528f6df9e0";
+      sha512 = "2afaee16f155edcb0bdb46ebe282a733cf041ec6f562aebd06f8b675e46917f6f500fcc532fc54d74f3f4b0b489a88934a2c6c304f849873de4bc2690b9056a0";
     };
     patches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- High security fixes.
- Other updates and fixes.

https://www.thunderbird.net/en-US/thunderbird/91.7.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2022-12/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
