### PR TITLE
nixos/syncoid: don't delegate permissions to source's parent

### DIFF
--- a/nixos/modules/services/backup/syncoid.nix
+++ b/nixos/modules/services/backup/syncoid.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.services.syncoid;
 
-  # Extract local dasaset names (so no datasets containing "@")
+  # Extract local dataset names (so no datasets containing "@")
   localDatasetName =
     d:
     lib.optionals (d != null) (
@@ -24,75 +24,74 @@ let
       builtins.split "[^a-zA-Z0-9_.\\-]+" name
     );
 
-  # Function to build "zfs allow" commands for the filesystems we've delegated
-  # permissions to. It also checks if the target dataset exists before
-  # delegating permissions, if it doesn't exist we delegate it to the parent
-  # dataset (if it exists). This should solve the case of provisoning new
-  # datasets.
   buildAllowCommand =
+    action: permissions: dataset:
+    lib.escapeShellArgs [
+      "zfs"
+      action
+      cfg.user
+      (lib.concatStringsSep "," permissions)
+      dataset
+    ];
+
+  # Function to build "zfs allow" commands to allow syncoid to access the
+  # source dataset.
+  buildSourceAllowScript =
     permissions: dataset:
     (
       "-+${pkgs.writeShellScript "zfs-allow-${dataset}" ''
-        # Here we explicitly use the booted system to guarantee the stable API needed by ZFS
+        ${buildAllowCommand "allow" permissions dataset}
+      ''}"
+    );
 
+  # Function to build "zfs unallow" commands to remove delegated permissions
+  # from the source dataset.
+  buildSourceUnallowScript =
+    permissions: dataset:
+    (
+      "-+${pkgs.writeShellScript "zfs-unallow-${dataset}" ''
+        ${buildAllowCommand "unallow" permissions dataset}
+      ''}"
+    );
+
+  # Function to build "zfs allow" commands for the target dataset we've
+  # delegated permissions to. It also checks if the target dataset
+  # exists before delegating permissions, if it doesn't exist we
+  # delegate it to the parent dataset. This should solve the case of
+  # provisoning new datasets.
+  buildTargetAllowScript =
+    permissions: dataset:
+    (
+      "-+${pkgs.writeShellScript "zfs-allow-${dataset}" ''
         # Run a ZFS list on the dataset to check if it exists
         if ${
           lib.escapeShellArgs [
-            "/run/booted-system/sw/bin/zfs"
+            "zfs"
             "list"
             dataset
           ]
         } 2> /dev/null; then
-          ${lib.escapeShellArgs [
-            "/run/booted-system/sw/bin/zfs"
-            "allow"
-            cfg.user
-            (lib.concatStringsSep "," permissions)
-            dataset
-          ]}
-        ${lib.optionalString ((builtins.dirOf dataset) != ".") ''
-          else
-            ${lib.escapeShellArgs [
-              "/run/booted-system/sw/bin/zfs"
-              "allow"
-              cfg.user
-              (lib.concatStringsSep "," permissions)
-              # Remove the last part of the path
-              (builtins.dirOf dataset)
-            ]}
-        ''}
+          ${buildAllowCommand "allow" permissions dataset}
+        else
+          # Remove the last part of the path
+          ${buildAllowCommand "allow" permissions (builtins.dirOf dataset)}
         fi
       ''}"
     );
 
-  # Function to build "zfs unallow" commands for the filesystems we've
+  # Function to build "zfs unallow" commands for the target datasets we've
   # delegated permissions to. Here we unallow both the target but also
   # on the parent dataset because at this stage we have no way of
   # knowing if the allow command did execute on the parent dataset or
   # not in the pre-hook. We can't run the same if in the post hook
   # since the dataset should have been created at this point.
-  buildUnallowCommand =
+  buildTargetUnallowScript =
     permissions: dataset:
     (
       "-+${pkgs.writeShellScript "zfs-unallow-${dataset}" ''
-        # Here we explicitly use the booted system to guarantee the stable API needed by ZFS
-        ${lib.escapeShellArgs [
-          "/run/booted-system/sw/bin/zfs"
-          "unallow"
-          cfg.user
-          (lib.concatStringsSep "," permissions)
-          dataset
-        ]}
-        ${lib.optionalString ((builtins.dirOf dataset) != ".") (
-          lib.escapeShellArgs [
-            "/run/booted-system/sw/bin/zfs"
-            "unallow"
-            cfg.user
-            (lib.concatStringsSep "," permissions)
-            # Remove the last part of the path
-            (builtins.dirOf dataset)
-          ]
-        )}
+        ${buildAllowCommand "unallow" permissions dataset}
+        # Remove the last part of the path
+        ${buildAllowCommand "unallow" permissions (builtins.dirOf dataset)}
       ''}"
     );
 in
@@ -362,15 +361,16 @@ in
             description = "Syncoid ZFS synchronization from ${c.source} to ${c.target}";
             after = [ "zfs.target" ];
             startAt = cfg.interval;
+            # Explicitly use the booted system to guarantee the stable API needed by ZFS
             # syncoid may need zpool to get feature@extensible_dataset
-            path = [ "/run/booted-system/sw/bin/" ];
+            path = [ "/run/booted-system/sw" ];
             serviceConfig = {
               ExecStartPre =
-                (map (buildAllowCommand c.localSourceAllow) (localDatasetName c.source))
-                ++ (map (buildAllowCommand c.localTargetAllow) (localDatasetName c.target));
+                (map (buildSourceAllowScript c.localSourceAllow) (localDatasetName c.source))
+                ++ (map (buildTargetAllowScript c.localTargetAllow) (localDatasetName c.target));
               ExecStopPost =
-                (map (buildUnallowCommand c.localSourceAllow) (localDatasetName c.source))
-                ++ (map (buildUnallowCommand c.localTargetAllow) (localDatasetName c.target));
+                (map (buildSourceUnallowScript c.localSourceAllow) (localDatasetName c.source))
+                ++ (map (buildTargetUnallowScript c.localTargetAllow) (localDatasetName c.target));
               ExecStart = lib.escapeShellArgs (
                 [ "${cfg.package}/bin/syncoid" ]
                 ++ lib.optionals c.useCommonArgs cfg.commonArgs


### PR DESCRIPTION
###### Description of changes

The source dataset may be an entire pool, which doesn't have a parent. This causes `builtins.dirOf` to return `.`, which ZFS doesn't like. The source dataset must always exist, so there is no reason to worry about delegating to its parent. On the other hand, the target dataset must not be the pool root, so it will always have a parent.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
