### PR TITLE
berglas: 0.5.1 -> 0.6.2

### DIFF
--- a/pkgs/tools/admin/berglas/default.nix
+++ b/pkgs/tools/admin/berglas/default.nix
@@ -1,19 +1,44 @@
 { lib, buildGoModule, fetchFromGitHub }:
 
+let
+  skipTests = {
+    access = "Access";
+    create = "Create";
+    delete = "Delete";
+    list = "List";
+    read = "Read";
+    replace = "Replace";
+    resolver = "Resolve";
+    revoke = "Revoke";
+    update = "Update";
+  };
+
+  skipTestsCommand =
+    builtins.foldl' (acc: goFileName:
+      let testName = builtins.getAttr goFileName skipTests; in
+      ''
+        ${acc}
+        substituteInPlace pkg/berglas/${goFileName}_test.go \
+          --replace "TestClient_${testName}_storage" "SkipClient_${testName}_storage" \
+          --replace "TestClient_${testName}_secretManager" "SkipClient_${testName}_secretManager"
+      ''
+    ) "" (builtins.attrNames skipTests);
+in
+
 buildGoModule rec {
   pname = "berglas";
-  version = "0.5.1";
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0y393g36h35zzqyf5b10j6qq2jhvz83j17cmasnv6wbyrb3vnn0n";
+    sha256 = "sha256-aLsrrK+z080qn7L2zggA8yD+QqLaSRJLTjWQnFKFogQ=";
   };
 
-  vendorSha256 = null;
+  vendorSha256 = "sha256-HjZT0jezJzoEvXuzrjoTv/zSex+xDuGoP1h82CIlX14=";
 
-  doCheck = false;
+  postPatch = skipTestsCommand;
 
   meta = with lib; {
     description = "A tool for managing secrets on Google Cloud";


### PR DESCRIPTION
berglas: 0.5.1 -> 0.6.2

* Tests enabled. Failing tests are skipped.

Note: Test list to disable was long. So I abstracted it somewhat. Either way it is not pretty. Bash is too painful (lacks better map/nested data structures) so I used Nix. At least, it is working at it is.