### PR TITLE
pipecontrol: init at 0.2.2

### DIFF
--- a/pkgs/applications/audio/pipecontrol/default.nix
+++ b/pkgs/applications/audio/pipecontrol/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     cmake
     extra-cmake-modules
     wrapQtAppsHook
+    qttools
   ];
 
   buildInputs = [
@@ -37,7 +38,6 @@ stdenv.mkDerivation rec {
     kirigami2
     kcoreaddons
     ki18n
-    qttools
     qtquickcontrols2
   ];
 

--- a/pkgs/applications/audio/pipecontrol/default.nix
+++ b/pkgs/applications/audio/pipecontrol/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "portaloffreedom";
     repo = pname;
-    rev = "v" + version;
+    rev = "v${version}";
     sha256 = "sha256-BeubRDx82MQX1gB7GnGJlQ2FyYX1S83C3gqPZgIjgoM=";
   };
 
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
     wrapQtAppsHook
   ];
+
   buildInputs = [
     pipewire
     qtbase
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Pipewire control GUI program in Qt (Kirigami2)";
     homepage = "https://github.com/portaloffreedom/pipecontrol";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ tilcreator ];
   };
 }

--- a/pkgs/applications/audio/pipecontrol/default.nix
+++ b/pkgs/applications/audio/pipecontrol/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pipewire
+, cmake
+, extra-cmake-modules
+, gnumake
+, wrapQtAppsHook
+, qtbase
+, qttools
+, kirigami2
+, kcoreaddons
+, ki18n
+, qtquickcontrols2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pipecontrol";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "portaloffreedom";
+    repo = pname;
+    rev = "v" + version;
+    sha256 = "sha256-BeubRDx82MQX1gB7GnGJlQ2FyYX1S83C3gqPZgIjgoM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+  buildInputs = [
+    pipewire
+    qtbase
+    kirigami2
+    kcoreaddons
+    ki18n
+    qttools
+    qtquickcontrols2
+  ];
+
+  meta = with lib; {
+    description = "Pipewire control GUI program in Qt (Kirigami2)";
+    homepage = "https://github.com/portaloffreedom/pipecontrol";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ tilcreator ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8835,6 +8835,8 @@ with pkgs;
 
   pipe-rename = callPackage ../tools/misc/pipe-rename { };
 
+  pipecontrol = libsForQt5.callPackage ../applications/audio/pipecontrol { };
+
   pipectl = callPackage ../tools/misc/pipectl { };
 
   pitivi = callPackage ../applications/video/pitivi { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
