### PR TITLE
lib/trivial: add warnIfNot and throwIf

### DIFF
--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -323,7 +323,14 @@ rec {
 
     Type: bool -> string -> a -> a
   */
-  warnIf = cond: msg: if cond then warn msg else id;
+  warnIf = cond: msg: if cond then warn msg else x: x;
+
+  /*
+    Like warnIf, but negated (warn if the first argument is `false`).
+
+    Type: bool -> string -> a -> a
+  */
+  warnIfNot = cond: msg: if cond then x: x else warn msg;
 
   /*
     Like the `assert b; e` expression, but with a custom error message and
@@ -346,6 +353,13 @@ rec {
 
   */
   throwIfNot = cond: msg: if cond then x: x else throw msg;
+
+  /*
+    Like throwIfNot, but negated (throw if the first argument is `true`).
+
+    Type: bool -> string -> a -> a
+  */
+  throwIf = cond: msg: if cond then throw msg else x: x;
 
   /* Check if the elements in a list are valid values from a enum, returning the identity function, or throwing an error message otherwise.
 


### PR DESCRIPTION
Negated versions of warnIf and throwIfNot.

Just found myself needing these.