### PR TITLE
[21.11] python39: 3.9.6  -> 3.9.11; python310: 3.10.0 -> 3.10.3

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -123,10 +123,10 @@ with pkgs;
       sourceVersion = {
         major = "3";
         minor = "9";
-        patch = "10";
+        patch = "11";
         suffix = "";
       };
-      sha256 = "sha256-Co+/tSh+vDoT6brz1U4I+gZ3j/7M9jEa74Ibs6ZYbMg=";
+      sha256 = "sha256-ZnZ6NTCdck83DfnlA8FytO5ET0nWK5i8TspyUSPibEk=";
     };
     };
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -132,10 +132,10 @@ with pkgs;
       sourceVersion = {
         major = "3";
         minor = "10";
-        patch = "2";
+        patch = "3";
         suffix = "";
       };
-      sha256 = "sha256-F946x9qfJRmqnWQ3jGA6c6DprVjf+ogS5FFgwIbeZMc=";
+      sha256 = "sha256-WWxy3pmNw5IFvE9w7w2/ft7HQKMG0JtJqb0Kd4BnMNw=";
     };
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -183,10 +183,10 @@ in {
     sourceVersion = {
       major = "3";
       minor = "10";
-      patch = "0";
+      patch = "1";
       suffix = "";
     };
-    sha256 = "00mhn6kj4qkvkkv6hh2klnnjr0yk0c9hspp7njc7n6m1lvkzi6as";
+    sha256 = "0xz1wrd6xi20sbli30vm6jclc4rlnnd03irybknf2p8sdrdjdwd7";
     inherit (darwin) configd;
     inherit passthruFun;
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -123,10 +123,10 @@ with pkgs;
       sourceVersion = {
         major = "3";
         minor = "9";
-        patch = "8";
+        patch = "9";
         suffix = "";
       };
-      sha256 = "sha256-Z1zgm/I8CYNr8ZabdEsepMGhjDJ4hiZjJSXwhETrrVw=";
+      sha256 = "sha256-BoKMBKVzwHOk5RxCkqJ8G+SuJmIcPtx8+TGEGM47bSc=";
     };
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -123,10 +123,11 @@ with pkgs;
       sourceVersion = {
         major = "3";
         minor = "9";
-        patch = "9";
+        patch = "10";
         suffix = "";
       };
-      sha256 = "sha256-BoKMBKVzwHOk5RxCkqJ8G+SuJmIcPtx8+TGEGM47bSc=";
+      sha256 = "sha256-Co+/tSh+vDoT6brz1U4I+gZ3j/7M9jEa74Ibs6ZYbMg=";
+    };
     };
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -128,6 +128,14 @@ with pkgs;
       };
       sha256 = "sha256-ZnZ6NTCdck83DfnlA8FytO5ET0nWK5i8TspyUSPibEk=";
     };
+    python310 = {
+      sourceVersion = {
+        major = "3";
+        minor = "10";
+        patch = "2";
+        suffix = "";
+      };
+      sha256 = "sha256-F946x9qfJRmqnWQ3jGA6c6DprVjf+ogS5FFgwIbeZMc=";
     };
   };
 
@@ -178,18 +186,11 @@ in {
     inherit passthruFun;
   } // sources.python39);
 
-  python310 = callPackage ./cpython {
+  python310 = callPackage ./cpython ({
     self = python310;
-    sourceVersion = {
-      major = "3";
-      minor = "10";
-      patch = "1";
-      suffix = "";
-    };
-    sha256 = "0xz1wrd6xi20sbli30vm6jclc4rlnnd03irybknf2p8sdrdjdwd7";
     inherit (darwin) configd;
     inherit passthruFun;
-  };
+  } // sources.python310);
 
   # Minimal versions of Python (built without optional dependencies)
   python3Minimal = (callPackage ./cpython ({

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -123,10 +123,10 @@ with pkgs;
       sourceVersion = {
         major = "3";
         minor = "9";
-        patch = "6";
+        patch = "8";
         suffix = "";
       };
-      sha256 = "12hhw2685i68pwfx5hdkqngzhbji4ccyjmqb5rzvkigg6fpj0y9r";
+      sha256 = "sha256-Z1zgm/I8CYNr8ZabdEsepMGhjDJ4hiZjJSXwhETrrVw=";
     };
   };
 

--- a/pkgs/development/python-modules/aiohttp-wsgi/default.nix
+++ b/pkgs/development/python-modules/aiohttp-wsgi/default.nix
@@ -26,6 +26,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  disabledTests = [
+    # makes http request to another server
+    "testEnviron"
+  ];
+
   pythonImportsCheck = [ "aiohttp_wsgi" ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/aiojobs/default.nix
+++ b/pkgs/development/python-modules/aiojobs/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pythonOlder
 , aiohttp
 , pytestCheckHook
@@ -10,13 +10,16 @@
 
 buildPythonPackage rec {
   pname = "aiojobs";
-  version = "0.3.0";
+  version = "1.0.0";
   format = "flit";
-  disabled = pythonOlder "3.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-9mMdQtxDCPfYg6u9cNTpdvP8w1o7oejq5dSvSUCh4MM=";
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "aio-libs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "EQwD0b2B9qFVd/8thKInaio0hpPzvVIjvCN0TcARu2w=";
   };
 
   nativeBuildInputs = [
@@ -32,11 +35,13 @@ buildPythonPackage rec {
     pytest-aiohttp
   ];
 
-  pythonImportsCheck = [ "aiojobs" ];
+  pythonImportsCheck = [
+    "aiojobs"
+  ];
 
   meta = with lib; {
-    homepage = "https://github.com/aio-libs/aiojobs";
     description = "Jobs scheduler for managing background task (asyncio)";
+    homepage = "https://github.com/aio-libs/aiojobs";
     license = licenses.asl20;
     maintainers = with maintainers; [ cmcdragonkai ];
   };

--- a/pkgs/development/python-modules/ansible-runner/default.nix
+++ b/pkgs/development/python-modules/ansible-runner/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage rec {
     "test_callback_plugin_task_args_leak" # requires internet
     "test_env_accuracy"
     "test_large_stdout_blob" # times out on slower hardware
+    "test_prepare_env_defaults" # missing artifact
   ]
     # test_process_isolation_settings is currently broken on Darwin Catalina
     # https://github.com/ansible/ansible-runner/issues/413

--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -20,6 +20,10 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace requirements.txt \
       --replace "flake8<3.9.0,>=3.8.0" "flake8"
+    substituteInPlace hacking/checks/python23.py \
+      --replace 'H236: class Foo(object):\n    __metaclass__ = \' 'Okay: class Foo(object):\n    __metaclass__ = \'
+    substituteInPlace hacking/checks/except_checks.py \
+      --replace 'H201: except:' 'Okay: except:'
   '';
 
   nativeBuildInputs = [ pbr ];
@@ -35,9 +39,7 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    stestr run -e <(echo "
-      hacking.tests.test_doctest.HackingTestCase.test_flake8
-    ")
+    stestr run
   '';
 
   pythonImportsCheck = [ "hacking" ];

--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -35,7 +35,9 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    stestr run
+    stestr run -e <(echo "
+      hacking.tests.test_doctest.HackingTestCase.test_flake8
+    ")
   '';
 
   pythonImportsCheck = [ "hacking" ];

--- a/pkgs/development/python-modules/httpx-socks/default.nix
+++ b/pkgs/development/python-modules/httpx-socks/default.nix
@@ -38,6 +38,9 @@ buildPythonPackage rec {
     trio
   ];
 
+  # tests hang and fail at https urls
+  doCheck = false;
+
   checkInputs = [
     flask
     pytest-asyncio

--- a/pkgs/development/python-modules/metar/default.nix
+++ b/pkgs/development/python-modules/metar/default.nix
@@ -6,13 +6,13 @@
 
 buildPythonPackage rec {
   pname = "metar";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "python-metar";
     repo = "python-metar";
     rev = "v${version}";
-    sha256 = "019vfq9191cdvvq1afdcdgdgbzpj7wq6pz9li8ggim71azjnv5nn";
+    sha256 = "sha256-pl2NWRfFCYyM2qvBt4Ic3wgbGkYZvAO6pX2Set8zYW8=";
   };
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/metar/default.nix
+++ b/pkgs/development/python-modules/metar/default.nix
@@ -27,6 +27,11 @@ buildPythonPackage rec {
       url = "https://github.com/python-metar/python-metar/commit/a4f9a4764b99bb0313876366d30728169db2770b.patch";
       sha256 = "sha256-sURHUb4gCKVMqEWFklTsxF0kr0SxC02Yr0287rZIvC0=";
     })
+    (fetchpatch {
+      # Fix failing test: https://github.com/python-metar/python-metar/issues/165
+      url = "https://github.com/python-metar/python-metar/commit/a4f9a4764b99bb0313876366d30728169db2770b.patch";
+      hash = "sha256-sURHUb4gCKVMqEWFklTsxF0kr0SxC02Yr0287rZIvC0=";
+    })
   ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/metar/default.nix
+++ b/pkgs/development/python-modules/metar/default.nix
@@ -22,6 +22,11 @@ buildPythonPackage rec {
       url = "https://github.com/python-metar/python-metar/commit/716fa76682e6c2936643d1cf62e3d302ef29aedd.patch";
       sha256 = "sha256-y82NN+KDryOiH+eG+2ycXCO9lqQLsah4+YpGn6lM2As=";
     })
+    (fetchpatch {
+      # Fix failing test: https://github.com/python-metar/python-metar/issues/165
+      url = "https://github.com/python-metar/python-metar/commit/a4f9a4764b99bb0313876366d30728169db2770b.patch";
+      sha256 = "sha256-sURHUb4gCKVMqEWFklTsxF0kr0SxC02Yr0287rZIvC0=";
+    })
   ];
 
   checkInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/metar/default.nix
+++ b/pkgs/development/python-modules/metar/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , pytestCheckHook
 }:
 
@@ -14,6 +15,14 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "sha256-pl2NWRfFCYyM2qvBt4Ic3wgbGkYZvAO6pX2Set8zYW8=";
   };
+
+  patches = [
+    (fetchpatch {
+      # Fix flapping test; https://github.com/python-metar/python-metar/issues/161
+      url = "https://github.com/python-metar/python-metar/commit/716fa76682e6c2936643d1cf62e3d302ef29aedd.patch";
+      sha256 = "sha256-y82NN+KDryOiH+eG+2ycXCO9lqQLsah4+YpGn6lM2As=";
+    })
+  ];
 
   checkInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/metar/default.nix
+++ b/pkgs/development/python-modules/metar/default.nix
@@ -27,14 +27,14 @@ buildPythonPackage rec {
       url = "https://github.com/python-metar/python-metar/commit/a4f9a4764b99bb0313876366d30728169db2770b.patch";
       sha256 = "sha256-sURHUb4gCKVMqEWFklTsxF0kr0SxC02Yr0287rZIvC0=";
     })
-    (fetchpatch {
-      # Fix failing test: https://github.com/python-metar/python-metar/issues/165
-      url = "https://github.com/python-metar/python-metar/commit/a4f9a4764b99bb0313876366d30728169db2770b.patch";
-      hash = "sha256-sURHUb4gCKVMqEWFklTsxF0kr0SxC02Yr0287rZIvC0=";
-    })
   ];
 
   checkInputs = [ pytestCheckHook ];
+
+  disabledTests = [
+    # https://github.com/python-metar/python-metar/issues/165
+    "test_033_parseTime_auto_month"
+  ];
 
   pythonImportsCheck = [ "metar" ];
 

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -12,6 +12,12 @@ buildPythonPackage rec {
     sha256 = "069i9qnfanp7dn8df1vspnqb0flvsszzn22v00vj08nzlnd061yd";
   };
 
+  # remove pin with mypy>=0.920
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "typed_ast >= 1.4.0, < 1.5.0" "typed_ast >= 1.4.0, < 2"
+  '';
+
   propagatedBuildInputs = [ typed-ast psutil mypy-extensions typing-extensions ];
 
   # Tests not included in pip package.

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -12,7 +12,8 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
   disabledTests = [ "test_clean_confounds" ];  # https://github.com/nilearn/nilearn/issues/2608
-  pytestFlagsArray = [ "nilearn" ];
+  # do subset of tests which don't fetch resources
+  pytestFlagsArray = [ "nilearn/connectome/tests" ];
 
   propagatedBuildInputs = [
     joblib

--- a/pkgs/development/python-modules/nilearn/default.nix
+++ b/pkgs/development/python-modules/nilearn/default.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytestCheckHook ];
   disabledTests = [ "test_clean_confounds" ];  # https://github.com/nilearn/nilearn/issues/2608
+  pytestFlagsArray = [ "nilearn" ];
 
   propagatedBuildInputs = [
     joblib

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -27,12 +27,12 @@
 
 buildPythonPackage rec {
   pname = "pandas";
-  version = "1.3.4";
+  version = "1.3.5";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a2aa18d3f0b7d538e21932f637fbfe8518d085238b429e4790a35e1e44a96ffc";
+    sha256 = "1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -27,11 +27,11 @@
 
 buildPythonPackage rec {
   pname = "pandas";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "272c8cb14aa9793eada6b1ebe81994616e647b5892a370c7135efb2924b701df";
+    sha256 = "a2aa18d3f0b7d538e21932f637fbfe8518d085238b429e4790a35e1e44a96ffc";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -3,15 +3,9 @@
 , buildPythonPackage
 , fetchPypi
 , python
-, beautifulsoup4
-, bottleneck
 , cython
+, numpy
 , python-dateutil
-, html5lib
-, jinja2
-, lxml
-, numexpr
-, openpyxl
 , pytz
 , scipy
 , sqlalchemy
@@ -21,6 +15,7 @@
 # Test inputs
 , glibcLocales
 , hypothesis
+, jinja2
 , pytestCheckHook
 , pytest-xdist
 , pytest-asyncio
@@ -44,19 +39,9 @@ buildPythonPackage rec {
   buildInputs = lib.optional stdenv.isDarwin libcxx;
 
   propagatedBuildInputs = [
-    beautifulsoup4
-    bottleneck
+    numpy
     python-dateutil
-    html5lib
-    numexpr
-    lxml
-    openpyxl
     pytz
-    scipy
-    sqlalchemy
-    tables
-    xlrd
-    xlwt
   ];
 
   checkInputs = [

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage rec {
                 "['pandas/src/klib', 'pandas/src', '$cpp_sdk']"
   '';
 
-  doCheck = !stdenv.isAarch64; # upstream doesn't test this architecture
+  doCheck = !stdenv.isAarch32 && !stdenv.isAarch64; # upstream doesn't test this architecture
 
   pytestFlagsArray = [
     "--skip-slow"

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -28,6 +28,7 @@
 buildPythonPackage rec {
   pname = "pandas";
   version = "1.3.4";
+  format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
@@ -91,6 +92,8 @@ buildPythonPackage rec {
     "test_from_coo"
     # AssertionError: No common DType exists for the given inputs
     "test_comparison_invalid"
+    # AssertionError: Regex pattern '"quotechar" must be string, not int'
+    "python-kwargs2"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_locale"
     "test_clipboard"

--- a/pkgs/development/python-modules/potentials/default.nix
+++ b/pkgs/development/python-modules/potentials/default.nix
@@ -1,19 +1,21 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, ipywidgets
-, cdcs
 , bibtexparser
-, habanero
-, pandas
-, requests
-, numpy
-, matplotlib
-, unidecode
+, buildPythonPackage
+, cdcs
 , datamodeldict
-, xmltodict
+, fetchPypi
+, habanero
+, ipywidgets
+, lxml
+, matplotlib
+, numpy
+, pandas
 , pytestCheckHook
 , pythonOlder
+, requests
+, scipy
+, unidecode
+, xmltodict
 }:
 
 buildPythonPackage rec {
@@ -29,16 +31,18 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    ipywidgets
-    cdcs
     bibtexparser
+    cdcs
+    datamodeldict
     habanero
+    ipywidgets
+    lxml
+    matplotlib
+    numpy
     pandas
     requests
-    numpy
-    matplotlib
+    scipy
     unidecode
-    datamodeldict
     xmltodict
   ];
 

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "pyatv";
-  version = "0.9.6";
+  version = "0.9.7";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "postlund";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0navm7a0k1679kj7nbkbyl7s2q0wq0xmcnizmnvp0arkd5xqmqv1";
+    sha256 = "1ikv9m1348sjv31gch5w0sj97jlr4yjxbqfyds7alxxcm5hrhai4";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -21,8 +21,8 @@
 buildPythonPackage rec {
   pname = "pyatv";
   version = "0.9.6";
-
   format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchFromGitHub {
@@ -31,11 +31,6 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "0navm7a0k1679kj7nbkbyl7s2q0wq0xmcnizmnvp0arkd5xqmqv1";
   };
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "pytest-runner" ""
-  '';
 
   propagatedBuildInputs = [
     aiohttp
@@ -55,6 +50,18 @@ buildPythonPackage rec {
     pytest-asyncio
     pytest-timeout
     pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-runner" ""
+    # Remove all version pinning
+    sed -i -e "s/==[0-9.]*//" requirements/requirements.txt
+  '';
+
+  disabledTestPaths = [
+    # Test doesn't work in the sandbox
+    "tests/protocols/companion/test_companion_auth.py"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -36,6 +36,8 @@ buildPythonPackage rec {
     "test_rsync_report"
     "test_init_rsync_roots"
     "test_rsyncignore"
+    # flakey
+    "test_internal_errors_propagate_to_controller"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "requests-cache";
-  version = "0.9.0";
+  version = "0.9.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,8 @@ buildPythonPackage rec {
     owner = "reclosedev";
     repo = "requests-cache";
     rev = "v${version}";
-    sha256 = "0gz6fyc6lgbab9k92cihrp3711r1wcp4xhs25qp176zbzgccbj43";
+    sha256 = "sha256-MZ3N0zbo745erF52D6DqOEb4OPpXFwSsemi0z6Do02c=
+";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/requests-cache/default.nix
+++ b/pkgs/development/python-modules/requests-cache/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "requests-cache";
-  version = "0.8.1";
+  version = "0.9.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "reclosedev";
     repo = "requests-cache";
     rev = "v${version}";
-    sha256 = "sha256-HzOcPWmvUhqPtb/7Mnw6wWY7a4CwGRwPgq+7QoHJAc8=";
+    sha256 = "0gz6fyc6lgbab9k92cihrp3711r1wcp4xhs25qp176zbzgccbj43";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -111,6 +111,7 @@ buildPythonPackage rec {
     "test_custom_loop_asyncio"
     "test_custom_loop_asyncio_deferred_signal"
     "FileFeedStoragePreFeedOptionsTest"  # https://github.com/scrapy/scrapy/issues/5157
+    "test_timeout_download_from_spider_nodata_rcvd"
     # Fails with AssertionError
     "test_peek_fifo"
     "test_peek_one_element"

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -1,15 +1,19 @@
 { lib
 , buildPythonPackage
-, pythonOlder
 , fetchPypi
-, nose
-, pandas
 , matplotlib
+, pytestCheckHook
+, numpy
+, pandas
+, pythonOlder
+, scipy
 }:
 
 buildPythonPackage rec {
   pname = "seaborn";
   version = "0.11.2";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
@@ -17,16 +21,20 @@ buildPythonPackage rec {
     sha256 = "cf45e9286d40826864be0e3c066f98536982baf701a7caa386511792d61ff4f6";
   };
 
-  checkInputs = [ nose ];
-  propagatedBuildInputs = [ pandas matplotlib ];
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+    pandas
+    scipy
+  ];
 
-  checkPhase = ''
-    nosetests -v
-  '';
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # Computationally very demanding tests
-  doCheck = false;
-  pythonImportsCheck= [ "seaborn" ];
+  pythonImportsCheck= [
+    "seaborn"
+  ];
 
   meta = {
     description = "Statisitical data visualization";

--- a/pkgs/development/python-modules/surepy/default.nix
+++ b/pkgs/development/python-modules/surepy/default.nix
@@ -20,6 +20,7 @@ buildPythonPackage rec {
   pname = "surepy";
   version = "0.7.2";
   format = "pyproject";
+
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
@@ -31,8 +32,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'click = "^7.1.2"' 'click = "*"' \
-      --replace 'attrs = "^20.3.0"' 'attrs = "*"'
+      --replace 'aiohttp = {extras = ["speedups"], version = "^3.7.4"}' 'aiohttp = {extras = ["speedups"], version = ">=3.7.4"}' \
+      --replace 'async-timeout = "^3.0.1"' 'async-timeout = ">=3.0.1"'
   '';
 
   nativeBuildInputs = [
@@ -56,7 +57,9 @@ buildPythonPackage rec {
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [ "surepy" ];
+  pythonImportsCheck = [
+    "surepy"
+  ];
 
   meta = with lib; {
     description = "Python library to interact with the Sure Petcare API";

--- a/pkgs/development/python-modules/typed-ast/default.nix
+++ b/pkgs/development/python-modules/typed-ast/default.nix
@@ -1,12 +1,12 @@
 { buildPythonPackage, fetchFromGitHub, lib, pythonOlder, pytest }:
 buildPythonPackage rec {
   pname = "typed-ast";
-  version = "1.4.3";
+  version = "1.5.0";
   src = fetchFromGitHub {
     owner = "python";
     repo = "typed_ast";
     rev = version;
-    sha256 = "16mn9snwik5n2ib65sw2xcaqdm02j8ps21zgjxf8kyy7qnx2mx4w";
+    sha256 = "sha256-z3l5gMG1Jp6EI7SnGn5ABVXVBi+bK///iJBqEWn4d+s=";
   };
   # Only works with Python 3.3 and newer;
   disabled = pythonOlder "3.3";

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -882,6 +882,8 @@ in with py.pkgs; buildPythonApplication rec {
     # august/test_lock.py: AssertionError: assert 'unlocked' == 'locked' / assert 'off' == 'on'
     "test_lock_update_via_pubnub"
     "test_door_sense_update_via_pubnub"
+    # tests/helpers/test_event.py: flaky date/time issue
+    "test_periodic_task_entering_dst"
   ];
 
   preCheck = ''


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/164473.

I'm not sure when we move python interpreters in and out of the `sources` attrset, so we might need to correct some of these changes for 21.11.