### PR TITLE
source-{sans,serif}-pro: reintroduce older font versions

### DIFF
--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchzip }:
+
+# Source Sans Pro got renamed to Source Sans 3 (see
+# https://github.com/adobe-fonts/source-sans/issues/192). This is the
+# last version named "Pro". It is useful for backward compatibility
+# with older documents/templates/etc.
+let
+  version = "3.006";
+in fetchzip {
+  name = "source-sans-pro-${version}";
+
+  url = "https://github.com/adobe-fonts/source-sans/archive/${version}R.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+
+  sha256 = "sha256-uWr/dFyLF65v0o6+oN/3RQoe4ziPspzGB1rgiBkoTYY=";
+
+  meta = with lib; {
+    homepage = "https://adobe-fonts.github.io/source-sans/";
+    description = "Sans serif font family for user interface environments";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
+}

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,0 +1,30 @@
+{ lib, fetchzip }:
+
+# Source Serif Pro got renamed to Source Serif 4 (see
+# https://github.com/adobe-fonts/source-serif/issues/77). This is the
+# last version named "Pro". It is useful for backward compatibility
+# with older documents/templates/etc.
+let
+  version = "3.001";
+in fetchzip {
+  name = "source-serif-pro-${version}";
+
+  url = "https://github.com/adobe-fonts/source-serif/releases/download/${version}R/source-serif-pro-${version}R.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/{opentype,truetype,variable}
+    unzip -j $downloadedFile "*/OTF/*.otf" -d $out/share/fonts/opentype
+    unzip -j $downloadedFile "*/TTF/*.ttf" -d $out/share/fonts/truetype
+    unzip -j $downloadedFile "*/VAR/*.otf" -d $out/share/fonts/variable
+  '';
+
+  sha256 = "sha256-rYWk8D41QMuuSP+cQMk8ttT7uX3a7gBk4OqjA7K9udk=";
+
+  meta = with lib; {
+    homepage = "https://adobe-fonts.github.io/source-serif/";
+    description = "Typeface for setting text in many sizes, weights, and languages. Designed to complement Source Sans";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ttuegel ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1123,8 +1123,6 @@ mapAliases ({
   source-han-serif-korean = source-han-serif;
   source-han-serif-simplified-chinese = source-han-serif;
   source-han-serif-traditional-chinese = source-han-serif;
-  source-sans-pro = source-sans; # Added 2021-10-20
-  source-serif-pro = source-serif; # Added 2021-10-20
 
   spaceOrbit = throw "'spaceOrbit' has been renamed to/replaced by 'space-orbit'"; # Converted to throw 2022-02-22
   spectral = neochat; # Added 2020-12-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24239,8 +24239,10 @@ with pkgs;
   source-code-pro = callPackage ../data/fonts/source-code-pro {};
 
   source-sans = callPackage ../data/fonts/source-sans { };
+  source-sans-pro = callPackage ../data/fonts/source-sans-pro { };
 
   source-serif = callPackage ../data/fonts/source-serif { };
+  source-serif-pro = callPackage ../data/fonts/source-serif-pro { };
 
   source-han-code-jp = callPackage ../data/fonts/source-han-code-jp { };
 


### PR DESCRIPTION
###### Description of changes

Recently, Source Sans/Serif Pro fonts got renamed. The "Pro" suffix was replaced with the major version of the font name.

In the case of Source Serif, the change was announced in https://github.com/adobe-fonts/source-serif/issues/77 and besides the name font metric have been changed too. Therefore, documents using the old "Pro" version might look differently when the font is changed to the new "4" version.

In the case of Source Sans, the metrics seem [not to have been changed](https://github.com/adobe-fonts/source-sans/issues/192), but [this comment](https://github.com/adobe-fonts/source-sans/issues/192#issuecomment-790143280) suggests that it might happen in the future.

Due to the above, it makes sense to keep both old "Pro" and new (numbered) fonts as separate packages. This commit reintroduces the old "Pro" versions.

It seems that Arch Linux is also distributing both versions: https://github.com/archlinux/svntogit-packages/blob/0d70461e5a26cde02cadfda64078eb93192c6caa/trunk/PKGBUILD

Closes #157972

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
