### PR TITLE
lambdabot: apply upstream patches for GHC 9.0.2 support

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2477,7 +2477,7 @@ self: super: {
   # 2022-03-16: Bounds need to be loosened https://github.com/obsidiansystems/dependent-sum-aeson-orphans/issues/10
   dependent-sum-aeson-orphans = doJailbreak super.dependent-sum-aeson-orphans;
 
-  # 2022-04-16: package qualified import issue: https://github.com/ghcjs/ghcjs-dom/issues/101
+  # 2022-03-16: package qualified import issue: https://github.com/ghcjs/ghcjs-dom/issues/101
   ghcjs-dom = assert super.ghcjs-dom.version == "0.9.5.0"; overrideCabal (old: {
     postPatch = ''
       sed -i 's/import "jsaddle-dom" GHCJS.DOM.Document/import "ghcjs-dom-jsaddle" GHCJS.DOM.Document/' src/GHCJS/DOM/Document.hs

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2372,6 +2372,12 @@ self: super: {
   # https://github.com/kuribas/mfsolve/issues/8
   mfsolve = dontCheck super.mfsolve;
 
+  # compatibility with random-fu 0.3 https://github.com/mokus0/misfortune/pull/5
+  misfortune = appendPatch ./patches/misfortune-ghc9.patch (overrideCabal (drv: {
+    revision = null;
+    editedCabalFile = null;
+  }) super.misfortune);
+
   # Ships a custom cabal-doctest Setup.hs in the release tarball, but the actual
   # test suite is commented out, so the required dependency is missing naturally.
   # We need to use a default Setup.hs instead. Current master doesn't exhibit

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2389,6 +2389,13 @@ self: super: {
     editedCabalFile = null;
   }) super.dice);
 
+  # GHC 9 support https://github.com/lambdabot/lambdabot/pull/204
+  lambdabot-core = appendPatch ./patches/lambdabot-core-ghc9.patch (overrideCabal (drv: {
+    revision = null;
+    editedCabalFile = null;
+  }) super.lambdabot-core);
+  lambdabot-novelty-plugins = appendPatch ./patches/lambdabot-novelty-plugins-ghc9.patch super.lambdabot-novelty-plugins;
+
   # Ships a custom cabal-doctest Setup.hs in the release tarball, but the actual
   # test suite is commented out, so the required dependency is missing naturally.
   # We need to use a default Setup.hs instead. Current master doesn't exhibit

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2378,6 +2378,17 @@ self: super: {
     editedCabalFile = null;
   }) super.misfortune);
 
+  # GHC 9 support https://github.com/lambdabot/dice/pull/2
+  dice = appendPatch (pkgs.fetchpatch {
+    name = "dice-ghc9.patch";
+    url = "https://github.com/lambdabot/dice/commit/80d6fd443cb17b21d91b725f994ece6e8274e0a0.patch";
+    excludes = [ ".gitignore" ];
+    sha256 = "sha256-MtS1n7v5D6MRWWzzTyKl3Lqd/NhD1bV+g80wnhZ3P/Y=";
+  }) (overrideCabal (drv: {
+    revision = null;
+    editedCabalFile = null;
+  }) super.dice);
+
   # Ships a custom cabal-doctest Setup.hs in the release tarball, but the actual
   # test suite is commented out, so the required dependency is missing naturally.
   # We need to use a default Setup.hs instead. Current master doesn't exhibit

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2372,6 +2372,8 @@ self: super: {
   # https://github.com/kuribas/mfsolve/issues/8
   mfsolve = dontCheck super.mfsolve;
 
+  knob = appendPatch ./patches/knob-ghc9.patch super.knob;
+
   # compatibility with random-fu 0.3 https://github.com/mokus0/misfortune/pull/5
   misfortune = appendPatch ./patches/misfortune-ghc9.patch (overrideCabal (drv: {
     revision = null;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -47,8 +47,6 @@ self: super: {
     Cabal = self.Cabal_3_6_3_0;
   });
 
-  knob = appendPatch ./patches/knob-ghc9.patch super.knob;
-
   # Jailbreaks & Version Updates
 
   # This `doJailbreak` can be removed once the following PR is released to Hackage:

--- a/pkgs/development/haskell-modules/patches/lambdabot-core-ghc9.patch
+++ b/pkgs/development/haskell-modules/patches/lambdabot-core-ghc9.patch
@@ -1,0 +1,95 @@
+diff --git a/lambdabot-core.cabal b/lambdabot-core.cabal
+index 861a28b..87175a3 100644
+--- a/lambdabot-core.cabal
++++ b/lambdabot-core.cabal
+@@ -19,7 +19,7 @@ homepage:               https://wiki.haskell.org/Lambdabot
+ 
+ build-type:             Simple
+ cabal-version:          >= 1.10
+-tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4
++tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.2
+ 
+ extra-source-files:     AUTHORS.md
+                         COMMENTARY.md
+@@ -89,9 +89,8 @@ library
+                         network-bsd             >= 2.7 && < 2.9,
+                         parsec                  >= 3,
+                         prim-uniq               >= 0.2 && < 0.4,
+-                        random                  >= 1,
+-                        random-fu               >= 0.2.6.2,
+-                        random-source           >= 0.3,
++                        random                  >= 1.2,
++                        random-fu               >= 0.3.0.0,
+                         regex-tdfa              >= 1.1 && < 1.4,
+                         SafeSemaphore           >= 0.9,
+                         split                   >= 0.2,
+diff --git a/src/Lambdabot/Bot.hs b/src/Lambdabot/Bot.hs
+index 1b0de2e..833fb4c 100644
+--- a/src/Lambdabot/Bot.hs
++++ b/src/Lambdabot/Bot.hs
+@@ -1,6 +1,5 @@
+ {-# LANGUAGE GADTs #-}
+ {-# LANGUAGE ScopedTypeVariables #-}
+-{-# LANGUAGE TemplateHaskell #-}
+ -- | The guts of lambdabot.
+ --
+ -- The LB/Lambdabot monad
+@@ -37,7 +36,6 @@ import Control.Monad.Error
+ import Control.Monad.Reader
+ import Control.Monad.State
+ import qualified Data.Map as M
+-import Data.Random.Source
+ import qualified Data.Set as S
+ 
+ ------------------------------------------------------------------------
+@@ -136,17 +134,3 @@ ircPrivmsg who msg = do
+ ircPrivmsg' :: Nick -> String -> LB ()
+ ircPrivmsg' who ""  = ircPrivmsg' who " "
+ ircPrivmsg' who msg = send $ privmsg who msg
+-
+-------------------------------------------------------------------------
+-
+-monadRandom [d|
+-
+-    instance MonadRandom LB where
+-        getRandomWord8          = liftIO getRandomWord8
+-        getRandomWord16         = liftIO getRandomWord16
+-        getRandomWord32         = liftIO getRandomWord32
+-        getRandomWord64         = liftIO getRandomWord64
+-        getRandomDouble         = liftIO getRandomDouble
+-        getRandomNByteInteger n = liftIO (getRandomNByteInteger n)
+-
+- |]
+diff --git a/src/Lambdabot/Util.hs b/src/Lambdabot/Util.hs
+index effdf71..259699b 100644
+--- a/src/Lambdabot/Util.hs
++++ b/src/Lambdabot/Util.hs
+@@ -23,14 +23,15 @@ module Lambdabot.Util (
+         randomSuccessMsg
+     ) where
+ 
++import Control.Concurrent.Lifted
+ import Control.Monad.Trans
++import Control.Monad.Trans.Control
+ import Data.Char
+ import Data.List
+ import Data.Random
+-import Control.Concurrent.Lifted
+-import Control.Monad.Trans.Control
+ import Lambdabot.Config
+ import Lambdabot.Config.Core
++import System.Random.Stateful (newIOGenM, newStdGen)
+ 
+ ------------------------------------------------------------------------
+ 
+@@ -63,7 +64,9 @@ listToStr conj (item:items) =
+ 
+ -- | Pick a random element of the list.
+ random :: MonadIO m => [a] -> m a
+-random = io . sample . randomElement
++random l = do
++  g <- newIOGenM =<< newStdGen
++  sampleFrom g (randomElement l)
+ 
+ ------------------------------------------------------------------------
+ 

--- a/pkgs/development/haskell-modules/patches/lambdabot-novelty-plugins-ghc9.patch
+++ b/pkgs/development/haskell-modules/patches/lambdabot-novelty-plugins-ghc9.patch
@@ -1,0 +1,58 @@
+diff --git a/lambdabot-novelty-plugins.cabal b/lambdabot-novelty-plugins.cabal
+index 69c8447..50a35f6 100644
+--- a/lambdabot-novelty-plugins.cabal
++++ b/lambdabot-novelty-plugins.cabal
+@@ -36,7 +36,7 @@ homepage:               https://wiki.haskell.org/Lambdabot
+ 
+ build-type:             Simple
+ cabal-version:          >= 1.10
+-tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4
++tested-with:            GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4, GHC == 9.0.2
+ 
+ source-repository head
+   type:                 git
+@@ -71,7 +71,8 @@ library
+                         lambdabot-core          >= 5.3 && < 5.4,
+                         misfortune              >= 0.1,
+                         process                 >= 1.1,
+-                        random-fu               >= 0.2.6.2,
++                        random                  >= 1.2,
++                        random-fu               >= 0.3.0.0,
+                         regex-tdfa              >= 1.1,
+ 
+                         -- runtime dependencies
+diff --git a/src/Lambdabot/Plugin/Novelty/Numberwang.hs b/src/Lambdabot/Plugin/Novelty/Numberwang.hs
+index ae41eb4..8321a14 100644
+--- a/src/Lambdabot/Plugin/Novelty/Numberwang.hs
++++ b/src/Lambdabot/Plugin/Novelty/Numberwang.hs
+@@ -7,7 +7,9 @@ import Control.Monad
+ import Data.Random
+ import Data.Random.Distribution.Poisson
+ import Lambdabot.Plugin
++import Lambdabot.Util
+ import Numeric
++import System.Random.Stateful (newIOGenM, newStdGen)
+ 
+ 
+ data NumberwangState = State
+@@ -23,7 +25,9 @@ conDist = poisson (32  :: Double)
+ 
+ numberwangPlugin :: Module NumberwangState
+ numberwangPlugin = newModule
+-    { moduleDefState = sample (State <$> cmdDist <*> conDist)
++    { moduleDefState = do
++        g <- newIOGenM =<< newStdGen
++        sampleFrom g (State <$> cmdDist <*> conDist)
+     , moduleCmds = return
+         [ (command "numberwang")
+             { help = say "@numberwang <number>: Determines if it is Numberwang."
+@@ -61,7 +65,8 @@ checkNumberwang :: (MonadLBState m, LBState m ~ NumberwangState) =>
+ checkNumberwang cmd l = withState cmd $ \ n setN nDist -> do
+     if n <= l
+         then do
+-            setN =<< lb (sample nDist)
++            g <- newIOGenM =<< newStdGen
++            setN =<< sampleFrom g nDist
+             return True
+         else do
+             setN (n - l)

--- a/pkgs/development/haskell-modules/patches/misfortune-ghc9.patch
+++ b/pkgs/development/haskell-modules/patches/misfortune-ghc9.patch
@@ -1,0 +1,70 @@
+diff --git a/misfortune.cabal b/misfortune.cabal
+index f5d0dd3..faa5794 100644
+--- a/misfortune.cabal
++++ b/misfortune.cabal
+@@ -113,7 +113,8 @@ Library
+                         directory,
+                         filepath,
+                         knob,
+-                        random-fu >= 0.2.2,
++                        random,
++                        random-fu >= 0.3,
+                         semigroups,
+                         text,
+                         utf8-string,
+diff --git a/src/Data/Fortune.hs b/src/Data/Fortune.hs
+index 16d221e..ffbc970 100644
+--- a/src/Data/Fortune.hs
++++ b/src/Data/Fortune.hs
+@@ -64,6 +64,7 @@ import Paths_misfortune
+ import System.Directory
+ import System.Environment
+ import System.FilePath
++import System.Random.Stateful (newIOGenM, newStdGen)
+ 
+ -- |The number of fortune strings in the index
+ numFortunes :: S.FortuneStats -> Int
+@@ -233,9 +234,10 @@ randomFortune paths = withFortuneFiles '%' False paths $ \fs -> do
+ -- random fortune from that file (unformly).
+ randomFortuneFromRandomFile :: RVar FortuneFile -> IO String
+ randomFortuneFromRandomFile file = do
+-    f <- sample file
++    gen <- newStdGen >>= newIOGenM
++    f <- sampleFrom gen file
+     n <- getNumFortunes f
+-    i <- sample (uniform 0 (n-1))
++    i <- sampleFrom gen (uniform 0 (n-1))
+     T.unpack <$> getFortune f i
+ 
+ -- |Given a list of 'FortuneFile's, compute a distrubution over them weighted by the number
+diff --git a/src/Fortune.hs b/src/Fortune.hs
+index 5a27578..d6ffb74 100644
+--- a/src/Fortune.hs
++++ b/src/Fortune.hs
+@@ -21,6 +21,7 @@ import System.Environment
+ import System.Exit
+ import System.FilePath
+ import System.IO
++import System.Random.Stateful (newIOGenM, newStdGen)
+ import Text.Printf
+ import Text.Regex.Base
+ import Text.Regex.PCRE
+@@ -200,6 +201,7 @@ main = do
+     fortunes <- filterM (filterFile args) (fortuneFiles args)
+     
+     dist <- getDist args fortunes
++    gen <- newStdGen >>= newIOGenM
+     
+     when (numEvents dist == 0) $ do
+         hPutStrLn stderr "No fortunes matched the filter criteria"
+@@ -225,8 +227,8 @@ main = do
+             , let pctStr = printf "(%.2f%%)" (100 * weight / totalWeight dist) :: String
+             ]
+         else do
+-            (file, fortuneDist) <- sample dist
+-            fortune <- sample fortuneDist
++            (file, fortuneDist) <- sampleFrom gen dist
++            fortune <- sampleFrom gen fortuneDist
+             putStrLn . T.unpack =<< getFortune file fortune
+ 
+ getDist :: Args -> [FortuneFile] -> IO (Categorical Float (FortuneFile, Categorical Float Int))


### PR DESCRIPTION
Tested by building `lambdabot` and running `dice d10` (from the dice plugin) and `yow` (from the fortune plugin) at the prompt.