### PR TITLE
nodejs: Fix setup-hook addNodePath quoting

### DIFF
--- a/pkgs/development/web/nodejs/setup-hook.sh
+++ b/pkgs/development/web/nodejs/setup-hook.sh
@@ -1,5 +1,5 @@
 addNodePath () {
-    addToSearchPath NODE_PATH $1/lib/node_modules
+    addToSearchPath NODE_PATH "$1/lib/node_modules"
 }
 
 addEnvHooks "$hostOffset" addNodePath


### PR DESCRIPTION
###### Description of changes

The argument to `addNodePath` previously wasn't being quoted, leading to problems when the argument contains characters interpreted specially by bash, which was happening for me in a usage of [npmlock2nix](https://github.com/nix-community/npmlock2nix).

Ping @svanderburg @Radvendii @0xSbock

###### Things done

- [x] Confirmed that this fixes the problem
- [ ] Rebuilt all changed packages -> No because it includes chromium which takes forever to build and this change can't cause any breakages