### PR TITLE
linux: silence unused option warnings on 5.x kernels

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -48,7 +48,6 @@ let
       TIMER_STATS               = whenOlder "4.11" yes;
       DEBUG_NX_TEST             = whenOlder "4.11" no;
       DEBUG_STACK_USAGE         = no;
-      DEBUG_STACKOVERFLOW       = option no;
       RCU_TORTURE_TEST          = no;
       SCHEDSTATS                = no;
       DETECT_HUNG_TASK          = yes;
@@ -383,7 +382,7 @@ let
 
       EXT4_FS_POSIX_ACL = yes;
       EXT4_FS_SECURITY  = yes;
-      EXT4_ENCRYPTION   = { optional = true; tristate = if (versionOlder version "4.8") then "m" else "y"; };
+      EXT4_ENCRYPTION   = whenOlder "5.1" yes;
 
       REISERFS_FS_XATTR     = option yes;
       REISERFS_FS_POSIX_ACL = option yes;
@@ -404,7 +403,7 @@ let
 
       F2FS_FS             = module;
       F2FS_FS_SECURITY    = option yes;
-      F2FS_FS_ENCRYPTION  = option yes;
+      F2FS_FS_ENCRYPTION  = whenOlder "5.1" yes;
       F2FS_FS_COMPRESSION = whenAtLeast "5.6" yes;
       UDF_FS              = module;
 
@@ -483,7 +482,7 @@ let
       MODULE_SIG            = no; # r13y, generates a random key during build and bakes it in
       # Depends on MODULE_SIG and only really helps when you sign your modules
       # and enforce signatures which we don't do by default.
-      SECURITY_LOCKDOWN_LSM = option no;
+      SECURITY_LOCKDOWN_LSM = whenAtLeast "5.4" no;
     } // optionalAttrs (!stdenv.hostPlatform.isAarch32) {
 
       # Detect buffer overflows on the stack
@@ -595,10 +594,8 @@ let
       XEN_PVH                     = option yes;
       XEN_PVHVM                   = option yes;
       XEN_SAVE_RESTORE            = option yes;
-      XEN_SCRUB_PAGES             = option yes;
-      XEN_SELFBALLOONING          = option yes;
-      XEN_STUB                    = option yes;
-      XEN_TMEM                    = option yes;
+      XEN_SCRUB_PAGES             = whenOlder "4.19" yes;
+      XEN_SELFBALLOONING          = whenOlder "5.3" yes;
     };
 
     media = {
@@ -685,7 +682,8 @@ let
       LOCK_TORTURE_TEST        = option no;
       MTD_TESTS                = option no;
       NOTIFIER_ERROR_INJECTION = option no;
-      RCU_PERF_TEST            = option no;
+      RCU_PERF_TEST            = whenBetween "4.13" "5.9" no;
+      RCU_SCALE_TEST           = whenAtLeast "5.10" no;
       RCU_TORTURE_TEST         = option no;
       TEST_ASYNC_DRIVER_PROBE  = option no;
       WW_MUTEX_SELFTEST        = option no;


### PR DESCRIPTION
###### Description of changes

Fixes:
```
warning: unused option: DEBUG_STACKOVERFLOW
warning: unused option: EXT4_ENCRYPTION
warning: unused option: F2FS_FS_ENCRYPTION
warning: unused option: RCU_PERF_TEST
warning: unused option: XEN_SCRUB_PAGES
warning: unused option: XEN_SELFBALLOONING
warning: unused option: XEN_STUB
warning: unused option: XEN_TMEM
```

- DEBUG_STACKOVERFLOW: [defaults to no, remnant of grsecurity support](https://github.com/NixOS/nixpkgs/commit/52cd3538ff0214f0416455322cec299d2a43a436)
- EXT4_ENCRYPTION: [removed in 5.1](https://github.com/torvalds/linux/commit/643fa9612bf1a29153eee46fd398117632f93cbe)
- F2FS_FS_ENCRYPTION: [removed in 5.1](https://github.com/torvalds/linux/commit/643fa9612bf1a29153eee46fd398117632f93cbe)
- RCU_PERF_TEST: [renamed in 5.10](https://github.com/torvalds/linux/commit/4e88ec4a9eb17527e640b063f79e5b875733eb53)
- XEN_SCRUB_PAGES: [removed in 4.19](https://github.com/torvalds/linux/commit/197ecb3802c04499d8ff4f8cb28f6efa008067db)
- XEN_SELFBALLOONING: [removed in 5.3](https://github.com/torvalds/linux/commit/814bbf49dcd0ad642e7ceb8991e57555c5472cce)
- XEN_STUB: [marked broken in 3.9](https://github.com/torvalds/linux/commit/76fc253723add627cf28c09c79fb67e71f9e4782)
- XEN_TMEM: [removed in 5.3, defaulted to module prior](https://github.com/torvalds/linux/commit/814bbf49dcd0ad642e7ceb8991e57555c5472cce)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
