### PR TITLE
firefox: add pgo support

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -17,6 +17,14 @@
     <itemizedlist>
       <listitem>
         <para>
+          The <literal>firefox</literal> browser on
+          <literal>x86_64-linux</literal> is now making use of
+          profile-guided optimization resulting in a much more
+          responsive browsing experience.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>security.acme.defaults</literal> has been added to
           simplify configuring settings for many certificates at once.
           This also opens up the the option to use DNS-01 validation

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -6,6 +6,10 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 ## Highlights {#sec-release-22.05-highlights}
 
+- The `firefox` browser on `x86_64-linux` is now making use of
+  profile-guided optimization resulting in a much more responsive
+  browsing experience.
+
 - `security.acme.defaults` has been added to simplify configuring
   settings for many certificates at once. This also opens up the
   the option to use DNS-01 validation when using `enableACME` on

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -141,12 +141,10 @@ let
     bootBintools = null;
   };
 
-  buildStdenv = if ltoSupport
-    # LTO requires LLVM bintools including ld.lld and llvm-ar.
-    then overrideCC llvmPackages.stdenv (llvmPackages.stdenv.cc.override {
-      inherit (llvmPackages) bintools;
-    })
-    else stdenv;
+  # LTO requires LLVM bintools including ld.lld and llvm-ar.
+  buildStdenv = overrideCC llvmPackages.stdenv (llvmPackages.stdenv.cc.override {
+    inherit (llvmPackages) bintools;
+  });
 
   # Compile the wasm32 sysroot to build the RLBox Sandbox
   # https://hacks.mozilla.org/2021/12/webassembly-and-back-again-fine-grained-sandboxing-in-firefox-95/
@@ -289,7 +287,6 @@ buildStdenv.mkDerivation ({
     "--with-system-webp"
     "--with-system-zlib"
   ]
-  ++ lib.optional (!ltoSupport) "--with-clang-path=${llvmPackages.clang}/bin/clang"
   # LTO is done using clang and lld on Linux.
   ++ lib.optionals ltoSupport [
      "--enable-lto=cross" # Cross-Language LTO

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -127,7 +127,7 @@
 }:
 
 assert stdenv.cc.libc or null != null;
-assert pipewireSupport -> !waylandSupport || !webrtcSupport -> throw "pipewireSupport requires both wayland and webrtc support.";
+assert pipewireSupport -> !waylandSupport || !webrtcSupport -> throw "${pname}: pipewireSupport requires both wayland and webrtc support.";
 
 let
   flag = tf: x: [(if tf then "--enable-${x}" else "--disable-${x}")];

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -83,6 +83,7 @@
 , gssSupport ? true, libkrb5
 , jemallocSupport ? true, jemalloc
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
+, pgoSupport ? (stdenv.isLinux && stdenv.isx86_64 && stdenv.hostPlatform == stdenv.buildPlatform), xvfb-run
 , pipewireSupport ? waylandSupport && webrtcSupport
 , pulseaudioSupport ? stdenv.isLinux, libpulseaudio
 , waylandSupport ? true, libxkbcommon, libdrm
@@ -164,6 +165,13 @@ buildStdenv.mkDerivation ({
 
   inherit src unpackPhase meta;
 
+  # Add another configure-build-profiling run before the final configure phase if we build with pgo
+  preConfigurePhases = lib.optionals pgoSupport [
+    "configurePhase"
+    "buildPhase"
+    "profilingPhase"
+  ];
+
   patches = [
   ]
   ++ lib.optional (lib.versionAtLeast version "86") ./env_var_for_system_dir-ff86.patch
@@ -199,6 +207,7 @@ buildStdenv.mkDerivation ({
     which
     wrapGAppsHook
   ]
+  ++ lib.optionals pgoSupport [ xvfb-run ]
   ++ extraNativeBuildInputs;
 
   setOutputFlags = false; # `./mach configure` doesn't understand `--*dir=` flags.
@@ -214,6 +223,9 @@ buildStdenv.mkDerivation ({
     export MOZ_OBJDIR=$(pwd)/mozobj
     export MOZBUILD_STATE_PATH=$(pwd)/mozbuild
 
+    # Don't try to send libnotify notifications during build
+    export MOZ_NOSPAM=1
+
     # Set consistent remoting name to ensure wmclass matches with desktop file
     export MOZ_APP_REMOTINGNAME="${binaryName}"
 
@@ -228,6 +240,25 @@ buildStdenv.mkDerivation ({
     # RBox WASM Sandboxing
     export WASM_CC=${pkgsCross.wasi32.stdenv.cc}/bin/${pkgsCross.wasi32.stdenv.cc.targetPrefix}cc
     export WASM_CXX=${pkgsCross.wasi32.stdenv.cc}/bin/${pkgsCross.wasi32.stdenv.cc.targetPrefix}c++
+ '' + lib.optionalString pgoSupport ''
+   if [ -e "$TMPDIR/merged.profdata" ]; then
+     echo "Configuring with profiling data"
+     for i in "''${!configureFlagsArray[@]}"; do
+       if [[ ''${configureFlagsArray[i]} = "--enable-profile-generate=cross" ]]; then
+         unset 'configureFlagsArray[i]'
+       fi
+     done
+     configureFlagsArray+=(
+       "--enable-profile-use=cross"
+       "--with-pgo-profile-path="$TMPDIR/merged.profdata""
+       "--with-pgo-jarlog="$TMPDIR/jarlog""
+     )
+   else
+     echo "Configuring to generate profiling data"
+     configureFlagsArray+=(
+       "--enable-profile-generate=cross"
+     )
+   fi
   '' + lib.optionalString googleAPISupport ''
     # Google API key used by Chromium and Firefox.
     # Note: These are for NixOS/nixpkgs use ONLY. For your own distribution,
@@ -336,8 +367,33 @@ buildStdenv.mkDerivation ({
   ++ lib.optional  jemallocSupport jemalloc
   ++ extraBuildInputs;
 
+  profilingPhase = lib.optionalString pgoSupport ''
+    # Package up Firefox for profiling
+    ./mach package
+
+    # Run profiling
+    (
+      export HOME=$TMPDIR
+      export LLVM_PROFDATA=llvm-profdata
+      export JARLOG_FILE="$TMPDIR/jarlog"
+
+      xvfb-run -w 10 -s "-screen 0 1920x1080x24" \
+        ./mach python ./build/pgo/profileserver.py
+    )
+
+    # Copy profiling data to a place we can easily reference
+    cp ./merged.profdata $TMPDIR/merged.profdata
+
+    # Clean build dir
+    ./mach clobber
+  '';
+
   preBuild = ''
     cd mozobj
+  '';
+
+  postBuild = ''
+    cd ..
   '';
 
   makeFlags = extraMakeFlags;
@@ -346,6 +402,10 @@ buildStdenv.mkDerivation ({
 
   # tests were disabled in configureFlags
   doCheck = false;
+
+  preInstall = ''
+    cd mozobj
+  '';
 
   postInstall = lib.optionalString buildStdenv.isLinux ''
     # Remove SDK cruft. FIXME: move to a separate output?

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -78,5 +78,6 @@ rec {
   }).override {
     crashreporterSupport = false;
     enableOfficialBranding = false;
+    pgoSupport = false; # Profiling gets stuck and doesn't terminate.
   };
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -8,7 +8,7 @@ let
 in
 
 rec {
-  thunderbird = common rec {
+  thunderbird = (common rec {
     pname = "thunderbird";
     version = "91.7.0";
     application = "comm/mail";
@@ -35,5 +35,7 @@ rec {
     updateScript = callPackage ./update.nix {
       attrPath = "thunderbird-unwrapped";
     };
+  }).override {
+    pgoSupport = false; # console.warn: feeds: "downloadFeed: network connection unavailable"
   };
 }


### PR DESCRIPTION
PGO support is an optimization that the binary builds from Mozilla already have and our source builds currently lack.

This PR is still a work in progress and I have not done any testing on how this affects other consumers of firefox' common.nix.

This is currently rebased on top of #165161. If you want to check out the pgo changes look for the last commit.

---

Tested `firefox` and `firefox-esr` on x86_64-linux.
Build `firefox` on aarch64-linux in progress … currently stuck in the profiling phase, I think it's stuck.

```
created virtual environment CPython3.9.10.final.0-64 in 46ms
  creator CPython3Posix(dest=/build/firefox-98.0.2/mozobj/_virtualenvs/common, clear=False, no_vcs_ignore=False, global=False)
  activators BashActivator,CShellActivator,FishActivator,PowerShellActivator,PythonActivator

(firefox:49839): Gtk-WARNING **: 02:55:38.164: Could not find the icon 'window-minimize-symbolic'. The 'hicolor' theme
was not found either, perhaps you need to install it.
You can get a copy from:
        http://icon-theme.freedesktop.org/releases
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) [GFX1-]: glxtest: libpci missing
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) [GFX1-]: glxtest: libEGL no display
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) [GFX1-]: glxtest: GLX extension missing
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) [GFX1-]: glxtest: libEGL no display
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) |[4][GFX1-]: No GPUs detected via PCI (t=1.94093) [GFX1-]: No GPUs detected via PCI
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) |[4][GFX1-]: No GPUs detected via PCI (t=1.94093) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=2.82433) [GFX1-]: Failed GL context creation for WebRender: 0
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) |[4][GFX1-]: No GPUs detected via PCI (t=1.94093) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=2.82433) |[6][GFX1-]: FEATURE_FAILURE_WEBRENDER_INITIALIZE_UNSPECIFIED (t=2.82437) [GFX1-]: FEATURE_FAILURE_WEBRENDER_INITIALIZE_UNSPECIFIED
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) |[4][GFX1-]: No GPUs detected via PCI (t=1.94093) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=2.82433) |[6][GFX1-]: FEATURE_FAILURE_WEBRENDER_INITIALIZE_UNSPECIFIED (t=2.82437) |[7][GFX1-]: Failed to connect WebRenderBridgeChild. (t=2.82574) [GFX1-]: Failed to connect WebRenderBridgeChild.
Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=1.94067) |[1][GFX1-]: glxtest: libEGL no display (t=1.9409) |[2][GFX1-]: glxtest: GLX extension missing (t=1.94091) |[3][GFX1-]: glxtest: libEGL no display (t=1.94091) |[4][GFX1-]: No GPUs detected via PCI (t=1.94093) |[5][GFX1-]: Failed GL context creation for WebRender: 0 (t=2.82433) |[6][GFX1-]: FEATURE_FAILURE_WEBRENDER_INITIALIZE_UNSPECIFIED (t=2.82437) |[7][GFX1-]: Failed to connect WebRenderBridgeChild. (t=2.82574) |[8][GFX1-]: Fallback WR to SW-WR (t=2.82839) [GFX1-]: Fallback WR to SW-WR
```