### PR TITLE
[gnome] Pantheon: drop dark style preference patch part 1

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -222,7 +222,6 @@ in
       programs.evince.enable = mkDefault true;
       programs.evince.package = pkgs.pantheon.evince;
       programs.file-roller.enable = mkDefault true;
-      programs.file-roller.package = pkgs.pantheon.file-roller;
 
       # Settings from elementary-default-settings
       environment.etc."gtk-3.0/settings.ini".source = "${pkgs.pantheon.elementary-default-settings}/etc/gtk-3.0/settings.ini";

--- a/pkgs/desktops/gnome/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome/apps/file-roller/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , desktop-file-utils
 , gettext
 , glibcLocales
@@ -22,9 +21,7 @@
 , libarchive
 , libnotify
 , nautilus
-, pantheon
 , unzip
-, withPantheon ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -35,15 +32,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "Bi5rSO1re8o9ONAoY9apsBP0zNNbpvvjXFaYeQDf7Ok=";
   };
-
-  patches = lib.optionals withPantheon [
-    # Make this respect dark mode settings from Pantheon
-    # https://github.com/elementary/fileroller/
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/elementary/fileroller/f183eac36c68c9c9441e72294d4e305cf5fe36ed/fr-application-prefers-color-scheme.patch";
-      sha256 = "sha256-d/sqf4Oen9UrzYqru7Ck15o/6g6WfxRDH/iAGFXgYAA=";
-    })
-  ];
 
   LANG = "en_US.UTF-8"; # postinstall.py
 
@@ -71,8 +59,6 @@ stdenv.mkDerivation rec {
     libarchive
     libnotify
     nautilus
-  ] ++ lib.optionals withPantheon [
-    pantheon.granite
   ];
 
   PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";

--- a/pkgs/desktops/gnome/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome/core/epiphany/default.nix
@@ -11,7 +11,6 @@
 , icu
 , wrapGAppsHook
 , gnome
-, pantheon
 , libportal-gtk3
 , libxml2
 , libxslt
@@ -52,13 +51,6 @@ stdenv.mkDerivation rec {
     # Pantheon specific patches for epiphany
     # https://github.com/elementary/browser
     #
-    # Make this respect dark mode settings from Pantheon
-    # https://github.com/elementary/browser/pull/21
-    # https://github.com/elementary/browser/pull/41
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/elementary/browser/cc17559a7ac6effe593712b4f3d0bbefde6e3b62/dark-style.patch";
-      sha256 = "sha256-RzMUc9P51UN3tRFefzRtMniXR9duOOmLj5eu5gL2TEQ=";
-    })
     # Patch to unlink nav buttons
     # https://github.com/elementary/browser/pull/18
     (fetchpatch {
@@ -110,8 +102,6 @@ stdenv.mkDerivation rec {
     p11-kit
     sqlite
     webkitgtk
-  ] ++ lib.optionals withPantheon [
-    pantheon.granite
   ];
 
   # Tests need an X display

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -85,8 +85,6 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   evince = pkgs.evince.override { withPantheon = true; };
 
-  file-roller = pkgs.gnome.file-roller.override { withPantheon = true; };
-
   sideload = callPackage ./apps/sideload { };
 
   #### DESKTOP
@@ -247,6 +245,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   elementary-screenshot-tool = throw "The ‘pantheon.elementary-screenshot-tool’ alias was removed on 2022-02-02, please use ‘pantheon.elementary-screenshot’ directly."; # added 2021-07-21
 
   extra-elementary-contracts = throw "extra-elementary-contracts has been removed as all contracts have been upstreamed."; # added 2021-12-01
+
+  file-roller = pkgs.gnome.file-roller; # added 2022-03-12
 
   notes-up = throw "The ‘pantheon.notes-up’ alias was removed on 2022-02-02, please use ‘pkgs.notes-up’ directly."; # added 2021-12-18
 


### PR DESCRIPTION
###### Description of changes

Those patches no longer applies ~~and we no longer need them~~ (?).
This is part 1 because looks like we need to bump `libarchive` first (in staging-next) before bumping `evince`...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
