### PR TITLE
gummy: init at 0.1

### DIFF
--- a/pkgs/development/libraries/sdbus-cpp/default.nix
+++ b/pkgs/development/libraries/sdbus-cpp/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, systemd
+, expat
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sdbus-cpp";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "kistler-group";
+    repo = "sdbus-cpp";
+    rev = "v${version}";
+    sha256 = "sha256-AjaZ6YmMlnN0jAcUBkft01XHkrze0nSr3dUMechsLrQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    systemd
+    expat
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_CODE_GEN=ON"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Kistler-Group/sdbus-cpp";
+    changelog = "https://github.com/Kistler-Group/sdbus-cpp/blob/v${version}/ChangeLog";
+    description = "High-level C++ D-Bus library designed to provide easy-to-use yet powerful API";
+    longDescription = ''
+      sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide expressive, easy-to-use API in modern C++.
+      It adds another layer of abstraction on top of sd-bus, a nice, fresh C D-Bus implementation by systemd.
+      It's been written primarily as a replacement of dbus-c++, which currently suffers from a number of (unresolved) bugs,
+      concurrency issues and inherent design complexities and limitations.
+    '';
+    mainProgram = "sdbus-c++-xml2cpp";
+    license = licenses.lgpl2Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/tools/misc/gummy/default.nix
+++ b/pkgs/tools/misc/gummy/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, testVersion
+, gummy
+, cmake
+, libX11
+, libXext
+, sdbus-cpp
+, udev
+, coreutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gummy";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "fushko";
+    repo = "gummy";
+    rev = version;
+    sha256 = "sha256-CbZFuvFMmbFVX8k3duhhsg0fd9kVmhsj0VeFYil9YiE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    libX11
+    libXext
+    sdbus-cpp
+    udev
+  ];
+
+  cmakeFlags = [
+    "-DUDEV_DIR=${placeholder "out"}/lib/udev"
+  ];
+
+  # Fixes the "gummy start" command, without this it cannot find the binary.
+  # Setting this through cmake does not seem to work.
+  postPatch = ''
+    substituteInPlace src/gummy/gummy.cpp \
+      --replace "CMAKE_INSTALL_DAEMON_PATH" "\"${placeholder "out"}/libexec/gummyd\""
+  '';
+
+  preFixup = ''
+    substituteInPlace $out/lib/udev/99-gummy.rules \
+      --replace "/bin/chmod" "${coreutils}/bin/chmod"
+
+    ln -s $out/libexec/gummyd $out/bin/gummyd
+  '';
+
+  passthru.tests.version = testVersion { package = gummy; };
+
+  meta = with lib; {
+    homepage = "https://github.com/Fushko/gummy";
+    description = "Brightness and temperature manager for X11";
+    longDescription = ''
+      CLI screen manager for X11 that allows automatic and manual brightness/temperature adjustments,
+      via backlight (currently only for embedded displays) and gamma. Multiple monitors are supported.
+    '';
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33283,6 +33283,8 @@ with pkgs;
 
   gummi = callPackage ../applications/misc/gummi { };
 
+  gummy = callPackage ../tools/misc/gummy { };
+
   gxemul = callPackage ../applications/emulators/gxemul { };
 
   hatari = callPackage ../applications/emulators/hatari { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1100,6 +1100,8 @@ with pkgs;
 
   redfang = callPackage ../tools/networking/redfang { };
 
+  sdbus-cpp = callPackage ../development/libraries/sdbus-cpp { };
+
   sdlookup = callPackage ../tools/security/sdlookup { };
 
   sx-go = callPackage ../tools/security/sx-go { };


### PR DESCRIPTION
###### Description of changes
This adds [gummy](https://github.com/Fushko/gummy), a brightness and display temperature manager for X11. It can automatically adjust based off of the contents on the screen which is pretty interesting. In the future I'll add a nixos/home-manager module for it as well, since you need to start up a daemon for it.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
