### PR TITLE
udisks2: correct patch

### DIFF
--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     description = "A daemon, tools and libraries to access and manipulate disks, storage devices and technologies";
     homepage = "https://www.freedesktop.org/wiki/Software/udisks/";
     license = with licenses; [ lgpl2Plus gpl2Plus ]; # lgpl2Plus for the library, gpl2Plus for the tools & daemon
-    maintainers = with maintainers; [ johnazoidberg ];
+    maintainers = teams.freedesktop.members ++ (with maintainers; [ johnazoidberg ]);
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -25,9 +25,11 @@ stdenv.mkDerivation rec {
       blkid = "${util-linux}/bin/blkid";
       false = "${coreutils}/bin/false";
       mdadm = "${mdadm}/bin/mdadm";
+      mkswap = "${util-linux}/bin/mkswap";
       sed = "${gnused}/bin/sed";
       sh = "${bash}/bin/sh";
       sleep = "${coreutils}/bin/sleep";
+      swapon = "${util-linux}/bin/swapon";
       true = "${coreutils}/bin/true";
     })
     (substituteAll {

--- a/pkgs/os-specific/linux/udisks/fix-paths.patch
+++ b/pkgs/os-specific/linux/udisks/fix-paths.patch
@@ -1,17 +1,5 @@
-diff --git a/Makefile.am b/Makefile.am
-index 56922b79..697f8c6e 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -1,6 +1,6 @@
- ## Process this file with automake to produce Makefile.in
- 
--SHELL = @BASH@
-+SHELL = @bash@
- .SHELLFLAGS = -o pipefail -c
- 
- PYTHON ?= python3
 diff --git a/data/80-udisks2.rules b/data/80-udisks2.rules
-index 39bfa28b..ee1ca90a 100644
+index ca802cce..bfd1c29e 100644
 --- a/data/80-udisks2.rules
 +++ b/data/80-udisks2.rules
 @@ -17,9 +17,9 @@ ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="?*", GOTO="udisks_probe_end"
@@ -66,9 +54,27 @@ index e7df4ed2..ab4356d9 100644
  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  #
 diff --git a/src/tests/integration-test b/src/tests/integration-test
-index 4499a6a9..8b711f95 100755
+index 07e4e029..3bd8ec51 100755
 --- a/src/tests/integration-test
 +++ b/src/tests/integration-test
+@@ -299,7 +299,7 @@ class UDisksTestCase(unittest.TestCase):
+         if not device:
+             device = cls.devname(partition)
+         result = {}
+-        cmd = subprocess.Popen(['blkid', '-p', '-o', 'udev', device], stdout=subprocess.PIPE)
++        cmd = subprocess.Popen(['@blkid@', '-p', '-o', 'udev', device], stdout=subprocess.PIPE)
+         for l in cmd.stdout:
+             (key, value) = l.decode('UTF-8').split('=', 1)
+             result[key] = value.strip()
+@@ -437,7 +437,7 @@ class UDisksTestCase(unittest.TestCase):
+                 f.write('KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", '
+                         'ATTRS{model}=="scsi_debug*", '
+                         'ENV{ID_CDROM_MEDIA}=="?*", '
+-                        'IMPORT{program}="/sbin/blkid -o udev -p -u noraid $tempnode"\n')
++                        'IMPORT{program}="@blkid@ -o udev -p -u noraid $tempnode"\n')
+             # reload udev
+             subprocess.call('sync; pkill --signal HUP udevd || '
+                             'pkill --signal HUP systemd-udevd',
 @@ -1142,7 +1142,7 @@ class FS(UDisksTestCase):
          self.assertFalse(os.access(f, os.X_OK))
  
@@ -150,6 +156,3 @@ index 3ddbdf2c..a87f960a 100644
    udisks_spawned_job_start (job);
    g_object_unref (job);
  }
--- 
-2.33.1
-


### PR DESCRIPTION
###### Description of changes

This was forgotten during https://github.com/NixOS/nixpkgs/pull/147606

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
