### PR TITLE
nss: refactor into latest and esr

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1808,6 +1808,16 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>nss</literal> package was split into
+          <literal>nss_esr</literal> and <literal>nss_latest</literal>,
+          with <literal>nss</literal> being an alias for
+          <literal>nss_esr</literal>. This was done to ease maintenance
+          of <literal>nss</literal> and dependent high-profile packages
+          like <literal>firefox</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>spark3</literal> package has been updated from
           3.1.2 to 3.2.1
           (<link xlink:href="https://github.com/NixOS/nixpkgs/pull/160075">#160075</link>):

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -623,6 +623,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `R` package now builds again on `aarch64-darwin` ([#158992](https://github.com/NixOS/nixpkgs/pull/158992)).
 
+- The `nss` package was split into `nss_esr` and `nss_latest`, with `nss` being an alias for `nss_esr`. This was done to ease maintenance of `nss` and dependent high-profile packages like `firefox`.
+
 - The `spark3` package has been updated from 3.1.2 to 3.2.1 ([#160075](https://github.com/NixOS/nixpkgs/pull/160075)):
 
   - Testing has been enabled for `aarch64-linux` in addition to `x86_64-linux`.

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -61,7 +61,8 @@
 , libwebp
 , nasm
 , nspr
-, nss
+, nss_esr
+, nss_latest
 , pango
 , xorg
 , zip
@@ -356,7 +357,6 @@ buildStdenv.mkDerivation ({
     libwebp
     nasm
     nspr
-    nss
     pango
     perl
     xorg.libX11
@@ -373,6 +373,7 @@ buildStdenv.mkDerivation ({
     zip
     zlib
   ]
+  ++ [ (if (lib.versionAtLeast version "92") then nss_latest else nss_esr) ]
   ++ lib.optional  alsaSupport alsa-lib
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gssSupport libkrb5

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -38,7 +38,7 @@
 , adwaita-icon-theme
 , libGLU, libGL
 , nspr
-, nss
+, nss_latest
 , pango
 , pipewire
 , pciutils
@@ -132,7 +132,7 @@ stdenv.mkDerivation {
       libnotify
       libGLU libGL
       nspr
-      nss
+      nss_latest
       pango
       pipewire
       pciutils

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -20,7 +20,7 @@ let
   blocklist = writeText "cacert-blocklist.txt" (lib.concatStringsSep "\n" blacklist);
   extraCertificatesBundle = writeText "cacert-extra-certificates-bundle.crt" (lib.concatStringsSep "\n\n" extraCertificateStrings);
 
-  srcVersion = "3.74";
+  srcVersion = "3.77";
   version = if nssOverride != null then nssOverride.version else srcVersion;
   meta = with lib; {
     homepage = "https://curl.haxx.se/docs/caextract.html";
@@ -35,7 +35,7 @@ let
 
     src = if nssOverride != null then nssOverride.src else fetchurl {
       url = "mirror://mozilla/security/nss/releases/NSS_${lib.replaceStrings ["."] ["_"] version}_RTM/src/nss-${version}.tar.gz";
-      sha256 = "0mnhdkm4galhpvfz4rv0918jwmjlwkvcvb1f5va8f3zlz48qi4l8";
+      sha256 = "1pfy33b51914sivqyaxdwfd930hzb77gm07z4f57hnyk5xddypl2";
     };
 
     dontBuild = true;

--- a/pkgs/development/libraries/nss/85_security_load_3.77+.patch
+++ b/pkgs/development/libraries/nss/85_security_load_3.77+.patch
@@ -1,0 +1,76 @@
+diff --git nss/cmd/shlibsign/shlibsign.c nss/cmd/shlibsign/shlibsign.c
+index ad8f3b84e..74676d039 100644
+--- nss/cmd/shlibsign/shlibsign.c
++++ nss/cmd/shlibsign/shlibsign.c
+@@ -875,6 +875,8 @@ main(int argc, char **argv)
+         goto cleanup;
+     }
+     lib = PR_LoadLibrary(libname);
++    if (!lib)
++        lib = PR_LoadLibrary(NIX_NSS_LIBDIR"libsoftokn3.so");
+     assert(lib != NULL);
+     if (!lib) {
+         PR_fprintf(PR_STDERR, "loading softokn3 failed");
+diff --git nss/lib/pk11wrap/pk11load.c nss/lib/pk11wrap/pk11load.c
+index 119c8c512..720d39ccc 100644
+--- nss/lib/pk11wrap/pk11load.c
++++ nss/lib/pk11wrap/pk11load.c
+@@ -486,6 +486,15 @@ secmod_LoadPKCS11Module(SECMODModule *mod, SECMODModule **oldModule)
+ #else
+         library = PR_LoadLibrary(mod->dllName);
+ #endif // defined(_WIN32)
++#ifndef NSS_STATIC_SOFTOKEN
++        if ((library == NULL) &&
++            !rindex(mod->dllName, PR_GetDirectorySeparator())) {
++            library = PORT_LoadLibraryFromOrigin(my_shlib_name,
++                (PRFuncPtr) &softoken_LoadDSO,
++                mod->dllName);
++        }
++#endif
++
+         mod->library = (void *)library;
+ 
+         if (library == NULL) {
+diff --git nss/lib/util/secload.c nss/lib/util/secload.c
+index 12efd2f75..8b74478f6 100644
+--- nss/lib/util/secload.c
++++ nss/lib/util/secload.c
+@@ -70,9 +70,14 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+ 
+     /* Remove the trailing filename from referencePath and add the new one */
+     c = strrchr(referencePath, PR_GetDirectorySeparator());
++    if (!c) { /* referencePath doesn't contain a / means that dladdr gave us argv[0]
++               * and program was called from $PATH. Hack to get libs from NIX_NSS_LIBDIR */
++        referencePath = NIX_NSS_LIBDIR;
++        c = (char*) &referencePath[sizeof(NIX_NSS_LIBDIR) - 1]; /* last / */
++    }
+     if (c) {
+         size_t referencePathSize = 1 + c - referencePath;
+-        fullName = (char*)PORT_Alloc(strlen(name) + referencePathSize + 1);
++        fullName = (char*) PORT_Alloc(strlen(name) + referencePathSize + 5);
+         if (fullName) {
+             memcpy(fullName, referencePath, referencePathSize);
+             strcpy(fullName + referencePathSize, name);
+@@ -82,6 +87,11 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+ #endif
+             libSpec.type = PR_LibSpec_Pathname;
+             libSpec.value.pathname = fullName;
++            if ((referencePathSize >= 4) &&
++                (strncmp(fullName + referencePathSize - 4, "bin", 3) == 0)) {
++                memcpy(fullName + referencePathSize -4, "lib", 3);
++            }
++            strcpy(fullName + referencePathSize, name);
+             dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL
+ #ifdef PR_LD_ALT_SEARCH_PATH
+                                                        /* allow library's dependencies to be found in the same directory
+@@ -89,6 +99,10 @@ loader_LoadLibInReferenceDir(const char* referencePath, const char* name)
+                                                        | PR_LD_ALT_SEARCH_PATH
+ #endif
+                                           );
++            if (! dlh) {
++                strcpy(fullName + referencePathSize, name);
++                dlh = PR_LoadLibraryWithFlags(libSpec, PR_LD_NOW | PR_LD_LOCAL);
++            }
+             PORT_Free(fullName);
+         }
+     }

--- a/pkgs/development/libraries/nss/esr.nix
+++ b/pkgs/development/libraries/nss/esr.nix
@@ -1,0 +1,4 @@
+import ./generic.nix {
+  version = "3.68.3";
+  sha256 = "sha256-5NDZsLVhfLM0gSZC7YAfjlH1mVyN2FwN78jMra/Lwzc=";
+}

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -1,3 +1,4 @@
+{ version, sha256 }:
 { lib
 , stdenv
 , fetchurl
@@ -22,14 +23,7 @@ let
     sha256 = "10ibz6y0hknac15zr6dw4gv9nb5r5z9ym6gq18j3xqx7v7n3vpdw";
   };
 
-  # NOTE: Whenever you updated this version check if the `cacert` package also
-  #       needs an update. You can run the regular updater script for cacerts.
-  #       It will rebuild itself using the version of this package (NSS) and if
-  #       an update is required do the required changes to the expression.
-  #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
-  version = "3.76";
   underscoreVersion = lib.replaceStrings [ "." ] [ "_" ] version;
-
 in
 stdenv.mkDerivation rec {
   pname = "nss";
@@ -37,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://mozilla/security/nss/releases/NSS_${underscoreVersion}_RTM/src/${pname}-${version}.tar.gz";
-    sha256 = "0c0nmajcvnm8gqz2v6wrlq04yzy3y7hcs806wjnx4r6kml8073hv";
+    inherit sha256;
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation rec {
     homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS";
     description = "A set of libraries for development of security-enabled client and server applications";
     changelog = "https://github.com/nss-dev/nss/blob/master/doc/rst/releases/nss_${underscoreVersion}.rst";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ hexa ajs124 ];
     license = licenses.mpl20;
     platforms = platforms.all;
   };

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -62,9 +62,13 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Based on http://patch-tracker.debian.org/patch/series/dl/nss/2:3.15.4-1/85_security_load.patch
-    ./85_security_load.patch
     ./ckpem.patch
     ./fix-cross-compilation.patch
+    (if (lib.versionOlder version "3.77") then
+      ./85_security_load.patch
+    else
+      ./85_security_load_3.77+.patch
+    )
   ];
 
   patchFlags = [ "-p0" ];

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.76";
-  sha256 = "0c0nmajcvnm8gqz2v6wrlq04yzy3y7hcs806wjnx4r6kml8073hv";
+  version = "3.76.1";
+  sha256 = "0ai37ncg50n4s5243bfvsip8isqq1y6w2swg1n4xgqg2fk1h8cg1";
 }

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -5,6 +5,6 @@
 #       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
 
 import ./generic.nix {
-  version = "3.76.1";
-  sha256 = "0ai37ncg50n4s5243bfvsip8isqq1y6w2swg1n4xgqg2fk1h8cg1";
+  version = "3.77";
+  sha256 = "1pfy33b51914sivqyaxdwfd930hzb77gm07z4f57hnyk5xddypl2";
 }

--- a/pkgs/development/libraries/nss/latest.nix
+++ b/pkgs/development/libraries/nss/latest.nix
@@ -1,0 +1,10 @@
+# NOTE: Whenever you updated this version check if the `cacert` package also
+#       needs an update. You can run the regular updater script for cacerts.
+#       It will rebuild itself using the version of this package (NSS) and if
+#       an update is required do the required changes to the expression.
+#       Example: nix-shell ./maintainers/scripts/update.nix --argstr package cacert
+
+import ./generic.nix {
+  version = "3.76";
+  sha256 = "0c0nmajcvnm8gqz2v6wrlq04yzy3y7hcs806wjnx4r6kml8073hv";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19487,7 +19487,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  nss = lowPrio (callPackage ../development/libraries/nss { });
+  nss_latest = callPackage ../development/libraries/nss/latest.nix { };
+  nss_esr = callPackage ../development/libraries/nss/esr.nix { };
+  nss = nss_esr;
   nssTools = nss.tools;
 
   nss_wrapper = callPackage ../development/libraries/nss_wrapper { };


### PR DESCRIPTION
###### Description of changes
This should ease maintenance of firefox while having a supported version for everything else, so the mass rebuilds can go through staging and nss_latest can just be bumped and both can be backported, on the release and one to staging.

cacert still uses nss_latest, so we always have an up to date certificate store.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).