### PR TITLE
nixos/nextcloud: Add support for caddy webserver

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1184,6 +1184,15 @@
       </listitem>
       <listitem>
         <para>
+          The nextcloud module now offers the ability to select a
+          different webserver backend via
+          <link xlink:href="options.html#opt-services.nextcloud.webserver"><literal>services.nextcloud.webserver</literal></link>.
+          Currently <literal>nginx</literal> and
+          <literal>caddy</literal> are supported.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The
           <literal>writers.writePyPy2</literal>/<literal>writers.writePyPy3</literal>
           and corresponding

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -442,6 +442,10 @@ In addition to numerous new and upgraded packages, this release has the followin
   * Legacy options have been mapped to the corresponding options under under [nix.settings](options.html#opt-nix.settings) but may be deprecated in the future.
   * [nix.buildMachines.publicHostKey](options.html#opt-nix.buildMachines.publicHostKey) has been added.
 
+- The nextcloud module now offers the ability to select a different webserver
+  backend via [`services.nextcloud.webserver`](options.html#opt-services.nextcloud.webserver).
+  Currently `nginx` and `caddy` are supported.
+
 - The `writers.writePyPy2`/`writers.writePyPy3` and corresponding `writers.writePyPy2Bin`/`writers.writePyPy3Bin` convenience functions to create executable Python 2/3 scripts using the PyPy interpreter were added.
 
 - Some improvements have been made to the `hadoop` module:

--- a/nixos/tests/nextcloud/basic.nix
+++ b/nixos/tests/nextcloud/basic.nix
@@ -1,4 +1,4 @@
-args@{ pkgs, nextcloudVersion ? 22, ... }:
+args@{ pkgs, nextcloudVersion ? 22, webserver ? "nginx", ... }:
 
 (import ../make-test-python.nix ({ pkgs, ...}: let
   adminpass = "notproduction";
@@ -34,13 +34,14 @@ in {
       networking.firewall.allowedTCPPorts = [ 80 ];
 
       systemd.tmpfiles.rules = [
-        "d /var/lib/nextcloud-data 0750 nextcloud nginx - -"
+        "d /var/lib/nextcloud-data 0750 nextcloud ${webserver} - -"
       ];
 
       services.nextcloud = {
         enable = true;
         datadir = "/var/lib/nextcloud-data";
         hostName = "nextcloud";
+        webserver = webserver;
         config = {
           # Don't inherit adminuser since "root" is supposed to be the default
           adminpassFile = "${pkgs.writeText "adminpass" adminpass}"; # Don't try this at home!

--- a/nixos/tests/nextcloud/default.nix
+++ b/nixos/tests/nextcloud/default.nix
@@ -5,17 +5,22 @@
 
 with pkgs.lib;
 
-foldl
-  (matrix: ver: matrix // {
-    "basic${toString ver}" = import ./basic.nix { inherit system pkgs; nextcloudVersion = ver; };
+forEach [ 22 23 ] (ver:
+  forEach [ "nginx" "caddy" ] (webserver: {
+    "basic${toString ver}" = import ./basic.nix {
+      inherit system pkgs;
+      nextcloudVersion = ver;
+      webserver = webserver;
+    };
     "with-postgresql-and-redis${toString ver}" = import ./with-postgresql-and-redis.nix {
       inherit system pkgs;
       nextcloudVersion = ver;
+      webserver = webserver;
     };
     "with-mysql-and-memcached${toString ver}" = import ./with-mysql-and-memcached.nix {
       inherit system pkgs;
       nextcloudVersion = ver;
+      webserver = webserver;
     };
   })
-{ }
-  [ 22 23 ]
+)

--- a/nixos/tests/nextcloud/with-mysql-and-memcached.nix
+++ b/nixos/tests/nextcloud/with-mysql-and-memcached.nix
@@ -1,4 +1,4 @@
-args@{ pkgs, nextcloudVersion ? 22, ... }:
+args@{ pkgs, nextcloudVersion ? 22, webserver ? "nginx", ... }:
 
 (import ../make-test-python.nix ({ pkgs, ...}: let
   adminpass = "hunter2";
@@ -20,6 +20,7 @@ in {
         enable = true;
         hostName = "nextcloud";
         https = true;
+        webserver = webserver;
         package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
         caching = {
           apcu = true;

--- a/nixos/tests/nextcloud/with-postgresql-and-redis.nix
+++ b/nixos/tests/nextcloud/with-postgresql-and-redis.nix
@@ -1,4 +1,4 @@
-args@{ pkgs, nextcloudVersion ? 22, ... }:
+args@{ pkgs, nextcloudVersion ? 22, webserver ? "nginx", ... }:
 
 (import ../make-test-python.nix ({ pkgs, ...}: let
   adminpass = "hunter2";
@@ -20,6 +20,7 @@ in {
         enable = true;
         hostName = "nextcloud";
         package = pkgs.${"nextcloud" + (toString nextcloudVersion)};
+        webserver = webserver;
         caching = {
           apcu = false;
           redis = true;


### PR DESCRIPTION
###### Description of changes

This PR adds support for caddy webserver. Everything should work as before but with this you'll be able to choose between Nginx and Caddy as a web server:
```
services.nextcloud = {
  enable = true;
  webserver = "caddy";
}
```

- [x] Update tests
- [x] Update release notes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
