### PR TITLE
openswitcher: init at 0.5.0 (packaging not working yet, help requested)

### DIFF
--- a/pkgs/applications/video/openswitcher/default.nix
+++ b/pkgs/applications/video/openswitcher/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchgit
+, gtk3
+, glib
+, gobject-introspection
+, meson
+, pkg-config
+, python3
+, stdenv
+, libhandy
+, ninja
+}:
+
+stdenv.mkDerivation rec {
+  name = "openswitcher-${version}";
+  version="0.5.0";
+
+  src = fetchgit {
+    url = "https://git.sr.ht/~martijnbraam/pyatem";
+    rev = "${version}";
+    sha256 = "a7XdoPpFARx4wKt6osTb4WZpFsG4o+/R1+x83dDB3AQ=";
+  };
+
+  buildInputs = [
+    gtk3
+    libhandy
+  ];
+
+  postPatch = ''
+    # FIXME: Is the postinstall script important? it doesn't work.
+    #patchShebangs build-aux/meson/postinstall.py
+    sed -i -e '/build-aux\/meson\/postinstall\.py/d' meson.build
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    glib
+    gobject-introspection
+    python3.pkgs.pygobject3
+  ];
+
+  meta = with lib; {
+    description = "Open Switcher (for Blackmagic ATEM video mixers)";
+    homepage = "https://openswitcher.org/";
+    license = licenses.lgpl3;
+    broken = true;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8480,6 +8480,8 @@ with pkgs;
 
   opensnitch-ui = libsForQt5.callPackage ../tools/networking/opensnitch/ui.nix { };
 
+  openswitcher = callPackage ../applications/video/openswitcher { };
+
   obexfs = callPackage ../tools/bluetooth/obexfs { };
 
   obexftp = callPackage ../tools/bluetooth/obexftp { };


### PR DESCRIPTION
###### Description of changes

Added `openswitcher`, an open source controller for Black Magic video mixer hardware devices. https://openswitcher.org/

**NOT WORKING YET!**

This packaging doesn't work yet. The build succeeds but the installed scripts can't find the application's Python code, which exists in the same source repository.

I have made various attempts to package this but it hasn't gone well. Maybe someone who knows Nix/Python tooling could help me get it working?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
