### PR TITLE
nodePackages: fix eval

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -228,7 +228,7 @@ let
 
     near-cli = super.near-cli.override {
       nativeBuildInputs = with pkgs; [
-        libusb
+        libusb1
         nodePackages.prebuild-install
         nodePackages.node-gyp-build
         pkg-config


### PR DESCRIPTION
Remove use of aliases so that eval succeeds with allowAliases = false

See https://github.com/NixOS/nixpkgs/pull/158623

https://github.com/NixOS/nixpkgs/blob/0975400071e33a293d5bdfcb9b429d77370879db/pkgs/top-level/aliases.nix#L616