### PR TITLE
[21.11] libressl: 3.4.1 -> 3.4.3, libressl_3_2: add patch for CVE-2022-0778

### DIFF
--- a/pkgs/development/libraries/libressl/3.2-CVE-2022-0778.patch
+++ b/pkgs/development/libraries/libressl/3.2-CVE-2022-0778.patch
@@ -1,0 +1,43 @@
+Upstream https://github.com/libressl-portable/portable/blob/3a4ec28b238edf9d85759b7a3d78fd85e4d5aaef/patches/bn_sqrt.patch
+with filenames adjusted to apply to the release tarball. taken from
+libressl's own patching mechanism, but that appears to operate when
+building the release tarball, and we're isomg the pre-built tarballs.
+
+--- a/crypto/bn/bn_sqrt.c	Fri Feb 18 16:30:39 2022
++++ b/crypto/bn/bn_sqrt.c	Sat Mar 12 11:23:53 2022
+@@ -351,21 +351,22 @@
+ 			goto vrfy;
+ 		}
+ 
+-
+-		/* find smallest  i  such that  b^(2^i) = 1 */
+-		i = 1;
+-		if (!BN_mod_sqr(t, b, p, ctx))
+-			goto end;
+-		while (!BN_is_one(t)) {
+-			i++;
+-			if (i == e) {
+-				BNerror(BN_R_NOT_A_SQUARE);
+-				goto end;
++		/* Find the smallest i with 0 < i < e such that b^(2^i) = 1. */
++		for (i = 1; i < e; i++) {
++			if (i == 1) {
++				if (!BN_mod_sqr(t, b, p, ctx))
++					goto end;
++			} else {
++				if (!BN_mod_sqr(t, t, p, ctx))
++					goto end;
+ 			}
+-			if (!BN_mod_mul(t, t, t, p, ctx))
+-				goto end;
++			if (BN_is_one(t))
++				break;
+ 		}
+-
++		if (i >= e) {
++			BNerror(BN_R_NOT_A_SQUARE);
++			goto end;
++		}
+ 
+ 		/* t := y^2^(e - i - 1) */
+ 		if (!BN_copy(t, y))

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -89,6 +89,9 @@ in {
   libressl_3_2 = generic {
     version = "3.2.7";
     sha256 = "112bjfrwwqlk0lak7fmfhcls18ydf62cp7gxghf4gklpfl1zyckw";
+    patches = [
+      ./3.2-CVE-2022-0778.patch
+    ];
   };
   libressl_3_4 = generic {
     version = "3.4.1";

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -94,7 +94,7 @@ in {
     ];
   };
   libressl_3_4 = generic {
-    version = "3.4.1";
-    sha256 = "0766yxb599lx7qmlmsddiw9wgminz9mc311mav5q23l0rbkflz0h";
+    version = "3.4.2";
+    sha256 = "sha256-y4LKfVRzNpFzUvvSPbL8SDxsRNNRV7MngCFOx0GXs84=";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -94,7 +94,7 @@ in {
     ];
   };
   libressl_3_4 = generic {
-    version = "3.4.2";
-    sha256 = "sha256-y4LKfVRzNpFzUvvSPbL8SDxsRNNRV7MngCFOx0GXs84=";
+    version = "3.4.3";
+    sha256 = "sha256-/4i//jVIGLPM9UXjyv5FTFAxx6dyFwdPUzJx1jw38I0=";
   };
 }

--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wasm-pack";
-  version = "0.10.1";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "rustwasm";
     repo = "wasm-pack";
     rev = "v${version}";
-    sha256 = "sha256-I5TxpJTSus3fXMV0We9SCVMEERS0wIdYvC8SHo8zEHY=";
+    sha256 = "sha256-nhO/SLeJTq2viDqsJCRNLbgjyDKRli3RWExUNzKT9ug=";
   };
 
-  cargoSha256 = "sha256-MmbQb2JYaDpLijKRAxzD9pR4gh+Eoem0MtfdiuRC7Tg=";
+  cargoSha256 = "sha256-6qrCHpg92IRPsf/dK6xcLGX8BLmqox3vgLRqsV4ubsY=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
###### Description of changes
Like #164294 but patching `libressl_3_2` instead of deleting it. Upstream use a patching mechanism of their own to apply changes, this just borrows the patch they use to fix CVE-2022-0778 for 3.4.x.

Backport of  #164291

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
