### PR TITLE
pianotrans: init at 1.0

### DIFF
--- a/pkgs/applications/audio/pianotrans/default.nix
+++ b/pkgs/applications/audio/pianotrans/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, fetchFromGitHub
+, python3
+, ffmpeg
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "pianotrans";
+  version = "1.0";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "azuwis";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-6Otup1Yat1dBZdSoR4lDfpytUQ2RbDXC6ieo835Nw+U=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    piano-transcription-inference
+    torch
+    tkinter
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  makeWrapperArgs = [
+    ''--prefix PATH : "${lib.makeBinPath [ ffmpeg ]}"''
+  ];
+
+  meta = with lib; {
+    description = "Simple GUI for ByteDance's Piano Transcription with Pedals";
+    homepage = "https://github.com/azuwis/pianotrans";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azuwis ];
+  };
+}

--- a/pkgs/development/python-modules/piano-transcription-inference/default.nix
+++ b/pkgs/development/python-modules/piano-transcription-inference/default.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, fetchurl
+, librosa
+, matplotlib
+, mido
+, torch
+, torchlibrosa
+}:
+
+buildPythonPackage rec {
+  pname = "piano-transcription-inference";
+  version = "0.0.5";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-nbhuSkXuWrekFxwdNHaspuag+3K1cKwq90IpATBpWPY=";
+  };
+
+  checkpoint = fetchurl {
+    name = "piano-transcription-inference.pth";
+    # The download url can be found in
+    # https://github.com/qiuqiangkong/piano_transcription_inference/blob/master/piano_transcription_inference/inference.py
+    url = "https://zenodo.org/record/4034264/files/CRNN_note_F1%3D0.9677_pedal_F1%3D0.9186.pth?download=1";
+    hash = "sha256-w/qXMHJb9Kdi8cFLyAzVmG6s2gGwJvWkolJc1geHYUE=";
+  };
+
+  propagatedBuildInputs = [
+    librosa
+    matplotlib
+    mido
+    torch
+    torchlibrosa
+  ];
+
+  patches = [
+    # Fix run against librosa 0.9.0
+    # https://github.com/qiuqiangkong/piano_transcription_inference/pull/10
+    (fetchpatch {
+      url = "https://github.com/qiuqiangkong/piano_transcription_inference/commit/b2d448916be771cd228f709c23c474942008e3e8.patch";
+      hash = "sha256-8O4VtFij//k3fhcbMRz4J8Iz4AdOPLkuk3UTxuCSy8U=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace piano_transcription_inference/inference.py --replace \
+      "checkpoint_path='{}/piano_transcription_inference_data/note_F1=0.9677_pedal_F1=0.9186.pth'.format(str(Path.home()))" \
+      "checkpoint_path='$out/share/checkpoint.pth'"
+  '';
+
+  postInstall = ''
+    mkdir "$out/share"
+    ln -s "${checkpoint}" "$out/share/checkpoint.pth"
+  '';
+
+  # Project has no tests.
+  # In order to make pythonImportsCheck work, NUMBA_CACHE_DIR env var need to
+  # be set to a writable dir (https://github.com/numba/numba/issues/4032#issuecomment-488102702).
+  # pythonImportsCheck has no pre* hook, use checkPhase to wordaround that.
+  checkPhase = ''
+    export NUMBA_CACHE_DIR="$(mktemp -d)"
+  '';
+  pythonImportsCheck = [ "piano_transcription_inference" ];
+
+  meta = with lib; {
+    description = "A piano transcription inference package";
+    homepage = "https://github.com/qiuqiangkong/piano_transcription_inference";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azuwis ];
+  };
+}

--- a/pkgs/development/python-modules/torchlibrosa/default.nix
+++ b/pkgs/development/python-modules/torchlibrosa/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, fetchpatch
+, librosa
+, numpy
+, torch
+}:
+
+buildPythonPackage rec {
+  pname = "torchlibrosa";
+  version = "0.0.9";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-+LzejKvLlJIIwWm9rYPCWQDSueIwnG5gbkwNE+wbv0A=";
+  };
+
+  propagatedBuildInputs = [
+    librosa
+    numpy
+    torch
+  ];
+
+  patches = [
+    # Fix run against librosa 0.9.0, https://github.com/qiuqiangkong/torchlibrosa/pull/8
+    (fetchpatch {
+      url = "https://github.com/qiuqiangkong/torchlibrosa/commit/eec7e7559a47d0ef0017322aee29a31dad0572d5.patch";
+      hash = "sha256-c1x3MA14Plm7+lVuqiuLWgSY6FW615qnKbcWAfbrcas=";
+    })
+  ];
+
+  # Project has no tests.
+  # In order to make pythonImportsCheck work, NUMBA_CACHE_DIR env var need to
+  # be set to a writable dir (https://github.com/numba/numba/issues/4032#issuecomment-488102702).
+  # pythonImportsCheck has no pre* hook, use checkPhase to workaround that.
+  checkPhase = ''
+    export NUMBA_CACHE_DIR="$(mktemp -d)"
+  '';
+  pythonImportsCheck = [ "torchlibrosa" ];
+
+  meta = with lib; {
+    description = "PyTorch implemention of part of librosa functions";
+    homepage = "https://github.com/qiuqiangkong/torchlibrosa";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azuwis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31606,6 +31606,8 @@ with pkgs;
 
   pianoteq = callPackage ../applications/audio/pianoteq { };
 
+  pianotrans = callPackage ../applications/audio/pianotrans { };
+
   picard = callPackage ../applications/audio/picard { };
 
   picocom = callPackage ../tools/misc/picocom {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11349,6 +11349,8 @@ self: super: with self; {
 
   torchinfo = callPackage ../development/python-modules/torchinfo { };
 
+  torchlibrosa = callPackage ../development/python-modules/torchlibrosa { };
+
   torchvision = callPackage ../development/python-modules/torchvision { };
 
   torchvision-bin = callPackage ../development/python-modules/torchvision/bin.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6960,6 +6960,8 @@ self: super: with self; {
 
   pi1wire = callPackage ../development/python-modules/pi1wire { };
 
+  piano-transcription-inference = callPackage ../development/python-modules/piano-transcription-inference { };
+
   piccata = callPackage ../development/python-modules/piccata { };
 
   pick = callPackage ../development/python-modules/pick { };


### PR DESCRIPTION
###### Description of changes

Add new pakcages:

`pianotrans`: Simple GUI for ByteDance's Piano Transcription with Pedals https://github.com/azuwis/pianotrans
`piano-transcription-inference`: A piano transcription inference package https://github.com/qiuqiangkong/piano_transcription_inference
`torchlibrosa`: PyTorch implemention of part of librosa functions https://github.com/qiuqiangkong/torchlibrosa

`pianotrans` depends on `piano-transcription-inference` and `torchlibrosa`.

aarch64-darwin needs https://github.com/NixOS/nixpkgs/pull/161668

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
