### PR TITLE
_7zz: correct license

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -719,6 +719,12 @@
       </listitem>
       <listitem>
         <para>
+          <literal>pkgs._7zz</literal> is now correctly licensed as
+          LGPL3+ and BSD3 with optional unfree unRAR licensed code
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>tilp2</literal> was removed together with its module
         </para>
       </listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -281,6 +281,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `pkgs.docbookrx` was removed since it's unmaintained
 
+- `pkgs._7zz` is now correctly licensed as LGPL3+ and BSD3 with optional unfree unRAR licensed code
+
 - `tilp2` was removed together with its module
 
 - The F-PROT antivirus (`fprot` package) and its service module were removed because it

--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -1,4 +1,14 @@
-{ stdenv, lib, fetchurl, p7zip, uasm, useUasm ? stdenv.isx86_64 }:
+{ stdenv
+, lib
+, fetchurl
+
+, uasm
+, useUasm ? stdenv.isx86_64
+
+  # RAR code is under non-free unRAR license
+  # see the meta.license section below for more details
+, enableUnfree ? false
+}:
 
 let
   inherit (stdenv.hostPlatform) system;
@@ -14,17 +24,38 @@ stdenv.mkDerivation rec {
   version = "21.07";
 
   src = fetchurl {
-    url = "https://7-zip.org/a/7z${lib.replaceStrings [ "." ] [ "" ] version}-src.7z";
-    sha256 = "sha256-0QdNVvQVqrmdmeWXp7ZtxFXbpjSa6KTInfdkdbahKEw=";
+    url = "https://7-zip.org/a/7z${lib.replaceStrings [ "." ] [ "" ] version}-src.tar.xz";
+    sha256 = {
+      free = "sha256-SMM6kQ6AZ05s4miJjMoE4NnsXQ0tlkdWx0q2HKjhaM8=";
+      unfree = "sha256-IT1ZRAfLjvy6NmELFSykkh7aFBYzELQ5A9E+aDE+Hjk=";
+    }.${if enableUnfree then "unfree" else "free"};
+    downloadToTemp = (!enableUnfree);
+    # remove the unRAR related code from the src drv
+    # > the license requires that you agree to these use restrictions,
+    # > or you must remove the software (source and binary) from your hard disks
+    # https://fedoraproject.org/wiki/Licensing:Unrar
+    postFetch = lib.optionalString (!enableUnfree) ''
+      mkdir tmp
+      tar xf $downloadedFile -C ./tmp
+      rm -r ./tmp/CPP/7zip/Compress/Rar*
+      tar cfJ $out -C ./tmp . \
+        --sort=name \
+        --mtime="@$SOURCE_DATE_EPOCH" \
+        --owner=0 --group=0 --numeric-owner \
+        --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime
+    '';
   };
 
   sourceRoot = "CPP/7zip/Bundles/Alone2";
 
-  makeFlags = lib.optionals useUasm [ "MY_ASM=uasm" ];
+  makeFlags =
+    lib.optionals useUasm [ "MY_ASM=uasm" ] ++
+    # it's the compression code with the restriction, see DOC/License.txt
+    lib.optionals (!enableUnfree) [ "DISABLE_RAR_COMPRESS=true" ];
 
   makefile = "../../cmpl_gcc${platformSuffix}.mak";
 
-  nativeBuildInputs = [ p7zip ] ++ lib.optionals useUasm [ uasm ];
+  nativeBuildInputs = lib.optionals useUasm [ uasm ];
 
   enableParallelBuilding = true;
 
@@ -40,14 +71,27 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
 
   installCheckPhase = ''
+    runHook preInstallCheck
+
     $out/bin/7zz --help | grep ${version}
+
+    runHook postInstallCheck
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Command line archiver utility";
     homepage = "https://7-zip.org";
-    license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ anna328p peterhoeg ];
+    license = with licenses;
+      # 7zip code is largely lgpl2Plus
+      # CPP/7zip/Compress/LzfseDecoder.cpp is bsd3
+      [ lgpl2Plus /* and */ bsd3 ] ++
+      # and CPP/7zip/Compress/Rar* are unfree with the unRAR license restriction
+      # the unRAR compression code is disabled by default
+      lib.optionals enableUnfree [ unfree ];
+    maintainers = with maintainers; [ anna328p peterhoeg jk ];
     platforms = platforms.linux;
+    mainProgram = "7zz";
   };
 }

--- a/pkgs/tools/archivers/7zz/update.sh
+++ b/pkgs/tools/archivers/7zz/update.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils gnused curl jq
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+DRV_DIR="$PWD"
+
+OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+
+NEW_VERSION="$(curl "https://sourceforge.net/projects/sevenzip/best_release.json" | jq '.platform_releases.linux.filename' -r | cut -d/ -f3)"
+
+echo "comparing versions $OLD_VERSION => $NEW_VERSION"
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+    echo "Already up to date! Doing nothing"
+    exit 0
+fi
+
+NIXPKGS_ROOT="$(realpath "$DRV_DIR/../../../..")"
+
+echo "getting free source hash"
+OLD_FREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; _7zz.src.drvAttrs.outputHash" | tr -d '"')"
+echo "getting unfree source hash"
+OLD_UNFREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; (_7zz.override { enableUnfree = true; }).src.drvAttrs.outputHash" | tr -d '"')"
+
+NEW_VERSION_FORMATTED="$(echo "$NEW_VERSION" | tr -d '.')"
+URL="https://7-zip.org/a/7z${NEW_VERSION_FORMATTED}-src.tar.xz"
+
+
+NEW_FREE_HASH=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "_7zz.src" --url "$URL")
+
+NEW_UNFREE_OUT=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "(_7zz.override { enableUnfree = true; }).src" --url "$URL" --output raw --print-path)
+# first line of raw output is the hash
+NEW_UNFREE_HASH="$(echo "$NEW_UNFREE_OUT" | sed -n 1p)"
+# second line of raw output is the src path
+NEW_UNFREE_SRC="$(echo "$NEW_UNFREE_OUT" | sed -n 2p)"
+# make sure to nuke the unfree src from the updater's machine
+# > the license requires that you agree to these use restrictions, or you must remove the software (source and binary) from your hard disks
+# https://fedoraproject.org/wiki/Licensing:Unrar
+nix-store --delete "$NEW_UNFREE_SRC"
+
+
+echo "updating version"
+sed -i "s/version = \"$OLD_VERSION\";/version = \"$NEW_VERSION\";/" "$DRV_DIR/default.nix"
+
+echo "updating free hash"
+sed -i "s@free = \"$OLD_FREE_HASH\";@free = \"$NEW_FREE_HASH\";@" "$DRV_DIR/default.nix"
+echo "updating unfree hash"
+sed -i "s@unfree = \"$OLD_UNFREE_HASH\";@unfree = \"$NEW_UNFREE_HASH\";@" "$DRV_DIR/default.nix"
+
+echo "done"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- `_7zz`: correct license and remove p7zip dependency
  - The code under `Compress/Rar*` is licensed under a specific unRAR license
  - Also `Compress/LzfseDecoder.cpp` is covered by BSD3
  - Meta has been updated and tweaked
  - Source is now downloaded from sourceforge in the `.tar.xz` version to avoid depending on `p7zip`
- `_7zz`: add notice of the license updates and optional unRAR licenced code


Resolves #163680


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
