### PR TITLE
lean2: 2017-07-22 -> 2018-10-01, unbreak

### DIFF
--- a/pkgs/applications/science/logic/lean2/default.nix
+++ b/pkgs/applications/science/logic/lean2/default.nix
@@ -1,0 +1,46 @@
+{ lib, stdenv, fetchpatch, fetchFromGitHub, cmake, gmp, mpfr, python3
+, jemalloc, ninja, makeWrapper }:
+
+stdenv.mkDerivation {
+  pname = "lean2";
+  version = "2018-10-01";
+
+  src = fetchFromGitHub {
+    owner  = "leanprover";
+    repo   = "lean2";
+    rev    = "8072fdf9a0b31abb9d43ab894d7a858639e20ed7";
+    sha256 = "12bscgihdgvaq5xi0hqf5r4w386zxm3nkx1n150lv5smhg8ga3gg";
+  };
+
+  patches = [
+    # https://github.com/leanprover/lean2/pull/13
+    (fetchpatch {
+      name = "lean2-fix-compilation-error.patch";
+      url = "https://github.com/collares/lean2/commit/09b316ce75fd330b3b140d138bcdae2b0e909234.patch";
+      sha256 = "060mvqn9y8lsn4l20q9rhamkymzsgh0r1vzkjw78gnj8kjw67jl5";
+    })
+  ];
+  nativeBuildInputs = [ cmake makeWrapper ninja ];
+  buildInputs = [ gmp mpfr python3 jemalloc ];
+
+  preConfigure = ''
+    patchShebangs bin/leantags
+    cd src
+  '';
+
+  cmakeFlags = [ "-GNinja" ];
+
+  postInstall = ''
+    wrapProgram $out/bin/linja --prefix PATH : $out/bin:${ninja}/bin
+  '';
+
+  meta = with lib; {
+    description = "Automatic and interactive theorem prover (version with HoTT support)";
+    homepage    = "http://leanprover.github.io";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice gebner ];
+    broken      = stdenv.isAarch64;
+    mainProgram = "lean";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33276,6 +33276,7 @@ with pkgs;
   keymapviz = callPackage ../tools/misc/keymapviz { };
 
   lean = callPackage ../applications/science/logic/lean {};
+  lean2 = callPackage ../applications/science/logic/lean2 {};
   lean3 = lean;
   elan = callPackage ../applications/science/logic/elan {};
   mathlibtools = with python3Packages; toPythonApplication mathlibtools;


### PR DESCRIPTION
###### Description of changes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
