### PR TITLE
sabnzbd: use sabyenc3 4.0.0

### DIFF
--- a/pkgs/development/python-modules/sabyenc3/4.x.nix
+++ b/pkgs/development/python-modules/sabyenc3/4.x.nix
@@ -1,0 +1,22 @@
+{ lib, fetchPypi, python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "sabyenc3";
+  version = "4.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-PwwQ2jChKIqh7jJ6E2hkqPquTDSN4MklghfJ+MkM0n0";
+  };
+
+  # tests are not included in pypi distribution
+  doCheck = false;
+
+  meta = {
+    description = "yEnc Decoding for Python 3";
+    homepage = "https://github.com/sabnzbd/sabyenc/";
+    license = lib.licenses.lgpl3;
+    maintainers = [ lib.maintainers.lovek323 ];
+  };
+
+}

--- a/pkgs/servers/sabnzbd/default.nix
+++ b/pkgs/servers/sabnzbd/default.nix
@@ -17,7 +17,7 @@ let
     cryptography
     configobj
     feedparser
-    sabyenc3
+    sabyenc3_4
     puremagic
     guessit
     pysocks

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8917,6 +8917,8 @@ in {
 
   sabyenc3 = callPackage ../development/python-modules/sabyenc3 { };
 
+  sabyenc3_4 = callPackage ../development/python-modules/sabyenc3/4.x.nix { };
+
   sabyenc = callPackage ../development/python-modules/sabyenc { };
 
   sacn = callPackage ../development/python-modules/sacn { };


### PR DESCRIPTION
###### Description of changes

SABnzbd requires `sabyenc3` at version `4.0.0`, but it was updated to `5.0.1`.
I've added a `sabyenc3_4` Python module so that we can require that explicitly
in the SABnzbd definition.

This fixes the error:

```
SABYenc disabled: no correct version found! (Found v5.0.1, expecting v4.0.0)
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
