### PR TITLE
gdb: fix w/musl

### DIFF
--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
   postPatch = if stdenv.isDarwin then ''
     substituteInPlace gdb/darwin-nat.c \
       --replace '#include "bfd/mach-o.h"' '#include "mach-o.h"'
+  '' else if stdenv.hostPlatform.isMusl then ''
+    substituteInPlace sim/ppc/emul_unix.c --replace sys/termios.h termios.h
   '' else null;
 
   patches = [

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -52,7 +52,11 @@ stdenv.mkDerivation rec {
     })
   ] ++ lib.optionals stdenv.isDarwin [
     ./darwin-target-match.patch
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isMusl (fetchpatch {
+    name = "musl-fix-pagesize-page_size.patch";
+    url = "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=fd0975b96b16d96010dce439af9620d3dfb65426";
+    hash = "sha256-M3U7uIIFJnYu0g8/sMLJPhm02q7cGOi6pLjgsUUjeKI=";
+  });
 
   nativeBuildInputs = [ pkg-config texinfo perl setupDebugInfoDirs ];
 


### PR DESCRIPTION
###### Description of changes

Fix minor issues with headers in musl:

* `termios.h` not `sys/termios.h`
* Pick upstream patch avoiding issues with header-provided
  PAGESIZE/PAGE_SIZE.

Alternatively, especially if this becomes a burden to maintain,
we could simply disable `-Werror` for gdb:
c6bea27bd24a6ecb6c673d628cf8a60e4c8a6239 .

I started there, but then I wanted to understand what warnings were
lingering (and why), and in the process ended up fixing them all (and
finding the upstream patch).

I thought sourceware.org patches were sketchy long-term but I'm not
sure.  While this will go away when upgraded (and patches included),
if the source is indeed unstable we may prefer to vendor these patches
so they don't disappear in the future (impacting reproducibility)
for anyone still making use of these expressions / versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->