### PR TITLE
vim wrapper improvements

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -18,7 +18,7 @@ Adding custom .vimrc lines can be done using the following code:
 
 ```nix
 vim_configurable.customize {
-  # `name` specifies the name of the executable and package
+  # `name` optionally specifies the name of the executable and package
   name = "vim-with-plugins";
 
   vimrcConfig.customRC = ''
@@ -28,6 +28,9 @@ vim_configurable.customize {
 ```
 
 This configuration is used when Vim is invoked with the command specified as name, in this case `vim-with-plugins`.
+You can also omit `name` to customize Vim itself. See the
+[definition of `vimUtils.makeCustomizable`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/editors/vim/plugins/vim-utils.nix#L408)
+for all supported options.
 
 For Neovim the `configure` argument can be overridden to achieve the same:
 

--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -796,6 +796,54 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>vim.customize</literal> function produced by
+          <literal>vimUtils.makeCustomizable</literal> now has a
+          slightly different interface:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              The wrapper now includes everything in the given Vim
+              derivation if <literal>name</literal> is
+              <literal>&quot;vim&quot;</literal> (the default). This
+              makes the <literal>wrapManual</literal> argument obsolete,
+              but this behavior can be overriden by setting the
+              <literal>standalone</literal> argument.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              All the executables present in the given derivation (or,
+              in <literal>standalone</literal> mode, only the
+              <literal>*vim</literal> ones) are wrapped. This makes the
+              <literal>wrapGui</literal> argument obsolete.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              The <literal>vimExecutableName</literal> and
+              <literal>gvimExecutableName</literal> arguments were
+              replaced by a single <literal>executableName</literal>
+              argument in which the shell variable
+              <literal>$exe</literal> can be used to refer to the
+              wrapped executable’s name.
+            </para>
+          </listitem>
+        </itemizedlist>
+        <para>
+          See the comments in
+          <literal>pkgs/applications/editors/vim/plugins/vim-utils.nix</literal>
+          for more details.
+        </para>
+        <para>
+          <literal>vimUtils.vimWithRC</literal> was removed. You should
+          instead use <literal>customize</literal> on a Vim derivation,
+          which now accepts <literal>vimrcFile</literal> and
+          <literal>gvimrcFile</literal> arguments.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>tilp2</literal> was removed together with its module
         </para>
       </listitem>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -315,6 +315,15 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `pkgs._7zz` is now correctly licensed as LGPL3+ and BSD3 with optional unfree unRAR licensed code
 
+- The `vim.customize` function produced by `vimUtils.makeCustomizable` now has a slightly different interface:
+  * The wrapper now includes everything in the given Vim derivation if `name` is `"vim"` (the default). This makes the `wrapManual` argument obsolete, but this behavior can be overriden by setting the `standalone` argument.
+  * All the executables present in the given derivation (or, in `standalone` mode, only the `*vim` ones) are wrapped. This makes the `wrapGui` argument obsolete.
+  * The `vimExecutableName` and `gvimExecutableName` arguments were replaced by a single `executableName` argument in which the shell variable `$exe` can be used to refer to the wrapped executable's name.
+
+  See the comments in `pkgs/applications/editors/vim/plugins/vim-utils.nix` for more details.
+
+  `vimUtils.vimWithRC` was removed. You should instead use `customize` on a Vim derivation, which now accepts `vimrcFile` and `gvimrcFile` arguments.
+
 - `tilp2` was removed together with its module
 
 - The F-PROT antivirus (`fprot` package) and its service module were removed because it

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -3,7 +3,7 @@
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 , vimPlugins
-, makeWrapper
+, makeWrapper, makeBinaryWrapper
 , wrapGAppsHook
 , runtimeShell
 
@@ -134,7 +134,9 @@ in stdenv.mkDerivation rec {
   ++ lib.optional wrapPythonDrv makeWrapper
   ++ lib.optional nlsSupport gettext
   ++ lib.optional perlSupport perl
-  ++ lib.optional (guiSupport == "gtk3") wrapGAppsHook
+  # Make the inner wrapper binary to avoid double wrapping issues with wrapPythonDrv
+  # (https://github.com/NixOS/nixpkgs/pull/164163)
+  ++ lib.optional (guiSupport == "gtk3") (wrapGAppsHook.override { makeWrapper = makeBinaryWrapper; })
   ;
 
   buildInputs = [
@@ -177,37 +179,13 @@ in stdenv.mkDerivation rec {
     patchelf --set-rpath \
       "$(patchelf --print-rpath $out/bin/vim):${lib.makeLibraryPath buildInputs}" \
       "$out"/bin/vim
-    if [[ -e "$out"/bin/gvim ]]; then
-      patchelf --set-rpath \
-        "$(patchelf --print-rpath $out/bin/vim):${lib.makeLibraryPath buildInputs}" \
-        "$out"/bin/gvim
-    fi
 
     ln -sfn '${nixosRuntimepath}' "$out"/share/vim/vimrc
-  '' + lib.optionalString wrapPythonDrv ''
+  '';
+
+  postFixup = lib.optionalString wrapPythonDrv ''
     wrapProgram "$out/bin/vim" --prefix PATH : "${python3}/bin" \
       --set NIX_PYTHONPATH "${python3}/${python3.sitePackages}"
-  '' + lib.optionalString (guiSupport == "gtk3") ''
-
-    rewrap () {
-      rm -f "$out/bin/$1"
-      echo -e '#!${runtimeShell}\n"'"$out/bin/vim"'" '"$2"' "$@"' > "$out/bin/$1"
-      chmod a+x "$out/bin/$1"
-    }
-
-    rewrap ex -e
-    rewrap view -R
-    rewrap gvim -g
-    rewrap gex -eg
-    rewrap gview -Rg
-    rewrap rvim -Z
-    rewrap rview -RZ
-    rewrap rgvim -gZ
-    rewrap rgview -RgZ
-    rewrap evim    -y
-    rewrap eview   -yR
-    rewrap vimdiff -d
-    rewrap gvimdiff -gd
   '';
 
   dontStrip = true;

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -25,7 +25,6 @@
 , ximSupport        ? config.vim.xim or true        # less than 15KB, needed for deadkeys
 , darwinSupport     ? config.vim.darwin or false    # Enable Darwin support
 , ftNixSupport      ? config.vim.ftNix or true      # Add .nix filetype detection and minimal syntax highlighting support
-, ...
 }:
 
 

--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -175,10 +175,6 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     ln -s $out/bin/vim $out/bin/vi
   '' + lib.optionalString stdenv.isLinux ''
-    patchelf --set-rpath \
-      "$(patchelf --print-rpath $out/bin/vim):${lib.makeLibraryPath buildInputs}" \
-      "$out"/bin/vim
-
     ln -sfn '${nixosRuntimepath}' "$out"/share/vim/vimrc
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24717,7 +24717,7 @@ with pkgs;
   assign-lb-ip = callPackage ../applications/networking/cluster/assign-lb-ip { };
 
   astroid = callPackage ../applications/networking/mailreaders/astroid {
-    vim = vim_configurable.override { features = "normal"; gui = "auto"; };
+    vim = vim_configurable.override { features = "normal"; };
   };
 
   aucatctl = callPackage ../applications/audio/aucatctl { };
@@ -29721,8 +29721,6 @@ with pkgs;
   vim_configurable = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/configurable.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Cocoa Foundation CoreData;
     inherit (darwin) libobjc;
-    gtk2 = if stdenv.isDarwin then gtk2-x11 else gtk2;
-    gtk3 = if stdenv.isDarwin then gtk3-x11 else gtk3;
   });
 
   vim-darwin = (vim_configurable.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29706,9 +29706,9 @@ with pkgs;
 
   veusz = libsForQt5.callPackage ../applications/graphics/veusz { };
 
-  vim = callPackage ../applications/editors/vim {
+  vim = vimUtils.makeCustomizable (callPackage ../applications/editors/vim {
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
-  };
+  });
 
   vimiv = callPackage ../applications/graphics/vimiv { };
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/126386.

The current wrapper only includes vim, gvim and the man pages (optionally). This rewrite distinguishes two scenarios, which I expect cover the majority of use cases:

- standalone mode, when `name != "vim"`, means the user already has a vim in scope and only wants to add a customized version with a different name. In this case we only include wrappers for `/bin/*vim`.
- non-standalone mode, when `name == "vim"`, means the user expects a normal vim package that uses the specified configuration. In this case we include everything in the original derivation, with wrappers for all the executables that accept a vimrc.

Other cases are possible using the arguments. I've added warnings when the old arguments are used to hopefully make the transition easy.

I also simplified the `vim_configurable` derivation a bit. In the future I'd also like to unify the two derivations (`default.nix` and `configurable.nix`). It seems like `vim` could be an instance of `vim_configurable` with some things disabled.