### PR TITLE
trace-cmd: 2.9.7 -> 3.1.1

### DIFF
--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -1,18 +1,19 @@
-{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl }:
+{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
-  version = "1.5.1";
+  version = "1.5.3";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
     rev = "libtraceevent-${version}";
-    sha256 = "sha256-g4dB8QhCG6SgZVAU3TCtb70vYYh1KN7FrcldzTGAUnI=";
+    sha256 = "sha256-TaJOwunejEdJz84p3CkGvtR++jN+hXedyxxN+RoeXko=";
   };
 
   # Don't build and install html documentation
   postPatch = ''
     sed -i -e '/^all:/ s/html//' -e '/^install:/ s/install-html//' Documentation/Makefile
+    substituteInPlace scripts/utils.mk --replace /bin/pwd ${coreutils}/bin/pwd
   '';
 
   outputs = [ "out" "dev" "devman" ];

--- a/pkgs/os-specific/linux/libtraceevent/default.nix
+++ b/pkgs/os-specific/linux/libtraceevent/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libtraceevent";
-  version = "1.5.3";
+  version = "1.6.1";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git";
     rev = "libtraceevent-${version}";
-    sha256 = "sha256-TaJOwunejEdJz84p3CkGvtR++jN+hXedyxxN+RoeXko=";
+    sha256 = "sha256-Yt7W+ouEZ/pJEKyY2Cgh+mYG0qz0lOIou5JufAD9Zd0=";
   };
 
   # Don't build and install html documentation

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libtracefs";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
     rev = "libtracefs-${version}";
-    sha256 = "sha256-Kg1mPjTZ2UCeco18Fa8GqmLo2R35XvUE/q2J1HAmtEc=";
+    sha256 = "sha256-jwgDveDSXekHMvvxtK8LYVgeppeZLccSheevVusWYws=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/libtracefs/default.nix
+++ b/pkgs/os-specific/linux/libtracefs/default.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libtracefs";
-  version = "1.3.1";
+  version = "1.4.1";
 
   src = fetchgit {
     url = "git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git";
     rev = "libtracefs-${version}";
-    sha256 = "sha256-jwgDveDSXekHMvvxtK8LYVgeppeZLccSheevVusWYws=";
+    sha256 = "sha256-htif1Hty/AQkx6jALHUVMBF1wIpVwLmdINP8QUZmv/s=";
   };
 
   postPatch = ''

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,12 +1,12 @@
-{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xsl, libxslt, libtraceevent, libtracefs }:
+{ lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libtraceevent, libtracefs, zstd, sourceHighlight }:
 stdenv.mkDerivation rec {
   pname = "trace-cmd";
-  version = "2.9.7";
+  version = "3.0.3";
 
   src = fetchgit {
     url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
     rev    = "trace-cmd-v${version}";
-    sha256 = "sha256-04qsTlOVYh/jHVWxaGuqYj4DkUpcEYcpfUqnqhphIMg=";
+    sha256 = "sha256-28/XEtVlqgD/by0FmvYHAJHKdNi+JHhiM1xPMymuaIY=";
   };
 
   # Don't build and install html documentation
@@ -15,9 +15,9 @@ stdenv.mkDerivation rec {
        Documentation{,/trace-cmd,/libtracecmd}/Makefile
   '';
 
-  nativeBuildInputs = [ asciidoc libxslt pkg-config xmlto ];
+  nativeBuildInputs = [ asciidoc libxslt pkg-config xmlto docbook_xsl docbook_xml_dtd_45 sourceHighlight ];
 
-  buildInputs = [ libtraceevent libtracefs ];
+  buildInputs = [ libtraceevent libtracefs zstd ];
 
   outputs = [ "out" "lib" "dev" "man" ];
 

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchgit, pkg-config, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libtraceevent, libtracefs, zstd, sourceHighlight }:
 stdenv.mkDerivation rec {
   pname = "trace-cmd";
-  version = "3.0.3";
+  version = "3.1.1";
 
   src = fetchgit {
     url    = "git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/";
     rev    = "trace-cmd-v${version}";
-    sha256 = "sha256-28/XEtVlqgD/by0FmvYHAJHKdNi+JHhiM1xPMymuaIY=";
+    sha256 = "sha256-zYw6DObwmroAU3ikUNo9XrwQeDlyLppe7E63WFjn44Q=";
   };
 
   # Don't build and install html documentation
@@ -27,19 +27,28 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   makeFlags = [
-    "all" "libs" "doc"
     # The following values appear in the generated .pc file
     "prefix=${placeholder "lib"}"
-    "libdir=${placeholder "lib"}/lib"
-    "includedir=${placeholder "dev"}/include"
   ];
 
-  installTargets = [ "install_cmd" "install_libs" "install_doc" ];
+  # We do not mention targets (like "doc") explicitly in makeFlags
+  # because the Makefile would not print warnings about too old
+  # libraries (see "warning:" in the Makefile)
+  postBuild = ''
+    make libs doc -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
+  '';
+
+  installTargets = [
+    "install_cmd"
+    "install_libs"
+    "install_doc"
+  ];
   installFlags = [
+    "LDCONFIG=false"
     "bindir=${placeholder "out"}/bin"
-    "man_dir=${placeholder "man"}/share/man"
+    "mandir=${placeholder "man"}/share/man"
     "libdir=${placeholder "lib"}/lib"
-    "pkgconfig_dir=${placeholder "lib"}/lib/pkgconfig"
+    "pkgconfig_dir=${placeholder "dev"}/lib/pkgconfig"
     "includedir=${placeholder "dev"}/include"
     "BASH_COMPLETE_DIR=${placeholder "out"}/share/bash-completion/completions"
   ];


### PR DESCRIPTION
###### Description of changes

New trace-cmd version was released. It needs an libtracefs update. libtraceevent needs not to be updated, but the latest version contains several fixes, which might be useful.

- [trace-cmd release notes 3.0](https://lore.kernel.org/linux-trace-users/20220310164422.41c57c7c@gandalf.local.home/T/#u), [3.1](https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/tag/?h=trace-cmd-v3.1), [3.1.1](https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/tag/?h=trace-cmd-v3.1.1)
- [libtracefs changes](https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/log/?h=libtracefs-1.3.0&qt=range&q=libtracefs-1.3.0..libtracefs-1.3.1), [release notes 1.4.0](https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/tag/?h=libtracefs-1.4.0), [1.4.1](https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/tag/?h=libtracefs-1.4.1)
- [libtraceevent changes](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/log/?qt=range&q=libtraceevent-1.5.1..libtraceevent-1.5.2), [1.6 release notes](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.6.0), [1.6.1](https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/tag/?h=libtraceevent-1.6.1)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
