### PR TITLE
kotlin-language-server: fix missing JDK in PATH

### DIFF
--- a/pkgs/development/tools/kotlin-language-server/default.nix
+++ b/pkgs/development/tools/kotlin-language-server/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, unzip, openjdk11, gradle }:
+{ lib, stdenv, fetchurl, unzip, openjdk11, gradle, makeWrapper, maven }:
 
 stdenv.mkDerivation rec {
   pname = "kotlin-language-server";
@@ -17,14 +17,19 @@ stdenv.mkDerivation rec {
     cp -r bin/* $out/bin
   '';
 
-  nativeBuildInputs = [ unzip gradle ];
+  nativeBuildInputs = [ unzip gradle makeWrapper ];
   buildInputs = [ openjdk11 gradle ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/kotlin-language-server" --set JAVA_HOME ${openjdk11} --prefix PATH : ${lib.strings.makeBinPath [ openjdk11 maven ] }
+  '';
 
   meta = {
     description = "kotlin language server";
     longDescription = ''
       About Kotlin code completion, linting and more for any editor/IDE
       using the Language Server Protocol Topics'';
+    maintainers = with lib.maintainers; [ vtuan10 ];
     homepage = "https://github.com/fwcd/kotlin-language-server";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;

--- a/pkgs/development/tools/kotlin-language-server/default.nix
+++ b/pkgs/development/tools/kotlin-language-server/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchurl, unzip, openjdk11, gradle, makeWrapper, maven }:
+{ lib, stdenv, fetchzip, openjdk11, gradle, makeWrapper, maven }:
 
 stdenv.mkDerivation rec {
   pname = "kotlin-language-server";
   version = "1.3.0";
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/fwcd/kotlin-language-server/releases/download/${version}/server.zip";
-    sha256 = "sha256-yyqI+87vtggSeAfb3OEftalknqbTDEQ5gTJwB/EMIlY=";
+    hash = "sha256-nqrZoSntomNLUMTni/yoiVhDOJFSFmZeGze8IJhITu0=";
   };
 
   dontBuild = true;
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     cp -r bin/* $out/bin
   '';
 
-  nativeBuildInputs = [ unzip gradle makeWrapper ];
+  nativeBuildInputs = [ gradle makeWrapper ];
   buildInputs = [ openjdk11 gradle ];
 
   postFixup = ''


### PR DESCRIPTION
###### Description of changes
The `kotlin-language-server` crashes on start. Fixed by adding the `JDK` to `PATH` and set `JAVA_HOME`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
