### PR TITLE
terraform-providers: update 2022-03-14

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -40,10 +40,10 @@
     "owner": "aliyun",
     "provider-source-address": "registry.terraform.io/aliyun/alicloud",
     "repo": "terraform-provider-alicloud",
-    "rev": "v1.159.0",
-    "sha256": "0vfpmagxrlv6fqaq008lhygxd49br06d0bi1w6dsazfszw3ihj02",
-    "vendorSha256": "05vkn52s0x6kcyxxs0p7w6z1nclmvvla7rjv1ippzw7fgn2s19m0",
-    "version": "1.159.0"
+    "rev": "v1.160.0",
+    "sha256": "sha256-ijSOvBS8bcFKX0qa2Cl/xqDdwduamVdCWzgTCWao1Sg=",
+    "vendorSha256": "sha256-oKaghX3u8H9vDFvmo+jelTIbvuHnAt27Z9N0oEWxcxc=",
+    "version": "1.160.0"
   },
   "ansible": {
     "owner": "nbering",
@@ -94,28 +94,28 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/aws",
     "repo": "terraform-provider-aws",
-    "rev": "v4.4.0",
-    "sha256": "082bllsihmc4jndi1hrv1chcrdm755vphlgpajg22s1ajmylqgm5",
-    "vendorSha256": "0j6ghjr2mhi7nixkk8v9vwm6sr78h0wnj1lxs19lkrpnvy6jc31i",
-    "version": "4.4.0"
+    "rev": "v4.5.0",
+    "sha256": "sha256-L1LRuinU3YrqywRGpmUqGQgjZ1JuYhECjCN6ysYPzco=",
+    "vendorSha256": "sha256-3akEup/M7Zc5MPf2XA+324PxQiHegIwzR05JNSjYanw=",
+    "version": "4.5.0"
   },
   "azuread": {
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/azuread",
     "repo": "terraform-provider-azuread",
-    "rev": "v2.18.0",
-    "sha256": "06l4w9g4p48gnb9c9mmnydvpyr89f8rijpf103ndsg6ack6k4mg2",
+    "rev": "v2.19.1",
+    "sha256": "sha256-n5jDlcy5rwCcrqoL3ut+HThDLQ8hPj2mZ15d7hhALFw=",
     "vendorSha256": null,
-    "version": "2.18.0"
+    "version": "2.19.1"
   },
   "azurerm": {
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/azurerm",
     "repo": "terraform-provider-azurerm",
-    "rev": "v2.98.0",
-    "sha256": "0cfdw70q1kh6f50gsc94mh1xi7s4z47wfsmskp1ahx7av7wpz1p6",
+    "rev": "v2.99.0",
+    "sha256": "sha256-HXLr22UVciRvW1iaa46sy37ivG41hKqhrQtCXpnl8ss=",
     "vendorSha256": null,
-    "version": "2.98.0"
+    "version": "2.99.0"
   },
   "azurestack": {
     "owner": "hashicorp",
@@ -148,10 +148,10 @@
     "owner": "DrFaust92",
     "provider-source-address": "registry.terraform.io/DrFaust92/bitbucket",
     "repo": "terraform-provider-bitbucket",
-    "rev": "v2.4.1",
-    "sha256": "07y0biab2g6plkyp8scqf7b12alijnxq2zqqr05lbm6wgrc22kvk",
-    "vendorSha256": null,
-    "version": "2.4.1"
+    "rev": "v2.8.0",
+    "sha256": "sha256-W+mAud3DpBViLeFwXLWIwZ1+TOco8FWZnVrIbHUwgIU=",
+    "vendorSha256": "sha256-hSMVLDZXC9QMpcgREjEUjhxArtotrIrIyfdNIZw8uM4=",
+    "version": "2.8.0"
   },
   "brightbox": {
     "owner": "brightbox",
@@ -166,10 +166,10 @@
     "owner": "checkly",
     "provider-source-address": "registry.terraform.io/checkly/checkly",
     "repo": "terraform-provider-checkly",
-    "rev": "v1.4.2",
-    "sha256": "1wd9834d3yi2y35yrcrgxmzijrb2ymz11gqmva9m1hd10i0aqj9f",
-    "vendorSha256": "0pjxrdpsn99g6hjp0flrk7czjb05ibnsjcggrvvpwzrbj55rqzgd",
-    "version": "1.4.2"
+    "rev": "v1.4.3",
+    "sha256": "sha256-5VF1cAFgdm2TR4wvuNlycpgQuVdHesFYnTv34MeauxY=",
+    "vendorSha256": "sha256-7X2cS5Erf373zu8xqe2KBSz52ZmZOnAlNC8lq2/LXV4=",
+    "version": "1.4.3"
   },
   "checkpoint": {
     "deleteVendor": true,
@@ -194,10 +194,10 @@
     "owner": "cloudflare",
     "provider-source-address": "registry.terraform.io/cloudflare/cloudflare",
     "repo": "terraform-provider-cloudflare",
-    "rev": "v3.9.1",
-    "sha256": "02kyjf2mizvxv1a2fkw2wsk0gmilj83sj3qv1d7g0wxxkxx00nd2",
-    "vendorSha256": "167jafxr4g43y9gvqjq5z7vd9cyf15d69wbrdvqsfzj8sszqfq5l",
-    "version": "3.9.1"
+    "rev": "v3.10.1",
+    "sha256": "sha256-2Ulavo82Y8dEOXtgpbgCwuCTOhAEoOFbgL4bK5HXQlY=",
+    "vendorSha256": "sha256-CgK1/Ddau3glxmzb7Y6o1RZbMV8dwA84F6n2OzuyZrU=",
+    "version": "3.10.1"
   },
   "cloudfoundry": {
     "owner": "cloudfoundry-community",
@@ -257,10 +257,10 @@
     "owner": "DataDog",
     "provider-source-address": "registry.terraform.io/DataDog/datadog",
     "repo": "terraform-provider-datadog",
-    "rev": "v3.8.1",
-    "sha256": "0mvl80dsqzab1r3p5n446737dadzfbsyfbdy2w2xvmz4fgx6aklh",
-    "vendorSha256": "0p8czqb4hn5z9bfgsfajdpx46hwil0ax75j8xljlh1ccvpp2rvyz",
-    "version": "3.8.1"
+    "rev": "v3.9.0",
+    "sha256": "sha256-CncMqWIa1JiHkIkNAgIQl4fcKZVKZGD4BZSjuv5cw18=",
+    "vendorSha256": "sha256-U1gVP4o1mj21NW9z8jyV5KhuJNJRYAV1Qvg1fV1zGO4=",
+    "version": "3.9.0"
   },
   "dhall": {
     "owner": "awakesecurity",
@@ -275,10 +275,10 @@
     "owner": "digitalocean",
     "provider-source-address": "registry.terraform.io/digitalocean/digitalocean",
     "repo": "terraform-provider-digitalocean",
-    "rev": "v2.17.1",
-    "sha256": "0dfw4sjmsfzrs28gf5k4vqjs6phwa6w3pwi7fpbngnw6l2r4m6h9",
+    "rev": "v2.18.0",
+    "sha256": "sha256-MuJpBLOB8AeAlNhQC+rwT6mkZriU4+XgAqQY33xjFck=",
     "vendorSha256": null,
-    "version": "2.17.1"
+    "version": "2.18.0"
   },
   "dme": {
     "owner": "DNSMadeEasy",
@@ -329,19 +329,19 @@
     "owner": "phillbaker",
     "provider-source-address": "registry.terraform.io/phillbaker/elasticsearch",
     "repo": "terraform-provider-elasticsearch",
-    "rev": "v2.0.0-beta.4",
-    "sha256": "0ypw916sziy8dhvbv96f7d4as08ps18xxx8h6ip69mk74vf029sm",
-    "vendorSha256": "1w92k895ikrqm9n1hf36wlh9nq278vifl3r14v0rxa8g9awizfdr",
-    "version": "2.0.0-beta.4"
+    "rev": "v2.0.0",
+    "sha256": "sha256-wl8pRAB97JObpZvi2rdyDZP5itKcOnm6Gsbku1+5oqQ=",
+    "vendorSha256": "sha256-OCXTZg0JkaxJDEgoF2Qs4BcMSiYkQpLmehWdCpEmTzk=",
+    "version": "2.0.0"
   },
   "exoscale": {
     "owner": "exoscale",
     "provider-source-address": "registry.terraform.io/exoscale/exoscale",
     "repo": "terraform-provider-exoscale",
-    "rev": "v0.32.0",
-    "sha256": "1jnpbw50cqzkxr1xgxxnkg0fp65mz84v9fqxpv4j29djgvi94w2m",
+    "rev": "v0.33.0",
+    "sha256": "sha256-mih0Bo6fcNgpyeCQ+GWSPyTrPlGzmBXkEO43TOVWMds=",
     "vendorSha256": null,
-    "version": "0.32.0"
+    "version": "0.33.0"
   },
   "external": {
     "owner": "hashicorp",
@@ -356,10 +356,10 @@
     "owner": "fastly",
     "provider-source-address": "registry.terraform.io/fastly/fastly",
     "repo": "terraform-provider-fastly",
-    "rev": "v1.1.1",
-    "sha256": "1n7lwvfp4y0k1rh13jz94im367h6mxmvglik2nddq58pmxwns2lz",
+    "rev": "v1.1.2",
+    "sha256": "sha256-CxyVW9uE9mK+ZF8fyjAsrFKY82xAyGn9k1jOFqTaAhA=",
     "vendorSha256": null,
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "flexibleengine": {
     "owner": "FlexibleEngineCloud",
@@ -392,39 +392,39 @@
     "owner": "integrations",
     "provider-source-address": "registry.terraform.io/integrations/github",
     "repo": "terraform-provider-github",
-    "rev": "v4.20.1",
-    "sha256": "1kqi41g1lw2phar7gy35rf92qb5s32p7q780d9wrmyimriwhlh4j",
+    "rev": "v4.21.0",
+    "sha256": "sha256-ayL22zlfZkGL/ycyQX384g7CjFHDgK8k010kg1fI4h4=",
     "vendorSha256": null,
-    "version": "4.20.1"
+    "version": "4.21.0"
   },
   "gitlab": {
     "owner": "gitlabhq",
     "provider-source-address": "registry.terraform.io/gitlabhq/gitlab",
     "repo": "terraform-provider-gitlab",
-    "rev": "v3.11.1",
-    "sha256": "19l2m1d8jn5c8kd39fhw34f805ckad36vs4a2xalpb3whj89sfwy",
-    "vendorSha256": "0flvda6jrq5ff8lk0405bxs90rwpaw3aci85bfd9k258sp3ign9s",
-    "version": "3.11.1"
+    "rev": "v3.12.0",
+    "sha256": "sha256-6CrM2Pt4yB0ZaXvcgUPreIhJrUhXCNt/xt+fExzGJqc=",
+    "vendorSha256": "sha256-78/7+t75xFjLt1JfoVpHVPlM7q5BX+NI/I9ugfjdv+g=",
+    "version": "3.12.0"
   },
   "google": {
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/google",
     "proxyVendor": true,
     "repo": "terraform-provider-google",
-    "rev": "v4.12.0",
-    "sha256": "0yrzzg7b1dqfsz6wpqh869qwdwbi747hr5xwcjycl8mz4ajlwzsz",
-    "vendorSha256": "1rfhcapahzss8frpnyag53r5s7iqwq7ndqjv30bmhzw3ilwgdfdr",
-    "version": "4.12.0"
+    "rev": "v4.13.0",
+    "sha256": "sha256-QSHlnvsWmkdUE7dd6HqzYtyYC+XDW69dIp/h7u1jD9g=",
+    "vendorSha256": "sha256-1tiFBc03RyIAtnu/NqhU3RowM8JhuLNS+blfyjXBcW0=",
+    "version": "4.13.0"
   },
   "google-beta": {
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/google-beta",
     "proxyVendor": true,
     "repo": "terraform-provider-google-beta",
-    "rev": "v4.12.0",
-    "sha256": "0dbhzch3vixl8lpdd39p1crx997kdg25scliha7nj2g7a8cli73y",
-    "vendorSha256": "1rfhcapahzss8frpnyag53r5s7iqwq7ndqjv30bmhzw3ilwgdfdr",
-    "version": "4.12.0"
+    "rev": "v4.13.0",
+    "sha256": "sha256-jjYUijzUgIiSC9eL6rbgtuBSh6bbHLjeifN+GIndrVs=",
+    "vendorSha256": "sha256-1tiFBc03RyIAtnu/NqhU3RowM8JhuLNS+blfyjXBcW0=",
+    "version": "4.13.0"
   },
   "grafana": {
     "owner": "grafana",
@@ -511,10 +511,10 @@
     "owner": "IBM-Cloud",
     "provider-source-address": "registry.terraform.io/IBM-Cloud/ibm",
     "repo": "terraform-provider-ibm",
-    "rev": "v1.39.1",
-    "sha256": "1f7zhczsz9w4lk2fzcbk1w1pjwnmbgn7lk8nsyk5azkspbf4hjzv",
-    "vendorSha256": "1dhm99h7srnfwscdqy2zaj3wjdb0v1ybb7arv60522xvhsdnb99r",
-    "version": "1.39.1"
+    "rev": "v1.39.2",
+    "sha256": "sha256-9r0tt0N3m/IYq/9oepQ4DcB78ds8pb1up1TyjFYzX1U=",
+    "vendorSha256": "sha256-8qgm1zDdwKNE/bs1n5cpY/DUD3SKtFmnvEgwtKorASk=",
+    "version": "1.39.2"
   },
   "icinga2": {
     "owner": "Icinga",
@@ -565,10 +565,10 @@
     "owner": "kingsoftcloud",
     "provider-source-address": "registry.terraform.io/kingsoftcloud/ksyun",
     "repo": "terraform-provider-ksyun",
-    "rev": "v1.3.41",
-    "sha256": "0p8fl7dkp2nfw73ij769svm83cpvi1rw3aykf0qx33n9si78m892",
-    "vendorSha256": "1pm4kld23mvgs14z54fpfdvnj0alm8frkkmf0851hi58nazc54dq",
-    "version": "1.3.41"
+    "rev": "v1.3.42",
+    "sha256": "sha256-wj4o2XSz8ylZJdseIi/TadlhOwFWZ6nfDOUezbeGYw4=",
+    "vendorSha256": "sha256-nbAEaRFtFtB4ftLgnCv3MmkjFFbcNkCuxZc+G8/ObPE=",
+    "version": "1.3.42"
   },
   "kubectl": {
     "owner": "gavinbunney",
@@ -610,10 +610,10 @@
     "owner": "linode",
     "provider-source-address": "registry.terraform.io/linode/linode",
     "repo": "terraform-provider-linode",
-    "rev": "v1.25.2",
-    "sha256": "18w9x80zary64873d1r824g28l5dhkda1qq0lr895afwh8g11dfp",
-    "vendorSha256": "0c882yafydhdhnp5awb8llzbmiljfdbamqlx740347ywpliy0ga2",
-    "version": "1.25.2"
+    "rev": "v1.26.1",
+    "sha256": "sha256-bd0raIIh/VmTlSVYnNd98fpppRKnO46g8FI5OwZPjMg=",
+    "vendorSha256": "sha256-SCTWvTgJ0QYh2DEbTI9coa3Fp4fBHusytF+JFzAq2XA=",
+    "version": "1.26.1"
   },
   "linuxbox": {
     "owner": "numtide",
@@ -628,10 +628,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/local",
     "repo": "terraform-provider-local",
-    "rev": "v2.1.0",
-    "sha256": "0lv1mvy4pkx0sc49xny4j0h30m64lvr3rnmqk85i5p0xhyn77gf2",
-    "vendorSha256": null,
-    "version": "2.1.0"
+    "rev": "v2.2.2",
+    "sha256": "sha256-JpTdRi9EagrnhYnlq6sl6+t4SE6i7T7YrGTsYCDync8=",
+    "vendorSha256": "sha256-Ha/MGbXwwhbVxaHbkU2xBhyNcDxLivk7vYQjfVzWOcY=",
+    "version": "2.2.2"
   },
   "logicmonitor": {
     "deleteVendor": true,
@@ -719,10 +719,10 @@
     "owner": "newrelic",
     "provider-source-address": "registry.terraform.io/newrelic/newrelic",
     "repo": "terraform-provider-newrelic",
-    "rev": "v2.39.0",
-    "sha256": "03raj9a0qxvss03ab78pdqwbkc4hc95khzi7lg1a156vxfnibdr2",
-    "vendorSha256": "0sch3wdgy6mx8a983miwi5ihky2j4mzvcg8wilwlp7nsgrfv6ghc",
-    "version": "2.39.0"
+    "rev": "v2.39.2",
+    "sha256": "sha256-NfszsBliZAjY52kPWB7yhOEYZB2V4yOp6IDffF7EG6k=",
+    "vendorSha256": "sha256-DD6zXX7anks5jRw9tn8lUvgJY4k81oGSQr0a/xofkGk=",
+    "version": "2.39.2"
   },
   "nomad": {
     "owner": "hashicorp",
@@ -771,22 +771,22 @@
     "version": "1.3.0"
   },
   "oci": {
-    "owner": "terraform-providers",
+    "owner": "oracle",
     "provider-source-address": "registry.terraform.io/hashicorp/oci",
     "repo": "terraform-provider-oci",
-    "rev": "v4.66.0",
-    "sha256": "0iyh87ckv18f3krlhklj07shv5jwskp6fd70fq3zzfdl07jyy429",
+    "rev": "v4.67.0",
+    "sha256": "sha256-kgnyGLF6UbWRbrjXDkh7y11jx4JO3hFo7/qdJzwX0rU=",
     "vendorSha256": null,
-    "version": "4.66.0"
+    "version": "4.67.0"
   },
   "okta": {
     "owner": "okta",
     "provider-source-address": "registry.terraform.io/okta/okta",
     "repo": "terraform-provider-okta",
-    "rev": "v3.22.0",
-    "sha256": "1fsxdljpyb9qxc32jgi1yrwrs8rb8iz7ld11a0sm65qhh5yvl5jh",
-    "vendorSha256": "0l0di6cmm41z7i4d498xxc8wcrbg6r9w4vcdksqhz92s1gqs3f4z",
-    "version": "3.22.0"
+    "rev": "v3.22.1",
+    "sha256": "sha256-G1KJJSxJmzFlIUWOs+7htcgp61oWCu+ryCKaIHzxhzw=",
+    "vendorSha256": "sha256-n7ih8QtapA+xno1twlM2b2XGEesdJdJIPD+QWpmJDVA=",
+    "version": "3.22.1"
   },
   "oktaasa": {
     "owner": "oktadeveloper",
@@ -811,10 +811,10 @@
     "owner": "OpenNebula",
     "provider-source-address": "registry.terraform.io/OpenNebula/opennebula",
     "repo": "terraform-provider-opennebula",
-    "rev": "v0.4.1",
-    "sha256": "13z14p8zkrmffai5pdiwi33xsznan015nl9b9cfyxi1is4m5i41m",
-    "vendorSha256": "0qyzavig8wnnjzm63pny5azywqyrnjm978yg5y0sr6zw8wghjd15",
-    "version": "0.4.1"
+    "rev": "v0.4.2",
+    "sha256": "sha256-h2trcyXJcdWQyonjdDLkJkcawE4AoFYnzLZtKPotMY0=",
+    "vendorSha256": "sha256-JTQJH0f8m6yBL8+jk6q02WPuvyre3mHql9Zy9OJW32M=",
+    "version": "0.4.2"
   },
   "openstack": {
     "owner": "terraform-provider-openstack",
@@ -829,10 +829,10 @@
     "owner": "opentelekomcloud",
     "provider-source-address": "registry.terraform.io/opentelekomcloud/opentelekomcloud",
     "repo": "terraform-provider-opentelekomcloud",
-    "rev": "v1.27.6",
-    "sha256": "1vq2h4ldvskw874fdnjqh1np5z09dh3q3lrqjmfand8ksrzacjjm",
-    "vendorSha256": "0bkya9ckh82bacaksqbb6010fwclz9wh1b5k1s9z9d0d6bgvf60m",
-    "version": "1.27.6"
+    "rev": "v1.27.7",
+    "sha256": "sha256-8y++zfxRam4sZvGWajyGiPv/5G8K7D4+ReNU7DBlqe8=",
+    "vendorSha256": "sha256-OqN+QGclKYo4jjQi0HJ/80zVTPkcOQyl4n6i2BpDZQE=",
+    "version": "1.27.7"
   },
   "opsgenie": {
     "owner": "opsgenie",
@@ -991,10 +991,10 @@
     "owner": "splunk-terraform",
     "provider-source-address": "registry.terraform.io/splunk-terraform/signalfx",
     "repo": "terraform-provider-signalfx",
-    "rev": "v6.9.0",
-    "sha256": "08p33mjshi3m36yxhlvlsghnqmw2pnihglxm2p9iapi0zg3wxqbq",
-    "vendorSha256": "0hw7gz08k27kswbn42kab730f8gj2sjksmkc662hb9nbq8ykazbd",
-    "version": "6.9.0"
+    "rev": "v6.10.0",
+    "sha256": "sha256-ZfNxab95ZDz68fEPfYd+w0E/fS/FPBVIs4kHTBhG858=",
+    "vendorSha256": "sha256-bX01PcLLpgWFMWxWPaUW8iEHxllqCmIX1/OIicB/h0M=",
+    "version": "6.10.0"
   },
   "skytap": {
     "owner": "skytap",
@@ -1027,10 +1027,10 @@
     "owner": "spotinst",
     "provider-source-address": "registry.terraform.io/spotinst/spotinst",
     "repo": "terraform-provider-spotinst",
-    "rev": "v1.68.0",
-    "sha256": "0llyy4rskspw4cy8jdbk175rli9s53mabj4b9yarm7apg17ai399",
-    "vendorSha256": "0j0airkc1p0y9w1w40fbwxmymf8rbal2ycrkp31x1c06f8s4lhzm",
-    "version": "1.68.0"
+    "rev": "v1.69.0",
+    "sha256": "sha256-pTQvqjh52B9w383yLvhNjDujSgQI1k8WpA1vpcY7RKI=",
+    "vendorSha256": "sha256-X7K0eHbmGBYnJ5ovnD/y6O9r7TTHgK7f7s9w4R5ThBU=",
+    "version": "1.69.0"
   },
   "stackpath": {
     "owner": "stackpath",
@@ -1045,10 +1045,10 @@
     "owner": "StatusCakeDev",
     "provider-source-address": "registry.terraform.io/StatusCakeDev/statuscake",
     "repo": "terraform-provider-statuscake",
-    "rev": "v1.0.1",
-    "sha256": "16pwsna1bkrdppxn2vjgbx552vsg4f2igykcb26mw3vp6n9piwfl",
-    "vendorSha256": null,
-    "version": "1.0.1"
+    "rev": "v2.0.0-pre",
+    "sha256": "sha256-S9VJRGREoRJPIb9gv822Y/8ZRa0x7WoPjU7BxLlRpOM=",
+    "vendorSha256": "sha256-wKrbjxRCDk8GFAR0OFz4w9UnkIXH9EO/S+p2RKNLJaM=",
+    "version": "2.0.0-pre"
   },
   "sumologic": {
     "owner": "SumoLogic",
@@ -1072,10 +1072,10 @@
     "owner": "tencentcloudstack",
     "provider-source-address": "registry.terraform.io/tencentcloudstack/tencentcloud",
     "repo": "terraform-provider-tencentcloud",
-    "rev": "v1.63.0",
-    "sha256": "1d5mzmr5r01gqf519r7f3mfcm1w7hryansymwazjbwy2rxpsn958",
+    "rev": "v1.65.0",
+    "sha256": "sha256-NpKZ4KbEDxCYmG2E4F/bHEUmK6invkcIaNkXDZjhmDI=",
     "vendorSha256": null,
-    "version": "1.63.0"
+    "version": "1.65.0"
   },
   "tfe": {
     "owner": "hashicorp",
@@ -1200,10 +1200,10 @@
     "owner": "hashicorp",
     "provider-source-address": "registry.terraform.io/hashicorp/vsphere",
     "repo": "terraform-provider-vsphere",
-    "rev": "v2.1.0",
-    "sha256": "193qprm7psx0gshv5q7idm05k78rpi2vpdg5pgs7bq1wpzlaqrpa",
+    "rev": "v2.1.1",
+    "sha256": "sha256-Xu5BMmOHEX+ctPu8374BDGsRC5hnvzji5oI69ptIi3Y=",
     "vendorSha256": null,
-    "version": "2.1.0"
+    "version": "2.1.1"
   },
   "vultr": {
     "owner": "vultr",
@@ -1218,10 +1218,10 @@
     "owner": "vmware",
     "provider-source-address": "registry.terraform.io/vmware/wavefront",
     "repo": "terraform-provider-wavefront",
-    "rev": "v3.0.0",
-    "sha256": "1awi74b7ny021krck0vp1gv6v93a4h0rgdl5xib82lf5pxnx4wgn",
-    "vendorSha256": "0gbwj4cqywip22irkx9hyghy6zx9dirm6gd3i70nclchvkg9dm1x",
-    "version": "3.0.0"
+    "rev": "v3.0.1",
+    "sha256": "sha256-6SQjYaN0yhcHdmM+vGvIDPHKxN34ns3Yz+CMTEo13s0=",
+    "vendorSha256": "sha256-PdSW3tyQUWbBiaM9U3NsqX/j4fMw9ZmjEDdyjxmRfD0=",
+    "version": "3.0.1"
   },
   "yandex": {
     "owner": "yandex-cloud",


### PR DESCRIPTION
###### Description of changes

Manual update as the `oci` provider currently breaks the update script, the `repo` has moved but the `provider-source-address` hasn't been updated on the registry.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
