### PR TITLE
services.prometheus.exporters.gitlab-ci-pipelines: init module

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -231,6 +231,13 @@
       </listitem>
       <listitem>
         <para>
+          <link xlink:href="https://github.com/mvisonneau/gitlab-ci-pipelines-exporter">prometheus-gitlab-ci-pipelines-exporter</link>,
+          a prometheus exporter for gitlab CI pipelines. Available as
+          <link xlink:href="options.html#opt-services.prometheus.exporters.gitlab-ci-pipelines-exporter">services.prometheus.exporters.gitlab-ci-pipelines</link>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <link xlink:href="https://github.com/netbox-community/netbox">netbox</link>,
           infrastructure resource modeling (IRM) tool. Available as
           <link xlink:href="options.html#opt-services.netbox.enable">services.netbox</link>.

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -67,6 +67,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [prometheus-pve-exporter](https://github.com/prometheus-pve/prometheus-pve-exporter), a tool that exposes information from the Proxmox VE API for use by Prometheus. Available as [services.prometheus.exporters.pve](options.html#opt-services.prometheus.exporters.pve).
 
+- [prometheus-gitlab-ci-pipelines-exporter](https://github.com/mvisonneau/gitlab-ci-pipelines-exporter), a prometheus exporter for gitlab CI pipelines. Available as [services.prometheus.exporters.gitlab-ci-pipelines](options.html#opt-services.prometheus.exporters.gitlab-ci-pipelines-exporter).
+
 - [netbox](https://github.com/netbox-community/netbox), infrastructure resource modeling (IRM) tool. Available as [services.netbox](options.html#opt-services.netbox.enable).
 
 - [tetrd](https://tetrd.app), share your internet connection from your device to your PC and vice versa through a USB cable. Available at [services.tetrd](#opt-services.tetrd.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -35,6 +35,7 @@ let
     "dovecot"
     "fastly"
     "fritzbox"
+    "gitlab-ci-pipelines"
     "influxdb"
     "json"
     "jitsi"

--- a/nixos/modules/services/monitoring/prometheus/exporters/gitlab-ci-pipelines.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/gitlab-ci-pipelines.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, options }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.gitlab-ci-pipelines;
+in
+{
+  port = 9080;
+  extraOpts = {
+    configuration = mkOption {
+      type = types.attrs;
+      default =
+        { };
+      description = ''
+        gitlab-ci-pipelines configuration as a nix attrset.
+
+        See the official documentation for the supported options:
+        https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/blob/main/docs/configuration_syntax.md
+      '';
+      example = {
+        gitlab.url = "https://gitlab.com";
+        projects = [{ name = "foo/project"; }];
+      };
+    };
+
+    environmentFile = mkOption
+      {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/run/secrets/gitlab-ci-pipelines.env";
+        description = ''
+          Path to a file that defines secrets for the gitlab-ci-pipelines exporter.
+          This file should conform to systemd EnvironmentFile syntax. See systemd.exec(5) man page.
+        '';
+      };
+
+  };
+
+  serviceOpts =
+    let
+      addressConfig = {
+        server.listen_address = "${cfg.listenAddress}:${toString cfg.port}";
+      };
+      combinedConfig = recursiveUpdate addressConfig cfg.configuration;
+      configFile = "${pkgs.writeText "gitlab-ci-pipelines-conf.yml" (builtins.toJSON combinedConfig) }";
+    in
+    {
+      serviceConfig = {
+        DynamicUser = true;
+        EnvironmentFile = optional (cfg.environmentFile != null) cfg.environmentFile;
+        ExecStart = ''
+          ${pkgs.prometheus-gitlab-ci-pipelines-exporter}/bin/gitlab-ci-pipelines-exporter run \
+          --config ${escapeShellArg configFile}
+        '';
+      };
+    };
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a module for the gitlab-ci-pipelines prometheus exporter, which is already packaged in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
  - [X] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
