### PR TITLE
neochat: 1.2 -> 22.02

### DIFF
--- a/pkgs/applications/networking/instant-messengers/neochat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/neochat/default.nix
@@ -8,6 +8,7 @@
 , kconfig
 , kdbusaddons
 , ki18n
+, kio
 , kirigami2
 , kitemmodels
 , knotifications
@@ -16,23 +17,25 @@
 , libquotient
 , libsecret
 , olm
+, qcoro
 , qqc2-desktop-style
 , qtgraphicaleffects
 , qtkeychain
 , qtmultimedia
 , qtquickcontrols2
+, sonnet
 }:
 
 mkDerivation rec {
   pname = "neochat";
-  version = "1.2";
+  version = "22.02";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "network";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-Kpv7BY/qS0A3xFlYFhz1RRNwQVsyhOTHHGDbWRTTv1I=";
+    sha256 = "sha256-7EBnHuwpyJ/bGrCldZHWOwcnJWDIDaNWZXHkCYkOTjs=";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules pkg-config ];
@@ -41,6 +44,7 @@ mkDerivation rec {
     cmark
     kconfig
     kdbusaddons
+    kio
     ki18n
     kirigami2
     kitemmodels
@@ -50,11 +54,13 @@ mkDerivation rec {
     libquotient
     libsecret
     olm
+    qcoro
     qtgraphicaleffects
     qtkeychain
     qtmultimedia
     qtquickcontrols2
     qqc2-desktop-style
+    sonnet
   ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

22.02:
  https://invent.kde.org/network/neochat/-/commit/dd4ef2e4ac63fc7f536d0a0dfeb80b16d860f329
21.12:
  https://invent.kde.org/network/neochat/-/commit/041a5ff590ae8faed37150c0b4d83a6c99bb8b71

I was using `spectral` before, so far this looks great! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->