### PR TITLE
jellycli: init at 0.9.1

### DIFF
--- a/pkgs/applications/audio/jellycli/default.nix
+++ b/pkgs/applications/audio/jellycli/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchFromGitHub, buildGoModule, alsa-lib }:
+
+buildGoModule rec {
+  pname = "jellycli";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "tryffel";
+    repo = "jellycli";
+    rev = "v${version}";
+    sha256 = "1awzcxnf175a794rhzbmqxxjss77mfa1yrr0wgdxaivrlkibxjys";
+  };
+
+  vendorSha256 = "02fwsnrhj09m0aa199plpqlsjrwpmrk4c80fszzm07s5vmjqvnfy";
+
+  patches = [
+    # Fixes log file path for tests.
+    ./fix-test-dir.patch
+  ];
+
+  buildInputs = [ alsa-lib ];
+
+  meta = with lib; {
+    description = "Jellyfin terminal client";
+    longDescription = ''
+      Terminal music player, works with Jellyfin (>= 10.6) , Emby (>= 4.4), and
+      Subsonic comptabile servers (API >= 1.16), e.g., Navidrome.
+    '';
+    homepage = "https://github.com/tryffel/jellycli";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ oxzi ];
+  };
+}

--- a/pkgs/applications/audio/jellycli/fix-test-dir.patch
+++ b/pkgs/applications/audio/jellycli/fix-test-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/config/config_test.go b/config/config_test.go
+index 9f63a7e..7e790b8 100644
+--- a/config/config_test.go
++++ b/config/config_test.go
+@@ -110,7 +110,7 @@ func TestInitEmptyConfig(t *testing.T) {
+ 		Subsonic: Subsonic{},
+ 		Player: Player{
+ 			Server:                "jellyfin",
+-			LogFile:               "/tmp/jellycli.log",
++			LogFile:               "/build/jellycli.log",
+ 			LogLevel:              "info",
+ 			AudioBufferingMs:      150,
+ 			HttpBufferingS:        5,

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3369,6 +3369,8 @@ with pkgs;
 
   iotools = callPackage ../tools/misc/iotools { };
 
+  jellycli = callPackage ../applications/audio/jellycli { };
+
   jellyfin = callPackage ../servers/jellyfin { };
 
   jellyfin-media-player = libsForQt5.callPackage ../applications/video/jellyfin-media-player {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Add [jellycli](https://github.com/tryffel/jellycli) as a new package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
