### PR TITLE
elementary-planner: hardcoded themes & vala 0.56 fixes

### DIFF
--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -70,6 +70,11 @@ stdenv.mkDerivation rec {
     substituteInPlace src/Application.vala \
       --replace '"gtk-theme-name", "elementary"' '"gtk-theme-name", "io.elementary.stylesheet.blueberry"'
 
+    # Fix build with vala 0.56
+    # https://github.com/alainm23/planner/pull/884
+    substituteInPlace src/Application.vala \
+      --replace "public const OptionEntry[] PLANNER_OPTIONS" "private const OptionEntry[] PLANNER_OPTIONS"
+
     chmod +x build-aux/meson/post_install.py
     patchShebangs build-aux/meson/post_install.py
   '';

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -78,6 +78,8 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(
       # The GTK theme is hardcoded.
       --prefix XDG_DATA_DIRS : "${pantheon.elementary-gtk-theme}/share"
+      # The icon theme is hardcoded.
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
     )
   '';
 

--- a/pkgs/applications/office/elementary-planner/default.nix
+++ b/pkgs/applications/office/elementary-planner/default.nix
@@ -64,13 +64,19 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
+    # The GTK theme has been renamed in elementary OS 6
+    # https://github.com/elementary/flatpak-platform/blob/6.1.0/io.elementary.Sdk.json#L182
+    # Remove this in https://github.com/NixOS/nixpkgs/pull/159249
+    substituteInPlace src/Application.vala \
+      --replace '"gtk-theme-name", "elementary"' '"gtk-theme-name", "io.elementary.stylesheet.blueberry"'
+
     chmod +x build-aux/meson/post_install.py
     patchShebangs build-aux/meson/post_install.py
   '';
 
   preFixup = ''
     gappsWrapperArgs+=(
-      # the theme is hardcoded
+      # The GTK theme is hardcoded.
       --prefix XDG_DATA_DIRS : "${pantheon.elementary-gtk-theme}/share"
     )
   '';


### PR DESCRIPTION
###### Description of changes

- Fixes the wrong hardcoded GTK theme name
- Tries to address #163623
- Fixes build with vala 0.56

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
