### PR TITLE
mupdf: Fix darwin

### DIFF
--- a/pkgs/applications/misc/mupdf/0001-Use-command-v-in-favor-of-which.patch
+++ b/pkgs/applications/misc/mupdf/0001-Use-command-v-in-favor-of-which.patch
@@ -1,0 +1,25 @@
+From b2935ed7e2962d73f3b493c38c0bb1e8659c0a60 Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Tue, 8 Mar 2022 23:59:19 +0100
+Subject: [PATCH 1/2] Use command -v in favor of which
+
+---
+ Makerules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makerules b/Makerules
+index 0fdaecb..6d52cca 100644
+--- a/Makerules
++++ b/Makerules
+@@ -145,7 +145,7 @@ else ifeq ($(OS),MACOS)
+   LD = xcrun ld
+   RANLIB = xcrun ranlib
+ 
+-  ifeq (, $(shell which pkg-config))
++  ifeq (, $(shell command -v pkg-config))
+     $(warning "No pkg-config found, install it for proper integration of libcrypto")
+   else
+     HAVE_LIBCRYPTO := $(shell pkg-config --exists 'libcrypto >= 1.1.0' && echo yes)
+-- 
+2.17.2 (Apple Git-113)
+

--- a/pkgs/applications/misc/mupdf/0002-Add-Darwin-deps.patch
+++ b/pkgs/applications/misc/mupdf/0002-Add-Darwin-deps.patch
@@ -1,0 +1,57 @@
+From 0f0ccfc01cfe72d96eafee57ec6c5107f09c7238 Mon Sep 17 00:00:00 2001
+From: toonn <toonn@toonn.io>
+Date: Wed, 9 Mar 2022 00:08:28 +0100
+Subject: [PATCH 2/2] Add Darwin deps
+
+---
+ Makerules | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/Makerules b/Makerules
+index 6d52cca..a6bd0ed 100644
+--- a/Makerules
++++ b/Makerules
+@@ -153,6 +153,40 @@ else ifeq ($(OS),MACOS)
+ 	  LIBCRYPTO_CFLAGS := $(shell pkg-config --cflags libcrypto) -DHAVE_LIBCRYPTO
+ 	  LIBCRYPTO_LIBS := $(shell pkg-config --libs libcrypto)
+     endif
++    # Required for mupdf-gl
++    ifeq ($(shell pkg-config --exists harfbuzz && echo yes),yes)
++          SYS_HARFBUZZ_CFLAGS := $(shell pkg-config --cflags harfbuzz)
++          SYS_HARFBUZZ_LIBS := $(shell pkg-config --libs harfbuzz)
++    endif
++    ifeq ($(shell pkg-config --exists libopenjp2 && echo yes),yes)
++          SYS_OPENJPEG_CFLAGS := $(shell pkg-config --cflags libopenjp2)
++          SYS_OPENJPEG_LIBS := $(shell pkg-config --libs libopenjp2)
++    endif
++    ifeq ($(shell pkg-config --exists freetype2 && echo yes),yes)
++          SYS_FREETYPE_CFLAGS := $(shell pkg-config --cflags freetype2)
++          SYS_FREETYPE_LIBS := $(shell pkg-config --libs freetype2)
++    endif
++    ifeq ($(shell pkg-config --exists gumbo && echo yes),yes)
++          SYS_GUMBO_CFLAGS := $(shell pkg-config --cflags gumbo)
++          SYS_GUMBO_LIBS := $(shell pkg-config --libs gumbo)
++    endif
++    # Required for mupdf-x11
++    HAVE_X11 := $(shell pkg-config --exists x11 xext && echo yes)
++    ifeq ($(HAVE_X11),yes)
++          X11_CFLAGS := $(shell pkg-config --cflags x11 xext)
++          X11_LIBS := $(shell pkg-config --libs x11 xext)
++    endif
++    # Required for mupdf-x11-curl
++    HAVE_SYS_CURL := $(shell pkg-config --exists libcurl && echo yes)
++    ifeq ($(HAVE_SYS_CURL),yes)
++          SYS_CURL_CFLAGS := $(shell pkg-config --cflags libcurl)
++          SYS_CURL_LIBS := $(shell pkg-config --libs libcurl)
++    endif
++    HAVE_PTHREAD := yes
++    ifeq ($(HAVE_PTHREAD),yes)
++          PTHREAD_CFLAGS :=
++          PTHREAD_LIBS := -lpthread
++    endif
+   endif
+ 
+ else ifeq ($(OS),Linux)
+-- 
+2.17.2 (Apple Git-113)
+

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -21,6 +21,7 @@
 , enableGL ? true
 , freeglut
 , libGLU
+, xcbuild
 }:
 let
 
@@ -39,7 +40,9 @@ stdenv.mkDerivation rec {
     sha256 = "1vfyhlqq1a0k0drcggly4bgsjasmf6lmpfbdi5xcrwdbzkagrbr1";
   };
 
-  patches = ./0001-Use-command-v-in-favor-of-which.patch;
+  patches = [ ./0001-Use-command-v-in-favor-of-which.patch
+              ./0002-Add-Darwin-deps.patch
+            ];
 
   postPatch = ''
     sed -i "s/__OPENJPEG__VERSION__/${openJpegVersion}/" source/fitz/load-jpx.c
@@ -54,6 +57,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
+    ++ lib.optional stdenv.isDarwin xcbuild
     ++ lib.optionals enableX11 [ libX11 libXext libXi libXrandr ]
     ++ lib.optionals enableCurl [ curl openssl ]
     ++ lib.optionals enableGL (

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vfyhlqq1a0k0drcggly4bgsjasmf6lmpfbdi5xcrwdbzkagrbr1";
   };
 
+  patches = ./0001-Use-command-v-in-favor-of-which.patch;
+
   postPatch = ''
     sed -i "s/__OPENJPEG__VERSION__/${openJpegVersion}/" source/fitz/load-jpx.c
   '';


### PR DESCRIPTION
###### Description of changes

The expression was inadvertently broken for Darwin in the most recent bump.
I made the Darwin patch unconditional because it doesn't interfere with the Linux build and this way the source is identical across platforms and we'll catch the patch breaking sooner.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
