### PR TITLE
nats-server: 2.7.2 -> 2.7.4

### DIFF
--- a/pkgs/servers/nats-server/default.nix
+++ b/pkgs/servers/nats-server/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname   = "nats-server";
-  version = "2.7.2";
+  version = "2.7.4";
 
   src = fetchFromGitHub {
     rev    = "v${version}";
     owner  = "nats-io";
     repo   = pname;
-    sha256 = "0w4hjz1x6zwcxhnd1y3874agyn8nsdra4fky6kc2rrfikjcw003y";
+    sha256 = "sha256-lMwFh+njzQr1hOJFbO3LnPdBK7U4XmX4F/6MlIRILlU=";
   };
 
-  vendorSha256 = "1gvvjwx1g8mhcqi3ssb3k5ylkz0afpmnf6h2zfny9rc4dk2cp2dy";
+  vendorSha256 = "sha256-EEOvDOqMbqfB0S3Nf7RQMKGSZX802eqa3eGaNjUHxQ4=";
 
   doCheck = false;
 

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -1,18 +1,22 @@
-{  buildGoPackage, fetchFromGitHub, lib  }:
+{ buildGoModule, fetchFromGitHub, lib  }:
 
 with lib;
 
-buildGoPackage rec {
+buildGoModule rec {
   pname   = "nats-streaming-server";
-  version = "0.23.0";
-  goPackagePath = "github.com/nats-io/${pname}";
+  version = "0.24.3";
 
   src = fetchFromGitHub {
     rev    = "v${version}";
     owner  = "nats-io";
     repo   = pname;
-    sha256 = "sha256-Uol1A4+0V4dUQ7Qw0qRUWHzFBugVDYSulDGTJZ4a+ts=";
+    sha256 = "sha256-vpDOiFuxLpqor+9SztdZrJvwC8QGwt5+df4R2OTcxlA=";
   };
+
+  vendorSha256 = "sha256:1m783cq20xlv5aglf252g5127r5ilfq4fqj00vim38v271511hmy";
+
+  # tests fail and ask to `go install`
+  doCheck = false;
 
   meta = {
     description = "NATS Streaming System Server";


### PR DESCRIPTION
###### Description of changes
Fixes: CVE-2022-26652

https://www.openwall.com/lists/oss-security/2022/03/10/1

Still working on the nats-streaming-server update.

```
=== RUN   TestSignalTrapsSIGTERM
    server_test.go:191: process not started yet, make sure you `go install` first!
        1 - github.com/nats-io/nats-streaming-server/server/server_test.go:190
        2 - github.com/nats-io/nats-streaming-server/server/server_test.go:304
        3 - github.com/nats-io/nats-streaming-server/server/signal_test.go:141
        4 - testing/testing.go:1259
        5 - runtime/asm_amd64.s:1581
--- FAIL: TestSignalTrapsSIGTERM (2.01s)
=== RUN   TestSignalReload
    server_test.go:191: process not started yet, make sure you `go install` first!
        1 - github.com/nats-io/nats-streaming-server/server/server_test.go:190
        2 - github.com/nats-io/nats-streaming-server/server/server_test.go:304
        3 - github.com/nats-io/nats-streaming-server/server/signal_test.go:169
        4 - testing/testing.go:1259
        5 - runtime/asm_amd64.s:1581
--- FAIL: TestSignalReload (2.01s)
=== RUN   TestNATSServerConfigReloadFollowedByReopen
    server_test.go:191: open nss.log: no such file or directory
        1 - github.com/nats-io/nats-streaming-server/server/server_test.go:190
        2 - github.com/nats-io/nats-streaming-server/server/server_test.go:304
        3 - github.com/nats-io/nats-streaming-server/server/signal_test.go:210
        4 - testing/testing.go:1259
        5 - runtime/asm_amd64.s:1581
--- FAIL: TestNATSServerConfigReloadFollowedByReopen (2.02s)
FAIL
FAIL    github.com/nats-io/nats-streaming-server/server 203.149s
FAIL
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
