### PR TITLE
kde/plasma5: 5.24.0 -> 5.24.3

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -519,7 +519,7 @@ in
         with plasma5; with kdeApplications; with kdeFrameworks;
         [
           # Basic packages without which Plasma Mobile fails to work properly.
-          plasma-phone-components
+          plasma-mobile
           plasma-nano
           pkgs.maliit-framework
           pkgs.maliit-keyboard
@@ -573,7 +573,7 @@ in
         };
       };
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.libsForQt5.plasma5.plasma-phone-components ];
+      services.xserver.displayManager.sessionPackages = [ pkgs.libsForQt5.plasma5.plasma-mobile ];
     })
   ];
 }

--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "kde-rounded-corners";
-  version = "unstable-2021-11-06";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "matinlotfali";
     repo = "KDE-Rounded-Corners";
-    rev = "8ad8f5f5eff9d1625abc57cb24dc484d51f0e1bd";
-    sha256 = "0xbskf7jd03d2invfz1nnfc82klzvc784snw539n4kn6c6rc381p";
+    rev = "v${version}";
+    hash = "sha256-cXpJabeOHnat7OljtRzduUdOaA6Z3z6vV3aBKwiIrR0=";
   };
 
   postConfigure = ''

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -133,10 +133,10 @@ let
       milou = callPackage ./milou.nix {};
       oxygen = callPackage ./oxygen.nix {};
       plasma-browser-integration = callPackage ./plasma-browser-integration.nix {};
-      plasma-phone-components = callPackage ./plasma-phone-components {};
       plasma-desktop = callPackage ./plasma-desktop {};
       plasma-disks = callPackage ./plasma-disks.nix {};
       plasma-integration = callPackage ./plasma-integration {};
+      plasma-mobile = callPackage ./plasma-mobile {};
       plasma-nano = callPackage ./plasma-nano {};
       plasma-nm = callPackage ./plasma-nm {};
       plasma-pa = callPackage ./plasma-pa.nix { inherit gconf; };
@@ -168,6 +168,7 @@ let
 
     } // lib.optionalAttrs (config.allowAliases or true) {
       ksysguard = throw "ksysguard has been replaced with plasma-systemmonitor";
+      plasma-phone-components = throw "'plasma-phone-components' has been renamed to/replaced by 'plasma-mobile'";
     };
 in
 lib.makeScope libsForQt5.newScope packages

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.24.0/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.24.3/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/plasma-mobile/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-mobile/default.nix
@@ -7,7 +7,7 @@
 
   kdeclarative, kdelibs4support, kpeople, kconfig, krunner, kinit, kwayland, kwin,
   plasma-framework, telepathy, libphonenumber, protobuf, libqofono, modemmanager-qt,
-  plasma-workspace,
+  networkmanager-qt, plasma-workspace,
   maliit-framework, maliit-keyboard,
 
   qtwayland, qttools
@@ -16,14 +16,14 @@
 let inherit (lib) getBin getLib; in
 
 mkDerivation {
-  pname = "plasma-phone-components";
+  pname = "plasma-mobile";
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
     appstream libdbusmenu pam wayland
     kdeclarative kdelibs4support kpeople kconfig krunner kinit kwayland kwin
     plasma-framework telepathy libphonenumber protobuf libqofono modemmanager-qt
-    maliit-framework maliit-keyboard
+    networkmanager-qt maliit-framework maliit-keyboard
   ];
 
   postPatch = ''

--- a/pkgs/desktops/plasma-5/plasma-workspace/0001-startkde.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/0001-startkde.patch
@@ -71,10 +71,10 @@ index 008fdfcaf..72468f21c 100644
  }
  
  void cleanupPlasmaEnvironment(const std::optional<QProcessEnvironment> &oldSystemdEnvironment)
-@@ -500,7 +500,7 @@ QProcess *setupKSplash()
-         KConfigGroup ksplashCfg = cfg.group("KSplash");
+@@ -501,7 +501,7 @@ QProcess *setupKSplash()
          if (ksplashCfg.readEntry("Engine", QStringLiteral("KSplashQML")) == QLatin1String("KSplashQML")) {
              p = new QProcess;
+             p->setProcessChannelMode(QProcess::ForwardedChannels);
 -            p->start(QStringLiteral("ksplashqml"), {ksplashCfg.readEntry("Theme", QStringLiteral("Breeze"))});
 +            p->start(QStringLiteral(CMAKE_INSTALL_FULL_BINDIR "/ksplashqml"), {ksplashCfg.readEntry("Theme", QStringLiteral("Breeze"))});
          }

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -4,435 +4,427 @@
 
 {
   bluedevil = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/bluedevil-5.24.0.tar.xz";
-      sha256 = "128br83hkxxrb6wca3d1racygdnfgk3r5md1gcjvgwb0gpy6bnzp";
-      name = "bluedevil-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/bluedevil-5.24.3.tar.xz";
+      sha256 = "1hlyqhn14yq7960zfjwjygkpkvbmrlsanm1g1wrr7dwbmrp5dlcx";
+      name = "bluedevil-5.24.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/breeze-5.24.0.tar.xz";
-      sha256 = "08b3hihz98z7kdybb0y1b74q1dn511ga81qqqxzlfirgpp8c9f9q";
-      name = "breeze-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/breeze-5.24.3.tar.xz";
+      sha256 = "0h19m6wmhjw8v6ys47kgzcb0h2nb9w2fcjzypnvmkvbjbkjr53sb";
+      name = "breeze-5.24.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/breeze-grub-5.24.0.tar.xz";
-      sha256 = "0p0pzmsd6scssyxcm9n58mp7fc9vz1lg4n7c1ch4bqragih1gnlr";
-      name = "breeze-grub-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/breeze-grub-5.24.3.tar.xz";
+      sha256 = "15cpmqp7klp4dhcil3i78iff4kjasfx273v36ml8y05hm8w0igjq";
+      name = "breeze-grub-5.24.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/breeze-gtk-5.24.0.tar.xz";
-      sha256 = "090cczxc1ciic6wghz3p21gpfdwnc8pjcvq6wn7bfkp1i3r5mihp";
-      name = "breeze-gtk-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/breeze-gtk-5.24.3.tar.xz";
+      sha256 = "1922s17mh4ifaqbf4b7p6yj8pwd6z3qwpbf21j1fqhmdk4pvn499";
+      name = "breeze-gtk-5.24.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/breeze-plymouth-5.24.0.tar.xz";
-      sha256 = "1qqpwgp1yy3p1s0z21xwds6wx4z8daibkgk1bynj73cx7a2wch9g";
-      name = "breeze-plymouth-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/breeze-plymouth-5.24.3.tar.xz";
+      sha256 = "0nkf0ll4hcawmkd7nrh8gcf6hhbl0ajxiz2azf9njab9pv2lcz1j";
+      name = "breeze-plymouth-5.24.3.tar.xz";
     };
   };
   discover = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/discover-5.24.0.tar.xz";
-      sha256 = "0dbfvqana31wqharsbyb8rcrw1w6l9x1g6p02aqwiph0inkrz20q";
-      name = "discover-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/discover-5.24.3.tar.xz";
+      sha256 = "097m5njz86vi4innap1mvizas60r1qcrdzdgsid1hd6p5a92rwca";
+      name = "discover-5.24.3.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/drkonqi-5.24.0.tar.xz";
-      sha256 = "1ismgg7rcxijkprn4sci15wn4w2gmdn0fdbgvzxdcrqaf4g6qc3s";
-      name = "drkonqi-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/drkonqi-5.24.3.tar.xz";
+      sha256 = "1n6psvr3washk796zrc8ag011fwy677h2mdkw9ijx8dhrk80br0k";
+      name = "drkonqi-5.24.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kactivitymanagerd-5.24.0.tar.xz";
-      sha256 = "12dvgm3ilyqlxzm8209b7g42nfk0ahfzizs3pbmi18zapjszcsps";
-      name = "kactivitymanagerd-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kactivitymanagerd-5.24.3.tar.xz";
+      sha256 = "0qxf3j36dj1yklnl27znsi9qdjmn6nr779cnzms38x76dq9kxblw";
+      name = "kactivitymanagerd-5.24.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kde-cli-tools-5.24.0.tar.xz";
-      sha256 = "0l8a4ysz1cqwdh3c20q51qamwh58vvs8yzb5jdvbp8bahsyyc4mr";
-      name = "kde-cli-tools-5.24.0.tar.xz";
-    };
-  };
-  kde-gtk-config = {
-    version = "5.24.0";
-    src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kde-gtk-config-5.24.0.tar.xz";
-      sha256 = "024pglycz2kbp9npnvbx5qpkz9381wyyp6xkalqynzr9gy58syrx";
-      name = "kde-gtk-config-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kde-cli-tools-5.24.3.tar.xz";
+      sha256 = "00z8yxic5ibk05x8c25dsc4ijvk6yv0aw1iyfhnpnzmdwdydlr7y";
+      name = "kde-cli-tools-5.24.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kdecoration-5.24.0.tar.xz";
-      sha256 = "0xl8892w49z11k9mxgh7lp8a4l1x8wldmaij82kd1vnh9sxvb3f3";
-      name = "kdecoration-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kdecoration-5.24.3.tar.xz";
+      sha256 = "0dpnaf5myn1h368cnkq9g6xfm1sqmyam6bxyidbd5j3dyy1kvz5v";
+      name = "kdecoration-5.24.3.tar.xz";
+    };
+  };
+  kde-gtk-config = {
+    version = "5.24.3";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.24.3/kde-gtk-config-5.24.3.tar.xz";
+      sha256 = "0p50kf34csdrgck1y09d3lnz0r9ly0ca4778achrc59yr4qcsjzv";
+      name = "kde-gtk-config-5.24.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kdeplasma-addons-5.24.0.tar.xz";
-      sha256 = "0q8yf0gz4gjn1kyf545i8fpsn2dpy48qhjpm8ssp3ywv6s2abjxn";
-      name = "kdeplasma-addons-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kdeplasma-addons-5.24.3.tar.xz";
+      sha256 = "0g7jcvd6abnlzz9ibnc7phzm58pn6dv3795w4hhy47738jkhizl6";
+      name = "kdeplasma-addons-5.24.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kgamma5-5.24.0.tar.xz";
-      sha256 = "07w7l25snpi98j5bxg3zri5lsymabnli6h9d5w0qx0c19wzjwayl";
-      name = "kgamma5-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kgamma5-5.24.3.tar.xz";
+      sha256 = "0rwqvz14a50s43p74n19v1zzd9y8f2lylfappxmhrdyxmbgkpnk6";
+      name = "kgamma5-5.24.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/khotkeys-5.24.0.tar.xz";
-      sha256 = "0gjdwdzg5vybalima8jnwrprqj0rnxmzds0x8w707nb9ypz4k7k6";
-      name = "khotkeys-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/khotkeys-5.24.3.tar.xz";
+      sha256 = "1jxg91rpz09sh13fz270pxfw40qdy6p50j5xw7cpnyqlk2l5zx0p";
+      name = "khotkeys-5.24.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kinfocenter-5.24.0.tar.xz";
-      sha256 = "09fq69q4300ppi1y9pp8s4h1bbai1p5qsz384bb445pjvwsyn6nf";
-      name = "kinfocenter-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kinfocenter-5.24.3.tar.xz";
+      sha256 = "08z2044bl0v4ydlx2chv849y6m4py0yd4lnw76sycd14lnvsrxfj";
+      name = "kinfocenter-5.24.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kmenuedit-5.24.0.tar.xz";
-      sha256 = "0bjiqdw4wqi5vpkn98wjjz23x6k47lvxac8nyxs8ddd9i8mlklij";
-      name = "kmenuedit-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kmenuedit-5.24.3.tar.xz";
+      sha256 = "1yivrdix4jiycfbw9g6pzx8zkmdq4g8g51ndc7sy3r0qxzgx1icb";
+      name = "kmenuedit-5.24.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kscreen-5.24.0.tar.xz";
-      sha256 = "19kqvvgj209ri035ldzn1k5l36l54rvagsnfzhw61v8rd9r6r02x";
-      name = "kscreen-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kscreen-5.24.3.tar.xz";
+      sha256 = "1wjbd33h8473v8i5qxdccxrsv04v6jyd7scrqdxqaln9n8ylp08f";
+      name = "kscreen-5.24.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kscreenlocker-5.24.0.tar.xz";
-      sha256 = "0d827h5br27sdd925brljb1mwnkzj739g5q0k8xkw9f9q9bxk8l8";
-      name = "kscreenlocker-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kscreenlocker-5.24.3.tar.xz";
+      sha256 = "1dh3z55hwakj11ffn2fm79vnlw7gcg1nkcxbxvcdcpq84ahpq583";
+      name = "kscreenlocker-5.24.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/ksshaskpass-5.24.0.tar.xz";
-      sha256 = "1xiw25imhmkcikp746q9s393djmkdpkh9jb7h1diwwhambnimy6d";
-      name = "ksshaskpass-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/ksshaskpass-5.24.3.tar.xz";
+      sha256 = "0ivq9nyyqm1rrm6ck26jlsh8qv9q98dz5qwvcnpgpmxb3mr1dgiv";
+      name = "ksshaskpass-5.24.3.tar.xz";
     };
   };
   ksystemstats = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/ksystemstats-5.24.0.tar.xz";
-      sha256 = "1182dfcg1av9329g9p9ll64yiwyxm46kczakxb3vj4d2ajaclzm1";
-      name = "ksystemstats-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/ksystemstats-5.24.3.tar.xz";
+      sha256 = "03ikpd3m0qk8cb92g63i7q9c8bks7ggf1pmmig559cmg7gbknc2c";
+      name = "ksystemstats-5.24.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kwallet-pam-5.24.0.tar.xz";
-      sha256 = "0jzi2rcwxxjp3lg8cywp96ysnwm51a0m9pdwk8z7n3v1ncr2p38q";
-      name = "kwallet-pam-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kwallet-pam-5.24.3.tar.xz";
+      sha256 = "0zxdrpjq8sg3qw2gfkvjs567b41labi940cq4qrix395v7251p9k";
+      name = "kwallet-pam-5.24.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kwayland-integration-5.24.0.tar.xz";
-      sha256 = "1yq9cjb8xcvqr747p5hm8xxg4rn6mahchd5c2camv3qrjbqm8ll6";
-      name = "kwayland-integration-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kwayland-integration-5.24.3.tar.xz";
+      sha256 = "1kq5vrrplbdxri8610h89apfz07a6xi1gnlvmr8gbsvas5zicvwz";
+      name = "kwayland-integration-5.24.3.tar.xz";
     };
   };
   kwayland-server = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kwayland-server-5.24.0.tar.xz";
-      sha256 = "1zbi4c14zvjwkxxqlg80mv749ybnkmcdvn72irmrzbbf4g1z7k32";
-      name = "kwayland-server-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kwayland-server-5.24.3.tar.xz";
+      sha256 = "0fq61qk3cp4xg9759ylqqw5ncx9s7kayjf0bilg5m725bfhj02sn";
+      name = "kwayland-server-5.24.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kwin-5.24.0.tar.xz";
-      sha256 = "19q5pphqnr1xc1c4z0sd3yr60jsiq190llwllfmlj4acjlbcbbn6";
-      name = "kwin-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kwin-5.24.3.tar.xz";
+      sha256 = "0szlrcsj4h4fa5yf27nmza7c4dyc0xcwdrihs05pl5qk5bivfkfq";
+      name = "kwin-5.24.3.tar.xz";
     };
   };
   kwrited = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/kwrited-5.24.0.tar.xz";
-      sha256 = "018wvkkqzg4qyjd0w1h2d3ms72ghlq8mg79rrsj518l7hhlv6rsg";
-      name = "kwrited-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/kwrited-5.24.3.tar.xz";
+      sha256 = "1sgd3iik647pz2zr5cpsbwm2ll8f11xyw2jv2sfxkbiiw53qaxid";
+      name = "kwrited-5.24.3.tar.xz";
     };
   };
   layer-shell-qt = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/layer-shell-qt-5.24.0.tar.xz";
-      sha256 = "0y3z2xr9vpxnm84gs1zpa1apma341wza7pjcpwibaqd6aiz9vpqv";
-      name = "layer-shell-qt-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/layer-shell-qt-5.24.3.tar.xz";
+      sha256 = "0h3xlvmgyxyzxvazgbbn0a9l14hg5d38cl9hclnwmrnpwbn0bqax";
+      name = "layer-shell-qt-5.24.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/libkscreen-5.24.0.tar.xz";
-      sha256 = "0h6sycib940gbw2rf6ax3v7mg77pzga36xzwzbyz9h49fba3dpjk";
-      name = "libkscreen-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/libkscreen-5.24.3.tar.xz";
+      sha256 = "18777lwn5j0isc347dks25731byyfdyls79lj6hnxqb6807lz1x6";
+      name = "libkscreen-5.24.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/libksysguard-5.24.0.tar.xz";
-      sha256 = "1f0hwk2kzmgpjxmsjfd4g25sr91qyazp4hysyfjdhrrs2ajdkm0b";
-      name = "libksysguard-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/libksysguard-5.24.3.tar.xz";
+      sha256 = "18piiy24rd5fzvp4cnhgx0d4x4m6fnxx01zm1mx0sh676g7m31hl";
+      name = "libksysguard-5.24.3.tar.xz";
     };
   };
   milou = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/milou-5.24.0.tar.xz";
-      sha256 = "0sxsisrzfancxwk8lsxhj2b85sgjdb9gzy4l0nax4fp942ygiirs";
-      name = "milou-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/milou-5.24.3.tar.xz";
+      sha256 = "06xx4afym92hfpvbiqrv7mx30bdm3dhdfn8vki5zxq2k0rv0pmri";
+      name = "milou-5.24.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/oxygen-5.24.0.tar.xz";
-      sha256 = "0ym74q29c2f32l1xm3kd0s2p7zzbg6a96g7d39fkp5paxicx5fb7";
-      name = "oxygen-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/oxygen-5.24.3.tar.xz";
+      sha256 = "02j0drc24mf2pfhdgzri5sdcscq1bbj4lhhmhp6bn1v74wybv381";
+      name = "oxygen-5.24.3.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-browser-integration-5.24.0.tar.xz";
-      sha256 = "1gp9m7drwxflb0ms0vbvk7qydm1bghhzalc00lpcjh4nrf0bgh33";
-      name = "plasma-browser-integration-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-browser-integration-5.24.3.tar.xz";
+      sha256 = "1msib3c8arybqbv1vfj1ijx74a34a02hn8gvjy4sf95zcl07mc20";
+      name = "plasma-browser-integration-5.24.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-desktop-5.24.0.tar.xz";
-      sha256 = "1brnm6yivjy2piy88ncmclv4g2rxkaiyi923c557dmiipah2bx7z";
-      name = "plasma-desktop-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-desktop-5.24.3.tar.xz";
+      sha256 = "1lwizprs6nk6nibydwkwmpi9c7c50lvg2k188pb6ddz2sb7pwgjq";
+      name = "plasma-desktop-5.24.3.tar.xz";
     };
   };
   plasma-disks = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-disks-5.24.0.tar.xz";
-      sha256 = "1c3pwnyhdmj7grk3gjh4kw5437m5cxhp70qsbhnfsaacps3mdv5d";
-      name = "plasma-disks-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-disks-5.24.3.tar.xz";
+      sha256 = "0nklcimxyvci3xa6nc5jxbcxds4a14vkkwihgc6xfpc7xcca0wcy";
+      name = "plasma-disks-5.24.3.tar.xz";
     };
   };
   plasma-firewall = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-firewall-5.24.0.tar.xz";
-      sha256 = "1jjw414547qksjxg2x5n666iq6qildbn9k9c8hqipmwnlkprpbb1";
-      name = "plasma-firewall-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-firewall-5.24.3.tar.xz";
+      sha256 = "0r7gh3asnc5lbfsp1jb33lmgcxfpjmlrqlyz41g0wv9aj9x6pwxz";
+      name = "plasma-firewall-5.24.3.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-integration-5.24.0.tar.xz";
-      sha256 = "17dqf6j1za3q8hzk7jfc5wc7s4kr28slrkq5iqvzqgyqjqy3z7rv";
-      name = "plasma-integration-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-integration-5.24.3.tar.xz";
+      sha256 = "031w205icblf50ps7bw7wp5q4azbqpcp4bnig2wh5d1lc8xqzvvs";
+      name = "plasma-integration-5.24.3.tar.xz";
     };
   };
   plasma-mobile = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-mobile-5.24.0.tar.xz";
-      sha256 = "0g9mbb8dzqcngc1sq43knwyc3kr81w3vl359wyrgvnr8r1qikv2z";
-      name = "plasma-mobile-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-mobile-5.24.3.tar.xz";
+      sha256 = "1bwmy7xvd8wmh0snqqjh9jjgawib8ks2g30w48sqxwhplhf3da58";
+      name = "plasma-mobile-5.24.3.tar.xz";
     };
   };
   plasma-nano = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-nano-5.24.0.tar.xz";
-      sha256 = "0i8lsp83g2i3c88djkmxawwbwa6lr0w89lzxj73fr6az6vdcrypj";
-      name = "plasma-nano-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-nano-5.24.3.tar.xz";
+      sha256 = "13jxhfi3c3dhg7zdyfqnsii661h1am0w9dsv82dalqvwr1mw28l5";
+      name = "plasma-nano-5.24.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-nm-5.24.0.tar.xz";
-      sha256 = "17pmyklmr46qg21w4ql9q5nhfdjw1xmmv1qz7lyhlww7qa6mz1ny";
-      name = "plasma-nm-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-nm-5.24.3.tar.xz";
+      sha256 = "1z9vzj2mbvqklnjxf2izpx9s6cq097im0kz41fy4c5cjxna4xxic";
+      name = "plasma-nm-5.24.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-pa-5.24.0.tar.xz";
-      sha256 = "19n2plbk455qwgq0lcpb7rj2ck78ck64fpvlldmh53j9vxyzcasl";
-      name = "plasma-pa-5.24.0.tar.xz";
-    };
-  };
-  plasma-phone-components = {
-    version = "5.24.0";
-    src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-phone-components-5.24.0.tar.xz";
-      sha256 = "0g9mbb8dzqcngc1sq43knwyc3kr81w3vl359wyrgvnr8r1qikv2z";
-      name = "plasma-phone-components-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-pa-5.24.3.tar.xz";
+      sha256 = "0n87rb04izd0ix50iy2dgj6yzzr626vhpfk76lnqr57jz6fbx3z1";
+      name = "plasma-pa-5.24.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-sdk-5.24.0.tar.xz";
-      sha256 = "16fn98rv4qaci3b5whzjs6csbbxyrnmnr9gngn5dirdpla8cffld";
-      name = "plasma-sdk-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-sdk-5.24.3.tar.xz";
+      sha256 = "0g6nypqsbmsp9msixd7p25lk58zismdamkp41f5lx3cbb49x1fpr";
+      name = "plasma-sdk-5.24.3.tar.xz";
     };
   };
   plasma-systemmonitor = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-systemmonitor-5.24.0.tar.xz";
-      sha256 = "0zkvbgwm2rpyisbx72a75ywy45d2primjjpnmw76x6924j8sp7pd";
-      name = "plasma-systemmonitor-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-systemmonitor-5.24.3.tar.xz";
+      sha256 = "17a3q1az4d3xpk2ifqsj6sz7r4apxy58kk2r2l14p6s6aszhqk4h";
+      name = "plasma-systemmonitor-5.24.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-tests-5.24.0.tar.xz";
-      sha256 = "1q95mrrb0p9ah4dg3bhkc9yh2ydasdmyd87jclraybcsfl6fi9kf";
-      name = "plasma-tests-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-tests-5.24.3.tar.xz";
+      sha256 = "1x5hr465kj3dg6c335lji2lxvp7cbn86181l78qk4l75sj1ss721";
+      name = "plasma-tests-5.24.3.tar.xz";
     };
   };
   plasma-thunderbolt = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-thunderbolt-5.24.0.tar.xz";
-      sha256 = "1vsb3wf2sgbfbm2wk8kj18qhv4z9l4yzxaf8g30zpz4d1sva7jdc";
-      name = "plasma-thunderbolt-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-thunderbolt-5.24.3.tar.xz";
+      sha256 = "1px5vfk37ak6hj6q3ipljj2dpazdbgdsga6nbkwcfn31708c7gjj";
+      name = "plasma-thunderbolt-5.24.3.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-vault-5.24.0.tar.xz";
-      sha256 = "1vk38iarhsr6rdrmhbcyjziw3dn8yjmgyn4dy2xdr0l4yqpq7qzz";
-      name = "plasma-vault-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-vault-5.24.3.tar.xz";
+      sha256 = "0f5yhz7qz4bqj7mc7hv7mvh2ji82pp02c901ws5cwwsh23yrhjcd";
+      name = "plasma-vault-5.24.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-workspace-5.24.0.tar.xz";
-      sha256 = "0jnksl2i2viw5aaqv38b371z4lxrxah6p1bjp40a1zfa68vr8dz3";
-      name = "plasma-workspace-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-workspace-5.24.3.tar.xz";
+      sha256 = "1d1a8k75q0rdbbwkx8p1i38hc6xv9kggvfm6973lh3q0pc75qk0h";
+      name = "plasma-workspace-5.24.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plasma-workspace-wallpapers-5.24.0.tar.xz";
-      sha256 = "0329ks3q32nb9k3dxddlmxccjilgyxx5jplwbpln5b0p4plkn77k";
-      name = "plasma-workspace-wallpapers-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plasma-workspace-wallpapers-5.24.3.tar.xz";
+      sha256 = "0j1qqjc27grh3k02dgfb657ps11gym28lc9hzcw3qdxkf3djw9fs";
+      name = "plasma-workspace-wallpapers-5.24.3.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/plymouth-kcm-5.24.0.tar.xz";
-      sha256 = "1pcvfrv8vmk43s14209iv8gngi3al9g4za74yz2l79nxscyppzh5";
-      name = "plymouth-kcm-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/plymouth-kcm-5.24.3.tar.xz";
+      sha256 = "196nx8h54bnnrly12zvnwl22ksr9nk2mi6g39k4xmp28agw94jv5";
+      name = "plymouth-kcm-5.24.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.24.0";
+    version = "1-5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/polkit-kde-agent-1-5.24.0.tar.xz";
-      sha256 = "1qayxff5hl8qr9p5bsfrq0cz3x1jlwc8f0nx66rkbngphdm7085n";
-      name = "polkit-kde-agent-1-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/polkit-kde-agent-1-5.24.3.tar.xz";
+      sha256 = "1mbr8xpjvd8w9b5nd6k8fxcnjykzzygwqk19il4wirqyh4n3k3bq";
+      name = "polkit-kde-agent-1-5.24.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/powerdevil-5.24.0.tar.xz";
-      sha256 = "06mrahlrqibvgfhcxywh72h6jblqq6sjsxqjzbq7zbq61vgc3jg3";
-      name = "powerdevil-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/powerdevil-5.24.3.tar.xz";
+      sha256 = "047h4lz8d1kdyakh5x7fr3kpk35r38z39vm7wb974rd9hjz7alj9";
+      name = "powerdevil-5.24.3.tar.xz";
     };
   };
   qqc2-breeze-style = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/qqc2-breeze-style-5.24.0.tar.xz";
-      sha256 = "11kwrqsq5i1y1kvhg75hvax7bz122cjdsvb66f6hvni09yfcgyci";
-      name = "qqc2-breeze-style-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/qqc2-breeze-style-5.24.3.tar.xz";
+      sha256 = "1y21ldxwlb12kfqzxpyhdw9lkcaf5sfamwhg68r512hy785sg490";
+      name = "qqc2-breeze-style-5.24.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/sddm-kcm-5.24.0.tar.xz";
-      sha256 = "011b68vca8nnmj9rxlyl5gl3xrrbysmcrx8szyfhha0wl9rgy2hx";
-      name = "sddm-kcm-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/sddm-kcm-5.24.3.tar.xz";
+      sha256 = "15n6drklwk3lmiaklw1af98qcixml4w83hngy23lwwv2lbnirl6h";
+      name = "sddm-kcm-5.24.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/systemsettings-5.24.0.tar.xz";
-      sha256 = "1jx1kllfd5561fq11d90r7m68736rsdlyzb109yq8awdwrl1vkp3";
-      name = "systemsettings-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/systemsettings-5.24.3.tar.xz";
+      sha256 = "11fmjdh6v0a4gacqshhrk374i07px989p3x70w8438gr6y0n2032";
+      name = "systemsettings-5.24.3.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.24.0";
+    version = "5.24.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.0/xdg-desktop-portal-kde-5.24.0.tar.xz";
-      sha256 = "0f5wv4557avzcn7gf2hjqpn2p9r0d16k1iqcijzcfdmnvh2cp69d";
-      name = "xdg-desktop-portal-kde-5.24.0.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.3/xdg-desktop-portal-kde-5.24.3.tar.xz";
+      sha256 = "06qdr7j2m9s9l60mk8vspb2173va10zdv6sinhmkhxxp78h857z6";
+      name = "xdg-desktop-portal-kde-5.24.3.tar.xz";
     };
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1433,7 +1433,7 @@ mapAliases ({
     ksshaskpass ksystemlog kteatime ktimer ktorrent ktouch kturtle kwallet-pam
     kwalletmanager kwave kwayland-integration kwin kwrited marble milou minuet
     okular oxygen oxygen-icons5 picmi plasma-browser-integration plasma-desktop
-    plasma-integration plasma-nano plasma-nm plasma-pa plasma-phone-components
+    plasma-integration plasma-nano plasma-nm plasma-pa plasma-mobile
     plasma-systemmonitor plasma-thunderbolt plasma-vault plasma-workspace
     plasma-workspace-wallpapers polkit-kde-agent powerdevil qqc2-breeze-style
     sddm-kcm skanlite spectacle systemsettings xdg-desktop-portal-kde yakuake


### PR DESCRIPTION
###### Description of changes

Now that https://github.com/NixOS/nixpkgs/pull/158716 has landed in master, here's 5.24.3 which includes four weeks of bugfixes:
- https://kde.org/announcements/plasma/5/5.24.1
- https://kde.org/announcements/plasma/5/5.24.2
- https://kde.org/announcements/plasma/5/5.24.3

A few additional changes were required:
- Renamed `plasma-phone-components` to `plasma-mobile` in line with upstream; feedback would be appreciated here as I've never renamed a package before and I'm not sure if I did it correctly!
- Added `networkmanager-qt` as a build input for `plasma-mobile`
- Updated `kde-rounded-corners` to the latest release (`v0.1.1`) to fix an error when building against KWin ≥ 5.24.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
