### PR TITLE
terraform-providers: refactor scripts

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-all-providers
@@ -5,7 +5,7 @@
 # Update all providers which have specified provider source address
 set -euo pipefail
 
-providers=$(
+readarray -t providers < <(
   jq -r 'to_entries
   | map_values(.value + { alias: .key })
   | .[]
@@ -13,10 +13,13 @@ providers=$(
   | .alias' providers.json
 )
 
-echo "Will update providers:"
-echo "${providers}"
+cat <<EOF
+Will update ${#providers[@]} providers:
 
-for provider in ${providers}; do
-  echo "Updating ${provider}"
+${providers[*]}
+
+EOF
+
+for provider in "${providers[@]}"; do
   ./update-provider "$@" "${provider}"
 done

--- a/pkgs/applications/networking/cluster/terraform-providers/update-provider
+++ b/pkgs/applications/networking/cluster/terraform-providers/update-provider
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=../../../../.. -i bash -p coreutils curl jq moreutils nix nix-prefetch
+#! nix-shell -I nixpkgs=../../../../.. -i bash -p coreutils curl git jq moreutils nix nix-prefetch
 # shellcheck shell=bash
 # vim: ft=sh
 #
@@ -75,45 +75,46 @@ if [[ -z ${provider} ]]; then
   exit 1
 fi
 
-provider_name=$(basename "${provider}")
-
 # Usage: read_attr <key>
 read_attr() {
-  jq -r ".\"${provider_name}\".\"$1\"" providers.json
+  jq -r ".\"${provider}\".\"$1\"" providers.json
 }
 
 # Usage: update_attr <key> <value>
 update_attr() {
   if [[ $2 == "null" ]]; then
-    jq -S ".\"${provider_name}\".\"$1\" = null" providers.json | sponge providers.json
+    jq -S ".\"${provider}\".\"$1\" = null" providers.json | sponge providers.json
   else
-    jq -S ".\"${provider_name}\".\"$1\" = \"$2\"" providers.json | sponge providers.json
+    jq -S ".\"${provider}\".\"$1\" = \"$2\"" providers.json | sponge providers.json
   fi
 }
 
-prefetch_github() {
-  # of a given owner, repo and rev, fetch the tarball and return the output of
-  # `nix-prefetch-url`
-  local owner=$1
-  local repo=$2
-  local rev=$3
-  nix-prefetch-url --unpack "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"
+repo_root=$(git rev-parse --show-toplevel)
+
+generate_hash() {
+  nix-prefetch -I nixpkgs="${repo_root}" \
+    "{ sha256 }: (import ${repo_root} {}).terraform-providers.${provider}.$1.overrideAttrs (_: { $2 = sha256; })"
 }
 
-old_source_address="$(read_attr provider-source-address)"
-old_vendor_sha256=$(read_attr vendorSha256)
-old_version=$(read_attr version)
+echo_provider() {
+  echo "== terraform-providers.${provider}: $* =="
+}
 
 if [[ ${provider} =~ ^[^/]+/[^/]+$ ]]; then
+  echo_provider "init"
   source_address=registry.terraform.io/${provider}
+  provider=$(basename "${provider}")
+  update_attr "provider-source-address" "${source_address}"
+  update_attr version "0"
+  # create empty stings so nix-prefetch works
+  update_attr sha256 ""
+  update_attr vendorSha256 ""
 else
-  source_address=${old_source_address}
+  source_address="$(read_attr provider-source-address)"
 fi
-if [[ ${source_address} == "null" ]]; then
-  echo "Could not find the source address for provider: ${provider}"
-  exit 1
-fi
-update_attr "provider-source-address" "${source_address}"
+
+old_vendor_sha256=$(read_attr vendorSha256)
+old_version=$(read_attr version)
 
 # The provider source address (used inside Terraform `required_providers` block) is
 # used to compute the registry API endpoint
@@ -125,8 +126,10 @@ registry_response=$(curl -s https://"${source_address/\///v1/providers/}")
 
 version="$(jq -r '.version' <<<"${registry_response}")"
 if [[ ${old_version} == "${version}" && ${force} != 1 && -z ${vendorSha256} && ${old_vendor_sha256} != "${vendorSha256}" ]]; then
-  echo "${provider_name} is already at version ${version}"
+  echo_provider "already at version ${version}"
   exit
+else
+  echo_provider "updating from ${old_version} to ${version}"
 fi
 update_attr version "${version}"
 
@@ -138,28 +141,23 @@ repo="$(echo "${provider_source_url}" | cut -d '/' -f 5)"
 update_attr repo "${repo}"
 rev="$(jq -r '.tag' <<<"${registry_response}")"
 update_attr rev "${rev}"
-sha256=$(prefetch_github "${org}" "${repo}" "${rev}")
+echo_provider "calculating sha256"
+sha256=$(generate_hash src outputHash)
 update_attr sha256 "${sha256}"
 
 if [[ -z ${vendorSha256} ]]; then
   if [[ ${old_vendor_sha256} == null ]]; then
     vendorSha256=null
-  elif [[ -n ${old_vendor_sha256} ]]; then
-    echo "=== Calculating vendorSha256 ==="
-    vendorSha256=$(nix-prefetch -I nixpkgs=../../../../.. "{ sha256 }: (import ../../../../.. {}).terraform-providers.${provider_name}.go-modules.overrideAttrs (_: { vendorSha256 = sha256; })")
-    # Deal with nix unstable
-    if [[ ${vendorSha256} == sha256-* ]]; then
-      vendorSha256=$(nix --extra-experimental-features nix-command hash to-base32 "${vendorSha256}")
-    fi
+  else
+    echo_provider "calculating vendorSha256"
+    vendorSha256=$(generate_hash go-modules vendorSha256)
   fi
 fi
 
-if [[ -n ${vendorSha256} ]]; then
-  update_attr vendorSha256 "${vendorSha256}"
-fi
+update_attr vendorSha256 "${vendorSha256}"
 
 # Check that the provider builds
 if [[ ${build} == 1 ]]; then
-  echo "=== Building terraform-providers.${provider_name} ==="
-  nix-build --no-out-link ../../../../.. -A "terraform-providers.${provider_name}"
+  echo_provider "building"
+  nix-build --no-out-link "${repo_root}" -A "terraform-providers.${provider}"
 fi


### PR DESCRIPTION
###### Description of changes

- improve script output
- use sri hashes, same as recent versions of `nix`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
