### PR TITLE
kde/frameworks: 5.91 -> 5.92

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.91/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.92/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -4,667 +4,667 @@
 
 {
   attica = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/attica-5.91.0.tar.xz";
-      sha256 = "0svvy7qflidwxns12y2lra54gg6lhglcddzmrw7ccvbdyqcy2pn0";
-      name = "attica-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/attica-5.92.0.tar.xz";
+      sha256 = "0cy9dd8kazfkhas87bxjj5smmzay3gvkjwsmy6gvkfxc6rvpqr5z";
+      name = "attica-5.92.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/baloo-5.91.0.tar.xz";
-      sha256 = "1cqjbaiwqba707xaz9zsrdz9cms2mdrhv6jpwsq8q7f4g4rxcx3m";
-      name = "baloo-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/baloo-5.92.0.tar.xz";
+      sha256 = "0xd4a0p22gjm523ymlyd5nfgp8z3ayb0nq6a04h5py507mc70d98";
+      name = "baloo-5.92.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/bluez-qt-5.91.0.tar.xz";
-      sha256 = "0p37jrmppwahh4vaq3wkw6xn0ms8dxcxpfd4glzjlnw426zrwnjr";
-      name = "bluez-qt-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/bluez-qt-5.92.0.tar.xz";
+      sha256 = "1dlasb39kqrcql6hq0sl74ax3n5bdcy3pkhvc9vwpf9dxn1j93gm";
+      name = "bluez-qt-5.92.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/breeze-icons-5.91.0.tar.xz";
-      sha256 = "0aj24gn48c17n9jzrj0az04ph4hpx7zf2rj4vgwl19iip69vfzf1";
-      name = "breeze-icons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/breeze-icons-5.92.0.tar.xz";
+      sha256 = "0rj30r52ca6njx00gmmni4k70yn8873ihxfbc66lklwzk1irdq29";
+      name = "breeze-icons-5.92.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/extra-cmake-modules-5.91.0.tar.xz";
-      sha256 = "0k65rvxh926ya6qahzk2ns7g1fya1429648mlx7iipxa61g8h5wp";
-      name = "extra-cmake-modules-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/extra-cmake-modules-5.92.0.tar.xz";
+      sha256 = "1vq3sd4qfr4hjcgqyfpykcz5wyagbfvrd4p24pdki1zjqn5j76pq";
+      name = "extra-cmake-modules-5.92.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/frameworkintegration-5.91.0.tar.xz";
-      sha256 = "1176ql8f96ap4gzjaj8vm4cr6f2rsx9z93gpc4hx4jcqjhxqrg3z";
-      name = "frameworkintegration-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/frameworkintegration-5.92.0.tar.xz";
+      sha256 = "0pgcwfxxzvfvqyjfgqzsllzfy9il4y8xr8dzdyjmd5vccpvgd3mx";
+      name = "frameworkintegration-5.92.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kactivities-5.91.0.tar.xz";
-      sha256 = "03y4hx7jgrhac12ys8pm22h0f49kms8b71gck4xv577p3ywi3j60";
-      name = "kactivities-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kactivities-5.92.0.tar.xz";
+      sha256 = "1kfvg23gdl4k6azs6700j8i8ncl8c7rrc70w1i2xhphz27ybc1pw";
+      name = "kactivities-5.92.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kactivities-stats-5.91.0.tar.xz";
-      sha256 = "0864qfljh20723djfzdv8h6nipw01825lhiknyqz17aj2x2ymzcq";
-      name = "kactivities-stats-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kactivities-stats-5.92.0.tar.xz";
+      sha256 = "0lgp7zxgjmjm02x4mydlv6ivmlxqjkklav5vfwgjgf6v1qp161i2";
+      name = "kactivities-stats-5.92.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kapidox-5.91.0.tar.xz";
-      sha256 = "1xxpl8rn49d2cr7ld94j3wsg21019l2kq14p5bvilisnj3salka3";
-      name = "kapidox-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kapidox-5.92.0.tar.xz";
+      sha256 = "0vd5k4wmmawbhyy3cxj0gjidf4haghwbsbly9yr3zg3qb3g02ljg";
+      name = "kapidox-5.92.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/karchive-5.91.0.tar.xz";
-      sha256 = "1kjc47zzdd9jhcmynq6zw6y6zaj2c1i8pxvszx3d9x5asaz2qq53";
-      name = "karchive-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/karchive-5.92.0.tar.xz";
+      sha256 = "1blzm6vf8kpflam4671r1y4svrsb79bglln7aia7baqh7a6a4xjh";
+      name = "karchive-5.92.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kauth-5.91.0.tar.xz";
-      sha256 = "001svdyvs8qc6h8zkb9x072npkz6xabz6j0djjb380gl9h9wnrgq";
-      name = "kauth-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kauth-5.92.0.tar.xz";
+      sha256 = "0a27z9xr5ccxfcxmx93vs4hgxc388nsd9ac906mdh475ivv4p0j4";
+      name = "kauth-5.92.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kbookmarks-5.91.0.tar.xz";
-      sha256 = "0iqfngsvpbgxk6h8l68idcp97df28sa2zwj707zs0mf2bl9k68m4";
-      name = "kbookmarks-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kbookmarks-5.92.0.tar.xz";
+      sha256 = "0hym3558xnp3h7q8kf1ljcy65r3g37mcmqb1ll3nxd912rv4wl4r";
+      name = "kbookmarks-5.92.0.tar.xz";
     };
   };
   kcalendarcore = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcalendarcore-5.91.0.tar.xz";
-      sha256 = "0gkn0mzk3za86pjrpi8gd9d71bfv0ihzkgn8yy1ik3dw1rf9gxip";
-      name = "kcalendarcore-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcalendarcore-5.92.0.tar.xz";
+      sha256 = "0fhbas8i7i08z4x32yq49admiz8vk4h9vwgkh7qy14lbzf6ydwkg";
+      name = "kcalendarcore-5.92.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcmutils-5.91.0.tar.xz";
-      sha256 = "009r9r7fz1588g2cnqw585d2fz170x8j8bip1zqr7i4jl21ms68s";
-      name = "kcmutils-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcmutils-5.92.0.tar.xz";
+      sha256 = "0fldpkhq4ysma4m6qylr7kqvxw0rb11x5abz5921bhl5zicfcjfx";
+      name = "kcmutils-5.92.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcodecs-5.91.0.tar.xz";
-      sha256 = "0qkwvbp4vp3w57f3fyjknxd66qac77hl77mf042c7jxjl5vq7h1y";
-      name = "kcodecs-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcodecs-5.92.0.tar.xz";
+      sha256 = "0xfjc0diljx081as3b500awybay9l3sfl59792h5z3clafjbgrfn";
+      name = "kcodecs-5.92.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcompletion-5.91.0.tar.xz";
-      sha256 = "1l6z85a4rh3vrf4x5g3pqvp0q36gwmw0fbp9ny1iaqyy21dlh8i4";
-      name = "kcompletion-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcompletion-5.92.0.tar.xz";
+      sha256 = "1svwvj9jxkgcddfdila10ggdmsabs22vnhf9k7isp2zfdif55w88";
+      name = "kcompletion-5.92.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kconfig-5.91.0.tar.xz";
-      sha256 = "0axdnqipa8xgx864zylxllnzchlp50q59bbfw3c98svvvkm3yg56";
-      name = "kconfig-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kconfig-5.92.0.tar.xz";
+      sha256 = "08q57f3wxj22d485s0ph53p44yrkjb376817470a0s43p10vc0bq";
+      name = "kconfig-5.92.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kconfigwidgets-5.91.0.tar.xz";
-      sha256 = "01mvv01hv64wadjh8xk3hhp1vbs04cvbrjpfl1g9cv2sa6hr7102";
-      name = "kconfigwidgets-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kconfigwidgets-5.92.0.tar.xz";
+      sha256 = "0ji799xd45lpnd70a9bizicfz2bsmlxq6r0fqgn0ghwsbp9ywna2";
+      name = "kconfigwidgets-5.92.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcontacts-5.91.0.tar.xz";
-      sha256 = "1c839c9rvys3jwmi3fzw06r1nhgvrb4z8sdh8gda0w03vqh7h1hv";
-      name = "kcontacts-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcontacts-5.92.0.tar.xz";
+      sha256 = "1kik4pvy8snvj6rsc9pfbcpc8rrcn0k4pjj1h9m221zma1p00xhj";
+      name = "kcontacts-5.92.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcoreaddons-5.91.0.tar.xz";
-      sha256 = "16vimllvcs6rnb1ccbv9zg8hxbzacisgrlffyvwm608f4q1xmqyz";
-      name = "kcoreaddons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcoreaddons-5.92.0.tar.xz";
+      sha256 = "0rv63byrxwf9zdpx347rxybpk2j9yyjqm323j60vb8ja6a7p2pyz";
+      name = "kcoreaddons-5.92.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kcrash-5.91.0.tar.xz";
-      sha256 = "0gdknmp5a36ipvzms4jhxywyxpjh0vy26861c54jfsk13yircjal";
-      name = "kcrash-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kcrash-5.92.0.tar.xz";
+      sha256 = "1ir64mlv49vh3vz81r22q3sx0fichiwjr8qw5jf5vx96a1dn1icv";
+      name = "kcrash-5.92.0.tar.xz";
     };
   };
   kdav = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdav-5.91.0.tar.xz";
-      sha256 = "026w3bk2lmc7lqzra8w9jq8i2l1hvqsxz36r1jzj9p01skhdm32v";
-      name = "kdav-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdav-5.92.0.tar.xz";
+      sha256 = "1i5i6bkjairz1slk3fhrxd3s8wkcdaqg55jg2bv86kqh7d3nrcgk";
+      name = "kdav-5.92.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdbusaddons-5.91.0.tar.xz";
-      sha256 = "18qhpj0s4abypkb8ix2d84wv1kqv6qxyblninn2f9hjkl2dnlwis";
-      name = "kdbusaddons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdbusaddons-5.92.0.tar.xz";
+      sha256 = "0m5fd396xi3dhc45zwxjrrxr2bhlrc8g8m7n17jq1ylzqhyg60vw";
+      name = "kdbusaddons-5.92.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdeclarative-5.91.0.tar.xz";
-      sha256 = "183df5c0xyjqsip0izqvvk4wy2bjb973900s1wqsldhhvc7gpf7z";
-      name = "kdeclarative-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdeclarative-5.92.0.tar.xz";
+      sha256 = "1cymh8clcajk9cl6r443cpqk6vmp4x12ngc6wgp08z53zrvlv5py";
+      name = "kdeclarative-5.92.0.tar.xz";
     };
   };
   kded = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kded-5.91.0.tar.xz";
-      sha256 = "1zi0sixlzaxvw4lfil2r36i3xrav3vfwxp2r1lp4n65dpl7nv7p5";
-      name = "kded-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kded-5.92.0.tar.xz";
+      sha256 = "0v0fak84nw4lb4qc1irb9sn5nh5k7qrhnfav5smn3cvchldm6dc3";
+      name = "kded-5.92.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kdelibs4support-5.91.0.tar.xz";
-      sha256 = "1373fi9vi7ki8frr0lsw6yp335i95v8yq2j41s7ip003dpy4hr2g";
-      name = "kdelibs4support-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kdelibs4support-5.92.0.tar.xz";
+      sha256 = "1q7d0i09klkhsiwq7i91ypxakdr5b841zdb60q7yjzcdmn25wbi9";
+      name = "kdelibs4support-5.92.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kdesignerplugin-5.91.0.tar.xz";
-      sha256 = "07lvvryc3k418hd0j7ddlqhid26c51isa8mvk7g6gd0v2x3gp76q";
-      name = "kdesignerplugin-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kdesignerplugin-5.92.0.tar.xz";
+      sha256 = "0kial8k6qr39871v103952d0qcs0hm25y6k0vdg4y8ns8nrmjs06";
+      name = "kdesignerplugin-5.92.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdesu-5.91.0.tar.xz";
-      sha256 = "1wj099w810dabqn43pqis4sism3zwq3d1qa9mvcdyjafqbl7xnjm";
-      name = "kdesu-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdesu-5.92.0.tar.xz";
+      sha256 = "1yjyz4v0gn7ys7zy4ymn47zggxxmgd37big005c6g85dm63xr1s6";
+      name = "kdesu-5.92.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kdewebkit-5.91.0.tar.xz";
-      sha256 = "1mln0w1dzrbpm373vfpcyss4xxnrfgwh9nhzr8wmzs8965bn3wqq";
-      name = "kdewebkit-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kdewebkit-5.92.0.tar.xz";
+      sha256 = "1dni134qbs5yff7zgk4n3sfjwblzarblg16rj35l59l6mly7f2jd";
+      name = "kdewebkit-5.92.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdnssd-5.91.0.tar.xz";
-      sha256 = "1smzwh7lvz8g7vydxnd2kkh0ymg7yp6akc7k2vg8q65pa6pxqn3g";
-      name = "kdnssd-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdnssd-5.92.0.tar.xz";
+      sha256 = "1m24v36pphy591z1xp90i0yxv70c62iinvy4gspdi15bz94sydjz";
+      name = "kdnssd-5.92.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kdoctools-5.91.0.tar.xz";
-      sha256 = "02lr4l4n5gnv7ffzml8lbrdwgfpq6m7ayhz3bdqqijdfvw6h283n";
-      name = "kdoctools-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kdoctools-5.92.0.tar.xz";
+      sha256 = "0w08fa8rl0dhp59lv6xcvypahl6pxda6cr0vv0f0xv0xp6wax8w6";
+      name = "kdoctools-5.92.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kemoticons-5.91.0.tar.xz";
-      sha256 = "1jznkiq87rkndv10xs6974b5k0v82ly32agy5acxc2xy9wq7la0h";
-      name = "kemoticons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kemoticons-5.92.0.tar.xz";
+      sha256 = "01wzy3mwfz4sqpq8i1hfbbymajp55axryiaqkfr9r2n1844y7kzx";
+      name = "kemoticons-5.92.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kfilemetadata-5.91.0.tar.xz";
-      sha256 = "1z030irzcvmjq329nwfk3h8cd51dwy9mppnwbgcd0lw6y3bka0rq";
-      name = "kfilemetadata-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kfilemetadata-5.92.0.tar.xz";
+      sha256 = "1khmx9kd1jhd6j7rmfww3vmyjz2pg36mpsdn0bc77kwl21ax696n";
+      name = "kfilemetadata-5.92.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kglobalaccel-5.91.0.tar.xz";
-      sha256 = "09wscg6f19sh314ywpxp47pdr1xf1wzpjchg9rcjg207zrfhqqf0";
-      name = "kglobalaccel-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kglobalaccel-5.92.0.tar.xz";
+      sha256 = "0lhlb274pvv7rpkcsccqbv81bh8iklanp29g0k28wrv3kckiwyxy";
+      name = "kglobalaccel-5.92.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kguiaddons-5.91.0.tar.xz";
-      sha256 = "0gn8lvpm4i11s5vavlpm162bizjkmh5cb4dhj3p34dlp4vcc4mky";
-      name = "kguiaddons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kguiaddons-5.92.0.tar.xz";
+      sha256 = "0pyzgyrglvz2m11b82rycs9fbmzpfgzabnjkvsq00agjcnjparqg";
+      name = "kguiaddons-5.92.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kholidays-5.91.0.tar.xz";
-      sha256 = "165vfmi5y8l00ng494469w5s1gjnf9zkggqrzmq65dfkdis3amdm";
-      name = "kholidays-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kholidays-5.92.0.tar.xz";
+      sha256 = "042bdg46hkpg66vdp9gk13wck5yhks8s6i9qz9xzh2mikz285lqf";
+      name = "kholidays-5.92.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/khtml-5.91.0.tar.xz";
-      sha256 = "1ldkk1f954mmgz30vqa895z1nw2jaknnb53lsd5vqxzxi3cmc054";
-      name = "khtml-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/khtml-5.92.0.tar.xz";
+      sha256 = "06hpjcm5yrfj1056vvv9dklccd0a1y09zm8ch4a5d8l2lfgdg8ci";
+      name = "khtml-5.92.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/ki18n-5.91.0.tar.xz";
-      sha256 = "11gdd2gvzsz3r8zvqbxxwbpwjvjwnzzhzyrd4spbpdy0w7j8n6ly";
-      name = "ki18n-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/ki18n-5.92.0.tar.xz";
+      sha256 = "0xsp77iaxf72i0ri3pb6x5rrdz3cv8rxcaqcrynisvsmx7l35005";
+      name = "ki18n-5.92.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kiconthemes-5.91.0.tar.xz";
-      sha256 = "1khh4ngivwdj9rxxcpx08ka8anskc9i1z9n2zijp4m5ix8mmj3c2";
-      name = "kiconthemes-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kiconthemes-5.92.0.tar.xz";
+      sha256 = "08yb6f980p620dfklfiyp83lcsqw4dds9qwzd6xpn2mzz07p2a11";
+      name = "kiconthemes-5.92.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kidletime-5.91.0.tar.xz";
-      sha256 = "12qmiwc8p3izj1y5h0rndj2s496ckm1p85dv4g51zbpg7m8a48qv";
-      name = "kidletime-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kidletime-5.92.0.tar.xz";
+      sha256 = "1mw0jarqv2ypxwgf4qaxqlw0sijw0is36sasrfz8grbykwi18bz1";
+      name = "kidletime-5.92.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kimageformats-5.91.0.tar.xz";
-      sha256 = "0df8in33xwajqay487w0hjfsplz8y51w9sjb75na7yqsn75p38xb";
-      name = "kimageformats-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kimageformats-5.92.0.tar.xz";
+      sha256 = "0sd3xhqh3zgy4jq8fc1llqjrxizylbsz58njz2dxqjas2a4rj16f";
+      name = "kimageformats-5.92.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kinit-5.91.0.tar.xz";
-      sha256 = "1y62k24mwzbg4gchvjb8wn6ygq57wc72clb3jgyipw034czdihvi";
-      name = "kinit-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kinit-5.92.0.tar.xz";
+      sha256 = "1kpkqnq9krxlzhripwjhw3n55p5sxqsvj6nb2pqb9m0ppw97jlfb";
+      name = "kinit-5.92.0.tar.xz";
     };
   };
   kio = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kio-5.91.0.tar.xz";
-      sha256 = "14v28qilb5ayv9shw86hb88k60nr4bbd2pa4vwsqij9xkwlympgj";
-      name = "kio-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kio-5.92.0.tar.xz";
+      sha256 = "1cscsjb2v0zygzazfhcflc3gb5ny1a79g3i6glyzw6ppj2c3yhyl";
+      name = "kio-5.92.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kirigami2-5.91.0.tar.xz";
-      sha256 = "0ifljwa6hli2rndfadpzs30dpwc99nnvcm3yi9j5dim2bdf6glwc";
-      name = "kirigami2-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kirigami2-5.92.0.tar.xz";
+      sha256 = "0p1x40p38pr9rvzwil57asgsaa95qpjqi9npwv4pgibhxacgznha";
+      name = "kirigami2-5.92.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kitemmodels-5.91.0.tar.xz";
-      sha256 = "189kgrw2vjr9067mqr4f2sv06xmnjaapry0bf8s41v6r9v7py708";
-      name = "kitemmodels-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kitemmodels-5.92.0.tar.xz";
+      sha256 = "16z8m11cyrapf6m56gmpjmvcgan7s50si8rl1cbbid02src7yp76";
+      name = "kitemmodels-5.92.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kitemviews-5.91.0.tar.xz";
-      sha256 = "16cm4zmv1ngrsmy6k0ybv5wxd0g8cc8zwq6ab7jvs7a04sykv238";
-      name = "kitemviews-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kitemviews-5.92.0.tar.xz";
+      sha256 = "1ml6i1km22xsprldkzmngfh9xs5vdhlfvc6f7aq5hx9q5114v2q5";
+      name = "kitemviews-5.92.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kjobwidgets-5.91.0.tar.xz";
-      sha256 = "14pkyd6j78kignr62xfkvpyi2fwvzcvcsdnn23h8jxkhwm2ri42v";
-      name = "kjobwidgets-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kjobwidgets-5.92.0.tar.xz";
+      sha256 = "09l5zgr5mn29v410ng5rccdg2bki9r6cb8y2lrijzgfxfxpvj96z";
+      name = "kjobwidgets-5.92.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kjs-5.91.0.tar.xz";
-      sha256 = "0jbwlnmf8whzgjkrbnsvdsnn3kv0h44ghf63m2qcgg2l9wb0j8rj";
-      name = "kjs-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kjs-5.92.0.tar.xz";
+      sha256 = "067ilsm78x03kf5fs2xmlasvy2712k0xrsa404g2zj81fm92s1q4";
+      name = "kjs-5.92.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kjsembed-5.91.0.tar.xz";
-      sha256 = "124y7518jhjg3y2x7bcyl6b3c0bfxfbgd2sz6dwk45y4byx7rl60";
-      name = "kjsembed-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kjsembed-5.92.0.tar.xz";
+      sha256 = "0db0r8v0bhp3razwyvmvk9r4psl14vgn23c4cm2q1b5pl0w6bhnp";
+      name = "kjsembed-5.92.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kmediaplayer-5.91.0.tar.xz";
-      sha256 = "0rn9azrj8k1m67y9ni0f3nwl9ldf1ksiqv6dgnzrx6xh0rxfm2h1";
-      name = "kmediaplayer-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kmediaplayer-5.92.0.tar.xz";
+      sha256 = "19lpib2wj91w8shsf9056nwi46qja8nh96hj164ydqlkslpfnf7y";
+      name = "kmediaplayer-5.92.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/knewstuff-5.91.0.tar.xz";
-      sha256 = "0akaxi9klmpwn4pyr6ys5sxcapdspldq1f64im7vd6byzqrgpnax";
-      name = "knewstuff-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/knewstuff-5.92.0.tar.xz";
+      sha256 = "0gvclv1a6xyrqa24svb56kp9zf2wi98as3q30lnwf0bpbpjsw52b";
+      name = "knewstuff-5.92.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/knotifications-5.91.0.tar.xz";
-      sha256 = "1207rimq8si1zxnn827631a1hskrd3m3ilgaj3wj859qrbkqmxzm";
-      name = "knotifications-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/knotifications-5.92.0.tar.xz";
+      sha256 = "1dwlx8w810l0cvy72mj52saf4x7i9p3xpqpjx4chy54n7mg0jklc";
+      name = "knotifications-5.92.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/knotifyconfig-5.91.0.tar.xz";
-      sha256 = "07m5mphd8mrak5sdqlldbcd51946v49xpcwi9fhn7w0kx29hknyf";
-      name = "knotifyconfig-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/knotifyconfig-5.92.0.tar.xz";
+      sha256 = "0fii74r0ap3n08lp9kj7pki0msqjsia2jnmavyps51kq37im5x7p";
+      name = "knotifyconfig-5.92.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kpackage-5.91.0.tar.xz";
-      sha256 = "12w8lfwifa107wlrld3zz774hczn9mkib6wqxw24yxxmzfw9lc2i";
-      name = "kpackage-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kpackage-5.92.0.tar.xz";
+      sha256 = "1av6v0629a8yi0wpl7xgyd0gsn5gi228abdlvbk4dzrx9vxpa7rn";
+      name = "kpackage-5.92.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kparts-5.91.0.tar.xz";
-      sha256 = "10ni6b114acjnmrahvvqw75iqkc10ii97y3z7lirj2727a3qmzzj";
-      name = "kparts-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kparts-5.92.0.tar.xz";
+      sha256 = "061kzss4b0bw67j3mc8h36mbaji077k3alk2ghcir7qix6r1hkh9";
+      name = "kparts-5.92.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kpeople-5.91.0.tar.xz";
-      sha256 = "09l2q8cg9p8g7zkd1mjx6x08bqkr4ykxjibskc184asff7v47gvp";
-      name = "kpeople-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kpeople-5.92.0.tar.xz";
+      sha256 = "0wf555pqiannxb115mlbl43ds1365im95vadsbzv1gdz668p44xk";
+      name = "kpeople-5.92.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kplotting-5.91.0.tar.xz";
-      sha256 = "0rgmmliw9cfi0j2miszqz2kphqm04r5nfs8dqq6pnvclk1k9kss6";
-      name = "kplotting-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kplotting-5.92.0.tar.xz";
+      sha256 = "1l8y0xlwjyv1l4g0mag4bgf906jc654ygky1bribzay4wki66pf9";
+      name = "kplotting-5.92.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kpty-5.91.0.tar.xz";
-      sha256 = "1yy1k96kikvvnlyd00krc08ifiqbrz0x5vwv3pgdbpnwgl8p580d";
-      name = "kpty-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kpty-5.92.0.tar.xz";
+      sha256 = "0lp0bqlg1i0a5vl6gvvkngbsha8ab38z6b3sjvpmk83vixgsq7fb";
+      name = "kpty-5.92.0.tar.xz";
     };
   };
   kquickcharts = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kquickcharts-5.91.0.tar.xz";
-      sha256 = "1ghiymm257b8xgmkibb7s7bwb28x3zhnrgrrsya47q5njb87h0ck";
-      name = "kquickcharts-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kquickcharts-5.92.0.tar.xz";
+      sha256 = "0y467vqx2r6dcyqwn6p7hbg4q7n0xdh4lcqwyin4cdxi14lhwhqs";
+      name = "kquickcharts-5.92.0.tar.xz";
     };
   };
   kross = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kross-5.91.0.tar.xz";
-      sha256 = "06f8220jmvjsfbzjkr2ybwicwjffbi3yw9sr3bcyrilchrrpgqal";
-      name = "kross-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kross-5.92.0.tar.xz";
+      sha256 = "1gqy1h5mqsfgbpqkdrhs7xf77kw4yy19mryda1fwjcqzxd02i7hj";
+      name = "kross-5.92.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/krunner-5.91.0.tar.xz";
-      sha256 = "17iaw55rkzyfpgkbw2an6pa4wid79b0dnb3310vfaq0xkm0gjxq6";
-      name = "krunner-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/krunner-5.92.0.tar.xz";
+      sha256 = "1vcgqjyx9i8k9q4j6q9p4f7sp76aap8gqn2v269lb7imcrfhrj1z";
+      name = "krunner-5.92.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kservice-5.91.0.tar.xz";
-      sha256 = "0m4j7djiyapi1hm23lz9nd238rrlldxlggzkqq056z486v2137bp";
-      name = "kservice-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kservice-5.92.0.tar.xz";
+      sha256 = "1y1fr1galhhi6yf9w9qcvkp1zb63ifvr4wb43jwpvpms9djxkqjj";
+      name = "kservice-5.92.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/ktexteditor-5.91.0.tar.xz";
-      sha256 = "1bkz6v1y5vyxav398a6224ldqa9pqhbad3vmhxrjb2hxcbha2cpm";
-      name = "ktexteditor-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/ktexteditor-5.92.0.tar.xz";
+      sha256 = "137v8g7j8kkv9yh30ysmm5n6imyyd3jmd0f6w5ni00kxl0y1rl5w";
+      name = "ktexteditor-5.92.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/ktextwidgets-5.91.0.tar.xz";
-      sha256 = "0xmzrak5mwg1l4v38g14i7j1yr3j6sj13q2iqa433hs5agl6l6n4";
-      name = "ktextwidgets-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/ktextwidgets-5.92.0.tar.xz";
+      sha256 = "030bz67n6m3fkbldnr48mzicm9cgnr9gdpwipaghl5x5k3s7p1py";
+      name = "ktextwidgets-5.92.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kunitconversion-5.91.0.tar.xz";
-      sha256 = "0n2v0f08s71z2imhn41jkm2knjvk7bkwmcz70gs8h97ykrj6niap";
-      name = "kunitconversion-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kunitconversion-5.92.0.tar.xz";
+      sha256 = "17ph75rg3y652ii0yxm9s8xrbpjs9pdfsrsajm220mi9ng2b9qj7";
+      name = "kunitconversion-5.92.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kwallet-5.91.0.tar.xz";
-      sha256 = "1z1qb6a2b5rqj7js88ms8n67fbs885pw6djbf1l86na2zhf0adip";
-      name = "kwallet-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kwallet-5.92.0.tar.xz";
+      sha256 = "1ra0cxw70vb6pks8sqw5k895rnrfzwxhg6vh4yc5dgzdn1nagb3i";
+      name = "kwallet-5.92.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kwayland-5.91.0.tar.xz";
-      sha256 = "1a03ckacp39lpsqyykkm6lxajxm71s6ifpzgj8q0a37v75jzmz9y";
-      name = "kwayland-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kwayland-5.92.0.tar.xz";
+      sha256 = "15fizsbdl6psmi24fvpfk9dvh61q07irzavpkl961qp4zg79gq4m";
+      name = "kwayland-5.92.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kwidgetsaddons-5.91.0.tar.xz";
-      sha256 = "03pj98sgybkcz487vr774x05w46imnipq2794nkv426nnhyxrd73";
-      name = "kwidgetsaddons-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kwidgetsaddons-5.92.0.tar.xz";
+      sha256 = "0b0z24j162j39zfycl5al69xcqgdsr96p7ii3prm1mbyda6mbqyh";
+      name = "kwidgetsaddons-5.92.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kwindowsystem-5.91.0.tar.xz";
-      sha256 = "1yy02fvfabrsvdpmrkdnjdsdd3d2crxavsl47si6ry8fdxb90y95";
-      name = "kwindowsystem-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kwindowsystem-5.92.0.tar.xz";
+      sha256 = "103xvhzlggi05k16s9kssy7g5a74k9yildj1a4igqwi39wmvvnyw";
+      name = "kwindowsystem-5.92.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/kxmlgui-5.91.0.tar.xz";
-      sha256 = "1qww2isx99lx0mn1dv0vzrvmr2xdp8zgikyvgw1wf8hfay3v2s1g";
-      name = "kxmlgui-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/kxmlgui-5.92.0.tar.xz";
+      sha256 = "0hxpjyjr77q2gyi3hg13119aza3634rvmllbj66pi7y37h6lr2z0";
+      name = "kxmlgui-5.92.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/portingAids/kxmlrpcclient-5.91.0.tar.xz";
-      sha256 = "1bnymf5wq4apjsgshvbhcggdw7jc0yxv4jag3k19ff9820lskhph";
-      name = "kxmlrpcclient-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/portingAids/kxmlrpcclient-5.92.0.tar.xz";
+      sha256 = "1axy34g5ahd1c3qg7ab7h786jibpaj4dvj45x50x5czq06idqchf";
+      name = "kxmlrpcclient-5.92.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/modemmanager-qt-5.91.0.tar.xz";
-      sha256 = "15l46lkh8nkal1nai494dabaysy581jzi8nwrv4kjvc6qwc3yrx2";
-      name = "modemmanager-qt-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/modemmanager-qt-5.92.0.tar.xz";
+      sha256 = "162qzq1aqv2l3bi0r01xrfan20r1zhaaqih4dqbaj7vqibsb9l3y";
+      name = "modemmanager-qt-5.92.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/networkmanager-qt-5.91.0.tar.xz";
-      sha256 = "0f27qin2ks3q7rin53sk9vjjnadjnax99d9k245sjr6fjpczy81f";
-      name = "networkmanager-qt-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/networkmanager-qt-5.92.0.tar.xz";
+      sha256 = "0r7s3fw9fk3pkrzrl1bxsmkf1qbgv3p0jrsskp28f3561vncipai";
+      name = "networkmanager-qt-5.92.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/oxygen-icons5-5.91.0.tar.xz";
-      sha256 = "0j3j2lyxr2iz68vasvpjqkix4bnnj6wc4sr97i6x6z06zq0kawai";
-      name = "oxygen-icons5-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/oxygen-icons5-5.92.0.tar.xz";
+      sha256 = "1wcy8bv4d6jns7vaisbvjc8nxriw9vkiz7j4za5ry7wnvlzv126a";
+      name = "oxygen-icons5-5.92.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/plasma-framework-5.91.0.tar.xz";
-      sha256 = "0ydhhpnwf7lfl3kdjsw92mgsza5gy292f7v6kyby4ygjnir1hizl";
-      name = "plasma-framework-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/plasma-framework-5.92.0.tar.xz";
+      sha256 = "1xq66lyagjsgfashhqgqgqhda0rqfqf0l5yf1gc4ziv48mibrhn6";
+      name = "plasma-framework-5.92.0.tar.xz";
     };
   };
   prison = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/prison-5.91.0.tar.xz";
-      sha256 = "0k1zp3jzh8gjsji6wh5g8k41zdl8s1vd58ipm0lxy670a71wcqcg";
-      name = "prison-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/prison-5.92.0.tar.xz";
+      sha256 = "07p47q8sva82hglfzp145a1sajlal8b3qshhkicc9rkbsngywvvy";
+      name = "prison-5.92.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/purpose-5.91.0.tar.xz";
-      sha256 = "1z6wpz7d9byx4n5zx6chmyy9k1jkmghdgahsvkqsc33z6hnh2b4m";
-      name = "purpose-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/purpose-5.92.0.tar.xz";
+      sha256 = "02j09zf18dwjk17mn841m7cm0qsn7gcz5lff8dad3yah0lc3wqcl";
+      name = "purpose-5.92.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/qqc2-desktop-style-5.91.0.tar.xz";
-      sha256 = "0rd9rvffhif8yckwr7axjcv5iqn5b0jdviij7f9y8vjpkzyjvm8i";
-      name = "qqc2-desktop-style-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/qqc2-desktop-style-5.92.0.tar.xz";
+      sha256 = "1b5xr71lan7ixvd1nfxy9wj21h4wwidsaxa192sha1d8p49hhlwp";
+      name = "qqc2-desktop-style-5.92.0.tar.xz";
     };
   };
   solid = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/solid-5.91.0.tar.xz";
-      sha256 = "1a4k0amyg8mvfr2ld7v8zyphhxv33yybh55vqcshwv4a0jm1wmjg";
-      name = "solid-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/solid-5.92.0.tar.xz";
+      sha256 = "172sid8l1znzxxz0hi5m19yy4vg7l1nbghvzjvh18ssbmxcwh9l9";
+      name = "solid-5.92.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/sonnet-5.91.0.tar.xz";
-      sha256 = "067xj5mllpzl0gnxxljhfi9y4xdgrpqbckm7pykczzqrklrrx8dx";
-      name = "sonnet-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/sonnet-5.92.0.tar.xz";
+      sha256 = "08jps1hy0qvk62wnzn50qi8iaay7xav3hbcj55sk70mm7pd1vz1i";
+      name = "sonnet-5.92.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/syndication-5.91.0.tar.xz";
-      sha256 = "1f2kb6mh1xc1k1bn536lq9gq0j2lb65qw4vpp4ixynlfij4zq1gy";
-      name = "syndication-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/syndication-5.92.0.tar.xz";
+      sha256 = "0ijxpnsygwzzybic5lp8gfq57y84vrp3bq7vdbjh3h0345vvk6hw";
+      name = "syndication-5.92.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/syntax-highlighting-5.91.0.tar.xz";
-      sha256 = "0fprqi2z8issh3jkql6labszkwd3cpvd6qadsg9fi46vfjr4a2ip";
-      name = "syntax-highlighting-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/syntax-highlighting-5.92.0.tar.xz";
+      sha256 = "03p5qzf13nbf54gzad3q1q6i33iggz3ik0ydr9szhj92kfppwd4r";
+      name = "syntax-highlighting-5.92.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.91.0";
+    version = "5.92.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.91/threadweaver-5.91.0.tar.xz";
-      sha256 = "1900kqglkwzkjc24mvl0j7jf7xcx6cr6b1g78s5b5m18rw050j12";
-      name = "threadweaver-5.91.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.92/threadweaver-5.92.0.tar.xz";
+      sha256 = "008in2wbl6zr404m9hbqdvy3d4r06mmb3jrr13myldwljqywzc28";
+      name = "threadweaver-5.92.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes
Bump [KDE Frameworks (kf5) to version 5.92, released in 12 March 2022](https://kde.org/announcements/frameworks/5/5.92.0/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
