### PR TITLE
haskellPackages.knob: add patch for GHC 9 support

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -47,6 +47,8 @@ self: super: {
     Cabal = self.Cabal_3_6_3_0;
   });
 
+  knob = appendPatch ./patches/knob-ghc9.patch super.knob;
+
   # Jailbreaks & Version Updates
 
   # This `doJailbreak` can be removed once the following PR is released to Hackage:

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -60,6 +60,8 @@ self: super: {
   # Tests fail in GHC 9.2
   extra = dontCheck super.extra;
 
+  knob = appendPatch ./patches/knob-ghc9.patch super.knob;
+
   # Jailbreaks & Version Updates
 
   # This `doJailbreak` can be removed once the following PR is released to Hackage:

--- a/pkgs/development/haskell-modules/patches/knob-ghc9.patch
+++ b/pkgs/development/haskell-modules/patches/knob-ghc9.patch
@@ -1,0 +1,62 @@
+diff --git a/knob.cabal b/knob.cabal
+index a8abae0..45bd5c7 100644
+--- a/knob.cabal
++++ b/knob.cabal
+@@ -52,7 +52,7 @@ library
+   ghc-options: -Wall -O2
+ 
+   build-depends:
+-      base >= 4.2 && < 4.15
++      base >= 4.2 && < 5
+     , bytestring >= 0.9
+     , transformers >= 0.2
+ 
+diff --git a/lib/Data/Knob.hs b/lib/Data/Knob.hs
+index fa87ad2..f01d0a7 100644
+--- a/lib/Data/Knob.hs
++++ b/lib/Data/Knob.hs
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE DeriveDataTypeable #-}
++{-# LANGUAGE DeriveDataTypeable, DeriveAnyClass #-}
+ 
+ -- |
+ -- Module: Data.Knob
+@@ -58,7 +58,7 @@ import qualified System.IO as IO
+ newtype Knob = Knob (MVar.MVar ByteString)
+ 
+ data Device = Device IO.IOMode (MVar.MVar ByteString) (MVar.MVar Int)
+-	deriving (Typeable)
++	deriving (Typeable, IO.RawIO)
+ 
+ instance IO.IODevice Device where
+ 	ready _ _ _ = return True
+@@ -68,21 +68,21 @@ instance IO.IODevice Device where
+ 	
+ 	seek (Device _ _ var) IO.AbsoluteSeek off = do
+ 		checkOffset off
+-		MVar.modifyMVar_ var (\_ -> return (fromInteger off))
+-	
++		MVar.modifyMVar var (\_ -> return (fromInteger off, off))
++
+ 	seek (Device _ _ var) IO.RelativeSeek off = do
+-		MVar.modifyMVar_ var (\old_off -> do
++		MVar.modifyMVar var (\old_off -> do
+ 			let new_off = toInteger old_off + off
+ 			checkOffset new_off
+-			return (fromInteger new_off))
+-	
++			return (fromInteger new_off, new_off))
++
+ 	seek dev@(Device _ _ off_var) IO.SeekFromEnd off = do
+-		MVar.modifyMVar_ off_var (\_ -> do
++		MVar.modifyMVar off_var (\_ -> do
+ 			size <- IO.getSize dev
+ 			let new_off = size + off
+ 			checkOffset new_off
+-			return (fromInteger new_off))
+-	
++			return (fromInteger new_off, new_off))
++
+ 	tell (Device _ _ var) = fmap toInteger (MVar.readMVar var)
+ 	getSize (Device _ var _) = do
+ 		bytes <- MVar.readMVar var


### PR DESCRIPTION
Patch sent to upstream via email, but the package hasn't been updated in ten years.

Changes:
- IO.seek should now return the new offset so I used modifyMVar instead of modifyMVar_
- mkFileHandle now requires a RawIO instance for Device. Since this was not the case before and I don't think we need to actually support raw IO, I used DeriveAnyClass.
