### PR TITLE
nixos/switch-to-configuration: fix installBootLoader escaping

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -67,7 +67,10 @@ openlog("nixos", "", LOG_USER);
 
 # Install or update the bootloader.
 if ($action eq "switch" || $action eq "boot") {
-    system('@installBootLoader@', $out) == 0 or exit 1;
+    chomp(my $installBootLoader = <<'EOFBOOTLOADER');
+@installBootLoader@
+EOFBOOTLOADER
+    system("$installBootLoader $out") == 0 or exit 1;
 }
 
 # Just in case the new configuration hangs the system, do a sync now.


### PR DESCRIPTION
Use a quoted heredoc to inject installBootLoader safely into the script, and restore the previous invocation of `system` with a single argument so that shell commands keep working.

See https://github.com/NixOS/nixpkgs/pull/163069#issuecomment-1066209601, cc @dasJ 
