### PR TITLE
polkadot: 0.9.17 -> 0.9.18

### DIFF
--- a/pkgs/applications/blockchains/polkadot/default.nix
+++ b/pkgs/applications/blockchains/polkadot/default.nix
@@ -8,15 +8,21 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "polkadot";
-  version = "0.9.17";
+  version = "0.9.18";
 
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "polkadot";
     rev = "v${version}";
-    sha256 = "sha256-m47Y4IXGc43XLs5d6ehlD0A53BWC5kO3K2BS/xbYgl8=";
+    sha256 = "sha256-pjHSiVspBV15jKUFv+Uf2l3tah40l55Pv8vwDuwgwjc=";
 
-    # see the comment below on fakeGit for how this is used
+    # the build process of polkadot requires a .git folder in order to determine
+    # the git commit hash that is being built and add it to the version string.
+    # since having a .git folder introduces reproducibility issues to the nix
+    # build, we check the git commit hash after fetching the source and save it
+    # into a .git_commit file, and then delete the .git folder. we can then use
+    # this file to populate an environment variable with the commit hash, which
+    # is picked up by polkadot's build process.
     leaveDotGit = true;
     postFetch = ''
       ( cd $out; git rev-parse --short HEAD > .git_commit )
@@ -24,28 +30,14 @@ rustPlatform.buildRustPackage rec {
     '';
   };
 
-  cargoSha256 = "sha256-JBacioy2woAfKQuK6tXU9as4DNc+3uY3F3GWksCf6WU=";
+  cargoSha256 = "sha256-Gc5WbayQUlsl7Fk8NyLPh2Zg2yrLl3WJqKorNZMLi94=";
 
-  nativeBuildInputs =
-    let
-      # the build process of polkadot requires a .git folder in order to determine
-      # the git commit hash that is being built and add it to the version string.
-      # since having a .git folder introduces reproducibility issues to the nix
-      # build, we check the git commit hash after fetching the source and save it
-      # into a .git_commit file, and then delete the .git folder. then we create a
-      # fake git command that will just return the contents of this file, which will
-      # be used when the polkadot build calls `git rev-parse` to fetch the commit
-      # hash.
-      fakeGit = writeShellScriptBin "git" ''
-        if [[ $@ = "rev-parse --short HEAD" ]]; then
-          cat /build/source/.git_commit
-        else
-          >&2 echo "Unknown command: $@"
-          exit 1
-        fi
-      '';
-    in
-    [ clang fakeGit ];
+  nativeBuildInputs = [ clang ];
+
+  preBuild = ''
+    export SUBSTRATE_CLI_GIT_COMMIT_HASH=$(cat .git_commit)
+    rm .git_commit
+  '';
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
