### PR TITLE
sfxr-qt: 1.4.0 -> 1.5.0, add test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -468,6 +468,7 @@ in
   seafile = handleTest ./seafile.nix {};
   searx = handleTest ./searx.nix {};
   service-runner = handleTest ./service-runner.nix {};
+  sfxr-qt = handleTest ./sfxr-qt.nix {};
   shadow = handleTest ./shadow.nix {};
   shadowsocks = handleTest ./shadowsocks {};
   shattered-pixel-dungeon = handleTest ./shattered-pixel-dungeon.nix {};

--- a/nixos/tests/sfxr-qt.nix
+++ b/nixos/tests/sfxr-qt.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "sfxr-qt";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ fgaz ];
+  };
+
+  machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+    sound.enable = true;
+    environment.systemPackages = [ pkgs.sfxr-qt ];
+  };
+
+  enableOCR = true;
+
+  testScript =
+    ''
+      machine.wait_for_x()
+      # Add a dummy sound card, or the program won't start
+      machine.execute("modprobe snd-dummy")
+
+      machine.execute("sfxr-qt >&2 &")
+
+      machine.wait_for_window(r"sfxr")
+      machine.sleep(10)
+      machine.wait_for_text("requency")
+      machine.screenshot("screen")
+    '';
+})

--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -9,6 +9,7 @@
 , SDL
 , python3
 , callPackage
+, nixosTests
 }:
 
 mkDerivation rec {
@@ -44,6 +45,7 @@ mkDerivation rec {
 
   passthru.tests = {
     export-square-wave = callPackage ./test-export-square-wave {};
+    sfxr-qt-starts = nixosTests.sfxr-qt;
   };
 
   meta = with lib; {

--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -8,6 +8,7 @@
 , qtquickcontrols2
 , SDL
 , python3
+, callPackage
 }:
 
 mkDerivation rec {
@@ -40,6 +41,10 @@ mkDerivation rec {
     qtquickcontrols2
     SDL
   ];
+
+  passthru.tests = {
+    export-square-wave = callPackage ./test-export-square-wave {};
+  };
 
   meta = with lib; {
     homepage = "https://github.com/agateau/sfxr-qt";

--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -1,6 +1,7 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , extra-cmake-modules
 , qtbase
@@ -11,15 +12,22 @@
 
 mkDerivation rec {
   pname = "sfxr-qt";
-  version = "1.4.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "agateau";
     repo = "sfxr-qt";
     rev = version;
-    sha256 = "sha256-Mn+wcwu70BwsTLFlc12sOOe6U1AJ8hR7bCIPlPnCooE=";
+    sha256 = "sha256-Ce5NJe1f+C4pPmtenHYvtkxste+nPuxJoB+N7K2nyRo=";
     fetchSubmodules = true;
   };
+
+  # Remove on next release
+  patches = [(fetchpatch {
+    name = "sfxr-qr-missing-qpainterpath-include";
+    url = "https://github.com/agateau/sfxr-qt/commit/ef051f473654052112b647df987eb263e38faf47.patch";
+    sha256 = "sha256-bqMnxHUzdS5oG/2hfr5MvkpwrtZW+GTN5fS2WpV2W2c=";
+  })];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/audio/sfxr-qt/test-export-square-wave/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/test-export-square-wave/default.nix
@@ -1,0 +1,6 @@
+{ runCommand, sfxr-qt }:
+
+runCommand "sfxr-qt-test-export-square-wave" ''
+  mkdir $out
+  ${sfxr-qt}/bin/sfxr-qt --export --output $out/output.wav ${./input.sfxj}
+''

--- a/pkgs/applications/audio/sfxr-qt/test-export-square-wave/input.sfxj
+++ b/pkgs/applications/audio/sfxr-qt/test-export-square-wave/input.sfxj
@@ -1,0 +1,29 @@
+{
+    "properties": {
+        "attackTime": 0,
+        "baseFrequency": 1,
+        "changeAmount": 0,
+        "changeSpeed": 0,
+        "decayTime": 1,
+        "deltaSlide": 0,
+        "dutySweep": 0,
+        "hpFilterCutoff": 0,
+        "hpFilterCutoffSweep": 0,
+        "lpFilterCutoff": 1,
+        "lpFilterCutoffSweep": 0,
+        "lpFilterResonance": 0,
+        "minFrequency": 0,
+        "phaserOffset": 0,
+        "phaserSweep": 0,
+        "repeatSpeed": 0,
+        "slide": 0,
+        "squareDuty": 0,
+        "sustainPunch": 0,
+        "sustainTime": 1,
+        "vibratoDepth": 0,
+        "vibratoSpeed": 0,
+        "volume": 1,
+        "waveForm": "Square"
+    },
+    "version": 1
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/agateau/sfxr-qt/releases/tag/1.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

~~note: sfxr-qt 1.5.0 segfaults when the gui is run, but so does 1.4.0 (#165010). I don't know at which point it started failing, as there is no nixos test (yet). I'll have to bisect, but for now let's update to 1.5.0 so at least there's a working cli (see changelog)~~ it works in a nixos test. it's just my system.