### PR TITLE
openssl_1_1; 1.1.1m -> 1.1.1.n; openssl_3_0: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -186,8 +186,8 @@ in {
   };
 
   openssl_1_1 = common rec {
-    version = "1.1.1m";
-    sha256 = "sha256-+JGZvosjykX8fLnx2NPuZzEjGChq0DD1MWrKZGLbbJY=";
+    version = "1.1.1n";
+    sha256 = "sha256-QNzrUaT2pSdb3g5r8g70uRv8Mu1XwFUuLo4VRjNysXo=";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -201,8 +201,8 @@ in {
   };
 
   openssl_3_0 = common {
-    version = "3.0.1";
-    sha256 = "sha256-wxGthTNTvOeW7a0BqGLFCopYf2Ln4hAO9GWrU+ybBtE=";
+    version = "3.0.2";
+    sha256 = "sha256-mOkczq1NR1auPJzeXgkZGo5YbZ9NUIOOfsCdZBHf22M=";
     patches = [
       ./3.0/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
###### Description of changes

https://github.com/openssl/openssl/blob/openssl-3.0.2/CHANGES.md#changes-between-301-and-302-15-mar-2022
https://github.com/openssl/openssl/blob/OpenSSL_1_1_1n/CHANGES#L10

Denial of service when parsing elliptic curve certificates with non-prime moduli.

Fixes: CVE-2022-0778

Assuming this will go directly into master/release-21.11 unless people disagree.

```

  *) Fixed a bug in the BN_mod_sqrt() function that can cause it to loop forever
     for non-prime moduli.

     Internally this function is used when parsing certificates that contain
     elliptic curve public keys in compressed form or explicit elliptic curve
     parameters with a base point encoded in compressed form.

     It is possible to trigger the infinite loop by crafting a certificate that
     has invalid explicit curve parameters.

     Since certificate parsing happens prior to verification of the certificate
     signature, any process that parses an externally supplied certificate may
     thus be subject to a denial of service attack. The infinite loop can also
     be reached when parsing crafted private keys as they can contain explicit
     elliptic curve parameters.

     Thus vulnerable situations include:

      - TLS clients consuming server certificates
      - TLS servers consuming client certificates
      - Hosting providers taking certificates or private keys from customers
      - Certificate authorities parsing certification requests from subscribers
      - Anything else which parses ASN.1 elliptic curve parameters

     Also any other applications that use the BN_mod_sqrt() where the attacker
     can control the parameter values are vulnerable to this DoS issue.
     (CVE-2022-0778)
     [Tomáš Mráz]

```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
