### PR TITLE
crow-translate: 2.9.1 → 2.9.2

### DIFF
--- a/pkgs/applications/misc/crow-translate/default.nix
+++ b/pkgs/applications/misc/crow-translate/default.nix
@@ -34,8 +34,8 @@ let
   qonlinetranslator = fetchFromGitHub {
     owner = "crow-translate";
     repo = "QOnlineTranslator";
-    rev = "1.5.2";
-    sha256 = "sha256-iGi25aKwff2hNNx6o4kHZV8gVbEQcMgpTTvop3CoLjM=";
+    rev = "1.5.3";
+    sha256 = "sha256-L8y4vazbWD5SC7itxQOjEcX10w0laewxTOGz+Yd+kVM=";
   };
   circleflags = fetchFromGitHub {
     owner = "HatScripts";
@@ -52,13 +52,13 @@ let
 in
 mkDerivation rec {
   pname = "crow-translate";
-  version = "2.9.1";
+  version = "2.9.2";
 
   src = fetchFromGitHub {
     owner = "crow-translate";
     repo = pname;
     rev = version;
-    sha256 = "sha256-7Zb6PZO8eLeGPEZD37ja+LZydIQdsgy5gMAMtlS4k5Y=";
+    sha256 = "sha256-cxfBdoqGVmtCaXyw6QzXj2V44wKyVal/uqsddwIdvjw=";
   };
 
   patches = [

--- a/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
+++ b/pkgs/applications/misc/crow-translate/dont-fetch-external-libs.patch
@@ -46,7 +46,7 @@ index c92e745..f265f03 100644
  
  FetchContent_Declare(QOnlineTranslator
 -    GIT_REPOSITORY https://github.com/crow-translate/QOnlineTranslator
--    GIT_TAG 1.5.2
+-    GIT_TAG 1.5.3
 +    SOURCE_DIR @qonlinetranslator@
  )
  


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/crow-translate/crow-translate/releases)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
