### PR TITLE
x86info: 1.30 -> unstable-2021-08-07

### DIFF
--- a/pkgs/os-specific/linux/x86info/default.nix
+++ b/pkgs/os-specific/linux/x86info/default.nix
@@ -1,32 +1,45 @@
-{lib, stdenv, fetchurl, pciutils, python2}:
+{ lib
+, stdenv
+, fetchFromGitHub
+, pciutils
+, pkg-config
+, python3
+}:
 
 stdenv.mkDerivation rec {
-  version = "1.30";
   pname = "x86info";
+  version = "unstable-2021-08-07";
 
-  src = fetchurl {
-    url = "http://codemonkey.org.uk/projects/x86info/${pname}-${version}.tgz";
-    sha256 = "0a4lzka46nabpsrg3n7akwr46q38f96zfszd73xcback1s2hjc7y";
+  src = fetchFromGitHub {
+    owner = "kernelslacker";
+    repo = pname;
+    rev = "061ea35ecb0697761b6260998fa2045b8bb0be68";
+    hash = "sha256-/qWioC4dV1bQkU4SiTR8duYqoGIMIH7s8vuAXi75juo=";
   };
 
-  preConfigure = ''
-    patchShebangs .
+  nativeBuildInputs = [
+    pkg-config
+    python3
+  ];
 
-    # ignore warnings
-    sed -i 's/-Werror -Wall//' Makefile
+  buildInputs = [
+    pciutils
+  ];
+
+  postBuild = ''
+    patchShebangs lsmsr/createheader.py
+    make -C lsmsr
   '';
-
-  buildInputs = [ pciutils python2 ];
 
   installPhase = ''
     mkdir -p $out/bin
-    cp x86info lsmsr $out/bin
+    cp x86info $out/bin
+    cp lsmsr/lsmsr $out/bin
   '';
 
   meta = {
     description = "Identification utility for the x86 series of processors";
-    longDescription =
-    ''
+    longDescription = ''
       x86info will identify all Intel/AMD/Centaur/Cyrix/VIA CPUs. It leverages
       the cpuid kernel module where possible.  it supports parsing model specific
       registers (MSRs) via the msr kernel module.  it will approximate processor
@@ -34,7 +47,7 @@ stdenv.mkDerivation rec {
     '';
     platforms = [ "i686-linux" "x86_64-linux" ];
     license = lib.licenses.gpl2;
-    homepage = "http://codemonkey.org.uk/projects/x86info/";
-    maintainers = with lib.maintainers; [jcumming];
+    homepage = "https://github.com/kernelslacker/x86info";
+    maintainers = with lib.maintainers; [ jcumming ];
   };
 }


### PR DESCRIPTION
###### Description of changes
Update source location, homepage. Should remove another python2 dep. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
