### PR TITLE
python3Packages.coqui-trainer: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/development/python-modules/coqui-trainer/default.nix
+++ b/pkgs/development/python-modules/coqui-trainer/default.nix
@@ -4,7 +4,7 @@
 
 , coqpit
 , fsspec
-, pytorch-bin
+, pytorch
 
 , pytestCheckHook
 , soundfile
@@ -14,7 +14,7 @@
 
 let
   pname = "coqui-trainer";
-  version = "0.0.4";
+  version = "0.0.5";
 in
 buildPythonPackage {
   inherit pname version;
@@ -23,21 +23,19 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "Trainer";
-    # https://github.com/coqui-ai/Trainer/issues/4
-    rev = "776eba829231543d3207927fc69b321d121e527c";
-    hash = "sha256-ICveftJjBNsCgegTmd/ewd/Y6XGMg7YOvchx640RFPI=";
+    rev = "v${version}";
+    hash = "sha256-NsgCh+N2qWmRkTOjXqisVCP5aInH2zcNz6lsnIfVLiY=";
   };
 
   propagatedBuildInputs = [
     coqpit
     fsspec
-    pytorch-bin
+    pytorch
     soundfile
     tensorboardx
   ];
 
-  # tests are failing; tests require the clearml library
-  # https://github.com/coqui-ai/Trainer/issues/5
+  # only one test and that requires training data from the internet
   doCheck = false;
 
   checkInputs = [


### PR DESCRIPTION
###### Description of changes
https://github.com/coqui-ai/Trainer/releases/tag/v0.0.5

Switch back to pytorch source build because of multiple torch packages
in the dependency set.

Tests are still not runnable for us, since they try to download test
data.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
