### PR TITLE
nix-output-monitor: 1.1.1.0 -> 1.1.2.0

### DIFF
--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -6,6 +6,7 @@
   async,
   attoparsec,
   base,
+  bytestring,
   cassava,
   containers,
   data-default,
@@ -36,13 +37,14 @@
   unix,
   vector,
   wcwidth,
+  word8,
 }:
 mkDerivation {
   pname = "nix-output-monitor";
-  version = "1.1.1.0";
+  version = "1.1.2.0";
   src = fetchzip {
-    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.1.0.tar.gz";
-    sha256 = "1zw7x1snyycl1bp5w7jh8wwnynqvw3g4glr293bnzi5jyirj5wlg";
+    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.2.0.tar.gz";
+    sha256 = "03qhy4xzika41pxlmvpz3psgy54va72ipn9v1lv33l6369ikrhl1";
   };
   isLibrary = true;
   isExecutable = true;
@@ -51,6 +53,7 @@ mkDerivation {
     async
     attoparsec
     base
+    bytestring
     cassava
     containers
     data-default
@@ -74,12 +77,14 @@ mkDerivation {
     unix
     vector
     wcwidth
+    word8
   ];
   executableHaskellDepends = [
     ansi-terminal
     async
     attoparsec
     base
+    bytestring
     cassava
     containers
     data-default
@@ -103,12 +108,14 @@ mkDerivation {
     unix
     vector
     wcwidth
+    word8
   ];
   testHaskellDepends = [
     ansi-terminal
     async
     attoparsec
     base
+    bytestring
     cassava
     containers
     data-default
@@ -134,6 +141,7 @@ mkDerivation {
     unix
     vector
     wcwidth
+    word8
   ];
   homepage = "https://github.com/maralorn/nix-output-monitor";
   description = "Parses output of nix-build to show additional information";
@@ -148,11 +156,9 @@ mkDerivation {
     ${expect}/bin/unbuffer nix-build "\$@" 2>&1 | exec $out/bin/nom
     EOF
     chmod a+x $out/bin/nom-build
-    installShellCompletion --zsh --name _nom-build ${
-      builtins.toFile "completion.zsh" ''
-        #compdef nom-build
-        compdef nom-build=nix-build
-      ''
-    }
+    installShellCompletion --zsh --name _nom-build ${builtins.toFile "completion.zsh" ''
+      #compdef nom-build
+      compdef nom-build=nix-build
+    ''}
   '';
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Contains a bug fix, where colored input could lead to failed parsing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
