### PR TITLE
fig: init at 1.0.56

### DIFF
--- a/pkgs/development/tools/fig/default.nix
+++ b/pkgs/development/tools/fig/default.nix
@@ -1,0 +1,37 @@
+{ stdenv
+, fetchurl
+, lib
+, makeWrapper
+, undmg
+, unzip
+}:
+stdenv.mkDerivation rec {
+  pname = "fig";
+  appname = "Fig";
+  binname = "fig-darwin-universal";
+  version = "1.0.56";
+  revision = "414";
+  src = fetchurl {
+    name = "fig-${version}.dmg";
+    url = "https://versions.withfig.com/fig%20${revision}.dmg";
+    sha256 = "04cfvmxk187y4b0275b9mdy2y2c1vmvx4r95g0w0gwywzvz0p0rf";
+  };
+
+  meta = with lib; {
+    description = "Adds IDE-style autocomplete to your existing terminal";
+    homepage = "https://fig.io";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ opeik ];
+    platforms = platforms.darwin;
+  };
+
+  sourceRoot = "${appname}.app";
+  nativeBuildInputs = [ makeWrapper undmg unzip ];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{Applications/${appname}.app,bin}
+    cp -R . $out/Applications/${appname}.app
+    makeWrapper $out/Applications/${appname}.app/Contents/MacOS/${binname} $out/bin/${pname}
+    runHook postInstall
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5481,6 +5481,8 @@ with pkgs;
 
   fierce = callPackage ../tools/security/fierce { };
 
+  fig = callPackage ../development/tools/fig { };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file {


### PR DESCRIPTION
###### Description of changes

Added package `fig` for macOS.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

- Added `pkgs/development/tools/fig/default.nix`
- Added `fig` to `pkgs/top-level/all-packages.nix`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
