### PR TITLE
 firefox: spring cleaning 🦊

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation {
       ln -s ${policiesJson} "$out/lib/firefox-bin-${version}/distribution/policies.json";
     '';
 
-  passthru.applicationName = "firefox";
+  passthru.binaryName = "firefox";
   passthru.libName = "firefox-bin-${version}";
   passthru.execdir = "/bin";
   passthru.ffmpegSupport = true;

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -248,7 +248,6 @@ buildStdenv.mkDerivation ({
     unset AS
   '' + (lib.optionalString enableOfficialBranding ''
     export MOZILLA_OFFICIAL=1
-    export BUILD_OFFICIAL=1
   '');
 
   configureFlags = [

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -19,7 +19,7 @@
 , libffi
 , libvpx
 , libwebp
-, icu, libpng, glib, pciutils
+, icu, libpng, glib
 , autoconf, which, gnused, rustPackages, rustPlatform
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
@@ -135,9 +135,6 @@ buildStdenv.mkDerivation ({
 
   postPatch = ''
     rm -rf obj-x86_64-pc-linux-gnu
-    substituteInPlace toolkit/xre/glxtest.cpp \
-      --replace 'dlopen("libpci.so' 'dlopen("${pciutils}/lib/libpci.so'
-
     patchShebangs mach
   '' + extraPostPatch;
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -7,11 +7,11 @@
 { lib, stdenv, pkg-config, pango, perl, python3, zip
 , libjpeg, zlib, dbus, dbus-glib, bzip2, xorg
 , freetype, fontconfig, file, nspr, nss
-, yasm, libGLU, libGL, sqlite, unzip, makeWrapper
+, libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification
 , libvpx
-, icu70, libpng, glib, pciutils
-, autoconf213, which, gnused, rustPackages, rustPlatform
+, icu, libpng, glib, pciutils
+, autoconf, which, gnused, rustPackages, rustPlatform
 , rust-cbindgen, nodejs, nasm, fetchpatch
 , gnum4
 , gtk3, wrapGAppsHook
@@ -157,18 +157,14 @@ buildStdenv.mkDerivation ({
     gnum4 gtk3 perl zip libjpeg zlib bzip2
     dbus dbus-glib pango freetype fontconfig xorg.libXi xorg.libXcursor
     xorg.libX11 xorg.libXrender xorg.libXft xorg.libXt file
-    xorg.pixman yasm libGLU libGL
+    xorg.pixman libGLU libGL
     xorg.xorgproto
     xorg.libXdamage
     xorg.libXext
     xorg.libXtst
-    libevent libstartup_notification /* cairo */
+    libevent libstartup_notification
     libpng glib
-    nasm icu70 libvpx
-    # >= 66 requires nasm for the AV1 lib dav1d
-    # yasm can potentially be removed in future versions
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=1501796
-    # https://groups.google.com/forum/#!msg/mozilla.dev.platform/o-8levmLU80/SM_zQvfzCQAJ
+    nasm icu libvpx
     nspr nss
   ]
   ++ lib.optional  alsaSupport alsa-lib
@@ -193,7 +189,7 @@ buildStdenv.mkDerivation ({
 
   nativeBuildInputs =
     [
-      autoconf213
+      autoconf
       cargo
       gnused
       llvmPackages.llvm # llvm-objdump
@@ -220,7 +216,7 @@ buildStdenv.mkDerivation ({
     rm -f configure
     rm -f js/src/configure
     rm -f .mozconfig*
-    # this will run autoconf213
+    # this will run autoconf
     configureScript="$(realpath ./mach) configure"
     export MOZBUILD_STATE_PATH=$(pwd)/mozbuild
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -260,7 +260,6 @@ buildStdenv.mkDerivation ({
     "--with-system-icu"
     "--enable-system-ffi"
     "--enable-system-pixman"
-    #"--enable-system-cairo"
     "--disable-tests"
     "--disable-updater"
     "--enable-default-toolkit=${default-toolkit}"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -262,7 +262,6 @@ buildStdenv.mkDerivation ({
     "--enable-system-pixman"
     #"--enable-system-cairo"
     "--disable-tests"
-    "--disable-necko-wifi" # maybe we want to enable this at some point
     "--disable-updater"
     "--enable-default-toolkit=${default-toolkit}"
     "--with-libclang-path=${llvmPackages.libclang.lib}/lib"
@@ -286,6 +285,7 @@ buildStdenv.mkDerivation ({
   ++ flag pulseaudioSupport "pulseaudio"
   ++ flag ffmpegSupport "ffmpeg"
   ++ flag jemallocSupport "jemalloc"
+  ++ flag geolocationSupport "necko-wifi"
   ++ flag gssSupport "negotiateauth"
   ++ flag webrtcSupport "webrtc"
   ++ flag crashreporterSupport "crashreporter"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -16,6 +16,7 @@
 , freetype, fontconfig, file, nspr, nss
 , libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification
+, libffi
 , libvpx
 , libwebp
 , icu, libpng, glib, pciutils
@@ -157,6 +158,7 @@ buildStdenv.mkDerivation ({
     libevent libstartup_notification
     libpng glib
     nasm icu libvpx
+    libffi
     libwebp
     nspr nss
   ]
@@ -224,13 +226,13 @@ buildStdenv.mkDerivation ({
 
   configureFlags = [
     "--enable-application=${application}"
+    "--with-system-ffi"
     "--with-system-jpeg"
     "--with-system-zlib"
     "--with-system-libevent"
     "--with-system-libvpx"
     "--with-system-png" # needs APNG support
     "--with-system-icu"
-    "--enable-system-ffi"
     "--enable-system-pixman"
     "--disable-tests"
     "--disable-updater"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -17,6 +17,7 @@
 , libGLU, libGL, sqlite, unzip, makeWrapper
 , hunspell, libevent, libstartup_notification
 , libvpx
+, libwebp
 , icu, libpng, glib, pciutils
 , autoconf, which, gnused, rustPackages, rustPlatform
 , rust-cbindgen, nodejs, nasm, fetchpatch
@@ -179,6 +180,7 @@ buildStdenv.mkDerivation ({
     libevent libstartup_notification
     libpng glib
     nasm icu libvpx
+    libwebp
     nspr nss
   ]
   ++ lib.optional  alsaSupport alsa-lib
@@ -267,6 +269,7 @@ buildStdenv.mkDerivation ({
     "--with-libclang-path=${llvmPackages.libclang.lib}/lib"
     "--with-system-nspr"
     "--with-system-nss"
+    "--with-system-webp"
   ]
   ++ lib.optional (buildStdenv.isDarwin) "--disable-xcode-checks"
   ++ lib.optional (!ltoSupport) "--with-clang-path=${llvmPackages.clang}/bin/clang"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -37,7 +37,7 @@
 , waylandSupport ? true, libxkbcommon, libdrm
 , ltoSupport ? (stdenv.isLinux && stdenv.is64bit), overrideCC, buildPackages
 , gssSupport ? true, libkrb5
-, pipewireSupport ? waylandSupport && webrtcSupport, pipewire
+, pipewireSupport ? waylandSupport && webrtcSupport
 # Jemalloc could reduce memory consumption.
 , jemallocSupport ? true, jemalloc
 
@@ -187,7 +187,6 @@ buildStdenv.mkDerivation ({
   ++ lib.optional  pulseaudioSupport libpulseaudio # only headers are needed
   ++ lib.optional  gssSupport libkrb5
   ++ lib.optionals waylandSupport [ libxkbcommon libdrm ]
-  ++ lib.optional  pipewireSupport pipewire
   ++ lib.optional  jemallocSupport jemalloc
   ++ lib.optionals buildStdenv.isDarwin [ CoreMedia ExceptionHandling Kerberos
                                           AVFoundation MediaToolbox CoreLocation

--- a/pkgs/applications/networking/browsers/firefox/librewolf/default.nix
+++ b/pkgs/applications/networking/browsers/firefox/librewolf/default.nix
@@ -6,7 +6,7 @@ rec {
 
   inherit (src) packageVersion firefox source;
 
-  patches = [ ./verify-telemetry-macros.patch ];
+  extraPatches = [ ./verify-telemetry-macros.patch ];
 
   extraConfigureFlags = [
     "--with-app-name=librewolf"
@@ -34,7 +34,7 @@ rec {
   extraPoliciesFiles = [ "${source}/submodules/settings/distribution/policies.json" ];
 
   extraPassthru = {
-    librewolf = { inherit src patches; };
+    librewolf = { inherit src extraPatches; };
     inherit extraPrefsFiles extraPoliciesFiles;
   };
 }

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -67,7 +67,7 @@ let
           ++ extraNativeMessagingHosts
         );
       libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups ]
-            ++ lib.optional (pipewireSupport && lib.versionAtLeast version "83") pipewire
+            ++ lib.optional pipewireSupport pipewire
             ++ lib.optional ffmpegSupport ffmpeg
             ++ lib.optional gssSupport libkrb5
             ++ lib.optional useGlvnd libglvnd

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -20,7 +20,7 @@ browser:
 
 let
   wrapper =
-    { applicationName ? browser.applicationName or (lib.getName browser)
+    { applicationName ? browser.binaryName or (lib.getName browser)
     , pname ? applicationName
     , version ? lib.getVersion browser
     , desktopName ? # applicationName with first letter capitalized
@@ -179,14 +179,10 @@ let
       buildInputs = [ browser.gtk3 ];
 
 
-      buildCommand = lib.optionalString stdenv.isDarwin ''
-        mkdir -p $out/Applications
-        cp -R --no-preserve=mode,ownership ${browser}/Applications/${applicationName}.app $out/Applications
-        rm -f $out${browser.execdir or "/bin"}/${applicationName}
-      '' + ''
-        if [ ! -x "${browser}${browser.execdir or "/bin"}/${applicationName}" ]
+      buildCommand = ''
+        if [ ! -x "${browser}/bin/${applicationName}" ]
         then
-            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            echo "cannot find executable file \`${browser}/bin/${applicationName}'"
             exit 1
         fi
 
@@ -223,12 +219,12 @@ let
 
         # create the wrapper
 
-        executablePrefix="$out${browser.execdir or "/bin"}"
+        executablePrefix="$out/bin"
         executablePath="$executablePrefix/${applicationName}"
 
         if [ ! -x "$executablePath" ]
         then
-            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            echo "cannot find executable file \`${browser}/bin/${applicationName}'"
             exit 1
         fi
 
@@ -243,18 +239,18 @@ let
           oldExe="$(readlink -v --canonicalize-existing "$executablePath")"
         fi
 
-        if [ ! -x "${browser}${browser.execdir or "/bin"}/${applicationName}" ]
+        if [ ! -x "${browser}/bin/${applicationName}" ]
         then
-            echo "cannot find executable file \`${browser}${browser.execdir or "/bin"}/${applicationName}'"
+            echo "cannot find executable file \`${browser}/bin/${applicationName}'"
             exit 1
         fi
 
         makeWrapper "$oldExe" \
-          "$out${browser.execdir or "/bin"}/${applicationName}${nameSuffix}" \
+          "$out/bin/${applicationName}${nameSuffix}" \
             --prefix LD_LIBRARY_PATH ':' "$libs" \
             --suffix-each GTK_PATH ':' "$gtk_modules" \
             --prefix PATH ':' "${xdg-utils}/bin" \
-            --suffix PATH ':' "$out${browser.execdir or "/bin"}" \
+            --suffix PATH ':' "$out/bin" \
             --set MOZ_APP_LAUNCHER "${applicationName}${nameSuffix}" \
             --set MOZ_SYSTEM_DIR "$out/lib/mozilla" \
             --set MOZ_LEGACY_PROFILES 1 \
@@ -278,7 +274,7 @@ let
             mkdir -p "$out/share/icons/hicolor/''${res}x''${res}/apps"
             icon=$( find "${browser}/lib/" -name "default''${res}.png" )
               if [ -e "$icon" ]; then ln -s "$icon" \
-                "$out/share/icons/hicolor/''${res}x''${res}/apps/${applicationName}.png"
+                "$out/share/icons/hicolor/''${res}x''${res}/apps/${icon}.png"
               fi
             done
         fi

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -12,6 +12,7 @@
 , libva
 , mesa # firefox wants gbm for drm+dmabuf
 , cups
+, pciutils
 }:
 
 ## configurability of the wrapper itself
@@ -66,7 +67,7 @@ let
           ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );
-      libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups ]
+      libs =   lib.optionals stdenv.isLinux [ udev libva mesa libnotify xorg.libXScrnSaver cups pciutils ]
             ++ lib.optional pipewireSupport pipewire
             ++ lib.optional ffmpegSupport ffmpeg
             ++ lib.optional gssSupport libkrb5

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -17,7 +17,7 @@ rec {
       url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
       sha512 = "2afaee16f155edcb0bdb46ebe282a733cf041ec6f562aebd06f8b675e46917f6f500fcc532fc54d74f3f4b0b489a88934a2c6c304f849873de4bc2690b9056a0";
     };
-    patches = [
+    extraPatches = [
       # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
       ./no-buildconfig.patch
     ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29455,7 +29455,6 @@ with pkgs;
   thunderbirdPackages = recurseIntoAttrs (callPackage ../applications/networking/mailreaders/thunderbird/packages.nix {
     callPackage = newScope {
       inherit (rustPackages) cargo rustc;
-      gnused = gnused_422;
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25971,7 +25971,6 @@ with pkgs;
   firefoxPackages = recurseIntoAttrs (callPackage ../applications/networking/browsers/firefox/packages.nix {
     callPackage = newScope {
       inherit (rustPackages) cargo rustc;
-      gnused = gnused_422;
     };
   });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25972,10 +25972,6 @@ with pkgs;
     callPackage = newScope {
       inherit (rustPackages) cargo rustc;
       gnused = gnused_422;
-      inherit (darwin.apple_sdk.frameworks) CoreMedia ExceptionHandling
-                                            Kerberos AVFoundation MediaToolbox
-                                            CoreLocation Foundation AddressBook;
-      inherit (darwin) libobjc;
     };
   });
 
@@ -29461,10 +29457,6 @@ with pkgs;
     callPackage = newScope {
       inherit (rustPackages) cargo rustc;
       gnused = gnused_422;
-      inherit (darwin.apple_sdk.frameworks) CoreMedia ExceptionHandling
-                                            Kerberos AVFoundation MediaToolbox
-                                            CoreLocation Foundation AddressBook;
-      inherit (darwin) libobjc;
     };
   });
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Lots, best to check the commits one by one, the last one reformats things quite a bit, so the overall diff is a bit noisy.

Tested on x86_64-linux w/ sway/pipewire and everything performs as usual.

Things to test:
- I enabled the necko wifi scanner, which should improve geolocation support by relying on NetworkManager to provide a list of visible BSSIDs
  - For some reason geolocation doesn't work at all for me :thinking: 
  - Requested a Mozilla API key for us, not sure if that will pan out in short time
- Check whether #165107 is fixed (on GNOME?)
- Other consumers of `common.nix`: Thunderbird & Librewolf

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
