### PR TITLE
dmtcp: 2021-03-01 -> 2022-02-28

### DIFF
--- a/pkgs/os-specific/linux/dmtcp/default.nix
+++ b/pkgs/os-specific/linux/dmtcp/default.nix
@@ -1,16 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, bash, perl, python2 }:
-
-# There are fixes for python3 compatibility on master
+{ lib, stdenv, fetchFromGitHub, bash, perl, python3 }:
 
 stdenv.mkDerivation rec {
   pname = "dmtcp";
-  version = "unstable-2021-03-01";
+  version = "unstable-2022-02-28";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "f999adbb8e88fe452a0e57ceb43b6eed7b4409f9";
-    sha256 = "sha256-codCHQui3fGfUZSNq8GuH4ad/GjD6I/S9rX83o8oFPc=";
+    rev = "133687764c6742906006a1d247e3b83cd860fa1d";
+    hash = "sha256-9Vr8IhoeATCfyt7Lp7kYe/7e87mFX9KMNGTqxJgIztE=";
   };
 
   dontDisableStatic = true;
@@ -30,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace test/autotest.py \
       --replace /bin/bash ${bash}/bin/bash \
       --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace /usr/bin/python ${python2}/bin/python \
+      --replace /usr/bin/python ${python3.interpreter} \
       --replace "os.environ['USER']" "\"nixbld1\"" \
       --replace "os.getenv('USER')" "\"nixbld1\""
   '';


### PR DESCRIPTION
###### Description of changes
https://github.com/dmtcp/dmtcp/compare/f999adbb8e88fe452a0e57ceb43b6eed7b4409f9..133687764c6742906006a1d247e3b83cd860fa1d
Upstream has python3 support now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
