### PR TITLE
pomerium: 0.15.7 -> 0.17.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1324,6 +1324,16 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>pomerium-cli</literal> command has been moved out
+          of the <literal>pomerium</literal> package into the
+          <literal>pomerium-cli</literal> package, following upstream’s
+          repository split. If you are using the
+          <literal>pomerium-cli</literal> command, you should now
+          install the <literal>pomerium-cli</literal> package.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The option
           <link linkend="opt-networking.networkmanager.enableFccUnlock">services.networking.networkmanager.enableFccUnlock</link>
           was added to support FCC unlock procedures. Since release

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -479,6 +479,11 @@ In addition to numerous new and upgraded packages, this release has the followin
   Reason is that the old name has been deprecated upstream.
   Using the old option name will still work, but produce a warning.
 
+- The `pomerium-cli` command has been moved out of the `pomerium` package into
+  the `pomerium-cli` package, following upstream's repository split. If you are
+  using the `pomerium-cli` command, you should now install the `pomerium-cli`
+  package.
+
 - The option
   [services.networking.networkmanager.enableFccUnlock](#opt-networking.networkmanager.enableFccUnlock)
   was added to support FCC unlock procedures. Since release 1.18.4, the ModemManager

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -11,18 +11,17 @@ let
 in
 buildGoModule rec {
   pname = "pomerium";
-  version = "0.15.7";
+  version = "0.17.0";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256:0adlk4ylny1z43x1dw3ny0s1932vhb61hpf5wdz4r65y8k9qyfgr";
+    hash = "sha256:1hv76i6k9f0kp527nxlxqhklsvkh2cmfnqlszmlk2hxij31qnf8q";
   };
 
-  vendorSha256 = "sha256:1fszfbra84pcs8v1h2kf7iy603vf9v2ysg6il76aqmqrxmb1p7nv";
+  vendorSha256 = "sha256:1cq4m5a7z64yg3v1c68d15ilw78il6p53vaqzxgn338zjggr3kig";
   subPackages = [
     "cmd/pomerium"
-    "cmd/pomerium-cli"
   ];
 
   ldflags = let
@@ -74,7 +73,6 @@ buildGoModule rec {
 
   installPhase = ''
     install -Dm0755 $GOPATH/bin/pomerium $out/bin/pomerium
-    install -Dm0755 $GOPATH/bin/pomerium-cli $out/bin/pomerium-cli
   '';
 
   passthru.tests = {

--- a/pkgs/servers/http/pomerium/default.nix
+++ b/pkgs/servers/http/pomerium/default.nix
@@ -4,6 +4,7 @@
 , envoy
 , zip
 , nixosTests
+, pomerium-cli
 }:
 
 let
@@ -77,6 +78,7 @@ buildGoModule rec {
 
   passthru.tests = {
     inherit (nixosTests) pomerium;
+    inherit pomerium-cli;
   };
 
   meta = with lib; {

--- a/pkgs/tools/security/pomerium-cli/default.nix
+++ b/pkgs/tools/security/pomerium-cli/default.nix
@@ -1,0 +1,58 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, pomerium
+}:
+
+let
+  inherit (lib) concatStringsSep concatMap id mapAttrsToList;
+in
+buildGoModule rec {
+  pname = "pomerium-cli";
+  version = pomerium.version;
+  src = fetchFromGitHub {
+    owner = "pomerium";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256:0230b22xjnpykj8bcdahzzlsvlrd63z2cmg6yb246c5ngjs835q1";
+  };
+
+  vendorSha256 = "sha256:0xx22lmh6wip1d1bjrp4lgab3q9yilw54v4lg24lf3xhbsr5si9b";
+  subPackages = [
+    "cmd/pomerium-cli"
+  ];
+
+  ldflags = let
+    # Set a variety of useful meta variables for stamping the build with.
+    setVars = {
+      "github.com/pomerium/cli/version" = {
+        Version = "v${version}";
+        BuildMeta = "nixpkgs";
+        ProjectName = "pomerium-cli";
+        ProjectURL = "github.com/pomerium/cli";
+      };
+    };
+    concatStringsSpace = list: concatStringsSep " " list;
+    mapAttrsToFlatList = fn: list: concatMap id (mapAttrsToList fn list);
+    varFlags = concatStringsSpace (
+      mapAttrsToFlatList (package: packageVars:
+        mapAttrsToList (variable: value:
+          "-X ${package}.${variable}=${value}"
+        ) packageVars
+      ) setVars);
+  in [
+    "${varFlags}"
+  ];
+
+  installPhase = ''
+    install -Dm0755 $GOPATH/bin/pomerium-cli $out/bin/pomerium-cli
+  '';
+
+  meta = with lib; {
+    homepage = "https://pomerium.io";
+    description = "Client-side helper for Pomerium authenticating reverse proxy";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lukegb ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21613,6 +21613,7 @@ with pkgs;
   pflogsumm = callPackage ../servers/mail/postfix/pflogsumm.nix { };
 
   pomerium = callPackage ../servers/http/pomerium { };
+  pomerium-cli = callPackage ../tools/security/pomerium-cli { };
 
   postgrey = callPackage ../servers/mail/postgrey { };
 


### PR DESCRIPTION
###### Description of changes

Bumped Pomerium from 0.15.7 to 0.17.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
