### PR TITLE
Revert "fish: 3.3.1 -> 3.4.0"

### DIFF
--- a/pkgs/shells/fish/default.nix
+++ b/pkgs/shells/fish/default.nix
@@ -134,7 +134,7 @@ let
 
   fish = stdenv.mkDerivation rec {
     pname = "fish";
-    version = "3.4.0";
+    version = "3.3.1";
 
     src = fetchurl {
       # There are differences between the release tarball and the tarball GitHub
@@ -144,8 +144,10 @@ let
       # --version`), as well as the local documentation for all builtins (and
       # maybe other things).
       url = "https://github.com/fish-shell/fish-shell/releases/download/${version}/${pname}-${version}.tar.xz";
-      sha256 = "sha256-tbSKuEhrGe9xajL39GuIuepTVhVfDpZ+6Z9Ak2RUE8U=";
+      sha256 = "sha256-tbTuGlJpdiy76ZOkvWUH5nXkEAzpu+hCFKXusrGfrok=";
     };
+
+    patches = [ ./tests-pcre2-update.patch ]; # should be included in >= 3.4
 
     # Fix FHS paths in tests
     postPatch = ''

--- a/pkgs/shells/fish/tests-pcre2-update.patch
+++ b/pkgs/shells/fish/tests-pcre2-update.patch
@@ -1,0 +1,7 @@
+Adapted formating to 3.3.1 from
+https://github.com/fish-shell/fish-shell/commit/ec8844d834cc9fe626e9fc326c6f5410341d532a
+--- a/src/fish_tests.cpp
++++ b/src/fish_tests.cpp
+@@ -5726,2 +5725,0 @@
+-        {{L"string", L"match", L"-r", L"(?=ab\\K)", L"ab", 0}, STATUS_CMD_OK, L"\n"},
+-        {{L"string", L"match", L"-r", L"(?=ab\\K)..(?=cd\\K)", L"abcd", 0}, STATUS_CMD_OK, L"\n"},


### PR DESCRIPTION
Reverts NixOS/nixpkgs#163886

Failed to build on aarch64-linux, as caught by ofborg: https://github.com/NixOS/nixpkgs/pull/163886#issuecomment-1065962175.