### PR TITLE
eggnog-mapper: 1.0.3 -> 2.1.7

### DIFF
--- a/pkgs/applications/science/biology/eggnog-mapper/default.nix
+++ b/pkgs/applications/science/biology/eggnog-mapper/default.nix
@@ -1,29 +1,43 @@
-{ lib, fetchFromGitHub, fetchpatch, makeWrapper, python27Packages, wget, diamond, hmmer }:
+{ lib
+, autoPatchelfHook
+, fetchFromGitHub
+, python3Packages
+, wget
+, zlib
+}:
 
-python27Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "eggnog-mapper";
-  version = "1.0.3";
+  version = "2.1.7";
 
   src = fetchFromGitHub {
     owner = "eggnogdb";
-    repo = "eggnog-mapper";
+    repo = pname;
     rev = version;
-    sha256 = "1aaaflppy84bhkh2hb5gnzm4xgrz0rz0cgfpadr9w8cva8p0sqdv";
+    hash = "sha256-auVD/r8m3TAB1KYMQ7Sae23eDg6LRx/daae0505cjwU=";
   };
 
-  patches = (fetchpatch {
-    url = "https://github.com/eggnogdb/eggnog-mapper/commit/6972f601ade85b65090efca747d2302acb58507f.patch";
-    sha256 = "0abnmn0bh11jihf5d3cggiild1ykawzv5f5fhb4cyyi8fvy4hcxf";
-  });
+  postPatch = ''
+    # Not a great solution...
+    substituteInPlace setup.cfg \
+      --replace "==" ">="
+  '';
 
-  nativeBuildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ python27Packages.biopython wget diamond hmmer ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
 
-  # make emapper find diamond & hmmer
-  makeWrapperArgs = [
-    ''--prefix PATH ':' "${diamond}/bin"''
-    ''--prefix PATH ':' "${hmmer}/bin"''
-    ];
+  buildInputs = [
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    wget
+  ] ++ (with python3Packages; [
+    biopython
+    psutil
+    XlsxWriter
+  ]);
 
   # Tests rely on some of the databases being available, which is not bundled
   # with this package as (1) in total, they represent >100GB of data, and (2)


### PR DESCRIPTION
###### Description of changes
https://github.com/eggnogdb/eggnog-mapper/releases
The scripts run, but I'm not qualified enough to properly test the functionality of this.
(This targets staging because it needs #161217)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
