### PR TITLE
Pantheon: prepare for vala 0.56

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-mail/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -33,6 +34,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-ooqVNMgeAqGlFcfachPPfhSiKTEEcNGv5oWdM7VLWOc=";
   };
+
+  patches = [
+    # Fix build with vala 0.56
+    # https://github.com/elementary/mail/pull/765
+    (fetchpatch {
+      url = "https://github.com/elementary/mail/commit/c3aa61d226f49147d7685cc00013469ff4df369a.patch";
+      sha256 = "sha256-OxNBGIC1hrEaFSufQ59Wb0AMfdzqPt6diL4g3hbL/Ig=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , meson
 , ninja
@@ -40,6 +41,15 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-NhF/WgS6IOwgALSCNyFNxz8ROVTb+mUX+lBtnWEyhEI=";
   };
+
+  patches = [
+    # Fix build with vala 0.56
+    # https://github.com/elementary/photos/pull/711
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/6594f1323726fb0d38519a7bdafe16f9170353cb.patch";
+      sha256 = "sha256-Ie9ULC8Xw4KLQJANPXh4LDywMjWfniPX/P76eHW8LHc=";
+    })
+  ];
 
   nativeBuildInputs = [
     appstream


### PR DESCRIPTION
###### Description of changes

So they won't fail to build when vala 0.56 becomes default (which will likely happen in the [GNOME 42 pull request](https://github.com/NixOS/nixpkgs/pull/160343)).

Previous "prepare for xxx" PR: #154837

###### Things done

- On x86_64-linux, use Vala 0.55.91 to build Pantheon packages:
  - [x] Built nixosTests.pantheon
  - [x] Built pantheon.appcenter pantheon.sideload
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
