### PR TITLE
python3Packages.opensfm: refactor after upstreaming cmake patch

### DIFF
--- a/pkgs/development/python-modules/opensfm/default.nix
+++ b/pkgs/development/python-modules/opensfm/default.nix
@@ -117,7 +117,7 @@ buildPythonPackage rec {
   meta = {
     maintainers = [ lib.maintainers.SomeoneSerge ];
     license = lib.licenses.bsd2;
-    changelog = "${src.meta.homepage}/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/mapillary/OpenSfM/blob/${src.rev}/CHANGELOG.md";
     description = "Open source Structure-from-Motion pipeline from Mapillary";
     homepage = "https://opensfm.org/";
   };

--- a/pkgs/development/python-modules/opensfm/default.nix
+++ b/pkgs/development/python-modules/opensfm/default.nix
@@ -44,7 +44,7 @@ let
 in
 buildPythonPackage rec {
   pname = "OpenSfM";
-  version = "0.5.2pre";
+  version = "unstable-2022-03-10";
 
   src = fetchFromGitHub {
     owner = "mapillary";

--- a/pkgs/development/python-modules/opensfm/default.nix
+++ b/pkgs/development/python-modules/opensfm/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
     owner = "mapillary";
     repo = pname;
     rev = "536b6e1414c8a93f0815dbae85d03749daaa5432";
-    sha256 = "sha256-Nfl20dFF2PKOkIvHbRxu1naU+qhz4whLXJvX5c5Wnwo=";
+    sha256 = "Nfl20dFF2PKOkIvHbRxu1naU+qhz4whLXJvX5c5Wnwo=";
   };
   patches = [
     ./0002-cmake-find-system-distributed-gtest.patch

--- a/pkgs/development/python-modules/opensfm/default.nix
+++ b/pkgs/development/python-modules/opensfm/default.nix
@@ -117,6 +117,7 @@ buildPythonPackage rec {
   meta = {
     maintainers = [ lib.maintainers.SomeoneSerge ];
     license = lib.licenses.bsd2;
+    changelog = "${src.meta.homepage}/blob/${src.rev}/CHANGELOG.md";
     description = "Open source Structure-from-Motion pipeline from Mapillary";
     homepage = "https://opensfm.org/";
   };

--- a/pkgs/development/python-modules/opensfm/default.nix
+++ b/pkgs/development/python-modules/opensfm/default.nix
@@ -44,19 +44,15 @@ let
 in
 buildPythonPackage rec {
   pname = "OpenSfM";
-  version = "0.5.2";
+  version = "0.5.2pre";
 
   src = fetchFromGitHub {
     owner = "mapillary";
     repo = pname;
-    rev = "79aa4bdd8bd08dc0cd9e3086d170cedb29ac9760";
-    sha256 = "sha256-dHBrkYwLA1OUxUSoe7DysyeEm9Yy70tIJvAsXivdjrM=";
+    rev = "536b6e1414c8a93f0815dbae85d03749daaa5432";
+    sha256 = "sha256-Nfl20dFF2PKOkIvHbRxu1naU+qhz4whLXJvX5c5Wnwo=";
   };
   patches = [
-    (fetchpatch {
-      url = "https://github.com/mapillary/OpenSfM/pull/872/commits/a76671db11038f3f4dfe5b8f17582fb447ad7dd5.patch";
-      sha256 = "sha256-4nizQiZIjucdydOLrETvs1xdV3qiYqAQ7x1HECKvlHs=";
-    })
     ./0002-cmake-find-system-distributed-gtest.patch
     ./0003-cmake-use-system-pybind11.patch
     ./0004-pybind_utils.h-conflicts-with-nixpkgs-pybind.patch


### PR DESCRIPTION
###### Description of changes

- The patch that fixes eigen/ceres discovery in CMake has been [merged upstream](https://github.com/mapillary/OpenSfM/pull/872). Neither the previous nor the new revision have been released yet, so I'm just updating to the latest one and removing the redundant patch
- Added changelog URL

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
