### PR TITLE
nixos services.xserver.displayManager.session: drop type

### DIFF
--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -219,24 +219,7 @@ in
 
       session = mkOption {
         default = [];
-        type = with types; listOf (submodule ({ ... }: {
-          options = {
-            manage = mkOption {
-              description = "Whether this is a desktop or a window manager";
-              type = enum [ "desktop" "window" ];
-            };
-
-            name = mkOption {
-              description = "Name of this session";
-              type = str;
-            };
-
-            start = mkOption {
-              description = "Commands to run to start this session";
-              type = lines;
-            };
-          };
-        }));
+        type = types.listOf types.attrs;
         example = literalExpression
           ''
             [ { manage = "desktop";


### PR DESCRIPTION
For now at least.  I expect someone will find a working type later.
It's incorrect and was causing bad issues.  Example test case:
nix-instantiate nixos/release.nix -A tests.xfce.x86_64-linux --dry-run

This is a partial revert of commit b2d803c from PR #162271.
<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
