### PR TITLE
lib.types: Add postTransform

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -153,6 +153,9 @@ checkConfigOutput '^12$' config.value ./declare-coerced-value-unsound.nix
 checkConfigError 'A definition for option .* is not of type .*. Definition values:\n\s*- In .*: "1000"' config.value ./declare-coerced-value-unsound.nix ./define-value-string-bigint.nix
 checkConfigError 'json.exception.parse_error' config.value ./declare-coerced-value-unsound.nix ./define-value-string-arbitrary.nix
 
+# Check transformed value
+checkConfigOutput '^"42"$' config.value ./declare-transformed-value.nix
+
 # Check mkAliasOptionModule.
 checkConfigOutput '^true$' config.enable ./alias-with-priority.nix
 checkConfigOutput '^true$' config.enableAlias ./alias-with-priority.nix

--- a/lib/tests/modules/declare-transformed-value.nix
+++ b/lib/tests/modules/declare-transformed-value.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+
+{
+  options = {
+    value = lib.mkOption {
+      default = 42;
+      type = lib.types.postTransform builtins.toString lib.types.int;
+    };
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -742,6 +742,36 @@ rec {
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
+    # Apply a function after merging.
+    #
+    # A safe alternative to `t // { merge = f t.merge; }` that refuses to be
+    # forgotten by type merging.
+    #
+    # Try to avoid post-composing functions to types, because it does not
+    # support type merging and may hide information that could be relevant for
+    # other modules and for debugging.
+    #
+    # However, if you do need to post-compose a function to a type, use this
+    # combinator, as it won't cause the post-composition to be forgotten by
+    # the type merging algorithm; a problem which occurs with `//`-based
+    # type modifications on type-mergeable types.
+    #
+    # One known use case is usage inside `freeformType`, where the freeform
+    # values are deprecated and need special treatment.
+    postTransform = f: type: mkOptionType {
+      name = "postTransform";
+      description = "transformed ${type.description}";
+      check = type.check;
+      merge = loc: defs: f (type.merge loc defs);
+      nestedTypes.type = type;
+      # Does not support type-merging, as functions do not compose commutatively.
+      # That said, we could treat null as the identity function and treat
+      # it specially, as it does compose.
+      # However, that does not solve the problem that we can't type-merge a
+      # `postTransform $x` and an `$x`, as one may expect to be able to.
+      # For the best ux, postTransform should probably get special treatment
+      # in the type merging algorithm.
+    };
   };
 };
 


### PR DESCRIPTION
###### Description of changes

From the doc:

Apply a function after merging.
    
A safe alternative to `t // { merge = f t.merge; }` that refuses to be forgotten by type merging.
    
Try to avoid post-composing functions to types, because it does no  support type merging and may hide information that could be relevant for other modules and for debugging.

However, if you do need to post-compose a function to a type, use this combinator, as it won't cause the post-composition to be forgotten by  the type merging algorithm; a problem which occurs with `//`-based type modifications on type-mergeable types.

 One known use case is usage inside `freeformType`, where the freeform values are deprecated and need special treatment.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
