### PR TITLE
CODEOWNERS: add @NixOS/systemd for systemd files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,9 +79,9 @@
 
 # Systemd
 /nixos/modules/system/boot/systemd.nix      @NixOS/systemd
-/nixos/modules/system/boot/systemd    @NixOS/systemd
-/nixos/lib/systemd-*.nix             @NixOS/systemd
-/pkgs/os-specific/linux/systemd      @NixOS/systemd
+/nixos/modules/system/boot/systemd          @NixOS/systemd
+/nixos/lib/systemd-*.nix                    @NixOS/systemd
+/pkgs/os-specific/linux/systemd             @NixOS/systemd
 
 # Updaters
 ## update.nix

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,10 +78,10 @@
 /nixos/lib/test-driver  @tfc
 
 # Systemd
-/nixos/modules/system/boot/systemd.nix      @NixOS/systemd @Kloenk
-/nixos/modules/system/boot/systemd    @NixOS/systemd @Kloenk
-/nixos/lib/systemd-*.nix             @NixOS/systemd @Kloenk
-/pkgs/os-specific/linux/systemd      @NixOS/systemd @Kloenk
+/nixos/modules/system/boot/systemd.nix      @NixOS/systemd
+/nixos/modules/system/boot/systemd    @NixOS/systemd
+/nixos/lib/systemd-*.nix             @NixOS/systemd
+/pkgs/os-specific/linux/systemd      @NixOS/systemd
 
 # Updaters
 ## update.nix

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,8 +78,8 @@
 /nixos/lib/test-driver  @tfc
 
 # Systemd
-/nixos/modules/boot/systemd.nix      @NixOS/systemd @Kloenk
-/nixos/modules/boot/systemd-*.nix    @NixOS/systemd @Kloenk
+/nixos/modules/system/boot/systemd.nix      @NixOS/systemd @Kloenk
+/nixos/modules/system/boot/systemd    @NixOS/systemd @Kloenk
 /nixos/lib/systemd-*.nix             @NixOS/systemd @Kloenk
 /pkgs/os-specific/linux/systemd      @NixOS/systemd @Kloenk
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,10 +78,10 @@
 /nixos/lib/test-driver  @tfc
 
 # Systemd
-/nixos/modules/boot/systemd.nix      @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
-/nixos/modules/boot/systemd-*.nix    @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
-/nixos/lib/systemd-*.nix             @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
-/pkgs/os-specific/linux/systemd      @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
+/nixos/modules/boot/systemd.nix      @NixOS/systemd @Kloenk
+/nixos/modules/boot/systemd-*.nix    @NixOS/systemd @Kloenk
+/nixos/lib/systemd-*.nix             @NixOS/systemd @Kloenk
+/pkgs/os-specific/linux/systemd      @NixOS/systemd @Kloenk
 
 # Updaters
 ## update.nix

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,12 @@
 # NixOS integration test driver
 /nixos/lib/test-driver  @tfc
 
+# Systemd
+/nixos/modules/boot/systemd.nix      @NixOS/systemd
+/nixos/modules/boot/systemd-*.nix    @NixOS/systemd
+/nixos/lib/systemd-*.nix             @NixOS/systemd
+/pkgs/os-specific/linux/systemd      @NixOS/systemd
+
 # Updaters
 ## update.nix
 /maintainers/scripts/update.nix   @jtojnar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,10 +78,10 @@
 /nixos/lib/test-driver  @tfc
 
 # Systemd
-/nixos/modules/boot/systemd.nix      @NixOS/systemd
-/nixos/modules/boot/systemd-*.nix    @NixOS/systemd
-/nixos/lib/systemd-*.nix             @NixOS/systemd
-/pkgs/os-specific/linux/systemd      @NixOS/systemd
+/nixos/modules/boot/systemd.nix      @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
+/nixos/modules/boot/systemd-*.nix    @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
+/nixos/lib/systemd-*.nix             @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
+/pkgs/os-specific/linux/systemd      @NixOS/systemd @flokli @arianvp @NinjaTrappeur @aanderse
 
 # Updaters
 ## update.nix


### PR DESCRIPTION
###### Description of changes

In response to review spam on https://github.com/NixOS/nixpkgs/pull/164016 and a follow-up conversation on Matrix https://matrix.to/#/#systemd:nixos.org

There is a team called @NixOS/systemd, but CODEOWNERS doesn't refer to this team. This results in PRs regarding systemd will add a reviewer unrelated to systemd to the PR.

This PR attempts to make @NixOS/systemd codeowner for all systemd-related files.

When https://github.com/NixOS/nixpkgs/pull/164016 is merged, this file needs to include `/nixos/modules/systemd` instead of `/nixos/modules/systemd-*`.

The GitHub linter tells me @NixOS/systemd needs to have write access to nixpkgs. It seems `NixOS/darwin-maintainers` is also in there with the same warning. Is this true to make automatic adding of reviewers work? If not, should @NixOS/systemd have write access to be able to merge systemd PRs?

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
