### PR TITLE
Bump DisnixOS version and apply compatibility fixes

### DIFF
--- a/pkgs/tools/package-management/disnix/disnixos/default.nix
+++ b/pkgs/tools/package-management/disnix/disnixos/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "disnixos";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchurl {
     url = "https://github.com/svanderburg/disnixos/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "0zcghb9nm911bfwpzcgj4ga2cndxbzp5pmrxff711qydrwgy7sg7";
+    sha256 = "0nm7g184xh6xzjz4a40a7kgfnpmq043x6v0cynpffa6wd9jv89s9";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/package-management/disnix/dysnomia/default.nix
+++ b/pkgs/tools/package-management/disnix/dysnomia/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchurl, netcat
 
 # Optional packages
-, systemd ? null, ejabberd ? null, mysql ? null, postgresql ? null, subversion ? null
+, systemd ? null, ejabberd ? null, mariadb ? null, postgresql ? null, subversion ? null
 , mongodb ? null, mongodb-tools ? null, influxdb ? null, supervisor ? null, docker ? null
 , nginx ? null, s6-rc ? null, xinetd ? null
 
@@ -26,7 +26,7 @@
 , getopt
 }:
 
-assert enableMySQLDatabase -> mysql != null;
+assert enableMySQLDatabase -> mariadb != null;
 assert enablePostgreSQLDatabase -> postgresql != null;
 assert enableSubversionRepository -> subversion != null;
 assert enableEjabberdDump -> ejabberd != null;
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ getopt netcat ]
     ++ lib.optional stdenv.isLinux systemd
     ++ lib.optional enableEjabberdDump ejabberd
-    ++ lib.optional enableMySQLDatabase mysql.out
+    ++ lib.optional enableMySQLDatabase mariadb.out
     ++ lib.optional enablePostgreSQLDatabase postgresql
     ++ lib.optional enableSubversionRepository subversion
     ++ lib.optionals enableMongoDatabase [ mongodb mongodb-tools ]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33720,7 +33720,9 @@ with pkgs;
 
   disnixos = callPackage ../tools/package-management/disnix/disnixos { };
 
-  DisnixWebService = callPackage ../tools/package-management/disnix/DisnixWebService { };
+  DisnixWebService = callPackage ../tools/package-management/disnix/DisnixWebService {
+    jdk = jdk8;
+  };
 
   i3a = callPackage ../misc/i3a { };
 


### PR DESCRIPTION
###### Description of changes

Bumps DisnixOS to 0.9.3 that fixes NixOS test driver integration. Compile the web service integration with OpenJDK8 to retain compatibility with Tomcat 9.x. Replace some deprecated references.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
