### PR TITLE
minio: declarative creation of buckets/groups/policies/users (#89559)

### DIFF
--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -5,16 +5,52 @@ with lib;
 let
   cfg = config.services.minio;
 
-  legacyCredentials = cfg: pkgs.writeText "minio-legacy-credentials" ''
-    MINIO_ROOT_USER=${cfg.accessKey}
-    MINIO_ROOT_PASSWORD=${cfg.secretKey}
-  '';
-in
-{
+  legacyCredentials = cfg:
+    pkgs.writeText "minio-legacy-credentials" ''
+      MINIO_ROOT_USER=${cfg.accessKey}
+      MINIO_ROOT_PASSWORD=${cfg.secretKey}
+    '';
+in {
   meta.maintainers = [ maintainers.bachp ];
 
   options.services.minio = {
     enable = mkEnableOption "Minio Object Storage";
+
+    ensureUsers = mkOption {
+      # TODO type should be more specific
+      type = types.attrs;
+      default = { };
+      description = ''
+        Ensure users exist
+      '';
+    };
+
+    ensurePolicies = mkOption {
+      # TODO type should be more specific
+      type = types.attrs;
+      default = { };
+      description = ''
+        Ensure Policies exist
+      '';
+    };
+
+    ensureBuckets = mkOption {
+      # TODO type should be more specific
+      type = types.attrs;
+      default = { };
+      description = ''
+        Ensure Buckets exist
+      '';
+    };
+
+    ensureGroups = mkOption {
+      # TODO type should be more specific
+      type = types.attrs;
+      default = { };
+      description = ''
+        Ensure groups exist
+      '';
+    };
 
     listenAddress = mkOption {
       default = ":9000";
@@ -31,13 +67,15 @@ in
     dataDir = mkOption {
       default = [ "/var/lib/minio/data" ];
       type = types.listOf types.path;
-      description = "The list of data directories for storing the objects. Use one path for regular operation and the minimum of 4 endpoints for Erasure Code mode.";
+      description =
+        "The list of data directories for storing the objects. Use one path for regular operation and the minimum of 4 endpoints for Erasure Code mode.";
     };
 
     configDir = mkOption {
       default = "/var/lib/minio/config";
       type = types.path;
-      description = "The config directory, for the access keys and other settings.";
+      description =
+        "The config directory, for the access keys and other settings.";
     };
 
     accessKey = mkOption {
@@ -60,7 +98,7 @@ in
       '';
     };
 
-    rootCredentialsFile = mkOption  {
+    rootCredentialsFile = mkOption {
       type = types.nullOr types.path;
       default = null;
       description = ''
@@ -110,9 +148,12 @@ in
         User = "minio";
         Group = "minio";
         LimitNOFILE = 65536;
-        EnvironmentFile = if (cfg.rootCredentialsFile != null) then cfg.rootCredentialsFile
-                          else if ((cfg.accessKey != "") || (cfg.secretKey != "")) then (legacyCredentials cfg)
-                          else null;
+        EnvironmentFile = if (cfg.rootCredentialsFile != null) then
+          cfg.rootCredentialsFile
+        else if ((cfg.accessKey != "") || (cfg.secretKey != "")) then
+          (legacyCredentials cfg)
+        else
+          null;
       };
       environment = {
         MINIO_REGION = "${cfg.region}";
@@ -126,5 +167,127 @@ in
     };
 
     users.groups.minio.gid = config.ids.uids.minio;
+
+    systemd.targets = {
+      minio-users = { after = [ "minio-policies.target" ]; };
+      minio-policies = { before = [ "minio-users.target" ]; };
+      minio-buckets = { };
+    };
+
+    systemd.services = mapAttrs' (name: value:
+      lib.attrsets.nameValuePair ("minio-bucket-" + name) (
+
+        {
+          enable = true;
+          path = [ pkgs.minio pkgs.minio-client ];
+          requiredBy = [ "multi-user.target" ];
+          after = [ "minio.service" ];
+          partOf = [ "minio-buckets.target" ];
+          serviceConfig = {
+            Type = "simple";
+            User = "minio";
+            Group = "minio";
+            RuntimeDirectory = "minio-bucket-${name}";
+            EnvironmentFile = config.services.minio.rootCredentialsFile;
+          };
+          script = ''
+            set -e
+            CONFIG_DIR=$RUNTIME_DIRECTORY
+            mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+            mc --config-dir "$CONFIG_DIR" mb --ignore-existing minio/${name}
+            mc --config-dir "$CONFIG_DIR" policy set-json ${value.policyPath} minio/${name}
+          '';
+        })) cfg.ensureBuckets //
+
+
+      mapAttrs' (name: value:
+        lib.attrsets.nameValuePair ("minio-group-" + name) ({
+
+          enable = true;
+          path = [ pkgs.minio pkgs.minio-client ];
+          requiredBy = [ "multi-groups.target" ];
+          after =
+            [ "minio.service" "minio-policies.target" ]; # ++ policy-units;
+          partOf = [ "minio-groups.target" ];
+          serviceConfig = {
+            Type = "simple";
+            User = "minio";
+            Group = "minio";
+            RuntimeDirectory = "minio-group-${name}";
+            EnvironmentFile = config.services.minio.rootCredentialsFile;
+          };
+
+          # TODO
+          # environment = {
+          #   USER_SECRET_KEY_PATH = value.secret-key-path;
+          #   POLICY_NAME = value.policy;
+          # };
+          # script = ''
+          #   set -e
+          #   CONFIG_DIR=$RUNTIME_DIRECTORY
+          #   export USER_SECRET_KEY=$(<"$USER_SECRET_KEY_PATH")
+          #   mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+          #   mc --config-dir "$CONFIG_DIR" admin user add minio "${name}" "$USER_SECRET_KEY"
+          #   mc --config-dir "$CONFIG_DIR" admin policy set minio "$POLICY_NAME" user="${name}"
+          # '';
+        })) cfg.ensureGroups //
+
+      mapAttrs' (name: value:
+        lib.attrsets.nameValuePair ("minio-user-" + name) ({
+
+          enable = true;
+          path = [ pkgs.minio pkgs.minio-client ];
+          requiredBy = [ "multi-user.target" ];
+          after =
+            [ "minio.service" "minio-policies.target" ]; # ++ policy-units;
+          partOf = [ "minio-users.target" ];
+          serviceConfig = {
+            Type = "simple";
+            User = "minio";
+            Group = "minio";
+            RuntimeDirectory = "minio-user-${name}";
+            EnvironmentFile = config.services.minio.rootCredentialsFile;
+          };
+
+          environment = {
+            USER_SECRET_KEY_PATH = value.secret-key-path;
+            POLICY_NAME = value.policy;
+          };
+          script = ''
+            set -e
+            CONFIG_DIR=$RUNTIME_DIRECTORY
+            export USER_SECRET_KEY=$(<"$USER_SECRET_KEY_PATH")
+            mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+            mc --config-dir "$CONFIG_DIR" admin user add minio "${name}" "$USER_SECRET_KEY"
+            mc --config-dir "$CONFIG_DIR" admin policy set minio "$POLICY_NAME" user="${name}"
+          '';
+        })) cfg.ensureUsers //
+
+      mapAttrs' (name: value:
+        lib.attrsets.nameValuePair ("minio-policy-" + name) ({
+
+          enable = true;
+          path = [ pkgs.minio pkgs.minio-client ];
+          requiredBy = [ "multi-user.target" "minio-policies.target" ];
+          after = [ "minio.service" ];
+          partOf = [ "minio-policies.target" ];
+          serviceConfig = {
+            Type = "simple";
+            User = "minio";
+            Group = "minio";
+            RuntimeDirectory = "minio-policy-${name}";
+            EnvironmentFile = config.services.minio.rootCredentialsFile;
+          };
+
+          environment = { POLICY_PATH = value; };
+
+          script = ''
+            set -e
+            CONFIG_DIR=$RUNTIME_DIRECTORY
+            mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+            mc --config-dir "$CONFIG_DIR" admin policy add minio "${name}" "$POLICY_PATH"
+          '';
+        })) cfg.ensurePolicies;
+
   };
 }

--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -217,19 +217,13 @@ in {
             EnvironmentFile = config.services.minio.rootCredentialsFile;
           };
 
-          # TODO
-          # environment = {
-          #   USER_SECRET_KEY_PATH = value.secret-key-path;
-          #   POLICY_NAME = value.policy;
-          # };
-          # script = ''
-          #   set -e
-          #   CONFIG_DIR=$RUNTIME_DIRECTORY
-          #   export USER_SECRET_KEY=$(<"$USER_SECRET_KEY_PATH")
-          #   mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
-          #   mc --config-dir "$CONFIG_DIR" admin user add minio "${name}" "$USER_SECRET_KEY"
-          #   mc --config-dir "$CONFIG_DIR" admin policy set minio "$POLICY_NAME" user="${name}"
-          # '';
+          script = ''
+            set -e
+            CONFIG_DIR=$RUNTIME_DIRECTORY
+            mc --config-dir "$CONFIG_DIR" config host add minio http://localhost:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+            mc --config-dir "$CONFIG_DIR" admin group add minio "${name}" ${toString value.members}
+          '';
+
         })) cfg.ensureGroups //
 
       mapAttrs' (name: value:


### PR DESCRIPTION
###### Description of changes

I'd like to add the functionality as requested in  #89559 to allow creating buckets, groups, users and policies declaratively in minio. The units added are based on the work of @expipiplus1 and @JosephLucas.

Pinging @bachp and @hamishmack for review and test. I'm going to need help testing and implementing this, let me know where to start and what is still missing. There might be more elegant ways of doing this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
