### PR TITLE
Jupyter kernel: link extra paths and fix missing docs in sagemath jupyter

### DIFF
--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -143,6 +143,9 @@ in {
             language = "python";
             logo32 = "''${env.sitePackages}/ipykernel/resources/logo-32x32.png";
             logo64 = "''${env.sitePackages}/ipykernel/resources/logo-64x64.png";
+            extraPaths = {
+              "cool.txt" = pkgs.writeText "cool" "cool content";
+            };
           };
         }
       '';

--- a/nixos/modules/services/development/jupyter/kernel-options.nix
+++ b/nixos/modules/services/development/jupyter/kernel-options.nix
@@ -56,5 +56,14 @@ with lib;
         Path to 64x64 logo png.
       '';
     };
+
+    extraPaths = mkOption {
+      type = types.attrsOf types.path;
+      default = { };
+      example = literalExpression ''"{ examples = ''${env.sitePack}/IRkernel/kernelspec/kernel.js"; }'';
+      description = ''
+        Extra paths to link in kernel directory
+      '';
+    };
   };
 }

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -39,26 +39,22 @@ in
 
       ${concatStringsSep "\n" (mapAttrsToList (kernelName: unfilteredKernel:
         let
-          allowedKernelKeys = ["argv" "displayName" "language" "interruptMode" "env" "metadata" "logo32" "logo64"];
+          allowedKernelKeys = ["argv" "displayName" "language" "interruptMode" "env" "metadata" "logo32" "logo64" "extraPaths"];
           kernel = filterAttrs (n: v: (any (x: x == n) allowedKernelKeys)) unfilteredKernel;
           config = builtins.toJSON (
             kernel
             // {display_name = if (kernel.displayName != "") then kernel.displayName else kernelName;}
             // (optionalAttrs (kernel ? interruptMode) { interrupt_mode = kernel.interruptMode; })
           );
-          logo32 =
-            if (kernel.logo32 != null)
-            then "ln -s ${kernel.logo32} 'kernels/${kernelName}/logo-32x32.png';"
-            else "";
-          logo64 =
-            if (kernel.logo64 != null)
-            then "ln -s ${kernel.logo64} 'kernels/${kernelName}/logo-64x64.png';"
-            else "";
+          extraPaths = kernel.extraPaths or {}
+            // lib.optionalAttrs (kernel.logo32 != null) { "logo-32x32.png" = kernel.logo32; }
+            // lib.optionalAttrs (kernel.logo64 != null) { "logo-64x64.png" = kernel.logo64; }
+          ;
+          linkExtraPaths = lib.mapAttrsToList (name: value: "ln -s ${value} 'kernels/${kernelName}/${name}';") extraPaths;
         in ''
           mkdir 'kernels/${kernelName}';
           echo '${config}' > 'kernels/${kernelName}/kernel.json';
-          ${logo32}
-          ${logo64}
+          ${lib.concatStringsSep "\n" linkExtraPaths}
         '') definitions)}
 
       mkdir $out

--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -9,7 +9,7 @@
 # is always preferred, see `sage-src.nix` for that.
 
 let
-  inherit (pkgs) symlinkJoin callPackage nodePackages;
+  inherit (pkgs) symlinkJoin callPackage nodePackages lib;
 
   python3 = pkgs.python3.override {
     packageOverrides = self: super: {
@@ -46,7 +46,7 @@ let
     # just one 16x16 logo is available
     logo32 = "${sage-src}/src/doc/common/themes/sage/static/sageicon.png";
     logo64 = "${sage-src}/src/doc/common/themes/sage/static/sageicon.png";
-  };
+  } // lib.optionalAttrs withDoc { extraPaths = { "doc" = "${sagedoc}/share/doc/sage/html/en"; }; };
 
   three = callPackage ./threejs-sage.nix { };
 


### PR DESCRIPTION
###### Description of changes

Add ability to link extra paths in jupyter kernels. So far, I have encountered two cases where this is useful

- sagemath expects its documentation at `{kernel}/doc`. Currently, attempting to open the documentation from within jupyter would yield a 404 error.
- IRkernel provides a `kernel.js` file (https://github.com/IRkernel/IRkernel/blob/master/inst/kernelspec/kernel.js).

I believe allowing linkage of arbitrary paths is better than attempting to provide options for all possible files.

For the nixos module, I still have to come up with a good example.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
