### PR TITLE
python3Packages.slixmpp: 1.8.0.1 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -4,30 +4,24 @@
 , aiohttp
 , fetchPypi
 , gnupg
-, isPy3k
 , pyasn1
 , pyasn1-modules
 , pytestCheckHook
 , substituteAll
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "slixmpp";
-  version = "1.8.0.1";
+  version = "1.8.1";
+  format = "setuptools";
 
-  disabled = !isPy3k;
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-J3znZl77jST94KhUBQcCxSK0qnsVWIYTG6u3po5FHh8=";
+    hash = "sha256-QgTIC+4JtAD9nnS+fJKZwF0aJEIrFmPHkYg8cPgXmcA=";
   };
-
-  patches = [
-    (substituteAll {
-      src = ./hardcode-gnupg-path.patch;
-      inherit gnupg;
-    })
-  ];
 
   propagatedBuildInputs = [
     aiodns
@@ -36,15 +30,28 @@ buildPythonPackage rec {
     pyasn1-modules
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
 
-  # Exclude live tests
-  disabledTestPaths = [ "tests/live_test.py" ];
+  patches = [
+    (substituteAll {
+      src = ./hardcode-gnupg-path.patch;
+      inherit gnupg;
+    })
+  ];
 
-  pythonImportsCheck = [ "slixmpp" ];
+  disabledTestPaths = [
+    # Exclude live tests
+    "tests/live_test.py"
+  ];
+
+  pythonImportsCheck = [
+    "slixmpp"
+  ];
 
   meta = with lib; {
-    description = "Elegant Python library for XMPP";
+    description = "Python library for XMPP";
     homepage = "https://slixmpp.readthedocs.io/";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 1.8.1
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
