### PR TITLE
libinput: 1.19.3 → 1.20.0

### DIFF
--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
-, fetchurl
+, fetchFromGitLab
+, gitUpdater
 , pkg-config
 , meson
 , ninja
@@ -44,13 +45,16 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libinput";
-  version = "1.19.3";
+  version = "1.20.0";
 
   outputs = [ "bin" "out" "dev" ];
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/libinput/libinput-${version}.tar.xz";
-    sha256 = "sha256-PK54zN4Z19Dzh+WLxzTU0Xq19kJvVKnotyjJCxe6oGg=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "libinput";
+    repo = "libinput";
+    rev = version;
+    sha256 = "Ey6ItBIrf1POACp2+6R0B4KxJq5V1HoO+y4j6hZSGAE=";
   };
 
   patches = [
@@ -113,8 +117,14 @@ stdenv.mkDerivation rec {
     sed -i "/install_subdir('libinput', install_dir : dir_etc)/d" meson.build
   '';
 
-  passthru.tests = {
-    libinput-module = nixosTests.libinput;
+  passthru = {
+    tests = {
+      libinput-module = nixosTests.libinput;
+    };
+    updateScript = gitUpdater {
+      inherit pname version;
+      patchlevel-unstable = true;
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

https://gitlab.freedesktop.org/libinput/libinput/-/releases/1.19.901
https://gitlab.freedesktop.org/libinput/libinput/-/releases/1.20.0

https://gitlab.freedesktop.org/libinput/libinput/-/compare/1.19.3...1.19.901
https://gitlab.freedesktop.org/libinput/libinput/-/compare/1.19.901...1.20.0

r-ryantm won't work for this update and we are back to fetchFromGitLab again :laughing:

(happy to drop the updateScript if anyone decide r-ryantm + repology is better for this package, I think `patchlevel-unstable` should work here since patchVersion haven't exceed 90 in stable releases so far)

> - High-resolution scroll is more reliable thanks to the inclusion of new heuristics
> - Better handling of BTN_TOOL_PEN on top of BTN_TOOL_RUBBER on graphics tablets that trigger a kernel bug
> - libinput doesn't handle joysticks and gamepads. The detection algorithm has been improved to avoid tagging some of those devices as keyboards
> - Improved clickpad detection
> - New quirks and bug fixing

###### Things done

- [x] Rebuilt my laptop on https://github.com/NixOS/nixpkgs/pull/163554/commits/aac2283c26f138ad43727aac9673fbe9b3d69dff and use it for a while

![屏幕截图 2022-03-14 16 17 16](https://user-images.githubusercontent.com/20080233/158132006-3b91b318-f7a8-43bb-a041-8b7d7a43ac66.png)


- On `x86_64-linux` (aac2283c26f138ad43727aac9673fbe9b3d69dff):
  - [x] built `libinput` with `documentationSupport`, `eventGUISupport`, `testsSupport` enabled
  - [x] built `nixosTests.libinput`, `xorg.xf86inputlibinput`, `touchegg`
  - [x] built `sway`, `nixosTests.sway`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
