### PR TITLE
[21.11] libressl: 3.4.1 -> 3.4.3, drop 3.2

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -91,7 +91,7 @@ in {
     sha256 = "112bjfrwwqlk0lak7fmfhcls18ydf62cp7gxghf4gklpfl1zyckw";
   };
   libressl_3_4 = generic {
-    version = "3.4.1";
-    sha256 = "0766yxb599lx7qmlmsddiw9wgminz9mc311mav5q23l0rbkflz0h";
+    version = "3.4.2";
+    sha256 = "sha256-y4LKfVRzNpFzUvvSPbL8SDxsRNNRV7MngCFOx0GXs84=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -91,7 +91,7 @@ in {
     sha256 = "112bjfrwwqlk0lak7fmfhcls18ydf62cp7gxghf4gklpfl1zyckw";
   };
   libressl_3_4 = generic {
-    version = "3.4.2";
-    sha256 = "sha256-y4LKfVRzNpFzUvvSPbL8SDxsRNNRV7MngCFOx0GXs84=";
+    version = "3.4.3";
+    sha256 = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -86,10 +86,6 @@ let
   };
 
 in {
-  libressl_3_2 = generic {
-    version = "3.2.7";
-    sha256 = "112bjfrwwqlk0lak7fmfhcls18ydf62cp7gxghf4gklpfl1zyckw";
-  };
   libressl_3_4 = generic {
     version = "3.4.3";
     sha256 = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";

--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wasm-pack";
-  version = "0.10.1";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "rustwasm";
     repo = "wasm-pack";
     rev = "v${version}";
-    sha256 = "sha256-I5TxpJTSus3fXMV0We9SCVMEERS0wIdYvC8SHo8zEHY=";
+    sha256 = "sha256-nhO/SLeJTq2viDqsJCRNLbgjyDKRli3RWExUNzKT9ug=";
   };
 
-  cargoSha256 = "sha256-MmbQb2JYaDpLijKRAxzD9pR4gh+Eoem0MtfdiuRC7Tg=";
+  cargoSha256 = "sha256-6qrCHpg92IRPsf/dK6xcLGX8BLmqox3vgLRqsV4ubsY=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19033,11 +19033,8 @@ with pkgs;
   openvdb = callPackage ../development/libraries/openvdb {};
 
   inherit (callPackages ../development/libraries/libressl { })
-    libressl_3_2
     libressl_3_4;
 
-  # Please keep this pointed to the latest version. See also
-  # https://discourse.nixos.org/t/nixpkgs-policy-regarding-libraries-available-in-multiple-versions/7026/2
   libressl = libressl_3_4;
 
   boringssl = callPackage ../development/libraries/boringssl { };
@@ -33265,7 +33262,6 @@ with pkgs;
 
   wasm-pack = callPackage ../development/tools/wasm-pack {
     inherit (darwin.apple_sdk.frameworks) Security;
-    libressl = libressl_3_2;
   };
 
   wavegain = callPackage ../applications/audio/wavegain { };


### PR DESCRIPTION
###### Description of changes

Fixes CVE-2022-0778.

Release Notes are here (but the version is not yet published on the website): https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.3-relnotes.txt

See #164291.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
