### PR TITLE
nixos/v2ray: change the type of `config` field

### DIFF
--- a/nixos/modules/services/networking/v2ray.nix
+++ b/nixos/modules/services/networking/v2ray.nix
@@ -2,7 +2,9 @@
 
 with lib;
 
-{
+let
+  json = pkgs.formats.json { };
+in {
   options = {
 
     services.v2ray = {
@@ -39,7 +41,7 @@ with lib;
       };
 
       config = mkOption {
-        type = types.nullOr (types.attrsOf types.unspecified);
+        type = types.nullOr json.type;
         default = null;
         example = {
           inbounds = [{


### PR DESCRIPTION
Currently, the type of `config` is `types.attrsOf types.unspecified`. It results
that the merging of list doesn't perform as expected.

For example, I declare two part of config in two files:

`a.nix`:
```
config = {
  routing = {
    rules = [
      {
        type = "field";
        outboundTag = "direct";
        domain = [ "geosite:cn" ];
      }
    ];
  };
};
```

`b.nix`:
```
config = {
  routing = {
    rules = [
      {
        type = "field";
        outboundTag = "direct";
        ip = [
          "geoip:cn"
          "geoip:private"
        ];
      }
    ];
  };
};
```

After merging, only the content of `b.nix` left, the content of `a.nix` is
removed.

This commit give the right type of config, which makes the merging of config
acts as expected.

---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
