### PR TITLE
php.packages.phive: init at 0.15.0

### DIFF
--- a/pkgs/development/php-packages/box/default.nix
+++ b/pkgs/development/php-packages/box/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/box/box.phar
     makeWrapper ${php}/bin/php $out/bin/box \
       --add-flags "-d phar.readonly=0 $out/libexec/box/box.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/deployer/default.nix
+++ b/pkgs/development/php-packages/deployer/default.nix
@@ -14,6 +14,7 @@ mkDerivation rec {
   nativeBuildInputs = [ makeWrapper installShellFiles ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/deployer/deployer.phar
     makeWrapper ${php}/bin/php $out/bin/dep --add-flags "$out/libexec/deployer/deployer.phar"
@@ -22,6 +23,7 @@ mkDerivation rec {
     installShellCompletion --cmd dep \
       --bash <($out/bin/dep autocomplete --install) \
       --zsh <($out/bin/dep autocomplete --install)
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phing/default.nix
+++ b/pkgs/development/php-packages/phing/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/phing/phing.phar
     makeWrapper ${php}/bin/php $out/bin/phing \
       --add-flags "$out/libexec/phing/phing.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phive/default.nix
+++ b/pkgs/development/php-packages/phive/default.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, fetchurl, makeWrapper, lib, php }:
+
+mkDerivation rec {
+  pname = "phive";
+  version = "0.15.0";
+
+  src = fetchurl {
+    url = "https://github.com/phar-io/phive/releases/download/${version}/phive-${version}.phar";
+    sha256 = "sha256-crMr8d5nsVt7+zQ5xPeph/JXmTEn6jJFVtp3mOgylB4=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -D $src $out/libexec/phive/phive.phar
+    makeWrapper ${php}/bin/php $out/bin/phive \
+      --add-flags "$out/libexec/phive/phive.phar"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The Phar Installation and Verification Environment (PHIVE)";
+    homepage = "https://github.com/phar-io/phive";
+    license = licenses.bsd3;
+    maintainers = with maintainers; teams.php.members;
+  };
+}

--- a/pkgs/development/php-packages/php-cs-fixer/default.nix
+++ b/pkgs/development/php-packages/php-cs-fixer/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/php-cs-fixer/php-cs-fixer.phar
     makeWrapper ${php}/bin/php $out/bin/php-cs-fixer \
       --add-flags "$out/libexec/php-cs-fixer/php-cs-fixer.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/php-parallel-lint/default.nix
+++ b/pkgs/development/php-packages/php-parallel-lint/default.nix
@@ -20,15 +20,19 @@ mkDerivation {
   ];
 
   buildPhase = ''
+    runHook preBuild
     composer dump-autoload
     box build
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D parallel-lint.phar $out/libexec/php-parallel-lint/php-parallel-lint.phar
     makeWrapper ${php}/bin/php $out/bin/php-parallel-lint \
       --add-flags "$out/libexec/php-parallel-lint/php-parallel-lint.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phpcbf/default.nix
+++ b/pkgs/development/php-packages/phpcbf/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/phpcbf/phpcbf.phar
     makeWrapper ${php}/bin/php $out/bin/phpcbf \
       --add-flags "$out/libexec/phpcbf/phpcbf.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phpcs/default.nix
+++ b/pkgs/development/php-packages/phpcs/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/phpcs/phpcs.phar
     makeWrapper ${php}/bin/php $out/bin/phpcs \
       --add-flags "$out/libexec/phpcs/phpcs.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phpmd/default.nix
+++ b/pkgs/development/php-packages/phpmd/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/phpmd/phpmd.phar
     makeWrapper ${php}/bin/php $out/bin/phpmd \
       --add-flags "$out/libexec/phpmd/phpmd.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/phpstan/default.nix
+++ b/pkgs/development/php-packages/phpstan/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/phpstan/phpstan.phar
     makeWrapper ${php}/bin/php $out/bin/phpstan \
       --add-flags "$out/libexec/phpstan/phpstan.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/psalm/default.nix
+++ b/pkgs/development/php-packages/psalm/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     install -D $src $out/libexec/psalm/psalm.phar
     makeWrapper ${php}/bin/php $out/bin/psalm \
       --add-flags "$out/libexec/psalm/psalm.phar"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/development/php-packages/psysh/default.nix
+++ b/pkgs/development/php-packages/psysh/default.nix
@@ -16,10 +16,12 @@ mkDerivation {
   nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     tar -xzf $src -C $out/bin
     chmod +x $out/bin/psysh
     wrapProgram $out/bin/psysh --prefix PATH : "${lib.makeBinPath [ php ]}"
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -144,6 +144,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     phing = callPackage ../development/php-packages/phing { };
 
+    phive = callPackage ../development/php-packages/phive { };
+
     php-cs-fixer = callPackage ../development/php-packages/php-cs-fixer { };
 
     php-parallel-lint = callPackage ../development/php-packages/php-parallel-lint { };


### PR DESCRIPTION
Add Phive to Nix.

TODO:

- [x] Get clarification about the license. Currently it is set to MIT, but it seems that [the license of the project](https://github.com/phar-io/phive/blob/master/LICENSE) is not MIT - See message to the author: https://twitter.com/drupol/status/1502956751632703495 ping @theseer (follow up: https://github.com/phar-io/phive/issues/362)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
