### PR TITLE
Ansible: 2.10.16 -> 2.10.17; 2.12.2 -> 2.12.3; Collections: 5.2.0 -> 5.5.0

### DIFF
--- a/pkgs/development/python-modules/ansible/base.nix
+++ b/pkgs/development/python-modules/ansible/base.nix
@@ -28,11 +28,11 @@ let
 in
 buildPythonPackage rec {
   pname = "ansible-base";
-  version = "2.10.16";
+  version = "2.10.17";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-2XQhTtA6wSnCmZZ6pMmCBZQ7o28gBA5/63JI4MPi6hU=";
+    sha256 = "sha256-75JYgsqNTDwszQkc3hmeDIaQJMytDQejN9zyB7/zLzQ=";
   };
 
   # ansible_connection is already wrapped, so don't pass it through

--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -23,17 +23,17 @@
 
 let
   ansible-collections = callPackage ./collections.nix {
-    version = "5.2.0";
-    sha256 = "sha256:1jwraha3s15s692d47kgcr7jy1ngbg6ipmkb0ak7fjnb57r4im66";
+    version = "5.5.0";
+    sha256 = "sha256-uKdtc3iJyb/Q5rDyJ23PjYNtpmcGejVXdvNQTXpm1Rg=";
   };
 in
 buildPythonPackage rec {
   pname = "ansible-core";
-  version = "2.12.2";
+  version = "2.12.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256:1hz7j8gsgxbfjdf9562cbyxia3c4crdv50fm0p0wp4js79rf2ydw";
+    sha256 = "sha256-ihNan3TJfKtndZKTdErTQ1D3GVI+i9m7kAjfTPlTryA=";
   };
 
   # ansible_connection is already wrapped, so don't pass it through

--- a/pkgs/development/python-modules/jxmlease/default.nix
+++ b/pkgs/development/python-modules/jxmlease/default.nix
@@ -18,6 +18,10 @@ buildPythonPackage rec {
     lxml
   ];
 
+  # tests broken in expat bump
+  # https://github.com/Juniper/jxmlease/issues/26
+  doCheck = false;
+
   checkPhase = ''
     runHook preCheck
     ${python.interpreter} -m unittest discover -v


### PR DESCRIPTION
###### Description of changes
https://github.com/ansible/ansible/blob/v2.12.3/changelogs/CHANGELOG-v2.12.rst#id9
https://github.com/ansible/ansible/blob/v2.10.17/changelogs/CHANGELOG-v2.10.rst#v2-10-17
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
