### PR TITLE
kubemq: init kubemq-community at 2.2.12 and kubemqctl at 3.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1688,6 +1688,12 @@
     githubId = 355401;
     name = "Brian Hicks";
   };
+  brianmcgee = {
+    name = "Brian McGee";
+    email = "brian@41north.dev";
+    github = "brianmcgee";
+    githubId = 1173648;
+  };
   Br1ght0ne = {
     email = "brightone@protonmail.com";
     github = "Br1ght0ne";

--- a/pkgs/applications/networking/cluster/kubemqctl/default.nix
+++ b/pkgs/applications/networking/cluster/kubemqctl/default.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubemqctl";
+  version = "3.5.1";
+  src = fetchFromGitHub {
+    owner = "kubemq-io";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0daqvd1y6b87xvnpdl2k0sa91zdmp48r0pgp6dvnb2l44ml8a4z0";
+  };
+
+  ldflags = [ "-w" "-s" "-X main.version=${version}" ];
+
+  doCheck = false; # TODO tests are failing
+
+  vendorSha256 = "1agn6i7cnsb5igvvbjzlaa5fgssr5h7h25y440q44bk16jxk6s74";
+
+  meta = {
+    homepage = "https://github.com/kubemq-io/kubemqctl";
+    description = "Kubemqctl is a command line interface (CLI) for Kubemq Kubernetes Message Broker.";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ brianmcgee ];
+  };
+}

--- a/pkgs/servers/kubemq-community/default.nix
+++ b/pkgs/servers/kubemq-community/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubemq-community";
+  version = "2.2.12";
+  src = fetchFromGitHub {
+    owner = "kubemq-io";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "06n3avcqknqzf9y03xqcsg36pwcha29j2psp9xsnir7hrx66zww8";
+  };
+
+  CGO_ENABLED=0;
+
+  ldflags=[ "-w" "-s" "-X main.version=${version}" ];
+
+  doCheck = false;  # grpc tests are flaky
+
+  vendorSha256 = "1sh0dzz8z065964k2gzkzw9p3db3rcf6mv901zym0wqm4p71045w";
+
+  meta = {
+    homepage = "https://github.com/kubemq-io/kubemq-community";
+    description = "KubeMQ Community is the open-source version of KubeMQ, the Kubernetes native message broker.";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ brianmcgee ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26987,6 +26987,8 @@ with pkgs;
   kubernetes = callPackage ../applications/networking/cluster/kubernetes { };
   kubectl = callPackage ../applications/networking/cluster/kubernetes/kubectl.nix { };
 
+  kubemqctl = callPackage ../applications/networking/cluster/kubemqctl { };
+
   kubeseal = callPackage ../applications/networking/cluster/kubeseal { };
 
   kubernix = callPackage ../applications/networking/cluster/kubernix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15264,6 +15264,8 @@ with pkgs;
 
   kubei = callPackage ../tools/security/kubei { };
 
+  kubemq-community = callPackage ../servers/kubemq-community { };
+
   kubeone = callPackage ../applications/networking/cluster/kubeone { };
 
   kubeprompt = callPackage ../development/tools/kubeprompt { };


### PR DESCRIPTION
###### Description of changes

Introduces the community edition of the [KubeMQ](https://kubemq.io) server and it's associated cli. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
