### PR TITLE
lib.types: Add deferredModule

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -467,7 +467,9 @@ rec {
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
-        config = addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
+        config =
+          lib.throwIfNot (isAttrs m) "module ${file} (${key}) does not look like a module."
+          addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -462,14 +462,13 @@ rec {
           config = addFreeformType (addMeta (m.config or {}));
         }
     else
+      lib.throwIfNot (isAttrs m) "module ${file} (${key}) does not look like a module."
       { _file = toString m._file or file;
         key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
-        config =
-          lib.throwIfNot (isAttrs m) "module ${file} (${key}) does not look like a module."
-          addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
+        config = addFreeformType (addMeta (removeAttrs m ["_file" "key" "disabledModules" "require" "imports" "freeformType"]));
       };
 
   applyModuleArgsIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -194,6 +194,9 @@ checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-s
 ## Paths should be allowed as values and work as expected
 checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.nix
 
+## Deferred module
+checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix
+
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -199,6 +199,7 @@ checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.
 checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix
 # errors from the default module are reported with accurate location
 checkConfigError 'In `the-file-that-contains-the-bad-config.nix, via option default'\'': "bogus"' config.nodes.foo.bottom ./deferred-module.nix
+checkConfigError '.*lib/tests/modules/deferred-module-error.nix, via option deferred [(]:anon-1:anon-1:anon-1[)] does not look like a module.' config.result ./deferred-module-error.nix
 
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -198,7 +198,7 @@ checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.
 # default module is merged into nodes.foo
 checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix
 # errors from the default module are reported with accurate location
-checkConfigError 'In `default from the-file-that-contains-the-bad-config.nix'\'': "bogus"' config.nodes.foo.bottom ./deferred-module.nix
+checkConfigError 'In `the-file-that-contains-the-bad-config.nix, via option default'\'': "bogus"' config.nodes.foo.bottom ./deferred-module.nix
 
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -194,8 +194,11 @@ checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-s
 ## Paths should be allowed as values and work as expected
 checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.nix
 
-## Deferred module
+## deferredModule
+# default module is merged into nodes.foo
 checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix
+# errors from the default module are reported with accurate location
+checkConfigError 'In `default from the-file-that-contains-the-bad-config.nix'\'': "bogus"' config.nodes.foo.bottom ./deferred-module.nix
 
 # Check the file location information is propagated into submodules
 checkConfigOutput the-file.nix config.submodule.internalFiles.0 ./submoduleFiles.nix

--- a/lib/tests/modules/deferred-module-error.nix
+++ b/lib/tests/modules/deferred-module-error.nix
@@ -1,0 +1,20 @@
+{ config, lib, ... }:
+let
+  inherit (lib) types mkOption setDefaultModuleLocation evalModules;
+  inherit (types) deferredModule lazyAttrsOf submodule str raw enum;
+in
+{
+  options = {
+    deferred = mkOption {
+      type = deferredModule;
+    };
+    result = mkOption {
+      default = (evalModules { modules = [ config.deferred ]; }).config.result;
+    };
+  };
+  config = {
+    deferred = { ... }:
+      # this should be an attrset, so this fails
+      true;
+  };
+}

--- a/lib/tests/modules/deferred-module.nix
+++ b/lib/tests/modules/deferred-module.nix
@@ -1,0 +1,54 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption setDefaultModuleLocation;
+  inherit (types) deferredModule lazyAttrsOf submodule str raw;
+in
+{
+  imports = [
+    # generic module, declaring submodules:
+    #   - nodes.<name>
+    #   - default
+    # where all nodes include the default
+    ({ config, ... }: {
+      _file = "generic.nix";
+      options.nodes = mkOption {
+        type = lazyAttrsOf (submodule { imports = config.default; });
+        default = {};
+      };
+      options.default = mkOption {
+        type = deferredModule;
+        default = { };
+        description = ''
+          Module that is included in all nodes.
+        '';
+      };
+    })
+
+    {
+      _file = "default-1.nix";
+      default = { config, ... }: {
+        options.settingsDict = lib.mkOption { type = lazyAttrsOf str; default = {}; };
+      };
+    }
+
+    {
+      _file = "default-a-is-b.nix";
+      default = { config, ... }: {
+        settingsDict.a = config.settingsDict.b;
+      };
+    }
+
+    {
+      _file = "nodes-foo.nix";
+      nodes.foo.settingsDict.b = "beta";
+    }
+
+    {
+      _file = "nodes-foo-c-is-a.nix";
+      nodes.foo = { config, ... }: {
+        settingsDict.c = config.settingsDict.a;
+      };
+    }
+
+  ];
+}

--- a/lib/tests/modules/deferred-module.nix
+++ b/lib/tests/modules/deferred-module.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 let
   inherit (lib) types mkOption setDefaultModuleLocation;
-  inherit (types) deferredModule lazyAttrsOf submodule str raw;
+  inherit (types) deferredModule lazyAttrsOf submodule str raw enum;
 in
 {
   imports = [
@@ -28,6 +28,7 @@ in
       _file = "default-1.nix";
       default = { config, ... }: {
         options.settingsDict = lib.mkOption { type = lazyAttrsOf str; default = {}; };
+        options.bottom = lib.mkOption { type = enum []; };
       };
     }
 
@@ -41,6 +42,11 @@ in
     {
       _file = "nodes-foo.nix";
       nodes.foo.settingsDict.b = "beta";
+    }
+
+    {
+      _file = "the-file-that-contains-the-bad-config.nix";
+      default.bottom = "bogus";
     }
 
     {

--- a/lib/tests/modules/deferred-module.nix
+++ b/lib/tests/modules/deferred-module.nix
@@ -12,7 +12,7 @@ in
     ({ config, ... }: {
       _file = "generic.nix";
       options.nodes = mkOption {
-        type = lazyAttrsOf (submodule { imports = config.default; });
+        type = lazyAttrsOf (submodule { imports = [ config.default ]; });
         default = {};
       };
       options.default = mkOption {

--- a/lib/tests/modules/deferred-module.nix
+++ b/lib/tests/modules/deferred-module.nix
@@ -34,9 +34,7 @@ in
 
     {
       _file = "default-a-is-b.nix";
-      default = { config, ... }: {
-        settingsDict.a = config.settingsDict.b;
-      };
+      default = ./define-settingsDict-a-is-b.nix;
     }
 
     {

--- a/lib/tests/modules/define-settingsDict-a-is-b.nix
+++ b/lib/tests/modules/define-settingsDict-a-is-b.nix
@@ -1,0 +1,3 @@
+{ config, ... }: {
+  settingsDict.a = config.settingsDict.b;
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -544,7 +544,7 @@ rec {
       name = "deferredModule";
       description = "module";
       check = t: isAttrs t || isFunction t;
-      merge = loc: defs: map (def: lib.setDefaultModuleLocation "${showOption loc} from ${def.file}" def.value) defs;
+      merge = loc: defs: map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
     };
 
     # The type of a type!

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -549,7 +549,9 @@ rec {
       name = "deferredModule";
       description = "module";
       check = x: isAttrs x || isFunction x || path.check x;
-      merge = loc: defs: staticModules ++ map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
+      merge = loc: defs: {
+        imports = staticModules ++ map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
+      };
       inherit (submoduleWith { modules = staticModules; })
         getSubOptions
         getSubModules;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -539,6 +539,14 @@ rec {
       modules = toList modules;
     };
 
+    # A module to be imported in some other part of the configuration.
+    deferredModule = mkOptionType {
+      name = "deferredModule";
+      description = "module";
+      check = t: isAttrs t || isFunction t;
+      merge = loc: defs: map (def: lib.setDefaultModuleLocation "${showOption loc} from ${def.file}" def.value) defs;
+    };
+
     # The type of a type!
     optionType = mkOptionType {
       name = "optionType";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -543,7 +543,7 @@ rec {
     deferredModule = mkOptionType {
       name = "deferredModule";
       description = "module";
-      check = t: isAttrs t || isFunction t;
+      check = x: isAttrs x || isFunction x || path.check x;
       merge = loc: defs: map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
     };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -540,11 +540,31 @@ rec {
     };
 
     # A module to be imported in some other part of the configuration.
-    deferredModule = mkOptionType {
+    deferredModule = deferredModuleWith { };
+
+    # A module to be imported in some other part of the configuration.
+    # `staticModules`' options will be added to the documentation, unlike
+    # options declared via `config`.
+    deferredModuleWith = attrs@{ staticModules ? [] }: mkOptionType {
       name = "deferredModule";
       description = "module";
       check = x: isAttrs x || isFunction x || path.check x;
-      merge = loc: defs: map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
+      merge = loc: defs: staticModules ++ map (def: lib.setDefaultModuleLocation "${def.file}, via option ${showOption loc}" def.value) defs;
+      inherit (submoduleWith { modules = staticModules; })
+        getSubOptions
+        getSubModules;
+      substSubModules = m: deferredModuleWith (attrs // {
+        staticModules = m;
+      });
+      functor = defaultFunctor "deferredModuleWith" // {
+        type = types.deferredModuleWith;
+        payload = {
+          inherit staticModules;
+        };
+        binOp = lhs: rhs: {
+          staticModules = lhs.staticModules ++ rhs.staticModules;
+        };
+      };
     };
 
     # The type of a type!

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -227,8 +227,9 @@ Value types are types that take a value parameter.
 
     It can be set multiple times.
 
-    Module authors can use its value, which is always a list of module values,
-    in `imports` or in `submoduleWith`'s `modules` parameter.
+    Module authors can use its value in `imports`, in `submoduleWith`'s `modules`
+    or in `evalModules`' `modules` parameter, among other places.
+
     Note that `imports` must be evaluated before the module fixpoint. Because
     of this, deferred modules can only be imported into "other" fixpoints, such
     as submodules.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -220,6 +220,25 @@ Value types are types that take a value parameter.
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
 
+`types.deferredModule`
+
+:   Whereas `submodule` represents an option tree, `deferredModule` represents
+    a module value, such as a module file or a configuration.
+
+    It can be set multiple times.
+
+    Module authors can use its value, which is always a list of module values,
+    in `imports` or in `submoduleWith`'s `modules` parameter.
+    Note that `imports` must be evaluated before the module fixpoint. Because
+    of this, deferred modules can only be imported into "other" fixpoints, such
+    as submodules.
+
+    One use case for this type is the type of a "default" module that allow the
+    user to affect all submodules in an `attrsOf submodule` at once. This is
+    more convenient and discoverable than expecting the module user to
+    type-merge with the `attrsOf submodule` option. NixOps uses this type in
+    `network.defaults`.
+
 ## Composed Types {#sec-option-types-composed}
 
 Composed types are types that take a type as parameter. `listOf

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -237,8 +237,7 @@ Value types are types that take a value parameter.
     One use case for this type is the type of a "default" module that allow the
     user to affect all submodules in an `attrsOf submodule` at once. This is
     more convenient and discoverable than expecting the module user to
-    type-merge with the `attrsOf submodule` option. NixOps uses this type in
-    `network.defaults`.
+    type-merge with the `attrsOf submodule` option.
 
 ## Composed Types {#sec-option-types-composed}
 

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -427,6 +427,40 @@
           </itemizedlist>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term>
+          <literal>types.deferredModule</literal>
+        </term>
+        <listitem>
+          <para>
+            Whereas <literal>submodule</literal> represents an option
+            tree, <literal>deferredModule</literal> represents a module
+            value, such as a module file or a configuration.
+          </para>
+          <para>
+            It can be set multiple times.
+          </para>
+          <para>
+            Module authors can use its value, which is always a list of
+            module values, in <literal>imports</literal> or in
+            <literal>submoduleWith</literal>’s
+            <literal>modules</literal> parameter. Note that
+            <literal>imports</literal> must be evaluated before the
+            module fixpoint. Because of this, deferred modules can only
+            be imported into <quote>other</quote> fixpoints, such as
+            submodules.
+          </para>
+          <para>
+            One use case for this type is the type of a
+            <quote>default</quote> module that allow the user to affect
+            all submodules in an <literal>attrsOf submodule</literal> at
+            once. This is more convenient and discoverable than
+            expecting the module user to type-merge with the
+            <literal>attrsOf submodule</literal> option. NixOps uses
+            this type in <literal>network.defaults</literal>.
+          </para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </section>
   <section xml:id="sec-option-types-composed">

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -460,8 +460,7 @@
             all submodules in an <literal>attrsOf submodule</literal> at
             once. This is more convenient and discoverable than
             expecting the module user to type-merge with the
-            <literal>attrsOf submodule</literal> option. NixOps uses
-            this type in <literal>network.defaults</literal>.
+            <literal>attrsOf submodule</literal> option.
           </para>
         </listitem>
       </varlistentry>

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -441,14 +441,18 @@
             It can be set multiple times.
           </para>
           <para>
-            Module authors can use its value, which is always a list of
-            module values, in <literal>imports</literal> or in
-            <literal>submoduleWith</literal>’s
-            <literal>modules</literal> parameter. Note that
-            <literal>imports</literal> must be evaluated before the
-            module fixpoint. Because of this, deferred modules can only
-            be imported into <quote>other</quote> fixpoints, such as
-            submodules.
+            Module authors can use its value in
+            <literal>imports</literal>, in
+            <literal>submoduleWith</literal><quote>s
+            <literal>modules</literal> or in
+            <literal>evalModules</literal></quote>
+            <literal>modules</literal> parameter, among other places.
+          </para>
+          <para>
+            Note that <literal>imports</literal> must be evaluated
+            before the module fixpoint. Because of this, deferred
+            modules can only be imported into <quote>other</quote>
+            fixpoints, such as submodules.
           </para>
           <para>
             One use case for this type is the type of a


### PR DESCRIPTION
###### Description of changes

Great for submodule defaults. Example: `network.defaults` in NixOps.

Accepts modules, returns a list of modules, with a good default module location.

 I'll quote the docs below. Also look at the example.

`types.deferredModule`

Whereas `submodule` represents an option tree, `deferredModule` represents a module value, such as a module file or a configuration.

It can be set multiple times.

Module authors can use its value, which is always a list of module values, in `imports` or in `submoduleWith`'s `modules` parameter.
Note that `imports` must be evaluated before the module fixpoint. Because of this, deferred modules can only be imported into "other" fixpoints, such as submodules.

One use case for this type is the type of a "default" module that allow the user to affect all submodules in an `attrsOf submodule` at once. This is more convenient and discoverable than expecting the module user to type-merge with the `attrsOf submodule` option.

Refs https://github.com/NixOS/nixops/pull/1508

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
