### PR TITLE
python: remove ncurses flag

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -282,7 +282,7 @@ in with passthru; stdenv.mkDerivation {
 
   CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
   LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
-  LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"} ${optionalString (ncurses != null) "-lncurses"}";
+  LIBS = "${optionalString (!stdenv.isDarwin) "-lcrypt"}";
   NIX_LDFLAGS = lib.optionalString stdenv.cc.isGNU ({
     "glibc" = "-lgcc_s";
     "musl" = "-lgcc_eh";


### PR DESCRIPTION
###### Description of changes

Nix/NixOS's `python3-config --libs` output includes a `-lncurses` flag, which other distros (e.g. Debian) don't.
It seems it was added as a workaround for `readline` support in a very old commit 9d3b0a2cb7451bb09080965ef40fdaef6bc8cab7 and kept since then.

NixOS 21.11:
```console
$ nix-shell -p python39 --run 'python3.9-config --libs'
 -lpthread -ldl -lcrypt -lncurses -lutil -lm -lm
```

Nix staging, before:
```console
nixpkgs$ nix-build -A python39
nixpkgs$ ./result/bin/python3.9-config --libs
 -ldl -lcrypt -lncurses -lm -lm
```

Nix staging, after:
```console
nixpkgs$ nix-build -A python39
nixpkgs$ ./result/bin/python3.9-config --libs
 -ldl -lcrypt -lm -lm
```

(`-lpthread -lutil` are supposedly removed somewhere on the staging branch)

Closes #158256.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  ```console
  $ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
  52 packages added:
  ...
  37711 packages updated:
  ...
  26 packages removed:
  ```
  Then I cancelled it and only built `python39` and `youtube-dl` (plus whatever is in their closure).

- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
