### PR TITLE
mercurial: add patch to fix the libc buffer type for aarch64-linux

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -28,6 +28,11 @@ let
       sha256 = "sha256-hvmGReRWWpJWmR3N4it3uOfSLKb7tgwfTNvYRpo4zB8=";
     };
 
+    patches = [
+      # Fix the type of libc buffer for aarch64-linux
+      ./fix-rhg-type-aarch64.patch
+    ];
+
     format = "other";
 
     passthru = { inherit python; }; # pass it so that the same version can be used in hg2git

--- a/pkgs/applications/version-management/mercurial/fix-rhg-type-aarch64.patch
+++ b/pkgs/applications/version-management/mercurial/fix-rhg-type-aarch64.patch
@@ -1,0 +1,12 @@
+diff --git a/rust/hg-core/src/lock.rs b/rust/hg-core/src/lock.rs
+--- a/rust/hg-core/src/lock.rs
++++ b/rust/hg-core/src/lock.rs
+@@ -145,7 +145,7 @@ lazy_static::lazy_static! {
+ 
+         /// Same as https://github.com/python/cpython/blob/v3.10.0/Modules/socketmodule.c#L5414
+         const BUFFER_SIZE: usize = 1024;
+-        let mut buffer = [0_i8; BUFFER_SIZE];
++        let mut buffer = [0 as libc::c_char; BUFFER_SIZE];
+         let hostname_bytes = unsafe {
+             let result = libc::gethostname(buffer.as_mut_ptr(), BUFFER_SIZE);
+             if result != 0 {


### PR DESCRIPTION
###### Description of changes

Unbreak Mercurial 6.1 builds on aarch64-linux.

I don't have an aarch64-linux machine to hand, so going to rely on OfBorg for this one.

Fixing upstream: https://phab.mercurial-scm.org/D12373

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
