### PR TITLE
libvirt: Fix a segfault when undefining a domain

### DIFF
--- a/pkgs/development/libraries/libvirt/0001-qemu-segmentation-fault-in-virtqemud-executing-qemuD.patch
+++ b/pkgs/development/libraries/libvirt/0001-qemu-segmentation-fault-in-virtqemud-executing-qemuD.patch
@@ -1,0 +1,48 @@
+From 823a62ec8aac4fb75e6e281164f3eb56ae47597c Mon Sep 17 00:00:00 2001
+From: Boris Fiuczynski <fiuczy@linux.ibm.com>
+Date: Tue, 1 Mar 2022 18:47:59 +0100
+Subject: [PATCH] qemu: segmentation fault in virtqemud executing
+ qemuDomainUndefineFlags
+
+Commit 5adfb3472342741c443ac91dee0abb18b5a3d038 causes a segmentation fault.
+
+Stack trace of thread 664419:
+ #0  0x000003ff62ec553c in qemuDomainUndefineFlags (dom=0x3ff6c002810, flags=<optimized out>) at ../src/qemu/qemu_driver.c:6618
+ #1  0x000003ff876a7e5c in virDomainUndefineFlags (domain=domain@entry=0x3ff6c002810, flags=<optimized out>) at ../src/libvirt-domain.c:6519
+ #2  0x000002aa2b64a808 in remoteDispatchDomainUndefineFlags (server=0x2aa2c3d7880, msg=0x2aa2c3d2770, args=<optimized out>, rerr=0x3ff8287b950, client=<optimized out>)
+        at src/remote/remote_daemon_dispatch_stubs.h:13080
+ #3  remoteDispatchDomainUndefineFlagsHelper (server=0x2aa2c3d7880, client=<optimized out>, msg=0x2aa2c3d2770, rerr=0x3ff8287b950, args=<optimized out>, ret=0x0)
+        at src/remote/remote_daemon_dispatch_stubs.h:13059
+ #4  0x000003ff8758bbf4 in virNetServerProgramDispatchCall (msg=0x2aa2c3d2770, client=0x2aa2c3e3050, server=0x2aa2c3d7880, prog=0x2aa2c3d8010)
+        at ../src/rpc/virnetserverprogram.c:428
+ #5  virNetServerProgramDispatch (prog=0x2aa2c3d8010, server=server@entry=0x2aa2c3d7880, client=0x2aa2c3e3050, msg=0x2aa2c3d2770) at ../src/rpc/virnetserverprogram.c:302
+ #6  0x000003ff8758c260 in virNetServerProcessMsg (msg=<optimized out>, prog=<optimized out>, client=<optimized out>, srv=0x2aa2c3d7880) at ../src/rpc/virnetserver.c:140
+ #7  virNetServerHandleJob (jobOpaque=0x2aa2c3e2d30, opaque=0x2aa2c3d7880) at ../src/rpc/virnetserver.c:160
+ #8  0x000003ff874c49aa in virThreadPoolWorker (opaque=<optimized out>) at ../src/util/virthreadpool.c:164
+ #9  0x000003ff874c3f62 in virThreadHelper (data=<optimized out>) at ../src/util/virthread.c:256
+ #10 0x000003ff86c1cf8c in start_thread () from /lib64/libc.so.6
+ #11 0x000003ff86c9650e in thread_start () from /lib64/libc.so.6
+
+Signed-off-by: Boris Fiuczynski <fiuczy@linux.ibm.com>
+Reviewed-by: Jim Fehlig <jfehlig@suse.com>
+Reviewed-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/qemu/qemu_driver.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qemu/qemu_driver.c b/src/qemu/qemu_driver.c
+index bcd9bdb436..8337eed510 100644
+--- a/src/qemu/qemu_driver.c
++++ b/src/qemu/qemu_driver.c
+@@ -6615,7 +6615,7 @@ qemuDomainUndefineFlags(virDomainPtr dom,
+         }
+     }
+ 
+-    if (vm->def->os.loader->nvram) {
++    if (vm->def->os.loader && vm->def->os.loader->nvram) {
+         nvram_path = g_strdup(vm->def->os.loader->nvram);
+     } else if (vm->def->os.firmware == VIR_DOMAIN_OS_DEF_FIRMWARE_EFI) {
+         qemuDomainNVRAMPathFormat(cfg, vm->def, &nvram_path);
+-- 
+2.35.1
+

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -130,6 +130,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
+    ./0001-qemu-segmentation-fault-in-virtqemud-executing-qemuD.patch
   ];
 
   # remove some broken tests


### PR DESCRIPTION
###### Description of changes

libvirt 8.1.0 will crash when trying to undefine a domain.
Backport a patch to fix this.

Original commit:
https://gitlab.com/libvirt/libvirt/-/commit/823a62ec8aac4fb75e6e281164f3eb56ae47597c

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
