### PR TITLE
lispPackages: add legit, flow and nbd

### DIFF
--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/flow.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/flow.nix
@@ -1,0 +1,29 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "flow";
+  version = "20200610-git";
+
+  description = "A flowchart and generalised graph library.";
+
+  deps = [ args."closer-mop" args."documentation-utils" args."trivial-indent" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/flow/2020-06-10/flow-20200610-git.tgz";
+    sha256 = "1z1krk1iiz7n1mvpnmqnrgfhicpppb45i0jgkqnrds749xjnx194";
+  };
+
+  packageName = "flow";
+
+  asdFilesToKeep = ["flow.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM flow DESCRIPTION A flowchart and generalised graph library. SHA256
+    1z1krk1iiz7n1mvpnmqnrgfhicpppb45i0jgkqnrds749xjnx194 URL
+    http://beta.quicklisp.org/archive/flow/2020-06-10/flow-20200610-git.tgz MD5
+    f0767467d5e9bfda6fe5777a26719811 NAME flow FILENAME flow DEPS
+    ((NAME closer-mop FILENAME closer-mop)
+     (NAME documentation-utils FILENAME documentation-utils)
+     (NAME trivial-indent FILENAME trivial-indent))
+    DEPENDENCIES (closer-mop documentation-utils trivial-indent) VERSION
+    20200610-git SIBLINGS (flow-visualizer) PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/lambda-fiddle.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/lambda-fiddle.nix
@@ -1,0 +1,27 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "lambda-fiddle";
+  version = "20190710-git";
+
+  description = "A collection of functions to process lambda-lists.";
+
+  deps = [ ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/lambda-fiddle/2019-07-10/lambda-fiddle-20190710-git.tgz";
+    sha256 = "0v4qjpp9fq9rlxhr5f6mjs5f076xrjk19rl6qgp1ap1ykcrx8k4j";
+  };
+
+  packageName = "lambda-fiddle";
+
+  asdFilesToKeep = ["lambda-fiddle.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM lambda-fiddle DESCRIPTION
+    A collection of functions to process lambda-lists. SHA256
+    0v4qjpp9fq9rlxhr5f6mjs5f076xrjk19rl6qgp1ap1ykcrx8k4j URL
+    http://beta.quicklisp.org/archive/lambda-fiddle/2019-07-10/lambda-fiddle-20190710-git.tgz
+    MD5 78f68f144ace9cb8f634ac14b3414e5e NAME lambda-fiddle FILENAME
+    lambda-fiddle DEPS NIL DEPENDENCIES NIL VERSION 20190710-git SIBLINGS NIL
+    PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/legit.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/legit.nix
@@ -1,0 +1,35 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "legit";
+  version = "20190710-git";
+
+  description = "CL interface to the GIT binary.";
+
+  deps = [ args."alexandria" args."bordeaux-threads" args."cl-ppcre" args."documentation-utils" args."lambda-fiddle" args."simple-inferiors" args."trivial-indent" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/legit/2019-07-10/legit-20190710-git.tgz";
+    sha256 = "0g7cn50qvivsn0w9yszqw2qh22jsj60067pmg5pvwsjm03xdl9s9";
+  };
+
+  packageName = "legit";
+
+  asdFilesToKeep = ["legit.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM legit DESCRIPTION CL interface to the GIT binary. SHA256
+    0g7cn50qvivsn0w9yszqw2qh22jsj60067pmg5pvwsjm03xdl9s9 URL
+    http://beta.quicklisp.org/archive/legit/2019-07-10/legit-20190710-git.tgz
+    MD5 9b380fc23d4bab086df8a0e4a598457a NAME legit FILENAME legit DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME cl-ppcre FILENAME cl-ppcre)
+     (NAME documentation-utils FILENAME documentation-utils)
+     (NAME lambda-fiddle FILENAME lambda-fiddle)
+     (NAME simple-inferiors FILENAME simple-inferiors)
+     (NAME trivial-indent FILENAME trivial-indent) (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (alexandria bordeaux-threads cl-ppcre documentation-utils lambda-fiddle
+     simple-inferiors trivial-indent uiop)
+    VERSION 20190710-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/nbd.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/nbd.nix
@@ -1,0 +1,33 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "nbd";
+  version = "20200925-git";
+
+  parasites = [ "nbd/simple-in-memory" ];
+
+  description = "Network Block Device server library.";
+
+  deps = [ args."bordeaux-threads" args."flexi-streams" args."lisp-binary" args."wild-package-inferred-system" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/nbd/2020-09-25/nbd-20200925-git.tgz";
+    sha256 = "1npq9a8l3mn67n22ywqm8wh6kr9xv9djla2yj2m535gkysrlvnky";
+  };
+
+  packageName = "nbd";
+
+  asdFilesToKeep = ["nbd.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM nbd DESCRIPTION Network Block Device server library. SHA256
+    1npq9a8l3mn67n22ywqm8wh6kr9xv9djla2yj2m535gkysrlvnky URL
+    http://beta.quicklisp.org/archive/nbd/2020-09-25/nbd-20200925-git.tgz MD5
+    f32b7a508ac87c1e179c259b171dc837 NAME nbd FILENAME nbd DEPS
+    ((NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME flexi-streams FILENAME flexi-streams)
+     (NAME lisp-binary FILENAME lisp-binary)
+     (NAME wild-package-inferred-system FILENAME wild-package-inferred-system))
+    DEPENDENCIES
+    (bordeaux-threads flexi-streams lisp-binary wild-package-inferred-system)
+    VERSION 20200925-git SIBLINGS NIL PARASITES (nbd/simple-in-memory)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-inferiors.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/simple-inferiors.nix
@@ -1,0 +1,33 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "simple-inferiors";
+  version = "20200325-git";
+
+  description = "A very simple library to use inferior processes.";
+
+  deps = [ args."alexandria" args."bordeaux-threads" args."documentation-utils" args."trivial-indent" args."uiop" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/simple-inferiors/2020-03-25/simple-inferiors-20200325-git.tgz";
+    sha256 = "15gjizqrazr0ahdda2l6bkv7ii5ax1wckn9mnj5haiv17jba8pn5";
+  };
+
+  packageName = "simple-inferiors";
+
+  asdFilesToKeep = ["simple-inferiors.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM simple-inferiors DESCRIPTION
+    A very simple library to use inferior processes. SHA256
+    15gjizqrazr0ahdda2l6bkv7ii5ax1wckn9mnj5haiv17jba8pn5 URL
+    http://beta.quicklisp.org/archive/simple-inferiors/2020-03-25/simple-inferiors-20200325-git.tgz
+    MD5 f90ae807c10d5b3c4b9eef1134a537c8 NAME simple-inferiors FILENAME
+    simple-inferiors DEPS
+    ((NAME alexandria FILENAME alexandria)
+     (NAME bordeaux-threads FILENAME bordeaux-threads)
+     (NAME documentation-utils FILENAME documentation-utils)
+     (NAME trivial-indent FILENAME trivial-indent) (NAME uiop FILENAME uiop))
+    DEPENDENCIES
+    (alexandria bordeaux-threads documentation-utils trivial-indent uiop)
+    VERSION 20200325-git SIBLINGS NIL PARASITES NIL) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-output/wild-package-inferred-system.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-output/wild-package-inferred-system.nix
@@ -1,0 +1,30 @@
+/* Generated file. */
+args @ { fetchurl, ... }:
+rec {
+  baseName = "wild-package-inferred-system";
+  version = "20200325-git";
+
+  parasites = [ "wild-package-inferred-system/test" ];
+
+  description = "Introduces the wildcards `*' and `**' into package-inferred-system";
+
+  deps = [ args."fiveam" ];
+
+  src = fetchurl {
+    url = "http://beta.quicklisp.org/archive/wild-package-inferred-system/2020-03-25/wild-package-inferred-system-20200325-git.tgz";
+    sha256 = "1ypnpzy9z4zkna29sgl4afc386ksa61302bm5kznxb3zz2v1sjas";
+  };
+
+  packageName = "wild-package-inferred-system";
+
+  asdFilesToKeep = ["wild-package-inferred-system.asd"];
+  overrides = x: x;
+}
+/* (SYSTEM wild-package-inferred-system DESCRIPTION
+    Introduces the wildcards `*' and `**' into package-inferred-system SHA256
+    1ypnpzy9z4zkna29sgl4afc386ksa61302bm5kznxb3zz2v1sjas URL
+    http://beta.quicklisp.org/archive/wild-package-inferred-system/2020-03-25/wild-package-inferred-system-20200325-git.tgz
+    MD5 4dfd9f90d780b1e67640543dd4acbf21 NAME wild-package-inferred-system
+    FILENAME wild-package-inferred-system DEPS ((NAME fiveam FILENAME fiveam))
+    DEPENDENCIES (fiveam) VERSION 20200325-git SIBLINGS (foo-wild) PARASITES
+    (wild-package-inferred-system/test)) */

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -157,6 +157,7 @@ iterate
 jonathan
 jsown
 lack
+legit
 let-plus
 lev
 lfarm-client

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -138,6 +138,7 @@ file-attributes
 fiveam
 flexi-streams
 float-features
+flow
 form-fiddle
 fset
 generic-cl

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-systems.txt
@@ -185,6 +185,7 @@ moptilities
 more-conditions
 mt19937
 named-readtables
+nbd
 net-telent-date
 nibbles
 optima

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -297,6 +297,15 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "wild-package-inferred-system" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."wild-package-inferred-system" or (x: {}))
+       (import ./quicklisp-to-nix-output/wild-package-inferred-system.nix {
+         inherit fetchurl;
+           "fiveam" = quicklisp-to-nix-packages."fiveam";
+       }));
+
+
   "parseq" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."parseq" or (x: {}))
@@ -2707,6 +2716,18 @@ let quicklisp-to-nix-packages = rec {
        (qlOverrides."net-telent-date" or (x: {}))
        (import ./quicklisp-to-nix-output/net-telent-date.nix {
          inherit fetchurl;
+       }));
+
+
+  "nbd" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."nbd" or (x: {}))
+       (import ./quicklisp-to-nix-output/nbd.nix {
+         inherit fetchurl;
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "flexi-streams" = quicklisp-to-nix-packages."flexi-streams";
+           "lisp-binary" = quicklisp-to-nix-packages."lisp-binary";
+           "wild-package-inferred-system" = quicklisp-to-nix-packages."wild-package-inferred-system";
        }));
 
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -3360,6 +3360,17 @@ let quicklisp-to-nix-packages = rec {
        }));
 
 
+  "flow" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."flow" or (x: {}))
+       (import ./quicklisp-to-nix-output/flow.nix {
+         inherit fetchurl;
+           "closer-mop" = quicklisp-to-nix-packages."closer-mop";
+           "documentation-utils" = quicklisp-to-nix-packages."documentation-utils";
+           "trivial-indent" = quicklisp-to-nix-packages."trivial-indent";
+       }));
+
+
   "float-features" = buildLispPackage
     ((f: x: (x // (f x)))
        (qlOverrides."float-features" or (x: {}))

--- a/pkgs/development/lisp-modules/quicklisp-to-nix.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix.nix
@@ -369,6 +369,43 @@ let quicklisp-to-nix-packages = rec {
            "usocket" = quicklisp-to-nix-packages."usocket";
        }));
 
+  "simple-inferiors" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."simple-inferiors" or (x: {}))
+       (import ./quicklisp-to-nix-output/simple-inferiors.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "documentation-utils" = quicklisp-to-nix-packages."documentation-utils";
+           "trivial-indent" = quicklisp-to-nix-packages."trivial-indent";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
+
+
+  "lambda-fiddle" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."lambda-fiddle" or (x: {}))
+       (import ./quicklisp-to-nix-output/lambda-fiddle.nix {
+         inherit fetchurl;
+       }));
+
+
+  "iolib_dot_grovel" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."iolib_dot_grovel" or (x: {}))
+       (import ./quicklisp-to-nix-output/iolib_dot_grovel.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "babel" = quicklisp-to-nix-packages."babel";
+           "cffi" = quicklisp-to-nix-packages."cffi";
+           "iolib_dot_asdf" = quicklisp-to-nix-packages."iolib_dot_asdf";
+           "iolib_dot_base" = quicklisp-to-nix-packages."iolib_dot_base";
+           "iolib_dot_common-lisp" = quicklisp-to-nix-packages."iolib_dot_common-lisp";
+           "iolib_dot_conf" = quicklisp-to-nix-packages."iolib_dot_conf";
+           "split-sequence" = quicklisp-to-nix-packages."split-sequence";
+           "trivial-features" = quicklisp-to-nix-packages."trivial-features";
+           "uiop" = quicklisp-to-nix-packages."uiop";
+       }));
 
   "trivia_dot_quasiquote" = buildLispPackage
     ((f: x: (x // (f x)))
@@ -2968,6 +3005,22 @@ let quicklisp-to-nix-packages = rec {
            "alexandria" = quicklisp-to-nix-packages."alexandria";
            "anaphora" = quicklisp-to-nix-packages."anaphora";
            "lift" = quicklisp-to-nix-packages."lift";
+       }));
+
+
+  "legit" = buildLispPackage
+    ((f: x: (x // (f x)))
+       (qlOverrides."legit" or (x: {}))
+       (import ./quicklisp-to-nix-output/legit.nix {
+         inherit fetchurl;
+           "alexandria" = quicklisp-to-nix-packages."alexandria";
+           "bordeaux-threads" = quicklisp-to-nix-packages."bordeaux-threads";
+           "cl-ppcre" = quicklisp-to-nix-packages."cl-ppcre";
+           "documentation-utils" = quicklisp-to-nix-packages."documentation-utils";
+           "lambda-fiddle" = quicklisp-to-nix-packages."lambda-fiddle";
+           "simple-inferiors" = quicklisp-to-nix-packages."simple-inferiors";
+           "trivial-indent" = quicklisp-to-nix-packages."trivial-indent";
+           "uiop" = quicklisp-to-nix-packages."uiop";
        }));
 
 


### PR DESCRIPTION
###### Description of changes

I just edited the txt file and ran the update script.

@7c6f434c Can you review this please?

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

