### PR TITLE
make-darwin-bundle: Use output bin

### DIFF
--- a/pkgs/build-support/make-darwin-bundle/default.nix
+++ b/pkgs/build-support/make-darwin-bundle/default.nix
@@ -16,12 +16,10 @@ writeShellScript "make-darwin-bundle-${name}" (''
     mkdir -p "''${!outputBin}/Applications/${name}.app/Contents/Resources"
 
     if [ -n "${icon}" ]; then
-      ln -s "${icon}" \
-        "''${!outputBin}/Applications/${name}.app/Contents/Resources"
+      ln -s "${icon}" "''${!outputBin}/Applications/${name}.app/Contents/Resources"
     fi
 
-    ${writeDarwinBundle}/bin/write-darwin-bundle "''${!outputBin}" "${name}" \
-      "${exec}"
+    ${writeDarwinBundle}/bin/write-darwin-bundle "''${!outputBin}" "${name}" "${exec}"
   }
 
   preDistPhases+=" makeDarwinBundlePhase"

--- a/pkgs/build-support/make-darwin-bundle/default.nix
+++ b/pkgs/build-support/make-darwin-bundle/default.nix
@@ -12,14 +12,14 @@
 
 writeShellScript "make-darwin-bundle-${name}" (''
   function makeDarwinBundlePhase() {
-    mkdir -p "$out/Applications/${name}.app/Contents/MacOS"
-    mkdir -p "$out/Applications/${name}.app/Contents/Resources"
+    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/MacOS"
+    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/Resources"
 
     if [ -n "${icon}" ]; then
-      ln -s "${icon}" "$out/Applications/${name}.app/Contents/Resources"
+      ln -s "${icon}" "${!outputBin}/Applications/${name}.app/Contents/Resources"
     fi
 
-    ${writeDarwinBundle}/bin/write-darwin-bundle "$out" "${name}" "${exec}"
+    ${writeDarwinBundle}/bin/write-darwin-bundle "${!outputBin}" "${name}" "${exec}"
   }
 
   preDistPhases+=" makeDarwinBundlePhase"

--- a/pkgs/build-support/make-darwin-bundle/default.nix
+++ b/pkgs/build-support/make-darwin-bundle/default.nix
@@ -12,14 +12,16 @@
 
 writeShellScript "make-darwin-bundle-${name}" (''
   function makeDarwinBundlePhase() {
-    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/MacOS"
-    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/Resources"
+    mkdir -p "''${!outputBin}/Applications/${name}.app/Contents/MacOS"
+    mkdir -p "''${!outputBin}/Applications/${name}.app/Contents/Resources"
 
     if [ -n "${icon}" ]; then
-      ln -s "${icon}" "${!outputBin}/Applications/${name}.app/Contents/Resources"
+      ln -s "${icon}" \
+        "''${!outputBin}/Applications/${name}.app/Contents/Resources"
     fi
 
-    ${writeDarwinBundle}/bin/write-darwin-bundle "${!outputBin}" "${name}" "${exec}"
+    ${writeDarwinBundle}/bin/write-darwin-bundle "''${!outputBin}" "${name}" \
+      "${exec}"
   }
 
   preDistPhases+=" makeDarwinBundlePhase"

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -154,12 +154,12 @@ convertDesktopFile() {
     local -r iconName=$(getDesktopParam "${file}" "^Icon")
     local -r squircle=$(getDesktopParam "${file}" "X-macOS-SquircleIcon")
 
-    mkdir -p "$out/Applications/${name}.app/Contents/MacOS"
-    mkdir -p "$out/Applications/${name}.app/Contents/Resources"
+    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/MacOS"
+    mkdir -p "${!outputBin}/Applications/${name}.app/Contents/Resources"
 
-    convertIconTheme "$out/Applications/${name}.app/Contents/Resources" "$sharePath" "$iconName"
+    convertIconTheme "${!outputBin}/Applications/${name}.app/Contents/Resources" "$sharePath" "$iconName"
 
-    write-darwin-bundle "$out" "$name" "$exec" "$iconName" "$squircle"
+    write-darwin-bundle "${!outputBin}" "$name" "$exec" "$iconName" "$squircle"
 }
 
 convertDesktopFiles() {


### PR DESCRIPTION
###### Description of changes

Use `outputBin` rather than `out` for the destination of the application bundle. (This also determines the source where the desktop entry is expected.)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
