### PR TITLE
openjk: update and add Jedi Outcast output

### DIFF
--- a/pkgs/games/openjk/default.nix
+++ b/pkgs/games/openjk/default.nix
@@ -21,13 +21,13 @@ let
   };
 in stdenv.mkDerivation {
   pname = "OpenJK";
-  version = "2020-07-03";
+  version = "unstable-2022-01-30";
 
   src = fetchFromGitHub {
     owner = "JACoders";
     repo = "OpenJK";
-    rev = "0a336ce4dffe6505e3f754b59732402a1db95752";
-    sha256 = "1xagbz42hi3ivs208mnay2dbgh90pmwwbar2p1yfhj3zl3cghcs8";
+    rev = "235fb9e1a9c4537a603b2e54e444327d20d198a3";
+    sha256 = "sha256-DqP6wnu5sE7lQJGEdsEPOc6FIaJjqxt5ANKZ5eiabC4=";
   };
 
   dontAddPrefix = true;

--- a/pkgs/games/openjk/default.nix
+++ b/pkgs/games/openjk/default.nix
@@ -19,6 +19,15 @@ let
     genericName = "Jedi Academy";
     categories = [ "Game" ];
   };
+  josp = makeDesktopItem rec {
+    name = "josp";
+    exec = name;
+    icon = "OpenJK_Icon_128";
+    comment = "Open Source Jedi Outcast game released by Raven Software";
+    desktopName = "Jedi Outcast (Single Player)";
+    genericName = "Jedi Outcast";
+    categories = [ "Game" ];
+  };
 in stdenv.mkDerivation {
   pname = "OpenJK";
   version = "unstable-2022-01-30";
@@ -35,22 +44,39 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [ makeWrapper cmake ];
   buildInputs = [ libjpeg zlib libpng libGL SDL2 ];
 
+  outputs = [ "out" "openjo" "openja" ];
+
   # move from $out/JediAcademy to $out/opt/JediAcademy
   preConfigure = ''
     cmakeFlagsArray=("-DCMAKE_INSTALL_PREFIX=$out/opt")
   '';
+  cmakeFlags = ["-DBuildJK2SPEngine:BOOL=ON"
+                "-DBuildJK2SPGame:BOOL=ON"
+                "-DBuildJK2SPRdVanilla:BOOL=ON"];
 
   postInstall = ''
-    mkdir -p $out/bin $out/share/applications $out/share/icons/hicolor/128x128/apps
-    prefix=$out/opt/JediAcademy
+    mkdir -p $out/bin $openja/bin $openjo/bin
+    mkdir -p $openja/share/applications $openjo/share/applications
+    mkdir -p $openja/share/icons/hicolor/128x128/apps $openjo/share/icons/hicolor/128x128/apps
+    mkdir -p $openja/opt $openjo/opt
+    mv $out/opt/JediAcademy $openja/opt/
+    mv $out/opt/JediOutcast $openjo/opt/
+    jaPrefix=$openja/opt/JediAcademy
+    joPrefix=$openjo/opt/JediOutcast
 
-    makeWrapper $prefix/openjk.* $out/bin/jamp --run "cd $prefix"
-    makeWrapper $prefix/openjk_sp.* $out/bin/jasp --run "cd $prefix"
-    makeWrapper $prefix/openjkded.* $out/bin/openjkded --run "cd $prefix"
+    makeWrapper $jaPrefix/openjk.* $openja/bin/jamp --run "cd $jaPrefix"
+    makeWrapper $jaPrefix/openjk_sp.* $openja/bin/jasp --run "cd $jaPrefix"
+    makeWrapper $jaPrefix/openjkded.* $openja/bin/openjkded --run "cd $jaPrefix"
+    makeWrapper $joPrefix/openjo_sp.* $openjo/bin/josp --run "cd $joPrefix"
 
-    cp $src/shared/icons/OpenJK_Icon_128.png $out/share/icons/hicolor/128x128/apps
-    ln -s ${jamp}/share/applications/* $out/share/applications
-    ln -s ${jasp}/share/applications/* $out/share/applications
+    cp $src/shared/icons/OpenJK_Icon_128.png $openjo/share/icons/hicolor/128x128/apps
+    cp $src/shared/icons/OpenJK_Icon_128.png $openja/share/icons/hicolor/128x128/apps
+    ln -s ${jamp}/share/applications/* $openja/share/applications
+    ln -s ${jasp}/share/applications/* $openja/share/applications
+    ln -s ${josp}/share/applications/* $openjo/share/applications
+    ln -s $openja/bin/* $out/bin
+    ln -s $openjo/bin/* $out/bin
+    rm -rf $out/opt
   '';
 
   meta = with lib; {
@@ -58,6 +84,6 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/JACoders/OpenJK";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ tgunnoe ];
   };
 }


### PR DESCRIPTION
###### Description of changes
OpenJK can create binaries for both games Jedi Outcast and Jedi Academy, but the former was the only being output in this derivation. Now Jedi Outcast singleplayer exists as well. I also added myself as maintainer.

###### Things done
Update to latest unstable. No release versions exist
Add Jedi Outcast singleplayer output
Split up Jedi Academy multiplayer/singleplayer and Jedi Outcast singleplayer (mp unavailable) to separate outputs

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
