### PR TITLE
wrapGAppsHook: use makeBinaryWrapper

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -3,7 +3,7 @@
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 , vimPlugins
-, makeWrapper, makeBinaryWrapper
+, makeWrapper
 , wrapGAppsHook
 , runtimeShell
 
@@ -133,9 +133,7 @@ in stdenv.mkDerivation rec {
   ++ lib.optional wrapPythonDrv makeWrapper
   ++ lib.optional nlsSupport gettext
   ++ lib.optional perlSupport perl
-  # Make the inner wrapper binary to avoid double wrapping issues with wrapPythonDrv
-  # (https://github.com/NixOS/nixpkgs/pull/164163)
-  ++ lib.optional (guiSupport == "gtk3") (wrapGAppsHook.override { makeWrapper = makeBinaryWrapper; })
+  ++ lib.optional (guiSupport == "gtk3") wrapGAppsHook
   ;
 
   buildInputs = [

--- a/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-binary-wrapper.sh
@@ -33,6 +33,8 @@ assertExecutable() {
 # To troubleshoot a binary wrapper after you compiled it,
 # use the `strings` command or open the binary file in a text editor.
 makeWrapper() {
+    local NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK
+    unset NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK
     local original="$1"
     local wrapper="$2"
     shift 2

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , makeSetupHook
-, makeWrapper
+, makeBinaryWrapper
 , gobject-introspection
 , isGraphical ? true
 , gtk3
@@ -34,7 +34,7 @@ makeSetupHook {
   ] ++ [
 
     # We use the wrapProgram function.
-    makeWrapper
+    makeBinaryWrapper
   ];
   substitutions = {
     passthru.tests = let
@@ -59,8 +59,8 @@ makeSetupHook {
         tested = basic;
       in testLib.runTest "basic-contains-dconf" (
         testLib.skip stdenv.isDarwin ''
-          ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GIO_EXTRA_MODULES=" "${dconf.lib}/lib/gio/modules"}
-          ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GIO_EXTRA_MODULES=" "${dconf.lib}/lib/gio/modules"}
+          ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GIO_EXTRA_MODULES" "${dconf.lib}/lib/gio/modules"}
+          ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GIO_EXTRA_MODULES" "${dconf.lib}/lib/gio/modules"}
         ''
       );
 
@@ -98,8 +98,8 @@ makeSetupHook {
       typelib-user-has-gi-typelib-path = let
         tested = typelib-user;
       in testLib.runTest "typelib-user-has-gi-typelib-path" ''
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH=" "${typelib-Mahjong}/lib/girepository-1.0"}
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH=" "${typelib-Mahjong}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH" "${typelib-Mahjong}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH" "${typelib-Mahjong}/lib/girepository-1.0"}
       '';
 
       # Simple derivation containing a gobject-introspection typelib in lib output.
@@ -143,8 +143,8 @@ makeSetupHook {
       typelib-multiout-user-has-gi-typelib-path = let
         tested = typelib-multiout-user;
       in testLib.runTest "typelib-multiout-user-has-gi-typelib-path" ''
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH=" "${typelib-Bechamel.lib}/lib/girepository-1.0"}
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH=" "${typelib-Bechamel.lib}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH" "${typelib-Bechamel.lib}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH" "${typelib-Bechamel.lib}/lib/girepository-1.0"}
       '';
 
       # Simple derivation that contains a typelib as well as a program using it.
@@ -169,8 +169,8 @@ makeSetupHook {
       typelib-self-user-has-gi-typelib-path = let
         tested = typelib-self-user;
       in testLib.runTest "typelib-self-user-has-gi-typelib-path" ''
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH=" "${typelib-self-user}/lib/girepository-1.0"}
-        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH=" "${typelib-self-user}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/bin/foo" "GI_TYPELIB_PATH" "${typelib-self-user}/lib/girepository-1.0"}
+        ${expectSomeLineContainingYInFileXToMentionZ "${tested}/libexec/bar" "GI_TYPELIB_PATH" "${typelib-self-user}/lib/girepository-1.0"}
       '';
     };
   };

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook/tests/lib.nix
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook/tests/lib.nix
@@ -1,5 +1,4 @@
-{ runCommand
-}:
+{ lib, runCommand }:
 
 rec {
   runTest = name: body: runCommand name { } ''
@@ -19,12 +18,14 @@ rec {
   '';
 
   expectSomeLineContainingYInFileXToMentionZ = file: filter: expected: ''
-    if ! cat "${file}" | grep "${filter}"; then
-        ${fail "The file “${file}” should include a line containing “${filter}”."}
+    file=${lib.escapeShellArg file} filter=${lib.escapeShellArg filter} expected=${lib.escapeShellArg expected}
+
+    if ! grep --text --quiet "$filter" "$file"; then
+        ${fail "The file “$file” should include a line containing “$filter”."}
     fi
 
-    if ! cat "${file}" | grep "${filter}" | grep ${expected}; then
-        ${fail "The file “${file}” should include a line containing “${filter}” that also contains “${expected}”."}
+    if ! grep --text "$filter" "$file" | grep --text --quiet "$expected"; then
+        ${fail "The file “$file” should include a line containing “$filter” that also contains “$expected”."}
     fi
   '';
 }


### PR DESCRIPTION
WIP to make the GApps wrapper use `makeBinaryWrapper` instead of `makeWrapper`. cc @bergkvist @doronbehar @tfc

The basic motivation is that some applications like thunar are wrapped twice, once by `wrapGAppsHook` and once manually to add support for plugins, and because of the way shell scripts work this results in thunar's argv0 being set to `.thunar-wrapped_`, which is reflected in the X11 class name for all thunar windows. I already mentioned this issue at https://github.com/NixOS/nixpkgs/pull/126248#issuecomment-859896534 and this was one of the motivations for `makeBinaryWrapper` (https://github.com/NixOS/nixpkgs/pull/124556). Making the outer wrapper binary isn't enough to solve this, hence this PR.

This isn't as easy as it sounds for at least two reasons (more may arise!):

1. `makeBinaryWrapper` uses a wrapped GCC and will hence respect `NIX_CFLAGS_COMPILE`, which resulted in an error when trying to build `libreoffice` because a flag in its `NIX_CFLAGS_COMPILE` was for C++ only. I believe the wrapper shouldn't be affected by whatever CFLAGS happen to be set in the calling derivation, so I unset those variables in d399e701aa79815148ce08b41ed7263f122f1d24 (more unsetting may be needed). (I also tried to use `gcc-unwrapped` but got more errors)
2. some programs have both `makeWrapper` and `wrapGAppsHook` in their build inputs, and because setup hooks are propagated, both versions of the wrapping functions are installed and it seems like the binary ones win. This made the build of `minecraft` fail because the binary version doesn't implement `--run`, so I replaced every instance of `--run "cd $foo"` I could find with `--chdir "$foo"` in a4b32633e8c6429d2f2a02f70373d20e5d966ee6 and made `makeWrapper` implement `--chdir` in 2e3ae88a9c830ba18163c778ade179e7cc820cd3. I am not sure how exactly we want to resolve the issue of conflicting versions of wrapper hooks; maybe it's a good thing that all wrappers around a program are of the same "type".

I tried building a few things but I don't have a build farm handy and my server ran out of disk space 😬. Can I request a dedicated hydra jobset for this branch or something? cc @vcunat 