### PR TITLE
modules/nginx: Only send one set of HTTP/3 headers

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -264,11 +264,14 @@ let
           + (if ssl && vhost.http3 then ''
           # UDP listener for **QUIC+HTTP/3
           listen ${addr}:${toString port} http3 reuseport;
+          '' else "");
+
+        advertiseHttp3 = optionalString (hasSSL && vhost.http3) ''
           # Advertise that HTTP/3 is available
           add_header Alt-Svc 'h3=":443"';
           # Sent when QUIC was used
           add_header QUIC-Status $quic;
-          '' else "");
+        '';
 
         redirectListen = filter (x: !x.ssl) defaultListen;
 
@@ -301,6 +304,7 @@ let
 
         server {
           ${concatMapStringsSep "\n" listenString hostListen}
+          ${advertiseHttp3}
           server_name ${vhost.serverName} ${concatStringsSep " " vhost.serverAliases};
           ${acmeLocation}
           ${optionalString (vhost.root != null) "root ${vhost.root};"}


### PR DESCRIPTION
###### Description of changes

Currently, enabling `http3` in an nginx virtual host results in a config that sends multiple sets of `Alt-Svc` and `QUIC-Status` headers for each listening interface. For example, I have a machine has IPv4 and IPv6 enabled, and the configuration looks like this:

```nginx
        listen 0.0.0.0:443 ssl http2 ;# UDP listener for **QUIC+HTTP/3
        listen 0.0.0.0:443 http3 reuseport;
        # Advertise that HTTP/3 is available
        add_header Alt-Svc 'h3=":443"';
        # Sent when QUIC was used
        add_header QUIC-Status $quic;
        listen [::0]:443 ssl http2 ;# UDP listener for **QUIC+HTTP/3
        listen [::0]:443 http3 reuseport;
        # Advertise that HTTP/3 is available
        add_header Alt-Svc 'h3=":443"';
        # Sent when QUIC was used
        add_header QUIC-Status $quic;
```

The multiple `add_header` options cause the same headers to be sent twice.

###### Things done

This change will cause the configuration to only add these headers once.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
