### PR TITLE
am2r: init

### DIFF
--- a/pkgs/games/am2r/default.nix
+++ b/pkgs/games/am2r/default.nix
@@ -1,0 +1,127 @@
+{ lib
+, stdenv
+, fetchzip
+, requireFile
+, autoPatchelfHook
+, copyDesktopItems
+, makeDesktopItem
+, xdelta
+
+, openssl_1_0_2
+, openalSoft
+, libXxf86vm
+, libglvnd
+, libXrandr
+, libGLU
+, curl
+, jstest-gtk
+
+, hqMusic ? true
+, modifiersIni ? null
+
+, patchPath ? null # Must point to the data folder
+, pname ? "am2r"
+, desktopName ? "AM2R"
+, version ? "1.5.5"
+, meta ? with lib; {
+    description = "Another Metroid 2 Remake (Community Edition)";
+    longDescription = "Another Metroid 2 Remake is an unofficial fan remake of Metroid II: Return of Samus, with community patches";
+    homepage = "https://github.com/AM2R-Community-Developers/AM2RLauncher";
+    changelog = "https://am2r-community-developers.github.io/DistributionCenter/changelog.html";
+    # Incredibly unsure if it's the license I should use
+    license = licenses.gpl3; # https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux/blob/master/LICENSE
+    maintainers = [ maintainers.martfont ];
+    platforms = platforms.linux;
+    hydraPlatforms = [];
+    broken = true; # The executable segfaults
+  }
+}:
+
+stdenv.mkDerivation rec {
+  inherit pname version meta;
+  # Maybe this should make the derivation unfree...
+  src = requireFile rec {
+    name = "AM2R_11";
+    hashMode = "recursive";
+    sha256 = "0hbh9cqals6f97vxkv2fmqv1irysld2ipg4v1yal0fk9jv47qyx1";
+    message = ''
+      Due to Nintendo's DMCA takedown, we cannot download the original AM2R 1.1 zip automatically.
+      Please retrieve the original file yourself, extract the contents to a folder named ${name},
+      and add it to the Nix store using
+        nix-store --add-fixed --recursive sha256 ${name}
+    '';
+  };
+  communityPatch = fetchzip {
+    url = "https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux/releases/download/Patchdata-v25/PatchData-V25.zip";
+    sha256 = "sha256-7ReVBKDruJ0mPkciOAaMJPG/H7ky1Xdd6g7O3bUFaY0=";
+  } + "/data";
+
+  # https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux/blob/master/README.md#arch-including-manjaro-endeavouros-rebornos-etc-1
+  buildInputs = [
+    openssl_1_0_2
+    openalSoft
+    libXxf86vm
+    libglvnd
+    libXrandr
+    libGLU
+    curl
+    jstest-gtk
+  ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+    xdelta
+    copyDesktopItems
+  ];
+  # For some reason it doesn't appear in the application list.
+  desktopItems = lib.singleton (makeDesktopItem {
+    inherit desktopName;
+    name = pname;
+    exec = pname;
+    icon = "icon";
+    type = "Application";
+    categories = [ "Game" ];
+    comment = meta.description;
+  });
+
+  patch = if patchPath != null then patchPath else communityPatch;
+
+  # https://github.com/AM2R-Community-Developers/AM2RLauncher/blob/main/AM2RLauncher/AM2RLauncherCore/Profile.cs#L323
+  buildPhase = ''
+    mkdir -p $out/bin
+    xdelta3 -d -s $src/data.win $patch/game.xdelta $out/bin/game.unx
+    xdelta3 -d -s $src/AM2R.exe $patch/AM2R.xdelta $out/bin/${pname}
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    cp -r $src $out/bin/assets/
+    chmod a+w -R $out/bin/assets
+    cp -r $patch/files_to_copy/. $out/bin/assets/
+
+    mkdir -p $out/share/icons/hicolor/72x72/apps
+    mv $out/bin/assets/icon.png $out/share/icons/hicolor/72x72/apps/
+
+    rm $out/bin/assets/{D3DX9_43.dll,AM2R.exe,data.win}
+
+    runHook postInstall
+  ''
+  # Extract high quality music from the community patch if it's not in the selected patch
+  + lib.optionalString hqMusic (let hqMusicSource =
+      if builtins.pathExists (patch + "/HDR_HQ_in-game_music") then patch else communityPatch;
+    in ''
+      cp -rf ${hqMusicSource}/HDR_HQ_in-game_music/. $out/bin/assets
+    ''
+    )
+  + ''
+    # Rename music to lowercase
+    for file in $out/bin/assets/*.ogg; do
+      mv -f $file $(echo $file | tr '[:upper:]' '[:lower:]') || true
+    done
+  '' + lib.optionalString (modifiersIni != null) ''
+    cp -f $modifiersIni $out/bin/assets/modifiers.ini
+  '';
+
+  postFixup = ''
+    chmod a+x $out/bin/${pname}
+  '';
+}

--- a/pkgs/games/am2r/multitroid.nix
+++ b/pkgs/games/am2r/multitroid.nix
@@ -1,0 +1,47 @@
+{ lib, fetchzip, callPackage_i686, stdenv }:
+
+callPackage_i686 ./. {
+  patchPath = fetchzip {
+    url = "https://github.com/milesthenerd/AM2R-Multitroid/releases/download/v1.4.2/Multitroid_1.4.2_lin.zip";
+    sha256 = "sha256-cgF/JvzmxQebjlooWAG0z8PHexLtZrwDArlYov6xq+4=";
+    stripRoot = false;
+  };
+  pname = "am2r-multitroid";
+  desktopName = "AM2R Multitroid";
+  version = "1.4.2";
+  meta = with lib; {
+    description = "Multiplayer mod for AM2R";
+    homepage = "https://github.com/milesthenerd/AM2R-Multitroid";
+    # Maybe wrong, I don't know whater the same link applies (https://github.com/AM2R-Community-Developers/AM2R-Autopatcher-Linux/blob/master/LICENSE)
+    # Maybe this is the one that applies: https://github.com/milesthenerd/AM2R-Multitroid/blob/main/LICENSE
+    license = licenses.gpl3;
+    maintainers = [ maintainers.martfont ];
+    platforms = platforms.linux;
+    hydraPlatforms = [];
+    # It can execute, but for reason it doesn't detect game.unx
+    # if you are not on the same folder (it didn't do this before...).
+    broken = true; 
+  };
+}
+
+/*stdenv.mkDerivation {
+  pname = "am2r-multitroid-server";
+  version = "1.4.2";
+  src = fetchzip {
+    url = "https://github.com/milesthenerd/AM2R-Server/releases/download/v1.4.2/AM2R_Server_1.4.2_lin.zip";
+    sha256 = "c8376740d89130ea2df79064f484a181e58e9f798e5effe9d989aa45103d3afe";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r $src $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/milesthenerd/AM2R-Server";
+    license = licenses.mit;
+    maintainers = [ maintainers.martfont ];
+    platforms = platforms.linux;
+  };
+}*/

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30716,6 +30716,9 @@ with pkgs;
 
   ace-of-penguins = callPackage ../games/ace-of-penguins { };
 
+  am2r = callPackage_i686 ../games/am2r { };
+  am2r-multitroid = callPackage_i686 ../games/am2r/multitroid.nix { };
+
   among-sus = callPackage ../games/among-sus { };
 
   antsimulator = callPackage ../games/antsimulator { };


### PR DESCRIPTION
###### Description of changes

This is a failed attempt to package AM2R, the unofficial remake of Metroid II: Return of Samus, with community patches that also allow it to run on Linux.
The patch is supposed to be applied with [AM2R Launcher](https://github.com/AM2R-Community-Developers/AM2RLauncher/releases), which gives the result as an AppImage, a format that isn't very NixOS friendly, which is why I thought it was a good idea to make this package. I should have probably packaged the launcher instead... (and patch [this line](https://github.com/AM2R-Community-Developers/AM2RLauncher/blob/3e051adcbf1a2191c8d895b10307c60d8deaa40a/AM2RLauncher/AM2RLauncher/MainForm/MainForm.Methods.cs#L393))

Anyway, the result is unsatisfying, with the executable segfaulting for no reason. There is more than one possible patch though, and by using Multitroid instead the executable does open... but only if you are on the same folder (it didn't do this before, why?). Still, it is playable, so it is sort of a success?

I've lost my will to work on this, and I'm going to close the PR because the end result, while kind of usable, is too inconvenient to use. However, it may be useful to someone.