### PR TITLE
[21.11] nats-streaming-server: add patch for CVE-2022-26652

### DIFF
--- a/pkgs/servers/nats-streaming-server/2.2.1-CVE-2022-26652.patch
+++ b/pkgs/servers/nats-streaming-server/2.2.1-CVE-2022-26652.patch
@@ -1,0 +1,41 @@
+Based on upstream's nats-server fix
+https://github.com/nats-io/nats-server/commit/b4128693ed61aa0c32179af07677bcf1d8301dcd
+with test changes removed, the path -> filepath changes omitted
+(as it is for the benefit of windows, which we don't really support)
+and re-targeted at the vendored copy.
+
+--- a/vendor/github.com/nats-io/nats-server/v2/server/stream.go
++++ b/vendor/github.com/nats-io/nats-server/v2/server/stream.go
+@@ -3620,6 +3619,17 @@
+ 	}
+ 	defer os.RemoveAll(sdir)
+ 
++	logAndReturnError := func() error {
++		a.mu.RLock()
++		err := fmt.Errorf("unexpected content (account=%s)", a.Name)
++		if a.srv != nil {
++			a.srv.Errorf("Stream restore failed due to %v", err)
++		}
++		a.mu.RUnlock()
++		return err
++	}
++	sdirCheck := filepath.Clean(sdir) + string(os.PathSeparator)
++
+ 	tr := tar.NewReader(s2.NewReader(r))
+ 	for {
+ 		hdr, err := tr.Next()
+@@ -3629,7 +3639,13 @@
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-		fpath := path.Join(sdir, filepath.Clean(hdr.Name))
++		if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
++			return nil, logAndReturnError()
++		}
++		fpath := filepath.Join(sdir, filepath.Clean(hdr.Name))
++		if !strings.HasPrefix(fpath, sdirCheck) {
++			return nil, logAndReturnError()
++		}
+ 		os.MkdirAll(filepath.Dir(fpath), defaultDirPerms)
+ 		fd, err := os.OpenFile(fpath, os.O_CREATE|os.O_RDWR, 0600)
+ 		if err != nil {

--- a/pkgs/servers/nats-streaming-server/default.nix
+++ b/pkgs/servers/nats-streaming-server/default.nix
@@ -14,6 +14,8 @@ buildGoPackage rec {
     sha256 = "sha256-VdYyui0fyoNf1q3M1xTg/UMlxIFABqAbqQaD0bLpKCY=";
   };
 
+  patches = [ ./2.2.1-CVE-2022-26652.patch ];
+
   meta = {
     description = "NATS Streaming System Server";
     license = licenses.asl20;


### PR DESCRIPTION
###### Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2022-26652

Using the same patch as #164009 adapted to patch the vendored copy of `nats-server`. To check the validity of the patch, I ran the test provided with the original commit against a patched `nats-server` 2.3.1 (which is the version of nats-server vendored here) with success.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
