### PR TITLE
llvmPackages_14: 14.0.0-rc2 -> 14.0.0-rc4

### DIFF
--- a/pkgs/development/compilers/llvm/14/default.nix
+++ b/pkgs/development/compilers/llvm/14/default.nix
@@ -19,7 +19,7 @@
 
 let
   release_version = "14.0.0";
-  candidate = "rc2"; # empty or "rcN"
+  candidate = "rc4"; # empty or "rcN"
   dash-candidate = lib.optionalString (candidate != "") "-${candidate}";
   rev = ""; # When using a Git commit
   rev-version = ""; # When using a Git commit
@@ -30,7 +30,7 @@ let
     owner = "llvm";
     repo = "llvm-project";
     rev = if rev != "" then rev else "llvmorg-${version}";
-    sha256 = "sha256-5wJEaWvwJohtjqlIsBkqQ5rE6rcWw07MaQnN1RxPb5w=";
+    sha256 = "0xm3hscg6xv48rjdi7sg9ky960af1qyg5k3jyavnaqimlaj9wxgp";
   };
 
   llvm_meta = {

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -209,6 +209,9 @@ in stdenv.mkDerivation (rec {
 
   checkTarget = "check-all";
 
+  # For the update script:
+  passthru.monorepoSrc = monorepoSrc;
+
   requiredSystemFeatures = [ "big-parallel" ];
   meta = llvm_meta // {
     homepage = "https://llvm.org/";

--- a/pkgs/development/compilers/llvm/update.sh
+++ b/pkgs/development/compilers/llvm/update.sh
@@ -20,7 +20,11 @@ sed -Ei \
 
 readonly ATTRSET="llvmPackages_$VERSION_MAJOR"
 
-if [ "$VERSION_MAJOR" -ge "13" ]; then
+if [ "$VERSION_MAJOR" -ge "14" ]; then
+  readonly SOURCES=(
+    "llvm.monorepoSrc"
+  )
+elif [ "$VERSION_MAJOR" -eq "13" ]; then
   readonly SOURCES=(
     "llvm.src"
   )
@@ -43,7 +47,7 @@ fi
 for SOURCE in "${SOURCES[@]}"; do
   echo "Updating the hash of $SOURCE:"
   declare ATTR="$ATTRSET.$SOURCE"
-  declare OLD_HASH="$(nix eval -f . $ATTR.outputHash)"
+  declare OLD_HASH="$(nix --extra-experimental-features nix-command eval -f . $ATTR.outputHash)"
   declare NEW_HASH="\"$(nix-prefetch-url -A $ATTR)\""
   find "$DIR" -type f -exec sed -i "s/$OLD_HASH/$NEW_HASH/" {} +
 done


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
