### PR TITLE
souffle: 2.0.2 -> 2.2

### DIFF
--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch
+{ lib, stdenv, fetchFromGitHub
 , bash-completion, perl, ncurses, zlib, sqlite, libffi
 , mcpp, cmake, bison, flex, doxygen, graphviz
 , makeWrapper

--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch
-, perl, ncurses, zlib, sqlite, libffi
-, autoreconfHook, mcpp, bison, flex, doxygen, graphviz
+, bash-completion, perl, ncurses, zlib, sqlite, libffi
+, mcpp, cmake, bison, flex, doxygen, graphviz
 , makeWrapper
 }:
 
@@ -10,42 +10,23 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "souffle";
-  version = "2.0.2";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner  = "souffle-lang";
     repo   = "souffle";
     rev    = version;
-    sha256 = "1fa6yssgndrln8qbbw2j7j199glxp63irfrz1c2y424rq82mm2r5";
+    sha256 = "sha256-whvC+DL9XbQLc4wf2kFxUKXSyJnGkYq0/0uLCLbliJU=";
   };
 
-  patches = [
-    # Pull pending unstream inclusion fix for ncurses-6.3:
-    #  https://github.com/souffle-lang/souffle/pull/2134
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/souffle-lang/souffle/commit/9e4bdf86d051ef2e1b1a1be64aff7e498fd5dd20.patch";
-      sha256 = "0jw1b6qfdf49dx2qlzn1b2yzrgpnkil4w9y3as1m28w8ws7iphpa";
-    })
-  ];
-
-  nativeBuildInputs = [ autoreconfHook bison flex mcpp doxygen graphviz makeWrapper perl ];
-  buildInputs = [ ncurses zlib sqlite libffi ];
-
+  nativeBuildInputs = [ bison cmake flex mcpp doxygen graphviz makeWrapper perl ];
+  buildInputs = [ bash-completion ncurses zlib sqlite libffi ];
   # these propagated inputs are needed for the compiled Souffle mode to work,
   # since generated compiler code uses them. TODO: maybe write a g++ wrapper
   # that adds these so we can keep the propagated inputs clean?
   propagatedBuildInputs = [ ncurses zlib sqlite libffi ];
 
-  # see 565a8e73e80a1bedbb6cc037209c39d631fc393f and parent commits upstream for
-  # Wno-error fixes
-  postPatch = ''
-    substituteInPlace ./src/Makefile.am \
-      --replace '-Werror' '-Werror -Wno-error=deprecated -Wno-error=other'
-
-    substituteInPlace configure.ac \
-      --replace "m4_esyscmd([git describe --tags --always | tr -d '\n'])" "${version}"
-  '';
+  cmakeFlags = [ "-DSOUFFLE_GIT=OFF" ];
 
   postInstall = ''
     wrapProgram "$out/bin/souffle" --prefix PATH : "${toolsPath}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13452,9 +13452,7 @@ with pkgs;
     boost = boost172;
   };
 
-  souffle = callPackage ../development/compilers/souffle {
-    autoreconfHook = buildPackages.autoreconfHook269;
-  };
+  souffle = callPackage ../development/compilers/souffle { };
 
   spasm-ng = callPackage ../development/compilers/spasm-ng { };
 


### PR DESCRIPTION
###### Description of changes

Update `souffle` to 2.2. [Here's a link to the changelog](https://github.com/souffle-lang/souffle/blob/2.2/debian/changelog.in)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This supercedes, and is largely based on, #135688

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
