### PR TITLE
Add python pandoc-xnos

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9904,6 +9904,12 @@
       fingerprint = "48AD DE10 F27B AFB4 7BB0  CCAF 2D25 95A0 0D08 ACE0";
     }];
   };
+  ppenguin = {
+    name = "Jeroen Versteeg";
+    email = "hieronymusv@gmail.com";
+    github = "ppenguin";
+    githubId = 17690377;
+  };
   ppom = {
     name = "Paco Pompeani";
     email = "paco@ecomail.io";

--- a/pkgs/development/python-modules/pandoc-xnos/default.nix
+++ b/pkgs/development/python-modules/pandoc-xnos/default.nix
@@ -1,0 +1,32 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, pandocfilters
+, psutil
+}:
+
+buildPythonPackage rec {
+  pname = "pandoc-xnos";
+  version = "2.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tomduck";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-beiGvN0DS6s8wFjcDKozDuwAM2OApX3lTRaUDRUqLeU=";
+  };
+
+  propagatedBuildInputs = [ pandocfilters psutil ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "pandocxnos" ];
+
+  meta = with lib; {
+    description = "Pandoc filter suite providing facilities for cross-referencing in markdown documents";
+    homepage = "https://github.com/tomduck/pandoc-xnos";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ppenguin ];
+  };
+}

--- a/pkgs/development/python-modules/pandoc-xnos/default.nix
+++ b/pkgs/development/python-modules/pandoc-xnos/default.nix
@@ -19,8 +19,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pandocfilters psutil ];
 
-  doCheck = true;
-
   pythonImportsCheck = [ "pandocxnos" ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/pandoc-eqnos/default.nix
+++ b/pkgs/tools/misc/pandoc-eqnos/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+, pandoc-xnos
+}:
+
+buildPythonApplication rec {
+  pname = "pandoc-eqnos";
+  version = "2.5.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tomduck";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-7GQdfGHhtQs6LZK+ZyMmcPSkoFfBWmATTMejMiFcS7Y=";
+  };
+
+  propagatedBuildInputs = [ pandoc-xnos ];
+
+  # Different pandoc executables are not available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone pandoc filter from the pandoc-xnos suite for numbering equations and equation references";
+    homepage = "https://github.com/tomduck/pandoc-eqnos";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ppenguin ];
+  };
+}

--- a/pkgs/tools/misc/pandoc-fignos/default.nix
+++ b/pkgs/tools/misc/pandoc-fignos/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+, pandoc-xnos
+}:
+
+buildPythonApplication rec {
+  pname = "pandoc-fignos";
+  version = "2.4.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tomduck";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-eDwAW0nLB4YqrWT3Ajt9bmX1A43wl+tOPm2St5VpCLk=";
+  };
+
+  propagatedBuildInputs = [ pandoc-xnos ];
+
+  # Different pandoc executables are not available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone pandoc filter from the pandoc-xnos suite for numbering figures and figure references";
+    homepage = "https://github.com/tomduck/pandoc-fignos";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ppenguin ];
+  };
+}

--- a/pkgs/tools/misc/pandoc-secnos/default.nix
+++ b/pkgs/tools/misc/pandoc-secnos/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+, pandoc-xnos
+}:
+
+buildPythonApplication rec {
+  pname = "pandoc-secnos";
+  version = "2.2.2";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tomduck";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-J9KLZvioYM3Pl2UXjrEgd4PuLTwCLYy9SsJIzgw5/jU=";
+  };
+
+  propagatedBuildInputs = [ pandoc-xnos ];
+
+  patches = [
+    ./patch/fix-manifest.patch
+  ];
+
+  # Different pandoc executables are not available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone pandoc filter from the pandoc-xnos suite for numbering sections and section references";
+    homepage = "https://github.com/tomduck/pandoc-secnos";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ppenguin ];
+  };
+}

--- a/pkgs/tools/misc/pandoc-secnos/patch/fix-manifest.patch
+++ b/pkgs/tools/misc/pandoc-secnos/patch/fix-manifest.patch
@@ -1,0 +1,39 @@
+From 165ee1f4c1208636254392335d34934dc50d273e Mon Sep 17 00:00:00 2001
+From: ppenguin <hieronymusv@gmail.com>
+Date: Tue, 15 Mar 2022 23:15:07 +0100
+Subject: [PATCH] fix setup.py to work in nixpkgs
+
+---
+ setup.py | 13 ++-----------
+ 1 file changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index d705846..d7345a2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -42,10 +42,10 @@
+ 
+     author='Thomas J. Duck',
+     author_email='tomduck@tomduck.ca',
+-    description='Equation number filter for pandoc',
++    description='Section number filter for pandoc',
+     long_description=DESCRIPTION,
+     license='GPL',
+-    keywords='pandoc equation numbers filter',
++    keywords='pandoc section numbers filter',
+     url='https://github.com/tomduck/pandoc-secnos',
+     download_url='https://github.com/tomduck/pandoc-secnos/tarball/' + \
+                  __version__,
+@@ -63,12 +63,3 @@
+         'Programming Language :: Python'
+         ]
+ )
+-
+-# Check that the pandoc-secnos script is on the PATH
+-if not shutil.which('pandoc-secnos'):
+-    msg = """
+-          ERROR: `pandoc-secnos` script not found. This will need to 
+-          be corrected.  If you need help, please file an Issue at
+-          https://github.com/tomduck/pandoc-secnos/issues.\n"""
+-    print(textwrap.dedent(msg))
+-    sys.exit(-1)

--- a/pkgs/tools/misc/pandoc-tablenos/default.nix
+++ b/pkgs/tools/misc/pandoc-tablenos/default.nix
@@ -1,0 +1,30 @@
+{ buildPythonApplication
+, fetchFromGitHub
+, lib
+, pandoc-xnos
+}:
+
+buildPythonApplication rec {
+  pname = "pandoc-tablenos";
+  version = "2.3.0";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "tomduck";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-FwzsRziY3PoySo9hIFuLw6tOO9oQij6oQEyoY8HgnII=";
+  };
+
+  propagatedBuildInputs = [ pandoc-xnos ];
+
+  # Different pandoc executables are not available
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Standalone pandoc filter from the pandoc-xnos suite for numbering tables and table references";
+    homepage = "https://github.com/tomduck/pandoc-tablenos";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ppenguin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8335,6 +8335,7 @@ with pkgs;
   # pandoc-*nos is a filter suite, where pandoc-xnos has all functionality and the others are used for only specific functionality
   pandoc-eqnos = python3Packages.callPackage ../tools/misc/pandoc-eqnos { };
   pandoc-fignos = python3Packages.callPackage ../tools/misc/pandoc-fignos { };
+  pandoc-secnos = python3Packages.callPackage ../tools/misc/pandoc-secnos { };
 
   patray = callPackage ../tools/audio/patray { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8332,7 +8332,8 @@ with pkgs;
 
   pandoc-plantuml-filter = python3Packages.callPackage ../tools/misc/pandoc-plantuml-filter { };
 
-  panicparse = callPackage ../tools/misc/panicparse { };
+  # pandoc-*nos is a filter suite, where pandoc-xnos has all functionality and the others are used for only specific functionality
+  pandoc-eqnos = python3Packages.callPackage ../tools/misc/pandoc-eqnos { };
 
   patray = callPackage ../tools/audio/patray { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8336,6 +8336,7 @@ with pkgs;
   pandoc-eqnos = python3Packages.callPackage ../tools/misc/pandoc-eqnos { };
   pandoc-fignos = python3Packages.callPackage ../tools/misc/pandoc-fignos { };
   pandoc-secnos = python3Packages.callPackage ../tools/misc/pandoc-secnos { };
+  pandoc-tablenos = python3Packages.callPackage ../tools/misc/pandoc-tablenos { };
 
   patray = callPackage ../tools/audio/patray { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8334,6 +8334,7 @@ with pkgs;
 
   # pandoc-*nos is a filter suite, where pandoc-xnos has all functionality and the others are used for only specific functionality
   pandoc-eqnos = python3Packages.callPackage ../tools/misc/pandoc-eqnos { };
+  pandoc-fignos = python3Packages.callPackage ../tools/misc/pandoc-fignos { };
 
   patray = callPackage ../tools/audio/patray { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5886,6 +5886,8 @@ in {
 
   pandoc-attributes = callPackage ../development/python-modules/pandoc-attributes { };
 
+  pandoc-xnos = callPackage ../development/python-modules/pandoc-xnos { };
+
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
   panel = callPackage ../development/python-modules/panel { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`pandoc-xnos` is a python-based `pandoc` filter (consisting of `pandoc-xnos` which can be called by separate binaries for cross-references to equations, tables, sections, figures) when converting from markdown with pandoc.

See upstream: https://github.com/tomduck/pandoc-xnos

The binary installed can be called with `pandoc --filter pandoc-xnos`.

To use only a specific filter (subset of `xnos`) install the related packages `pandoc-{eq|fig|table|sec}nos` also included in this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
