### PR TITLE
distrobox: 1.2.13 -> 1.2.14

### DIFF
--- a/pkgs/applications/virtualization/distrobox/default.nix
+++ b/pkgs/applications/virtualization/distrobox/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "distrobox";
-  version = "1.2.13";
+  version = "1.2.14";
 
   src = fetchFromGitHub {
     owner = "89luca89";
     repo = pname;
     rev = version;
-    sha256 = "047mrhsfi88mgwylnnyxg6xa7hjjrajn2pf7vfmb6161myqybvfy";
+    sha256 = "sha256-gHKyuIL4K/SLBJw8xNuPdNifDcHI91AFTiHaiv38gus=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Here is the changelog of changes:

+ README: Installation update by [@misobarisic](https://github.com/misobarisic) in [#179]=(https://github.com/89luca89/distrobox/pull/179)
+ README: New Logo by [@j4ckr3d](https://github.com/j4ckr3d) in [#198](https://github.com/89luca89/distrobox/pull/198)
+ docs: add more usage examples and tips
+ docs: document ssh x forwarding, fix [#172](https://github.com/89luca89/distrobox/issues/172)
+ docs: better specify security implications of distrobox
+ docs: update compatibility list
+ all: detect if running sudo and improve error messages for container managers, pointing to documentation [#177](https://github.com/89luca89/distrobox/issues/177)
+ all: better variables escaping, Fix [#183](https://github.com/89luca89/distrobox/issues/183)
+ fix: move selinux fix into create phase
+ install: Remove permissions check and dest_path creation by [@nathanchance](https://github.com/nathanchance) in [#180](https://github.com/89luca89/distrobox/pull/180)
+ install: Prefix install/uninstall option by [@misobarisic](https://github.com/misobarisic) in [#190](https://github.com/89luca89/distrobox/pull/190)
+ install: inform user about PATH at end of installation [#177](https://github.com/89luca89/distrobox/issues/177)
+ enter: escape --workdir argument [#181](https://github.com/89luca89/distrobox/issues/181) by [@nm004](https://github.com/nm004) in [#182](https://github.com/89luca89/distrobox/pull/182)
+ enter: Enter at workdir through child path of '/run/host' by [@ennec-e](https://github.com/ennec-e) in [#186](https://github.com/89luca89/distrobox/pull/186)
+ stop: Add distrobox-stop command by [@misobarisic](https://github.com/misobarisic) in [#196](https://github.com/89luca89/distrobox/pull/196)
+ enter: use container's $PATH when entering by [@gbritton](https://github.com/gbritton) in [#209](https://github.com/89luca89/distrobox/pull/209)
+ create: resolve path before mounting [#204](https://github.com/89luca89/distrobox/issues/204)
+init: If user already exists in /etc/passwd set props again, do not skip by [@ennec-e](https://github.com/ennec-e) in [#176](https://github.com/89luca89/distrobox/pull/176)
+ init: Fix grep match of very short user or group names. by [@lynxnot](https://github.com/lynxnot) in [#197](https://github.com/89luca89/distrobox/pull/197)
+ init: tighter systemd integration with host
+ init: support LDAP/AD mail usernames ([#205](https://github.com/89luca89/distrobox/pull/205))
+ export: support exporting of system flatpaks and document it, Fix [#171](https://github.com/89luca89/distrobox/issues/171)
+ CI: introduce a pipeline to check compatibility problems from the table of supported guests on both docker and podman

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
