### PR TITLE
libthreadar: 1.3.5 -> 1.4.0

### DIFF
--- a/pkgs/development/libraries/libthreadar/default.nix
+++ b/pkgs/development/libraries/libthreadar/default.nix
@@ -1,17 +1,19 @@
-{ lib, stdenv, fetchurl }:
-
-with lib;
+{ lib, stdenv, fetchurl, gcc-unwrapped }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.5";
+  version = "1.4.0";
   pname = "libthreadar";
 
   src = fetchurl {
     url = "mirror://sourceforge/libthreadar/${pname}-${version}.tar.gz";
-    sha256 = "sha256-T5W83Ry3e1hHrnpmSLkfJDYHrVP6YDpXTqmf0WGCjB8=";
+    sha256 = "sha256-LkcVF4AnuslzpIg/S8sGNJQye6iGcQRGqCqAhg8aN5E=";
   };
 
   outputs = [ "out" "dev" ];
+
+  buildInputs = [ gcc-unwrapped ];
+
+  CXXFLAGS = [ "-std=c++14" ];
 
   configureFlags = [
     "--disable-build-html"
@@ -22,7 +24,7 @@ stdenv.mkDerivation rec {
     rm -r "$out"/share
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "http://libthreadar.sourceforge.net/";
     description = "A C++ library that provides several classes to manipulate threads";
     longDescription = ''
@@ -32,6 +34,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ izorkin ];
     license = licenses.lgpl3;
     platforms = platforms.unix;
-    broken = stdenv.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/libthreadar.x86_64-darwin
   };
 }


### PR DESCRIPTION
###### Description of changes
Update libthreadar to version 1.4.0

cc @bobby285271
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
