### PR TITLE
python3Packages.gasp: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/gasp/default.nix
+++ b/pkgs/development/python-modules/gasp/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildPythonPackage, fetchPypi, pythonOlder,
+fetchgit, tkinter, pygame, python3, xvfb-run }:
+
+buildPythonPackage rec {
+  pname = "gasp";
+  version = "0.6.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-3h90H+E0pvDtpT/eQUsLjnnFholbxxk7K66exB6W3vo=";
+  };
+
+  propagatedBuildInputs = [ tkinter pygame ];
+  checkInputs = [ xvfb-run tkinter pygame ];
+
+  dontUsePythonRemoveTestsDir = true;
+
+  checkPhase = ''
+    xvfb-run -s '-screen 0 800x600x24' ${python3.interpreter} tests/test_graphics.py
+  '';
+
+  pythonImportsCheck = [ "gasp" ];
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/GASP/GASP_Code";
+    description = "Module which helps to write 1980's style arcade games.";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ thehedgeh0g ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3363,6 +3363,8 @@ in {
 
   garminconnect = callPackage ../development/python-modules/garminconnect { };
 
+  gasp = callPackage ../development/python-modules/gasp { };
+
   gast = callPackage ../development/python-modules/gast { };
 
   garages-amsterdam = callPackage ../development/python-modules/garages-amsterdam { };


### PR DESCRIPTION
###### Description of changes
Added GASP(Graphics API for Students of Python)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
