### PR TITLE
mupdf: Refactor desktop item

### DIFF
--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
                       name = pname;
                       desktopName = pname;
                       comment = meta.description;
-                      icon = "mupdf-icon";
+                      icon = "mupdf";
                       exec = "${pname} %f";
                       terminal = false;
                       mimeTypes = [ "application/epub+zip"
@@ -118,6 +118,8 @@ stdenv.mkDerivation rec {
     moveToOutput "bin" "$bin"
   '' + lib.optionalString enableX11 ''
     ln -s "$bin/bin/mupdf-x11" "$bin/bin/mupdf"
+    mkdir -p $bin/share/icons/hicolor/48x48/apps
+    cp docs/logo/mupdf.png $bin/share/icons/hicolor/48x48/apps
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -58,9 +58,9 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (!enableX11) [ "HAVE_X11=no" ]
     ++ lib.optionals (!enableGL) [ "HAVE_GLUT=no" ];
 
-  nativeBuildInputs =
-    [ pkg-config ] ++ lib.optional (enableGL || enableX11) copyDesktopItems
-                   ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
+  nativeBuildInputs = [ pkg-config ]
+    ++ lib.optional (enableGL || enableX11) copyDesktopItems
+    ++ lib.optional stdenv.isDarwin desktopToDarwinBundle;
 
   buildInputs = [ freetype harfbuzz openjpeg jbig2dec libjpeg gumbo ]
     ++ lib.optional stdenv.isDarwin xcbuild
@@ -80,26 +80,29 @@ stdenv.mkDerivation rec {
     rm -rf thirdparty/{curl,freetype,glfw,harfbuzz,jbig2dec,libjpeg,openjpeg,zlib}
   '';
 
-  desktopItems = [ (makeDesktopItem {
-                      name = pname;
-                      desktopName = pname;
-                      comment = meta.description;
-                      icon = "mupdf";
-                      exec = "${pname} %f";
-                      terminal = false;
-                      mimeTypes = [ "application/epub+zip"
-                                    "application/oxps"
-                                    "application/pdf"
-                                    "application/vnd.ms-xpsdocument"
-                                    "application/x-cbz"
-                                    "application/x-pdf"
-                                  ];
-                      categories = [ "Graphics" "Viewer" ];
-                      keywords = [ "mupdf" "comic" "document" "ebook" "viewer"
-                                   "cbz" "epub" "fb2" "pdf" "xps"
-                                 ];
-                    })
-                 ];
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = pname;
+      comment = meta.description;
+      icon = "mupdf";
+      exec = "${pname} %f";
+      terminal = false;
+      mimeTypes = [
+        "application/epub+zip"
+        "application/oxps"
+        "application/pdf"
+        "application/vnd.ms-xpsdocument"
+        "application/x-cbz"
+        "application/x-pdf"
+      ];
+      categories = [ "Graphics" "Viewer" ];
+      keywords = [
+        "mupdf" "comic" "document" "ebook" "viewer"
+        "cbz" "epub" "fb2" "pdf" "xps"
+      ];
+    })
+  ];
 
   postInstall = ''
     mkdir -p "$out/lib/pkgconfig"

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -116,11 +116,14 @@ stdenv.mkDerivation rec {
     EOF
 
     moveToOutput "bin" "$bin"
-  '' + lib.optionalString enableX11 ''
-    ln -s "$bin/bin/mupdf-x11" "$bin/bin/mupdf"
+  '' + lib.optionalString (enableX11 || enableGL) ''
     mkdir -p $bin/share/icons/hicolor/48x48/apps
     cp docs/logo/mupdf.png $bin/share/icons/hicolor/48x48/apps
-  '';
+  '' + (if enableGL then ''
+    ln -s "$bin/bin/mupdf-gl" "$bin/bin/mupdf"
+  '' else lib.optionalString (enableX11) ''
+    ln -s "$bin/bin/mupdf-x11" "$bin/bin/mupdf"
+  '');
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/misc/mupdf/default.nix
+++ b/pkgs/applications/misc/mupdf/default.nix
@@ -94,6 +94,10 @@ stdenv.mkDerivation rec {
                                     "application/x-cbz"
                                     "application/x-pdf"
                                   ];
+                      categories = [ "Graphics" "Viewer" ];
+                      keywords = [ "mupdf" "comic" "document" "ebook" "viewer"
+                                   "cbz" "epub" "fb2" "pdf" "xps"
+                                 ];
                     })
                  ];
 


### PR DESCRIPTION
###### Description of changes

I refactor the expression to use `makeDesktopItem` and the `copyDesktopItems` hook so we don't have to manually craft and copy the desktop item.

I also improved the desktop item by adding the available icon and appropriate categories and keywords gleaned from the Debian package.

Generation of the desktop item is now conditional on either of the viewer binaries being built, rather than tied to `mupdf-x11`. `mupdf-gl` supercedes the former on Linux and on macOS the desktop item can be used to synthesize an application bundle.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
