### PR TITLE
pyside2: make qtwebengine optional

### DIFF
--- a/pkgs/applications/graphics/hydrus/default.nix
+++ b/pkgs/applications/graphics/hydrus/default.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonPackage rec {
     psutil
     pylzma
     pyopenssl
-    pyside2
+    (pyside2.override { enableQtwebengine = false;})
     pysocks
     pythonPackages.mpv
     pyyaml

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -1,5 +1,5 @@
 { python, fetchurl, lib, stdenv
-, cmake, ninja, qt5, shiboken2,
+, cmake, ninja, qt5, shiboken2
 , enableQtwebengine ? true
 }:
 

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -1,6 +1,7 @@
-{ python, fetchurl, lib, stdenv,
-  cmake, ninja, qt5, shiboken2,
-  enableQtwebengine ? true }:
+{ python, fetchurl, lib, stdenv
+, cmake, ninja, qt5, shiboken2,
+, enableQtwebengine ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "pyside2";

--- a/pkgs/development/python-modules/pyside2/default.nix
+++ b/pkgs/development/python-modules/pyside2/default.nix
@@ -1,5 +1,6 @@
 { python, fetchurl, lib, stdenv,
-  cmake, ninja, qt5, shiboken2 }:
+  cmake, ninja, qt5, shiboken2,
+  enableQtwebengine ? true }:
 
 stdenv.mkDerivation rec {
   pname = "pyside2";
@@ -26,8 +27,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ninja qt5.qmake python ];
   buildInputs = with qt5; [
     qtbase qtxmlpatterns qtmultimedia qttools qtx11extras qtlocation qtscript
-    qtwebsockets qtwebengine qtwebchannel qtcharts qtsensors qtsvg
-  ];
+    qtwebsockets qtwebchannel qtcharts qtsensors qtsvg
+  ] ++ lib.optional enableQtwebengine qt5.qtwebengine;
   propagatedBuildInputs = [ shiboken2 ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
###### Description of changes

[python3Packages.pyside2: allow disabling qtwebengine](https://github.com/NixOS/nixpkgs/commit/c70fd5470d226cbd151b3792fc5917ea5ece1c12)

Building without qtwebengine reduces closure size by quite a bit and compile times by ̃~50% (?)
qtwebengine is also notoriously slow to compile, so allowing programs to build without it speeds up rebuilds without the binary cache significantly (10x)

the tradeoff here is of course that hydra has to build two pyside2s

I also experimented with disabling the other modules in pyside2 but they only sum to ~1MB extra in closure size (and like 30 minutes less in compile time) on this computer.

This reduces closure size by like only 7% in hydrus

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
