### PR TITLE
ocamlPackages.buildDunePackage: add support for dune 3 (w/ related additions & updates)

### DIFF
--- a/doc/languages-frameworks/ocaml.section.md
+++ b/doc/languages-frameworks/ocaml.section.md
@@ -38,8 +38,12 @@ Here is a simple package example.
 
 - It uses the `fetchFromGitHub` fetcher to get its source.
 
-- `useDune2 = true` ensures that Dune version 2 is used for the
-  build (this is the default; set to `false` to use Dune version 1).
+- `duneVersion = "2"` ensures that Dune version 2 is used for the
+  build (this is the default; valid values are `"1"`, `"2"`, and `"3"`);
+  note that there is also a legacy `useDune2` boolean attribute:
+  set to `false` it corresponds to `duneVersion = "1"`; set to `true` it
+  corresponds to `duneVersion = "2"`. If both arguments (`duneVersion` and
+  `useDune2`) are given, the second one (`useDune2`) is silently ignored.
 
 - It sets the optional `doCheck` attribute such that tests will be run with
   `dune runtest -p angstrom` after the build (`dune build -p angstrom`) is
@@ -67,7 +71,7 @@ Here is a simple package example.
 buildDunePackage rec {
   pname = "angstrom";
   version = "0.15.0";
-  useDune2 = true;
+  duneVersion = "2";
 
   minimalOCamlVersion = "4.04";
 

--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -10,7 +10,7 @@ else
 buildDunePackage rec {
   pname = "stog";
   version = "0.20.0";
-  useDune2 = true;
+  duneVersion = "3";
   minimalOCamlVersion = "4.12";
   src = fetchFromGitLab {
     domain = "framagit.org";

--- a/pkgs/build-support/ocaml/dune.nix
+++ b/pkgs/build-support/ocaml/dune.nix
@@ -1,8 +1,11 @@
-{ lib, stdenv, ocaml, findlib, dune_1, dune_2 }:
+{ lib, stdenv, ocaml, findlib, dune_1, dune_2, dune_3 }:
 
 { pname, version, nativeBuildInputs ? [], enableParallelBuilding ? true, ... }@args:
 
-let Dune = if args.useDune2 or true then dune_2 else dune_1; in
+let Dune =
+  let dune-version = args . duneVersion or (if args.useDune2 or true then "2" else "1"); in
+  { "1" = dune_1; "2" = dune_2; "3" = dune_3; }."${dune-version}"
+; in
 
 if (args ? minimumOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimumOCamlVersion) ||
    (args ? minimalOCamlVersion && ! lib.versionAtLeast ocaml.version args.minimalOCamlVersion)
@@ -31,7 +34,7 @@ stdenv.mkDerivation ({
     runHook postInstall
   '';
 
-} // (builtins.removeAttrs args [ "minimalOCamlVersion" ]) // {
+} // (builtins.removeAttrs args [ "minimalOCamlVersion" "duneVersion" ]) // {
 
   name = "ocaml${ocaml.version}-${pname}-${version}";
 

--- a/pkgs/development/ocaml-modules/dune-action-plugin/default.nix
+++ b/pkgs/development/ocaml-modules/dune-action-plugin/default.nix
@@ -1,17 +1,17 @@
-{ lib, buildDunePackage, dune_2, dune-glob, dune-private-libs }:
+{ lib, buildDunePackage, dune_3, dune-glob, dune-private-libs }:
 
 buildDunePackage rec {
   pname = "dune-action-plugin";
-  inherit (dune_2) src version patches;
+  inherit (dune_3) src version;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   dontAddPrefix = true;
 
   propagatedBuildInputs = [ dune-glob dune-private-libs ];
 
   meta = with lib; {
-    inherit (dune_2.meta) homepage;
+    inherit (dune_3.meta) homepage;
     description = "API for writing dynamic Dune actions";
     maintainers = [ maintainers.marsam ];
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/dune-glob/default.nix
+++ b/pkgs/development/ocaml-modules/dune-glob/default.nix
@@ -1,17 +1,17 @@
-{ lib, buildDunePackage, dune_2, dune-private-libs }:
+{ lib, buildDunePackage, dune_3, dune-private-libs }:
 
 buildDunePackage rec {
   pname = "dune-glob";
-  inherit (dune_2) src version patches;
+  inherit (dune_3) src version;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   dontAddPrefix = true;
 
   propagatedBuildInputs = [ dune-private-libs ];
 
   meta = with lib; {
-    inherit (dune_2.meta) homepage;
+    inherit (dune_3.meta) homepage;
     description = "Glob string matching language supported by dune";
     maintainers = [ maintainers.marsam ];
     license = licenses.mit;

--- a/pkgs/development/ocaml-modules/dune-private-libs/default.nix
+++ b/pkgs/development/ocaml-modules/dune-private-libs/default.nix
@@ -1,15 +1,17 @@
-{ lib, buildDunePackage, dune_2 }:
+{ lib, buildDunePackage, dune_3, stdune }:
 
 buildDunePackage rec {
   pname = "dune-private-libs";
 
-  useDune2 = true;
+  duneVersion = "3";
 
-  inherit (dune_2) src version patches;
+  inherit (dune_3) src version;
 
-  minimumOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.08";
 
   dontAddPrefix = true;
+
+  propagatedBuildInputs = [ stdune ];
 
   meta = with lib; {
     description = "Private libraries of Dune";

--- a/pkgs/development/ocaml-modules/dune-site/default.nix
+++ b/pkgs/development/ocaml-modules/dune-site/default.nix
@@ -1,10 +1,10 @@
-{ lib, buildDunePackage, dune_2, dune-private-libs }:
+{ lib, buildDunePackage, dune_3, dune-private-libs }:
 
 buildDunePackage rec {
   pname = "dune-site";
-  inherit (dune_2) src version patches;
+  inherit (dune_3) src version;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   dontAddPrefix = true;
 
@@ -12,7 +12,7 @@ buildDunePackage rec {
 
   meta = with lib; {
     description = "A library for embedding location information inside executable and libraries";
-    inherit (dune_2.meta) homepage;
+    inherit (dune_3.meta) homepage;
     maintainers = with lib.maintainers; [ ];
     license = licenses.mit;
   };

--- a/pkgs/development/ocaml-modules/dyn/default.nix
+++ b/pkgs/development/ocaml-modules/dyn/default.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, dune_3, ordering }:
+
+buildDunePackage {
+  pname = "dyn";
+  inherit (dune_3) version src;
+  duneVersion = "3";
+
+  dontAddPrefix = true;
+
+  propagatedBuildInputs = [ ordering ];
+
+  meta = dune_3.meta // {
+    description = "Dynamic type";
+  };
+}
+

--- a/pkgs/development/ocaml-modules/ordering/default.nix
+++ b/pkgs/development/ocaml-modules/ordering/default.nix
@@ -1,0 +1,13 @@
+{ lib, buildDunePackage, dune_3 }:
+
+buildDunePackage {
+  pname = "ordering";
+  inherit (dune_3) version src;
+  duneVersion = "3";
+
+  dontAddPrefix = true;
+
+  meta = dune_3.meta // {
+    description = "Element ordering";
+  };
+}

--- a/pkgs/development/ocaml-modules/stdune/default.nix
+++ b/pkgs/development/ocaml-modules/stdune/default.nix
@@ -1,0 +1,16 @@
+{ lib, buildDunePackage, dune_3, dyn, ordering }:
+
+buildDunePackage {
+  pname = "stdune";
+  inherit (dune_3) version src;
+  duneVersion = "3";
+
+  dontAddPrefix = true;
+
+  propagatedBuildInputs = [ dyn ordering ];
+
+  meta = dune_3.meta // {
+    description = "Dune's unstable standard library";
+  };
+}
+

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -330,6 +330,8 @@ let
 
     duration =  callPackage ../development/ocaml-modules/duration { };
 
+    dyn =  callPackage ../development/ocaml-modules/dyn { };
+
     earley = callPackage ../development/ocaml-modules/earley { };
 
     earlybird = callPackage ../development/ocaml-modules/earlybird { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1030,6 +1030,8 @@ let
 
     opus = callPackage ../development/ocaml-modules/opus { };
 
+    ordering = callPackage ../development/ocaml-modules/ordering { };
+
     otfm = callPackage ../development/ocaml-modules/otfm { };
 
     otoml = callPackage ../development/ocaml-modules/otoml { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1321,6 +1321,8 @@ let
 
     stdlib-shims = callPackage ../development/ocaml-modules/stdlib-shims { };
 
+    stdune = callPackage ../development/ocaml-modules/stdune { };
+
     stog = callPackage ../applications/misc/stog { };
 
     stringext = callPackage ../development/ocaml-modules/stringext { };


### PR DESCRIPTION
###### Description of changes

Motivated by https://github.com/NixOS/nixpkgs/pull/163766#issuecomment-1066100292 & #164287

This adds a new argument `duneVersion` to `buildDunePackages` that have precedence over `useDune2`. It can be used to choose which version of dune to use.

This PR (as a show case) makes `stog` use dune 3 (it just works).

This adds a few dune-3 related libraries.

This updates dune-related libraries that were already packaged.

cc @AllanBlanchard @marsam

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
