### PR TITLE
Update makemkv

### DIFF
--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -55,15 +55,15 @@ in mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin                          out/makemkv ../makemkv-bin-${version}/bin/amd64/makemkvcon
-    install -D     -t $out/lib                          out/lib{driveio,makemkv,mmbd}.so.*
-    install -D     -t $out/share/MakeMKV                ../makemkv-bin-${version}/src/share/*
-    install -Dm444 -t $out/share/applications           ../makemkv-oss-${version}/makemkvgui/share/makemkv.desktop
-    install -Dm444 -t $out/share/icons/hicolor/16x16    ../makemkv-oss-${version}/makemkvgui/share/icons/16x16/*
-    install -Dm444 -t $out/share/icons/hicolor/32x32    ../makemkv-oss-${version}/makemkvgui/share/icons/32x32/*
-    install -Dm444 -t $out/share/icons/hicolor/64x64    ../makemkv-oss-${version}/makemkvgui/share/icons/64x64/*
-    install -Dm444 -t $out/share/icons/hicolor/128x128  ../makemkv-oss-${version}/makemkvgui/share/icons/128x128/*
-    install -Dm444 -t $out/share/icons/hicolor/256x256  ../makemkv-oss-${version}/makemkvgui/share/icons/256x256/*
+    install -Dm555 -t $out/bin                              out/makemkv ../makemkv-bin-${version}/bin/amd64/makemkvcon
+    install -D     -t $out/lib                              out/lib{driveio,makemkv,mmbd}.so.*
+    install -D     -t $out/share/MakeMKV                    ../makemkv-bin-${version}/src/share/*
+    install -Dm444 -t $out/share/applications               ../makemkv-oss-${version}/makemkvgui/share/makemkv.desktop
+    install -Dm444 -t $out/share/icons/hicolor/16x16/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/16x16/*
+    install -Dm444 -t $out/share/icons/hicolor/32x32/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/32x32/*
+    install -Dm444 -t $out/share/icons/hicolor/64x64/apps   ../makemkv-oss-${version}/makemkvgui/share/icons/64x64/*
+    install -Dm444 -t $out/share/icons/hicolor/128x128/apps ../makemkv-oss-${version}/makemkvgui/share/icons/128x128/*
+    install -Dm444 -t $out/share/icons/hicolor/256x256/apps ../makemkv-oss-${version}/makemkvgui/share/icons/256x256/*
 
     runHook postInstall
   '';

--- a/pkgs/applications/video/makemkv/default.nix
+++ b/pkgs/applications/video/makemkv/default.nix
@@ -14,21 +14,21 @@
 }:
 
 let
-  version = "1.16.5";
+  version = "1.16.7";
   # Using two URLs as the first one will break as soon as a new version is released
   src_bin = fetchurl {
     urls = [
       "http://www.makemkv.com/download/makemkv-bin-${version}.tar.gz"
       "http://www.makemkv.com/download/old/makemkv-bin-${version}.tar.gz"
     ];
-    sha256 = "1y14yxhjj0sdq0s24qr58m0ddhna2rf0q0w3ny888as4wbqiwvm0";
+    sha256 = "sha256-YjsYW2MmzDZqOMdYlqE0dZ399Qq8hJRQ9BCViNexLHs=";
   };
   src_oss = fetchurl {
     urls = [
       "http://www.makemkv.com/download/makemkv-oss-${version}.tar.gz"
       "http://www.makemkv.com/download/old/makemkv-oss-${version}.tar.gz"
     ];
-    sha256 = "131vdi4gyc996z77rrcqb9nfbd62j8314ai4ib1jnilmrsrk93p5";
+    sha256 = "sha256-TL0PRP/pDg16qsbYi9RYyD0egNDaxuApmR86hiR/Rq8=";
   };
 
 in mkDerivation {


### PR DESCRIPTION
###### Description of changes

[Change log](https://www.makemkv.com/download/) 1.16.7 is mostly a bugfix update released 27.2.2022.

Fixed hicolor icon location to fit with the themes subdirectories.

```
nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
1 package built:
makemkv
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
