### PR TITLE
Clarify that lld package provides unwrapped lld

### DIFF
--- a/pkgs/development/compilers/llvm/10/lld/default.nix
+++ b/pkgs/development/compilers/llvm/10/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/11/lld/default.nix
+++ b/pkgs/development/compilers/llvm/11/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/12/lld/default.nix
+++ b/pkgs/development/compilers/llvm/12/lld/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/13/lld/default.nix
+++ b/pkgs/development/compilers/llvm/13/lld/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/14/lld/default.nix
+++ b/pkgs/development/compilers/llvm/14/lld/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/5/lld/default.nix
+++ b/pkgs/development/compilers/llvm/5/lld/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/6/lld/default.nix
+++ b/pkgs/development/compilers/llvm/6/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/7/lld/default.nix
+++ b/pkgs/development/compilers/llvm/7/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/8/lld/default.nix
+++ b/pkgs/development/compilers/llvm/8/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/9/lld/default.nix
+++ b/pkgs/development/compilers/llvm/9/lld/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features

--- a/pkgs/development/compilers/llvm/git/lld/default.nix
+++ b/pkgs/development/compilers/llvm/git/lld/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = llvm_meta // {
     homepage = "https://lld.llvm.org/";
-    description = "The LLVM linker";
+    description = "The LLVM linker (unwrapped)";
     longDescription = ''
       LLD is a linker from the LLVM project that is a drop-in replacement for
       system linkers and runs much faster than them. It also provides features


### PR DESCRIPTION
###### Description of changes

lld package provides an unwrapped lld. It doesn't always work on NixOS
(eg, it doesn't set rpath), and so dosen't always work.

What one should be using instead is the `lld` from
`llvmPackages.bintools` package. This super counterintutive.

One incremental step we can take here is to clarify that the `lld`
package is unrwapped -- right now, it looks like 100% legit thing one
should be using!

cc https://github.com/NixOS/nixpkgs/issues/24744.

If someone wants to do a more substantial change (like renaming the package to `lld_unwrapped` or even removing it altogether), that would be great! I don't have capacity for more invasive change myself though.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
