### PR TITLE
swtpm: fix build on darwin

### DIFF
--- a/pkgs/tools/security/swtpm/default.nix
+++ b/pkgs/tools/security/swtpm/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "swtpm";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "stefanberger";
     repo = "swtpm";
     rev = "v${version}";
-    sha256 = "sha256-LJQF8PlRkhCJ8rjZzDetg1BFuTb7GBJ8lW6u5hO134k=";
+    sha256 = "sha256-qeyPCJTNnwuaCosHzqnrQc0JNznGBfDTLsuDmuKREjU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/swtpm/default.nix
+++ b/pkgs/tools/security/swtpm/default.nix
@@ -28,23 +28,28 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config unixtools.netstat expect socat
     perl # for pod2man
+    python3
     autoreconfHook
   ];
 
   checkInputs = [
-    python3 which
+    which
   ];
 
   buildInputs = [
     libtpms
-    openssl libtasn1 libseccomp
-    fuse glib json-glib
+    openssl libtasn1
+    glib json-glib
     gnutls
+  ] ++ lib.optionals stdenv.isLinux [
+    fuse
+    libseccomp
   ];
 
   configureFlags = [
-    "--with-cuse"
     "--localstatedir=/var"
+  ] ++ lib.optionals stdenv.isLinux [
+    "--with-cuse"
   ];
 
   postPatch = ''
@@ -56,9 +61,31 @@ stdenv.mkDerivation rec {
 
     # Use the correct path to the certtool binary
     # instead of relying on it being in the environment
-    substituteInPlace src/swtpm_localca/swtpm_localca.c --replace \
+    substituteInPlace src/swtpm_localca/swtpm_localca.c \
+      --replace \
+        '# define CERTTOOL_NAME "gnutls-certtool"' \
+        '# define CERTTOOL_NAME "${gnutls}/bin/certtool"' \
+      --replace \
         '# define CERTTOOL_NAME "certtool"' \
         '# define CERTTOOL_NAME "${gnutls}/bin/certtool"'
+
+    substituteInPlace tests/common --replace \
+        'CERTTOOL=gnutls-certtool;;' \
+        'CERTTOOL=certtool;;'
+
+    # Fix error on macOS:
+    # stat: invalid option -- '%'
+    # This is caused by the stat program not being the BSD version,
+    # as is expected by the test
+    substituteInPlace tests/common --replace \
+        'if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then' \
+        'if [[ "$(uname -s)" =~ (Linux|Darwin|CYGWIN_NT-) ]]; then'
+
+    # Otherwise certtool seems to pick up the system language on macOS,
+    # which might cause a test to fail
+    substituteInPlace tests/test_swtpm_setup_create_cert --replace \
+        '$CERTTOOL' \
+        'LC_ALL=C.UTF-8 $CERTTOOL'
   '';
 
   doCheck = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build on darwin. Note that because netstat still uses `openssl-1.0.2u` on darwin, building this requires `NIXPKGS_ALLOW_INSECURE=1`. See #101229 and #150880.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
