### PR TITLE
ablog: init at 0.10.23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10398,6 +10398,12 @@
     githubId = 811827;
     name = "Gabriel Lievano";
   };
+  rgrinberg = {
+    name = "Rudi Grinberg";
+    email = "me@rgrinberg.com";
+    github = "rgrinberg";
+    githubId = 139003;
+  };
   rgrunbla = {
     email = "remy@grunblatt.org";
     github = "rgrunbla";

--- a/pkgs/applications/misc/ablog/default.nix
+++ b/pkgs/applications/misc/ablog/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, python3
+}:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "ablog";
+  version = "0.10.23";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-fqqB17dNzcDZmFw3nj85T5zvMzY6SN/JxbB3IASOas8=";
+  };
+
+  propagatedBuildInputs = [
+    feedgen
+    sphinx
+    invoke
+    watchdog
+    python-dateutil
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  nativeBuildInputs = [ setuptools-scm ];
+
+  meta = with lib; {
+    description = "ABlog for blogging with Sphinx";
+    homepage = "https://ablog.readthedocs.io/en/latest/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rgrinberg ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -914,6 +914,8 @@ with pkgs;
 
   abduco = callPackage ../tools/misc/abduco { };
 
+  ablog = callPackage ../applications/misc/ablog { };
+
   acct = callPackage ../tools/system/acct { };
 
   accuraterip-checksum = callPackage ../tools/audio/accuraterip-checksum { };


### PR DESCRIPTION
###### Description of changes

Introduce the package [ablog](https://ablog.readthedocs.io/en/latest/). Blogging software based on sphinx.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
