### PR TITLE
doxygen: 1.8.20 -> 1.9.3

### DIFF
--- a/pkgs/development/tools/documentation/doxygen/default.nix
+++ b/pkgs/development/tools/documentation/doxygen/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "doxygen";
-  version = "1.8.20";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "doxygen";
     repo = "doxygen";
     rev = "Release_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    sha256 = "17chvi3i80rj4750smpizf562xjzd2xcv5rfyh997pyvc1zbq5rh";
+    sha256 = "1xfsv31ffrv03qhxlscav0r5mdi3qz4654ib9cq35rvmxfj999bw";
   };
 
   nativeBuildInputs = [
@@ -30,19 +30,20 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE =
     lib.optionalString stdenv.isDarwin "-mmacosx-version-min=10.9";
 
-  enableParallelBuilding = false;
-
   meta = {
     license = lib.licenses.gpl2Plus;
-    homepage = "http://doxygen.nl/";
+    homepage = "https://www.doxygen.nl/";
+    changelog = "https://www.doxygen.nl/manual/changelog.html";
     description = "Source code documentation generator tool";
 
     longDescription = ''
-      Doxygen is a documentation system for C++, C, Java, Objective-C,
-      Python, IDL (CORBA and Microsoft flavors), Fortran, VHDL, PHP,
-      C\#, and to some extent D.  It can generate an on-line
-      documentation browser (in HTML) and/or an off-line reference
-      manual (in LaTeX) from a set of documented source files.
+      Doxygen is the de facto standard tool for generating documentation from
+      annotated C++ sources, but it also supports other popular programming
+      languages such as C, Objective-C, C#, PHP, Java, Python, IDL (Corba,
+      Microsoft, and UNO/OpenOffice flavors), Fortran, VHDL and to some extent
+      D. It can generate an on-line documentation browser (in HTML) and/or an
+      off-line reference manual (in LaTeX) from a set of documented source
+      files.
     '';
 
     platforms = if qt5 != null then lib.platforms.linux else lib.platforms.unix;


### PR DESCRIPTION
###### Description of changes

Latest upstream release: https://www.doxygen.nl/download.html#latestsrc

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  ```console
  $ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
  ...
  7 packages added:
  blas-ilp64 (init at 3) furnace (init at 0.5.6) lapack-ilp64 (init at 3) python310Packages.django_2 (init at 2.2.27) python39Packages.django_2 (init at 2.2.27) wxGTK30-gtk2 (init at 3.0.5) wxGTK31-gtk2 (init at 3.1.5)

  37673 packages updated:
  ...

  11 packages removed:
  pytest-check-hook (†) pytest-check-hook (†) python3.10-bitcoin-price-api (†0.0.4) python3.10-Django (†3.2.12) python3.10-nose-cover3 (†0.1.0) python3.10-pytest (†6.1.2) python3.9-bitcoin-price-api (†0.0.4) python3.9-Django (†3.2.12) python3.9-nose-cover3 (†0.1.0) python3.9-pytest (†6.1.2) zeroc-ice (†3.6.5)
  ```
  I did not try to compile all of these on my laptop.
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).