### PR TITLE
`bottles`: `2022.2.28-trento-1` -> `2022.3.14-trento-3` & add autoupdate

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -22,6 +22,8 @@ python3Packages.buildPythonApplication rec {
   pname = "bottles";
   version = "2022.2.28-trento-1";
   sha256 = "tE6YuuZZcs3RKxs1S6OoGt0CXz3oHUi/sopFN0iywds=";
+  # Note: Update via pkgs/applications/misc/bottles/update.py
+  # mostly copypasted from pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
@@ -95,6 +97,10 @@ python3Packages.buildPythonApplication rec {
   preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
+
+  passthru = {
+    updateScript = ./update.py;
+  };
 
   meta = with lib; {
     description = "An easy-to-use wineprefix manager";

--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -4,7 +4,7 @@
 , python3Packages, gettext
 , appstream-glib, gdk-pixbuf, glib, gobject-introspection, gspell, gtk3, gtksourceview4, gnome
 , steam, xdg-utils, pciutils, cabextract, wineWowPackages
-, freetype, p7zip, gamemode
+, freetype, p7zip, gamemode, mangohud
 , bottlesExtraLibraries ? pkgs: [ ] # extra packages to add to steam.run multiPkgs
 , bottlesExtraPkgs ? pkgs: [ ] # extra packages to add to steam.run targetPkgs
 }:
@@ -20,8 +20,8 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "bottles";
-  version = "2022.2.28-trento-1";
-  sha256 = "tE6YuuZZcs3RKxs1S6OoGt0CXz3oHUi/sopFN0iywds=";
+  version = "2022.3.14-trento-3";
+  sha256 = "0wdqj9l69a9pnray2zcfgl2yw0hmrh23njbgwgqccimch014ckdq";
   # Note: Update via pkgs/applications/misc/bottles/update.py
   # mostly copypasted from pkgs/applications/networking/instant-messengers/telegram/tdesktop/update.py
 
@@ -82,6 +82,7 @@ python3Packages.buildPythonApplication rec {
     freetype
     p7zip
     gamemode # programs.gamemode.enable
+    mangohud
   ];
 
   format = "other";
@@ -91,7 +92,9 @@ python3Packages.buildPythonApplication rec {
   preConfigure = ''
     patchShebangs build-aux/meson/postinstall.py
     substituteInPlace src/backend/wine/winecommand.py \
-      --replace '= f"{Paths.runners}' '= f"${steam-run}/bin/steam-run {Paths.runners}'
+      --replace \
+        'self.__get_runner()' \
+        '(lambda r: (f"${steam-run}/bin/steam-run {r}", r)[r == "wine" or r == "wine64"])(self.__get_runner())'
   '';
 
   preFixup = ''

--- a/pkgs/applications/misc/bottles/update.py
+++ b/pkgs/applications/misc/bottles/update.py
@@ -1,0 +1,65 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 nix nix-prefetch-git
+
+import fileinput
+import json
+import os
+import re
+import subprocess
+
+from datetime import datetime
+from urllib.request import urlopen, Request
+
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HEADERS = {'Accept': 'application/vnd.github.v3+json'}
+
+
+def github_api_request(endpoint):
+    base_url = 'https://api.github.com/'
+    request = Request(base_url + endpoint, headers=HEADERS)
+    with urlopen(request) as http_response:
+        return json.loads(http_response.read().decode('utf-8'))
+
+
+def get_commit_date(repo, sha):
+    url = f'https://api.github.com/repos/{repo}/commits/{sha}'
+    request = Request(url, headers=HEADERS)
+    with urlopen(request) as http_response:
+        commit = json.loads(http_response.read().decode())
+        date = commit['commit']['committer']['date'].rstrip('Z')
+        date = datetime.fromisoformat(date).date().isoformat()
+        return 'unstable-' + date
+
+
+def nix_prefetch_git(url, rev):
+    """Prefetches the requested Git revision (incl. submodules) of the given repository URL."""
+    print(f'nix-prefetch-git {url} {rev}')
+    out = subprocess.check_output(['nix-prefetch-git', '--quiet', '--url', url, '--rev', rev, '--fetch-submodules'])
+    return json.loads(out)['sha256']
+
+
+def nix_prefetch_url(url, unpack=False):
+    """Prefetches the content of the given URL."""
+    print(f'nix-prefetch-url {url}')
+    options = ['--type', 'sha256']
+    if unpack:
+        options += ['--unpack']
+    out = subprocess.check_output(['nix-prefetch-url'] + options + [url])
+    return out.decode('utf-8').rstrip()
+
+
+def update_file(relpath, version, sha256):
+    file_path = os.path.join(DIR, relpath)
+    with fileinput.FileInput(file_path, inplace=True) as f:
+        for line in f:
+            result = line
+            result = re.sub(r'^  version = ".+";', f'  version = "{version}";', result)
+            result = re.sub(r'^  sha256 = ".+";', f'  sha256 = "{sha256}";', result)
+            print(result, end='')
+
+
+if __name__ == "__main__":
+    bottles_version = github_api_request('repos/bottlesdevs/Bottles/releases/latest')['tag_name']
+    bottles_hash = nix_prefetch_git('https://github.com/bottlesdevs/Bottles.git', bottles_version)
+    update_file('default.nix', bottles_version, bottles_hash)


### PR DESCRIPTION
###### Description of changes
`bottles`: `2022.2.28-trento-1` -> `2022.3.14-trento-3`
And autoupdate added

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
