### PR TITLE
buildFHSUserEnv: fix error when share/glib-2.0/schemas is a link

### DIFF
--- a/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
+++ b/pkgs/build-support/build-fhs-userenv-bubblewrap/env.nix
@@ -97,17 +97,20 @@ let
       if [[ -d  $out/share/gsettings-schemas/ ]]; then
           # Recreate the standard schemas directory if its a symlink to make it writable
           if [[ -L $out/share/glib-2.0 ]]; then
-              ln -s $(readlink $out/share/glib-2.0) $out/share/glib-2.0.old
-              rm -rf $out/share/glib-2.0
+              target=$(readlink $out/share/glib-2.0)
+              rm $out/share/glib-2.0
+              mkdir $out/share/glib-2.0
+              ln -fs $target/* $out/share/glib-2.0
+          fi
+
+          if [[ -L $out/share/glib-2.0/schemas ]]; then
+              target=$(readlink $out/share/glib-2.0/schemas)
+              rm $out/share/glib-2.0/schemas
+              mkdir $out/share/glib-2.0/schemas
+              ln -fs $target/* $out/share/glib-2.0/schemas
           fi
 
           mkdir -p $out/share/glib-2.0/schemas
-
-          # symlink any schema files or overrides to the standard schema directory
-          if [[ -e $out/share/glib-2.0.old/schemas ]]; then
-              ln -fs $out/share/glib-2.0.old/schemas/*.xml $out/share/glib-2.0/schemas
-              ln -fs $out/share/glib-2.0.old/schemas/*.gsettings-schemas.override $out/share/glib-2.0/schemas
-          fi
 
           for d in $out/share/gsettings-schemas/*; do
               # Force symlink, in case there are duplicates

--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -138,17 +138,20 @@ let
       if [[ -d  $out/share/gsettings-schemas/ ]]; then
           # Recreate the standard schemas directory if its a symlink to make it writable
           if [[ -L $out/share/glib-2.0 ]]; then
-              ln -s $(readlink $out/share/glib-2.0) $out/share/glib-2.0.old
-              rm -rf $out/share/glib-2.0
+              target=$(readlink $out/share/glib-2.0)
+              rm $out/share/glib-2.0
+              mkdir $out/share/glib-2.0
+              ln -fs $target/* $out/share/glib-2.0
+          fi
+
+          if [[ -L $out/share/glib-2.0/schemas ]]; then
+              target=$(readlink $out/share/glib-2.0/schemas)
+              rm $out/share/glib-2.0/schemas
+              mkdir $out/share/glib-2.0/schemas
+              ln -fs $target/* $out/share/glib-2.0/schemas
           fi
 
           mkdir -p $out/share/glib-2.0/schemas
-
-          # symlink any schema files or overrides to the standard schema directory
-          if [[ -e $out/share/glib-2.0.old/schemas ]]; then
-              ln -fs $out/share/glib-2.0.old/schemas/*.xml $out/share/glib-2.0/schemas
-              ln -fs $out/share/glib-2.0.old/schemas/*.gsettings-schemas.override $out/share/glib-2.0/schemas
-          fi
 
           for d in $out/share/gsettings-schemas/*; do
               # Force symlink, in case there are duplicates


### PR DESCRIPTION
###### Description of changes

Fixes an error with
```
nix-build --expr 'with import <nixpkgs> {}; buildFHSUserEnv { name = "test"; targetPkgs = pkgs: with pkgs; [ gtk3 glib.dev ]; }'
```

```
created 1369 symlinks in user environment
ln: failed to create symbolic link '/nix/store/hfxdvdjaf4slwn2xhmm7v4kdmbaf9fzp-test-usr-target/share/glib-2.0/schemas/org.gtk.Demo.gschema.xml': Permission denied
ln: failed to create symbolic link '/nix/store/hfxdvdjaf4slwn2xhmm7v4kdmbaf9fzp-test-usr-target/share/glib-2.0/schemas/org.gtk.Settings.ColorChooser.gschema.xml': Permission denied
ln: failed to create symbolic link '/nix/store/hfxdvdjaf4slwn2xhmm7v4kdmbaf9fzp-test-usr-target/share/glib-2.0/schemas/org.gtk.Settings.Debug.gschema.xml': Permission denied
ln: failed to create symbolic link '/nix/store/hfxdvdjaf4slwn2xhmm7v4kdmbaf9fzp-test-usr-target/share/glib-2.0/schemas/org.gtk.Settings.EmojiChooser.gschema.xml': Permission denied
ln: failed to create symbolic link '/nix/store/hfxdvdjaf4slwn2xhmm7v4kdmbaf9fzp-test-usr-target/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml': Permission denied
```

This seems to have been introduced by #161739, @Artturin.

WIP because:

- [x] bubblewrap probably needs the same fix
- [ ] should this script be moved to a common location?
- [x] remove verbose copy
- [ ] use something safer than `.old`?
- [ ] is `*` okay without dotglob?
- [ ] perhaps there's a better/existing way of replacing a link with a directory containing links?
- [ ] what do I need to test to know I didn't break anything?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
