### PR TITLE
nix-output-monitor: 1.1.2.0 -> 1.1.2.1 + Refactor

### DIFF
--- a/pkgs/development/haskell-modules/non-hackage-packages.nix
+++ b/pkgs/development/haskell-modules/non-hackage-packages.nix
@@ -24,8 +24,6 @@ self: super: {
 
   nix-linter = self.callPackage ../../development/tools/analysis/nix-linter { };
 
-  nix-output-monitor = self.callPackage ../../tools/nix/nix-output-monitor { };
-
   # hasura graphql-engine is not released to hackage.
   # https://github.com/hasura/graphql-engine/issues/7391
   ci-info = self.callPackage ../misc/haskell/hasura/ci-info.nix {};

--- a/pkgs/tools/nix/nix-output-monitor/default.nix
+++ b/pkgs/tools/nix/nix-output-monitor/default.nix
@@ -1,164 +1,23 @@
-# This file has been autogenerate with cabal2nix.
-# Update via ./update.sh"
 {
-  mkDerivation,
-  ansi-terminal,
-  async,
-  attoparsec,
-  base,
-  bytestring,
-  cassava,
-  containers,
-  data-default,
-  directory,
+  haskell,
   expect,
-  extra,
-  fetchzip,
-  filepath,
-  generic-optics,
-  HUnit,
+  haskellPackages,
   installShellFiles,
-  lib,
-  lock-file,
-  MemoTrie,
-  mtl,
-  nix-derivation,
-  optics,
-  process,
-  random,
-  relude,
-  runtimeShell,
-  safe,
-  stm,
-  streamly,
-  terminal-size,
-  text,
-  time,
-  unix,
-  vector,
-  wcwidth,
-  word8,
-}:
-mkDerivation {
-  pname = "nix-output-monitor";
-  version = "1.1.2.0";
-  src = fetchzip {
-    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.2.0.tar.gz";
-    sha256 = "03qhy4xzika41pxlmvpz3psgy54va72ipn9v1lv33l6369ikrhl1";
+}: let
+  inherit (haskell.lib.compose) justStaticExecutables overrideCabal;
+  overrides = {
+    passthru.updateScript = ./update.sh;
+    testTarget = "unit-tests";
+    buildTools = [installShellFiles];
+    postInstall = ''
+      substitute "exe-sh/nom-build" "$out/bin/nom-build" \
+        --replace 'unbuffer' '${expect}/bin/unbuffer' \
+        --replace 'nom' "$out/bin/nom"
+      chmod a+x $out/bin/nom-build
+      installShellCompletion --zsh --name _nom-build completions/completion.zsh
+    '';
   };
-  isLibrary = true;
-  isExecutable = true;
-  libraryHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    generic-optics
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    random
-    relude
-    safe
-    stm
-    streamly
-    terminal-size
-    text
-    time
-    unix
-    vector
-    wcwidth
-    word8
-  ];
-  executableHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    generic-optics
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    random
-    relude
-    safe
-    stm
-    streamly
-    terminal-size
-    text
-    time
-    unix
-    vector
-    wcwidth
-    word8
-  ];
-  testHaskellDepends = [
-    ansi-terminal
-    async
-    attoparsec
-    base
-    bytestring
-    cassava
-    containers
-    data-default
-    directory
-    extra
-    filepath
-    generic-optics
-    HUnit
-    lock-file
-    MemoTrie
-    mtl
-    nix-derivation
-    optics
-    process
-    random
-    relude
-    safe
-    stm
-    streamly
-    terminal-size
-    text
-    time
-    unix
-    vector
-    wcwidth
-    word8
-  ];
-  homepage = "https://github.com/maralorn/nix-output-monitor";
-  description = "Parses output of nix-build to show additional information";
-  license = lib.licenses.agpl3Plus;
-  maintainers = with lib.maintainers; [maralorn];
-  passthru.updateScript = ./update.sh;
-  testTarget = "unit-tests";
-  buildTools = [installShellFiles];
-  postInstall = ''
-    cat > $out/bin/nom-build << EOF
-    #!${runtimeShell}
-    ${expect}/bin/unbuffer nix-build "\$@" 2>&1 | exec $out/bin/nom
-    EOF
-    chmod a+x $out/bin/nom-build
-    installShellCompletion --zsh --name _nom-build ${builtins.toFile "completion.zsh" ''
-      #compdef nom-build
-      compdef nom-build=nix-build
-    ''}
-  '';
-}
+in
+  justStaticExecutables
+  (overrideCabal overrides
+    (haskellPackages.callPackage ./generated-package.nix {}))

--- a/pkgs/tools/nix/nix-output-monitor/generated-package.nix
+++ b/pkgs/tools/nix/nix-output-monitor/generated-package.nix
@@ -1,0 +1,147 @@
+# This file has been autogenerate with cabal2nix.
+# Update via ./update.sh"
+{
+  mkDerivation,
+  ansi-terminal,
+  async,
+  attoparsec,
+  base,
+  bytestring,
+  cassava,
+  containers,
+  data-default,
+  directory,
+  extra,
+  fetchzip,
+  filepath,
+  generic-optics,
+  HUnit,
+  lib,
+  lock-file,
+  MemoTrie,
+  mtl,
+  nix-derivation,
+  optics,
+  process,
+  random,
+  relude,
+  safe,
+  stm,
+  streamly,
+  terminal-size,
+  text,
+  time,
+  unix,
+  vector,
+  wcwidth,
+  word8,
+}:
+mkDerivation {
+  pname = "nix-output-monitor";
+  version = "1.1.2.1";
+  src = fetchzip {
+    url = "https://github.com/maralorn/nix-output-monitor/archive/refs/tags/v1.1.2.1.tar.gz";
+    sha256 = "00jn963jskyqnwvbvn5x0z92x2gv105p5h8m13nlmr90lj4axynx";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    ansi-terminal
+    async
+    attoparsec
+    base
+    bytestring
+    cassava
+    containers
+    data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
+    word8
+  ];
+  executableHaskellDepends = [
+    ansi-terminal
+    async
+    attoparsec
+    base
+    bytestring
+    cassava
+    containers
+    data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
+    word8
+  ];
+  testHaskellDepends = [
+    ansi-terminal
+    async
+    attoparsec
+    base
+    bytestring
+    cassava
+    containers
+    data-default
+    directory
+    extra
+    filepath
+    generic-optics
+    HUnit
+    lock-file
+    MemoTrie
+    mtl
+    nix-derivation
+    optics
+    process
+    random
+    relude
+    safe
+    stm
+    streamly
+    terminal-size
+    text
+    time
+    unix
+    vector
+    wcwidth
+    word8
+  ];
+  homepage = "https://github.com/maralorn/nix-output-monitor";
+  description = "Parses output of nix-build to show additional information";
+  license = lib.licenses.agpl3Plus;
+  maintainers = with lib.maintainers; [maralorn];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3595,7 +3595,7 @@ with pkgs;
 
   nix-direnv = callPackage ../tools/misc/nix-direnv { };
 
-  nix-output-monitor = haskell.lib.compose.justStaticExecutables (haskellPackages.nix-output-monitor);
+  nix-output-monitor = callPackage ../tools/nix/nix-output-monitor { };
 
   nix-template = callPackage ../tools/package-management/nix-template {
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Description of changes

Moves nom-build script and completion into the nix-output-monitor repo.

Also refactors the update script to be contain less evil string incantations.

As requested by @mweinelt 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
