### PR TITLE
python3Packages.afdko: 3.7.1 -> 3.8.0; fonttools: 4.29.0 -> 4.30.0; and related updates

### DIFF
--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "afdko";
-  version = "3.7.1";
+  version = "3.8.0";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "05hj2mw3ppfjaig5zdk5db9vfrbbq5gmv5rzggmvvrj0yyfpr0pd";
+    sha256 = "1404jdwyv16mri5jh6qly63nli2iw9yq2nn37h8iqvlbawfbjj0p";
   };
 
   format = "pyproject";
@@ -40,12 +40,6 @@ buildPythonPackage rec {
 
     # Use antlr4 runtime from nixpkgs and link it dynamically
     ./use-dynamic-system-antlr4-runtime.patch
-
-    # Fix compatibility with latest fonttools.
-    (fetchpatch {
-      url = "https://github.com/adobe-type-tools/afdko/commit/120752c50a562e4f6c12ff4be1e3bd96ed664e82.patch";
-      sha256 = "RDGIpNAuCmK+zqZOeOK7ddCjr9BuqPpcnbnxdtoE48M=";
-    })
   ];
 
   # setup.py will always (re-)execute cmake in buildPhase

--- a/pkgs/development/python-modules/fontparts/default.nix
+++ b/pkgs/development/python-modules/fontparts/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, python
+{ lib, buildPythonPackage, fetchPypi, python, pythonOlder
 , fonttools, lxml, fs, unicodedata2
 , defcon, fontpens, fontmath, booleanoperations
 , pytest, setuptools-scm
@@ -6,11 +6,13 @@
 
 buildPythonPackage rec {
   pname = "fontParts";
-  version = "0.10.3";
+  version = "0.10.4";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-aHtjLHdc2/s3ppF8fz8qFAqxwEKMZJJAFNlBaZ7FAb4=";
+    sha256 = "1ic453q86s5hsw8mxnclk1vr4qp69fd67gywhv23zqwz9a7kb7lh";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -17,16 +17,15 @@
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.29.1";
+  version = "4.30.0";
 
-  # Bump to 3.7 when https://github.com/fonttools/fonttools/pull/2417 is merged
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner  = pname;
     repo   = pname;
     rev    = version;
-    sha256 = "sha256-xviNGFcb1wj5WuA6UxHpw3BkpdjSJL3fbsBytJacp8w=";
+    sha256 = "1y9f071bdl66rsx42j16j5v53h85xra5qlg860rz3m054s2rmin9";
   };
 
   # all dependencies are optional, but

--- a/pkgs/development/python-modules/psautohint/default.nix
+++ b/pkgs/development/python-modules/psautohint/default.nix
@@ -3,19 +3,20 @@
 , lxml, fs # for fonttools extras
 , setuptools-scm
 , pytestCheckHook, pytest-cov, pytest-xdist
+, runAllTests ? false, psautohint # for passthru.tests
 }:
 
 buildPythonPackage rec {
   pname = "psautohint";
-  version = "2.3.1";
+  version = "2.4.0";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "adobe-type-tools";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1knh428af0lvzijvd72i30jcvx9n6ga0hai69kxg8386jdpmmvkg";
+    sha256 = "125nx7accvbk626qlfar90va1995kp9qfrz6a978q4kv2kk37xai";
     fetchSubmodules = true; # data dir for tests
   };
 
@@ -34,10 +35,7 @@ buildPythonPackage rec {
     pytest-cov
     pytest-xdist
   ];
-  disabledTests = [
-    # Test that fails on pytest >= v6
-    # https://github.com/adobe-type-tools/psautohint/issues/284#issuecomment-742800965
-    "test_hashmap_old_version"
+  disabledTests = lib.optionals (!runAllTests) [
     # Slow tests, reduces test time from ~5 mins to ~30s
     "test_mmufo"
     "test_flex_ufo"
@@ -47,6 +45,10 @@ buildPythonPackage rec {
     "test_mmhint"
     "test_otf"
   ];
+
+  passthru.tests = {
+    fullTestsuite = psautohint.override { runAllTests = true; };
+  };
 
   meta = with lib; {
     description = "Script to normalize the XML and other data inside of a UFO";

--- a/pkgs/development/python-modules/zopfli/default.nix
+++ b/pkgs/development/python-modules/zopfli/default.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, setuptools-scm, zopfli, pytest }:
+{ lib, buildPythonPackage, fetchPypi, pythonOlder, setuptools-scm, zopfli, pytestCheckHook }:
 
 buildPythonPackage rec {
   pname = "zopfli";
-  version = "0.2.0";
+  version = "0.2.1";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-x9PzVcSR84TkNNsuYmheq269pmuWTonhdUuxFLLTjOo=";
+    sha256 = "1ipjkcgdbplsrhr31ypk48px8cax4cm9gcjj7yrcrhg20ql3s9p5";
     extension = "zip";
   };
 
@@ -15,8 +17,7 @@ buildPythonPackage rec {
   buildInputs = [ zopfli ];
   USE_SYSTEM_ZOPFLI = "True";
 
-  # doesn't work with pytestCheckHook
-  checkInputs = [ pytest ];
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     description = "cPython bindings for zopfli";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A ~big~ pile of font toolchain related package updates  which makes things easier since these packages all depend on each other.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
