### PR TITLE
modules/upower: add a reload trigger if the config changes

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -8,6 +8,22 @@ let
 
   cfg = config.services.upower;
 
+  configFile = generators.toINI {} {
+    UPower = {
+      EnableWattsUpPro = cfg.enableWattsUpPro;
+      NoPollBatteries = cfg.noPollBatteries;
+      IgnoreLid = cfg.ignoreLid;
+      UsePercentageForPolicy = cfg.usePercentageForPolicy;
+      PercentageLow = cfg.percentageLow;
+      PercentageCritical = cfg.percentageCritical;
+      PercentageAction = cfg.percentageAction;
+      TimeLow = cfg.timeLow;
+      TimeCritical = cfg.timeCritical;
+      TimeAction = cfg.timeAction;
+      CriticalPowerAction = cfg.criticalPowerAction;
+    };
+  };
+
 in
 
 {
@@ -219,21 +235,10 @@ in
 
     systemd.packages = [ cfg.package ];
 
-    environment.etc."UPower/UPower.conf".text = generators.toINI {} {
-      UPower = {
-        EnableWattsUpPro = cfg.enableWattsUpPro;
-        NoPollBatteries = cfg.noPollBatteries;
-        IgnoreLid = cfg.ignoreLid;
-        UsePercentageForPolicy = cfg.usePercentageForPolicy;
-        PercentageLow = cfg.percentageLow;
-        PercentageCritical = cfg.percentageCritical;
-        PercentageAction = cfg.percentageAction;
-        TimeLow = cfg.timeLow;
-        TimeCritical = cfg.timeCritical;
-        TimeAction = cfg.timeAction;
-        CriticalPowerAction = cfg.criticalPowerAction;
-      };
-    };
+    # this implicitly assumes the package has a `upower.service` unit file
+    systemd.services."upower".restartTriggers = [ configFile ];
+
+    environment.etc."UPower/UPower.conf".text = configFile;
   };
 
 }


### PR DESCRIPTION
We should restart the service if its config changes. Since the service
file from the upstream distribution is used, we have to manually add a
trigger for that to happen.

cc @mat8913 

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
