### PR TITLE
ipfetch: init at unstable-2022-03-24

### DIFF
--- a/pkgs/tools/networking/ipfetch/default.nix
+++ b/pkgs/tools/networking/ipfetch/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, lib, fetchFromGitHub, bash, wget, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "ipfetch";
+  version = "unstable-2022-03-24";
+
+  src = fetchFromGitHub {
+    owner = "trakBan";
+    repo = "ipfetch";
+    rev = "fc295bfda4f9fea6eee9f6f3f2dabc26b6f25be4";
+    sha256 = "sha256-YKQ9pRBj2hgPg2ShCqWGxzHs/n7kNhKRNyElRDwHDBU=";
+  };
+
+  strictDeps = true;
+  buildInputs = [ bash wget ];
+  nativeBuildInputs = [ makeWrapper ];
+  patchPhase = ''
+    patchShebangs --host ipfetch
+    # Not only does `/usr` have to be replaced but also `/flags` needs to be added because with Nix the script is broken without this. The `/flags` is somehow not needed if you install via the install script in the source repository.
+    substituteInPlace ./ipfetch --replace /usr/share/ipfetch $out/usr/share/ipfetch/flags
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/usr/share/ipfetch/
+    cp -r flags $out/usr/share/ipfetch/
+    cp ipfetch $out/bin/ipfetch
+    wrapProgram $out/bin/ipfetch --prefix PATH : ${
+      lib.makeBinPath [ bash wget ]
+    }
+  '';
+
+  meta = with lib; {
+    description = "Neofetch but for ip adresses";
+    license = licenses.gpl3Only;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ papojari ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6843,6 +6843,8 @@ with pkgs;
   iperf3 = callPackage ../tools/networking/iperf/3.nix { };
   iperf = iperf3;
 
+  ipfetch = callPackage ../tools/networking/ipfetch { };
+
   ipfs = callPackage ../applications/networking/ipfs {
     buildGoModule = buildGo116Module;
   };


### PR DESCRIPTION
###### Description of changes

Add ipfetch and therefore fix https://github.com/NixOS/nixpkgs/issues/164097

> Neofetch like tool that can lookup IPs. :earth_americas:
>
> https://github.com/trakBan/ipfetch

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
