### PR TITLE
facetimehd: support sensor calibration files

### DIFF
--- a/nixos/modules/hardware/all-firmware.nix
+++ b/nixos/modules/hardware/all-firmware.nix
@@ -84,7 +84,10 @@ in {
         b43Firmware_6_30_163_46
         b43FirmwareCutter
         xow_dongle-firmware
-      ] ++ optional pkgs.stdenv.hostPlatform.isx86 facetimehd-firmware;
+      ] ++ optionals pkgs.stdenv.hostPlatform.isx86 [
+        facetimehd-calibration
+        facetimehd-firmware
+      ];
     })
     (mkIf cfg.wirelessRegulatoryDatabase {
       hardware.firmware = [ pkgs.wireless-regdb ];

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -14,6 +14,18 @@ in
 
   options.hardware.facetimehd.enable = mkEnableOption "facetimehd kernel module";
 
+  options.hardware.facetimehd.withCalibration = mkOption {
+    default = false;
+    example = true;
+    type = types.bool;
+    description = ''
+      Whether to include sensor calibration files for facetimehd.
+      This makes colors look much better but is experimental, see
+      <link xlink:href="https://github.com/patjak/facetimehd/wiki/Extracting-the-sensor-calibration-files"/>
+      for details.
+    '';
+  };
+
   config = mkIf cfg.enable {
 
     assertions = singleton {
@@ -27,7 +39,8 @@ in
 
     boot.extraModulePackages = [ kernelPackages.facetimehd ];
 
-    hardware.firmware = [ pkgs.facetimehd-firmware ];
+    hardware.firmware = [ pkgs.facetimehd-firmware ]
+      ++ optional cfg.withCalibration pkgs.facetimehd-calibration;
 
     # unload module during suspend/hibernate as it crashes the whole system
     powerManagement.powerDownCommands = ''

--- a/pkgs/os-specific/linux/firmware/facetimehd-calibration/default.nix
+++ b/pkgs/os-specific/linux/firmware/facetimehd-calibration/default.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, fetchurl, unrar-wrapper, pkgs }:
+
+let
+
+  version = "5.1.5769";
+
+
+  # Described on https://github.com/patjak/facetimehd/wiki/Extracting-the-sensor-calibration-files
+
+  # From the wiki page, range extracted with binwalk:
+  zipUrl = "https://download.info.apple.com/Mac_OS_X/031-30890-20150812-ea191174-4130-11e5-a125-930911ba098f/bootcamp${version}.zip";
+  zipRange = "2338085-3492508"; # the whole download is 518MB, this deflate stream is 1.2MB
+
+  # CRC and length from the ZIP entry header (not strictly necessary, but makes it extract cleanly):
+  gzFooter = ''\x51\x1f\x86\x78\xcf\x5b\x12\x00'';
+
+  # Also from the wiki page:
+  calibrationFiles = [
+    { file = "1771_01XX.dat"; offset = "1644880"; size = "19040"; }
+    { file = "1871_01XX.dat"; offset = "1606800"; size = "19040"; }
+    { file = "1874_01XX.dat"; offset = "1625840"; size = "19040"; }
+    { file = "9112_01XX.dat"; offset = "1663920"; size = "33060"; }
+  ];
+
+in
+
+stdenv.mkDerivation {
+
+  pname = "facetimehd-calibration";
+  inherit version;
+  src = fetchurl {
+    url = zipUrl;
+    sha256 = "1dzyv457fp6d8ly29sivqn6llwj5ydygx7p8kzvdnsp11zvid2xi";
+    curlOpts = "-r ${zipRange}";
+  };
+
+  dontUnpack = true;
+  dontInstall = true;
+
+  buildInputs = [ unrar-wrapper ];
+
+  buildPhase = ''
+    { printf '\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00'
+      cat $src
+      printf '${gzFooter}'
+    } | zcat > AppleCamera64.exe
+    unrar x AppleCamera64.exe AppleCamera.sys
+
+    mkdir -p $out/lib/firmware/facetimehd
+  '' + lib.concatMapStrings ({file, offset, size}: ''
+    dd bs=1 skip=${offset} count=${size} if=AppleCamera.sys of=$out/lib/firmware/facetimehd/${file}
+  '') calibrationFiles;
+
+  meta = with lib; {
+    description = "facetimehd calibration";
+    homepage = "https://support.apple.com/kb/DL1837";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ womfoo grahamc ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22488,6 +22488,8 @@ with pkgs;
 
   extrace = callPackage ../os-specific/linux/extrace { };
 
+  facetimehd-calibration = callPackage ../os-specific/linux/firmware/facetimehd-calibration { };
+
   facetimehd-firmware = callPackage ../os-specific/linux/firmware/facetimehd-firmware { };
 
   fatrace = callPackage ../os-specific/linux/fatrace { };


### PR DESCRIPTION
###### Description of changes

This adds a new (non-free) firmware package called `facetimehd-calibration` that contains the [sensor calibration files][1] necessary for proper color reproduction on the Facetime HD webcam used in some MacBooks. Driver support for these is experimental, so as [suggested][2] by @Artturin on Matrix these are put behind a new, disabled-by-default NixOS option, `hardware.facetimehd.withCalibration` (as well as `hardware.enableAllFirmware`).

To avoid downloading the full 518 MB Boot Camp driver ZIP, the derivation only requests the byte range corresponding to the raw Deflate stream for the archive member we need, adds a valid gzip header and footer and decompresses the result. I’ll admit this is more than a bit insane (more so even than the way `facetimehd-firmware` cuts up the DMG file it needs), but I don’t see an easier approach here.

The new package specifies the same maintainers as the existing `facetimehd-firmware`, i.e. @womfoo and @grahamc; I’m not sure this is appropriate, so please approve or deny this. Many things are also shamelessly cribbed from there, so if I did something strange don’t assume I knew what I was doing.

[1]: https://github.com/patjak/facetimehd/wiki/Extracting-the-sensor-calibration-files
[2]: https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$OjVKqsraCcXuR3P764ZJAz1ZAz34TU1FSvyo4ytD3yU?via=matrix.org&via=nixos.dev&via=stratum0.org

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
   - [x] On my machine, `facetimehd` successfully picked up the calibration files, and color is indeed improved.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
