### PR TITLE
lorien: init at 0.5.0

### DIFF
--- a/pkgs/applications/graphics/lorien/default.nix
+++ b/pkgs/applications/graphics/lorien/default.nix
@@ -31,13 +31,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "lorien";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "mbrlabs";
     repo = "Lorien";
     rev = "v${version}";
-    sha256 = "sha256-Uoozqc+St/CAWor7sWwQzi/1Vavc4wmVd5BDfJAsKHw=";
+    sha256 = "sha256-x81Obana2BEGrYSoJHDdCkL6UaULfQGQ94tlrH5+kdY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/lorien/default.nix
+++ b/pkgs/applications/graphics/lorien/default.nix
@@ -1,0 +1,124 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+
+, copyDesktopItems
+, makeDesktopItem
+
+, godot-export-templates
+, godot-headless
+
+, alsa-lib
+, libGL
+, libGLU
+, libX11
+, libXcursor
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrandr
+, libXrender
+, zlib
+, udev # for libudev
+}:
+
+let
+  preset =
+    if stdenv.isLinux then "Linux/X11"
+    else if stdenv.isDarwin then "Mac OSX"
+    else throw "unsupported platform";
+in
+stdenv.mkDerivation rec {
+  pname = "lorien";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "mbrlabs";
+    repo = "Lorien";
+    rev = "v${version}";
+    sha256 = "sha256-Uoozqc+St/CAWor7sWwQzi/1Vavc4wmVd5BDfJAsKHw=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    godot-headless
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libGL
+    libGLU
+    libX11
+    libXcursor
+    libXext
+    libXfixes
+    libXi
+    libXinerama
+    libXrandr
+    libXrender
+    zlib
+    udev
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "lorien";
+      exec = "lorien";
+      icon = "lorien";
+      desktopName = "Lorien";
+      genericName = "Whiteboard";
+      comment = meta.description;
+      categories = [ "Graphics" "Office" ];
+      keywords = [ "whiteboard" ];
+    })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Cannot create file '/homeless-shelter/.config/godot/projects/...'
+    export HOME=$TMPDIR
+
+    # Link the export-templates to the expected location. The --export commands
+    # expects the template-file at .../templates/{godot-version}.stable/linux_x11_64_release
+    mkdir -p $HOME/.local/share/godot
+    ln -s ${godot-export-templates}/share/godot/templates $HOME/.local/share/godot
+
+    mkdir -p $out/share/lorien
+
+    godot-headless --path lorien --export "${preset}" $out/share/lorien/lorien
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s $out/share/lorien/lorien $out/bin
+
+    # Patch binaries.
+    interpreter=$(cat $NIX_CC/nix-support/dynamic-linker)
+    patchelf \
+      --set-interpreter $interpreter \
+      --set-rpath ${lib.makeLibraryPath buildInputs} \
+      $out/share/lorien/lorien
+
+    install -Dm644 images/lorien.png $out/share/pixmaps/lorien.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/mbrlabs/Lorien";
+    description = "An infinite canvas drawing/note-taking app";
+    longDescription = ''
+      An infinite canvas drawing/note-taking app that is focused on performance,
+      small savefiles and simplicity
+    '';
+    license = licenses.mit;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ hqurve ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8228,6 +8228,8 @@ with pkgs;
 
   longview = callPackage ../servers/monitoring/longview { };
 
+  lorien = callPackage ../applications/graphics/lorien { };
+
   lout = callPackage ../tools/typesetting/lout { };
 
   lr = callPackage ../tools/system/lr { };


### PR DESCRIPTION
###### Description of changes

Init https://github.com/mbrlabs/Lorien

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
