### PR TITLE
Export all nixos/modules/profiles from nixpkgs flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,21 @@
       legacyPackages = forAllSystems (system: import ./. { inherit system; });
 
       nixosModules = {
+        # Profiles included by nixos-generate-config
         notDetected = import ./nixos/modules/installer/scan/not-detected.nix;
+
+        # Additional profiles described in the manual
+        allHardware = import ./nixos/modules/profiles/all-hardware.nix;
+        base = import ./nixos/modules/profiles/base.nix;
+        cloneConfig = import ./nixos/modules/profiles/clone-config.nix;
+        demo = import ./nixos/modules/profiles/demo.nix;
+        dockerContainer = import ./nixos/modules/profiles/docker-container.nix;
+        graphical = import ./nixos/modules/profiles/graphical.nix;
+        hardened = import ./nixos/modules/profiles/hardened.nix;
+        headless = import ./nixos/modules/profiles/headless.nix;
+        installationDevice = import ./nixos/modules/profiles/installation-device.nix;
+        minimal = import ./nixos/modules/profiles/minimal.nix;
+        qemuGuest = import ./nixos/modules/profiles/qemu-guest.nix;
       };
     };
 }


### PR DESCRIPTION
###### Description of changes

Exports profiles [described in the manual](https://nixos.org/manual/nixos/stable/index.html#ch-profiles) from the nixpkgs flake as `nixosModules`. 

It cleans up the current somewhat inconvenient source code reference of profiles 

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
  };
  outputs = { self, nixpkgs }: {
    nixosConfigurations.my-desktop = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        "${nixpkgs}/nixos/modules/profiles/hardened"  # <-
        ./configuration.nix
      ];
    };
  };
}
```

Into a more cleanly referenced nixos module:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
  };
  outputs = { self, nixpkgs }: {
    nixosConfigurations.my-desktop = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        nixpkgs.nixosModules.hardened  # <-
        ./configuration.nix
      ];
    };
  };
}
```

It also provides a bit more guidance to people who previously relied on `<nixpkgs/nixos/modules/profiles/hardened.nix>` via `NIX_PATH` and are transitioning to flakes.

This was also suggested in the PR where `nixpkgs.nixosModules.notDetected` was exported https://github.com/NixOS/nixpkgs/pull/68897/commits/26e4d09c9cd847a0453d3edb730b9dfe3b1add57#r336158169.
