### PR TITLE
palemoon: 29.4.4 -> 30.0.0

### DIFF
--- a/pkgs/applications/networking/browsers/palemoon/default.nix
+++ b/pkgs/applications/networking/browsers/palemoon/default.nix
@@ -6,7 +6,7 @@
 , dbus
 , dbus-glib
 , desktop-file-utils
-, fetchzip
+, fetchFromGitea
 , ffmpeg
 , fontconfig
 , freetype
@@ -44,12 +44,15 @@ assert with lib.strings; (
 
 stdenv.mkDerivation rec {
   pname = "palemoon";
-  version = "29.4.4";
+  version = "30.0.0";
 
-  src = fetchzip {
-    name = "${pname}-${version}";
-    url = "http://archive.palemoon.org/source/${pname}-${version}.source.tar.xz";
-    sha256 = "sha256-0R0IJd4rd7NqnxQxkHSx10cNlwECqpKgJnlfYAMx4wc=";
+  src = fetchFromGitea {
+    domain = "repo.palemoon.org";
+    owner = "MoonchildProductions";
+    repo = "Pale-Moon";
+    rev = "${version}_Release";
+    fetchSubmodules = true;
+    sha256 = "02qdw8b7hphphc66m3m14r4pmcfiq2c5z4jcscm2nymy18ycb10f";
   };
 
   nativeBuildInputs = [
@@ -137,23 +140,14 @@ stdenv.mkDerivation rec {
 
     ./mach install
 
-    # Fix missing icon due to wrong WMClass
-    # https://forum.palemoon.org/viewtopic.php?f=3&t=26746&p=214221#p214221
-    substituteInPlace ./palemoon/branding/official/palemoon.desktop \
-      --replace 'StartupWMClass="pale moon"' 'StartupWMClass=Pale moon'
+    # Install official branding stuff (desktop file & icons)
     desktop-file-install --dir=$out/share/applications \
-      ./palemoon/branding/official/palemoon.desktop
-
-    # Install official branding icons
+      ./other-licenses/branding/palemoon/official/palemoon.desktop
     for iconname in default{16,22,24,32,48,256} mozicon128; do
       n=''${iconname//[^0-9]/}
       size=$n"x"$n
-      install -Dm644 ./palemoon/branding/official/$iconname.png $out/share/icons/hicolor/$size/apps/palemoon.png
+      install -Dm644 ./other-licenses/branding/palemoon/official/$iconname.png $out/share/icons/hicolor/$size/apps/palemoon.png
     done
-
-    # Remove unneeded SDK data from installation
-    # https://forum.palemoon.org/viewtopic.php?f=37&t=26796&p=214676#p214729
-    rm -rf $out/{include,share/idl,lib/palemoon-devel-${version}}
 
     runHook postInstall
   '';

--- a/pkgs/applications/networking/browsers/palemoon/mozconfig
+++ b/pkgs/applications/networking/browsers/palemoon/mozconfig
@@ -12,7 +12,7 @@ _BUILD_64=@build64@
 _GTK_VERSION=@gtkversion@
 
 # Standard build options for Pale Moon
-ac_add_options --enable-application=palemoon
+ac_add_options --enable-application=browser
 ac_add_options --enable-optimize="-O2 -w"
 ac_add_options --enable-default-toolkit=cairo-gtk$_GTK_VERSION
 ac_add_options --enable-jemalloc
@@ -20,8 +20,6 @@ ac_add_options --enable-strip
 ac_add_options --enable-devtools
 ac_add_options --enable-av1
 
-ac_add_options --disable-eme
-ac_add_options --disable-webrtc
 ac_add_options --disable-gamepad
 ac_add_options --disable-tests
 ac_add_options --disable-debug


### PR DESCRIPTION
###### Description of changes

https://www.palemoon.org/releasenotes.shtml

> Updated various in-tree libraries: cubeb, sqlite, cairo, ...
> Fixed an issue with the Linux desktop shortcut file to solve potential DE integration problems on common distributions.
> Fixed an issue with page and iframe content margins not being applied properly when passed as attributes instead of CSS.
> Ensured JavaScript and JSON files are always recognized as known MIME types so they can be opened appropriately from local sources.
> Fixed an issue with rapid loading and unloading of js modules causing browser crashes.
> Fixed an issue with tooltips being cut off at the end if containing exceedingly long unwrappable series of characters.
> Fixed several application crash scenarios. DiD
> Fixed a large number of thread locking/mutex issues. DiD
> Fixed a leak of content types due to inconsistent error reporting. (CVE-2022-22760)
> Fixed an issue with iframe sandboxing not being properly applied. (CVE-2022-22759)
> Fixed a potential leak of bookmarks from the exported bookmarks file if it included a malicious bookmarklet.
> Fixed an issue with drag-and-drop. (CVE-2022-22756)
> Fixed a potential crash due to truncated WAV files.
> Fixed a memory safety issue with XSLT. (CVE-2022-26485)

WIP. `mach build` & `mach install` complete but the rest of `installPhase` needs to be updated.

```console
 1:59.39(B '/nix/store/by69zqgj36k242p9xkwr4l6pwfx6hlsf-palemoon-30.0.0/bin/palemoon' -> '/nix/store/by69zqgj36k242p9xkwr4l6pwfx6hlsf-palemoon-30.0.0/lib/palemoon-30.0.0/palemoon'
 1:59.39(B To run the installed application, execute: .//nix/store/by69zqgj36k242p9xkwr4l6pwfx6hlsf-palemoon-30.0.0/bin/palemoon .
 1:59.39(B make[1]: Leaving directory '/build/source/obj-x86_64-pc-linux-gnu/browser/installer'
 1:59.39(B make: Leaving directory '/build/source/obj-x86_64-pc-linux-gnu'
substitute(): ERROR: file './palemoon/branding/official/palemoon.desktop' does not exist
builder for '/nix/store/d36gz3wkl6lygkqlzdr588w7ggfid6fl-palemoon-30.0.0.drv' failed with exit code 1
error: build of '/nix/store/d36gz3wkl6lygkqlzdr588w7ggfid6fl-palemoon-30.0.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
