### PR TITLE
ibus: 1.5.24 -> 1.5.26

### DIFF
--- a/nixos/modules/programs/environment.nix
+++ b/nixos/modules/programs/environment.nix
@@ -40,12 +40,14 @@ in
         KDEDIRS = [ "" ];
         QT_PLUGIN_PATH = [ "/lib/qt4/plugins" "/lib/kde4/plugins" ];
         QTWEBKIT_PLUGIN_PATH = [ "/lib/mozilla/plugins/" ];
-        GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" ];
+        GTK_PATH = [ "/lib/gtk-2.0" "/lib/gtk-3.0" "/lib/gtk-4.0" ];
         XDG_CONFIG_DIRS = [ "/etc/xdg" ];
         XDG_DATA_DIRS = [ "/share" ];
         MOZ_PLUGIN_PATH = [ "/lib/mozilla/plugins" ];
         LIBEXEC_PATH = [ "/lib/libexec" ];
       };
+
+    environment.pathsToLink = [ "/lib/gtk-2.0" "/lib/gtk-3.0" "/lib/gtk-4.0" ];
 
     environment.extraInit =
       ''

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , substituteAll
 , fetchurl
+, fetchpatch
 , fetchFromGitHub
 , autoreconfHook
 , gettext
@@ -9,12 +10,14 @@
 , vala
 , wrapGAppsHook
 , dbus
+, systemd
 , dconf ? null
 , glib
 , gdk-pixbuf
 , gobject-introspection
 , gtk2
 , gtk3
+, gtk4
 , gtk-doc
 , runCommand
 , isocodes
@@ -60,16 +63,22 @@ in
 
 stdenv.mkDerivation rec {
   pname = "ibus";
-  version = "1.5.24";
+  version = "1.5.26";
 
   src = fetchFromGitHub {
     owner = "ibus";
     repo = "ibus";
     rev = version;
-    sha256 = "sha256-1qx06MlEUjSS067FdQG1Bdi4ZAh3hPcNjUX5PIiC3Sk=";
+    sha256 = "7Vuj4Gyd+dLUoCkR4SPkfGPwVQPRo2pHk0pRAsmtjxc=";
   };
 
   patches = [
+    # Fixes systemd unit installation path https://github.com/ibus/ibus/pull/2388
+    (fetchpatch {
+      url = "https://github.com/ibus/ibus/commit/33b4b3932bfea476a841f8df99e20049b83f4b0e.patch";
+      sha256 = "kh8SBR+cqsov/B0A2YXLJVq1F171qoSRUKbBPHjPRHI=";
+    })
+
     (substituteAll {
       src = ./fix-paths.patch;
       pythonInterpreter = python3Runtime.interpreter;
@@ -94,6 +103,7 @@ stdenv.mkDerivation rec {
     (enableFeature enablePython2Library "python-library")
     (enableFeature enablePython2Library "python2") # XXX: python2 library does not work anyway
     (enableFeature enableUI "ui")
+    "--enable-gtk4"
     "--enable-install-tests"
     "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
     "--with-emoji-annotation-dir=${cldr-emoji-annotation}/share/unicode/cldr/common/annotations"
@@ -123,12 +133,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     dbus
+    systemd
     dconf
     gdk-pixbuf
     gobject-introspection
     python3.pkgs.pygobject3 # for pygobject overrides
     gtk2
     gtk3
+    gtk4
     isocodes
     json-glib
     libnotify

--- a/pkgs/tools/inputmethods/ibus/fix-paths.patch
+++ b/pkgs/tools/inputmethods/ibus/fix-paths.patch
@@ -1,6 +1,8 @@
+diff --git a/configure.ac b/configure.ac
+index a3cdb2da..cade9466 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -429,11 +429,11 @@
+@@ -469,11 +469,11 @@ PKG_CHECK_EXISTS([pygobject-3.0 >= $PYGOBJECT_REQUIRED],
  if test "x$enable_pygobject" = "xyes"; then
      PKG_CHECK_MODULES(PYTHON, [pygobject-3.0 >= $PYGOBJECT_REQUIRED])
  
@@ -14,7 +16,7 @@
          AC_SUBST(py2overridesdir)
      fi
  fi
-@@ -462,7 +462,7 @@
+@@ -502,7 +502,7 @@ if test x"$enable_python_library" = x"yes"; then
      PYTHON2_VERSION=`$PYTHON2 -c "import sys; sys.stdout.write(sys.version[[:3]])"`
      PYTHON2_LIBDIR="$PYTHON2_PREFIX/lib/python$PYTHON2_VERSION"
      python2dir="$PYTHON2_LIBDIR/site-packages"
@@ -23,9 +25,11 @@
      AC_SUBST(pkgpython2dir)
  else
      enable_python_library="no (disabled, use --enable-python-library to enable)"
+diff --git a/data/dconf/Makefile.am b/data/dconf/Makefile.am
+index 5360f033..6d5e726f 100644
 --- a/data/dconf/Makefile.am
 +++ b/data/dconf/Makefile.am
-@@ -50,7 +50,7 @@
+@@ -50,7 +50,7 @@ man_5dir = $(mandir)/man5
  
  install-data-hook:
  	if test -z "$(DESTDIR)"; then \
@@ -34,12 +38,14 @@
  	fi
  
  EXTRA_DIST = \
+diff --git a/setup/ibus-setup.in b/setup/ibus-setup.in
+index 474ce8a8..ee30808e 100644
 --- a/setup/ibus-setup.in
 +++ b/setup/ibus-setup.in
-@@ -27,5 +27,5 @@
+@@ -27,5 +27,5 @@ export IBUS_PREFIX=@prefix@
  export IBUS_DATAROOTDIR=@datarootdir@
  export IBUS_LOCALEDIR=@localedir@
  export IBUS_LIBEXECDIR=${libexecdir}
--exec ${PYTHON:-@PYTHON@} @prefix@/share/ibus/setup/main.py $@
-+exec @pythonInterpreter@ @prefix@/share/ibus/setup/main.py $@
+-exec ${PYTHON:-@PYTHON@} @prefix@/share/ibus/setup/main.py "$@"
++exec @pythonInterpreter@ @prefix@/share/ibus/setup/main.py "$@"
  


### PR DESCRIPTION
https://github.com/ibus/ibus/releases/tag/1.5.25
https://github.com/ibus/ibus/releases/tag/1.5.26

~Upstream added a dependency on systemd only to get the pkg-config variable `systemduserunitdir`, which is wrong for our purposes (we only want /lib/systemd/user without the systemd prefix) so we can drop the dependency.~

Also enabled GTK 4 in hope to fix #163683 (cc @jian-lin, not sure how to test this)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
