### PR TITLE
firefox: add lld to nativeBuildInputs to work around cc-wrapper bug

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -197,6 +197,7 @@ buildStdenv.mkDerivation ({
       cargo
       gnused
       llvmPackages.llvm # llvm-objdump
+      llvmPackages.lld
       makeWrapper
       nodejs
       perl


### PR DESCRIPTION
###### Description of changes

This change is a dirty hack to fix a build issue I'm experiencing on powerpc64le, where it fails like this since #163484 was merged:

```
/nix/store/yzz931sk5nsszb7amk9g6qzifv19rsmj-wasm32-unknown-wasi-clang-wrapper-12.0.1/bin/wasm32-unknown-wasi-c++ -std=gnu++17 --sysroot=/nix/store/y9a547ikx8ky2370fjncd5qpdjd3jxvm-wasi-sysroot -o rlbox.wasm -Wl,--export-all -Wl,--stack-first -Wl,-z,stack-size=262144 -Wl,--no-entry -Wl,--growable-table ogg_alloc.wasm ogg_bitwise.wasm ogg_framing.wasm xmlparse.wasm xmlrole.wasm xmltok.wasm wasm2c_sandbox_wrapper.wasm mozHunspellRLBoxSandbox.wasm affentry.wasm affixmgr.wasm csutil.wasm hashmgr.wasm hunspell.wasm phonet.wasm replist.wasm suggestmgr.wasm GraphiteExtra.wasm CmapCache.wasm Code.wasm Collider.wasm Decompressor.wasm Face.wasm FeatureMap.wasm FileFace.wasm Font.wasm GlyphCache.wasm GlyphFace.wasm Intervals.wasm Justifier.wasm NameTable.wasm Pass.wasm Position.wasm Segment.wasm Silf.wasm Slot.wasm Sparse.wasm TtfUtil.wasm UtfCodec.wasm call_machine.wasm gr_char_info.wasm gr_face.wasm gr_features.wasm gr_font.wasm gr_logging.wasm gr_segment.wasm gr_slot.wasm json.wasm RLBoxWOFF2Sandbox.wasm table_tags.wasm variable_length.wasm woff2_common.wasm woff2_dec.wasm woff2_out.wasm -lwasi-emulated-process-clocks
clang-12: error: unable to execute command: Executable "wasm-ld" doesn't exist!
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [/build/firefox-97.0.2/config/rules.mk:498: rlbox.wasm] Error 1
make[3]: Leaving directory '/build/firefox-97.0.2/obj-powerpc64le-unknown-linux-gnu/security/rlbox'
make[2]: *** [/build/firefox-97.0.2/config/recurse.mk:72: security/rlbox/target-objects] Error 2
make[2]: *** Waiting for unfinished jobs....
```

This seems to be because clang runs lld using `wasm-ld` from `$PATH`, so simply adding it via nativeBuildInputs fixes the build failure.

I'm submitting this as a draft PR since I don't believe doing that is the proper way to go about this: this problem arises because cc-wrapper doesn't set up the search path for this job correctly.
However, I don't understand the wrapper well enough to fix that myself.
It was recommended to me that I make this PR as a start-of-discussion and CC @Ericson2314, @matthewbauer and @alyssais as people who might know more about the involved parts of nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64le-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
