### PR TITLE
plantuml-server: fixed unstable deps

### DIFF
--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -1,69 +1,20 @@
-{ lib, stdenv, fetchFromGitHub, maven, jdk17_headless }:
+{ lib, stdenv, fetchurl }:
 
 let
   version = "1.2022.2";
-
-  src = fetchFromGitHub {
-    owner = "plantuml";
-    repo = "plantuml-server";
-    rev = "v${version}";
-    sha256 = "sha256-55IBhulFo42jscBFrHM39qA0GRgKBoYNye4q9QkmjsM=";
-  };
-
-  # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
-  deps = stdenv.mkDerivation {
-    name = "plantuml-server-${version}-deps";
-    inherit src;
-    nativeBuildInputs = [ jdk17_headless maven ];
-    buildPhase = ''
-      runHook preBuild
-
-      while mvn package -Dmaven.repo.local=$out/.m2; [ $? = 1 ]; do
-        echo "timeout, restart maven to continue downloading"
-      done
-
-      runHook postBuild
-    '';
-    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''
-      find $out/.m2 -type f -regex '.+\(\.lastUpdated\|resolver-status\.properties\|_remote\.repositories\)' -delete
-    '';
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "sha256-AheCBX5jFzDHqTI2pCWBIiDESEKMClXlvWIcFvu0goA=";
-  };
 in
-
 stdenv.mkDerivation rec {
   pname = "plantuml-server";
   inherit version;
-  inherit src;
+  src = fetchurl {
+    url = "https://github.com/plantuml/plantuml-server/releases/download/v${version}/plantuml-v${version}.war";
+    sha256 = "sha256-h4ulXzZ5L+VPhk2CnZQNxfnEJzWT3B9TNvDEWt4o9Hk=";
+  };
 
-  nativeBuildInputs = [ jdk17_headless maven ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    # maven can output reproducible files after setting project.build.outputTimestamp property
-    # see https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-do-i-configure-my-maven-build
-    # 'maven.repo.local' must be writable so copy it out of nix store
-    cp -R $src repo
-    chmod +w -R repo
-    cd repo
-    mvn package --offline \
-      -Dproject.build.outputTimestamp=0 \
-      -Dmaven.repo.local=$(cp -dpR ${deps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2
-
-    runHook postBuild
-  '';
-
+  dontUnpack = true;
   installPhase = ''
-    runHook preInstall
-
     mkdir -p "$out/webapps"
-    cp "target/plantuml.war" "$out/webapps/plantuml.war"
-
-    runHook postInstall
+    cp "$src" "$out/webapps/plantuml.war"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
after merging https://github.com/NixOS/nixpkgs/pull/163431 `plantuml-server-*-deps` derivation turned out unstable, this commit switches to fetching `plantuml.war` directly from releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`):
  1. `nix build '.#plantuml-server' '.#jdk' '.#jetty'` into 
  2. `"${PWD}/result-1/bin/java" -jar "${PWD}/result-2/start.jar" --module=deploy,http,jsp jetty.home="${PWD}/result-2" jetty.base="${PWD}/result" jetty.http.host=127.0.0.1 jetty.http.port=7890`
  3. visit `http://127.0.0.1:7890/plantuml` in a browser and tried to render something
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->