### PR TITLE
goldberg-emu: init at 0.2.5

### DIFF
--- a/pkgs/applications/emulators/goldberg-emu/default.nix
+++ b/pkgs/applications/emulators/goldberg-emu/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, cmake
+, protobuf
+ }:
+
+stdenv.mkDerivation rec {
+  pname = "goldberg-emu";
+  version = "0.2.5";
+
+  src = fetchFromGitLab {
+    owner = "mr_goldberg";
+    repo = "goldberg_emulator";
+    rev = version;
+    sha256 = "sha256-goOgMNjtDmIKOAv9sZwnPOY0WqTN90LFJ5iEp3Vkzog=";
+  };
+
+  # It attempts to install windows-only libraries which we never build
+  patches = [ ./dont-install-unsupported.patch ];
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ protobuf ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/share/goldberg"
+  ];
+
+  preFixup = ''
+    mkdir -p $out/{bin,lib}
+    chmod +x $out/share/goldberg/tools/find_interfaces.sh
+
+    ln -s $out/share/goldberg/libsteam_api.so $out/lib
+    ln -s $out/share/goldberg/lobby_connect/lobby_connect $out/bin
+    ln -s $out/share/goldberg/tools/generate_interfaces_file $out/bin
+    ln -s $out/share/goldberg/tools/find_interfaces.sh $out/bin/find_interfaces
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/Mr_Goldberg/goldberg_emulator";
+    changelog = "https://gitlab.com/Mr_Goldberg/goldberg_emulator/-/releases";
+    description = "Program that emulates steam online features";
+    longDescription = ''
+      Steam emulator that emulates steam online features. Lets you play games that
+      use the steam multiplayer apis on a LAN without steam or an internet connection.
+    '';
+    mainProgram = "lobby_connect";
+    license = licenses.lgpl3Only;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.ivar ];
+  };
+}

--- a/pkgs/applications/emulators/goldberg-emu/dont-install-unsupported.patch
+++ b/pkgs/applications/emulators/goldberg-emu/dont-install-unsupported.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index abaace2..5e3465c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -182,10 +182,10 @@ if(WIN32)
+     RUNTIME DESTINATION ./
+   )
+ else()
+-	install(TARGETS
+-    ${LIB_STEAMCLIENT}
+-    LIBRARY DESTINATION ./
+-  )
++    #    install(TARGETS
++    #${LIB_STEAMCLIENT}
++    #LIBRARY DESTINATION ./
++    #)
+ endif()
+ 
+ if(NOT WIN32)
+@@ -220,10 +220,10 @@ if(WIN32)
+     RUNTIME DESTINATION ./
+   )
+ else()
+-	install(TARGETS
+-    ${LIB_STEAMNETWORKINGSOCKETS}
+-    LIBRARY DESTINATION ./
+-  )
++    #	install(TARGETS
++    #    ${LIB_STEAMNETWORKINGSOCKETS}
++    #    LIBRARY DESTINATION ./
++    #  )
+ endif()
+ 
+ if(NOT WIN32)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25835,6 +25835,8 @@ with pkgs;
     tuigreet = callPackage ../os-specific/linux/tuigreet { };
   };
 
+  goldberg-emu = callPackage ../applications/emulators/goldberg-emu { };
+
   goldendict = libsForQt5.callPackage ../applications/misc/goldendict {
     inherit (darwin) libiconv;
   };


### PR DESCRIPTION
###### Description of changes
This adds [goldberg-emu](https://gitlab.com/Mr_Goldberg/goldberg_emulator), a program that emulates steam online features. Useful for using the steam multiplayer apis without steam.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and “core” functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
