### PR TITLE
pythonPackages/boto: enable Python 3.9

### DIFF
--- a/pkgs/development/python-modules/boto/bug-953970_python3.8-compat.patch
+++ b/pkgs/development/python-modules/boto/bug-953970_python3.8-compat.patch
@@ -1,0 +1,53 @@
+Index: python-boto/tests/unit/utils/test_utils.py
+===================================================================
+--- python-boto.orig/tests/unit/utils/test_utils.py
++++ python-boto/tests/unit/utils/test_utils.py
+@@ -85,7 +85,7 @@ class TestPassword(unittest.TestCase):
+         def hmac_hashfunc(cls, msg):
+             if not isinstance(msg, bytes):
+                 msg = msg.encode('utf-8')
+-            return hmac.new(b'mysecretkey', msg)
++            return hmac.new(b'mysecretkey', msg, digestmod='sha256')
+
+         class HMACPassword(Password):
+             hashfunc = hmac_hashfunc
+@@ -95,15 +95,15 @@ class TestPassword(unittest.TestCase):
+         password.set('foo')
+
+         self.assertEquals(str(password),
+-                          hmac.new(b'mysecretkey', b'foo').hexdigest())
++                          hmac.new(b'mysecretkey', b'foo', digestmod='sha256').hexdigest())
+
+     def test_constructor(self):
+-        hmac_hashfunc = lambda msg: hmac.new(b'mysecretkey', msg)
++        hmac_hashfunc = lambda msg: hmac.new(b'mysecretkey', msg, digestmod='sha256')
+
+         password = Password(hashfunc=hmac_hashfunc)
+         password.set('foo')
+         self.assertEquals(password.str,
+-                          hmac.new(b'mysecretkey', b'foo').hexdigest())
++                          hmac.new(b'mysecretkey', b'foo', digestmod='sha256').hexdigest())
+
+
+ class TestPythonizeName(unittest.TestCase):
+Index: python-boto/boto/ecs/item.py
+===================================================================
+--- python-boto.orig/boto/ecs/item.py
++++ python-boto/boto/ecs/item.py
+@@ -22,6 +22,7 @@
+
+ import xml.sax
+ import cgi
++from html import escape
+ from boto.compat import six, StringIO
+
+ class ResponseGroup(xml.sax.ContentHandler):
+@@ -67,7 +68,7 @@ class ResponseGroup(xml.sax.ContentHandl
+         return None
+
+     def endElement(self, name, value, connection):
+-        self._xml.write("%s</%s>" % (cgi.escape(value).replace("&amp;amp;", "&amp;"), name))
++        self._xml.write("%s</%s>" % (escape(value).replace("&amp;amp;", "&amp;"), name))
+         if len(self._nodepath) == 0:
+             return
+         obj = None

--- a/pkgs/development/python-modules/boto/default.nix
+++ b/pkgs/development/python-modules/boto/default.nix
@@ -2,8 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , pythonAtLeast
-, isPy38
-, isPy39
 , python
 , nose
 , mock
@@ -21,11 +19,16 @@ buildPythonPackage rec {
     sha256 = "ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a";
   };
 
+  patches = [
+    # fixes hmac tests
+    # https://sources.debian.org/src/python-boto/2.49.0-4/debian/patches/bug-953970_python3.8-compat.patch/
+    ./bug-953970_python3.8-compat.patch
+  ];
+
   checkPhase = ''
     ${python.interpreter} tests/test.py default
   '';
 
-  doCheck = !isPy38 && !isPy39; # hmac functionality has changed
   checkInputs = [ nose mock ];
   propagatedBuildInputs = [ requests httpretty ];
 

--- a/pkgs/development/python-modules/boto/default.nix
+++ b/pkgs/development/python-modules/boto/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , pythonAtLeast
 , isPy38
+, isPy39
 , python
 , nose
 , mock
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "boto";
   version = "2.49.0";
-  disabled = pythonAtLeast "3.9"; # no longer compatible with hmac std lib package
+  disabled = pythonAtLeast "3.10"; # cannot import name 'Mapping' from 'collections'
 
   src = fetchPypi {
     inherit pname version;
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     ${python.interpreter} tests/test.py default
   '';
 
-  doCheck = !isPy38; # hmac functionality has changed
+  doCheck = !isPy38 && !isPy39; # hmac functionality has changed
   checkInputs = [ nose mock ];
   propagatedBuildInputs = [ requests httpretty ];
 


### PR DESCRIPTION
Enable and test boto with python 3.9.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

@costrouc 