### PR TITLE
treewide: dont set dotnet env vars in update scripts

### DIFF
--- a/pkgs/applications/blockchains/nbxplorer/util/create-deps.sh
+++ b/pkgs/applications/blockchains/nbxplorer/util/create-deps.sh
@@ -20,7 +20,7 @@ chmod -R +w "$tmpdir"
 pushd "$tmpdir" > /dev/null
 mkdir home
 echo "Running dotnet restore for $sln"
-HOME=home DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+HOME=home \
   dotnet restore $customFlags -v normal --no-cache "$sln" > restore_log
 
 echo "{ fetchNuGet }: [" > "$depsFile"

--- a/pkgs/applications/emulators/ryujinx/updater.sh
+++ b/pkgs/applications/emulators/ryujinx/updater.sh
@@ -51,7 +51,7 @@ chmod -R +w "$SRC"
 pushd "$SRC"
 
 mkdir nuget_tmp.packages
-DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet restore Ryujinx.sln --packages nuget_tmp.packages
+dotnet restore Ryujinx.sln --packages nuget_tmp.packages
 
 nuget-to-nix ./nuget_tmp.packages >"$DEPS_FILE"
 

--- a/pkgs/applications/misc/ArchiSteamFarm/updater.sh
+++ b/pkgs/applications/misc/ArchiSteamFarm/updater.sh
@@ -23,9 +23,6 @@ chmod -R +w "$src"
 
 pushd "$src"
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 for i in $platforms; do
   nix-shell -p dotnet-sdk_6 --argstr system $i --run "
      mkdir ./nuget_pkgs-$i

--- a/pkgs/development/dotnet-modules/python-language-server/updater.sh
+++ b/pkgs/development/dotnet-modules/python-language-server/updater.sh
@@ -28,9 +28,6 @@ chmod -R +w "$src"
 
 pushd "$src"
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 mkdir ./nuget_pkgs
 dotnet restore src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj --packages ./nuget_pkgs
 

--- a/pkgs/games/osu-lazer/update.sh
+++ b/pkgs/games/osu-lazer/update.sh
@@ -22,9 +22,6 @@ chmod -R +w "$src"
 
 pushd "$src"
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 mkdir ./nuget_tmp.packages
 dotnet restore osu.Desktop --packages ./nuget_tmp.packages --runtime linux-x64
 

--- a/pkgs/servers/jackett/updater.sh
+++ b/pkgs/servers/jackett/updater.sh
@@ -22,9 +22,6 @@ chmod -R +w "$src"
 
 pushd "$src"
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 mkdir ./nuget_pkgs
 
 for project in src/Jackett.Server/Jackett.Server.csproj src/Jackett.Test/Jackett.Test.csproj; do

--- a/pkgs/servers/jellyfin/update.sh
+++ b/pkgs/servers/jellyfin/update.sh
@@ -3,9 +3,6 @@
 
 set -euo pipefail
 
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_NOLOGO=1
-
 latestVersion="$(curl -s "https://api.github.com/repos/jellyfin/jellyfin/releases?per_page=1" | jq -r ".[0].tag_name" | sed 's/^v//')"
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; jellyfin.version or (lib.getVersion jellyfin)" | tr -d '"')
 

--- a/pkgs/servers/web-apps/baget/updater.sh
+++ b/pkgs/servers/web-apps/baget/updater.sh
@@ -31,9 +31,6 @@ chmod -R +w "$src"
 
 pushd "$src"
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 mkdir ./nuget_pkgs
 dotnet restore src/BaGet/BaGet.csproj --packages ./nuget_pkgs
 

--- a/pkgs/tools/X11/opentabletdriver/update.sh
+++ b/pkgs/tools/X11/opentabletdriver/update.sh
@@ -31,9 +31,6 @@ chmod -R +w "$src"
 pushd "$src"
 trap "rm -rf $src" EXIT
 
-export DOTNET_NOLOGO=1
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-
 mkdir ./nuget_pkgs
 for project in OpenTabletDriver.{Console,Daemon,UX.Gtk,Tests}; do
   dotnet restore $project --packages ./nuget_pkgs


### PR DESCRIPTION

###### Description of changes
These already get set in dotnets setup hook. See also #162771.

cc @06kellyjac @SuperSandro2000 would you mind reviewing this PR as well?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
