### PR TITLE
fwup: fix darwin #165167 by removing unused dependencies

### DIFF
--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     coreutils
     unzip
     zip
-  ] ++ lib.optionals (!stdenv.isDarwin) [
+  ] ++ lib.optionals doCheck [
     mtools
     dosfstools
   ];

--- a/pkgs/tools/misc/fwup/default.nix
+++ b/pkgs/tools/misc/fwup/default.nix
@@ -48,10 +48,11 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [
     coreutils
-    dosfstools
-    mtools
     unzip
     zip
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    mtools
+    dosfstools
   ];
 
   checkInputs = [


### PR DESCRIPTION
###### Description of changes
    fwup: fix darwin #165167 by removing unused dependencies

    This change removes the mtools and dosfstools dependencies for darwin. These
    dependencies are only needed when check is enabled which is disabled for
    darwin. Currently mtools and dosfstools fail to build for aarch64-darwin.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@georgewhewell
