### PR TITLE
sage: adapt tachyon interface for 0.99.3

### DIFF
--- a/pkgs/applications/science/math/sage/patches/tachyon-renamed-focallength.patch
+++ b/pkgs/applications/science/math/sage/patches/tachyon-renamed-focallength.patch
@@ -1,0 +1,81 @@
+diff --git a/src/sage/interfaces/tachyon.py b/src/sage/interfaces/tachyon.py
+index 3f1dcdb538..b6fa8d1fbd 100644
+--- a/src/sage/interfaces/tachyon.py
++++ b/src/sage/interfaces/tachyon.py
+@@ -261,13 +261,13 @@ written in the sequence they are listed in the examples in this section.
+   The {\bf PROJECTION} keyword must be followed by one of the supported
+ camera projection mode identifiers {\bf PERSPECTIVE}, {\bf PERSPECTIVE_DOF},
+ {\bf ORTHOGRAPHIC}, or {\bf FISHEYE}.  The {\bf FISHEYE} projection mode
+-requires two extra parameters {\bf FOCALLENGTH} and {\bf APERTURE}
++requires two extra parameters {\bf FOCALDIST} and {\bf APERTURE}
+ which precede the regular camera options.
+ 
+ \begin{verbatim}
+ Camera
+   projection perspective_dof
+-  focallength 0.75
++  focaldist 0.75
+   aperture 0.02
+   Zoom 0.666667
+   Aspectratio 1.000000
+diff --git a/src/sage/plot/plot3d/tachyon.py b/src/sage/plot/plot3d/tachyon.py
+index 08caf38d67..3e827411ce 100644
+--- a/src/sage/plot/plot3d/tachyon.py
++++ b/src/sage/plot/plot3d/tachyon.py
+@@ -92,7 +92,7 @@ angle, right angle)::
+ Finally there is the ``projection='perspective_dof'`` option. ::
+ 
+     sage: T = Tachyon(xres=800, antialiasing=4, raydepth=10,
+-    ....: projection='perspective_dof', focallength='1.0', aperture='.0025')
++    ....: projection='perspective_dof', focaldist='1.0', aperture='.0025')
+     sage: T.light((0,5,7), 1.0, (1,1,1))
+     sage: T.texture('t1', opacity=1, specular=.3)
+     sage: T.texture('t2', opacity=1, specular=.3, color=(0,0,1))
+@@ -186,7 +186,7 @@ class Tachyon(WithEqualityById, SageObject):
+       or ``'fisheye'``.
+     - ``frustum`` - (default ''), otherwise list of four numbers. Only
+       used with projection='fisheye'.
+-    - ``focallength`` - (default ''), otherwise a number. Only used
++    - ``focaldist`` - (default ''), otherwise a number. Only used
+       with projection='perspective_dof'.
+     - ``aperture`` - (default ''), otherwise a number.  Only used
+       with projection='perspective_dof'.
+@@ -331,7 +331,7 @@ class Tachyon(WithEqualityById, SageObject):
+     Use of the ``projection='perspective_dof'`` option.  This may not be
+     implemented correctly. ::
+ 
+-        sage: T = Tachyon(xres=800,antialiasing=4, raydepth=10, projection='perspective_dof', focallength='1.0', aperture='.0025')
++        sage: T = Tachyon(xres=800,antialiasing=4, raydepth=10, projection='perspective_dof', focaldist='1.0', aperture='.0025')
+         sage: T.light((0,5,7), 1.0, (1,1,1))
+         sage: T.texture('t1', opacity=1, specular=.3)
+         sage: T.texture('t2', opacity=1, specular=.3, color=(0,0,1))
+@@ -365,7 +365,7 @@ class Tachyon(WithEqualityById, SageObject):
+                  look_at=[0, 0, 0],
+                  viewdir=None,
+                  projection='PERSPECTIVE',
+-                 focallength='',
++                 focaldist='',
+                  aperture='',
+                  frustum=''):
+         r"""
+@@ -391,7 +391,7 @@ class Tachyon(WithEqualityById, SageObject):
+             self._camera_position = (-3, 0, 0) # default value
+         self._updir = updir
+         self._projection = projection
+-        self._focallength = focallength
++        self._focaldist = focaldist
+         self._aperture = aperture
+         self._frustum = frustum
+         self._objects = []
+@@ -624,9 +624,9 @@ class Tachyon(WithEqualityById, SageObject):
+         camera_out = r"""
+            camera
+               projection %s""" % (tostr(self._projection))
+-        if self._focallength != '':
++        if self._focaldist != '':
+             camera_out = camera_out + r"""
+-              focallength %s""" % (float(self._focallength))
++              focaldist %s""" % (float(self._focaldist))
+         if self._aperture != '':
+             camera_out = camera_out + r"""
+               aperture %s""" % (float(self._aperture))

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -155,6 +155,9 @@ stdenv.mkDerivation rec {
       rev = "97d7958bed441cf2ccc714d88f83d3a8426bc085";
       sha256 = "sha256-y1STE0oxswnijGCsBw8eHWWqpmT1XMznIfA0vvX9pFA=";
     })
+
+    # adapted from https://trac.sagemath.org/ticket/23712#comment:22
+    ./patches/tachyon-renamed-focallength.patch
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
###### Description of changes

Post-#163641 fixup to Sage's tachyon interface. Being handled upstream at https://trac.sagemath.org/ticket/23712#comment:22, but the patch is import-able. I will replace the patch by an upstream version whenever it lands there.

From http://jedi.ks.uiuc.edu/~johns/raytracer/Changes:
```
10/23/2014  o Updated parser to look for "FocalDist" instead of 
              "FocalLength" for DOF scene definitions.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
