### PR TITLE
python3Packages.pyzbar: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/pyzbar/default.nix
+++ b/pkgs/development/python-modules/pyzbar/default.nix
@@ -18,11 +18,12 @@ buildPythonPackage rec {
   # find_library doesn't return an absolute path
   # https://github.com/NixOS/nixpkgs/issues/7307
   postPatch = ''
-    substituteInPlace pyzbar/zbar_library.py --replace "find_library('zbar')" "'${zbar.lib}/lib/libzbar.so.0'"
+    substituteInPlace pyzbar/zbar_library.py \
+      --replace "find_library('zbar')" "'${lib.getLib zbar}/lib/libzbar.so.0'"
   '';
 
   disabledTests = [
-    #  find_library has been replaced by a hardcoded path
+    # find_library has been replaced by a hardcoded path
     # the test fails due to find_library not called
     "test_found_non_windows"
     "test_not_found_non_windows"
@@ -31,7 +32,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pyzbar" ];
 
   meta = with lib; {
-    description = "Read one-dimensional barcodes and QR codes from Python 2 and 3 using the zbar library.";
+    description = "Read one-dimensional barcodes and QR codes from Python using the zbar library.";
     homepage = "https://github.com/NaturalHistoryMuseum/pyzbar";
     license = licenses.mit;
     maintainers = with maintainers; [ gador ];

--- a/pkgs/development/python-modules/pyzbar/default.nix
+++ b/pkgs/development/python-modules/pyzbar/default.nix
@@ -1,0 +1,39 @@
+{ lib, buildPythonPackage, fetchFromGitHub, numpy, pillow, zbar, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "pyzbar";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "NaturalHistoryMuseum";
+    repo = "pyzbar";
+    rev = "v${version}";
+    sha256 = "8IZQY6qB4r1SUPItDlTDnVQuPs0I38K3yJ6LiPJuwbU=";
+  };
+
+  propagatedBuildInputs = [ zbar pillow numpy ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  # find_library doesn't return an absolute path
+  # https://github.com/NixOS/nixpkgs/issues/7307
+  postPatch = ''
+    substituteInPlace pyzbar/zbar_library.py --replace "find_library('zbar')" "'${zbar.lib}/lib/libzbar.so.0'"
+  '';
+
+  disabledTests = [
+    #  find_library has been replaced by a hardcoded path
+    # the test fails due to find_library not called
+    "test_found_non_windows"
+    "test_not_found_non_windows"
+  ];
+
+  pythonImportsCheck = [ "pyzbar" ];
+
+  meta = with lib; {
+    description = "Read one-dimensional barcodes and QR codes from Python 2 and 3 using the zbar library.";
+    homepage = "https://github.com/NaturalHistoryMuseum/pyzbar";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6303,6 +6303,8 @@ in {
 
   pyutil = callPackage ../development/python-modules/pyutil { };
 
+  pyzbar = callPackage ../development/python-modules/pyzbar { };
+
   pkutils = callPackage ../development/python-modules/pkutils { };
 
   plac = callPackage ../development/python-modules/plac { };


### PR DESCRIPTION
Different implementation of a pure python barcode reading library, using zbar.

Signed-off-by: florian on nixos (Florian Brandes) <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
