### PR TITLE
llvmPackages_rocm.llvm: don't build shared libs

### DIFF
--- a/pkgs/development/compilers/llvm/rocm/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/rocm/llvm/default.nix
@@ -12,7 +12,7 @@
 , zlib
 , debugVersion ? false
 , enableManpages ? false
-, enableSharedLibraries ? !stdenv.hostPlatform.isStatic
+, enableSharedLibraries ? false
 
 , version
 , src
@@ -59,7 +59,7 @@ in stdenv.mkDerivation rec {
     "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
   ];
 
-  postPatch = ''
+  postPatch = lib.optional enableSharedLibraries ''
     substitute '${./outputs.patch}' ./outputs.patch --subst-var lib
     patch -p1 < ./outputs.patch
   '';

--- a/pkgs/development/libraries/rocm-comgr/default.nix
+++ b/pkgs/development/libraries/rocm-comgr/default.nix
@@ -27,15 +27,6 @@ stdenv.mkDerivation rec {
     "-DLLVM_TARGETS_TO_BUILD=\"AMDGPU;X86\""
   ];
 
-  # The comgr build tends to link against the static LLVM libraries
-  # *and* the dynamic library. Linking against both causes errors
-  # about command line options being registered twice. This patch
-  # removes the static library linking.
-  patchPhase = ''
-    sed -e '/^llvm_map_components_to_libnames/,/[[:space:]]*Symbolize)/d' \
-        -i CMakeLists.txt
-  '';
-
   passthru.updateScript = writeScript "update.sh" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl jq common-updater-scripts


### PR DESCRIPTION

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This seems to fix the notorious "CommandLine Error: Option 'xxxxx' registered more than once!" error in applications that use both Mesa and ROCm.

Since Mesa is built with `llvmPackages_latest` and ROCm stuff is built with `llvmPackages_rocm`, applications that use both (such as Blender) end up with two different `libLLVM*.so`s loaded, which breaks things.

This seems like a straightforward way to fix the problem, and since the ROCm stack seems to be the only thing in Nixpkgs that uses `llvmPackages_rocm` this hopefully shouldn't break anything.

While there might be another way to fix this problem that doesn't require disabling the shared libraries, I haven't been able to find it yet, and since this issue seems to affect a lot of people I think it might make sense to merge this fix for now and revisit it later if a better solution is found.

This also removes a small patch to rocm-comgr since there are no longer LLVM shared libraries for it to link against.

Closes #97401, closes #157457.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
