### PR TITLE
nixos/pantheon: enable xdg desktop integration

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -227,6 +227,7 @@ in
       # Settings from elementary-default-settings
       environment.etc."gtk-3.0/settings.ini".source = "${pkgs.pantheon.elementary-default-settings}/etc/gtk-3.0/settings.ini";
 
+      xdg.portal.enable = true;
       xdg.portal.extraPortals = with pkgs.pantheon; [
         elementary-files
         elementary-settings-daemon


### PR DESCRIPTION
###### Description of changes

This prevents the embarrassing situation in https://github.com/NixOS/nixpkgs/pull/163828 from happening again.

Maybe, we didn't see such issue on those patched apps previously due to https://github.com/elementary/granite/commit/f88712258f982c5507e371779ff331fa07b12429#diff-9c051dce9be6e885ed087c778e6fdd6ddc239ef72313eb6846004d4fc72ea503R115, but :-(

###### Things done

- [x] Cherry-picked to 6c85fd053052d9c3073973d127cf22c7b1a8797f and test locally with `nix run github:bobby285271/test-pantheon --override-input nixpkgs 'git+file:///home/bobby285271/nixpkgs?ref=gnome-42-fixup'`