### PR TITLE
nix-info: add BUILD_ID information

### DIFF
--- a/pkgs/tools/nix/info/info.sh
+++ b/pkgs/tools/nix/info/info.sh
@@ -84,7 +84,7 @@ desc_host_os() {
         (
             # shellcheck disable=SC1091
             . /etc/os-release
-            printf ", %s, %s" "${NAME:-$(uname -v)}" "${VERSION:-noversion}"
+            printf ", %s, %s, %s" "${NAME:-$(uname -v)}" "${VERSION:-noversion}" "${BUILD_ID:-nobuild}"
         )
     fi
 }


### PR DESCRIPTION
###### Description of changes

In 20.03 and 20.09 releases, `nix-info` was also showing `BUILD_ID` info as a [side effect of a bug](https://github.com/NixOS/nixpkgs/issues/127654). However, I got used this behaviour because it was extremely handy. It was easily distinguishable if a system is up to date (host os version vs channels(root) version) by running a single command:

```
nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 5.4.49, NixOS, 20.03.2411.30fb4e1e206 (Markhor)`
 - ...
 - channels(root): `"nixos-20.03.2520.add5529b3ee"`
```

This behaviour is gone with the 21.11 since the [issue has been fixed](https://github.com/NixOS/nixpkgs/pull/131967):
```
nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 5.10.101, NixOS, 21.11 (Porcupine)`
 - ...
 - channels(root): `"nixos-21.11.336515.0f85665118d"`
```

Now, I'm not really sure if it's feasible, but I think since previous 2 releases were fine and I haven't found any complaints regarding `nix-info` itself, just related to underlying information in `/etc/os-release`, I'm hoping this to be a non-breaking change.
Alternatively, we could introduce a new line, something like `host version` and put `BUILD_ID` in there.

This PR's behaviour (a tad different from 20.03 as it only appends the BUILD_ID ):
```
nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 5.10.105, NixOS, 21.11 (Porcupine), 21.11.336538.64fc73bd74f`
...
 - channels(root): `"nixos-21.11.336538.64fc73bd74f"`
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
