### PR TITLE
tree-sitter: update grammars

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-clojure.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/sogaiu/tree-sitter-clojure",
-  "rev": "39bf0977d223879436c1425fe6bfeb3bcfd86f92",
-  "date": "2021-08-15T13:16:31+09:00",
-  "path": "/nix/store/7kpf74gw4a68fby6jiw4n7lc4jfkgcf4-tree-sitter-clojure",
-  "sha256": "0ryj75znysvyvv4qaghygx1srrhlwhfmzmdilm652prkgj6yzh6b",
+  "rev": "1b24766fe9feacb8f5006233fe5c2ebd0ba31eff",
+  "date": "2022-02-19T08:24:15+09:00",
+  "path": "/nix/store/1vxhbw0dxg95z8rbs1b96nrcjvhrhb52-tree-sitter-clojure",
+  "sha256": "0sqi825gyjndn3v00kvk9scw6s5q0lr3ig6v49sccqc2addnr6di",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cpp.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-cpp",
-  "rev": "656d7ea44b2b0daece78791e30281e283f30001e",
-  "date": "2022-01-17T09:06:11-06:00",
-  "path": "/nix/store/w4qqya24zf0cd7rqw1440szrrad8nf23-tree-sitter-cpp",
-  "sha256": "0vfgv9rw8pw4d41p5rndy7cjw8w0k0vnn54cwpxkm3r2vblnjn58",
+  "rev": "a832195eb3685a279856bb480ce19cff19554b6d",
+  "date": "2022-03-14T15:34:21-05:00",
+  "path": "/nix/store/ixca3nass3hkf0pycf7zhz15h2yq11sk-tree-sitter-cpp",
+  "sha256": "1y0i3w21zg8khns97wy5wpw57bhni4c8faszaz9qb0nrgarbf3i6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-cuda.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/thehamsta/tree-sitter-cuda",
-  "rev": "14cd86e18ba45e327017de5b3e0f8d8f7f8e98ec",
-  "date": "2022-01-24T00:39:28+01:00",
-  "path": "/nix/store/3lskjrhqd16ymvsbrwzcsdd80cyr7ljj-tree-sitter-cuda",
-  "sha256": "09qpl5mfv39788smz87zbzp04i3rdhsckjjqngvr0w24dsw30nyx",
+  "rev": "5178a7a5b25dc7ee4a69bf72f31bd6d3ff0a0795",
+  "date": "2022-03-16T21:48:20+01:00",
+  "path": "/nix/store/gd5s063qfyas370a9rd8mn9wc9d68s15-tree-sitter-cuda",
+  "sha256": "17zqpd27b09izpp9lvkgc1hcnq5nc58i98pak0qi46z85r6zgp6g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dockerfile.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/camdencheek/tree-sitter-dockerfile",
-  "rev": "7af32bc04a66ab196f5b9f92ac471f29372ae2ce",
-  "date": "2021-12-16T07:47:57-07:00",
-  "path": "/nix/store/gh1pnracilf89q9z5czqr4z7lkd480xb-tree-sitter-dockerfile",
-  "sha256": "06hy683mrp1jcg2ypd6msbmv0pm2z85y8nqxgrnbr9vbi6syvmp5",
+  "rev": "d34a0cebd094e830bdd2106a28cb2f1fb22401d8",
+  "date": "2022-01-27T11:20:14-07:00",
+  "path": "/nix/store/3whf6fv79zqk5w0d6jbzfgs5jzm4cll4-tree-sitter-dockerfile",
+  "sha256": "0kf4c4xs5naj8lpcmr3pbdvwj526wl9p6zphxxpimbll7qv6qfnd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-dot.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/rydesun/tree-sitter-dot",
-  "rev": "92877bac7033e409ccfb3f07fe28ef1dfd359457",
-  "date": "2021-10-13T19:28:51+08:00",
-  "path": "/nix/store/h3dyw3kcgw77lma750wjgr1n8pjllxn6-tree-sitter-dot",
-  "sha256": "1l8g348nqqil7lygkhzw1ydwf3q2m5786qddp1f9jg1bdrv9p8rl",
+  "rev": "917230743aa10f45a408fea2ddb54bbbf5fbe7b7",
+  "date": "2022-03-11T21:17:49+08:00",
+  "path": "/nix/store/3xvainpyzwpbhbm30mmvvgxpgh4agljh-tree-sitter-dot",
+  "sha256": "1q2rbv16dihlmrbxlpn0x03na7xp8rdhf58vwm3lryn3nfcjckn2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-elixir.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/elixir-lang/tree-sitter-elixir",
-  "rev": "de20391afe5cb03ef1e8a8e43167e7b58cc52869",
-  "date": "2022-01-10T10:35:12-06:00",
-  "path": "/nix/store/099pwd7iv86g1j4fplgq33a4jpwbvv60-tree-sitter-elixir",
-  "sha256": "0zrkrwhw3g1vazsxcwrfd1fk4wvs9hdwmwp6073mfh370bz4140h",
+  "rev": "b4027d7cfc96935b50878bdf9faf80bd64ac73cf",
+  "date": "2022-03-04T15:40:04+00:00",
+  "path": "/nix/store/h3qh2s4q51bnq66p1v067g1fb8bd1743-tree-sitter-elixir",
+  "sha256": "1pf2n1j8j5w7mrh81yzvha1gh4w3vffngikj04kzd5gkx9asf3x6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-erlang.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/abstractmachineslab/tree-sitter-erlang",
-  "rev": "9d5fd0c329280a156bf7614a49dc5e8c58cc037c",
-  "date": "2021-08-03T11:57:52+02:00",
-  "path": "/nix/store/35ydhh12dgf4q016gjka35wnqnkwc1jg-tree-sitter-erlang",
-  "sha256": "0d6wl95wgys21vcix6j0bf7l000glkmk1n6shgcnp4baw9wxh009",
+  "rev": "fab680273af1a8f5cc0c3a0c62cbf5b1bea71f39",
+  "date": "2022-03-05T23:18:36+01:00",
+  "path": "/nix/store/vj28kyy3jg21qicwxq2g1ysrwfqd3mz9-tree-sitter-erlang",
+  "sha256": "0shzzik8yxwb76kxs3l0fccjwvkarck1q4wqyv5hdma6hwl52b69",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fennel.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/travonted/tree-sitter-fennel",
-  "rev": "fce4331731a960077ff5f98939bc675179f1908a",
-  "date": "2021-09-30T09:09:52-04:00",
-  "path": "/nix/store/mhpkw4gl6lzi306q21kckafqcdc0a715-tree-sitter-fennel",
-  "sha256": "1k8acyav26248liz0psk2r9dl7472mqgdyrjwg3pfxx94jgqjcik",
+  "rev": "d37fd84a702b78ff0282f223ece83c61ab062a6e",
+  "date": "2022-02-21T08:13:28-05:00",
+  "path": "/nix/store/lafx5rw9r9jp9056sv0sk89kxfjlb9x3-tree-sitter-fennel",
+  "sha256": "1wqvz8v877jh7shv50xbnx1bxvdlnfnpmndwzsb0smidnzx7lbw2",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-fish.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ram02z/tree-sitter-fish",
-  "rev": "04e54ab6585dfd4fee6ddfe5849af56f101b6d4f",
-  "date": "2021-08-02T21:46:56+01:00",
-  "path": "/nix/store/0n3jfh7gk16bmikix34y5m534ac12xgc-tree-sitter-fish",
-  "sha256": "1810z8ah1b09qpxcr4bh63bxsnxx24r6d2h46v2cpqv1lg0g4z14",
+  "rev": "d482d70ea8e191c05b2c1b613ed6fdff30a14da0",
+  "date": "2022-03-14T15:15:13+00:00",
+  "path": "/nix/store/5ajcf2hl1hph7iky6lwp5vh7a49k587s-tree-sitter-fish",
+  "sha256": "0idnm9lrvj1jhrvrgcddppkc09hr7inciz6k02d0nnxv8pqaw3w6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-haskell",
-  "rev": "d6ccd2d9c40bdec29fee0027ef04fe5ff1ae4ceb",
-  "date": "2022-01-07T03:13:04+01:00",
-  "path": "/nix/store/biyjfajma7nr175xviaw65jksqfak893-tree-sitter-haskell",
-  "sha256": "0zfxi3adqhy7d1w2dvnywkms8a4vfxkjswdhar7p5sxyps8a5wry",
+  "rev": "ed976b81b00ce7b72b99bca75e7a616cc526220c",
+  "date": "2022-03-20T00:05:14+01:00",
+  "path": "/nix/store/wzkfkix4q3vcrlsj2v4q32ihw0vdp1li-tree-sitter-haskell",
+  "sha256": "19g5f59gh6s4xpphrppmrqlh0nfld0q8zffy85pkby4gd6xh73zm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-java.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-java",
-  "rev": "a24ae7d16de3517bff243a87d087d0b4877a65c5",
-  "date": "2022-01-12T08:57:59-08:00",
-  "path": "/nix/store/dipis7syj55xrmc72gvx2f9q672mn6dg-tree-sitter-java",
-  "sha256": "0p01xkxzdjwx32hd6k4kqidlhkgj8q9b9lp4g4fra5gx9w159iqm",
+  "rev": "881b84fe7078651af5077cc4cea4c85f9fddde3b",
+  "date": "2022-03-21T10:50:51+01:00",
+  "path": "/nix/store/ii1dwsg972sbllim6vrmjbcaw9fcy2b1-tree-sitter-java",
+  "sha256": "0kvqqrx669fyaxm55l0p5vbswf9bfknl0brsr6llyzdz81dl0vk4",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-latex.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/latex-lsp/tree-sitter-latex",
-  "rev": "323b609de40b7729073482a3c59de76cfba7744f",
-  "date": "2022-02-08T21:23:53+01:00",
-  "path": "/nix/store/f6kvr0x41rbb64s36ii6bj30fqaallz4-tree-sitter-latex",
-  "sha256": "1qsw5wcqs65ip0qq17vq6bf2snnpvw61iq2ahgwl9842ir15hrbr",
+  "rev": "b71e4928a63a6d75bc1670004a5b5a98c850a149",
+  "date": "2022-03-16T20:19:11+01:00",
+  "path": "/nix/store/gzpihd6k8cqsl0facz7kfgn2dh294fxw-tree-sitter-latex",
+  "sha256": "1z2ywj57fpxaym6bv5ixvc01h8szazbhzmzzw960f49mlrima3n6",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-markdown.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/MDeiml/tree-sitter-markdown",
-  "rev": "8bee14c30ecadd55c2d65633973b4e81f93525e0",
-  "date": "2022-01-16T14:47:09+01:00",
-  "path": "/nix/store/cv7xqvcj4bjifzddkx5n2jd723dc6vlf-tree-sitter-markdown",
-  "sha256": "0vibmpp86pkqllfhb0kg6zhaz09sh8m6a2d1xa8p2qdi7ryy7wqa",
+  "rev": "b49b2da50864171eff56acc8ba067c3540a3991f",
+  "date": "2022-02-26T15:22:17+01:00",
+  "path": "/nix/store/vllxsz0nvlw6z9y6s199l5z8f5dlhcpv-tree-sitter-markdown",
+  "sha256": "1adypmkfsf6pgahba588d8l6ib59209rb2fkyk2dv0d3va76pr8x",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-nix.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/cstrahan/tree-sitter-nix",
-  "rev": "6d6aaa50793b8265b6a8b6628577a0083d3b923d",
-  "date": "2021-11-29T00:27:21-06:00",
-  "path": "/nix/store/6cjadxvqbrh205lsqnk2rnzq3badxdxv-tree-sitter-nix",
-  "sha256": "0cbk6dqppasrvnm87pwfgm718z6b0xmy9m7zj8ysil0h8bklz1w9",
+  "rev": "470b15a60520ff7b86f51732b8d8f1118c86041e",
+  "date": "2022-03-18T01:42:08-05:00",
+  "path": "/nix/store/c5y76kz7wmfq05hfw4xpqz2ahcdy924f-tree-sitter-nix",
+  "sha256": "1hl0mpy0i6r160v6v3nflrdi5fnmd8i5zbx963h5nj9fg4srkb5r",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-norg.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nvim-neorg/tree-sitter-norg",
-  "rev": "b7f879eaf9f20852f6b670439154b0128fbb6558",
-  "date": "2022-02-08T12:24:02+01:00",
-  "path": "/nix/store/q02py98zm9cmalzc5a0yqw8lg73ybx9g-tree-sitter-norg",
-  "sha256": "07hm5sysb25ivlz52ijnbka02hlqksha259w7v03awap85i9ydk6",
+  "rev": "17d61df817c1e0a9cdef8d915d4e4c556b7cf68c",
+  "date": "2022-03-16T16:23:43+01:00",
+  "path": "/nix/store/xjsyabq06584fnwjvqbyqf6yd19i4gn9-tree-sitter-norg",
+  "sha256": "161pmkpfyfhf4lcgkzcl1wdi4bsmmpwxcz7kjcb0jpjy7bamikch",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-perl.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/ganezdragon/tree-sitter-perl",
-  "rev": "ab2b39439f2fc82fd5ea0b7e08509760d4cbacd5",
-  "date": "2022-01-23T13:55:11-05:00",
-  "path": "/nix/store/s55aybm3r5n7l7nx916mhjyry96xcvin-tree-sitter-perl",
-  "sha256": "16ap0yq9gmh0kbyka7zcpjw3dl368n23sxp3v82z4ccwzmgfmaw4",
+  "rev": "bbf86084d9b7eb4768f3fb9fe094b3e0600057b1",
+  "date": "2022-02-26T01:42:56+05:30",
+  "path": "/nix/store/cpsi8sjl3d1v5sg2rcsw3arf7zwm4l06-tree-sitter-perl",
+  "sha256": "037kdl6kq47p35qd3p6j4560x6w24zzmjxnz2fkd28xrm0lsh9lm",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-prisma.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/victorhqc/tree-sitter-prisma",
-  "rev": "74a721e8eed1a4a25cf495d45974ba24f315f81a",
-  "date": "2021-11-19T19:52:32+01:00",
-  "path": "/nix/store/rbr2p57ic1kn0121ca6k0bh2r8svw066-tree-sitter-prisma",
-  "sha256": "1b8yil6v9jz9ndx2kzln639fkjkj1xb0qfcip1njxcq5mlqlfswd",
+  "rev": "bf0833cbedb2c5b39250f5ba900f1239a16c6749",
+  "date": "2022-03-18T18:56:29+01:00",
+  "path": "/nix/store/9pq2l5b34xvi3v6i9zq1qxh3r2ilg2qs-tree-sitter-prisma",
+  "sha256": "0idgrra41w4v3sa4sb0p3ba7k6sxfw74px4fkpprddjqjdnsrl50",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-rust.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/tree-sitter/tree-sitter-rust",
-  "rev": "a250c4582510ff34767ec3b7dcdd3c24e8c8aa68",
-  "date": "2022-02-04T13:11:35-08:00",
-  "path": "/nix/store/i1f2zyrqghy98pl7dfnvcpbs3jsnmhay-tree-sitter-rust",
-  "sha256": "174j5pxwf80c4xniri39l3a6bb7nq96g2s8hh5sgv4i7xvbpfsmg",
+  "rev": "0509e440ae042db6483984b3a56b3c5f24b5d9b9",
+  "date": "2022-03-09T12:11:47+01:00",
+  "path": "/nix/store/9jrsqsrql5wlbzmqna111w4a02hf75z2-tree-sitter-rust",
+  "sha256": "1r8n8441b8bppizlzh4xw7yy3amz4apfxpqxm8hw0n3j3iwnw4pz",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-vim.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/vigoux/tree-sitter-viml",
-  "rev": "bc573ef552adf8bed9e36eb687a0cccf43158634",
-  "date": "2022-01-24T16:13:56+01:00",
-  "path": "/nix/store/2i9n2fvjk0ymxv32ziq5z9ykv95svi7d-tree-sitter-viml",
-  "sha256": "0ckx9jh9fqfw5x9yb0sljczb0xsgxs8j6v2qbqywh5z6fcqx8sjc",
+  "rev": "c9d70082af14988842eb071c6c0b07e8d1d993ac",
+  "date": "2022-03-21T17:11:25+01:00",
+  "path": "/nix/store/z1bjg25frb0sq7kr0s3sp6jnz888p900-tree-sitter-viml",
+  "sha256": "05mf8i5ni0kp4g1gdpgwjxi2d86hna2ijp9k7c1gy9j33hsq9i8g",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/tree-sitter-zig.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/maxxnino/tree-sitter-zig",
-  "rev": "93331b8bd8b4ebee2b575490b2758f16ad4e9f30",
-  "date": "2022-01-10T15:22:15+09:00",
-  "path": "/nix/store/g54w7vid7nf9shzfipch646dk4d88ah7-tree-sitter-zig",
-  "sha256": "0irckd6bh3i1vr5bi2lwsbvibbpih3jv3xqdq0dbsiy447dfiv50",
+  "rev": "42e93d02ca945094699e2dc4de785bbaf8f740ec",
+  "date": "2022-02-11T10:40:42+09:00",
+  "path": "/nix/store/2yv27si133zqb93bm9gia0ymib9q2y75-tree-sitter-zig",
+  "sha256": "14p02b04v67cvkvj7apipsmkmvv3jnhykm0qrrmqqxnkprac31im",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
