### PR TITLE
linux: enable TASKSTATS, TASK_XACCT, TASK_DELAY_ACCT and TASK_IO_ACCOUNTING

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -906,6 +906,11 @@ let
       ANDROID_BINDER_IPC =     { optional = true; tristate = whenAtLeast "5.0" "y";};
       ANDROID_BINDERFS =       { optional = true; tristate = whenAtLeast "5.0" "y";};
       ANDROID_BINDER_DEVICES = { optional = true; freeform = whenAtLeast "5.0" "binder,hwbinder,vndbinder";};
+
+      TASKSTATS = yes;
+      TASK_DELAY_ACCT = yes;
+      TASK_XACCT = yes;
+      TASK_IO_ACCOUNTING = yes;
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enable CPU/memory hotplug support
       # Allows you to dynamically add & remove CPUs/memory to a VM client running NixOS without requiring a reboot


### PR DESCRIPTION
###### Description of changes

iotop needs TASKSTATS, TASK_DELAY_ACCT, TASK_XACCT and
TASK_IO_ACCOUNTING to work. For x86_64, all these options are enabled
by upstream[1]. For aarch64, however, only TASK_XACCT and
TASK_IO_ACCOUNTING are enabled by upstream[2].

This patch enables all these four options for aarch64, which have been
enabled by many other distributions, e.g. debian[3], fedora[4],
rhel[5] and gentoo[6].

I tried to only enable TASKSTATS and TASK_DELAY_ACCT since the other
two options are enabled by upstream, but it turns out that it's
necessary to explicitly enable all four options. I do not figure out
the reason though.

Additionally, given that debian enables these four options for all
arch[3], I think it's safe for us to do the same thing.

[1]: https://github.com/torvalds/linux/blob/56e337f2cf1326323844927a04e9dbce9a244835/arch/x86/configs/x86_64_defconfig#L8-L11
[2]: https://github.com/torvalds/linux/blob/56e337f2cf1326323844927a04e9dbce9a244835/arch/arm64/configs/defconfig#L10-L11
[3]: https://salsa.debian.org/kernel-team/linux/-/blob/da6ddc7d8f1a95980d9a1c499fe58066cfe1986b/debian/config/config#L6356-6359
[4]: https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-aarch64-fedora.config#_7398
[5]: https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-aarch64-rhel.config#_5885
[6]: https://github.com/gentoo/gentoo/blob/b839fccce25d49df2fcfe5ed184b557796b0d6bd/sys-kernel/gentoo-kernel/gentoo-kernel-5.15.29.ebuild#L27

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

