### PR TITLE
makeWrapper: add `--chdir` and migrate most uses of `--run cd`

### DIFF
--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -166,7 +166,7 @@ in
       } ''
         makeWrapper ${pythonEnv}/bin/etebase-server \
           $out/bin/etebase-server \
-          --run "cd ${cfg.dataDir}" \
+          --chdir ${escapeShellArg cfg.dataDir} \
           --prefix ETEBASE_EASY_CONFIG_PATH : "${configIni}"
       '')
     ];

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -179,7 +179,7 @@ let
           ${concatStrings (mapAttrsToList (name: value: "--set ${name} '${value}' ") gitlabEnv)} \
           --set PATH '${lib.makeBinPath [ pkgs.nodejs pkgs.gzip pkgs.git pkgs.gnutar postgresqlPackage pkgs.coreutils pkgs.procps ]}:$PATH' \
           --set RAKEOPT '-f ${cfg.packages.gitlab}/share/gitlab/Rakefile' \
-          --run 'cd ${cfg.packages.gitlab}/share/gitlab'
+          --chdir '${cfg.packages.gitlab}/share/gitlab'
      '';
   };
 
@@ -193,7 +193,7 @@ let
       makeWrapper ${cfg.packages.gitlab.rubyEnv}/bin/rails $out/bin/gitlab-rails \
           ${concatStrings (mapAttrsToList (name: value: "--set ${name} '${value}' ") gitlabEnv)} \
           --set PATH '${lib.makeBinPath [ pkgs.nodejs pkgs.gzip pkgs.git pkgs.gnutar postgresqlPackage pkgs.coreutils pkgs.procps ]}:$PATH' \
-          --run 'cd ${cfg.packages.gitlab}/share/gitlab'
+          --chdir '${cfg.packages.gitlab}/share/gitlab'
      '';
   };
 

--- a/pkgs/applications/audio/hivelytracker/default.nix
+++ b/pkgs/applications/audio/hivelytracker/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
     # files passed as arguments anyway, so this works well enough until the
     # issue is fixed.
     wrapProgram $out/bin/hivelytracker \
-      --run "cd $out/share/hivelytracker"
+      --chdir "$out/share/hivelytracker"
 
     # Also install the hvl2wav tool
     install -Dm755 hvl2wav/hvl2wav $out/bin/hvl2wav

--- a/pkgs/applications/audio/lyrebird/default.nix
+++ b/pkgs/applications/audio/lyrebird/default.nix
@@ -42,7 +42,7 @@ python3Packages.buildPythonApplication rec {
   makeWrapperArgs = [
     "--prefix 'PATH' ':' '${lib.makeBinPath [ sox pulseaudio ]}'"
     "--prefix 'PYTHONPATH' ':' '${placeholder "out"}/share/lyrebird'"
-    "--run 'cd ${placeholder "out"}/share/lyrebird'"
+    "--chdir '${placeholder "out"}/share/lyrebird'"
     ''"''${gappsWrapperArgs[@]}"''
   ];
 

--- a/pkgs/applications/blockchains/wasabibackend/default.nix
+++ b/pkgs/applications/blockchains/wasabibackend/default.nix
@@ -32,7 +32,7 @@ buildDotnetModule rec {
 
   preConfigure = ''
     makeWrapperArgs+=(
-      --run "cd $out/lib/${pname}"
+      --chdir "$out/lib/${pname}"
     )
   '';
 

--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -46,7 +46,7 @@ in mkDerivation {
 
     # AwesomeBump expects to find Core and Configs in its current directory.
     makeQtWrapper $d/AwesomeBump $out/bin/AwesomeBump \
-        --run "cd $d"
+        --chdir "$d"
   '';
 
   # $ cd Sources; qmake; make ../workdir/linux-g++-dgb-gl4/obj/glwidget.o

--- a/pkgs/applications/graphics/foxotron/default.nix
+++ b/pkgs/applications/graphics/foxotron/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     cp -R ${lib.optionalString stdenv.hostPlatform.isDarwin "Foxotron.app/Contents/MacOS/"}Foxotron \
       ../{config.json,Shaders,Skyboxes} $out/lib/foxotron/
     wrapProgram $out/lib/foxotron/Foxotron \
-      --run "cd $out/lib/foxotron"
+      --chdir "$out/lib/foxotron"
     ln -s $out/{lib/foxotron,bin}/Foxotron
 
     runHook postInstall

--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -97,7 +97,7 @@ in
       mkdir -p $out/bin
       install -m 0755 valley $out/bin/valley
       wrapProgram $out/bin/valley \
-        --run "cd $instdir" \
+        --chdir "$instdir" \
         --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib:$instdir/bin:$libPath
 
       runHook postInstall

--- a/pkgs/applications/misc/multibootusb/default.nix
+++ b/pkgs/applications/misc/multibootusb/default.nix
@@ -101,7 +101,7 @@ python3Packages.buildPythonApplication rec {
       --prefix "PATH" ":" "${lib.makeBinPath runTimeDeps}"
 
       # Finally, move to directory that contains data
-      --run "cd $out/share/${pname}"
+      --chdir "$out/share/${pname}"
     )
   '';
 

--- a/pkgs/applications/misc/tvbrowser/bin.nix
+++ b/pkgs/applications/misc/tvbrowser/bin.nix
@@ -41,7 +41,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/${pname} \
       --add-flags "-jar $out/share/java/${pname}/${pname}.jar" \
-      --run "cd $out/share/java/${pname}"
+      --chdir "$out/share/java/${pname}"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/xteddy/default.nix
+++ b/pkgs/applications/misc/xteddy/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     # this is needed, because xteddy expects images to reside
     # in the current working directory
-    wrapProgram $out/bin/xteddy --run "cd $out/share/images/"
+    wrapProgram $out/bin/xteddy --chdir "$out/share/images/"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -48,7 +48,7 @@ mkDerivation rec {
     install -Dm755 ${src}/Ripcord $out/Ripcord
     patchelf --replace-needed libsodium.so.18 libsodium.so $out/Ripcord
     makeQtWrapper $out/Ripcord $out/bin/ripcord \
-      --run "cd $out" \
+      --chdir "$out" \
       --set FONTCONFIG_FILE "${fontsConf}" \
       --prefix LD_LIBRARY_PATH ":" "${xorg.libXcursor}/lib" \
       --prefix QT_XKB_CONFIG_ROOT ":" "${xorg.xkeyboardconfig}/share/X11/xkb" \

--- a/pkgs/applications/networking/instant-messengers/torchat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/torchat/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     cp -rf * $out/lib/torchat
     makeWrapper ${python2}/bin/python $out/bin/torchat \
         --set PYTHONPATH $out/lib/torchat:$program_PYTHONPATH \
-        --run "cd $out/lib/torchat" \
+        --chdir "$out/lib/torchat" \
         --add-flags "-O $out/lib/torchat/torchat.py"
   '';
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
     # Clear Qt paths to prevent tripping over "foreign" Qt resources.
     # Clear Qt screen scaling settings to prevent over-scaling.
     makeWrapper $out/opt/zoom/ZoomLauncher $out/bin/zoom \
-      --run "cd $out/opt/zoom" \
+      --chdir "$out/opt/zoom" \
       --unset QML2_IMPORT_PATH \
       --unset QT_PLUGIN_PATH \
       --unset QT_SCREEN_SCALE_FACTORS \

--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -74,10 +74,10 @@ stdenv.mkDerivation rec {
     makeWrapper ${python3.pkgs.python}/bin/python $out/bin/tribler \
         --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms \
         --set QT_PLUGIN_PATH "${qt5.qtsvg.bin}/${qt5.qtbase.qtPluginPrefix}" \
-        --set _TRIBLERPATH $out/src \
+        --set _TRIBLERPATH "$out/src" \
         --set PYTHONPATH $out/src/tribler-core:$out/src/tribler-common:$out/src/tribler-gui:$program_PYTHONPATH \
         --set NO_AT_BRIDGE 1 \
-        --run 'cd $_TRIBLERPATH' \
+        --chdir "$out/src" \
         --add-flags "-O $out/src/run_tribler.py"
 
     mkdir -p $out/share/applications $out/share/icons

--- a/pkgs/applications/networking/remote/rustdesk/default.nix
+++ b/pkgs/applications/networking/remote/rustdesk/default.nix
@@ -86,7 +86,7 @@ rustPlatform.buildRustPackage rec {
     ln -s ${libsciter}/lib/libsciter-gtk.so $out/lib/rustdesk
 
     makeWrapper $out/lib/rustdesk/rustdesk $out/bin/rustdesk \
-      --run "cd $out/share"
+      --chdir "$out/share"
 
     cp -a $src/src/ui $out/share/src
 

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
         lib.optionalString stdenv.isDarwin ''-Xdock:name="Jameica" -XstartOnFirstThread''
       } de.willuhn.jameica.Main" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
-      --run "cd $out/share/java/"
+      --chdir "$out/share/java/"
   '';
 
   meta = with lib; {

--- a/pkgs/applications/science/astronomy/openspace/default.nix
+++ b/pkgs/applications/science/astronomy/openspace/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
       patchelf --set-rpath $rpath:${bundle}/lib $bin
 
       name=$(basename $bin)
-      makeWrapper $bin $out/bin/$name --run "cd ${bundle}"
+      makeWrapper $bin $out/bin/$name --chdir "${bundle}"
     done
   '';
 

--- a/pkgs/applications/science/logic/tlaplus/toolbox.nix
+++ b/pkgs/applications/science/logic/tlaplus/toolbox.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
       "$(find "$out/toolbox" -name jspawnhelper)"
 
     makeWrapper $out/toolbox/toolbox $out/bin/tla-toolbox \
-      --run "set -x; cd $out/toolbox" \
+      --chdir "$out/toolbox" \
       --add-flags "-data ~/.tla-toolbox" \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3 libXtst glib zlib ]}"  \
       "''${gappsWrapperArgs[@]}"

--- a/pkgs/applications/science/misc/netlogo/default.nix
+++ b/pkgs/applications/science/misc/netlogo/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
     # launcher with `cd` is required b/c otherwise the model library isn't usable
     makeWrapper "${jre}/bin/java" "$out/bin/netlogo" \
-      --run "cd $out/share/netlogo/app" \
+      --chdir "$out/share/netlogo/app" \
       --add-flags "-jar netlogo-${version}.jar"
 
     cp $src1 $out/share/icons/hicolor/256x256/apps/netlogo.png

--- a/pkgs/applications/science/robotics/sumorobot-manager/default.nix
+++ b/pkgs/applications/science/robotics/sumorobot-manager/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     dos2unix $out/opt/sumorobot-manager/main.py
     makeQtWrapper $out/opt/sumorobot-manager/main.py $out/bin/sumorobot-manager \
-      --run "cd $out/opt/sumorobot-manager"
+      --chdir "$out/opt/sumorobot-manager"
   '';
 
   preFixup = ''

--- a/pkgs/applications/video/epgstation/default.nix
+++ b/pkgs/applications/video/epgstation/default.nix
@@ -115,7 +115,7 @@ let
       ln -sfT /var/lib/epgstation/thumbnail thumbnail
 
       makeWrapper ${nodejs}/bin/npm $out/bin/epgstation \
-       --run "cd $out/lib/node_modules/epgstation" \
+       --chdir "$out/lib/node_modules/epgstation" \
        --prefix PATH : ${lib.makeBinPath runtimeDeps} \
        --set APP_ROOT_PATH "$out/lib/node_modules/epgstation"
 

--- a/pkgs/applications/video/mirakurun/default.nix
+++ b/pkgs/applications/video/mirakurun/default.nix
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
       mkdir -p $out/bin
 
       makeWrapper ${mirakurun}/bin/mirakurun-epgdump $out/bin/mirakurun-epgdump \
-        --run "cd ${mirakurun}/libexec/mirakurun/node_modules/mirakurun" \
+        --chdir "${mirakurun}/libexec/mirakurun/node_modules/mirakurun" \
         --prefix PATH : ${lib.makeBinPath runtimeDeps}
 
       # XXX: The original mirakurun command uses PM2 to manage the Mirakurun
@@ -70,7 +70,7 @@ stdenvNoCC.mkDerivation rec {
       # unique to PM2 is currently being used.
       makeWrapper ${yarn}/bin/yarn $out/bin/mirakurun-start \
         --add-flags "start" \
-        --run "cd ${mirakurun}/libexec/mirakurun/node_modules/mirakurun" \
+        --chdir "${mirakurun}/libexec/mirakurun/node_modules/mirakurun" \
         --prefix PATH : ${lib.makeBinPath runtimeDeps}
     '';
 

--- a/pkgs/build-support/setup-hooks/make-wrapper.sh
+++ b/pkgs/build-support/setup-hooks/make-wrapper.sh
@@ -18,6 +18,7 @@ assertExecutable() {
 # --set-default VAR VAL : like --set, but only adds VAR if not already set in
 #                         the environment
 # --unset       VAR     : remove VAR from the environment
+# --chdir       DIR     : change working directory (use instead of --run "cd DIR")
 # --run         COMMAND : run command before the executable
 # --add-flags   FLAGS   : add FLAGS to invocation of executable
 
@@ -126,6 +127,10 @@ makeWrapper() {
             varName="${params[$((n + 1))]}"
             n=$((n + 1))
             echo "unset $varName" >> "$wrapper"
+        elif [[ "$p" == "--chdir" ]]; then
+            dir="${params[$((n + 1))]}"
+            n=$((n + 1))
+            echo "cd ${dir@Q}" >> "$wrapper"
         elif [[ "$p" == "--run" ]]; then
             command="${params[$((n + 1))]}"
             n=$((n + 1))

--- a/pkgs/development/ruby-modules/bundler-app/default.nix
+++ b/pkgs/development/ruby-modules/bundler-app/default.nix
@@ -57,7 +57,7 @@ in
                                 "--set BUNDLE_FROZEN 1 "+
                                 "--set GEM_HOME ${basicEnv}/${ruby.gemPath} "+
                                 "--set GEM_PATH ${basicEnv}/${ruby.gemPath} "+
-                                "--run \"cd $srcdir\";\n") scripts)}
+                                "--chdir \"$srcdir\";\n") scripts)}
 
     ${lib.optionalString installManpages ''
     for section in {1..9}; do

--- a/pkgs/development/tools/database/sqldeveloper/default.nix
+++ b/pkgs/development/tools/database/sqldeveloper/default.nix
@@ -62,7 +62,7 @@ in
 
     makeWrapper $out/libexec/sqldeveloper/bin/sqldeveloper $out/bin/sqldeveloper \
       --set JAVA_HOME ${jdk.home} \
-      --run "cd $out/libexec/sqldeveloper/bin"
+      --chdir "$out/libexec/sqldeveloper/bin"
   '';
 
   meta = with lib; {

--- a/pkgs/games/airstrike/default.nix
+++ b/pkgs/games/airstrike/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     cp -r data airstrikerc $out/share
 
     wrapProgram $out/bin/airstrike \
-      --run "cd $out/share"
+      --chdir "$out/share"
   '';
 
   meta = with lib; {

--- a/pkgs/games/assaultcube/default.nix
+++ b/pkgs/games/assaultcube/default.nix
@@ -52,13 +52,13 @@ stdenv.mkDerivation rec {
       install -Dpm644 packages/misc/icon.png $out/share/pixmaps/assaultcube.png
 
       makeWrapper $out/bin/ac_client $out/bin/${pname} \
-        --run "cd $out/$gamedatadir" --add-flags "--home=\$HOME/.assaultcube/v1.2next --init"
+        --chdir "$out/$gamedatadir" --add-flags "--home=\$HOME/.assaultcube/v1.2next --init"
     fi
 
     if (test -e source/src/ac_server) then
       cp source/src/ac_server $bindir
       makeWrapper $out/bin/ac_server $out/bin/${pname}-server \
-        --run "cd $out/$gamedatadir" --add-flags "-Cconfig/servercmdline.txt"
+        --chdir "$out/$gamedatadir" --add-flags "-Cconfig/servercmdline.txt"
     fi
     '';
 

--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -63,10 +63,10 @@ in stdenv.mkDerivation {
     # Reimplement the two launchers mentioned in Unix_shortcutSpec.xml with makeWrapper
     mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/domination \
-      --run "cd $out/share/domination" \
+      --chdir "$out/share/domination" \
       --add-flags "-jar $out/share/domination/Domination.jar"
     makeWrapper ${jre}/bin/java $out/bin/domination-map-editor \
-      --run "cd $out/share/domination" \
+      --chdir "$out/share/domination" \
       --add-flags "-cp $out/share/domination/Domination.jar net.yura.domination.ui.swinggui.SwingGUIFrame"
 
     install -Dm644 \

--- a/pkgs/games/flare/default.nix
+++ b/pkgs/games/flare/default.nix
@@ -11,7 +11,7 @@ buildEnv {
   nativeBuildInputs = [ makeWrapper ];
   postBuild = ''
     mkdir -p $out/bin
-    makeWrapper $out/games/flare $out/bin/flare --run "cd $out/share/games/flare"
+    makeWrapper $out/games/flare $out/bin/flare --chdir "$out/share/games/flare"
   '';
 
   meta = with lib; {

--- a/pkgs/games/frogatto/default.nix
+++ b/pkgs/games/frogatto/default.nix
@@ -30,7 +30,7 @@ in buildEnv {
 
   postBuild = ''
     wrapProgram $out/bin/frogatto \
-      --run "cd $out/share/frogatto"
+      --chdir "$out/share/frogatto"
   '';
 
   meta = with lib; {

--- a/pkgs/games/iortcw/default.nix
+++ b/pkgs/games/iortcw/default.nix
@@ -17,7 +17,7 @@ in buildEnv {
   # so we can launch sp from mp game and vice versa
   postBuild = ''
     for i in `find -L $out/opt/iortcw -maxdepth 1 -type f -executable`; do
-      makeWrapper $i $out/bin/`basename $i` --run "cd $out/opt/iortcw"
+      makeWrapper $i $out/bin/`basename $i` --chdir "$out/opt/iortcw"
     done
   '';
 

--- a/pkgs/games/iortcw/sp.nix
+++ b/pkgs/games/iortcw/sp.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for i in `find $out/opt/iortcw -maxdepth 1 -type f -executable`; do
-      makeWrapper $i $out/bin/`basename $i` --run "cd $out/opt/iortcw"
+      makeWrapper $i $out/bin/`basename $i` --chdir "$out/opt/iortcw"
     done
   '';
 

--- a/pkgs/games/minecraft/default.nix
+++ b/pkgs/games/minecraft/default.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : ${envLibPath} \
       --prefix PATH : ${lib.makeBinPath [ jre ]} \
       --set JAVA_HOME ${lib.getBin jre} \
-      --run "cd /tmp" \
+      --chdir /tmp \
       "''${gappsWrapperArgs[@]}"
   '';
 

--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
       --set LUA_CPATH "${luaEnv}/lib/lua/${lua.luaversion}/?.so" \
       --prefix LUA_PATH : "$NIX_LUA_PATH" \
       --prefix LD_LIBRARY_PATH : "${libsForQt5.qtkeychain}/lib/" \
-      --run "cd $out";
+      --chdir "$out";
 
     runHook postInstall
   '';

--- a/pkgs/games/nanosaur/default.nix
+++ b/pkgs/games/nanosaur/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mv build $out
-    makeWrapper $out/Nanosaur $out/bin/Nanosaur --run "cd $out"
+    makeWrapper $out/Nanosaur $out/bin/Nanosaur --chdir "$out"
   '';
 
   meta = with lib; {

--- a/pkgs/games/openjk/default.nix
+++ b/pkgs/games/openjk/default.nix
@@ -44,9 +44,9 @@ in stdenv.mkDerivation {
     mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/128x128/apps
     prefix=$out/opt/JediAcademy
 
-    makeWrapper $prefix/openjk.* $out/bin/jamp --run "cd $prefix"
-    makeWrapper $prefix/openjk_sp.* $out/bin/jasp --run "cd $prefix"
-    makeWrapper $prefix/openjkded.* $out/bin/openjkded --run "cd $prefix"
+    makeWrapper $prefix/openjk.* $out/bin/jamp --chdir "$prefix"
+    makeWrapper $prefix/openjk_sp.* $out/bin/jasp --chdir "$prefix"
+    makeWrapper $prefix/openjkded.* $out/bin/openjkded --chdir "$prefix"
 
     cp $src/shared/icons/OpenJK_Icon_128.png $out/share/icons/hicolor/128x128/apps
     ln -s ${jamp}/share/applications/* $out/share/applications

--- a/pkgs/games/openmw/tes3mp.nix
+++ b/pkgs/games/openmw/tes3mp.nix
@@ -131,11 +131,11 @@ symlinkJoin rec {
     dir=\''${XDG_CONFIG_HOME:-\$HOME/.config}/openmw
 
     makeWrapper ${unwrapped}/libexec/tes3mp-browser $out/bin/tes3mp-browser \
-      --run "cd $out/bin"
+      --chdir "$out/bin"
 
     makeWrapper ${unwrapped}/libexec/tes3mp-server $out/bin/tes3mp-server \
       --run "mkdir -p $dir" \
       --run "${crudini}/bin/crudini --merge $dir/${cfgFile.name} < ${cfgFile}" \
-      --run "cd $out/bin"
+      --chdir "$out/bin"
   '';
 }

--- a/pkgs/games/openra/common.nix
+++ b/pkgs/games/openra/common.nix
@@ -34,7 +34,7 @@ in {
       --set TERM xterm
 
     makeWrapper $out/lib/openra${openraSuffix}/launch-game.sh $(mkdirp $out/bin)/openra${openraSuffix} \
-      --run "cd $out/lib/openra${openraSuffix}"
+      --chdir "$out/lib/openra${openraSuffix}"
   '';
 
   packageAttrs = {

--- a/pkgs/games/otto-matic/default.nix
+++ b/pkgs/games/otto-matic/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/OttoMatic
     mv Data $out/share/OttoMatic
     install -Dm755 {.,$out/bin}/OttoMatic
-    wrapProgram $out/bin/OttoMatic --run "cd $out/share/OttoMatic"
+    wrapProgram $out/bin/OttoMatic --chdir "$out/share/OttoMatic"
 
     runHook postInstall
   '';

--- a/pkgs/games/runelite/default.nix
+++ b/pkgs/games/runelite/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
     # RuneLite looks for `.so` files in $PWD/natives, so ensure that we set the PWD to the right place
     makeWrapper ${jre}/bin/java $out/bin/runelite \
-      --run "cd $out" \
+      --chdir "$out" \
       --prefix LD_LIBRARY_PATH : "${xorg.libXxf86vm}/lib" \
       --add-flags "-jar $out/share/runelite/RuneLite.jar"
   '';

--- a/pkgs/games/sauerbraten/default.nix
+++ b/pkgs/games/sauerbraten/default.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
     ln -s $out/share/sauerbraten/cube.png $out/share/icon/sauerbraten.png
 
     makeWrapper $out/share/sauerbraten/sauer_server $out/bin/sauerbraten_server \
-      --run "cd $out/share/sauerbraten"
+      --chdir "$out/share/sauerbraten"
     makeWrapper $out/share/sauerbraten/sauer_client $out/bin/sauerbraten_client \
-      --run "cd $out/share/sauerbraten" \
+      --chdir "$out/share/sauerbraten" \
       --add-flags "-q\''${HOME}/.config/sauerbraten"
 
     runHook postInstall

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -57,7 +57,8 @@ stdenv.mkDerivation rec {
     wrapProgram $out/starsector.sh \
       --prefix PATH : ${lib.makeBinPath [ openjdk ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
-      --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector; cd '"$out"
+      --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
+      --chdir "$out"
     ln -s $out/starsector.sh $out/bin/starsector
 
     runHook postInstall

--- a/pkgs/games/tome4/default.nix
+++ b/pkgs/games/tome4/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     install -Dm755 t-engine $dir/t-engine
     cp -r bootstrap game $dir
     makeWrapper $dir/t-engine $out/bin/${pname} \
-      --run "cd $dir"
+      --chdir "$dir"
 
     install -Dm755 ${desktop}/share/applications/${pname}.desktop $out/share/applications/${pname}.desktop
     substituteInPlace $out/share/applications/${pname}.desktop \

--- a/pkgs/games/ut2004/wrapper.nix
+++ b/pkgs/games/ut2004/wrapper.nix
@@ -38,7 +38,7 @@ in runCommand "ut2004" {
   for i in ${game}/System/*-bin; do
     name="$(basename "$i")"
     makeWrapper $i $out/bin/''${name%-bin} \
-      --run "cd ${game}/System"
+      --chdir "${game}/System"
   done
 
   mkdir -p $out/share/applications

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     for i in ${warsow-engine}/bin/*; do
-      makeWrapper "$i" "$out/bin/$(basename "$i")" --run "cd $out/share/warsow"
+      makeWrapper "$i" "$out/bin/$(basename "$i")" --chdir "$out/share/warsow"
     done
   '';
 

--- a/pkgs/games/zod/default.nix
+++ b/pkgs/games/zod/default.nix
@@ -44,7 +44,7 @@ let
     installPhase = ''
       mkdir -p $out/bin
       install -m755 zod $out/bin/
-      wrapProgram $out/bin/zod --run "cd ${zod_assets}/usr/lib/commander-zod"
+      wrapProgram $out/bin/zod --chdir "${zod_assets}/usr/lib/commander-zod"
     '';
   };
   zod_map_editor = stdenv.mkDerivation {
@@ -56,7 +56,7 @@ let
     installPhase = ''
       mkdir -p $out/bin
       install -m755 zod_map_editor $out/bin
-      wrapProgram $out/bin/zod_map_editor --run "cd ${zod_assets}/usr/lib/commander-zod"
+      wrapProgram $out/bin/zod_map_editor --chdir "${zod_assets}/usr/lib/commander-zod"
     '';
   };
   zod_launcher = stdenv.mkDerivation {

--- a/pkgs/os-specific/linux/displaylink/default.nix
+++ b/pkgs/os-specific/linux/displaylink/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       --set-rpath ${libPath} \
       $out/bin/DisplayLinkManager
     wrapProgram $out/bin/DisplayLinkManager \
-      --run "cd $out/lib/displaylink"
+      --chdir "$out/lib/displaylink"
 
     # We introduce a dependency on the source file so that it need not be redownloaded everytime
     echo $src >> "$out/share/workspace_dependencies.pin"

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     makeWrapper $out/aesm/aesm_service $out/bin/aesm_service \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ protobuf ]}:$out/aesm \
-      --run "cd $out/aesm"
+      --chdir "$out/aesm"
 
     # Make sure we didn't forget to handle any files
     rmdir $sgxPswDir || (echo "Error: The directory $installDir still contains unhandled files: $(ls -A $installDir)" >&2 && exit 1)

--- a/pkgs/os-specific/linux/sgx/samples/default.nix
+++ b/pkgs/os-specific/linux/sgx/samples/default.nix
@@ -41,7 +41,7 @@ let
       install *.so $out/lib
 
       wrapProgram "$out/bin/app" \
-        --run "cd $out/lib" \
+        --chdir "$out/lib" \
         ${lib.optionalString (!isSimulation)
         ''--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ sgx-psw ]}"''}
 
@@ -76,7 +76,7 @@ in
 
       for bin in $out/bin/*; do
         wrapProgram $bin \
-          --run "cd $out/lib" \
+          --chdir "$out/lib" \
           ${lib.optionalString (!isSimulation)
           ''--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ sgx-psw ]}"''}
       done

--- a/pkgs/servers/ombi/default.nix
+++ b/pkgs/servers/ombi/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
 
     makeWrapper $out/share/${pname}-${version}/Ombi $out/bin/Ombi \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ openssl icu ]} \
-      --run "cd $out/share/${pname}-${version}"
+      --chdir "$out/share/${pname}-${version}"
   '';
 
   passthru = {

--- a/pkgs/servers/plik/default.nix
+++ b/pkgs/servers/plik/default.nix
@@ -21,6 +21,6 @@ in
     mv plik-*/webapp/dist $out/libexec/plikd/webapp
     cp ${programs.plikd-unwrapped}/bin/plikd $out/libexec/plikd/bin/plikd
     makeWrapper $out/libexec/plikd/bin/plikd $out/bin/plikd \
-      --run "cd $out/libexec/plikd/bin"
+      --chdir "$out/libexec/plikd/bin"
   '';
 }

--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
       ${fixBin "${placeholder "out"}/Bridge/RoonBridgeHelper"}
 
       mkdir -p $out/bin
-      makeWrapper "$out/Bridge/RoonBridge" "$out/bin/RoonBridge" --run "cd $out"
+      makeWrapper "$out/Bridge/RoonBridge" "$out/bin/RoonBridge" --chdir "$out"
 
       runHook postInstall
     '';

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
             --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ alsa-lib icu66 ffmpeg openssl ]}" \
             --prefix PATH : "$dotnetDir" \
             --prefix PATH : "${lib.makeBinPath [ alsa-utils cifs-utils ffmpeg ]}" \
-            --run "cd $binDir" \
+            --chdir "$binDir" \
             --set DOTNET_ROOT "$dotnetDir"
         )
       '';
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
       ${wrapBin "$out/Server/RoonServer"}
 
       mkdir -p $out/bin
-      makeWrapper "$out/Server/RoonServer" "$out/bin/RoonServer" --run "cd $out"
+      makeWrapper "$out/Server/RoonServer" "$out/bin/RoonServer" --chdir "$out"
 
       # This is unused and depends on an ancient version of lttng-ust, so we
       # just patch it out

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -99,7 +99,7 @@ let
         ${lib.concatStrings (lib.mapAttrsToList (name: value: "--set ${name} '${value}' ") runtimeEnv)} \
         --prefix PATH : ${lib.makeBinPath runtimeDeps} \
         --set RAKEOPT '-f ${discourse}/share/discourse/Rakefile' \
-        --run 'cd ${discourse}/share/discourse'
+        --chdir '${discourse}/share/discourse'
   '';
 
   rubyEnv = bundlerEnv {

--- a/pkgs/tools/cd-dvd/ventoy-bin/default.nix
+++ b/pkgs/tools/cd-dvd/ventoy-bin/default.nix
@@ -79,13 +79,13 @@ in stdenv.mkDerivation rec {
              ExtendPersistentImg.sh_ventoy-extend-persistent; do
         makeWrapper "$VENTOY_PATH/''${f%_*}" "$out/bin/''${f#*_}" \
                     --prefix PATH : "${lib.makeBinPath buildInputs}" \
-                    --run "cd '$VENTOY_PATH' || exit 1"
+                    --chdir "$VENTOY_PATH"
     done
   '' + lib.optionalString (withGtk3 || withQt5) ''
     echo "${defaultGuiType}" > "$VENTOY_PATH/ventoy_gui_type"
     makeWrapper "$VENTOY_PATH/VentoyGUI.$ARCH" "$out/bin/ventoy-gui" \
                 --prefix PATH : "${lib.makeBinPath buildInputs}" \
-                --run "cd '$VENTOY_PATH' || exit 1"
+                --chdir "$VENTOY_PATH"
   '' + lib.optionalString (!withGtk3) ''
     rm "$out"/share/ventoy/tool/"$ARCH"/Ventoy2Disk.gtk3
   '' + lib.optionalString (!withQt5) ''

--- a/pkgs/tools/graphics/snapdragon-profiler/default.nix
+++ b/pkgs/tools/graphics/snapdragon-profiler/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       --suffix PATH : ${lib.makeBinPath [ jre androidenv.androidPkgs_9_0.platform-tools coreutils ]} \
       --prefix MONO_GAC_PREFIX : ${gtk-sharp-2_0} \
       --suffix LD_LIBRARY_PATH : $(echo $NIX_LDFLAGS | sed 's/ -L/:/g;s/ -rpath /:/g;s/-rpath //') \
-      --run "cd $out/lib/snapdragon-profiler" # Fixes themes not loading correctly
+      --chdir "$out/lib/snapdragon-profiler" # Fixes themes not loading correctly
 
     wrestool -x -t 14 SnapdragonProfiler.exe > snapdragon-profiler.ico
     icotool -x -i 1 -o $out/share/icons/hicolor/16x16/apps/snapdragon-profiler.png snapdragon-profiler.ico

--- a/pkgs/tools/graphics/structure-synth/default.nix
+++ b/pkgs/tools/graphics/structure-synth/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   # either $HOME or $PWD - so help it along by moving $PWD to 'share',
   # where we just copied those two directories:
   preFixup = ''
-    wrapProgram "$out/bin/structure-synth" --run "cd $out/share"
+    wrapProgram "$out/bin/structure-synth" --chdir "$out/share"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Extracted from https://github.com/NixOS/nixpkgs/pull/164163 since this is a harmless change that requires a mass rebuild, so that we can see more clearly what needs to be rebuilt after https://github.com/NixOS/nixpkgs/pull/164163.

~The change makes sense independently of that PR though, as it's a good idea to crash early if `cd` fails.~ Never mind that, forgot we were using `-e`.