### PR TITLE
cubicsdr: 0.2.5 -> 0.2.7

### DIFF
--- a/pkgs/applications/radio/cubicsdr/default.nix
+++ b/pkgs/applications/radio/cubicsdr/default.nix
@@ -1,33 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
+{ lib, stdenv, fetchFromGitHub, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
   pkg-config, soapysdr-with-plugins, wxGTK31-gtk3, enableDigitalLab ? false }:
 
 stdenv.mkDerivation rec {
   pname = "cubicsdr";
-  version = "0.2.5";
+  version = "0.2.7";
 
   src = fetchFromGitHub {
     owner = "cjcliffe";
     repo = "CubicSDR";
     rev = version;
-    sha256 = "1ihbn18bzdcdvwpa4hnb55ns38bj4b8xy53hkmra809f9qpbcjhn";
+    sha256 = "0cyv1vk97x4i3h3hhh7dx8mv6d1ad0fypdbx5fl26bz661sr8j2n";
   };
-
-  # Allow cubicsdr 0.2.5 to build with wxGTK 3.1.3
-  # these come from cubicsdr's master branch, subsequent releases may include them
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/cjcliffe/CubicSDR/commit/65a160fa356ce9665dfe05c6bfc6754535e16743.patch";
-      sha256 = "0vbr5x9fnm09bws5crqcm6kkhr1bg5r0bc1pxnwwjyc6jpvqi6ad";
-    })
-    (fetchpatch {
-      url = "https://github.com/cjcliffe/CubicSDR/commit/f449a65457e35bf8260d0b16b8a47b6bc0ea2c7e.patch";
-      sha256 = "1zjvjmhm8ybi6i9pq7by3fj3mvx37dy7gj4gk23d79yrnl9mk25p";
-    })
-    (fetchpatch {
-      url = "https://github.com/cjcliffe/CubicSDR/commit/0540d08c2dea79b668b32b1a6d58f235d65ce9d2.patch";
-      sha256 = "07l7b82f779sbcj0jza0mg463ac1153bs9hn6ai388j7dm3lvasn";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
@@ -44,4 +27,3 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/development/libraries/liquid-dsp/default.nix
+++ b/pkgs/development/libraries/liquid-dsp/default.nix
@@ -1,14 +1,14 @@
 {lib, stdenv, fetchFromGitHub, autoreconfHook }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "liquid-dsp";
-  version = "20170307";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "jgaeddert";
     repo = "liquid-dsp";
-    rev = "8c1978fa4f5662b8849fe712be716958f29cec0e";
-    sha256 = "0zpxvdsrw0vzzp3iaag3wh4z8ygl7fkswgjppp2fz2zhhqh93k2w";
+    rev = "v${version}";
+    sha256 = "0mr86z37yycrqwbrmsiayi1vqrgpjq0pn1c3p1qrngipkw45jnn0";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -19,5 +19,4 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };
-
 }


### PR DESCRIPTION
###### Description of changes

Updated to latest CubicSDR, which allows removal of some patches. Needed to update liquid-dsp library as well to get it to build. Tested inspectrum, the only other package that depends on liquid-dsp. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
