### PR TITLE
remove broken Tag from nvidia 340.108 and apply patches upto kernel 5.16

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/0001_kernel_5.7.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0001_kernel_5.7.patch
@@ -1,0 +1,780 @@
+From 2154cc447a2377cfd60a7b7c5b619e689ebf71b1 Mon Sep 17 00:00:00 2001
+From: graysky <graysky@archlinux.us>
+Date: Thu, 22 Oct 2020 06:58:53 -0400
+Subject: [PATCH 1/3] kernel-5.7
+
+credit: https://gitlab.manjaro.org/packages?utf8=%E2%9C%93&filter=nvidia-340xx
+---
+ kernel/Makefile              |   5 +
+ kernel/conftest.sh           |  81 +++++++++++++
+ kernel/dkms.conf             |   8 +-
+ kernel/nv-drm.c              | 229 ++++++++++++++++++++++++++++++++++-
+ kernel/nv-linux.h            |  49 ++++++++
+ kernel/nv-procfs.c           |  20 +++
+ kernel/nv-time.h             |   9 +-
+ kernel/nv.c                  |   2 +-
+ kernel/os-interface.c        |   8 +-
+ kernel/uvm/Makefile          |   1 +
+ kernel/uvm/conftest.sh       |   4 +
+ kernel/uvm/nvidia_uvm_lite.c |  29 ++++-
+ 12 files changed, 431 insertions(+), 14 deletions(-)
+
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 125a690..2597080 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -108,12 +108,14 @@ COMPILE_TESTS = \
+ 	acquire_console_sem \
+ 	console_lock \
+ 	kmem_cache_create \
++	kmem_cache_create_usercopy \
+ 	outer_flush_all \
+ 	on_each_cpu \
+ 	smp_call_function \
+ 	nvmap_support \
+ 	acpi_evaluate_integer \
+ 	ioremap_cache \
++	ioremap_nocache \
+ 	ioremap_wc \
+ 	proc_dir_entry \
+ 	INIT_WORK \
+@@ -122,6 +124,7 @@ COMPILE_TESTS = \
+ 	pci_domain_nr \
+ 	pci_dma_mapping_error \
+ 	file_operations \
++	proc_ops \
+ 	sg_alloc_table \
+ 	sg_init_table \
+ 	pci_get_domain_bus_and_slot \
+@@ -147,6 +150,8 @@ COMPILE_TESTS = \
+ 	vm_fault_present \
+ 	vm_fault_has_address \
+ 	drm_driver_unload_has_int_return_type \
++	drm_get_pci_dev \
++	drm_pci_init \
+ 	drm_legacy_pci_init \
+ 	timer_setup \
+ 	do_gettimeofday \
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index b7a85f0..a5225e5 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -176,6 +176,7 @@ test_headers() {
+     FILES="$FILES linux/ktime.h"
+     FILES="$FILES linux/file.h"
+ 
++    FILES_ARCH="$FILES_ARCH asm/pgtable.h"
+     FILES_ARCH="$FILES_ARCH asm/set_memory.h"
+ 
+     translate_and_find_header_files $HEADERS      $FILES
+@@ -440,6 +441,9 @@ compile_test() {
+             # Determine if the set_memory_array_uc() function is present.
+             #
+             CODE="
++            #if defined(NV_ASM_PGTABLE_H_PRESENT)
++            #include <asm/pgtable.h>
++            #endif
+             #if defined(NV_ASM_SET_MEMORY_H_PRESENT)
+             #include <asm/set_memory.h>
+             #else
+@@ -914,6 +918,21 @@ compile_test() {
+             fi
+         ;;
+ 
++        kmem_cache_create_usercopy)
++            #
++            # Determine if the kmem_cache_create_usercopy function exists.
++            #
++            # This function was added by:
++            #   2017-06-10  8eb8284b412906181357c2b0110d879d5af95e52
++            CODE="
++            #include <linux/slab.h>
++            void kmem_cache_create_usercopy(void) {
++                kmem_cache_create_usercopy();
++            }"
++
++            compile_check_conftest "$CODE" "NV_KMEM_CACHE_CREATE_USERCOPY_PRESENT" "" "functions"
++        ;;
++
+         smp_call_function)
+             #
+             # Determine if the smp_call_function() function is
+@@ -1188,6 +1207,22 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_IOREMAP_CACHE_PRESENT" "" "functions"
+         ;;
+ 
++        ioremap_nocache)
++            #
++            # Determine if the ioremap_nocache() function is present.
++            #
++            # Removed by commit 4bdc0d676a64 ("remove ioremap_nocache and
++            # devm_ioremap_nocache") in v5.6 (2020-01-06)
++            #
++            CODE="
++            #include <asm/io.h>
++            void conftest_ioremap_nocache(void) {
++                ioremap_nocache();
++            }"
++
++            compile_check_conftest "$CODE" "NV_IOREMAP_NOCACHE_PRESENT" "" "functions"
++        ;;
++
+         ioremap_wc)
+             #
+             # Determine if the ioremap_wc() function is present.
+@@ -1371,6 +1406,16 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_FILE_OPERATIONS_HAS_COMPAT_IOCTL" "" "types"
+         ;;
+ 
++        proc_ops)
++            CODE="
++            #include <linux/proc_fs.h>
++            int conftest_proc_ops(void) {
++                return offsetof(struct proc_ops, proc_open);
++            }"
++
++            compile_check_conftest "$CODE" "NV_HAVE_PROC_OPS" "" "types"
++        ;;
++
+         sg_init_table)
+             #
+             # Determine if the sg_init_table() function is present.
+@@ -2044,6 +2089,42 @@ compile_test() {
+             compile_check_conftest "$CODE" "NV_DRM_DRIVER_UNLOAD_HAS_INT_RETURN_TYPE" "" "types"
+         ;;
+ 
++        drm_get_pci_dev)
++            #
++            # Determine if drm_get_pci_dev() is present.
++            #
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++
++            #if defined(NV_DRM_DRM_PCI_H_PRESENT)
++            #include <drm/drm_pci.h>
++            #endif
++
++            void conftest_drm_legacy_pci_init(void) {
++                drm_get_pci_dev();
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_GET_PCI_DEV_PRESENT" "" "functions"
++        ;;
++
++        drm_pci_init)
++            #
++            # Determine if drm_pci_init() is present.
++            #
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++
++            void conftest_drm_legacy_pci_init(void) {
++                drm_pci_init();
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_PCI_INIT_PRESENT" "" "functions"
++        ;;
++
+         drm_legacy_pci_init)
+             #
+             # Determine if drm_legacy_pci_init() is present. drm_pci_init() was
+diff --git a/kernel/dkms.conf b/kernel/dkms.conf
+index 79a02ae..3140f03 100644
+--- a/kernel/dkms.conf
++++ b/kernel/dkms.conf
+@@ -1,7 +1,13 @@
++if [ -x /usr/bin/nproc ]; then
++  num_cpu_cores=$(nproc)
++else
++  num_cpu_cores=1
++fi
++
+ PACKAGE_NAME="nvidia"
+ PACKAGE_VERSION="340.108"
+ BUILT_MODULE_NAME[0]="$PACKAGE_NAME"
+ DEST_MODULE_LOCATION[0]="/kernel/drivers/video"
+-MAKE[0]="make module KERNEL_UNAME=${kernelver}"
++MAKE[0]="make -j$num_cpu_cores module KERNEL_UNAME=${kernelver}"
+ CLEAN="make clean"
+ AUTOINSTALL="yes"
+diff --git a/kernel/nv-drm.c b/kernel/nv-drm.c
+index 0d1cdbf..85db07e 100644
+--- a/kernel/nv-drm.c
++++ b/kernel/nv-drm.c
+@@ -50,9 +50,236 @@
+ #if defined(NV_DRM_LEGACY_PCI_INIT_PRESENT)
+ #define nv_drm_pci_init drm_legacy_pci_init
+ #define nv_drm_pci_exit drm_legacy_pci_exit
+-#else
++#elif defined(NV_DRM_PCI_INIT_PRESENT)
+ #define nv_drm_pci_init drm_pci_init
+ #define nv_drm_pci_exit drm_pci_exit
++#else
++#if defined(NV_DRM_GET_PCI_DEV_PRESENT)
++#define nv_drm_get_pci_dev drm_get_pci_dev
++#else
++#include <drm/drm_agpsupport.h>
++
++struct nv_drm_agp_head {
++    struct agp_kern_info agp_info;
++    struct list_head memory;
++    unsigned long mode;
++    struct agp_bridge_data *bridge;
++    int enabled;
++    int acquired;
++    unsigned long base;
++    int agp_mtrr;
++    int cant_use_aperture;
++    unsigned long page_mask;
++};
++
++struct nv_drm_agp_mem {
++    unsigned long handle;
++    struct agp_memory *memory;
++    unsigned long bound;
++    int pages;
++    struct list_head head;
++};
++
++/*
++ * Code from drm_agp_init/nv_drm_{free,unbind}_agp
++ * Extracted from commit: 5b8b9d0c6d0e0f1993c6c56deaf9646942c49d94, file: drivers/gpu/drm/drm_agpsupport.c
++ */
++struct drm_agp_head *nv_drm_agp_init(struct drm_device *dev)
++{
++    struct nv_drm_agp_head *head = NULL;
++
++    head = kzalloc(sizeof(*head), GFP_KERNEL);
++    if (!head)
++        return NULL;
++    head->bridge = agp_find_bridge(dev->pdev);
++    if (!head->bridge) {
++        head->bridge = agp_backend_acquire(dev->pdev);
++        if (!head->bridge) {
++            kfree(head);
++            return NULL;
++        }
++        agp_copy_info(head->bridge, &head->agp_info);
++        agp_backend_release(head->bridge);
++    } else {
++        agp_copy_info(head->bridge, &head->agp_info);
++    }
++    if (head->agp_info.chipset == NOT_SUPPORTED) {
++        kfree(head);
++        return NULL;
++    }
++    INIT_LIST_HEAD(&head->memory);
++    head->cant_use_aperture = head->agp_info.cant_use_aperture;
++    head->page_mask = head->agp_info.page_mask;
++    head->base = head->agp_info.aper_base;
++    return (struct drm_agp_head *)head;
++}
++
++void nv_drm_free_agp(struct agp_memory *handle, int pages)
++{
++    agp_free_memory(handle);
++}
++
++int nv_drm_unbind_agp(struct agp_memory *handle)
++{
++    return agp_unbind_memory(handle);
++}
++
++/*
++ * Code from drm_pci_agp_{clear,destroy,init}/drm_get_pci_dev
++ * Extracted from commit: 5b8b9d0c6d0e0f1993c6c56deaf9646942c49d94, file: drivers/gpu/drm/drm_pci.c
++ */
++static void nv_drm_pci_agp_init(struct drm_device *dev)
++{
++    if (drm_core_check_feature(dev, DRIVER_USE_AGP)) {
++        if (pci_find_capability(dev->pdev, PCI_CAP_ID_AGP))
++            dev->agp = nv_drm_agp_init(dev);
++        if (dev->agp) {
++            dev->agp->agp_mtrr = arch_phys_wc_add(
++                dev->agp->agp_info.aper_base,
++                dev->agp->agp_info.aper_size *
++                1024 * 1024);
++        }
++    }
++}
++
++void nv_drm_legacy_agp_clear(struct drm_device *dev)
++{
++    struct nv_drm_agp_mem *entry, *tempe;
++
++    if (!dev->agp)
++        return;
++    if (!drm_core_check_feature(dev, DRIVER_LEGACY))
++        return;
++
++    list_for_each_entry_safe(entry, tempe, &dev->agp->memory, head) {
++        if (entry->bound)
++            nv_drm_unbind_agp(entry->memory);
++        nv_drm_free_agp(entry->memory, entry->pages);
++        kfree(entry);
++    }
++    INIT_LIST_HEAD(&dev->agp->memory);
++
++    if (dev->agp->acquired)
++        drm_agp_release(dev);
++
++    dev->agp->acquired = 0;
++    dev->agp->enabled = 0;
++}
++
++void nv_drm_pci_agp_destroy(struct drm_device *dev)
++{
++    if (dev->agp) {
++        arch_phys_wc_del(dev->agp->agp_mtrr);
++        nv_drm_legacy_agp_clear(dev);
++        kfree(dev->agp);
++        dev->agp = NULL;
++    }
++}
++
++static int nv_drm_get_pci_dev(struct pci_dev *pdev,
++               const struct pci_device_id *ent,
++               struct drm_driver *driver)
++{
++    struct drm_device *dev;
++    int ret;
++
++    DRM_DEBUG("\n");
++
++    dev = drm_dev_alloc(driver, &pdev->dev);
++    if (IS_ERR(dev))
++        return PTR_ERR(dev);
++
++    ret = pci_enable_device(pdev);
++    if (ret)
++        goto err_free;
++
++    dev->pdev = pdev;
++#ifdef __alpha__
++    dev->hose = pdev->sysdata;
++#endif
++
++    if (drm_core_check_feature(dev, DRIVER_MODESET))
++        pci_set_drvdata(pdev, dev);
++
++    nv_drm_pci_agp_init(dev);
++
++    ret = drm_dev_register(dev, ent->driver_data);
++    if (ret)
++        goto err_agp;
++
++    /* No locking needed since shadow-attach is single-threaded since it may
++     * only be called from the per-driver module init hook. */
++    if (drm_core_check_feature(dev, DRIVER_LEGACY))
++        list_add_tail(&dev->legacy_dev_list, &driver->legacy_dev_list);
++
++    return 0;
++
++err_agp:
++    nv_drm_pci_agp_destroy(dev);
++    pci_disable_device(pdev);
++err_free:
++    drm_dev_put(dev);
++    return ret;
++}
++#endif
++
++/*
++ * Code from drm_legacy_pci_{init,exit}
++ * Extracted from tag: v5.6.3, file: drivers/gpu/drm/drm_pci.c
++ */
++int nv_drm_pci_init(struct drm_driver *driver, struct pci_driver *pdriver)
++{
++    struct pci_dev *pdev = NULL;
++    const struct pci_device_id *pid;
++    int i;
++
++    DRM_DEBUG("\n");
++
++    if (WARN_ON(!(driver->driver_features & DRIVER_LEGACY)))
++        return -EINVAL;
++
++    /* If not using KMS, fall back to stealth mode manual scanning. */
++    INIT_LIST_HEAD(&driver->legacy_dev_list);
++    for (i = 0; pdriver->id_table[i].vendor != 0; i++) {
++        pid = &pdriver->id_table[i];
++
++        /* Loop around setting up a DRM device for each PCI device
++         * matching our ID and device class.  If we had the internal
++         * function that pci_get_subsys and pci_get_class used, we'd
++         * be able to just pass pid in instead of doing a two-stage
++         * thing.
++         */
++        pdev = NULL;
++        while ((pdev =
++            pci_get_subsys(pid->vendor, pid->device, pid->subvendor,
++                       pid->subdevice, pdev)) != NULL) {
++            if ((pdev->class & pid->class_mask) != pid->class)
++                continue;
++
++            /* stealth mode requires a manual probe */
++            pci_dev_get(pdev);
++            nv_drm_get_pci_dev(pdev, pid, driver);
++        }
++    }
++    return 0;
++}
++
++void nv_drm_pci_exit(struct drm_driver *driver, struct pci_driver *pdriver)
++{
++    struct drm_device *dev, *tmp;
++    DRM_DEBUG("\n");
++
++    if (!(driver->driver_features & DRIVER_LEGACY)) {
++        WARN_ON(1);
++    } else {
++        list_for_each_entry_safe(dev, tmp, &driver->legacy_dev_list,
++                     legacy_dev_list) {
++            list_del(&dev->legacy_dev_list);
++            drm_put_dev(dev);
++        }
++    }
++    DRM_INFO("Module unloaded\n");
++}
+ #endif
+ 
+ extern nv_linux_state_t *nv_linux_devices;
+diff --git a/kernel/nv-linux.h b/kernel/nv-linux.h
+index a1d2c68..83e6433 100644
+--- a/kernel/nv-linux.h
++++ b/kernel/nv-linux.h
+@@ -688,11 +688,16 @@ extern nv_spinlock_t km_lock;
+         VM_ALLOC_RECORD(ptr, size, "vm_ioremap"); \
+     }
+ 
++#if defined(NV_IOREMAP_NOCACHE_PRESENT)
+ #define NV_IOREMAP_NOCACHE(ptr, physaddr, size) \
+     { \
+         (ptr) = ioremap_nocache(physaddr, size); \
+         VM_ALLOC_RECORD(ptr, size, "vm_ioremap_nocache"); \
+     }
++#else
++#define NV_IOREMAP_NOCACHE(ptr, physaddr, size) \
++    NV_IOREMAP(ptr, physaddr, size)
++#endif
+ 
+ #if defined(NV_IOREMAP_CACHE_PRESENT)
+ #define NV_IOREMAP_CACHE(ptr, physaddr, size)            \
+@@ -774,6 +779,17 @@ extern nv_spinlock_t km_lock;
+ #error "NV_KMEM_CACHE_CREATE() undefined (kmem_cache_create() unavailable)!"
+ #endif
+ 
++#if defined(NV_KMEM_CACHE_CREATE_USERCOPY_PRESENT)
++#define NV_KMEM_CACHE_CREATE_USERCOPY(kmem_cache, name, type)       \
++    {                                                               \
++        kmem_cache = kmem_cache_create_usercopy(name, sizeof(type), \
++                        0, 0, 0, sizeof(type), NULL);               \
++    }
++#else
++#define NV_KMEM_CACHE_CREATE_USERCOPY(kmem_cache, name, type)       \
++        NV_KMEM_CACHE_CREATE(kmem_cache, name, type)
++#endif
++
+ #define NV_KMEM_CACHE_ALLOC(ptr, kmem_cache, type)              \
+     {                                                           \
+         (ptr) = kmem_cache_alloc(kmem_cache, GFP_KERNEL);       \
+@@ -1971,6 +1987,19 @@ extern NvU32 nv_assign_gpu_count;
+     })
+ #endif
+ 
++#if defined(NV_HAVE_PROC_OPS)
++#define NV_CREATE_PROC_FILE(filename,parent,__name,__data)               \
++   ({                                                                    \
++        struct proc_dir_entry *__entry;                                  \
++        int mode = (S_IFREG | S_IRUGO);                                  \
++        const struct proc_ops *fops = &nv_procfs_##__name##_fops;        \
++        if (fops->proc_write != 0)                                       \
++            mode |= S_IWUSR;                                             \
++        __entry = NV_CREATE_PROC_ENTRY(filename, mode, parent, fops,     \
++            __data);                                                     \
++        __entry;                                                         \
++    })
++#else
+ #define NV_CREATE_PROC_FILE(filename,parent,__name,__data)               \
+    ({                                                                    \
+         struct proc_dir_entry *__entry;                                  \
+@@ -1982,6 +2011,7 @@ extern NvU32 nv_assign_gpu_count;
+             __data);                                                     \
+         __entry;                                                         \
+     })
++#endif
+ 
+ /*
+  * proc_mkdir_mode exists in Linux 2.6.9, but isn't exported until Linux 3.0.
+@@ -2023,6 +2053,24 @@ extern NvU32 nv_assign_gpu_count;
+     remove_proc_entry(entry->name, entry->parent);
+ #endif
+ 
++#if defined(NV_HAVE_PROC_OPS)
++#define NV_DEFINE_PROCFS_SINGLE_FILE(__name)                                  \
++    static int nv_procfs_open_##__name(                                       \
++        struct inode *inode,                                                  \
++        struct file *filep                                                    \
++    )                                                                         \
++    {                                                                         \
++        return single_open(filep, nv_procfs_read_##__name,                    \
++            NV_PDE_DATA(inode));                                              \
++    }                                                                         \
++                                                                              \
++    static const struct proc_ops nv_procfs_##__name##_fops = {                \
++        .proc_open       = nv_procfs_open_##__name,                           \
++        .proc_read       = seq_read,                                          \
++        .proc_lseek      = seq_lseek,                                         \
++        .proc_release    = single_release,                                    \
++    };
++#else
+ #define NV_DEFINE_PROCFS_SINGLE_FILE(__name)                                  \
+     static int nv_procfs_open_##__name(                                       \
+         struct inode *inode,                                                  \
+@@ -2040,6 +2088,7 @@ extern NvU32 nv_assign_gpu_count;
+         .llseek     = seq_lseek,                                              \
+         .release    = single_release,                                         \
+     };
++#endif
+ 
+ #endif  /* CONFIG_PROC_FS */
+ 
+diff --git a/kernel/nv-procfs.c b/kernel/nv-procfs.c
+index ebca3e8..9365c3c 100644
+--- a/kernel/nv-procfs.c
++++ b/kernel/nv-procfs.c
+@@ -409,6 +409,15 @@ done:
+     return ((status < 0) ? status : (int)count);
+ }
+ 
++#if defined(NV_HAVE_PROC_OPS)
++static struct proc_ops nv_procfs_registry_fops = {
++    .proc_open    = nv_procfs_open_registry,
++    .proc_read    = seq_read,
++    .proc_write   = nv_procfs_write_file,
++    .proc_lseek   = seq_lseek,
++    .proc_release = nv_procfs_close_registry,
++};
++#else
+ static struct file_operations nv_procfs_registry_fops = {
+     .owner   = THIS_MODULE,
+     .open    = nv_procfs_open_registry,
+@@ -417,6 +426,7 @@ static struct file_operations nv_procfs_registry_fops = {
+     .llseek  = seq_lseek,
+     .release = nv_procfs_close_registry,
+ };
++#endif
+ 
+ static int
+ nv_procfs_read_unbind_lock(
+@@ -538,6 +548,15 @@ done:
+     return rc;
+ }
+ 
++#if defined(NV_HAVE_PROC_OPS)
++static struct proc_ops nv_procfs_unbind_lock_fops = {
++    .proc_open    = nv_procfs_open_unbind_lock,
++    .proc_read    = seq_read,
++    .proc_write   = nv_procfs_write_file,
++    .proc_lseek   = seq_lseek,
++    .proc_release = nv_procfs_close_unbind_lock,
++};
++#else
+ static struct file_operations nv_procfs_unbind_lock_fops = {
+     .owner   = THIS_MODULE,
+     .open    = nv_procfs_open_unbind_lock,
+@@ -546,6 +565,7 @@ static struct file_operations nv_procfs_unbind_lock_fops = {
+     .llseek  = seq_lseek,
+     .release = nv_procfs_close_unbind_lock,
+ };
++#endif
+ 
+ static int
+ nv_procfs_read_text_file(
+diff --git a/kernel/nv-time.h b/kernel/nv-time.h
+index a34ceb2..780f8bc 100644
+--- a/kernel/nv-time.h
++++ b/kernel/nv-time.h
+@@ -28,7 +28,12 @@
+ #include <linux/ktime.h>
+ #endif
+ 
+-static inline void nv_gettimeofday(struct timeval *tv)
++struct nv_timeval {
++    __kernel_long_t      tv_sec;
++    __kernel_suseconds_t tv_usec;
++};
++
++static inline void nv_gettimeofday(struct nv_timeval *tv)
+ {
+ #ifdef NV_DO_GETTIMEOFDAY_PRESENT
+     do_gettimeofday(tv);
+@@ -37,7 +42,7 @@ static inline void nv_gettimeofday(struct timeval *tv)
+ 
+     ktime_get_real_ts64(&now);
+ 
+-    *tv = (struct timeval) {
++    *tv = (struct nv_timeval) {
+         .tv_sec = now.tv_sec,
+         .tv_usec = now.tv_nsec/1000,
+     };
+diff --git a/kernel/nv.c b/kernel/nv.c
+index a167be9..a218f83 100644
+--- a/kernel/nv.c
++++ b/kernel/nv.c
+@@ -752,7 +752,7 @@ int __init nvidia_init_module(void)
+     NV_SPIN_LOCK_INIT(&km_lock);
+ #endif
+ 
+-    NV_KMEM_CACHE_CREATE(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
++    NV_KMEM_CACHE_CREATE_USERCOPY(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
+     if (nv_stack_t_cache == NULL)
+     {
+         nv_printf(NV_DBG_ERRORS, "NVRM: stack cache allocation failed!\n");
+diff --git a/kernel/os-interface.c b/kernel/os-interface.c
+index 7190b26..0c0dc05 100644
+--- a/kernel/os-interface.c
++++ b/kernel/os-interface.c
+@@ -439,7 +439,7 @@ RM_STATUS NV_API_CALL os_get_current_time(
+     NvU32 *useconds
+ )
+ {
+-    struct timeval tm;
++    struct nv_timeval tm;
+ 
+     nv_gettimeofday(&tm);
+ 
+@@ -474,7 +474,7 @@ RM_STATUS NV_API_CALL os_delay_us(NvU32 MicroSeconds)
+     unsigned long usec;
+ 
+ #ifdef NV_CHECK_DELAY_ACCURACY
+-    struct timeval tm1, tm2;
++    struct nv_timeval tm1, tm2;
+ 
+     nv_gettimeofday(&tm1);
+ #endif
+@@ -514,9 +514,9 @@ RM_STATUS NV_API_CALL os_delay(NvU32 MilliSeconds)
+     unsigned long MicroSeconds;
+     unsigned long jiffies;
+     unsigned long mdelay_safe_msec;
+-    struct timeval tm_end, tm_aux;
++    struct nv_timeval tm_end, tm_aux;
+ #ifdef NV_CHECK_DELAY_ACCURACY
+-    struct timeval tm_start;
++    struct nv_timeval tm_start;
+ #endif
+ 
+     nv_gettimeofday(&tm_aux);
+diff --git a/kernel/uvm/Makefile b/kernel/uvm/Makefile
+index 0cad8ff..043a08d 100644
+--- a/kernel/uvm/Makefile
++++ b/kernel/uvm/Makefile
+@@ -207,6 +207,7 @@ ccflags-y += $(EXTRA_CFLAGS)
+ 
+ RM_MODULE_SYMVERS:= $(RM_OUT_DIR)/Module.symvers
+ UVM_MODULE_SYMVERS:= $(obj)/Module.symvers
++KBUILD_EXTRA_SYMBOLS:= $(UVM_MODULE_SYMVERS)
+ 
+ module $(MODULE_NAME).ko: $(UVM_MODULE_SYMVERS) debug_diagnostics_printing
+ 
+diff --git a/kernel/uvm/conftest.sh b/kernel/uvm/conftest.sh
+index b7a85f0..33e2a63 100755
+--- a/kernel/uvm/conftest.sh
++++ b/kernel/uvm/conftest.sh
+@@ -176,6 +176,7 @@ test_headers() {
+     FILES="$FILES linux/ktime.h"
+     FILES="$FILES linux/file.h"
+ 
++    FILES_ARCH="$FILES_ARCH asm/pgtable.h"
+     FILES_ARCH="$FILES_ARCH asm/set_memory.h"
+ 
+     translate_and_find_header_files $HEADERS      $FILES
+@@ -440,6 +441,9 @@ compile_test() {
+             # Determine if the set_memory_array_uc() function is present.
+             #
+             CODE="
++            #if defined(NV_ASM_PGTABLE_H_PRESENT)
++            #include <asm/pgtable.h>
++            #endif
+             #if defined(NV_ASM_SET_MEMORY_H_PRESENT)
+             #include <asm/set_memory.h>
+             #else
+diff --git a/kernel/uvm/nvidia_uvm_lite.c b/kernel/uvm/nvidia_uvm_lite.c
+index 6943e7c..9a7e3b6 100644
+--- a/kernel/uvm/nvidia_uvm_lite.c
++++ b/kernel/uvm/nvidia_uvm_lite.c
+@@ -131,8 +131,8 @@ static
+ RM_STATUS _preexisting_error_on_channel(UvmGpuMigrationTracking *pMigTracker,
+                                          UvmCommitRecord *pRecord);
+ 
+-static void _set_timeout_in_usec(struct timeval *src,
+-                                 struct timeval *result,
++static void _set_timeout_in_usec(struct nv_timeval *src,
++                                 struct nv_timeval *result,
+                                  unsigned long timeoutInUsec)
+ {
+     if (!src || !result)
+@@ -820,7 +820,13 @@ done:
+ }
+ 
+ #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++vm_fault_t _fault(struct vm_fault *vmf)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++int _fault(struct vm_fault *vmf)
++#else
+ int _fault(struct vm_area_struct *vma, struct vm_fault *vmf)
++#endif
+ {
+ #if defined(NV_VM_FAULT_HAS_ADDRESS)
+     unsigned long vaddr = vmf->address;
+@@ -828,8 +834,15 @@ int _fault(struct vm_area_struct *vma, struct vm_fault *vmf)
+     unsigned long vaddr = (unsigned long)vmf->virtual_address;
+ #endif
+     struct page *page = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++    vm_fault_t retval;
++#else
+     int retval;
+ 
++#endif
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++   struct vm_area_struct *vma = vmf->vma;
++#endif
+     retval = _fault_common(vma, vaddr, &page, vmf->flags);
+ 
+     vmf->page = page;
+@@ -868,7 +881,13 @@ static struct vm_operations_struct uvmlite_vma_ops =
+ // it's dealing with anonymous mapping (see handle_pte_fault).
+ //
+ #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++vm_fault_t _sigbus_fault(struct vm_fault *vmf)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++int _sigbus_fault(struct vm_fault *vmf)
++#else
+ int _sigbus_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
++#endif
+ {
+     vmf->page = NULL;
+     return VM_FAULT_SIGBUS;
+@@ -1992,9 +2011,9 @@ void umvlite_destroy_per_process_gpu_resources(UvmGpuUuid *gpuUuidStruct)
+ static RM_STATUS _check_ecc_errors(UvmGpuMigrationTracking *pMigTracker,
+                                     NvBool *pIsEccErrorSet)
+ {
+-    struct timeval eccErrorStartTime = {0};
+-    struct timeval eccErrorCurrentTime = {0};
+-    struct timeval eccTimeout = {0};
++    struct nv_timeval eccErrorStartTime = {0};
++    struct nv_timeval eccErrorCurrentTime = {0};
++    struct nv_timeval eccTimeout = {0};
+     NvBool bEccErrorTimeout = NV_FALSE;
+     NvBool bEccIncomingError = NV_FALSE;
+     unsigned rmInterruptSet = 0;
+-- 
+2.29.0
+

--- a/pkgs/os-specific/linux/nvidia-x11/0002_kernel_5.8.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0002_kernel_5.8.patch
@@ -1,0 +1,92 @@
+From 2cc3342b4b3c96bcc4062513011d35c079b009a2 Mon Sep 17 00:00:00 2001
+From: graysky <graysky@archlinux.us>
+Date: Thu, 22 Oct 2020 06:59:59 -0400
+Subject: [PATCH 2/3] kernel-5.8
+
+credit: https://launchpad.net/~kelebek333/+archive/ubuntu/nvidia-legacy/+packages
+extracted from: https://launchpadlibrarian.net/492468557/nvidia-graphics-drivers-340_340.108-1lmtrfocal3_340.108-2lmtrfocal.diff.gz
+---
+ kernel/nv-linux.h                | 8 ++++++++
+ kernel/nvidia-modules-common.mk  | 1 +
+ kernel/os-mlock.c                | 8 ++++++++
+ kernel/uvm/nvidia_uvm_lite_api.c | 4 ++++
+ 4 files changed, 21 insertions(+)
+
+diff --git a/kernel/nv-linux.h b/kernel/nv-linux.h
+index 83e6433..d055552 100644
+--- a/kernel/nv-linux.h
++++ b/kernel/nv-linux.h
+@@ -669,11 +669,19 @@ extern nv_spinlock_t km_lock;
+ #  define KM_FREE_RECORD(a,b,c)
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++#define NV_VMALLOC(ptr, size)                     \
++    {                                             \
++        (ptr) = __vmalloc(size, GFP_KERNEL);      \
++        VM_ALLOC_RECORD(ptr, size, "vm_vmalloc"); \
++    }
++#else
+ #define NV_VMALLOC(ptr, size)                               \
+     {                                                       \
+         (ptr) = __vmalloc(size, GFP_KERNEL, PAGE_KERNEL);   \
+         VM_ALLOC_RECORD(ptr, size, "vm_vmalloc");           \
+     }
++#endif
+ 
+ #define NV_VFREE(ptr, size)                         \
+     {                                               \
+diff --git a/kernel/nvidia-modules-common.mk b/kernel/nvidia-modules-common.mk
+index b94591b..0e4c228 100644
+--- a/kernel/nvidia-modules-common.mk
++++ b/kernel/nvidia-modules-common.mk
+@@ -222,6 +222,7 @@ build-sanity-checks:
+ define BUILD_MODULE_RULE
+  $(1): build-sanity-checks $(3)
+ 	@echo "NVIDIA: calling KBUILD..."; \
++	touch .nv-kernel.o.cmd; \
+ 	$$(MAKE) "CC=$$(CC)" NV_MODULE_SUFFIX=$$(strip $(2)) $$(KBUILD_PARAMS) modules; \
+ 	echo "NVIDIA: left KBUILD."; \
+ 	if ! [ -f $(1) ]; then \
+diff --git a/kernel/os-mlock.c b/kernel/os-mlock.c
+index 8a1fa2f..fc50543 100644
+--- a/kernel/os-mlock.c
++++ b/kernel/os-mlock.c
+@@ -44,11 +44,19 @@ RM_STATUS NV_API_CALL os_lock_user_pages(
+         return rmStatus;
+     }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++    down_read(&mm->mmap_lock);
++    ret = NV_GET_USER_PAGES((unsigned long)address,
++                            page_count, write, force, user_pages, NULL);
++    up_read(&mm->mmap_lock);
++    pinned = ret;
++#else
+     down_read(&mm->mmap_sem);
+     ret = NV_GET_USER_PAGES((unsigned long)address,
+                             page_count, write, force, user_pages, NULL);
+     up_read(&mm->mmap_sem);
+     pinned = ret;
++#endif
+ 
+     if (ret < 0)
+     {
+diff --git a/kernel/uvm/nvidia_uvm_lite_api.c b/kernel/uvm/nvidia_uvm_lite_api.c
+index 8448eb6..97a4818 100644
+--- a/kernel/uvm/nvidia_uvm_lite_api.c
++++ b/kernel/uvm/nvidia_uvm_lite_api.c
+@@ -30,6 +30,10 @@
+ #include "uvm_gpu_ops_tests.h"
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++#define mmap_sem mmap_lock
++#endif
++
+ //
+ // nvidia_uvm_lite_api.c
+ //
+-- 
+2.29.0
+

--- a/pkgs/os-specific/linux/nvidia-x11/0003_kernel_5.9.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0003_kernel_5.9.patch
@@ -1,0 +1,107 @@
+From fea401df7500bfbead5a42b1e74560dbddf2f5a3 Mon Sep 17 00:00:00 2001
+From: graysky <graysky@archlinux.us>
+Date: Thu, 22 Oct 2020 07:00:35 -0400
+Subject: [PATCH 3/3] kernel-5.9
+
+credit: https://github.com/warpme/minimyth2/blob/master/script/nvidia/nvidia-340.108/files/nvidia-340.108-fix-5.9-kernel-compile.patch
+---
+ kernel/nv-drm.c               | 8 ++++++++
+ kernel/nv-linux.h             | 9 +++++++--
+ kernel/nv.c                   | 4 ++++
+ kernel/uvm/nvidia_uvm_linux.h | 2 ++
+ 4 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nv-drm.c b/kernel/nv-drm.c
+index 85db07e..f0c1299 100644
+--- a/kernel/nv-drm.c
++++ b/kernel/nv-drm.c
+@@ -415,7 +415,11 @@ static struct drm_driver nv_drm_driver = {
+     .set_busid = drm_pci_set_busid,
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    .gem_free_object_unlocked = nv_gem_free,
++#else
+     .gem_free_object = nv_gem_free,
++#endif
+ 
+     .prime_handle_to_fd = drm_gem_prime_handle_to_fd,
+     .gem_prime_export = drm_gem_prime_export,
+@@ -511,8 +515,12 @@ RM_STATUS NV_API_CALL nv_alloc_os_descriptor_handle(
+ 
+ #if defined(NV_DRM_GEM_OBJECT_PUT_UNLOCKED_PRESENT)
+     drm_gem_object_put_unlocked(&nv_obj->base);
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    drm_gem_object_put_locked(&nv_obj->base);
+ #else
+     drm_gem_object_unreference_unlocked(&nv_obj->base);
++#endif
+ #endif
+ 
+     status = RM_OK;
+diff --git a/kernel/nv-linux.h b/kernel/nv-linux.h
+index d055552..524a8fe 100644
+--- a/kernel/nv-linux.h
++++ b/kernel/nv-linux.h
+@@ -136,8 +136,10 @@
+ 
+ #if defined(NVCPU_X86_64) && !defined(HAVE_COMPAT_IOCTL)
+ #include <linux/syscalls.h>         /* sys_ioctl()                      */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+ #include <linux/ioctl32.h>          /* register_ioctl32_conversion()    */
+ #endif
++#endif
+ 
+ #if !defined(NV_FILE_OPERATIONS_HAS_IOCTL) && \
+   !defined(NV_FILE_OPERATIONS_HAS_UNLOCKED_IOCTL)
+@@ -2249,10 +2251,13 @@ static inline NvU64 nv_node_end_pfn(int nid)
+                                             pages, vmas, NULL);
+ 
+         #else
+-
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++               return get_user_pages_remote(mm, start, nr_pages, flags,
++                                            pages, vmas, NULL);
++#else
+                return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+                                             pages, vmas);
+-
++#endif
+         #endif
+ 
+         }
+diff --git a/kernel/nv.c b/kernel/nv.c
+index a218f83..be4e0f8 100644
+--- a/kernel/nv.c
++++ b/kernel/nv.c
+@@ -2785,7 +2785,11 @@ nvidia_probe
+ 
+ #if defined(CONFIG_VGA_ARB)
+ #if defined(VGA_DEFAULT_DEVICE)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    vga_get(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK, 0);
++#else
+     vga_tryget(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK);
++#endif
+ #endif
+     vga_set_legacy_decoding(dev, VGA_RSRC_NONE);
+ #endif
+diff --git a/kernel/uvm/nvidia_uvm_linux.h b/kernel/uvm/nvidia_uvm_linux.h
+index 1625209..efc181f 100644
+--- a/kernel/uvm/nvidia_uvm_linux.h
++++ b/kernel/uvm/nvidia_uvm_linux.h
+@@ -158,8 +158,10 @@
+ 
+ #if defined(NVCPU_X86_64) && !defined(HAVE_COMPAT_IOCTL)
+ #include <linux/syscalls.h>         /* sys_ioctl()                      */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+ #include <linux/ioctl32.h>          /* register_ioctl32_conversion()    */
+ #endif
++#endif
+ 
+ #if !defined(NV_FILE_OPERATIONS_HAS_IOCTL) && \
+   !defined(NV_FILE_OPERATIONS_HAS_UNLOCKED_IOCTL)
+-- 
+2.29.0
+

--- a/pkgs/os-specific/linux/nvidia-x11/0004_kernel_5.10.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0004_kernel_5.10.patch
@@ -1,0 +1,18 @@
+https://github.com/warpme/minimyth2/tree/master/script/nvidia/nvidia-340.108/files
+
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c	2020-12-13 19:10:56.759999937 +0100
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c	2020-12-13 19:09:02.039999925 +0100
+@@ -322,8 +322,11 @@
+ {
+     struct nv_gem_object *nv_obj = container_of(obj, struct nv_gem_object, base);
+     int page_count = obj->size >> PAGE_SHIFT;
+-
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
++    return drm_prime_pages_to_sg(obj->dev, nv_obj->pages, page_count);
++#else
+     return drm_prime_pages_to_sg(nv_obj->pages, page_count);
++#endif
+ }
+ 
+ static void* nv_gem_prime_vmap(

--- a/pkgs/os-specific/linux/nvidia-x11/0005_kernel_5.11.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0005_kernel_5.11.patch
@@ -1,0 +1,174 @@
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/conftest.sh NVIDIA-Linux-x86_64-340.108-new/kernel/conftest.sh
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/conftest.sh	2021-05-24 20:08:18.743742335 +0200
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/conftest.sh	2021-05-24 20:13:18.019314390 +0200
+@@ -1578,21 +1578,21 @@
+             #include <drm/drm_drv.h>
+             #endif
+ 
+-            #if defined(NV_DRM_DRM_PRIME_H_PRESENT)
+-            #include <drm/drm_prime.h>
+-            #endif
+-
+             #if !defined(CONFIG_DRM) && !defined(CONFIG_DRM_MODULE)
+             #error DRM not enabled
+             #endif
++
+             void conftest_drm_available(void) {
+                 struct drm_driver drv;
+-                drv.gem_prime_pin = 0;
+-                drv.gem_prime_get_sg_table = 0;
+-                drv.gem_prime_vmap = 0;
+-                drv.gem_prime_vunmap = 0;
+-                (void)drm_gem_prime_import;
+-                (void)drm_gem_prime_export;
++
++                /* 2013-10-02 1bb72532ac260a2d3982b40bdd4c936d779d0d16 */
++                (void)drm_dev_alloc;
++
++                /* 2013-10-02 c22f0ace1926da399d9a16dfaf09174c1b03594c */
++                (void)drm_dev_register;
++
++                /* 2013-10-02 c3a49737ef7db0bdd4fcf6cf0b7140a883e32b2a */
++                (void)drm_dev_unregister;
+             }"
+ 
+             compile_check_conftest "$CODE" "NV_DRM_AVAILABLE" "" "generic"
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c	2021-05-24 20:08:18.779739237 +0200
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c	2021-05-24 20:42:13.443288819 +0200
+@@ -60,6 +60,8 @@
+ #else
+ #include <drm/drm_agpsupport.h>
+ 
++#include "linux/dma-buf.h"
++
+ struct nv_drm_agp_head {
+     struct agp_kern_info agp_info;
+     struct list_head memory;
+@@ -210,8 +212,10 @@
+ 
+     /* No locking needed since shadow-attach is single-threaded since it may
+      * only be called from the per-driver module init hook. */
++#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0)
+     if (drm_core_check_feature(dev, DRIVER_LEGACY))
+         list_add_tail(&dev->legacy_dev_list, &driver->legacy_dev_list);
++#endif
+ 
+     return 0;
+ 
+@@ -239,8 +243,10 @@
+     if (WARN_ON(!(driver->driver_features & DRIVER_LEGACY)))
+         return -EINVAL;
+ 
++#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0)
+     /* If not using KMS, fall back to stealth mode manual scanning. */
+     INIT_LIST_HEAD(&driver->legacy_dev_list);
++#endif
+     for (i = 0; pdriver->id_table[i].vendor != 0; i++) {
+         pid = &pdriver->id_table[i];
+ 
+@@ -273,11 +279,13 @@
+     if (!(driver->driver_features & DRIVER_LEGACY)) {
+         WARN_ON(1);
+     } else {
++#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0)
+         list_for_each_entry_safe(dev, tmp, &driver->legacy_dev_list,
+                      legacy_dev_list) {
+             list_del(&dev->legacy_dev_list);
+             drm_put_dev(dev);
+         }
++#endif
+     }
+     DRM_INFO("Module unloaded\n");
+ }
+@@ -402,6 +410,39 @@
+     .llseek = noop_llseek,
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
++struct sg_table *nv_drm_gem_prime_get_sg_table(struct drm_gem_object *gem)
++{
++    return nv_gem_prime_get_sg_table(gem);
++}
++
++static int nv_drm_gem_vmap(struct drm_gem_object *gem,
++                           struct dma_buf_map *map)
++{
++    map->vaddr = nv_gem_prime_vmap(gem);
++    if (map->vaddr == NULL) {
++        return -ENOMEM;
++    }
++    map->is_iomem = true;
++    return 0;
++}
++
++static void nv_drm_gem_vunmap(struct drm_gem_object *gem,
++                              struct dma_buf_map *map)
++{
++    nv_gem_prime_vunmap(gem, map->vaddr);
++    map->vaddr = NULL;
++}
++
++static struct drm_gem_object_funcs nv_drm_gem_object_funcs = {
++  .free = nv_gem_free,
++  .export = drm_gem_prime_export,
++  .get_sg_table = nv_drm_gem_prime_get_sg_table,
++  .vmap = nv_drm_gem_vmap,
++  .vunmap = nv_drm_gem_vunmap,
++};
++#endif
++
+ static struct drm_driver nv_drm_driver = {
+ 
+     .driver_features = DRIVER_GEM
+@@ -420,17 +461,19 @@
+     .set_busid = drm_pci_set_busid,
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+-    .gem_free_object_unlocked = nv_gem_free,
+-#else
++#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 8, 0)
+     .gem_free_object = nv_gem_free,
++#elif LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0)
++    .gem_free_object_unlocked = nv_gem_free,
+ #endif
+ 
+     .prime_handle_to_fd = drm_gem_prime_handle_to_fd,
++#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 10, 0)
+     .gem_prime_export = drm_gem_prime_export,
+     .gem_prime_get_sg_table = nv_gem_prime_get_sg_table,
+     .gem_prime_vmap = nv_gem_prime_vmap,
+     .gem_prime_vunmap = nv_gem_prime_vunmap,
++#endif
+ 
+     .name = "nvidia-drm",
+     .desc = "NVIDIA DRM driver",
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-linux.h NVIDIA-Linux-x86_64-340.108-new/kernel/nv-linux.h
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/nv-linux.h	2021-05-24 20:08:18.775739581 +0200
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/nv-linux.h	2021-05-24 20:09:18.748287771 +0200
+@@ -119,7 +119,9 @@
+ #include <asm/tlbflush.h>           /* flush_tlb(), flush_tlb_all()     */
+ #include <linux/cpu.h>              /* CPU hotplug support              */
+ #endif
+-#include <asm/kmap_types.h>         /* page table entry lookup          */
++#if LINUX_VERSION_CODE	< KERNEL_VERSION(5, 11,	0)
++	#include <asm/kmap_types.h>         /* page table entry lookup          */
++#endif
+ 
+ #include <linux/pci.h>              /* pci_find_class, etc              */
+ #include <linux/interrupt.h>        /* tasklets, interrupt helpers      */
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/uvm/nvidia_uvm_linux.h NVIDIA-Linux-x86_64-340.108-new/kernel/uvm/nvidia_uvm_linux.h
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/uvm/nvidia_uvm_linux.h	2021-05-24 20:08:18.775739581 +0200
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/uvm/nvidia_uvm_linux.h	2021-05-24 20:09:18.749287739 +0200
+@@ -141,7 +141,9 @@
+ #if !defined(NV_VMWARE)
+ #include <asm/tlbflush.h>           /* flush_tlb(), flush_tlb_all()     */
+ #endif
+-#include <asm/kmap_types.h>         /* page table entry lookup          */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
++	#include <asm/kmap_types.h>         /* page table entry lookup          */
++#endif
+ 
+ #include <linux/interrupt.h>        /* tasklets, interrupt helpers      */
+ #include <linux/timer.h>

--- a/pkgs/os-specific/linux/nvidia-x11/0006_kernel_5.14.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0006_kernel_5.14.patch
@@ -1,0 +1,213 @@
+diff -Naur NVIDIA-Linux-x86_64-340.108-no-compat32.5.13/kernel/nv-drm.c NVIDIA-Linux-x86_64-340.108-no-compat32.5.14/kernel/nv-drm.c
+--- NVIDIA-Linux-x86_64-340.108-no-compat32.5.13/kernel/nv-drm.c	2021-07-25 10:29:29.336505688 +0200
++++ NVIDIA-Linux-x86_64-340.108-no-compat32.5.14/kernel/nv-drm.c	2021-09-16 16:49:10.929858547 +0200
+@@ -57,8 +57,11 @@
+ #if defined(NV_DRM_GET_PCI_DEV_PRESENT)
+ #define nv_drm_get_pci_dev drm_get_pci_dev
+ #else
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
+ #include <drm/drm_agpsupport.h>
+-
++#else
++#include <drm/drm_legacy.h>
++#endif
+ #include "linux/dma-buf.h"
+ 
+ struct nv_drm_agp_head {
+@@ -82,6 +85,11 @@
+     struct list_head head;
+ };
+ 
++struct nv_drm_extra_priv_data {
++    struct pci_dev *pdev;
++    struct drm_agp_head *agp;
++};
++
+ /*
+  * Code from drm_agp_init/nv_drm_{free,unbind}_agp
+  * Extracted from commit: 5b8b9d0c6d0e0f1993c6c56deaf9646942c49d94, file: drivers/gpu/drm/drm_agpsupport.c
+@@ -89,13 +97,14 @@
+ struct drm_agp_head *nv_drm_agp_init(struct drm_device *dev)
+ {
+     struct nv_drm_agp_head *head = NULL;
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
+ 
+     head = kzalloc(sizeof(*head), GFP_KERNEL);
+     if (!head)
+         return NULL;
+-    head->bridge = agp_find_bridge(dev->pdev);
++    head->bridge = agp_find_bridge(extra->pdev);
+     if (!head->bridge) {
+-        head->bridge = agp_backend_acquire(dev->pdev);
++        head->bridge = agp_backend_acquire(extra->pdev);
+         if (!head->bridge) {
+             kfree(head);
+             return NULL;
+@@ -133,48 +142,71 @@
+ static void nv_drm_pci_agp_init(struct drm_device *dev)
+ {
+     if (drm_core_check_feature(dev, DRIVER_USE_AGP)) {
+-        if (pci_find_capability(dev->pdev, PCI_CAP_ID_AGP))
+-            dev->agp = nv_drm_agp_init(dev);
+-        if (dev->agp) {
+-            dev->agp->agp_mtrr = arch_phys_wc_add(
+-                dev->agp->agp_info.aper_base,
+-                dev->agp->agp_info.aper_size *
++        struct nv_drm_extra_priv_data *extra = dev->dev_private;
++
++        if (pci_find_capability(extra->pdev, PCI_CAP_ID_AGP))
++            extra->agp = nv_drm_agp_init(dev);
++        if (extra->agp) {
++            extra->agp->agp_mtrr = arch_phys_wc_add(
++                extra->agp->agp_info.aper_base,
++                extra->agp->agp_info.aper_size *
+                 1024 * 1024);
+         }
+     }
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
++
++#else
++/* copied from v5.14.5 */
++int nv_drm_legacy_agp_release(struct drm_device *dev)
++{
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
++
++    if (!extra->agp || !extra->agp->acquired)
++        return -EINVAL;
++    agp_backend_release(extra->agp->bridge);
++    extra->agp->acquired = 0;
++    return 0;
++}
++#endif
++
+ void nv_drm_legacy_agp_clear(struct drm_device *dev)
+ {
+     struct nv_drm_agp_mem *entry, *tempe;
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
+ 
+-    if (!dev->agp)
++    if (!extra->agp)
+         return;
+     if (!drm_core_check_feature(dev, DRIVER_LEGACY))
+         return;
+ 
+-    list_for_each_entry_safe(entry, tempe, &dev->agp->memory, head) {
++    list_for_each_entry_safe(entry, tempe, &extra->agp->memory, head) {
+         if (entry->bound)
+             nv_drm_unbind_agp(entry->memory);
+         nv_drm_free_agp(entry->memory, entry->pages);
+         kfree(entry);
+     }
+-    INIT_LIST_HEAD(&dev->agp->memory);
++    INIT_LIST_HEAD(&extra->agp->memory);
+ 
+-    if (dev->agp->acquired)
++    if (extra->agp->acquired)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
+         drm_agp_release(dev);
+-
+-    dev->agp->acquired = 0;
+-    dev->agp->enabled = 0;
++#else
++        nv_drm_legacy_agp_release(dev);
++#endif
++    extra->agp->acquired = 0;
++    extra->agp->enabled = 0;
+ }
+ 
+ void nv_drm_pci_agp_destroy(struct drm_device *dev)
+ {
+-    if (dev->agp) {
+-        arch_phys_wc_del(dev->agp->agp_mtrr);
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
++    if (extra->agp) {
++        arch_phys_wc_del(extra->agp->agp_mtrr);
+         nv_drm_legacy_agp_clear(dev);
+-        kfree(dev->agp);
+-        dev->agp = NULL;
++        kfree(extra->agp);
++        extra->agp = NULL;
+     }
+ }
+ 
+@@ -183,6 +215,7 @@
+                struct drm_driver *driver)
+ {
+     struct drm_device *dev;
++    struct nv_drm_extra_priv_data *extra;
+     int ret;
+ 
+     DRM_DEBUG("\n");
+@@ -191,11 +224,18 @@
+     if (IS_ERR(dev))
+         return PTR_ERR(dev);
+ 
++    extra = kzalloc(sizeof(*extra), GFP_KERNEL);
++    if (IS_ERR(extra))
++        goto err_free;
++
++    extra->pdev = pdev;
++
+     ret = pci_enable_device(pdev);
+     if (ret)
+-        goto err_free;
++        goto err_free2;
+ 
+-    dev->pdev = pdev;
++    /* use the not used (i hope) dev_private to store deprecated/legacy pointers */
++    dev->dev_private = extra;
+ #ifdef __alpha__
+     dev->hose = pdev->sysdata;
+ #endif
+@@ -221,6 +261,8 @@
+ err_agp:
+     nv_drm_pci_agp_destroy(dev);
+     pci_disable_device(pdev);
++err_free2:
++    kfree(extra);
+ err_free:
+     drm_dev_put(dev);
+     return ret;
+@@ -303,10 +345,11 @@
+ )
+ {
+     nv_linux_state_t *nvl;
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
+ 
+     for (nvl = nv_linux_devices; nvl != NULL; nvl = nvl->next)
+     {
+-        if (nvl->dev == dev->pdev)
++        if (nvl->dev == extra->pdev)
+         {
+             nvl->drm = dev;
+             return 0;
+@@ -327,10 +370,11 @@
+ )
+ {
+     nv_linux_state_t *nvl;
++    struct nv_drm_extra_priv_data *extra = dev->dev_private;
+ 
+     for (nvl = nv_linux_devices; nvl != NULL; nvl = nvl->next)
+     {
+-        if (nvl->dev == dev->pdev)
++        if (nvl->dev == extra->pdev)
+         {
+             BUG_ON(nvl->drm != dev);
+             nvl->drm = NULL;
+diff -Naur NVIDIA-Linux-x86_64-340.108-no-compat32.5.13/kernel/os-interface.c NVIDIA-Linux-x86_64-340.108-no-compat32.5.14/kernel/os-interface.c
+--- NVIDIA-Linux-x86_64-340.108-no-compat32.5.13/kernel/os-interface.c	2021-07-25 10:29:29.083168593 +0200
++++ NVIDIA-Linux-x86_64-340.108-no-compat32.5.14/kernel/os-interface.c	2021-09-16 13:17:43.345906445 +0200
+@@ -549,7 +549,11 @@
+         // the requested timeout has expired, loop until less
+         // than a jiffie of the desired delay remains.
+         //
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
++        current->__state = TASK_INTERRUPTIBLE;
++#else
+         current->state = TASK_INTERRUPTIBLE;
++#endif
+         do
+         {
+             schedule_timeout(jiffies);

--- a/pkgs/os-specific/linux/nvidia-x11/0007_kernel_5.15.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0007_kernel_5.15.patch
@@ -1,0 +1,14 @@
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c	2021-11-06 20:08:18.779739237 +0200
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c	2021-11-06 20:42:13.443288819 +0200
+@@ -529,7 +529,9 @@ RM_STATUS NV_API_CALL nv_alloc_os_descri
+ #if defined(NV_DRM_GEM_OBJECT_PUT_UNLOCKED_PRESENT)
+     drm_gem_object_put_unlocked(&nv_obj->base);
+ #else
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
++    drm_gem_object_put(&nv_obj->base);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
+     drm_gem_object_put_locked(&nv_obj->base);
+ #else
+     drm_gem_object_unreference_unlocked(&nv_obj->base);

--- a/pkgs/os-specific/linux/nvidia-x11/0008_kernel_5.16.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/0008_kernel_5.16.patch
@@ -1,0 +1,30 @@
+--- a/kernel/os-interface.h	2019-12-11 22:04:24.000000000 +0000
++++ b/kernel/os-interface.h	2022-01-10 02:04:26.740899810 +0000
+@@ -24,7 +24,12 @@
+ *                                                                           *
+ \***************************************************************************/
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++#include <linux/stdarg.h>
++#else
+ #include <stdarg.h>
++#endif
+ 
+ /*
+  * Define away Microsoft compiler extensions when possible
+--- a/kernel/nv.h	2019-12-11 22:04:24.000000000 +0000
++++ b/kernel/nv.h	2022-01-10 02:29:07.828733372 +0000
+@@ -13,7 +13,12 @@
+ #define _NV_H_
+ 
+ #include <nvtypes.h>
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
++#include <linux/stdarg.h>
++#else
+ #include <stdarg.h>
++#endif
+ 
+ #if !defined(NV_MIN)
+ #define NV_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -71,13 +71,13 @@ rec {
 
   legacy_340 = generic {
     version = "340.108";
-    sha256_32bit = "1jkwa1phf0x4sgw8pvr9d6krmmr3wkgwyygrxhdazwyr2bbalci0";
-    sha256_64bit = "06xp6c0sa7v1b82gf0pq0i5p0vdhmm3v964v0ypw36y0nzqx8wf6";
+    sha256_32bit = "4a221941e7697c30de4e1136694b93ef7a3045bd4f75712f3047bf697c2da9c0";
+    sha256_64bit = "4a221941e7697c30de4e1136694b93ef7a3045bd4f75712f3047bf697c2da9c0";
     settingsSha256 = "0zm29jcf0mp1nykcravnzb5isypm8l8mg2gpsvwxipb7nk1ivy34";
     persistencedSha256 = "1ax4xn3nmxg1y6immq933cqzw6cj04x93saiasdc0kjlv0pvvnkn";
-    useGLVND = false;
-
-    broken = with kernel; kernelAtLeast "5.5";
-    patches = [ ./vm_operations_struct-fault.patch ];
-  };
+    url="http://localhost/nvidia-340-516.run";
+ useGLVND = false;
+   # patches = [./0001_kernel_5.7.patch ./0002_kernel_5.8.patch ./0003_kernel_5.9.patch ./0004_kernel_5.10.patch ./0005_kernel_5.11.patch ./0006_kernel_5.14.patch ./0007_kernel_5.15.patch ./0008_kernel_5.16.patch  ./vm_operations_struct-fault.patch ];
+	  
+};
 }

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -71,13 +71,12 @@ rec {
 
   legacy_340 = generic {
     version = "340.108";
-    sha256_32bit = "4a221941e7697c30de4e1136694b93ef7a3045bd4f75712f3047bf697c2da9c0";
-    sha256_64bit = "4a221941e7697c30de4e1136694b93ef7a3045bd4f75712f3047bf697c2da9c0";
+    sha256_32bit = "1jkwa1phf0x4sgw8pvr9d6krmmr3wkgwyygrxhdazwyr2bbalci0";
+    sha256_64bit = "06xp6c0sa7v1b82gf0pq0i5p0vdhmm3v964v0ypw36y0nzqx8wf6"; 
     settingsSha256 = "0zm29jcf0mp1nykcravnzb5isypm8l8mg2gpsvwxipb7nk1ivy34";
     persistencedSha256 = "1ax4xn3nmxg1y6immq933cqzw6cj04x93saiasdc0kjlv0pvvnkn";
-    url="http://localhost/nvidia-340-516.run";
  useGLVND = false;
-   # patches = [./0001_kernel_5.7.patch ./0002_kernel_5.8.patch ./0003_kernel_5.9.patch ./0004_kernel_5.10.patch ./0005_kernel_5.11.patch ./0006_kernel_5.14.patch ./0007_kernel_5.15.patch ./0008_kernel_5.16.patch  ./vm_operations_struct-fault.patch ];
+    patches = [./0001_kernel_5.7.patch ./0002_kernel_5.8.patch ./0003_kernel_5.9.patch ./0004_kernel_5.10.patch ./0005_kernel_5.11.patch ./0006_kernel_5.14.patch ./0007_kernel_5.15.patch ./0008_kernel_5.16.patch ];
 	  
 };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -55,6 +55,7 @@ let
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
           url = args.url or "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run";
+
           sha256 = sha256_64bit;
         }
       else if stdenv.hostPlatform.system == "i686-linux" then


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  -  x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
