### PR TITLE
gitqlient: init at 1.4.3

### DIFF
--- a/pkgs/applications/version-management/gitqlient/default.nix
+++ b/pkgs/applications/version-management/gitqlient/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, mkDerivation
+, fetchFromGitHub
+, qmake
+, qtwebengine
+, gitUpdater
+}:
+
+mkDerivation rec {
+  pname = "gitqlient";
+  version = "1.4.3";
+
+  src = fetchFromGitHub {
+    owner = "francescmm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "018jz6b28zwr205jmgw13ddlfvlhxqf0cw1pfjiwsi6i8gay7w6s";
+  };
+
+  nativeBuildInputs = [
+    qmake
+  ];
+
+  buildInputs = [
+    qtwebengine
+  ];
+
+  qmakeFlags = [
+    "GitQlient.pro"
+  ];
+
+  passthru.updateScript = gitUpdater { inherit pname version; };
+
+  meta = with lib; {
+    homepage = "https://github.com/francescmm/GitQlient";
+    description = "Multi-platform Git client written with Qt";
+    license = licenses.lgpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5999,6 +5999,8 @@ with pkgs;
 
   gitaly = callPackage ../applications/version-management/gitlab/gitaly { };
 
+  gitqlient = libsForQt5.callPackage ../applications/version-management/gitqlient { };
+
   gitstats = callPackage ../applications/version-management/gitstats { };
 
   gitstatus = callPackage ../applications/version-management/git-and-tools/gitstatus { };


### PR DESCRIPTION
###### Description of changes

Add [GitClient](https://github.com/francescmm/GitQlient), a multi-platform Git client written with Qt.

Fixes https://github.com/NixOS/nixpkgs/issues/86702.

A continuation of https://github.com/NixOS/nixpkgs/pull/86706.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
