### PR TITLE
wl-color-picker: init at 1.3

### DIFF
--- a/pkgs/tools/wayland/wl-color-picker/default.nix
+++ b/pkgs/tools/wayland/wl-color-picker/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, slurp
+, grim
+, gnome
+, wl-clipboard
+, imagemagick
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "wl-color-picker";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "jgmdev";
+    repo = "wl-color-picker";
+    rev = "v${version}";
+    sha256 = "sha256-lvhpXy4Sd1boYNGhbPoZTJlBhlW5obltDOrEzB1Gq0A=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace 'which' 'ls' \
+      --replace 'grim' "${grim}/bin/grim" \
+      --replace 'slurp' "${slurp}/bin/slurp" \
+      --replace 'convert' "${imagemagick}/bin/convert" \
+      --replace 'zenity' "${gnome.zenity}/bin/zenity" \
+      --replace 'wl-copy' "${wl-clipboard}/bin/wl-copy"
+  '';
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/usr/bin/wl-color-picker \
+      --prefix PATH : ${lib.makeBinPath [
+         grim
+         slurp
+         imagemagick
+         gnome.zenity
+         wl-clipboard
+       ]}
+    mkdir -p $out/bin
+    ln -s $out/usr/bin/wl-color-picker $out/bin/wl-color-picker
+  '';
+
+  meta = with lib; {
+    description = "Wayland color picker that also works on wlroots";
+    homepage = "https://github.com/jgmdev/wl-color-picker";
+    license = licenses.mit;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2729,6 +2729,8 @@ with pkgs;
 
   wl-clipboard-x11 = callPackage ../tools/wayland/wl-clipboard-x11 { };
 
+  wl-color-picker = callPackage ../tools/wayland/wl-color-picker { };
+
   wl-mirror = callPackage ../tools/wayland/wl-mirror { };
 
   wlogout = callPackage ../tools/wayland/wlogout { };


### PR DESCRIPTION
###### Description of changes

This PR adds the script [wl-color-picker](https://github.com/jgmdev/wl-color-picker) for picking colors on a wayland desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
