### PR TITLE
pytorch-bin: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/coqui-trainer/default.nix
+++ b/pkgs/development/python-modules/coqui-trainer/default.nix
@@ -1,15 +1,16 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchFromGitHub
+, pythonAtLeast
 
 , coqpit
 , fsspec
-, pytorch
+, pytorch-bin
 
 , pytestCheckHook
 , soundfile
-, tensorboardx
-, torchvision
+, torchvision-bin
 }:
 
 let
@@ -20,6 +21,8 @@ buildPythonPackage {
   inherit pname version;
   format = "pyproject";
 
+  disabled = pythonAtLeast "3.10"; # https://github.com/coqui-ai/Trainer/issues/22
+
   src = fetchFromGitHub {
     owner = "coqui-ai";
     repo = "Trainer";
@@ -27,12 +30,18 @@ buildPythonPackage {
     hash = "sha256-NsgCh+N2qWmRkTOjXqisVCP5aInH2zcNz6lsnIfVLiY=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/coqui-ai/Trainer/commit/07b447abf3290c8f2e5e723687b8a480b7382265.patch";
+      sha256 = "0v1hl784d9rghkblcfwgzp0gg9d6r5r0yv2kapzdz2qymiajy7y2";
+    })
+  ];
+
   propagatedBuildInputs = [
     coqpit
     fsspec
-    pytorch
+    pytorch-bin
     soundfile
-    tensorboardx
   ];
 
   # only one test and that requires training data from the internet
@@ -40,7 +49,7 @@ buildPythonPackage {
 
   checkInputs = [
     pytestCheckHook
-    torchvision
+    torchvision-bin
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pytorch/bin.nix
+++ b/pkgs/development/python-modules/pytorch/bin.nix
@@ -4,6 +4,7 @@
 , isPy37
 , isPy38
 , isPy39
+, isPy310
 , python
 , addOpenGLRunpath
 , future
@@ -19,7 +20,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "1.10.0";
+  version = "1.11.0";
 in buildPythonPackage {
   inherit version;
 
@@ -28,7 +29,7 @@ in buildPythonPackage {
 
   format = "wheel";
 
-  disabled = !(isPy37 || isPy38 || isPy39);
+  disabled = !(isPy37 || isPy38 || isPy39 || isPy310);
 
   src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
 

--- a/pkgs/development/python-modules/pytorch/binary-hashes.nix
+++ b/pkgs/development/python-modules/pytorch/binary-hashes.nix
@@ -6,46 +6,61 @@
 # To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
 
 version : builtins.getAttr version {
-  "1.10.0" = {
+  "1.11.0" = {
     x86_64-linux-37 = {
-      name = "torch-1.10.0-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-KpDbklee2HXSqgrWr1U1nj8EJqUjBWp7SbACw8xtKtg=";
+      name = "torch-1.11.0-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-9WMzRw2uo8lweLN2B+ADXMz3L8XDb9hFRuGkuNmUTys=";
     };
     x86_64-linux-38 = {
-      name = "torch-1.10.0-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-zM3cMriUG9A+3in/ChzOLytRETpe4ju4uXkxasIRQYM=";
+      name = "torch-1.11.0-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-tqeZvbbuPZFOXmK920J21KECSMGvTy0hdzjl+e4nSFs=";
     };
     x86_64-linux-39 = {
-      name = "torch-1.10.0-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torch-1.10.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-w8UJDh4b5cgDu7ZSvDoKzNH4hiXEyRfvpycNOg+wJOg=";
+      name = "torch-1.11.0-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-6RJrCl2VcEvuQKnQ7xy9gtjceGPkY4o3a+9wLf1lk3A=";
+    };
+    x86_64-linux-310 = {
+      name = "torch-1.11.0-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-powzZXpUYTHrm8ROKpjS+nBKr66GFGCwUbgoE4Usy0Q=";
     };
     x86_64-darwin-37 = {
-      name = "torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp37-none-macosx_10_9_x86_64.whl";
-      hash = "sha256-RJkFVUcIfX736KdU8JwsTxRwKXrj5UkDY9umbHVQGyE=";
+      name = "torch-1.11.0-cp37-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp37-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-aGCx0b8LsLZ6a9R/haDkyCW1GO6hO11hAZmdu8vVvAw=";
     };
     x86_64-darwin-38 = {
-      name = "torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_10_9_x86_64.whl";
-      hash = "sha256-rvevti6bF0tODl4eSkLjurO4SQpmjWZvYvfUUXVZ+/I=";
+      name = "torch-1.11.0-cp38-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp38-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-DMyFzQYiej7fgJ4seV/Vdiw9Too4tcn3RMbnz4QTYbs=";
     };
     x86_64-darwin-39 = {
-      name = "torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp39-none-macosx_10_9_x86_64.whl";
-      hash = "sha256-1u+HRwtE35lw6EVCVH1bp3ILuJYWYCRB31VaObEk4rw=";
+      name = "torch-1.11.0-cp39-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp39-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-UP2b+FxXjIccKPHLCs6d/GAkQBx/OZsXT7DzcImfRFQ=";
+    };
+    x86_64-darwin-310 = {
+      name = "torch-1.11.0-cp310-none-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp39-none-macosx_10_9_x86_64.whl";
+      hash = "sha256-UP2b+FxXjIccKPHLCs6d/GAkQBx/OZsXT7DzcImfRFQ=";
     };
     aarch64-darwin-38 = {
-      name = "torch-1.10.0-cp38-none-macosx_11_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp38-none-macosx_11_0_arm64.whl";
-      hash = "sha256-1hhYJ7KFeAZTzdgdd6Cf3KdqWxkNWYbVUr4qXEQs+qQ=";
+      name = "torch-1.11.0-cp38-none-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp38-none-macosx_11_0_arm64.whl";
+      hash = "sha256-wVVOSddPGyw+cgLXcFa6LddGVDdYW6xkBitYD3FKROk=";
     };
     aarch64-darwin-39 = {
-      name = "torch-1.10.0-cp39-none-macosx_11_0_arm64.whl";
-      url = "https://download.pytorch.org/whl/cpu/torch-1.10.0-cp39-none-macosx_11_0_arm64.whl";
-      hash = "sha256-7qZ17AHsS0oGVf0phPFmpco7kz2uatTrTlLrpwJtwXY=";
+      name = "torch-1.11.0-cp39-none-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp39-none-macosx_11_0_arm64.whl";
+      hash = "sha256-DkivZq11Xw+cXyZkAopBT1fEnWrcN+d+Bv4ABNpO22E=";
+    };
+    aarch64-darwin-310 = {
+      name = "torch-1.11.0-cp310-none-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/cpu/torch-1.11.0-cp39-none-macosx_11_0_arm64.whl";
+      hash = "sha256-DkivZq11Xw+cXyZkAopBT1fEnWrcN+d+Bv4ABNpO22E=";
     };
   };
 }

--- a/pkgs/development/python-modules/pytorch/prefetch.sh
+++ b/pkgs/development/python-modules/pytorch/prefetch.sh
@@ -5,12 +5,21 @@ set -eou pipefail
 
 version=$1
 
-bucket="https://download.pytorch.org/whl/cu113"
+linux_bucket="https://download.pytorch.org/whl/cu113"
+darwin_bucket="https://download.pytorch.org/whl/cpu"
 
 url_and_key_list=(
-  "x86_64-linux-37 $bucket/torch-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torch-${version}-cp37-cp37m-linux_x86_64.whl"
-  "x86_64-linux-38 $bucket/torch-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torch-${version}-cp38-cp38-linux_x86_64.whl"
-  "x86_64-linux-39 $bucket/torch-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torch-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-37 $linux_bucket/torch-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torch-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $linux_bucket/torch-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torch-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $linux_bucket/torch-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torch-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-310 $linux_bucket/torch-${version}%2Bcu113-cp310-cp310-linux_x86_64.whl torch-${version}-cp310-cp310-linux_x86_64.whl"
+  "x86_64-darwin-37 $darwin_bucket/torch-${version}-cp37-none-macosx_10_9_x86_64.whl torch-${version}-cp37-none-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-38 $darwin_bucket/torch-${version}-cp38-none-macosx_10_9_x86_64.whl torch-${version}-cp38-none-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-39 $darwin_bucket/torch-${version}-cp39-none-macosx_10_9_x86_64.whl torch-${version}-cp39-none-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-310 $darwin_bucket/torch-${version}-cp310-none-macosx_10_9_x86_64.whl torch-${version}-cp310-none-macosx_10_9_x86_64.whl"
+  "aarch64-darwin-38 $darwin_bucket/torch-${version}-cp38-none-macosx_11_0_arm64.whl torch-${version}-cp38-none-macosx_11_0_arm64.whl"
+  "aarch64-darwin-39 $darwin_bucket/torch-${version}-cp39-none-macosx_11_0_arm64.whl torch-${version}-cp39-none-macosx_11_0_arm64.whl"
+  "aarch64-darwin-310 $darwin_bucket/torch-${version}-cp310-none-macosx_11_0_arm64.whl torch-${version}-cp310-none-macosx_11_0_arm64.whl"
 )
 
 hashfile="binary-hashes-$version.nix"

--- a/pkgs/development/python-modules/torchaudio/bin.nix
+++ b/pkgs/development/python-modules/torchaudio/bin.nix
@@ -2,6 +2,10 @@
 , stdenv
 , buildPythonPackage
 , fetchurl
+, isPy37
+, isPy38
+, isPy39
+, isPy310
 , python
 , pytorch-bin
 , pythonOlder
@@ -10,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "torchaudio";
-  version = "0.10.0";
+  version = "0.11.0";
   format = "wheel";
 
   src =
@@ -19,7 +23,7 @@ buildPythonPackage rec {
         srcs = (import ./binary-hashes.nix version)."${stdenv.system}-${pyVerNoDot}" or unsupported;
     in fetchurl srcs;
 
-  disabled = ! (pythonAtLeast "3.7" && pythonOlder "3.10");
+  disabled = !(isPy37 || isPy38 || isPy39 || isPy310);
 
   propagatedBuildInputs = [
     pytorch-bin

--- a/pkgs/development/python-modules/torchaudio/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchaudio/binary-hashes.nix
@@ -6,21 +6,61 @@
 # To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
 
 version : builtins.getAttr version {
-  "0.10.0" = {
+  "0.11.0" = {
     x86_64-linux-37 = {
-      name = "torchaudio-0.10.0-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-FspXTTODdkO0nPUJcJm8+vLIvckUa8gRfBPBT9LcKPw=";
+      name = "torchaudio-0.11.0-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.11.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-AdqgntXh2rTD7rBePshFAQ2tVl7b+734wG4r471/Y2U=";
     };
     x86_64-linux-38 = {
-      name = "torchaudio-0.10.0-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-Mf7QdXBSIIWRfT7ACthEwFA1V2ieid8legbMnRQnzqI=";
+      name = "torchaudio-0.11.0-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-zuCHDpz3bkOUjYWprqX9VXoUbXfR8Vhdf1VFfOUg8z4=";
     };
     x86_64-linux-39 = {
-      name = "torchaudio-0.10.0-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.10.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-LMSGNdmku1iHRy1jCRTTOYcQlRL+Oc9jjZC1nx++skA=";
+      name = "torchaudio-0.11.0-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.11.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-btI9TpsOjeLnIz6J56avNv4poJTpXjjhDbMy6+ZFQvI=";
+    };
+    x86_64-linux-310 = {
+      name = "torchaudio-0.11.0-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchaudio-0.11.0%2Bcu113-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-Zk+AWytEXfJ+HM69BAPhVsvN6pgQwC6uaW7Xux2row4=";
+    };
+    x86_64-darwin-37 = {
+      name = "torchaudio-0.11.0-cp37-cp37m-macosx_10_15_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp37-cp37m-macosx_10_15_x86_64.whl";
+      hash = "sha256-uaTT4athEWHAZe0hBoBIM/9LhfZNhAIexZBGg2MWn50=";
+    };
+    x86_64-darwin-38 = {
+      name = "torchaudio-0.11.0-cp38-cp38-macosx_10_15_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp38-cp38-macosx_10_15_x86_64.whl";
+      hash = "sha256-9OndqejTzgu9XnkZJiGfUFS4uFNlx5vi7pAzOs+a2/w=";
+    };
+    x86_64-darwin-39 = {
+      name = "torchaudio-0.11.0-cp39-cp39-macosx_10_15_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp39-cp39-macosx_10_15_x86_64.whl";
+      hash = "sha256-cNi8B/J3YI0jqaoI2z+68DVmAlS8EtmzYWQMRVZ3dVk=";
+    };
+    x86_64-darwin-310 = {
+      name = "torchaudio-0.11.0-cp310-cp310-macosx_10_15_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp310-cp310-macosx_10_15_x86_64.whl";
+      hash = "sha256-g2Pj2wqK9YIP19O/g5agryPcgiHJqdS2Di44mAVJKUQ=";
+    };
+    aarch64-darwin-38 = {
+      name = "torchaudio-0.11.0-cp38-cp38-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp38-cp38-macosx_11_0_arm64.whl";
+      hash = "sha256-MX/Y7Dn92zrx2tkGWTuezcPt9o5/V4DEL43pVlha5IA=";
+    };
+    aarch64-darwin-39 = {
+      name = "torchaudio-0.11.0-cp39-cp39-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp39-cp39-macosx_11_0_arm64.whl";
+      hash = "sha256-5eVRP83VeHAGGWW++/B2V4eyX0mcPgC1j02ETkQYMXc=";
+    };
+    aarch64-darwin-310 = {
+      name = "torchaudio-0.11.0-cp310-cp310-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchaudio-0.11.0-cp310-cp310-macosx_11_0_arm64.whl";
+      hash = "sha256-06OyzOuV8E7ZNtozvFO9Zm2rBxWnnbM65HGYUiQdwtI=";
     };
   };
 }

--- a/pkgs/development/python-modules/torchaudio/prefetch.sh
+++ b/pkgs/development/python-modules/torchaudio/prefetch.sh
@@ -5,12 +5,21 @@ set -eou pipefail
 
 version=$1
 
-bucket="https://download.pytorch.org/whl/cu113"
+linux_bucket="https://download.pytorch.org/whl/cu113"
+darwin_bucket="https://download.pytorch.org/whl"
 
 url_and_key_list=(
-  "x86_64-linux-37 $bucket/torchaudio-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchaudio-${version}-cp37-cp37m-linux_x86_64.whl"
-  "x86_64-linux-38 $bucket/torchaudio-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchaudio-${version}-cp38-cp38-linux_x86_64.whl"
-  "x86_64-linux-39 $bucket/torchaudio-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchaudio-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-37 $linux_bucket/torchaudio-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchaudio-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $linux_bucket/torchaudio-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchaudio-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $linux_bucket/torchaudio-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchaudio-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-310 $linux_bucket/torchaudio-${version}%2Bcu113-cp310-cp310-linux_x86_64.whl torchaudio-${version}-cp310-cp310-linux_x86_64.whl"
+  "x86_64-darwin-37 $darwin_bucket/torchaudio-${version}-cp37-cp37m-macosx_10_15_x86_64.whl torchaudio-${version}-cp37-cp37m-macosx_10_15_x86_64.whl"
+  "x86_64-darwin-38 $darwin_bucket/torchaudio-${version}-cp38-cp38-macosx_10_15_x86_64.whl torchaudio-${version}-cp38-cp38-macosx_10_15_x86_64.whl"
+  "x86_64-darwin-39 $darwin_bucket/torchaudio-${version}-cp39-cp39-macosx_10_15_x86_64.whl torchaudio-${version}-cp39-cp39-macosx_10_15_x86_64.whl"
+  "x86_64-darwin-310 $darwin_bucket/torchaudio-${version}-cp310-cp310-macosx_10_15_x86_64.whl torchaudio-${version}-cp310-cp310-macosx_10_15_x86_64.whl"
+  "aarch64-darwin-38 $darwin_bucket/torchaudio-${version}-cp38-cp38-macosx_11_0_arm64.whl torchaudio-${version}-cp38-cp38-macosx_11_0_arm64.whl"
+  "aarch64-darwin-39 $darwin_bucket/torchaudio-${version}-cp39-cp39-macosx_11_0_arm64.whl torchaudio-${version}-cp39-cp39-macosx_11_0_arm64.whl"
+  "aarch64-darwin-310 $darwin_bucket/torchaudio-${version}-cp310-cp310-macosx_11_0_arm64.whl torchaudio-${version}-cp310-cp310-macosx_11_0_arm64.whl"
 )
 
 hashfile=binary-hashes-"$version".nix

--- a/pkgs/development/python-modules/torchvision/bin.nix
+++ b/pkgs/development/python-modules/torchvision/bin.nix
@@ -5,6 +5,7 @@
 , isPy37
 , isPy38
 , isPy39
+, isPy310
 , patchelf
 , pillow
 , python
@@ -15,7 +16,7 @@ let
   pyVerNoDot = builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
   srcs = import ./binary-hashes.nix version;
   unsupported = throw "Unsupported system";
-  version = "0.11.1";
+  version = "0.12.0";
 in buildPythonPackage {
   inherit version;
 
@@ -25,7 +26,7 @@ in buildPythonPackage {
 
   src = fetchurl srcs."${stdenv.system}-${pyVerNoDot}" or unsupported;
 
-  disabled = !(isPy37 || isPy38 || isPy39);
+  disabled = !(isPy37 || isPy38 || isPy39 || isPy310);
 
   nativeBuildInputs = [
     patchelf

--- a/pkgs/development/python-modules/torchvision/binary-hashes.nix
+++ b/pkgs/development/python-modules/torchvision/binary-hashes.nix
@@ -6,21 +6,61 @@
 # To add a new version, run "prefetch.sh 'new-version'" to paste the generated file as follows.
 
 version : builtins.getAttr version {
-  "0.11.1" = {
+  "0.12.0" = {
     x86_64-linux-37 = {
-      name = "torchvision-0.11.1-cp37-cp37m-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp37-cp37m-linux_x86_64.whl";
-      hash = "sha256-2xKWqWNKqmOMyVJnPfbtF+B9PQ7z4S66J1T3P8EvM0I=";
+      name = "torchvision-0.12.0-cp37-cp37m-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp37-cp37m-linux_x86_64.whl";
+      hash = "sha256-i/qktZT+5HQYQjtTHtxOV751DcsP9AHMsSV9/svsGzA=";
     };
     x86_64-linux-38 = {
-      name = "torchvision-0.11.1-cp38-cp38-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp38-cp38-linux_x86_64.whl";
-      hash = "sha256-bFxvJaNEomytXXANHng+oU8YSLGkuO/TSzkoDskkaIE=";
+      name = "torchvision-0.12.0-cp38-cp38-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl";
+      hash = "sha256-NxM+jFsOwvAZmeWRFvbQ422a+xx/j1i9DD3ImW+DVBk=";
     };
     x86_64-linux-39 = {
-      name = "torchvision-0.11.1-cp39-cp39-linux_x86_64.whl";
-      url = "https://download.pytorch.org/whl/cu113/torchvision-0.11.1%2Bcu113-cp39-cp39-linux_x86_64.whl";
-      hash = "sha256-ysN3LmSKR+FVKYGnCGQJqa8lVApVT5rPMO+NHmmazAc=";
+      name = "torchvision-0.12.0-cp39-cp39-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp39-cp39-linux_x86_64.whl";
+      hash = "sha256-bGO5q+KEnv7SexmbbUWaIbsBcIxyDbL8pevZQbLwDbg=";
+    };
+    x86_64-linux-310 = {
+      name = "torchvision-0.12.0-cp310-cp310-linux_x86_64.whl";
+      url = "https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp310-cp310-linux_x86_64.whl";
+      hash = "sha256-ocsGOHa967HcZGV+1omD/xMHufmoi166Yg2Hr+SEhfE=";
+    };
+    x86_64-darwin-37 = {
+      name = "torchvision-0.12.0-cp37-cp37m-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp37-cp37m-macosx_10_9_x86_64.whl";
+      hash = "sha256-GJM7xZf0VjmTJJcZqWqV28fTN0yQ+7MNPafVGPOv60I=";
+    };
+    x86_64-darwin-38 = {
+      name = "torchvision-0.12.0-cp38-cp38-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp38-cp38-macosx_10_9_x86_64.whl";
+      hash = "sha256-DWAuCb1Fc2/y55aOjduw7s6Vb/ltcVSLGxtIeP33S9g=";
+    };
+    x86_64-darwin-39 = {
+      name = "torchvision-0.12.0-cp39-cp39-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp39-cp39-macosx_10_9_x86_64.whl";
+      hash = "sha256-RMye+ZLS4qtjsIg/fezrwiRNupO3JUe6EfV6yEUvbq0=";
+    };
+    x86_64-darwin-310 = {
+      name = "torchvision-0.12.0-cp310-cp310-macosx_10_9_x86_64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp310-cp310-macosx_10_9_x86_64.whl";
+      hash = "sha256-aTZW5nkLarIeSm6H6BwpgrrZ5FW16yThS7ZyOC7GEw8=";
+    };
+    aarch64-darwin-38 = {
+      name = "torchvision-0.12.0-cp38-cp38-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp38-cp38-macosx_11_0_arm64.whl";
+      hash = "sha256-n0JCD38LKc09YXdt8xV4JyV6DPFrLAJ3bcFslquxJW0=";
+    };
+    aarch64-darwin-39 = {
+      name = "torchvision-0.12.0-cp39-cp39-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp39-cp39-macosx_11_0_arm64.whl";
+      hash = "sha256-adgvR7Z7rW3cu4eDO6WVCmwnG6l7quTAlVYQBxvwNPU=";
+    };
+    aarch64-darwin-310 = {
+      name = "torchvision-0.12.0-cp310-cp310-macosx_11_0_arm64.whl";
+      url = "https://download.pytorch.org/whl/torchvision-0.12.0-cp310-cp310-macosx_11_0_arm64.whl";
+      hash = "sha256-oL5FAcoLobGVZEySQ/SaHEmiblKn83kkxCOdC/XsvY0=";
     };
   };
 }

--- a/pkgs/development/python-modules/torchvision/prefetch.sh
+++ b/pkgs/development/python-modules/torchvision/prefetch.sh
@@ -5,12 +5,21 @@ set -eou pipefail
 
 version=$1
 
-bucket="https://download.pytorch.org/whl/cu113"
+linux_bucket="https://download.pytorch.org/whl/cu113"
+darwin_bucket="https://download.pytorch.org/whl"
 
 url_and_key_list=(
-  "x86_64-linux-37 $bucket/torchvision-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchvision-${version}-cp37-cp37m-linux_x86_64.whl"
-  "x86_64-linux-38 $bucket/torchvision-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchvision-${version}-cp38-cp38-linux_x86_64.whl"
-  "x86_64-linux-39 $bucket/torchvision-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchvision-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-37 $linux_bucket/torchvision-${version}%2Bcu113-cp37-cp37m-linux_x86_64.whl torchvision-${version}-cp37-cp37m-linux_x86_64.whl"
+  "x86_64-linux-38 $linux_bucket/torchvision-${version}%2Bcu113-cp38-cp38-linux_x86_64.whl torchvision-${version}-cp38-cp38-linux_x86_64.whl"
+  "x86_64-linux-39 $linux_bucket/torchvision-${version}%2Bcu113-cp39-cp39-linux_x86_64.whl torchvision-${version}-cp39-cp39-linux_x86_64.whl"
+  "x86_64-linux-310 $linux_bucket/torchvision-${version}%2Bcu113-cp310-cp310-linux_x86_64.whl torchvision-${version}-cp310-cp310-linux_x86_64.whl"
+  "x86_64-darwin-37 $darwin_bucket/torchvision-${version}-cp37-cp37m-macosx_10_9_x86_64.whl torchvision-${version}-cp37-cp37m-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-38 $darwin_bucket/torchvision-${version}-cp38-cp38-macosx_10_9_x86_64.whl torchvision-${version}-cp38-cp38-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-39 $darwin_bucket/torchvision-${version}-cp39-cp39-macosx_10_9_x86_64.whl torchvision-${version}-cp39-cp39-macosx_10_9_x86_64.whl"
+  "x86_64-darwin-310 $darwin_bucket/torchvision-${version}-cp310-cp310-macosx_10_9_x86_64.whl torchvision-${version}-cp310-cp310-macosx_10_9_x86_64.whl"
+  "aarch64-darwin-38 $darwin_bucket/torchvision-${version}-cp38-cp38-macosx_11_0_arm64.whl torchvision-${version}-cp38-cp38-macosx_11_0_arm64.whl"
+  "aarch64-darwin-39 $darwin_bucket/torchvision-${version}-cp39-cp39-macosx_11_0_arm64.whl torchvision-${version}-cp39-cp39-macosx_11_0_arm64.whl"
+  "aarch64-darwin-310 $darwin_bucket/torchvision-${version}-cp310-cp310-macosx_11_0_arm64.whl torchvision-${version}-cp310-cp310-macosx_11_0_arm64.whl"
 )
 
 hashfile="binary-hashes-$version.nix"

--- a/pkgs/tools/audio/tts/default.nix
+++ b/pkgs/tools/audio/tts/default.nix
@@ -57,6 +57,7 @@ python.pkgs.buildPythonApplication rec {
         ''-e 's/${package}.*[<>=]+.*/${package}/g' \''
       ) relaxedConstraints)}
     requirements.txt
+    sed -i '/tensorboardX/d' requirements.txt
   '';
 
   nativeBuildInputs = with python.pkgs; [
@@ -84,7 +85,6 @@ python.pkgs.buildPythonApplication rec {
     pyworld
     scipy
     soundfile
-    tensorboardx
     tensorflow
     torchaudio-bin
     tqdm


### PR DESCRIPTION
###### Description of changes

This is still a work in progress (needs testing, etc)

1.11 Release of PyTorch:

* [Announcement](https://pytorch.org/blog/pytorch-1.11-released/)
* [Pytorch 1.11.0 release notes](https://github.com/pytorch/pytorch/releases/tag/v1.11.0)

Nix changes:

- [X] Bumped pytorch as well as pytorch-bin to 1.11
- [X] Added darwin dowloads to the prefetch script
- [X] Added cp310 to the prefetch script for linux
- [x] Enable pytorch-bin for (linux, python 3.10)

TODO

- [ ] Check: are torchdata, functorch automatically bundled into the release?
- [ ] Tensorboard dependency doesn't build on python 3.10 due to https://github.com/NixOS/nixpkgs/commit/a43876176fe7df59c793db8b367df26bec8b7084
  * See https://github.com/NixOS/nixpkgs/pull/164730
- [ ] ~CUDA appears to need updating~
* See https://github.com/NixOS/nixpkgs/pull/164338/files/2000db2e332b552c3a7237b8fafb60be2c6687d2#r830322195
```
-- Found CUDA: /nix/store/rclmj9izhxwhgwrgjk97mka3ndm4bzyn-cudatoolkit-10.1.243 (found version "10.1") 
-- Caffe2: CUDA detected: 10.1
-- Caffe2: CUDA nvcc is: /nix/store/rclmj9izhxwhgwrgjk97mka3ndm4bzyn-cudatoolkit-10.1.243/bin/nvcc
-- Caffe2: CUDA toolkit directory: /nix/store/rclmj9izhxwhgwrgjk97mka3ndm4bzyn-cudatoolkit-10.1.243
CMake Error at cmake/public/cuda.cmake:42 (message):
  PyTorch requires CUDA 10.2 or above.
Call Stack (most recent call first):
  cmake/Dependencies.cmake:1191 (include)
  CMakeLists.txt:653 (include)
```

- [ ] Needs building, testing, etc (in progress)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
