### PR TITLE
lunar-client: 2.9.3 -> 2.10.0

### DIFF
--- a/pkgs/games/lunar-client/default.nix
+++ b/pkgs/games/lunar-client/default.nix
@@ -2,13 +2,13 @@
 
 let
   name = "lunar-client";
-  version = "2.9.3";
+  version = "2.10.0";
 
   desktopItem = makeDesktopItem {
     name = "lunar-client";
     exec = "lunar-client";
     icon = "lunarclient";
-    comment = "Minecraft 1.7, 1.8, 1.12, 1.15, and 1.16 Client";
+    comment = "Minecraft 1.7, 1.8, 1.12, 1.15, 1.16, 1.17, and 1.18 Client";
     desktopName = "Lunar Client";
     genericName = "Minecraft Client";
     categories = [ "Game" ];
@@ -21,7 +21,7 @@ let
   src = fetchurl {
     url = "https://launcherupdates.lunarclientcdn.com/Lunar%20Client-${version}.AppImage";
     name = "lunar-client.AppImage";
-    sha256 = "sha256-2wlC+OAG2lvUB3yPxppNhhvNDZv4gxrNKpww9vAfStI=";
+    sha256 = "1kfi3rgy401ll3gn9k30j0a1zds1ghl5g2ibfwlsnr826nckfmzw";
   };
 in
 appimageTools.wrapType1 rec {
@@ -36,7 +36,7 @@ appimageTools.wrapType1 rec {
   extraPkgs = pkgs: [ pkgs.libpulseaudio ];
 
   meta = with lib; {
-    description = "Minecraft 1.7, 1.8, 1.12, 1.15, and 1.16 Client";
+    description = "Minecraft 1.7, 1.8, 1.12, 1.15, 1.16, 1.17, and 1.18 Client";
     homepage = "https://www.lunarclient.com/";
     license = with licenses; [ unfree ];
     maintainers = with maintainers; [ zyansheep Technical27 ];


### PR DESCRIPTION
###### Description of changes
Updated description to include new supported Minecraft versions, and updated application version number

Application patch notes:
https://www.lunarclient.com/news/patch-notes-18/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
