### PR TITLE
melt: init at 0.2.0

### DIFF
--- a/pkgs/tools/security/melt/default.nix
+++ b/pkgs/tools/security/melt/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-1f3QBbWaTiplEp/4ihds1PwrEnoq/81TzlT46TufGFs=";
 
-  doCheck = true;
-
   ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
 
   meta = with lib; {

--- a/pkgs/tools/security/melt/default.nix
+++ b/pkgs/tools/security/melt/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "melt";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "charmbracelet";
+    repo = "melt";
+    rev = "v${version}";
+    sha256 = "sha256-HambmUodAwgi1/r/Nj7P7gXNK5pyBO3omMZ9ZvSK7cc=4";
+  };
+
+  vendorSha256 = "sha256-1f3QBbWaTiplEp/4ihds1PwrEnoq/81TzlT46TufGFs=";
+
+  doCheck = true;
+
+  ldflags = [ "-s" "-w" "-X=main.Version=${version}" ];
+
+  meta = with lib; {
+    description = "Backup and restore Ed25519 SSH keys with seed words";
+    homepage = "https://github.com/charmbracelet/melt";
+    changelog = "https://github.com/charmbracelet/melt/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ penguwin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8044,6 +8044,8 @@ with pkgs;
 
   mscgen = callPackage ../tools/graphics/mscgen { };
 
+  melt = callPackage ../tools/security/melt { };
+
   metabigor = callPackage ../tools/security/metabigor { };
 
   metasploit = callPackage ../tools/security/metasploit { };


### PR DESCRIPTION
###### Description of changes

Add [melt](https://github.com/charmbracelet/melt/), a tool to backup and restore Ed25519 SSH keys with seed words to the nixpkgs collection. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
