### PR TITLE
brscan5: 1.2.7-0 -> 1.2.9.0

### DIFF
--- a/pkgs/applications/graphics/sane/backends/brscan5/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan5/default.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation rec {
       ${myPatchElf "opt/brother/scanner/brscan5/brscan_cnetconfig"}
       ${myPatchElf "opt/brother/scanner/brscan5/brscan_gnetconfig"}
 
-      for a in opt/brother/scanner/brscan5/*.so.* opt/brother/scanner/brscan5/brscan_[cg]netconfig; do
-        if ! test -L $a; then
-          patchelf --set-rpath ${lib.makeLibraryPath buildInputs} $a
+      for file in opt/brother/scanner/brscan5/*.so.* opt/brother/scanner/brscan5/brscan_[cg]netconfig; do
+        if ! test -L $file; then
+          patchelf --set-rpath ${lib.makeLibraryPath buildInputs} $file
         fi
       done
 

--- a/pkgs/applications/graphics/sane/backends/brscan5/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan5/default.nix
@@ -43,7 +43,12 @@ stdenv.mkDerivation rec {
 
     # driver is hardcoded to look in /opt/brother/scanner/brscan5/models for model metadata.
     # patch it to look in /etc/opt/brother/scanner/models instead, so nixos environment.etc can make it available
-    printf '/etc/opt/brother/scanner/models\x00' | dd of=opt/brother/scanner/brscan5/libsane-brother5.so.1.0.7 bs=1 seek=84632 conv=notrunc
+    if [[ "${stdenv.hostPlatform.system}" == "x86_64-linux" ]]; then
+      printf '/etc/opt/brother/scanner/models\x00' | dd of=opt/brother/scanner/brscan5/libsane-brother5.so.1.0.7 bs=1 seek=84632 conv=notrunc
+    fi
+    if [[ "${stdenv.hostPlatform.system}" == "i686-linux" ]]; then
+      printf '/etc/opt/brother/scanner/models\x00' | dd of=opt/brother/scanner/brscan5/libsane-brother5.so.1.0.7 bs=1 seek=77396 conv=notrunc
+    fi
   '';
 
   installPhase = with lib; ''

--- a/pkgs/applications/graphics/sane/backends/brscan5/default.nix
+++ b/pkgs/applications/graphics/sane/backends/brscan5/default.nix
@@ -9,15 +9,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "brscan5";
-  version = "1.2.7-0";
+  version = "1.2.9-0";
   src = {
     "i686-linux" = fetchurl {
       url = "https://download.brother.com/welcome/dlf104034/${pname}-${version}.i386.deb";
-      sha256 = "647d06f629c22408d25be7c0bf49a4b1c7280bf78a27aa2cde6c3e3fa8b6807a";
+      sha256 = "ac23c9a435818955e7882ab06380adf346203ff4e45f384b40e84b8b29642f07";
     };
     "x86_64-linux" = fetchurl {
       url = "https://download.brother.com/welcome/dlf104033/${pname}-${version}.amd64.deb";
-      sha256 = "867bd88ab0d90f8e9391dc8127385095127e533cb6bd2d5d13449df602b165ae";
+      sha256 = "4ec23ff4b457323ae778e871a0f1abcc1848ea105af17850b57f7dcaddcfd96d";
     };
   }."${stdenv.hostPlatform.system}";
 


### PR DESCRIPTION
###### Description of changes
Brother has yoinked the 1.2.7-0 driver from their website. Update brscan5 to use the currently-released 1.2.9-0 driver.

Confirmed this still works with my DS-640.

Also fixes an issue where the i686 version of the driver was being patched incorrectly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

/fixes #164840
