### PR TITLE
tensorflow-tensorboard: 2.6.0 -> 2.8.0 [WIP]

### DIFF
--- a/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
+++ b/pkgs/development/python-modules/tensorflow-tensorboard/default.nix
@@ -23,31 +23,17 @@
 
 buildPythonPackage rec {
   pname = "tensorflow-tensorboard";
-  version = "2.6.0";
+  version = "2.8.0";
   format = "wheel";
-  disabled = pythonOlder "3.6" || pythonAtLeast "3.10";
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     pname = "tensorboard";
     inherit version format;
     dist = "py3";
     python = "py3";
-    sha256 = "sha256-99rEzftS0UyeP3RYXOKq+OYgNiCoZOUfr4SYiwn3u9s=";
+    sha256 = "sha256:1vqd2w2z1pdkls6yc6yf5b7av4hp62zbs8s9c3r7k42f8bj3i8v5";
   };
-
-  postPatch = ''
-    chmod u+rwx -R ./dist
-    pushd dist
-    wheel unpack --dest unpacked ./*.whl
-    pushd unpacked/tensorboard-${version}
-
-    substituteInPlace tensorboard-${version}.dist-info/METADATA \
-      --replace "google-auth (<2,>=1.6.3)" "google-auth (<3,>=1.6.3)"
-
-    popd
-    wheel pack ./unpacked/tensorboard-${version}
-    popd
-  '';
 
   propagatedBuildInputs = [
     absl-py


### PR DESCRIPTION
###### Description of changes

(I'm abandoning this for the time being. I only wanted tensorboard 2.8.0 in order to get python 3.10 working)

Changes:

* [Release notes](https://github.com/tensorflow/tensorboard/blob/ea35c6034141ae4c0fbdd23716539a57d5447dc2/RELEASE.md)

TODO:

- [ ] Doesn't build with python 3.10 because "sanic-21.12.1 not supported for interpreter python3.10"
  * See https://github.com/NixOS/nixpkgs/pull/161869
- [ ] Test

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
