### PR TITLE
tor-browser-bundle-bin: 11.0.7 -> 11.0.9

### DIFF
--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -87,7 +87,7 @@ let
   fteLibPath = makeLibraryPath [ stdenv.cc.cc gmp ];
 
   # Upstream source
-  version = "11.0.7";
+  version = "11.0.9";
 
   lang = "en-US";
 
@@ -98,7 +98,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux64-${version}_${lang}.tar.xz"
       ];
-      sha256 = "197yf0abcb98kqds0xvki0b52rlhzyzdc98zmhrn7y8gmahc84cz";
+      sha256 = "0cl01bx64d6bmajknj7085nzc6841adkp65fz531r3y6nnpwr9ds";
     };
 
     i686-linux = fetchurl {
@@ -107,7 +107,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux32-${version}_${lang}.tar.xz"
       ];
-      sha256 = "0yylfsgmnfn6zww0r6kp1d1wmmb0lfa4lqwkgr7d8rzi6q9spmqk";
+      sha256 = "0j6alhm1pqp7fb6nk55vzvr1qjz6gyd3vn6v2dkkvj9mgm57x1j5";
     };
   };
 in


### PR DESCRIPTION
###### Description of changes

Package update. It seems it is primarily a bugfix release (Firefox is not updated), but it includes an openssl update to 1.1.1n, which has severity HIGH.

  * [TBB Announcement](https://blog.torproject.org/new-release-tor-browser-1109/):
    > This releases fixes bug tor-browser#40802 which caused some users to be unable to access client authorized onion services.
    > 
    > We use the opportunity as well to update various other components of Tor Browser:
    > 
    > * OpenSSL 1.1.1n
    > 
    > We also switch to the latest Go version (1.17.8) for building our Go-related projects.
  * [OpenSSL Announcement](https://mta.openssl.org/pipermail/openssl-announce/2022-March/000216.html):
    > The OpenSSL project team would like to announce the forthcoming release of OpenSSL versions 3.0.2 and 1.1.1n.
    > [...]
    > These are security-fix releases. The highest severity issue fixed in these releases is HIGH:

Therefore:
* Please consider adding the security label
* Please backport to release-21.11 after merging

Thanks!

###### Things done

Building on i686Linux (still) fails due to a dependency (graphene-hardened-malloc), as written [here](https://github.com/NixOS/nixpkgs/pull/163430#issuecomment-1063359956).

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  ```
  1 package updated:
  tor-browser-bundle-bin (11.0.7 → 11.0.9)
  ...
  1 package built:
  tor-browser-bundle-bin
  ```
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### Notify

@matejc (one of the maintainers), @lourkeur (reviewer during last updates)