### PR TITLE
nixos/btrbk: allow instances without timers and simplify

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9572,8 +9572,8 @@
     githubId = 14816024;
     name = "oxalica";
     keys = [{
-      longkeyid = "rsa4096/0xCED392DE0C483D00";
-      fingerprint = "5CB0 E9E5 D5D5 71F5 7F54  0FEA CED3 92DE 0C48 3D00";
+      longkeyid = "ed25519/0x7571654CF88E31C2";
+      fingerprint = "F90F FD6D 585C 2BA1 F13D  E8A9 7571 654C F88E 31C2";
     }];
   };
   oxij = {

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -1,18 +1,36 @@
 { config, pkgs, lib, ... }:
 let
+  inherit (lib)
+    concatMapStringsSep
+    concatStringsSep
+    filterAttrs
+    flatten
+    isAttrs
+    isString
+    literalExpression
+    mapAttrs'
+    mapAttrsToList
+    mkIf
+    mkOption
+    optionalString
+    partition
+    typeOf
+    types
+    ;
+
   cfg = config.services.btrbk;
   sshEnabled = cfg.sshAccess != [ ];
   serviceEnabled = cfg.instances != { };
   attr2Lines = attr:
     let
-      pairs = lib.attrsets.mapAttrsToList (name: value: { inherit name value; }) attr;
+      pairs = mapAttrsToList (name: value: { inherit name value; }) attr;
       isSubsection = value:
-        if builtins.isAttrs value then true
-        else if builtins.isString value then false
-        else throw "invalid type in btrbk config ${builtins.typeOf value}";
-      sortedPairs = lib.lists.partition (x: isSubsection x.value) pairs;
+        if isAttrs value then true
+        else if isString value then false
+        else throw "invalid type in btrbk config ${typeOf value}";
+      sortedPairs = partition (x: isSubsection x.value) pairs;
     in
-    lib.flatten (
+    flatten (
       # non subsections go first
       (
         map (pair: [ "${pair.name} ${pair.value}" ]) sortedPairs.wrong
@@ -22,7 +40,7 @@ let
         map
           (
             pair:
-            lib.mapAttrsToList
+            mapAttrsToList
               (
                 childname: value:
                   [ "${pair.name} ${childname}" ] ++ (map (x: " " + x) (attr2Lines value))
@@ -34,7 +52,7 @@ let
     )
   ;
   addDefaults = settings: { backend = "btrfs-progs-sudo"; } // settings;
-  mkConfigFile = settings: lib.concatStringsSep "\n" (attr2Lines (addDefaults settings));
+  mkConfigFile = settings: concatStringsSep "\n" (attr2Lines (addDefaults settings));
   mkTestedConfigFile = name: settings:
     let
       configFile = pkgs.writeText "btrbk-${name}.conf" (mkConfigFile settings);
@@ -55,38 +73,38 @@ in
 
   options = {
     services.btrbk = {
-      extraPackages = lib.mkOption {
+      extraPackages = mkOption {
         description = "Extra packages for btrbk, like compression utilities for <literal>stream_compress</literal>";
-        type = lib.types.listOf lib.types.package;
+        type = types.listOf types.package;
         default = [ ];
-        example = lib.literalExpression "[ pkgs.xz ]";
+        example = literalExpression "[ pkgs.xz ]";
       };
-      niceness = lib.mkOption {
+      niceness = mkOption {
         description = "Niceness for local instances of btrbk. Also applies to remote ones connecting via ssh when positive.";
-        type = lib.types.ints.between (-20) 19;
+        type = types.ints.between (-20) 19;
         default = 10;
       };
-      ioSchedulingClass = lib.mkOption {
+      ioSchedulingClass = mkOption {
         description = "IO scheduling class for btrbk (see ionice(1) for a quick description). Applies to local instances, and remote ones connecting by ssh if set to idle.";
-        type = lib.types.enum [ "idle" "best-effort" "realtime" ];
+        type = types.enum [ "idle" "best-effort" "realtime" ];
         default = "best-effort";
       };
-      instances = lib.mkOption {
+      instances = mkOption {
         description = "Set of btrbk instances. The instance named <literal>btrbk</literal> is the default one.";
-        type = with lib.types;
+        type = with types;
           attrsOf (
             submodule {
               options = {
-                onCalendar = lib.mkOption {
-                  type = lib.types.nullOr lib.types.str;
+                onCalendar = mkOption {
+                  type = types.nullOr types.str;
                   default = "daily";
                   description = ''
                     How often this btrbk instance is started. See systemd.time(7) for more information about the format.
                     Setting it to null disables the timer, thus this instance can only be started manually.
                   '';
                 };
-                settings = lib.mkOption {
-                  type = let t = lib.types.attrsOf (lib.types.either lib.types.str (t // { description = "instances of this type recursively"; })); in t;
+                settings = mkOption {
+                  type = let t = types.attrsOf (types.either types.str (t // { description = "instances of this type recursively"; })); in t;
                   default = { };
                   example = {
                     snapshot_preserve_min = "2d";
@@ -108,16 +126,16 @@ in
           );
         default = { };
       };
-      sshAccess = lib.mkOption {
+      sshAccess = mkOption {
         description = "SSH keys that should be able to make or push snapshots on this system remotely with btrbk";
-        type = with lib.types; listOf (
+        type = with types; listOf (
           submodule {
             options = {
-              key = lib.mkOption {
+              key = mkOption {
                 type = str;
                 description = "SSH public key allowed to login as user <literal>btrbk</literal> to run remote backups.";
               };
-              roles = lib.mkOption {
+              roles = mkOption {
                 type = listOf (enum [ "info" "source" "target" "delete" "snapshot" "send" "receive" ]);
                 example = [ "source" "info" "send" ];
                 description = "What actions can be performed with this SSH key. See ssh_filter_btrbk(1) for details";
@@ -130,7 +148,7 @@ in
     };
 
   };
-  config = lib.mkIf (sshEnabled || serviceEnabled) {
+  config = mkIf (sshEnabled || serviceEnabled) {
     environment.systemPackages = [ pkgs.btrbk ] ++ cfg.extraPackages;
     security.sudo.extraRules = [
       {
@@ -157,14 +175,14 @@ in
         (
           v:
           let
-            options = lib.concatMapStringsSep " " (x: "--" + x) v.roles;
+            options = concatMapStringsSep " " (x: "--" + x) v.roles;
             ioniceClass = {
               "idle" = 3;
               "best-effort" = 2;
               "realtime" = 1;
             }.${cfg.ioSchedulingClass};
           in
-          ''command="${pkgs.util-linux}/bin/ionice -t -c ${toString ioniceClass} ${lib.optionalString (cfg.niceness >= 1) "${pkgs.coreutils}/bin/nice -n ${toString cfg.niceness}"} ${pkgs.btrbk}/share/btrbk/scripts/ssh_filter_btrbk.sh --sudo ${options}" ${v.key}''
+          ''command="${pkgs.util-linux}/bin/ionice -t -c ${toString ioniceClass} ${optionalString (cfg.niceness >= 1) "${pkgs.coreutils}/bin/nice -n ${toString cfg.niceness}"} ${pkgs.btrbk}/share/btrbk/scripts/ssh_filter_btrbk.sh --sudo ${options}" ${v.key}''
         )
         cfg.sshAccess;
     };
@@ -174,7 +192,7 @@ in
       "d /var/lib/btrbk/.ssh 0700 btrbk btrbk"
       "f /var/lib/btrbk/.ssh/config 0700 btrbk btrbk - StrictHostKeyChecking=accept-new"
     ];
-    environment.etc = lib.mapAttrs'
+    environment.etc = mapAttrs'
       (
         name: instance: {
           name = "btrbk/${name}.conf";
@@ -182,7 +200,7 @@ in
         }
       )
       cfg.instances;
-    systemd.services = lib.mapAttrs'
+    systemd.services = mapAttrs'
       (
         name: _: {
           name = "btrbk-${name}";
@@ -204,7 +222,7 @@ in
       )
       cfg.instances;
 
-    systemd.timers = lib.mapAttrs'
+    systemd.timers = mapAttrs'
       (
         name: instance: {
           name = "btrbk-${name}";
@@ -219,7 +237,7 @@ in
           };
         }
       )
-      (lib.filterAttrs (name: instance: instance.onCalendar != null)
+      (filterAttrs (name: instance: instance.onCalendar != null)
         cfg.instances);
   };
 

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -51,6 +51,8 @@ let
     '';
 in
 {
+  meta.maintainers = with lib.maintainers; [ oxalica ];
+
   options = {
     services.btrbk = {
       extraPackages = lib.mkOption {
@@ -76,9 +78,12 @@ in
             submodule {
               options = {
                 onCalendar = lib.mkOption {
-                  type = lib.types.str;
+                  type = lib.types.nullOr lib.types.str;
                   default = "daily";
-                  description = "How often this btrbk instance is started. See systemd.time(7) for more information about the format.";
+                  description = ''
+                    How often this btrbk instance is started. See systemd.time(7) for more information about the format.
+                    Setting it to null disables the timer, thus this instance can only be started manually.
+                  '';
                 };
                 settings = lib.mkOption {
                   type = let t = lib.types.attrsOf (lib.types.either lib.types.str (t // { description = "instances of this type recursively"; })); in t;
@@ -214,7 +219,8 @@ in
           };
         }
       )
-      cfg.instances;
+      (lib.filterAttrs (name: instance: instance.onCalendar != null)
+        cfg.instances);
   };
 
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -62,6 +62,7 @@ in
   breitbandmessung = handleTest ./breitbandmessung.nix {};
   brscan5 = handleTest ./brscan5.nix {};
   btrbk = handleTest ./btrbk.nix {};
+  btrbk-no-timer = handleTest ./btrbk-no-timer.nix {};
   buildbot = handleTest ./buildbot.nix {};
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   caddy = handleTest ./caddy.nix {};

--- a/nixos/tests/btrbk-no-timer.nix
+++ b/nixos/tests/btrbk-no-timer.nix
@@ -1,0 +1,37 @@
+import ./make-test-python.nix ({ lib, pkgs, ... }:
+  {
+    name = "btrbk-no-timer";
+    meta.maintainers = with lib.maintainers; [ oxalica ];
+
+    nodes.machine = { ... }: {
+      environment.systemPackages = with pkgs; [ btrfs-progs ];
+      services.btrbk.instances.local = {
+        onCalendar = null;
+        settings.volume."/mnt" = {
+          snapshot_dir = "btrbk/local";
+          subvolume = "to_backup";
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      # Create btrfs partition at /mnt
+      machine.succeed("truncate --size=128M /data_fs")
+      machine.succeed("mkfs.btrfs /data_fs")
+      machine.succeed("mkdir /mnt")
+      machine.succeed("mount /data_fs /mnt")
+      machine.succeed("btrfs subvolume create /mnt/to_backup")
+      machine.succeed("mkdir -p /mnt/btrbk/local")
+
+      # The service should not have any triggering timer.
+      unit = machine.get_unit_info('btrbk-local.service')
+      assert "TriggeredBy" not in unit
+
+      # Manually starting the service should still work.
+      machine.succeed("echo foo > /mnt/to_backup/bar")
+      machine.start_job("btrbk-local.service")
+      machine.wait_until_succeeds("cat /mnt/btrbk/local/*/bar | grep foo")
+    '';
+  })


### PR DESCRIPTION
###### Description of changes

This allows btrbk instances with without a triggering timer by setting `onCalendar` to `null`. This is useful for manual-only btrbk backup settings.

Also my GPG key are rotated. Commits in this PR are signed by the new key. Currently both the old and the new keys are valid on GitHub (https://github.com/oxalica.gpg)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
