### PR TITLE
bloodhound: init at 4.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7441,6 +7441,12 @@
     githubId = 39707188;
     name = "Lynn Dong";
   };
+  lyrain = {
+    email = "myles.offord+nix@gmail.com";
+    github = "Lyrain";
+    githubId = 2564924;
+    name = "Myles Offord";
+  };
   lyt = {
     email = "wheatdoge@gmail.com";
     name = "Tim Liou";

--- a/pkgs/applications/misc/bloodhound/default.nix
+++ b/pkgs/applications/misc/bloodhound/default.nix
@@ -1,0 +1,127 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, alsa-lib
+, at-spi2-atk
+, at-spi2-core
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fontconfig
+, freetype
+, gdk-pixbuf
+, glib
+, gnome2
+, gtk3
+, libGL
+, libappindicator-gtk3
+, libdrm
+, libnotify
+, libpulseaudio
+, libuuid
+, libxcb
+, libxkbcommon
+, libxshmfence
+, mesa
+, nspr
+, nss
+, pango
+, systemd
+, unzip
+, xdg-utils
+, xorg
+}:
+stdenv.mkDerivation rec {
+  pname = "bloodhound";
+  binaryName = "BloodHound";
+  version = "4.1.0";
+  src = fetchurl {
+    url = "https://github.com/BloodHoundAD/BloodHound/releases/download/${version}/BloodHound-linux-x64.zip";
+    sha256 = "sha256-Sxll+yjFCv9jK65R4r/uFTAJeX8rV2kyB200cvmErmY=";
+  };
+
+  rpath = lib.makeLibraryPath [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gnome2.GConf
+    gtk3
+    libGL
+    libappindicator-gtk3
+    libdrm
+    libnotify
+    libpulseaudio
+    libuuid
+    libxcb
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    pango
+    systemd
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+    xorg.libxkbfile
+    xorg.libxshmfence
+  ] + ":${stdenv.cc.cc.lib}/lib64";
+
+  buildInputs = [
+    gtk3 # needed for GSETTINGS_SCHEMAS_PATH
+  ];
+
+  nativeBuildInputs = [ makeWrapper unzip ];
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    unzip $src
+    mkdir -p $out
+    mkdir -p $out/{bin,lib/${binaryName}}
+    mv BloodHound-linux-x64/* $out/lib/${binaryName}
+    chmod +x $out/lib/${binaryName}/${binaryName}
+
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+       $out/lib/${binaryName}/${binaryName}
+
+    makeWrapper $out/lib/${binaryName}/${binaryName} $out/bin/${binaryName} \
+      --prefix XDG_DATA_DIRS : $GSETTINGS_SCHEMAS_PATH \
+      --prefix PATH : ${lib.makeBinPath [xdg-utils]} \
+      --prefix LD_LIBRARY_PATH : ${rpath}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Six Degrees of Domain Admin";
+    homepage = "https://github.com/BloodHoundAD/BloodHound";
+    downloadPage = "https://github.com/BloodHoundAD/BloodHound/release";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ lyrain ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24842,6 +24842,8 @@ with pkgs;
 
   blogc = callPackage ../applications/misc/blogc { };
 
+  bloodhound = callPackage ../applications/misc/bloodhound { };
+
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
     inherit (haskellPackages) ghcWithPackages;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds bloodhound - a utility for visualizing Active Directory to identify security issues within a domain. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
