### PR TITLE
p7zip: clarify license and remove unRAR code from src drv

### DIFF
--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -8,7 +8,18 @@ stdenv.mkDerivation rec {
     owner  = "jinfeihan57";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "sha256-19F4hPV0nKVuFZNbOcXrcA1uW6Y3HQolaHVIYXGmh18=";
+    sha256 = {
+      free = "sha256-DrBuf2VPdcprHI6pMSmL7psm2ofOrUf0Oj0qwMjXzkk=";
+      unfree = "sha256-19F4hPV0nKVuFZNbOcXrcA1uW6Y3HQolaHVIYXGmh18=";
+    }.${if enableUnfree then "unfree" else "free"};
+    # remove the unRAR related code from the src drv
+    # > the license requires that you agree to these use restrictions,
+    # > or you must remove the software (source and binary) from your hard disks
+    # https://fedoraproject.org/wiki/Licensing:Unrar
+    extraPostFetch = lib.optionalString (!enableUnfree) ''
+      rm -r $out/CPP/7zip/Compress/Rar*
+      find $out -name makefile'*' -exec sed -i '/Rar/d' {} +
+    '';
   };
 
   # Default makefile is full of impurities on Darwin. The patch doesn't hurt Linux so I'm leaving it unconditional
@@ -25,11 +36,6 @@ stdenv.mkDerivation rec {
     substituteInPlace makefile.machine \
       --replace 'CC=gcc'  'CC=${stdenv.cc.targetPrefix}gcc' \
       --replace 'CXX=g++' 'CXX=${stdenv.cc.targetPrefix}g++'
-  '' + lib.optionalString (!enableUnfree) ''
-    # Remove non-free RAR source code
-    # (see DOC/License.txt, https://fedoraproject.org/wiki/Licensing:Unrar)
-    rm -r CPP/7zip/Compress/Rar*
-    find . -name makefile'*' -exec sed -i '/Rar/d' {} +
   '';
 
   makeFlags = [ "DEST_HOME=${placeholder "out"}" ];
@@ -46,13 +52,20 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=c++11-narrowing";
 
-  meta = {
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
     homepage = "https://github.com/jinfeihan57/p7zip";
     description = "A new p7zip fork with additional codecs and improvements (forked from https://sourceforge.net/projects/p7zip/)";
-    platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.raskin ];
+    license = with licenses;
+      # p7zip code is largely lgpl2Plus
+      # CPP/7zip/Compress/LzfseDecoder.cpp is bsd3
+      [ lgpl2Plus /* and */ bsd3 ] ++
+      # and CPP/7zip/Compress/Rar* are unfree with the unRAR license restriction
+      # the unRAR compression code is disabled by default
+      lib.optionals enableUnfree [ unfree ];
+    maintainers = with maintainers; [ raskin jk ];
+    platforms = platforms.unix;
     mainProgram = "7z";
-    # RAR code is under non-free UnRAR license, but we remove it
-    license = if enableUnfree then lib.licenses.unfree else lib.licenses.lgpl2Plus;
   };
 }

--- a/pkgs/tools/archivers/p7zip/update.sh
+++ b/pkgs/tools/archivers/p7zip/update.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils gnused curl jq
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+DRV_DIR="$PWD"
+
+OLD_VERSION="$(sed -nE 's/\s*version = "(.*)".*/\1/p' ./default.nix)"
+
+NEW_VERSION="$(curl https://api.github.com/repos/jinfeihan57/p7zip/releases/latest | jq .tag_name -r | tr -d 'v')"
+
+echo "comparing versions $OLD_VERSION => $NEW_VERSION"
+if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+    echo "Already up to date! Doing nothing"
+    exit 0
+fi
+
+NIXPKGS_ROOT="$(realpath "$DRV_DIR/../../../..")"
+
+echo "getting free source hash"
+OLD_FREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; p7zip.src.drvAttrs.outputHash" | tr -d '"')"
+echo "getting unfree source hash"
+OLD_UNFREE_HASH="$(nix-instantiate --eval --strict -E "with import $NIXPKGS_ROOT {}; (p7zip.override { enableUnfree = true; }).src.drvAttrs.outputHash" | tr -d '"')"
+
+
+NEW_FREE_HASH=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "p7zip.src" --rev "v$NEW_VERSION")
+
+NEW_UNFREE_OUT=$(nix-prefetch -f "$NIXPKGS_ROOT" -E "(p7zip.override { enableUnfree = true; }).src" --rev "v$NEW_VERSION" --output raw --print-path)
+# first line of raw output is the hash
+NEW_UNFREE_HASH="$(echo "$NEW_UNFREE_OUT" | sed -n 1p)"
+# second line of raw output is the src path
+NEW_UNFREE_SRC="$(echo "$NEW_UNFREE_OUT" | sed -n 2p)"
+# make sure to nuke the unfree src from the updater's machine
+# > the license requires that you agree to these use restrictions, or you must remove the software (source and binary) from your hard disks
+# https://fedoraproject.org/wiki/Licensing:Unrar
+nix-store --delete "$NEW_UNFREE_SRC"
+
+
+echo "updating version"
+sed -i "s/version = \"$OLD_VERSION\";/version = \"$NEW_VERSION\";/" "$DRV_DIR/default.nix"
+
+echo "updating free hash"
+sed -i "s@free = \"$OLD_FREE_HASH\";@free = \"$NEW_FREE_HASH\";@" "$DRV_DIR/default.nix"
+echo "updating unfree hash"
+sed -i "s@unfree = \"$OLD_UNFREE_HASH\";@unfree = \"$NEW_UNFREE_HASH\";@" "$DRV_DIR/default.nix"
+
+echo "done"


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- p7zip: clarify license and remove unRAR code from src drv
- ~p7zip: add notice of the license updates~


In the same vein as #163999 and inspired by #163680 this tackles unRAR code

p7zip was already correctly building without unRAR code by default but since the
unRAR licensing also refers to the code being on your hard drive it's best to nuke
it from the src drv like in #163999 (and most of the changes were reusable from there) 

cc: @7c6f434c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
