### PR TITLE
nix-tour: refactor, add desktop entry, 0.0.1 -> unstable-2022-01-03

### DIFF
--- a/pkgs/applications/misc/nix-tour/default.nix
+++ b/pkgs/applications/misc/nix-tour/default.nix
@@ -1,35 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, electron, runtimeShell } :
+{ lib
+, stdenv
+, fetchFromGitHub
+, electron
+, runtimeShell
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   pname = "nix-tour";
   version = "0.0.1";
 
-  buildInputs = [ electron ];
-
   src = fetchFromGitHub {
     owner = "nixcloud";
     repo = "tour_of_nix";
     rev = "v${version}";
-    sha256 = "sha256-a/P2ZMc9OpM4PxRFklSO6oVCc96AGWkxtGF/EmnfYSU=";
+    sha256 = "09b1vxli4zv1nhqnj6c0vrrl51gaira94i8l7ww96fixqxjgdwvb";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ electron ];
+
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share
-    cp -R * $out/share
-    chmod 0755 $out/share/ -R
-    echo "#!${runtimeShell}" > $out/bin/nix-tour
-    echo "cd $out/share/" >> $out/bin/nix-tour
-    echo "${electron}/bin/electron $out/share/electron-main.js" >> $out/bin/nix-tour
-    chmod 0755 $out/bin/nix-tour
+    install -d $out/bin $out/share/nix-tour
+    cp -R * $out/share/nix-tour
+    makeWrapper ${electron}/bin/electron $out/bin/nix-tour \
+      --add-flags $out/share/nix-tour/electron-main.js
   '';
 
   meta = with lib; {
     description = "'the tour of nix' from nixcloud.io/tour as offline version";
     homepage = "https://nixcloud.io/tour";
     license = licenses.gpl2;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ qknight ];
+    maintainers = with maintainers; [ qknight yuu ];
   };
-
 }

--- a/pkgs/applications/misc/nix-tour/default.nix
+++ b/pkgs/applications/misc/nix-tour/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nix-tour";
-  version = "0.0.1";
+  version = "unstable-2022-01-03";
 
   src = fetchFromGitHub {
     owner = "nixcloud";
     repo = "tour_of_nix";
-    rev = "v${version}";
-    sha256 = "09b1vxli4zv1nhqnj6c0vrrl51gaira94i8l7ww96fixqxjgdwvb";
+    rev = "6a6784983e6dc121574b97eb9b1d03592c8cb9a7";
+    sha256 = "sha256-BhQz59wkwwY0ShXzqUD6MQl4NE/jUik5RbLzseEc5Bc=";
   };
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems ];

--- a/pkgs/applications/misc/nix-tour/default.nix
+++ b/pkgs/applications/misc/nix-tour/default.nix
@@ -4,6 +4,8 @@
 , electron
 , runtimeShell
 , makeWrapper
+, copyDesktopItems
+, makeDesktopItem
 }:
 
 stdenv.mkDerivation rec {
@@ -17,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "09b1vxli4zv1nhqnj6c0vrrl51gaira94i8l7ww96fixqxjgdwvb";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
   buildInputs = [ electron ];
 
   installPhase = ''
@@ -26,6 +28,18 @@ stdenv.mkDerivation rec {
     makeWrapper ${electron}/bin/electron $out/bin/nix-tour \
       --add-flags $out/share/nix-tour/electron-main.js
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Tour of Nix";
+      genericName = "Tour of Nix";
+      comment =
+        "Interactive programming guide dedicated to the nix programming language";
+      categories = [ "Development" "Documentation" ];
+      exec = "nix-tour";
+    })
+  ];
 
   meta = with lib; {
     description = "'the tour of nix' from nixcloud.io/tour as offline version";

--- a/wklkl
+++ b/wklkl
@@ -1,3 +1,0 @@
-review 165492
-
-gnome3.eog gnome3.gnome-disk-utility lsd qbittorrent ripgrep sway

--- a/wklkl
+++ b/wklkl
@@ -1,0 +1,3 @@
+review 165492
+
+gnome3.eog gnome3.gnome-disk-utility lsd qbittorrent ripgrep sway


### PR DESCRIPTION
###### Description of changes
refactor, add desktop entry, 0.0.1 -> unstable-2022-01-03

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
