### PR TITLE
nixos/earlyoom: bring the module up to date

### DIFF
--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -78,10 +78,17 @@ in
       '';
     };
 
+    reportInterval = mkOption {
+      type = types.int;
+      default = 3600;
+      example = 0;
+      description = "Interval (in seconds) at which a memory report is printed (set to 0 to disable).";
+    };
+
     extraArgs = mkOption {
       type = types.listOf types.str;
       default = [];
-      example = [ "-r 60" "-g" "--prefer '(^|/)(java|chromium)$'" ];
+      example = [ "-g" "--prefer '(^|/)(java|chromium)$'" ];
       description = "Extra command-line arguments to be passed to earlyoom.";
     };
   };
@@ -112,6 +119,7 @@ in
           "${pkgs.earlyoom}/bin/earlyoom"
           "-m ${toString cfg.freeMemThreshold}"
           "-s ${toString cfg.freeSwapThreshold}"
+          "-r ${toString cfg.reportInterval}"
         ]
         ++ optional cfg.enableDebugInfo "-d"
         ++ optional cfg.enableNotifications "-n"

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -5,8 +5,8 @@ let
 
   inherit (lib)
     mkDefault mkEnableOption mkIf mkOption types
-    mkRemovedOptionModule
-    concatStringsSep optional;
+    mkRemovedOptionModule literalExpression
+    escapeShellArg concatStringsSep optional;
 
 in
 {
@@ -35,15 +35,6 @@ in
       '';
     };
 
-    # TODO: remove or warn after 1.7 (https://github.com/rfjakob/earlyoom/commit/7ebc4554)
-    ignoreOOMScoreAdjust = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        Ignore oom_score_adjust values of processes.
-      '';
-    };
-
     enableDebugInfo = mkOption {
       type = types.bool;
       default = false;
@@ -63,11 +54,35 @@ in
         local user to DoS your session by spamming notifications.
 
         To actually see the notifications in your GUI session, you need to have
-        <literal>systembus-notify</literal> running as your user which this
-        option handles.
+        <literal>systembus-notify</literal> running as your user, which this
+        option handles by enabling <option>services.systembus-notify</option>.
 
         See <link xlink:href="https://github.com/rfjakob/earlyoom#notifications">README</link> for details.
       '';
+    };
+
+    killHook = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = literalExpression ''
+        pkgs.writeShellScript "earlyoom-kill-hook" '''
+          echo "Process $EARLYOOM_NAME ($EARLYOOM_PID) was killed" >> /path/to/log
+        '''
+      '';
+      description = ''
+        An absolute path to an executable to be run for each process killed.
+        Some environment variables are available, see
+        <link xlink:href="https://github.com/rfjakob/earlyoom#notifications">README</link> and
+        <link xlink:href="https://github.com/rfjakob/earlyoom/blob/master/MANPAGE.md#-n-pathtoscript">the man page</link>
+        for details.
+      '';
+    };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "-r 60" "-g" "--prefer '(^|/)(java|chromium)$'" ];
+      description = "Extra command-line arguments to be passed to earlyoom.";
     };
   };
 
@@ -76,7 +91,11 @@ in
       This option is deprecated and ignored by earlyoom since 1.2.
     '')
     (mkRemovedOptionModule [ "services" "earlyoom" "notificationsCommand" ] ''
-      This option is deprecated and ignored by earlyoom since 1.6.
+      This option was removed in earlyoom 1.6, but was reimplemented in 1.7
+      and is available as the new option `services.earlyoom.killHook`.
+    '')
+    (mkRemovedOptionModule [ "services" "earlyoom" "ignoreOOMScoreAdjust" ] ''
+      This option is deprecated and ignored by earlyoom since 1.7.
     '')
   ];
 
@@ -94,9 +113,10 @@ in
           "-m ${toString cfg.freeMemThreshold}"
           "-s ${toString cfg.freeSwapThreshold}"
         ]
-        ++ optional cfg.ignoreOOMScoreAdjust "-i"
         ++ optional cfg.enableDebugInfo "-d"
         ++ optional cfg.enableNotifications "-n"
+        ++ optional (cfg.killHook != null) "-N ${escapeShellArg cfg.killHook}"
+        ++ cfg.extraArgs
         );
       };
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -132,6 +132,7 @@ in
   domination = handleTest ./domination.nix {};
   dovecot = handleTest ./dovecot.nix {};
   drbd = handleTest ./drbd.nix {};
+  earlyoom = handleTestOn ["x86_64-linux"] ./earlyoom.nix {};
   ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};
   ec2-nixops = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-nixops or {};
   ecryptfs = handleTest ./ecryptfs.nix {};

--- a/nixos/tests/earlyoom.nix
+++ b/nixos/tests/earlyoom.nix
@@ -1,0 +1,16 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "earlyoom";
+  meta = {
+    maintainers = with lib.maintainers; [ ncfavier ];
+  };
+
+  machine = {
+    services.earlyoom = {
+      enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("earlyoom.service")
+  '';
+})

--- a/pkgs/os-specific/linux/earlyoom/default.nix
+++ b/pkgs/os-specific/linux/earlyoom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pandoc, installShellFiles, withManpage ? false }:
+{ lib, stdenv, fetchFromGitHub, pandoc, installShellFiles, withManpage ? false, nixosTests }:
 
 stdenv.mkDerivation rec {
   pname = "earlyoom";
@@ -22,6 +22,10 @@ stdenv.mkDerivation rec {
   '' + lib.optionalString withManpage ''
     installManPage earlyoom.1
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) earlyoom;
+  };
 
   meta = with lib; {
     description = "Early OOM Daemon for Linux";


### PR DESCRIPTION
Removes deprecated option `ignoreOOMScoreAdjust`, introduces `killHook` as a replacement for `notificationsCommand`, and adds an `extraArgs` option for things not covered by the module.

Fixes #132783
Fixes #83504

Untested.

My example `killHook` script sucks, suggestions welcome.
