### PR TITLE
make-darwin-bundle: Fix icon for older macOS

### DIFF
--- a/pkgs/build-support/make-darwin-bundle/write-darwin-bundle.nix
+++ b/pkgs/build-support/make-darwin-bundle/write-darwin-bundle.nix
@@ -5,6 +5,7 @@ let
     CFBundleDevelopmentRegion = "English";
     CFBundleExecutable = "$name";
     CFBundleIconFile = "$icon";
+    CFBundleIconFiles = [ "$icon" ];
     CFBundleIdentifier = "org.nixos.$name";
     CFBundleInfoDictionaryVersion = "6.0";
     CFBundleName = "$name";
@@ -25,11 +26,8 @@ in writeScriptBin "write-darwin-bundle" ''
 ${pListText}
 EOF
 
-  if [[ $squircle != 0 && $squircle != "false" ]]; then
-    sed  "
-      s|CFBundleIconFile|CFBundleIconFiles|;
-      s|<string>$icon</string>|<array><string>$icon</string></array>|
-    " -i "$plist"
+  if [[ $squircle == 0 || $squircle == "false" ]]; then
+    sed  '/CFBundleIconFiles/,\|</array>|d' -i "$plist"
   fi
 
     cat > "$prefix/Applications/$name.app/Contents/MacOS/$name" <<EOF

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -18,7 +18,9 @@ convertIconTheme() {
     local -r iconName=$3
     local -r theme=${4:-hicolor}
 
-    local -ra iconSizes=(16 32 48 128 256 512)
+    # Sizes based on archived Apple documentation:
+    # https://developer.apple.com/design/human-interface-guidelines/macos/icons-and-images/app-icon#app-icon-sizes
+    local -ra iconSizes=(16 32 128 256 512)
     local -ra scales=([1]="" [2]="@2")
 
     # Based loosely on the algorithm at:
@@ -30,13 +32,6 @@ convertIconTheme() {
 
         local scaleSuffix=${scales[$scale]}
         local exactSize=${iconSize}x${iconSize}${scaleSuffix}
-
-        if [[ $exactSize = '48x48@2' ]]; then
-            # macOS does not support a 2x scale variant of 48x48 icons
-            # See: https://en.wikipedia.org/wiki/Apple_Icon_Image_format#Icon_types
-            echo "unsupported"
-            return 0
-        fi
 
         local -a validSizes=(
             ${exactSize}

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -132,8 +132,8 @@ convertIconTheme() {
     }
 
     iconsdir=$(getIcons "$sharePath" "apps/${iconName}" "$theme")
-        icnsutil compose "$out/${iconName}.icns" "$iconsdir/"*
     if [[ -n "$(ls -1 "$iconsdir/"*)" ]]; then
+        icnsutil compose --toc "$out/${iconName}.icns" "$iconsdir/"*
     else
         echo "Warning: no icons were found. Creating an empty icon for ${iconName}.icns."
         touch "$out/${iconName}.icns"

--- a/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
+++ b/pkgs/build-support/setup-hooks/desktop-to-darwin-bundle.sh
@@ -132,8 +132,8 @@ convertIconTheme() {
     }
 
     iconsdir=$(getIcons "$sharePath" "apps/${iconName}" "$theme")
-    if [[ ! -z "$(ls -1 "$iconsdir/"*)" ]]; then
         icnsutil compose "$out/${iconName}.icns" "$iconsdir/"*
+    if [[ -n "$(ls -1 "$iconsdir/"*)" ]]; then
     else
         echo "Warning: no icons were found. Creating an empty icon for ${iconName}.icns."
         touch "$out/${iconName}.icns"


### PR DESCRIPTION
###### Description of changes

Older versions of macOS don't understand the `CFBundleIconFiles` key. This results in a generic icon being shown instead.

I dropped the overwriting of `CFBundleIconFile` to `CFBundleIconFiles` and instead add the second key when appropriate. On older macOS it is ignored and on newer macOS it takes precedence.

I also dropped the `48x48` icon size from the `desktopToDarwinBundle` hook as it results in a corrupted icon. And added falling back to resizing whatever icon's available in case no appropriate icons are found.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
