### PR TITLE
license-generator: init at 0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7241,6 +7241,12 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  loicreynier = {
+    email = "loic@loireynier.fr";
+    github = "loicreynier";
+    githubId = 88983487;
+    name = "Loïc Reynier";
+  };
   lopsided98 = {
     email = "benwolsieffer@gmail.com";
     github = "lopsided98";

--- a/pkgs/tools/misc/license-generator/default.nix
+++ b/pkgs/tools/misc/license-generator/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchCrate, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+    pname = "license-generator";
+    version = "0.8.1";
+
+    src = fetchCrate {
+      inherit pname version;
+      sha256 = "sha256-ZVhsbaJJ9WBcQPx2yikIAQJeBXwC6ZAJkfCRmokNV3I=";
+    };
+
+    cargoSha256 = "sha256-Yh9q/aYHXUF2eIFpJ7ccgeyIO5mQMgRDCNr+ZyS166Y=";
+
+    meta = with lib; {
+      description = "A command-line tool for generating license files.";
+      homepage = "https://github.com/azu/license-generator";
+      license = licenses.mit;
+      maintainers = with maintainers; [ loicreynier ];
+    };
+}

--- a/pkgs/tools/misc/license-generator/default.nix
+++ b/pkgs/tools/misc/license-generator/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     cargoSha256 = "sha256-Yh9q/aYHXUF2eIFpJ7ccgeyIO5mQMgRDCNr+ZyS166Y=";
 
     meta = with lib; {
-      description = "A command-line tool for generating license files.";
+      description = "Command-line tool for generating license files";
       homepage = "https://github.com/azu/license-generator";
       license = licenses.mit;
       maintainers = with maintainers; [ loicreynier ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1084,6 +1084,8 @@ with pkgs;
 
   ksnip = libsForQt5.callPackage ../tools/misc/ksnip { };
 
+  license-generator = callPackage ../tools/misc/license-generator { };
+
   linux-router = callPackage ../tools/networking/linux-router { };
 
   linux-router-without-wifi = linux-router.override { useWifiDependencies = false; };


### PR DESCRIPTION
###### Description of changes

Add [`license-generator`](https://github.com/azu/license-generator), a command-line tool for generating `LICENSE`/`COPYNG` files.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
