### PR TITLE
[gnome] Pantheon: drop dark style preference patch part 2

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -302,7 +302,6 @@ in
       environment.systemPackages = with pkgs.pantheon; [
         contractor
         file-roller-contract
-        gnome-bluetooth-contract
       ];
 
       environment.pathsToLink = [

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -220,7 +220,6 @@ in
       ] config.environment.pantheon.excludePackages);
 
       programs.evince.enable = mkDefault true;
-      programs.evince.package = pkgs.pantheon.evince;
       programs.file-roller.enable = mkDefault true;
 
       # Settings from elementary-default-settings

--- a/pkgs/desktops/gnome/core/evince/default.nix
+++ b/pkgs/desktops/gnome/core/evince/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -32,7 +31,6 @@
 , gsettings-desktop-schemas
 , gnome-desktop
 , dbus
-, pantheon
 , python3
 , texlive
 , gst_all_1
@@ -40,7 +38,6 @@
 , supportMultimedia ? true # PDF multimedia
 , libgxps
 , supportXPS ? true # Open XML Paper Specification via libgxps
-, withPantheon ? false
 , withLibsecret ? true
 }:
 
@@ -54,16 +51,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/evince/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "XtLiXcPrxbJDdNgyVlTBICcDg5A42GANUWk52JJjte8=";
   };
-
-  patches = lib.optionals withPantheon [
-    # Make this respect dark mode settings from Pantheon
-    # https://github.com/elementary/evince/pull/21
-    # https://github.com/elementary/evince/pull/31
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/elementary/evince/c8364019ee2c2dffd2a1bccf79b8f4e526aa22af/dark-style.patch";
-      sha256 = "sha256-nKELRXnM6gMRTGmWdO1Qqlo9ciy+4HOK5z2CYOoi2Lo=";
-    })
-  ];
 
   postPatch = ''
     chmod +x meson_post_install.py
@@ -115,9 +102,7 @@ stdenv.mkDerivation rec {
     gst-plugins-bad
     gst-plugins-ugly
     gst-libav
-  ]) ++ lib.optionals withPantheon [
-    pantheon.granite
-  ];
+  ]);
 
   mesonFlags = [
     "-Dnautilus=false"

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -136,7 +136,7 @@ let self = stdenv.mkDerivation rec {
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
   passthru = {
-    libdir = "${self}/lib/mutter-9";
+    libdir = "${self}/lib/mutter-10";
 
     tests = {
       libdirExists = runCommand "mutter-libdir-exists" {} ''

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -83,8 +83,6 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   epiphany = pkgs.epiphany.override { withPantheon = true; };
 
-  evince = pkgs.evince.override { withPantheon = true; };
-
   sideload = callPackage ./apps/sideload { };
 
   #### DESKTOP
@@ -239,6 +237,8 @@ lib.makeScope pkgs.newScope (self: with self; {
   cerbere = throw "Cerbere is now obsolete https://github.com/elementary/cerbere/releases/tag/2.5.1."; # added 2020-04-06
 
   elementary-screenshot-tool = throw "The ‘pantheon.elementary-screenshot-tool’ alias was removed on 2022-02-02, please use ‘pantheon.elementary-screenshot’ directly."; # added 2021-07-21
+
+  evince = pkgs.gnome.evince; # added 2022-03-18
 
   extra-elementary-contracts = throw "extra-elementary-contracts has been removed as all contracts have been upstreamed."; # added 2021-12-01
 

--- a/pkgs/desktops/pantheon/desktop/gnome-bluetooth-contract/default.nix
+++ b/pkgs/desktops/pantheon/desktop/gnome-bluetooth-contract/default.nix
@@ -49,5 +49,8 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = teams.pantheon.members;
     platforms = platforms.linux;
+    # sendto device selection is removed in gnome-bluetooth 42
+    # https://github.com/elementary/gnome-bluetooth-contract/issues/1
+    broken = true;
   };
 }


### PR DESCRIPTION
###### Description of changes

For evince, this is a follow-up of #163828, the previous patch actually still applies but makes no sense to keep it anymore.

For https://github.com/NixOS/nixpkgs/pull/160343#issuecomment-1047582728, I think I will just disable the contract (and ask users to fork [worldofpeace/extra-elementary-contracts](https://github.com/worldofpeace/extra-elementary-contracts) and make one for blueman??? :thinking: ), anyway I expect it is also broken in elementary OS 7...

Also sneak in a nitpick for mutter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (evince)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
