### PR TITLE
e2fsprogs: build fuse2fs and add output for fuse2fs

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, buildPackages, fetchurl, fetchpatch, pkg-config, libuuid, gettext, texinfo
+, fuse
 , shared ? !stdenv.hostPlatform.isStatic
 , e2fsprogs, runCommand
 }:
@@ -12,11 +13,14 @@ stdenv.mkDerivation rec {
     sha256 = "1fgvwbj9ihz5svzrd2l0s18k16r4qg3wimrniv71fn3vdcg0shxp";
   };
 
-  outputs = [ "bin" "dev" "out" "man" "info" ];
+  # fuse2fs adds 14mb of dependencies
+  outputs = [ "bin" "dev" "out" "man" "info" ]
+    ++ lib.optionals stdenv.isLinux [ "fuse2fs" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ pkg-config texinfo ];
-  buildInputs = [ libuuid gettext ];
+  buildInputs = [ libuuid gettext ]
+    ++ lib.optionals stdenv.isLinux [ fuse ];
 
   # Only use glibc's __GNUC_PREREQ(X,Y) (checks if compiler is gcc version >= X.Y) when using glibc
   patches = if stdenv.hostPlatform.libc == "glibc" then null
@@ -62,6 +66,9 @@ stdenv.mkDerivation rec {
     if [ -f $out/lib/${pname}/e2scrub_all_cron ]; then
       mv $out/lib/${pname}/e2scrub_all_cron $bin/bin/
     fi
+  '' + lib.optionalString stdenv.isLinux ''
+    mkdir -p $fuse2fs/bin
+    mv $bin/bin/fuse2fs $fuse2fs/bin/fuse2fs
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -371,6 +371,7 @@ mapAliases ({
   fslint = throw "fslint has been removed: end of life. Upstream recommends using czkawka (https://qarmin.github.io/czkawka/) instead"; # Added 2022-01-15
   fuse_exfat = throw "'fuse_exfat' has been renamed to/replaced by 'exfat'"; # Converted to throw 2022-02-22
   fuseki = throw "'fuseki' has been renamed to/replaced by 'apache-jena-fuseki'"; # Converted to throw 2022-02-22
+  fuse2fs = if stdenv.isLinux then e2fsprogs.fuse2fs else null; # Added 2022-03-27 preserve, reason: convenience, arch has a package named fuse2fs too.
   fwupdate = throw "fwupdate was merged into fwupd"; # Added 2020-05-19
 
   ### G ###


### PR DESCRIPTION
it adds 14mb of dependencies
which can be significant for initrd

without a separate output
$ du -sch $(nix-store -qR ./result-bin) | sort -h

before fuse dep

618K	/nix/store/w2id1hwv4vv7hvp4slgsyrydrjbfqdxc-libidn2-2.3.2
698K	/nix/store/ki0x4wywp5b7rixwk1miq222wybdl3si-e2fsprogs-1.46.5-bin
732K	/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
747K	/nix/store/8ckxc8biqqfdwyhr0w70jgrcb4h7a4y5-libunistring-0.9.10
853K	/nix/store/kx41yd3yyr9bwrsk85fhhx6qhavfwql6-util-linux-2.37.3-lib
2,3M	/nix/store/7nkr1kzrj5j6vzq952p35g0vzk747xjz-e2fsprogs-1.46.5
16M	/nix/store/4s21k8k7p1mfik0b33r2spq5hq7774k1-glibc-2.33-108
22M	total

after fuse dep

38K	/nix/store/k15b817jqz4ckp8rp1mgpkvvx78xxp2n-shadow-4.8.1-su
112K	/nix/store/bqjh8dc6m5plswxrmmn9x4cpxrrw94lv-zlib-1.2.11
277K	/nix/store/nzw0c7ag22mbyc4xrqyy1q1azq9r8kis-audit-2.8.5
285K	/nix/store/ka1xx3ldpliww27wmskc1yxlgcfisdyf-libcap-ng-0.8.2
371K	/nix/store/mvgg2fk5wwrcmm3wbrjhjn034aivrik2-fuse-2.9.9
618K	/nix/store/w2id1hwv4vv7hvp4slgsyrydrjbfqdxc-libidn2-2.3.2
732K	/nix/store/4nmqxajzaf60yjribkgvj5j54x9yvr1r-bash-5.1-p12
738K	/nix/store/7wi0dn50wgimvfi30i3d4mxz40vcal10-e2fsprogs-1.46.5-bin
747K	/nix/store/8ckxc8biqqfdwyhr0w70jgrcb4h7a4y5-libunistring-0.9.10
853K	/nix/store/kx41yd3yyr9bwrsk85fhhx6qhavfwql6-util-linux-2.37.3-lib
1,3M	/nix/store/043lz8mvyx5vxl058c1i586yqc8ax4ig-glibc-2.33-108-bin
1,7M	/nix/store/fpzbv79ak68sh2sh6mag6jym553wfxws-db-4.8.30
2,3M	/nix/store/9w5l1zrdd21hjxgjp5jnxxr6jibpjxd4-shadow-4.8.1
2,3M	/nix/store/hjmxalhkvvajs2n26b0ry7ns56bh9k9s-e2fsprogs-1.46.5
2,5M	/nix/store/ndnqiz3nnifj1blhg9q626xlmkqq1nmh-gcc-10.3.0-lib
2,8M	/nix/store/pnp5qkmj8m07jl8pghhglfdczz2840r9-linux-pam-1.5.2
2,9M	/nix/store/h25q7c560bchn326363ms2001jjgf338-util-linux-2.37.3-bin
16M	/nix/store/4s21k8k7p1mfik0b33r2spq5hq7774k1-glibc-2.33-108
36M	total

###### Description of changes
adds a fuse2fs output closes https://github.com/NixOS/nixpkgs/issues/163881
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
