### PR TITLE
[NixOS 21.11] nixos/mattermost: fix evaluation with Nix >= 2.6

### DIFF
--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -7,7 +7,12 @@ let
   cfg = config.services.mattermost;
 
   defaultConfig = builtins.fromJSON (builtins.replaceStrings [ "\\u0026" ] [ "&" ]
-    (readFile "${pkgs.mattermost}/config/config.json")
+    # Use `unsafeDiscardStringContext` to support evaluation with Nix >= 2.6 where the
+    # string passed to `fromJSON` is not allowed to have a context.
+    # This is safe because `config.json` does not reference any store paths.
+    (builtins.unsafeDiscardStringContext
+      (readFile "${pkgs.mattermost}/config/config.json")
+    )
   );
 
   database = "postgres://${cfg.localDatabaseUser}:${cfg.localDatabasePassword}@localhost:5432/${cfg.localDatabaseName}?sslmode=disable&connect_timeout=10";


### PR DESCRIPTION
The following evaluation fails on NixOS 21.11 with Nix versions >= 2.6 and is fixed by this PR:
```bash
read -d '' nixosSystem <<'EOF' || :
(import /path/to/nixpkgs/nixos {
  configuration = { pkgs, lib, ... }: {
    services.mattermost = {
      enable = true;
      siteUrl = "";
    };
    boot.loader.systemd-boot.enable = true;
    fileSystems."/".device = "_";
  };
}).system.outPath
EOF
nix shell nixpkgs/38346f64616c3176f73ad0f20e51557ec0f3d75d#nix_2_6 -c nix eval --impure --expr "$nixosSystem"
```

See also: https://github.com/NixOS/nix/issues/6156