### PR TITLE
desync: 0.9.0 -> 0.9.2

### DIFF
--- a/pkgs/applications/networking/sync/desync/default.nix
+++ b/pkgs/applications/networking/sync/desync/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "desync";
-  version = "0.9.0";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "folbricht";
     repo = "desync";
-    sha256 = "0j9hixgkja268r2zn2dglrmlrb2z57sgz6q3wqb8dfwpan7b5rsy";
+    sha256 = "sha256-yGlf6Z38GnOWSc2pvt/u4arx5lCB0QpoqPdNamdL9b0=";
   };
 
-  vendorSha256 = "1gajh99jb6mbwk93dypddhl7r7n8h2s11s3s82firbrb5k24s4pz";
+  vendorSha256 = "sha256-c+Sz3WMKyzdEE/Hs+7dekQPn+62ddbmfvV21W0KeLDU=";
 
   # nix builder doesn't have access to test data; tests fail for reasons unrelated to binary being bad.
   doCheck = false;


### PR DESCRIPTION
###### Description of changes

Minor update. Changes include:

- Support for mounting a .caibx backed by a sparse cache
- A generic "converter" layer to allow encrypted stores
- Test suite compatibility with Go 1.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
