### PR TITLE
libinput-gestures: 2.39 -> 2.72

### DIFF
--- a/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0001-hardcode-name.patch
@@ -1,13 +1,13 @@
 diff --git a/libinput-gestures b/libinput-gestures
-index 66479b6..aca94ac 100755
+index 78c7c28..da04007 100755
 --- a/libinput-gestures
 +++ b/libinput-gestures
-@@ -6,7 +6,7 @@ from collections import OrderedDict
- from pathlib import Path
- from distutils.version import LooseVersion as Version
- 
--PROG = Path(sys.argv[0]).stem
-+PROG = "libinput-gestures"
- 
+@@ -27,7 +27,7 @@ except ImportError:
+
+ session_locked = False
+
+-PROGPATH = Path(sys.argv[0])
++PROGPATH = Path("libinput-gestures")
+ PROGNAME = PROGPATH.stem
+
  # Conf file containing gesture commands.
- # Search first for user file then system file.

--- a/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
+++ b/pkgs/tools/inputmethods/libinput-gestures/0002-paths.patch
@@ -1,45 +1,34 @@
 diff --git a/libinput-gestures b/libinput-gestures
-index aca94ac..c2f03ca 100755
+index 78c7c28..1a2c965 100755
 --- a/libinput-gestures
 +++ b/libinput-gestures
-@@ -77,7 +77,7 @@ def get_libinput_vers():
+@@ -87,11 +87,11 @@ def get_libinput_vers():
      'Return the libinput installed version number string'
      # Try to use newer libinput interface then fall back to old
      # (depreciated) interface.
 -    res = run(('libinput', '--version'), check=False)
 +    res = run(('@libinput@', '--version'), check=False)
-     return res.strip() if res else \
-             run(('libinput-list-devices', '--version'), check=False)
- 
-@@ -87,8 +87,8 @@ if not libvers:
-     sys.exit('libinput helper tools do not seem to be installed?')
- 
- if Version(libvers) >= Version('1.8'):
--    cmd_debug_events = 'libinput debug-events'
--    cmd_list_devices = 'libinput list-devices'
-+    cmd_debug_events = '@libinput@ debug-events'
-+    cmd_list_devices = '@libinput@ list-devices'
- else:
-     cmd_debug_events = 'libinput-debug-events'
-     cmd_list_devices = 'libinput-list-devices'
-@@ -199,7 +199,7 @@ class COMMAND_internal(COMMAND):
- 
-     def run(self):
-         'Get list of current workspaces and select next one'
--        stdout = run(('wmctrl', '-d'), check=False)
-+        stdout = run(('@wmctrl@', '-d'), check=False)
-         if not stdout:
-             # This command can fail on GNOME when you have only a single
-             # dynamic workspace using Xorg (probably a GNOME bug) so let's
-@@ -233,7 +233,7 @@ class COMMAND_internal(COMMAND):
- 
-         # Switch to desired workspace
-         if index >= minindex and index < maxindex:
--            run(('wmctrl', '-s', str(index)))
-+            run(('@wmctrl@', '-s', str(index)))
- 
- # Table of gesture handlers
- handlers = OrderedDict()
--- 
-2.19.1
+     if res:
+         return res.strip(), True
 
+-    res = run(('libinput-list-devices', '--version'), check=False)
++    res = run(('@libinput-list-devices@', '--version'), check=False)
+     return res and res.strip(), False
+
+ def get_devices_list(cmd_list_devices, device_list):
+@@ -694,11 +694,11 @@ def main():
+         sys.exit('libinput helper tools do not seem to be installed?')
+
+     if has_subcmd:
+-        cmd_debug_events = 'libinput debug-events'
+-        cmd_list_devices = 'libinput list-devices'
++        cmd_debug_events = '@libinput@ debug-events'
++        cmd_list_devices = '@libinput@ list-devices'
+     else:
+-        cmd_debug_events = 'libinput-debug-events'
+-        cmd_list_devices = 'libinput-list-devices'
++        cmd_debug_events = '@libinput@-debug-events'
++        cmd_list_devices = '@libinput@-list-devices'
+
+     if args.verbose:
+         # Output various info/version info

--- a/pkgs/tools/inputmethods/libinput-gestures/default.nix
+++ b/pkgs/tools/inputmethods/libinput-gestures/default.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "libinput-gestures";
-  version = "2.39";
+  version = "2.72";
 
   src = fetchFromGitHub {
     owner = "bulletmark";
     repo = "libinput-gestures";
     rev = version;
-    sha256 = "0bzyi55yhr9wyar9mnd09cr6pi88jkkp0f9lndm0a9jwi1xr4bdf";
+    sha256 = "sha256-si94aKyiJtRwg+JS0PazqRjGrA/zUwN8CCIKI5KLJNw=";
   };
   patches = [
     ./0001-hardcode-name.patch


### PR DESCRIPTION
###### Description of changes

https://github.com/bulletmark/libinput-gestures/releases/tag/2.72

updated the patches to reflect changes upstream

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
