### PR TITLE
llvmPackages_14.{mlir,flang}: init

### DIFF
--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -130,6 +130,10 @@ let
       inherit (darwin.apple_sdk.frameworks) Foundation Carbon Cocoa;
     };
 
+    mlir = callPackage ./mlir {
+      inherit llvm_meta;
+    };
+
     # Below, is the LLVM bootstrapping logic. It handles building a
     # fully LLVM toolchain from scratch. No GCC toolchain should be
     # pulled in. As a consequence, it is very quick to build different

--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -134,6 +134,10 @@ let
       inherit llvm_meta;
     };
 
+    flang = callPackage ./flang {
+      inherit llvm_meta;
+    };
+
     # Below, is the LLVM bootstrapping logic. It handles building a
     # fully LLVM toolchain from scratch. No GCC toolchain should be
     # pulled in. As a consequence, it is very quick to build different

--- a/pkgs/development/compilers/llvm/14/flang/default.nix
+++ b/pkgs/development/compilers/llvm/14/flang/default.nix
@@ -1,0 +1,60 @@
+{ lib, stdenv, llvm_meta
+, buildLlvmTools
+, symlinkJoin
+, monorepoSrc, runCommand
+, cmake
+, libclang
+, libllvm
+, libxml2
+, lit
+, mlir
+, version
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flang";
+  inherit version;
+
+  src = runCommand "${pname}-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/${pname} "$out"
+    mkdir -p "$out/llvm/utils"
+    cp -r ${monorepoSrc}/llvm/utils/unittest -t "$out/llvm/utils"
+  '';
+
+  sourceRoot = "${src.name}/${pname}";
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libclang libllvm libxml2 mlir ];
+
+  cmakeFlags = [
+    "-DCLANG_DIR=${libclang.dev}/lib/cmake/clang"
+    "-DMLIR_DIR=${mlir.dev}/lib/cmake/mlir"
+    "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.mlir}/bin/mlir-tblgen"
+    "-DLLVM_EXTERNAL_LIT=${lit}/bin/lit"
+    "-DLLVM_LIT_ARGS=-v"
+    "-DLLVM_BUILD_MAIN_SRC_DIR=${src}/llvm"
+  ];
+
+  doCheck = true;
+
+  checkTarget = "check-all";
+
+  # Point tests to new 'tools dir' that contains all tools + llvm-config (from .dev output)
+  # Only need it for /bin but symlinkJoin links over other directories too
+  postPatch =
+    let llvmToolsDir = symlinkJoin { name = "llvm-tools"; paths = [ libllvm libllvm.dev ]; };
+    in ''
+    for x in test/lit.site.cfg.py.in test/Unit/lit.site.cfg.py.in test/NonGtestUnit/lit.site.cfg.py.in; do
+      substituteInPlace "$x" --replace "@LLVM_TOOLS_DIR@" "${llvmToolsDir}/bin"
+    done
+  '';
+
+  meta = llvm_meta // {
+    homepage = "https://flang.llvm.org";
+    description = "LLVM Fortran Compiler";
+  };
+}

--- a/pkgs/development/compilers/llvm/14/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/14/mlir/default.nix
@@ -1,0 +1,88 @@
+{ lib, stdenv, llvm_meta
+, monorepoSrc, runCommand
+, cmake
+, libllvm
+, version
+
+# TODO: python bindings
+# TODO: ROCm, CUDA ?
+# TODO: Tests (unit+lit), not integration
+, enableRunners ? stdenv.hostPlatform == stdenv.buildPlatform
+, enableVulkan ? enableRunners
+, vulkan-headers
+, vulkan-loader
+}:
+
+let
+  # List of runners to build, native-only
+  runners = lib.optionals enableRunners ([
+    "cpu-runner" "spirv-cpu-runner"
+  ] ++ lib.optional enableVulkan "vulkan-runner");
+  # List of binaries to build + install
+  # LLVM_{BUILD,INSTALL}_UTILS=ON doesn't seem to work
+  bins = map (n: "mlir-" + n) (runners ++ [
+    "linalg-ods-yaml-gen" "tblgen" # needed for cross
+    "lsp-server" "opt" "pdll" "reduce" "translate" # misc utilities
+  ]);
+in
+stdenv.mkDerivation rec {
+  pname = "mlir";
+  inherit version;
+
+  src = runCommand "${pname}-src-${version}" {} ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/${pname} "$out"
+  '';
+
+  sourceRoot = "${src.name}/${pname}";
+
+  patches = [
+    ./gnu-install-dirs.patch
+  ];
+
+  outputs = [ "out" "lib" "dev" ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ libllvm ]
+    ++ lib.optionals enableVulkan [ vulkan-headers vulkan-loader ];
+
+  cmakeFlags = [
+    # Documentation suggests packagers may wish to disable, do so until needed
+    "-DMLIR_INSTALL_AGGREGATE_OBJECTS=OFF"
+  ] ++ lib.optionals enableRunners ([
+    "-DMLIR_ENABLE_SPIRV_CPU_RUNNER=ON"
+  ] ++ lib.optional enableVulkan "-DMLIR_ENABLE_VULKAN_RUNNER=ON");
+
+  # Patch around check for being built native (maybe because not built w/LLVM?)
+  postPatch = lib.optionalString enableRunners ''
+    for x in **/CMakeLists.txt; do
+      substituteInPlace "$x" --replace 'if(TARGET ''${LLVM_NATIVE_ARCH})' 'if (1)'
+    done
+  '';
+
+  postBuild = ''
+    make ${lib.concatStringsSep " " bins} -j$NIX_BUILD_CORES -l$NIX_BUILD_CORES
+  '';
+
+  postInstall = ''
+    install -Dm755 -t $out/bin ${lib.concatMapStringsSep " " (x: "bin/${x}") bins}
+
+    mkdir -p $out/share/vim-plugins/
+    cp -r ../utils/vim $out/share/vim-plugins/mlir
+    install -Dt $out/share/emacs/site-lisp ../utils/emacs/mlir-mode.el
+  '';
+
+  meta = llvm_meta // {
+    homepage = "https://mlir.llvm.org";
+    description = "Multi-Level Intermediate Representation";
+    longDescription = ''
+      The MLIR project is a novel approach to building reusable and extensible
+      compiler infrastructure.
+      MLIR aims to address software fragmentation, improve compilation for
+      heterogeneous hardware, significantly reduce the cost of building domain
+      specific compilers, and aid in connecting existing compilers together.
+    '';
+  };
+}
+

--- a/pkgs/development/compilers/llvm/14/mlir/gnu-install-dirs.patch
+++ b/pkgs/development/compilers/llvm/14/mlir/gnu-install-dirs.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/modules/AddMLIR.cmake b/cmake/modules/AddMLIR.cmake
+--- a/cmake/modules/AddMLIR.cmake
++++ b/cmake/modules/AddMLIR.cmake
+@@ -363,8 +363,8 @@ function(add_mlir_library_install name)
+   install(TARGETS ${name}
+     COMPONENT ${name}
+     ${export_to_mlirtargets}
+-    LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+-    ARCHIVE DESTINATION lib${LLVM_LIBDIR_SUFFIX}
++    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
++    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}"
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+     # Note that CMake will create a directory like:
+     #   objects-${CMAKE_BUILD_TYPE}/obj.LibName


### PR DESCRIPTION
###### Description of changes

Add packages for MLIR and Flang.

MLIR: https://mlir.llvm.org/
Flang: https://flang.llvm.org/docs/

Mostly came for packaging MLIR, but flang is nice to have and helps
check that the produced MLIR package is functional.

Note that (for now) using flang to produce binaries requires `gfortran`
available as well.

Editor bits for MLIR are installed as well as mlir-lsp-server.

Includes some of the `runners` for MLIR which are at least neat and while don't
significantly increase closure size, might be a liability should this
end up a dependency of something lighter (size or portability).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).