### PR TITLE
kodi: More robust handling of kodi webserver assets

### DIFF
--- a/pkgs/applications/video/kodi/add-KODI_WEBSERVER_EXTRA_WHITELIST.patch
+++ b/pkgs/applications/video/kodi/add-KODI_WEBSERVER_EXTRA_WHITELIST.patch
@@ -1,0 +1,88 @@
+From 620c3eb38f0dbea6e877e37e97508513e87a0732 Mon Sep 17 00:00:00 2001
+From: Jeremy Fleischman <jeremyfleischman@gmail.com>
+Date: Sun, 27 Mar 2022 00:44:52 -0700
+Subject: [PATCH] Add new KODI_WEBSERVER_EXTRA_WHITELIST cmake var to allow
+ access to more directories
+
+(This is a backport of
+https://github.com/xbmc/xbmc/commit/a6dedce7ba1f03bdd83b019941d1e369a06f7888
+to Kodi 19.4 Matrix)
+
+This is useful for NixOS, which often ends up creating a `KODI_HOME`
+with symlinks to other files (including the chorus2 interface). Kodi's
+webserver cautiously refuses to follow these symlinks, and you end up
+getting 404s rather than the web page.
+
+See https://forum.kodi.tv/showthread.php?tid=366338&pid=3079493 for a
+discussion of this on the Kodi forum.
+---
+ CMakeLists.txt           | 1 +
+ xbmc/CompileInfo.cpp.in  | 5 +++++
+ xbmc/CompileInfo.h       | 1 +
+ xbmc/utils/FileUtils.cpp | 6 +++++-
+ 4 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2d5369798df23..d5ef6d9390ef0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -243,6 +243,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
+                                             -DAPP_BUILD_DATE=${APP_BUILD_DATE}
+                                             -DAPP_SHARED_LIBRARY_SUFFIX="${APP_SHARED_LIBRARY_SUFFIX}"
+                                             -Dprefix=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}
++                                            -DKODI_WEBSERVER_EXTRA_WHITELIST="${KODI_WEBSERVER_EXTRA_WHITELIST}"
+                                             -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateVersionedFiles.cmake
+                    DEPENDS ${CMAKE_SOURCE_DIR}/version.txt
+                            export-files
+diff --git a/xbmc/CompileInfo.cpp.in b/xbmc/CompileInfo.cpp.in
+index f81fe77902236..4f19203a89cde 100644
+--- a/xbmc/CompileInfo.cpp.in
++++ b/xbmc/CompileInfo.cpp.in
+@@ -105,3 +105,8 @@ std::vector<std::string> CCompileInfo::GetAvailableWindowSystems()
+ {
+   return StringUtils::Split("@CORE_PLATFORM_NAME_LC@", ' ');
+ }
++
++const std::vector<std::string> CCompileInfo::GetWebserverExtraWhitelist()
++{
++  return StringUtils::Split("@KODI_WEBSERVER_EXTRA_WHITELIST@", ',');
++}
+diff --git a/xbmc/CompileInfo.h b/xbmc/CompileInfo.h
+index 553a0194ee77f..e2521324e6576 100644
+--- a/xbmc/CompileInfo.h
++++ b/xbmc/CompileInfo.h
+@@ -32,4 +32,5 @@ class CCompileInfo
+   static const char* GetVersionCode();
+   static std::vector<std::string> GetAvailableWindowSystems();
+   static std::vector<ADDON::RepoInfo> LoadOfficialRepoInfos();
++  static const std::vector<std::string> GetWebserverExtraWhitelist();
+ };
+diff --git a/xbmc/utils/FileUtils.cpp b/xbmc/utils/FileUtils.cpp
+index e51f3d631c256..fc717c9608098 100644
+--- a/xbmc/utils/FileUtils.cpp
++++ b/xbmc/utils/FileUtils.cpp
+@@ -6,6 +6,7 @@
+  *  See LICENSES/README.md for more information.
+  */
+ 
++#include "CompileInfo.h"
+ #include "FileUtils.h"
+ #include "ServiceBroker.h"
+ #include "guilib/GUIKeyboardFactory.h"
+@@ -261,12 +262,15 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
+     "/.ssh/",
+   };
+   // ALLOW kodi paths
+-  const std::vector<std::string> whitelist = {
++  std::vector<std::string> whitelist = {
+     CSpecialProtocol::TranslatePath("special://home"),
+     CSpecialProtocol::TranslatePath("special://xbmc"),
+     CSpecialProtocol::TranslatePath("special://musicartistsinfo")
+   };
+ 
++  auto kodiExtraWhitelist = CCompileInfo::GetWebserverExtraWhitelist();
++  whitelist.insert(whitelist.end(), kodiExtraWhitelist.begin(), kodiExtraWhitelist.end());
++
+   // image urls come in the form of image://... sometimes with a / appended at the end
+   // and can be embedded in a music or video file image://music@...
+   // strip this off to get the real file path

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -107,6 +107,15 @@ in stdenv.mkDerivation {
 
     src = kodi_src;
 
+    # This is a backport of
+    # https://github.com/xbmc/xbmc/commit/a6dedce7ba1f03bdd83b019941d1e369a06f7888
+    # to Kodi 19.4 Matrix.
+    # This can be removed once a new release of Kodi comes out and we upgrade
+    # to it.
+    patches = [
+      ./add-KODI_WEBSERVER_EXTRA_WHITELIST.patch
+    ];
+
     buildInputs = [
       gnutls libidn libtasn1 nasm p11-kit
       libxml2 python3Packages.python
@@ -185,6 +194,12 @@ in stdenv.mkDerivation {
       "-DSWIG_EXECUTABLE=${buildPackages.swig}/bin/swig"
       "-DFLATBUFFERS_FLATC_EXECUTABLE=${buildPackages.flatbuffers}/bin/flatc"
       "-DPYTHON_EXECUTABLE=${buildPackages.python3Packages.python}/bin/python"
+      # When wrapped KODI_HOME will likely contain symlinks to static assets
+      # that Kodi's built in webserver will cautiously refuse to serve up
+      # (because their realpaths are outside of KODI_HOME and the other
+      # whitelisted directories). This adds the entire nix store to the Kodi
+      # webserver whitelist to avoid this problem.
+      "-DKODI_WEBSERVER_EXTRA_WHITELIST=${builtins.storeDir}"
     ] ++ lib.optional waylandSupport [
       "-DWAYLANDPP_SCANNER=${buildPackages.waylandpp}/bin/wayland-scanner++"
     ];

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -35,11 +35,5 @@ buildEnv {
           (lib.concatMap
             (plugin: plugin.extraRuntimeDependencies or []) addons)}"
     done
-
-    # makeWrapper just created webinterface.default as a symlink. However,
-    # kodi's webserver carefully refuses to follow symlinks, so we need to copy
-    # these assets instead.
-    rm $out/share/kodi/addons/webinterface.default
-    cp -r ${kodi}/share/kodi/addons/webinterface.default/ $out/share/kodi/addons/webinterface.default
   '';
 }


### PR DESCRIPTION
This adds a backport of
https://github.com/xbmc/xbmc/commit/a6dedce7ba1f03bdd83b019941d1e369a06f7888
to Kodi 19.4 Matrix. This can be removed once a new release of Kodi comes
out and we upgrade to it.

What's nice about this approach is that it doesn't special case
webinterface.default. I've never actually tried using a non-default web
interface with Kodi, but I bet it wouldn't have worked before this
change, and I think it would work after this change =)

See and
https://github.com/NixOS/nixpkgs/pull/152675#issuecomment-1003442175 and
https://forum.kodi.tv/showthread.php?tid=366338&pid=3079493 for some
discussion about this approach.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
