### PR TITLE
python3.pkgs.iodata: init at 0.1.7

### DIFF
--- a/pkgs/development/python-modules/iodata/default.nix
+++ b/pkgs/development/python-modules/iodata/default.nix
@@ -1,0 +1,28 @@
+{ buildPythonPackage, lib, fetchFromGitHub, numpy, scipy, attrs, cython, nose }:
+
+buildPythonPackage rec {
+  pname = "iodata";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "theochem";
+    repo = pname;
+    rev = version;
+    hash = "sha256-Qn2xWFxdS12K92DhdHVzYrBjPRV+vYo7Cs27vkeCaxM=";
+  };
+
+  leaveDotGit = true;
+
+  nativeBuildInputs = [ cython nose ];
+  propagatedBuildInputs = [ numpy scipy attrs ];
+
+  pythonImportsCheck = [ "iodata" "iodata.overlap_accel" ];
+  doCheck = false; # Requires roberto or nose and a lenghtly setup to find the cython modules
+
+  meta = with lib; {
+    description = "Python library for reading, writing, and converting computational chemistry file formats and generating input files";
+    homepage = "https://github.com/theochem/iodata";
+    license = licenses.lgpl3Only;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4080,6 +4080,8 @@ in {
 
   invoke = callPackage ../development/python-modules/invoke { };
 
+  iodata = callPackage ../development/python-modules/iodata { };
+
   iocapture = callPackage ../development/python-modules/iocapture { };
 
   iotawattpy = callPackage ../development/python-modules/iotawattpy { };


### PR DESCRIPTION
###### Description of changes
Adds the iodata python module, which implements useful tools to communicate with various quantum chemistry programs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
