### PR TITLE
zdns: 20210327-8c53210 -> 2022-03-14-unstable

### DIFF
--- a/pkgs/tools/security/zdns/default.nix
+++ b/pkgs/tools/security/zdns/default.nix
@@ -5,19 +5,16 @@
 
 buildGoModule rec {
   pname = "zdns";
-  version = "20210327-${lib.strings.substring 0 7 rev}";
-  rev = "8c53210f0b9a4fe16c70a5d854e9413c3d0c1ba2";
+  version = "2022-03-14-unstable";
 
   src = fetchFromGitHub {
     owner = "zmap";
     repo = pname;
-    inherit rev;
-    sha256 = "0pdfz1489ynpw72flalnlkwybp683v826icjx7ljys45xvagdvck";
+    rev = "d659a361f6d5165462c10e1c1243f420175e066b";
+    hash = "sha256-856O6H03me3IM39/+6n56KJIetL+v4on6+lJx5D2Pcw=";
   };
 
-  vendorSha256 = "0b8h5n01xmhar1a09svb35ah48k9zdy1mn5balq0h2l0jxr05z78";
-
-  subPackages = [ "zdns" ];
+  vendorSha256 = "sha256-5kZ0voyicnqK/0yrMYW+gR1vVDyptW6I1HgyG4zleX8=";
 
   meta = with lib; {
     description = "CLI DNS lookup tool";


### PR DESCRIPTION
###### Description of changes
Update to later commit
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
