### PR TITLE
labeler: don't use path-based labeling for BSD

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,10 +5,6 @@
   - pkgs/development/libraries/agda/**/*
   - pkgs/top-level/agda-packages.nix
 
-"6.topic: bsd":
-  - pkgs/os-specific/bsd/**/*
-  - pkgs/stdenv/freebsd/**/*
-
 "6.topic: cinnamon":
   - pkgs/desktops/cinnamon/**/*
 


### PR DESCRIPTION
###### Description of changes


ofborg labels the bsd and darwin platforms based on the title, which
conflicts with the labeler action's `sync-labels` setting (if no paths
are changed, it'll remove the label).