### PR TITLE
alan: init at 3.0beta8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8844,6 +8844,12 @@
     githubId = 3747396;
     name = "Nathan Isom";
   };
+  neilmayhew = {
+    email = "nix@neil.mayhew.name";
+    github = "neilmayhew";
+    githubId = 166791;
+    name = "Neil Mayhew";
+  };
   nelsonjeppesen = {
     email = "nix@jeppesen.io";
     github = "NelsonJeppesen";

--- a/pkgs/development/compilers/alan/2.nix
+++ b/pkgs/development/compilers/alan/2.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, fetchFromGitHub
+}:
+
+stdenv.mkDerivation rec {
+  pname = "alan2";
+  version = "2.8.7";
+
+  src = fetchFromGitHub {
+    owner = "alan-if";
+    repo = "alan";
+    rev = "71f23ec79f7f5d66aa5ae9fd3f9b8dae41a89f15";
+    sha256 = "066jknqz1v6sismvfxjfffl35h14v8qwgcq99ibhp08dy2fwraln";
+  };
+
+  makefile = "Makefile.unix";
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/alan2
+    cp compiler/alan $out/bin/alan2
+    cp interpreter/arun $out/bin/arun2
+    cp alan.readme ChangeLog $out/share/alan2
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.alanif.se/";
+    description = "The Alan interactive fiction language (legacy version)";
+    license = licenses.artistic2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ neilmayhew ];
+  };
+}

--- a/pkgs/development/compilers/alan/default.nix
+++ b/pkgs/development/compilers/alan/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, lib, fetchFromGitHub
+, cgreen, openjdk, pkg-config, which
+}:
+
+stdenv.mkDerivation rec {
+  pname = "alan";
+  version = "3.0beta8";
+
+  src = fetchFromGitHub {
+    owner = "alan-if";
+    repo = "alan";
+    rev = "v${version}";
+    sha256 = "0zfg1frmb4yl39hk8h733bmlwk4rkikzfhvv7j34cxpdpsp7spzl";
+  };
+
+  postPatch = ''
+    patchShebangs --build bin
+    # The Makefiles have complex CFLAGS that don't allow separate control of optimization
+    sed -i 's/-O0/-O2/g' compiler/Makefile.common
+    sed -i 's/-Og/-O2/g' interpreter/Makefile.common
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/alan/examples
+    # Build the release tarball
+    make package
+    # The release tarball isn't split up into subdirectories
+    tar -xf alan*.tgz --strip-components=1 -C $out/share/alan
+    mv $out/share/alan/*.alan $out/share/alan/examples
+    chmod a-x $out/share/alan/examples/*.alan
+    mv $out/share/alan/{alan,arun} $out/bin
+    # a2a3 isn't included in the release tarball
+    cp bin/a2a3 $out/bin
+  '';
+
+  nativeBuildInputs = [
+    cgreen
+    openjdk pkg-config which
+  ];
+
+  meta = with lib; {
+    homepage = "https://www.alanif.se/";
+    description = "The Alan interactive fiction language";
+    license = licenses.artistic2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ neilmayhew ];
+  };
+}

--- a/pkgs/development/libraries/cgreen/default.nix
+++ b/pkgs/development/libraries/cgreen/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-aQrfsiPuNrEMscZrOoONiN665KlNmnOiYj9ZIyzW304=";
   };
 
+  postPatch = ''
+    for F in tools/discoverer_acceptance_tests.c tools/discoverer.c; do
+      substituteInPlace "$F" --replace "/usr/bin/nm" "nm"
+    done
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11896,6 +11896,8 @@ with pkgs;
     jdk = jdk8;
   };
 
+  alan = callPackage ../development/compilers/alan { };
+
   algol68g = callPackage ../development/compilers/algol68g { };
 
   armips = callPackage ../development/compilers/armips { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11898,6 +11898,8 @@ with pkgs;
 
   alan = callPackage ../development/compilers/alan { };
 
+  alan_2 = callPackage ../development/compilers/alan/2.nix { };
+
   algol68g = callPackage ../development/compilers/algol68g { };
 
   armips = callPackage ../development/compilers/armips { };


### PR DESCRIPTION
###### Description of changes

[The Alan interactive fiction language](https://www.alanif.se/)

Alan is a development system for writing interactive fiction games. It includes a compiler and an interpreter. The compiler produces a bytecode file that is run by the interpreter to enable a user to play the game.

The current version is version 3.0. The 2.x series is no longer maintained but it is useful to have a copy of 2.x in order to port older games (of which there are many since Alan has a long and respected history). The 3.x series includes an automatic converter for source files (`a2a3`) but the conversion isn't perfect so it's [recommended](https://alan-if.github.io/alan-docs/conversion/conversion.html#porting_strategy) to have an older copy of the tools available in order to check behaviour against the original. I have therefore included a derivation for `alan2`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).