### PR TITLE
nixVersions: add cachix, hci to passthru.tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -864,11 +864,11 @@ self: super: builtins.intersectAttrs super {
 
   rel8 = addTestToolDepend pkgs.postgresql super.rel8;
 
-  cachix = generateOptparseApplicativeCompletion "cachix" (super.cachix.override { nix = pkgs.nixVersions.nix_2_4; });
+  cachix = generateOptparseApplicativeCompletion "cachix" (super.cachix.override { nix = pkgs.nixVersions.hercules-ci; });
 
-  hercules-ci-agent = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-agent.override { nix = pkgs.nixVersions.nix_2_4; });
-  hercules-ci-cnix-expr = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-cnix-expr.override { nix = pkgs.nixVersions.nix_2_4; });
-  hercules-ci-cnix-store = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-cnix-store.override { nix = pkgs.nixVersions.nix_2_4; });
+  hercules-ci-agent = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-agent.override { nix = pkgs.nixVersions.hercules-ci; });
+  hercules-ci-cnix-expr = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-cnix-expr.override { nix = pkgs.nixVersions.hercules-ci; });
+  hercules-ci-cnix-store = appendConfigureFlag "-fnix-2_4" (super.hercules-ci-cnix-store.override { nix = pkgs.nixVersions.hercules-ci; });
 
   # Enable extra optimisations which increase build time, but also
   # later compiler performance, so we should do this for user's benefit.

--- a/pkgs/development/haskell-modules/nix-versions-overlay.nix
+++ b/pkgs/development/haskell-modules/nix-versions-overlay.nix
@@ -1,0 +1,29 @@
+# Wire up the alias and passthru.tests for the hercules-ci-cnix-* bindings
+{
+  # Latest nix version supported by haskellPackages.hercules-cnix-* bindings,
+  # used in hercules-ci-agent and cachix.
+  # Aliasing this separately unblocks updates that require a release of the
+  # bindings.
+  hercules-ci-cnix-nix-version ? "nix_2_4"
+
+  # passthru.tests
+, cachix
+, hercules-ci-agent
+, hci
+, lib
+}:
+
+self: super:
+lib.throwIfNot (lib.hasAttr hercules-ci-cnix-nix-version super)
+  "Please restore nixVersions.${hercules-ci-cnix-nix-version} or update the version in ${toString ./nix-versions-overlay.nix}"
+{
+  hercules-ci = self.${hercules-ci-cnix-nix-version};
+  # Add passthru.tests to the original def, so ofborg can always find them.
+  ${hercules-ci-cnix-nix-version} = super.${hercules-ci-cnix-nix-version}.overrideAttrs (o: {
+    passthru = o.passthru or { } // {
+      tests = o.passthru.tests or { } // {
+        inherit cachix hercules-ci-agent hci;
+      };
+    };
+  });
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33389,11 +33389,11 @@ with pkgs;
 
   neo = callPackage ../applications/misc/neo { };
 
-  nixVersions = recurseIntoAttrs (callPackage ../tools/package-management/nix {
+  nixVersions = recurseIntoAttrs ((callPackage ../tools/package-management/nix {
     storeDir = config.nix.storeDir or "/nix/store";
     stateDir = config.nix.stateDir or "/nix/var";
     inherit (darwin.apple_sdk.frameworks) Security;
-  });
+  }).extend (callPackage ../development/haskell-modules/nix-versions-overlay.nix {}));
 
   nix = nixVersions.stable;
 


### PR DESCRIPTION

###### Description of changes

This will make ofborg build `cachix`, `hci` and `hercules-ci-agent` when Nix is updated or changed, especially for patch updates. 

Nix minor releases will progress independently, as they currently do.

#### Implementation notes

A simpler solution wasn't possible because of the requirements
 - use a separate pin (as the bindings often need a new release)
 - add the passthru.tests to the correct version
 - specify the version only once (prone to bitrot otherwise)

... and the technical requirement that a dynamic attribute can not
redefine an attribute.
An overlay gives us a `super` attrset, which is perfect for the task.
The separation of concerns is also neat, imo.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
