### PR TITLE
bottles: added `gnutls` to `extraLibraries` to enable encryption support

### DIFF
--- a/pkgs/applications/misc/bottles/default.nix
+++ b/pkgs/applications/misc/bottles/default.nix
@@ -12,7 +12,7 @@
 let
   steam-run = (steam.override {
     # required by wine runner `caffe`
-    extraLibraries = pkgs: with pkgs; [ libunwind libusb1 ]
+    extraLibraries = pkgs: with pkgs; [ libunwind libusb1 gnutls ]
       ++ bottlesExtraLibraries pkgs;
     extraPkgs = pkgs: [ ]
       ++ bottlesExtraPkgs pkgs;


### PR DESCRIPTION
see #164997

###### Description of changes
Added gnutls to enable encryption support.

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
```
 asbachb@nixos-t14s  ~/dev/src/nix/nixpkgs   bugfix/bottles/164997 ±  nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
this path will be fetched (0.03 MiB download, 0.13 MiB unpacked):
  /nix/store/65wspd9lgps8ya24b3bs0mp9n3qrxgm2-nixpkgs-review-2.6.4
copying path '/nix/store/65wspd9lgps8ya24b3bs0mp9n3qrxgm2-nixpkgs-review-2.6.4' from 'https://cache.nixos.org'...
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 38, done.
remote: Counting objects: 100% (29/29), done.
remote: Compressing objects: 100% (13/13), done.
remote: Total 38 (delta 19), reused 16 (delta 16), pack-reused 9
Unpacking objects: 100% (38/38), 411.35 KiB | 2.74 MiB/s, done.
From https://github.com/NixOS/nixpkgs
   efff462fd30..3aa72cc4711  master     -> refs/nixpkgs-review/0
$ git worktree add /home/asbachb/.cache/nixpkgs-review/rev-e6157516711d016c04529e58d6171380f348b4ba/nixpkgs 3aa72cc4711262ca414bdf66d02d6194680b6e53
Preparing worktree (detached HEAD 3aa72cc4711)
Updating files: 100% (29938/29938), done.
HEAD is now at 3aa72cc4711 Merge pull request #157515 from jvanbruegge/isabelle-naproche
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-e6157516711d016c04529e58d6171380f348b4ba/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit --no-ff e6157516711d016c04529e58d6171380f348b4ba
Automatic merge went well; stopped before committing as requested
$ nix-env --option system x86_64-linux -f /home/asbachb/.cache/nixpkgs-review/rev-e6157516711d016c04529e58d6171380f348b4ba/nixpkgs -qaP --xml --out-path --show-trace --meta
1 package updated:
bottles

$ nix --experimental-features nix-command build --no-link --keep-going --option build-use-sandbox relaxed -f /home/asbachb/.cache/nixpkgs-review/rev-e6157516711d016c04529e58d6171380f348b4ba/build.nix
1 package built:
bottles

$ nix-shell /home/asbachb/.cache/nixpkgs-review/rev-e6157516711d016c04529e58d6171380f348b4ba/shell.nix
these 4 paths will be fetched (0.55 MiB download, 2.67 MiB unpacked):
  /nix/store/1z2v1kw0zzaf4wcl85vhws49rnb760ba-bash-interactive-5.1-p16-man
  /nix/store/5c9ixzdc3yr5yknb9axn2adagpi13m1n-bash-interactive-5.1-p16-dev
  /nix/store/5ksmddbawvixla5pqn9riaq0pjkf0y70-bash-interactive-5.1-p16-info
  /nix/store/bwirca0m40znali8k4mymwmi5v19paga-bash-interactive-5.1-p16-doc
copying path '/nix/store/bwirca0m40znali8k4mymwmi5v19paga-bash-interactive-5.1-p16-doc' from 'https://cache.nixos.org'...
copying path '/nix/store/5ksmddbawvixla5pqn9riaq0pjkf0y70-bash-interactive-5.1-p16-info' from 'https://cache.nixos.org'...
copying path '/nix/store/1z2v1kw0zzaf4wcl85vhws49rnb760ba-bash-interactive-5.1-p16-man' from 'https://cache.nixos.org'...
copying path '/nix/store/5c9ixzdc3yr5yknb9axn2adagpi13m1n-bash-interactive-5.1-p16-dev' from 'https://cache.nixos.org'...
``` 
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
