### PR TITLE
Add xschem and gaw

### DIFF
--- a/pkgs/applications/science/electronics/gaw/default.nix
+++ b/pkgs/applications/science/electronics/gaw/default.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, fetchurl
+, lib
+, gtk3
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gaw";
+  version = "20200922";
+
+  src = fetchurl {
+    url = "https://download.tuxfamily.org/gaw/download/gaw3-${version}.tar.gz";
+    sha256 = "0qmap11v470a1yj4ypfvdq6wkfni77ijqpknka8b4fndi62sl4wa";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ gtk3 ];
+
+  meta = with lib; {
+    description = "Gtk Analog Wave viewer";
+    longDescription = ''
+      Gaw is a software tool for displaying analog waveforms from
+      sampled datas, for example from the output of simulators or
+      input from sound cards. Data can be imported to gaw using files,
+      direct tcp/ip connection or directly from the sound card.
+    '';
+    homepage = "http://gaw.tuxfamily.org";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/science/electronics/xschem/default.nix
+++ b/pkgs/applications/science/electronics/xschem/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, fetchFromGitHub
+, lib
+, bison
+, cairo
+, flex
+, libX11
+, libXpm
+, pkg-config
+, tcl
+, tk
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xschem";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "StefanSchippers";
+    repo = "xschem";
+    rev = version;
+    sha256 = "sha256-C57jo8tAbiqQAgf4Xp2lpFGOr6F1knPpFcYxPiqSM4k=";
+  };
+
+  nativeBuildInputs = [ bison flex pkg-config ];
+
+  buildInputs = [ cairo libX11 libXpm tcl tk ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = with lib; {
+    description = "Schematic capture and netlisting EDA tool";
+    longDescription = ''
+      Xschem is a schematic capture program, it allows creation of
+      hierarchical representation of circuits with a top down approach.
+      By focusing on interfaces, hierarchy and instance properties a
+      complex system can be described in terms of simpler building
+      blocks. A VHDL or Verilog or Spice netlist can be generated from
+      the drawn schematic, allowing the simulation of the circuit.
+    '';
+    homepage = "https://xschem.sourceforge.io/stefan/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32734,6 +32734,8 @@ with pkgs;
 
   xoscope = callPackage ../applications/science/electronics/xoscope { };
 
+  xschem = callPackage ../applications/science/electronics/xschem { };
+
   xyce = callPackage ../applications/science/electronics/xyce { };
 
   xyce-parallel = callPackage ../applications/science/electronics/xyce {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32701,6 +32701,8 @@ with pkgs;
 
   fped = callPackage ../applications/science/electronics/fped { };
 
+  gaw = callPackage ../applications/science/electronics/gaw {};
+
   horizon-eda = callPackage ../applications/science/electronics/horizon-eda {};
 
   # this is a wrapper for kicad.base and kicad.libraries


### PR DESCRIPTION
###### Description of changes

Add schematic capture `xschem` and analog waveform viewer `gaw`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
