### PR TITLE
[21.11] perlPackages.NetSSLeay: add patch fixing build on macos monterey

### DIFF
--- a/pkgs/development/perl-modules/net-ssleay-1.88-macos-monterey.patch
+++ b/pkgs/development/perl-modules/net-ssleay-1.88-macos-monterey.patch
@@ -1,0 +1,52 @@
+Based on upstream d7d89ce1965473da97b65fe0620c2ad49bd80839 and
+d798aac9af69e052ddb9c58a9bf3642d388abb90 adjusted to apply cleanly
+to NetSSLeay 1.88
+
+--- a/Makefile.PL
++++ b/Makefile.PL
+@@ -2,6 +2,7 @@ use 5.8.1;
+ 
+ use strict;
+ use warnings;
++use English qw( $OSNAME -no_match_vars );
+ use ExtUtils::MakeMaker;
+ use Config;
+ use File::Spec;
+@@ -33,6 +34,7 @@ my %eumm_args = (
+   VERSION_FROM => 'lib/Net/SSLeay.pm',
+   MIN_PERL_VERSION => '5.8.1',
+   CONFIGURE_REQUIRES => {
++    'English' => '0',
+     'ExtUtils::MakeMaker' => '0',
+   },
+   TEST_REQUIRES => {
+@@ -142,8 +144,27 @@ sub ssleay_get_build_opts {
+     for ("$prefix/include", "$prefix/inc32", '/usr/kerberos/include') {
+       push @{$opts->{inc_paths}}, $_ if -f "$_/openssl/ssl.h";
+     }
+-    for ($prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll") {
+-      push @{$opts->{lib_paths}}, $_ if -d $_;
++
++    # Directory order matters. With macOS Monterey a poisoned dylib is
++    # returned if the directory exists without the desired
++    # library. See GH-329 for more information. With Strawberry Perl
++    # 5.26 and later the paths must be in different order or the link
++    # phase fails.
++    my @try_lib_paths = (
++	["$prefix/lib64", "$prefix/lib", "$prefix/out32dll", $prefix] => sub {$OSNAME eq 'darwin' },
++	[$prefix, "$prefix/lib64", "$prefix/lib", "$prefix/out32dll"] => sub { 1 },
++	);
++
++    while (
++	!defined $opts->{lib_paths}
++	&& defined( my $dirs = shift @try_lib_paths )
++	&& defined( my $cond = shift @try_lib_paths )
++    ) {
++	if ( $cond->() ) {
++	    foreach my $dir (@{$dirs}) {
++		push @{$opts->{lib_paths}}, $dir if -d $dir;
++	    }
++	}
+     }
+ 
+     my $rsaref  = ssleay_is_rsaref();

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16685,7 +16685,8 @@ let
       url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.88.tar.gz";
       sha256 = "1pfgh4h3szcpvqlcimc60pjbk9zwls99x5863sva0wc47i4dl010";
     };
-    buildInputs = [ pkgs.openssl ];
+    patches = [ ../development/perl-modules/net-ssleay-1.88-macos-monterey.patch ];
+    buildInputs = [ pkgs.openssl pkgs.zlib ];
     doCheck = false; # Test performs network access.
     preConfigure = ''
       mkdir openssl


### PR DESCRIPTION
###### Description of changes
Fixes build of this package on macos monterey as in #160228 without bumping by applying only the relevant upstream fix.

See also #160258.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
