### PR TITLE
octave-kernel: 0.32.0 -> 0.34.2

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
@@ -4,20 +4,18 @@ with python3Packages;
 
 buildPythonPackage rec {
   pname = "octave-kernel";
-  version = "0.32.0";
+  version = "0.34.2";
 
   src = fetchPypi {
     pname = "octave_kernel";
     inherit version;
-    sha256 = "0dfbxfcf3bz4jswnpkibnjwlkgy0y4j563nrhaqxv3nfa65bksif";
+    sha256 = "sha256-5ki2lekfK7frPsmPBIzYQOfANCUY9x+F2ZRAQSdPTxo=";
   };
 
   propagatedBuildInputs = [ metakernel ipykernel ];
 
-  # Tests require jupyter_kernel_test to run, but it hasn't seen a
-  # release since 2017 and seems slightly abandoned.
-  # Doing fetchPypi on it doesn't work, even though it exists here:
-  # https://pypi.org/project/jupyter_kernel_test/.
+  # Tests fail because the kernel appears to be halting or failing to launch
+  # There appears to be a similar problem with metakernel's tests
   doCheck = false;
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently 0.32.0 fails to plot graphs.

Also, I've attempted to get the check phase to run but the tests keep failing with `RuntimeError: Kernel didn't respond in 60 seconds`. Metakernel (under the same owner on github) also has tests disabled; allowing the checkphase to run seems to do nothing and waits forever. Just in case someone else could help getting the checks to run, it would be nice. This is what I have so far https://github.com/hqurve/nixpkgs/commits/octave-jupyter-update-check

Regardless, the kernel runs and the version bump fixes graphs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
