### PR TITLE
DRAFT: netbox: init at 3.0.7

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1000,6 +1000,7 @@
   ./services/web-apps/mediawiki.nix
   ./services/web-apps/miniflux.nix
   ./services/web-apps/moodle.nix
+  ./services/web-apps/netbox.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/node-red.nix

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -1,0 +1,249 @@
+{ lib
+, config
+, pkgs
+, ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.netbox;
+  package = pkgs.netbox.override {
+    configFile = configFile;
+  };
+
+  gunicornConfigFile = pkgs.writeText "netbox-gunicorn.py" ''
+    # The IP address (typically localhost) and port that the Netbox WSGI process should listen on
+    bind = 'unix:/run/netbox/netbox.sock'
+
+    # Number of gunicorn workers to spawn. This should typically be 2n+1, where
+    # n is the number of CPU cores present.
+    workers = 5
+
+    # Number of threads per worker process
+    threads = 3
+
+    # Timeout (in seconds) for a request to complete
+    timeout = 120
+
+    # The maximum number of requests a worker can handle before being respawned
+    max_requests = 5000
+    max_requests_jitter = 500
+  '';
+
+  configFile = pkgs.writeText "netbox-configuration.py" ''
+    #########################
+    #                       #
+    #   Required settings   #
+    #                       #
+    #########################
+
+    # This is a list of valid fully-qualified domain names (FQDNs) for the NetBox server. NetBox will not permit write
+    # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
+    #
+    # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
+    ALLOWED_HOSTS = ["${cfg.hostname}"]
+
+    # PostgreSQL database configuration. See the Django documentation for a complete list of available parameters:
+    #   https://docs.djangoproject.com/en/stable/ref/settings/#databases
+    DATABASE = {
+        'NAME': 'netbox',         # Database name
+        'USER': 'netbox',         # PostgreSQL username
+    }
+
+    # Redis database settings. Redis is used for caching and for queuing background tasks such as webhook events. A separate
+    # configuration exists for each. Full connection details are required in both sections, and it is strongly recommended
+    # to use two separate database IDs.
+    REDIS = {
+        'tasks': {
+            'HOST': 'localhost',
+            'PORT': 6379,
+            # Comment out `HOST` and `PORT` lines and uncomment the following if using Redis Sentinel
+            # 'SENTINELS': [('mysentinel.redis.example.com', 6379)],
+            # 'SENTINEL_SERVICE': 'netbox',
+            'PASSWORD': "",
+            'DATABASE': 0,
+            'SSL': False,
+            # Set this to True to skip TLS certificate verification
+            # This can expose the connection to attacks, be careful
+            # 'INSECURE_SKIP_TLS_VERIFY': False,
+        },
+        'caching': {
+            'HOST': 'localhost',
+            'PORT': 6379,
+            # Comment out `HOST` and `PORT` lines and uncomment the following if using Redis Sentinel
+            # 'SENTINELS': [('mysentinel.redis.example.com', 6379)],
+            # 'SENTINEL_SERVICE': 'netbox',
+            'PASSWORD': "",
+            'DATABASE': 1,
+            'SSL': False,
+            # Set this to True to skip TLS certificate verification
+            # This can expose the connection to attacks, be careful
+            # 'INSECURE_SKIP_TLS_VERIFY': False,
+        }
+    }
+
+    # This key is used for secure generation of random numbers and strings. It must never be exposed outside of this file.
+    # For optimal security, SECRET_KEY should be at least 50 characters in length and contain a mix of letters, numbers, and
+    # symbols. NetBox will not run without this defined. For more information, see
+    # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SECRET_KEY
+    from os import environ, path
+    SECRET_KEY = open(path.join(environ.get("CREDENTIALS_DIRECTORY"), "netbox.secret")).read()
+  '';
+in
+
+{
+  options.services.netbox = {
+    enable = mkEnableOption "NetBox, an infrastructure resourece modelling application";
+
+    hostname = mkOption {
+      type = types.str;
+      example = "netbox.example.com";
+      description = ''
+        Hostname under which to serve the NetBox instance.
+      '';
+    };
+
+    secretFile = mkOption {
+      type = types.path;
+      default = "/var/lib/netbox/secret";
+      example = /run/keys/netbox.secret;
+      description = ''
+        Path to the secret used for secure random number and string
+        generation. It should be at least 50 characaster in length and
+        consist of a mix of letters, nummbers and symbols.
+
+        Will be auto-generated at the given path if it does not exist.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.redis.enable = true;
+
+    services.postgresql = {
+      enable = true;
+      ensureDatabases = [
+        "netbox"
+      ];
+      ensureUsers = [ {
+        name = "netbox";
+        ensurePermissions = {
+          "DATABASE netbox" = "ALL PRIVILEGES";
+        };
+      } ];
+    };
+
+    services.nginx = {
+      enable = true;
+      recommendedProxySettings = true;
+      virtualHosts."${cfg.hostname}" = {
+        location."/static" = {
+          alias = "${package}/opt/netbox/static";
+        };
+        location."/" = {
+          proxyPass = "http://unix:/run/netbox/netbox.sock:/";
+        };
+      };
+    };
+
+    systemd.services = let
+      commonUnitConfig = {
+        documentation = "https://netbox.readthedocs.io/en/stable/";
+        after = [
+          "network-online.target"
+        ];
+        wants = [
+          "network-online.target"
+        ];
+
+        environment = {
+          PYTHONPATH = "${pkgs.netbox.pythonPath}:${pkgs.netbox}/opt/netbox";
+        };
+      };
+
+      commonServiceConfig = {
+        DynamicUser = true;
+        User = "netbox";
+        LoadCredential = "netbox.secret:${cfg.secretFile}";
+        WorkingDirectory = "${pkgs.netbox}/opt/netbox";
+        PrivateTmp = true;
+        Restart = "on-failure";
+        RestartSec = 30;
+      };
+    in
+    {
+      nginx.serviceConfig.SupplementaryGroups = [ "netbox" ];
+
+      netbox-setup = {
+        description = "NetBox setup service";
+        before = [
+          "netbox.service"
+          "netbox-rq.service"
+          "netbox-housekeeping.service"
+        ];
+        wantedBy = [
+          "multi-user.target"
+        ];
+        unitConfig = {
+          RequiresMountsFor = "${cfg.secretFile}";
+        };
+        script = ''
+          if [ ! -f "${cfg.secretFile}" ]; then
+            ./generate_secret_key.py > "${cfg.secretFile}"
+          fi
+
+          ./manage.py migrate
+          ./manage.py trace_paths --no-input
+          ./manage.py collectstatic --no-input
+          ./manage.py remove_stale_contenttypes --no-input
+          ./manage.py clearsessions
+
+        '';
+        serviceConfig = {
+          DynamicUser = true;
+          User = "netbox";
+          WorkingDirectory = "${pkgs.netbox}/opt/netbox";
+          UMask = "0077";
+        };
+      };
+
+      netbox = {
+        description = "NetBox WSGI service";
+        wantedBy = [
+          "multi-user.target"
+        ];
+        before = [
+          # the dynamic group needs to be available before nginx can start
+          "nginx.service"
+        ];
+        serviceConfig = {
+          ExecStart = "${pkgs.gunicorn}/bin/gunicorn --config ${gunicornConfig} --pid /run/netbox/netbox.pid netbox.wsgi";
+          PIDFile = "/run/netbox/netbox.pid";
+          RuntimeDirectory = "netbox";
+          RuntimeDirectoryMode = "0750";
+        } // commongServiceConfig;
+      } // commonUnitConfig;
+
+      netbox-rq = {
+        description = "NetBox Request Queue Worker";
+        wantedBy = [
+          "multi-user.target"
+        ];
+
+        serviceConfig = {
+          ExecStart = "manage.py rqworker high default low";
+        } // commonServieConfig;
+
+      } // commonUnitConfig;
+
+      netbox-housekeeping = {
+        description = "NetBox Housekeeping service";
+        startAt = "daily";
+        serviceConfig = {
+          ExecStart = "manage.py housekeeping";
+        } // commonServiceConfig;
+      } // commonUnitConfig;
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -288,6 +288,7 @@ in
   ndppd = handleTest ./ndppd.nix {};
   nebula = handleTest ./nebula.nix {};
   neo4j = handleTest ./neo4j.nix {};
+  netbox = handleTest ./netbox.nix {};
   netdata = handleTest ./netdata.nix {};
   networking.networkd = handleTest ./networking.nix { networkd = true; };
   networking.scripted = handleTest ./networking.nix { networkd = false; };

--- a/nixos/tests/netbox.nix
+++ b/nixos/tests/netbox.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+with lib;
+
+{
+  name = "netbox";
+  meta.maintainers = with maintainers; [ hexa ];
+
+  nodes.machine = { pkgs, ... }: {
+    networking.extraHosts = ''
+      netbox.example.com ::1
+    '';
+
+    services.netbox = {
+      enable = true;
+      hostname = "netbox.example.com";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("netbox.service")
+    machine.wait_for_open_port("80")
+    machine.succeed("curl --fail http://netbox.example.com/")
+  '';
+})

--- a/pkgs/servers/web-apps/netbox/default.nix
+++ b/pkgs/servers/web-apps/netbox/default.nix
@@ -1,0 +1,81 @@
+{ lib
+, python3
+, fetchFromGitHub
+
+, configFile ? false
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      django = super.django_3;
+    };
+  };
+in
+
+with python.pkgs;
+
+buildPythonApplication rec {
+  pname = "netbox";
+  version = "3.0.7";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "15231llr36nx6karqdhl3vvcan7g0hxwjxkf40vyalrnavrrh5v4";
+  };
+
+  propagatedBuildInputs = [
+    django
+    django-cors-headers
+    django-debug-toolbar
+    django-filter
+    django-graphiql-debug-toolbar
+    django-mptt
+    django-pglocks
+    django-prometheus
+    django-redis
+    django-rq
+    django-tables2
+    django-taggit
+    django-timezone-field
+    djangorestframework
+    drf-yasg
+    graphene-django
+    jinja2
+    jsonschema
+    markdown
+    markdown-include
+    netaddr
+    packaging
+    pillow
+    psycopg2
+    pyyaml
+    svgwrite
+    tablib
+  ];
+
+  installPhase = ''
+    install -d $out/opt/netbox
+    cp -r netbox/* $out/opt/netbox
+  '';
+
+  postInstall = lib.optionalString (configFile) ''
+    cp ${configFile} $out/opt/netbox/netbox/configuration.py
+  '';
+
+  doCheck = false; # testing requires a running postgresql instance
+
+  passthru = {
+    pythonPath = lib.makeLibPath propagatedBuildInputs;
+  };
+
+  meta = with lib; {
+    description = "Infrastructure resource modeling for network automation";
+    homepage = "https://github.com/netbox-community/netbox";
+    license = licenses.asl20;
+    maintainers = with maihntainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/web-apps/netbox/test-with-sqlite3.patch
+++ b/pkgs/servers/web-apps/netbox/test-with-sqlite3.patch
@@ -1,0 +1,19 @@
+diff --git a/netbox/netbox/configuration.testing.py b/netbox/netbox/configuration.testing.py
+index 59529b80c..acb14c475 100644
+--- a/netbox/netbox/configuration.testing.py
++++ b/netbox/netbox/configuration.testing.py
+@@ -6,12 +6,8 @@
+ ALLOWED_HOSTS = ['*']
+ 
+ DATABASE = {
+-    'NAME': 'netbox',
+-    'USER': 'netbox',
+-    'PASSWORD': 'netbox',
+-    'HOST': 'localhost',
+-    'PORT': '',
+-    'CONN_MAX_AGE': 300,
++    'ENGINE': 'sqlite3',
++    'NAME': ':memory:',
+ }
+ 
+ PLUGINS = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20818,6 +20818,8 @@ with pkgs;
 
   networkaudiod = callPackage ../servers/networkaudiod { };
 
+  netbox = callPackage ../servers/web-apps/netbox { };
+
   unifiedpush-common-proxies = callPackage ../servers/unifiedpush-common-proxies { };
 
   unit = callPackage ../servers/http/unit { };


### PR DESCRIPTION
###### Description of changes

Annoying. I prepared these changes back in september/october and never got around to upstream them. They're incomplete but I hope there's something worth recycling in #162624.

I failed to find this again at the time because it sat in a local working dir on a branch called django-things. :disappointed: 

@n0emis @RaitoBezarius PTAL.

NOT INTENDED FOR MERGE.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
