### PR TITLE
bass: init at 1.0

### DIFF
--- a/pkgs/shells/fish/plugins/bass.nix
+++ b/pkgs/shells/fish/plugins/bass.nix
@@ -1,0 +1,30 @@
+{ lib, buildFishPlugin, fetchFromGitHub, python3 }:
+
+buildFishPlugin rec {
+  pname = "bass";
+  version = "unstable-2021-02-18";
+
+  src = fetchFromGitHub {
+    owner = "edc";
+    repo = pname;
+    rev = "2fd3d2157d5271ca3575b13daec975ca4c10577a";
+    sha256 = "0mb01y1d0g8ilsr5m8a71j6xmqlyhf8w4xjf00wkk8k41cz3ypky";
+  };
+
+  #buildFishplugin will only move the .fish files, but bass also relies on python
+  postInstall = ''
+    cp functions/__bass.py $out/share/fish/vendor_functions.d/
+  '';
+
+  checkInputs = [ python3 ];
+  checkPhase = ''
+    make test
+  '';
+
+  meta = with lib; {
+    description = "Fish function making it easy to use utilities written for Bash in Fish shell";
+    homepage = "https://github.com/edc/bass";
+    license = licenses.mit;
+    maintainers = with maintainers; [ beezow ];
+  };
+}

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -6,6 +6,8 @@ lib.makeScope newScope (self: with self; {
 
   clownfish = callPackage ./clownfish.nix { };
 
+  bass = callPackage ./bass.nix { };
+
   done = callPackage ./done.nix { };
 
   # Fishtape 2.x and 3.x aren't compatible,


### PR DESCRIPTION
###### Description of changes

Add Bass plugin for fish shell.

[Bass is created to make it possible to use bash utilities in fish shell without any modification. It works by capturing what environment variables are modified by the utility of interest, and replay the changes in fish.](https://github.com/edc/bass)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
