### PR TITLE
crcpp: 1.1.0.0 -> 1.2.0.0

### DIFF
--- a/pkgs/development/libraries/crcpp/default.nix
+++ b/pkgs/development/libraries/crcpp/default.nix
@@ -1,27 +1,27 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchFromGitHub
+, cmake
 }:
 
 stdenv.mkDerivation rec {
   pname = "crcpp";
-  version = "1.1.0.0";
+  version = "1.2.0.0";
 
   src = fetchFromGitHub {
     owner = "d-bahr";
     repo = "CRCpp";
     rev = "release-${version}";
-    sha256 = "sha256-jBvh4dHSFChxNPVgkGVHy3TXSExsfwdVUfsA8XB1cn8=";
+    sha256 = "sha256-OY8MF8fwr6k+ZSA/p1U+9GnTFoMSnUZxKVez+mda2tA=";
   };
 
-  dontBuild = true;
+  nativeBuildInputs = [ cmake ];
 
-  installPhase = ''
-    mkdir -p $out/include
-    cp inc/CRC.h $out/include
-  '';
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/d-bahr/CRCpp";
+    changelog = "https://github.com/d-bahr/CRCpp/releases/tag/release-${version}";
     description = "Easy to use and fast C++ CRC library";
     platforms = platforms.all;
     maintainers = [ maintainers.ivar ];


### PR DESCRIPTION
###### Description of changes
Now using cmake and running unit tests :)

See [the changelog](https://github.com/d-bahr/CRCpp/releases/tag/release-1.2.0.0) for more information.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
