### PR TITLE
mercurial: add patches to fix tests on aarch64-linux 

### DIFF
--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -165,6 +165,9 @@ let
 
     # doesn't like the extra setlocale warnings emitted by our bash wrappers
     test-locale.t
+
+    # tricky and flaky on busy machines
+    test-racy-mutations.t
     EOF
 
     export HGTEST_REAL_HG="${mercurial}/bin/hg"

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -37,6 +37,12 @@ let
         url = "https://phab.mercurial-scm.org/D12374?id=32639&download=true";
         sha256 = "sha256-5+7FW1ghTqfUKjqzfiTDHZXilYVfhCi7rKfYOnHWoD0=";
       })
+
+      (fetchpatch {
+        name = "tests-fix-glob-pattern-for-dynamic-timer-alignment.patch";
+        url = "https://phab.mercurial-scm.org/D12381?id=32652&download=true";
+        sha256 = "sha256-TBJ1XmuWhwIqd7eH+tV8VHBwfW+GzDugsFKr4C+wT2o=";
+      })
     ];
 
     format = "other";

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -31,6 +31,12 @@ let
     patches = [
       # Fix the type of libc buffer for aarch64-linux
       ./fix-rhg-type-aarch64.patch
+
+      (fetchpatch {
+        name = "revlog-fix-wrong-type-of-rank_unknown-variable.patch";
+        url = "https://phab.mercurial-scm.org/D12374?id=32639&download=true";
+        sha256 = "sha256-5+7FW1ghTqfUKjqzfiTDHZXilYVfhCi7rKfYOnHWoD0=";
+      })
     ];
 
     format = "other";


### PR DESCRIPTION
###### Description of changes

See commit messages.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
