### PR TITLE
vscode-extensions.matklad.rust-analyzer: 0.2.834 -> 0.2.975

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -85,7 +85,7 @@ you will still need to commit the modified version of the lock files, but at lea
 
 each tool has an abstraction to just build the node_modules (dependencies) directory. you can always use the stdenv.mkDerivation with the node_modules to build the package (symlink the node_modules directory and then use the package build command). the node_modules abstraction can be also used to build some web framework frontends. For an example of this see how [plausible](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/web-apps/plausible/default.nix) is built. mkYarnModules to make the derivation containing node_modules. Then when building the frontend you can just symlink the node_modules directory
 
-## javascript packages inside nixpkgs {#javascript-packages-nixpkgs}
+## Javascript packages inside nixpkgs {#javascript-packages-nixpkgs}
 
 The `pkgs/development/node-packages` folder contains a generated collection of
 [NPM packages](https://npmjs.com/) that can be installed with the Nix package
@@ -121,12 +121,14 @@ requires `node-gyp-build`, so [we override](https://github.com/NixOS/nixpkgs/blo
     };
 ```
 
+### Adding and Updating Javascript packages in nixpkgs
+
 To add a package from NPM to nixpkgs:
 
 1. Modify `pkgs/development/node-packages/node-packages.json` to add, update
     or remove package entries to have it included in `nodePackages` and
     `nodePackages_latest`.
-2. Run the script: `cd pkgs/development/node-packages && ./generate.sh`.
+2. Run the script: `./pkgs/development/node-packages/generate.sh`.
 3. Build your new package to test your changes:
     `cd /path/to/nixpkgs && nix-build -A nodePackages.<new-or-updated-package>`.
     To build against the latest stable Current Node.js version (e.g. 14.x):
@@ -136,6 +138,26 @@ To add a package from NPM to nixpkgs:
 For more information about the generation process, consult the
 [README.md](https://github.com/svanderburg/node2nix) file of the `node2nix`
 tool.
+
+To update NPM packages in nixpkgs, run the same `generate.sh` script:
+
+```sh
+./pkgs/development/node-packages/generate.sh
+```
+
+#### Git protocol error
+
+Some packages may have Git dependencies from GitHub specified with `git://`.
+GitHub has
+[disabled unecrypted Git connections](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git),
+so you may see the following error when running the generate script:
+`The unauthenticated git protocol on port 9418 is no longer supported`.
+
+Use the following Git configuration to resolve the issue:
+
+```sh
+git config --global url."https://github.com/".insteadOf git://github.com/
+```
 
 ## Tool specific instructions {#javascript-tool-specific}
 

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/build-deps/package.json
@@ -1,26 +1,19 @@
 {
   "name": "rust-analyzer",
-  "version": "0.2.834",
+  "version": "0.2.975",
   "dependencies": {
-    "https-proxy-agent": "^5.0.0",
-    "node-fetch": "^2.6.1",
-    "vscode-languageclient": "8.0.0-next.2",
-    "d3": "^7.1.0",
+    "vscode-languageclient": "8.0.0-next.8",
+    "d3": "^7.3.0",
     "d3-graphviz": "^4.0.0",
-    "@types/glob": "^7.1.4",
-    "@types/mocha": "^8.2.3",
     "@types/node": "~14.17.5",
-    "@types/node-fetch": "^2.5.11",
-    "@types/vscode": "^1.57.0",
-    "@typescript-eslint/eslint-plugin": "^4.28.2",
-    "@typescript-eslint/parser": "^4.28.2",
-    "eslint": "^7.30.0",
-    "glob": "^7.1.6",
-    "mocha": "^9.0.2",
+    "@types/vscode": "~1.63.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.0",
+    "@typescript-eslint/parser": "^5.10.0",
+    "@vscode/test-electron": "^2.1.1",
+    "eslint": "^8.7.0",
     "tslib": "^2.3.0",
-    "typescript": "^4.3.5",
+    "typescript": "^4.5.5",
     "typescript-formatter": "^7.2.2",
-    "vsce": "^1.95.1",
-    "vscode-test": "^1.5.1"
+    "vsce": "^2.6.7"
   }
 }

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/default.nix
@@ -20,13 +20,13 @@ let
   # Use the plugin version as in vscode marketplace, updated by update script.
   inherit (vsix) version;
 
-  releaseTag = "2021-11-29";
+  releaseTag = "2022-03-07";
 
   src = fetchFromGitHub {
     owner = "rust-analyzer";
     repo = "rust-analyzer";
     rev = releaseTag;
-    sha256 = "sha256-vh7z8jupVxXPOko3sWUsOB7eji/7lKfwJ/CE3iw97Sw=";
+    sha256 = "sha256-/qKh4utesAjlyG8A3hEmSx+HBgh48Uje6ZRtUGz5f0g=";
   };
 
   build-deps = nodePackages."rust-analyzer-build-deps-../../applications/editors/vscode/extensions/rust-analyzer/build-deps";

--- a/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/rust-analyzer/update.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq libarchive
+#shellcheck shell=bash
+set -euo pipefail
+cd "$(dirname "$0")"
+nixpkgs=../../../../../../
+node_packages="$nixpkgs/pkgs/development/node-packages"
+owner=rust-analyzer
+repo=rust-analyzer
+ver=$(
+    curl -s "https://api.github.com/repos/$owner/$repo/releases" |
+    jq 'map(select(.prerelease | not)) | .[0].tag_name' --raw-output
+)
+node_src="$(nix-build "$nixpkgs" -A rust-analyzer.src --no-out-link)/editors/code"
+
+# Check vscode compatibility
+req_vscode_ver="$(jq '.engines.vscode' "$node_src/package.json" --raw-output)"
+req_vscode_ver="${req_vscode_ver#^}"
+cur_vscode_ver="$(nix-instantiate --eval --strict "$nixpkgs" -A vscode.version | tr -d '"')"
+if [[ "$(nix-instantiate --eval --strict -E "(builtins.compareVersions \"$req_vscode_ver\" \"$cur_vscode_ver\")")" -gt 0 ]]; then
+    echo "vscode $cur_vscode_ver is incompatible with the extension requiring ^$req_vscode_ver"
+    exit 1
+fi
+
+extension_ver=$(curl "https://github.com/rust-analyzer/rust-analyzer/releases/download/$ver/rust-analyzer-linux-x64.vsix" -L |
+    bsdtar -xf - --to-stdout extension/package.json | # Use bsdtar to extract vsix(zip).
+    jq --raw-output '.version')
+echo "Extension version: $extension_ver"
+
+# We need devDependencies to build vsix.
+# `esbuild` is a binary package an is already in nixpkgs so we omit it here.
+jq '{ name, version: $ver, dependencies: (.dependencies + .devDependencies | del(.esbuild)) }' "$node_src/package.json" \
+    --arg ver "$extension_ver" \
+    >"build-deps/package.json.new"
+
+old_deps="$(jq '.dependencies' build-deps/package.json)"
+new_deps="$(jq '.dependencies' build-deps/package.json.new)"
+if [[ "$old_deps" == "$new_deps" ]]; then
+    echo "package.json dependencies not changed, do simple version change"
+
+    sed -E '/^  "rust-analyzer-build-deps/,+3 s/version = ".*"/version = "'"$extension_ver"'"/' \
+        --in-place "$node_packages"/node-packages.nix
+    mv build-deps/package.json{.new,}
+else
+    echo "package.json dependencies changed, updating nodePackages"
+    mv build-deps/package.json{.new,}
+
+    ./"$node_packages"/generate.sh
+fi

--- a/pkgs/development/node-packages/generate.sh
+++ b/pkgs/development/node-packages/generate.sh
@@ -9,7 +9,7 @@ node2nix=$(nix-build ../../.. -A nodePackages.node2nix)
 rm -f ./node-env.nix
 
 # Track the latest active nodejs LTS here: https://nodejs.org/en/about/releases/
-${node2nix}/bin/node2nix \
+"${node2nix}/bin/node2nix" \
     -i node-packages.json \
     -o node-packages.nix \
     -c composition.nix \

--- a/pkgs/development/tools/rust/rust-analyzer/update.sh
+++ b/pkgs/development/tools/rust/rust-analyzer/update.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i bash -p curl jq nix-prefetch libarchive
+# shellcheck shell=bash
 set -euo pipefail
 cd "$(dirname "$0")"
 owner=rust-analyzer


### PR DESCRIPTION
###### Description of changes

1. Add an update script for `vscode-extensions.matklad.rust-analyzer`, mostly taken from the deleted parts of https://github.com/NixOS/nixpkgs/pull/150775
1. Update `vscode-extensions.matklad.rust-analyzer`
1. Document (hopefully correctly) the Javascript packages in nixpkgs update procedure
    - Somewhat counting on [Cunningham's Law](https://en.wikipedia.org/wiki/Ward_Cunningham#%22Cunningham's_Law%22) here :stuck_out_tongue: 

Fixes https://github.com/NixOS/nixpkgs/issues/162010.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).