### PR TITLE
fetchurl: Allow passing curl options with spaces

### DIFF
--- a/pkgs/build-support/fetchurl/builder.sh
+++ b/pkgs/build-support/fetchurl/builder.sh
@@ -22,6 +22,8 @@ if ! [ -f "$SSL_CERT_FILE" ]; then
     curl+=(--insecure)
 fi
 
+eval "curl+=($curlOptsList)"
+
 curl+=(
     $curlOpts
     $NIX_CURL_FLAGS

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -45,7 +45,12 @@ in
   urls ? []
 
 , # Additional curl options needed for the download to succeed.
+  # Warning: Each space (no matter the escaping) will start a new argument.
+  # If you wish to pass arguments with spaces, use `curlOptsList`
   curlOpts ? ""
+
+, # Additional curl options needed for the download to succeed.
+  curlOptsList ? []
 
 , # Name of the file.  If empty, use the basename of `url' (or of the
   # first element of `urls').
@@ -148,7 +153,14 @@ stdenvNoCC.mkDerivation {
 
   outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
-  inherit curlOpts showURLs mirrorsFile postFetch downloadToTemp executable;
+  curlOpts = lib.warnIf (lib.isList curlOpts) ''
+    fetchurl for ${toString (builtins.head urls_)}: curlOpts is a list (${lib.generators.toPretty { multiline = false; } curlOpts}), which is not supported anymore.
+    - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
+      curlOpts = ${lib.strings.escapeNixString (toString curlOpts)};
+    - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
+      curlOptsList = [ ${lib.concatMapStringsSep " " lib.strings.escapeNixString curlOpts} ];'' curlOpts;
+  curlOptsList = lib.escapeShellArgs curlOptsList;
+  inherit showURLs mirrorsFile postFetch downloadToTemp executable;
 
   impureEnvVars = impureEnvVars ++ netrcImpureEnvVars;
 

--- a/pkgs/build-support/fetchurl/tests.nix
+++ b/pkgs/build-support/fetchurl/tests.nix
@@ -1,0 +1,13 @@
+{ invalidateFetcherByDrvHash, fetchurl, jq, moreutils, ... }: {
+  # Tests that we can send custom headers with spaces in them
+  header =
+    let headerValue = "Test '\" <- These are some quotes";
+    in invalidateFetcherByDrvHash fetchurl {
+      url = "https://httpbin.org/headers";
+      sha256 = builtins.hashString "sha256" (headerValue + "\n");
+      curlOptsList = [ "-H" "Hello: ${headerValue}" ];
+      postFetch = ''
+        ${jq}/bin/jq -r '.headers.Hello' $out | ${moreutils}/bin/sponge $out
+      '';
+    };
+}

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -85,7 +85,7 @@ let
         (lib.overrideDerivation
           (fetchurl {
             inherit name url sha256;
-            curlOpts = [
+            curlOptsList = [
               "--get"
               "--data-urlencode" "username@username"
               "--data-urlencode" "token@token"

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -27,6 +27,7 @@ with pkgs;
   cc-multilib-gcc = callPackage ./cc-wrapper/multilib.nix { stdenv = gccMultiStdenv; };
   cc-multilib-clang = callPackage ./cc-wrapper/multilib.nix { stdenv = clangMultiStdenv; };
 
+  fetchurl = callPackages ../build-support/fetchurl/tests.nix { };
   fetchpatch = callPackages ../build-support/fetchpatch/tests.nix { };
   fetchgit = callPackages ../build-support/fetchgit/tests.nix { };
   fetchFirefoxAddon = callPackages ../build-support/fetchfirefoxaddon/tests.nix { };


### PR DESCRIPTION
###### Description of changes
It previously was impossible to pass arguments with spaces with `curlOpts`. This commit makes it possible with

    curlOptsList = [ "-H" "Some: Header" ];

This is fully backwards compatible, because the behavior of `curlOpts` is maintained, though it now throws a warning if a list is passed to it.

Fixes https://github.com/NixOS/nixpkgs/issues/41820 and https://github.com/NixOS/nixpkgs/issues/90034

###### Things done

Tested with
```nix
let pkgs = import ./. {};
in pkgs.fetchurl {
  url = "https://httpbin.org/headers";
  sha256 = "0000000000000000000000000000000000000000000000000000";
  curlOptsList = [
    "-s"
    "-H"
    ''Hello: Test '" <- these are some quotes''
  ];
  postFetch = "${pkgs.jq}/bin/jq -r '.headers.Hello' $out";
}
```

which sets the `Hello` header using `-H`, and `curl`s some API that returns the sent HTTP headers as a JSON response, then prints the `Hello` header that was sent

```
this derivation will be built:
  /nix/store/0s6z6jq9riri601gjgkw1rawm2d1z8ci-headers.drv
Resolved derivation: '/nix/store/0s6z6jq9riri601gjgkw1rawm2d1z8ci-headers.drv' -> '/nix/store/hzyjjn9y9m93cq887kmryvcr6h820349-headers.drv'...
building '/nix/store/hzyjjn9y9m93cq887kmryvcr6h820349-headers.drv'...

trying https://httpbin.org/headers
Test '" <- these are some quotes
error: hash mismatch in fixed-output derivation '/nix/store/hzyjjn9y9m93cq887kmryvcr6h820349-headers.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-Ycaj2hgkcF36d9oI3gPTPqOubJjJkytN1p78cyaIVFM=
error: build of '/nix/store/0s6z6jq9riri601gjgkw1rawm2d1z8ci-headers.drv' failed
```

If you were to use `curlOpts` for this instead, this would be the error and behavior:

```
trace: warning: fetchurl for https://httpbin.org/headers: curlOpts is a list ([ "-s" "-H" "Hello: Test '\" <- these are some quotes" ]), which is not supported anymore.
- If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
  curlOpts = "-s -H Hello: Test '\" <- these are some quotes";
- If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
  curlOptsList = [ "-s" "-H" "Hello: Test '\" <- these are some quotes" ];
this derivation will be built:
  /nix/store/y491zn21n61hhpykkc2lqcgkk8vvalh8-headers.drv
Resolved derivation: '/nix/store/y491zn21n61hhpykkc2lqcgkk8vvalh8-headers.drv' -> '/nix/store/sdxfnfsgy8lggfy515qw2yg326r8g6a9-headers.drv'...
building '/nix/store/sdxfnfsgy8lggfy515qw2yg326r8g6a9-headers.drv'...
error checking the existence of https://tarballs.nixos.org/sha256/0000000000000000000000000000000000000000000000000000:
curl: (6) Could not resolve host: Test
curl: (6) Could not resolve host: '"
curl: (6) Could not resolve host: <-
curl: (6) Could not resolve host: these
curl: (6) Could not resolve host: are
curl: (6) Could not resolve host: some
curl: (6) Could not resolve host: quotes
curl: (22) The requested URL returned error: 404
```