### PR TITLE
pcsx2: 1.7.2105 -> 1.7.2731, support Vulkan

### DIFF
--- a/pkgs/applications/emulators/pcsx2/default.nix
+++ b/pkgs/applications/emulators/pcsx2/default.nix
@@ -12,7 +12,9 @@
 , libpng
 , libpulseaudio
 , libsamplerate
-, libxml2
+, libXdmcp
+, openssl
+, pcre
 , perl
 , pkg-config
 , portaudio
@@ -20,6 +22,8 @@
 , soundtouch
 , stdenv
 , udev
+, vulkan-headers
+, vulkan-loader
 , wrapGAppsHook
 , wxGTK
 , zlib
@@ -28,14 +32,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pcsx2";
-  version = "1.7.2105";
+  version = "1.7.2731";
 
   src = fetchFromGitHub {
     owner = "PCSX2";
     repo = "pcsx2";
     fetchSubmodules = true;
     rev = "v${version}";
-    hash = "sha256-/A8u7oDIVs0Zmne0ebaXxOeIQbM9pr62KEH6FJR2umk=";
+    hash = "sha256-b3cK3ly9J44YMy/cNprlDCSsu8+DrlhRSLXv5xMouWo=";
   };
 
   cmakeFlags = [
@@ -44,9 +48,10 @@ stdenv.mkDerivation rec {
     "-DPACKAGE_MODE=TRUE"
     "-DWAYLAND_API=TRUE"
     "-DXDG_STD=TRUE"
+    "-DUSE_VULKAN=TRUE"
   ];
 
-  nativeBuildInputs = [ cmake perl pkg-config wrapGAppsHook ];
+  nativeBuildInputs = [ cmake perl pkg-config vulkan-headers wrapGAppsHook ];
 
   buildInputs = [
     alsa-lib
@@ -60,15 +65,28 @@ stdenv.mkDerivation rec {
     libpng
     libpulseaudio
     libsamplerate
-    libxml2
+    libXdmcp
+    openssl
+    pcre
     portaudio
     SDL2
     soundtouch
     udev
+    vulkan-loader
     wayland
     wxGTK
     zlib
   ];
+
+  # Wayland doesn't seem to work right now (crashes when booting a game).
+  # Try removing `--prefix GDK_BACKEND : x11` on the next update.
+  # (This may be solved when the project finshes migrating to Qt)
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+      --prefix GDK_BACKEND : x11
+    )
+  '';
 
   meta = with lib; {
     description = "Playstation 2 emulator";
@@ -81,13 +99,12 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://pcsx2.net";
     maintainers = with maintainers; [ hrdinka govanify ];
-    mainProgram = "PCSX2";
 
     # PCSX2's source code is released under LGPLv3+. It However ships
     # additional data files and code that are licensed differently.
     # This might be solved in future, for now we should stick with
     # license.free
     license = licenses.free;
-    platforms = platforms.x86;
+    platforms = platforms.x86_64;
   };
 }


### PR DESCRIPTION
###### Description of changes

Bump version (there have been lots of additions and improvements), add Vulkan support.

###### Things done

Both OpenGL on Vulkan work on X11/XWayland.

Trying to launch a game on Wayland crashes the application even on the software renderer, with no error message explaining what happened (the most I could get is `Gdk-Message: 17:36:53.652: Error flushing display: Broken pipe`). This is a regression.

It's not something to lose sleep over since opening PCSX2 with the .desktop file sets `GDK_BACKEND=x11` and the project is also moving to Qt, but it's still the reason I'm opening this as a draft.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
