### PR TITLE
separate-debug-info setup hook: strip debug symbols from static libs

### DIFF
--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -16,28 +16,40 @@ _separateDebugInfo() {
     # Find executables and dynamic libraries.
     local i
     while IFS= read -r -d $'\0' i; do
-        if ! isELF "$i"; then continue; fi
+        if isELF "$i"; then
 
-        # Extract the Build ID. FIXME: there's probably a cleaner way.
-        local id="$($READELF -n "$i" | sed 's/.*Build ID: \([0-9a-f]*\).*/\1/; t; d')"
-        if [ "${#id}" != 40 ]; then
-            echo "could not find build ID of $i, skipping" >&2
-            continue
+            # Extract the Build ID. FIXME: there's probably a cleaner way.
+            local id="$($READELF -n "$i" | sed 's/.*Build ID: \([0-9a-f]*\).*/\1/; t; d')"
+            if [ "${#id}" != 40 ]; then
+                echo "could not find build ID of $i, skipping" >&2
+                continue
+            fi
+
+            # Extract the debug info.
+            header "separating debug info from $i (build ID $id)"
+            mkdir -p "$dst/${id:0:2}"
+
+            # This may fail, e.g. if the binary is for a different
+            # architecture than we're building for.  (This happens with
+            # firmware blobs in QEMU.)
+            (
+                $OBJCOPY --only-keep-debug "$i" "$dst/${id:0:2}/${id:2}.debug"
+                $STRIP --strip-debug "$i"
+
+                # Also a create a symlink <original-name>.debug.
+                ln -sfn ".build-id/${id:0:2}/${id:2}.debug" "$dst/../$(basename "$i")"
+            ) || rmdir -p "$dst/${id:0:2}"
+
+        elif isAR "$i" && [ "${i##*.}" = "a" ]; then
+            # possibly a static library - build will likely have
+            # added debugging symbols to any static libraries produced
+            # too, making them huge. separate debug outputs have limited
+            # value for static libraries, so attempt to strip any
+            # found. a user can just use a `dontStrip` build if they
+            # need a static library with debug info.
+
+            header "stripping $i"
+            $STRIP --strip-debug -D "$i" || true
         fi
-
-        # Extract the debug info.
-        header "separating debug info from $i (build ID $id)"
-        mkdir -p "$dst/${id:0:2}"
-
-        # This may fail, e.g. if the binary is for a different
-        # architecture than we're building for.  (This happens with
-        # firmware blobs in QEMU.)
-        (
-            $OBJCOPY --only-keep-debug "$i" "$dst/${id:0:2}/${id:2}.debug"
-            $STRIP --strip-debug "$i"
-
-            # Also a create a symlink <original-name>.debug.
-            ln -sfn ".build-id/${id:0:2}/${id:2}.debug" "$dst/../$(basename "$i")"
-        ) || rmdir -p "$dst/${id:0:2}"
     done < <(find "$prefix" -type f -print0)
 }

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -414,11 +414,6 @@ in with passthru; stdenv.mkDerivation {
     # This allows build Python to import host Python's sysconfigdata
     mkdir -p "$out/${sitePackages}"
     ln -s "$out/lib/${libPrefix}/"_sysconfigdata*.py "$out/${sitePackages}/"
-
-    # debug info can't be separated from a static library and would otherwise be
-    # left in place by a separateDebugInfo build. force its removal here to save
-    # space in output.
-    $STRIP -S $out/lib/${libPrefix}/config-*/libpython*.a || true
     '' + optionalString stripConfig ''
     rm -R $out/bin/python*-config $out/lib/python*/config-*
     '' + optionalString stripIdlelib ''

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -200,6 +200,17 @@ isELF() {
     if [ "$magic" = $'\177ELF' ]; then return 0; else return 1; fi
 }
 
+# Return success if the specified file is an AR archive
+isAR() {
+    local fn="$1"
+    local fd
+    local magic
+    exec {fd}< "$fn"
+    read -r -N 8 -u "$fd" magic
+    exec {fd}<&-
+    if [ "$magic" = $'!<arch>\n' ]; then return 0; else return 1; fi
+}
+
 # Return success if the specified file is a Mach-O object.
 isMachO() {
     local fn="$1"


### PR DESCRIPTION
###### Description of changes

Currently, `separateDebugInfo = true` will cause binaries to be built with debug symbols, before "separating" them in a setup hook. The problem is, this setup hook doesn't take static libraries into account and so they end up retaining their debug info. This often makes them huge and is what caused the reversion of the first attempt at adding `separateDebugInfo` to cpython in #93083.

This adds the ability to detect AR archives to the generic setup script, then makes the `separate-debug-info.sh` attempt to strip any likely-static-libraries it finds.

Separate debug info for static libraries reportedly doesn't really work and outputting the unstripped version of the library to the debug output is something I don't see as being significantly more useful than making the user do a `dontStrip` build. Though it would significantly increase the size of debug outputs.

This PR results in some space savings for packages that output static libraries while using `separateDebugInfo`. `postgresql`'s `lib/libpgcommon.a` goes from ~800KB to ~200KB on x86_64 linux. A static build of `openssl` goes from 24MB to 6.5MB.

My hope with this is that people will be less hesitant to enable `separateDebugInfo` on packages as it is much less likely to cause unexpected bloat.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
