### PR TITLE
tonelib-metal: init at 1.1.0

### DIFF
--- a/pkgs/applications/audio/tonelib-metal/default.nix
+++ b/pkgs/applications/audio/tonelib-metal/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, alsa-lib
+, freetype
+, libglvnd
+, mesa
+, curl
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libjack2
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tonelib-metal";
+  version = "1.1.0";
+
+  src = fetchurl {
+    url = "https://www.tonelib.net/download/220218/ToneLib-Metal-amd64.deb";
+    sha256 = "sha256-F5EKwNQ9f/kdZLFI+QDZHvwevV/vDnxMdSmT/vnX6ug=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook dpkg ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    alsa-lib
+    freetype
+    libglvnd
+    mesa
+  ] ++ runtimeDependencies;
+
+  runtimeDependencies = map lib.getLib [
+    curl
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libjack2
+  ];
+
+  unpackCmd = "dpkg -x $curSrc source";
+
+  installPhase = ''
+    mv usr $out
+    substituteInPlace $out/share/applications/ToneLib-Metal.desktop --replace /usr/ $out/
+ '';
+
+  meta = with lib; {
+    description = "ToneLib Metal – Guitar amp simulator targeted at metal players";
+    homepage = "https://tonelib.net/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ dan4ik605743 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29342,6 +29342,8 @@ with pkgs;
 
   tonelib-zoom = callPackage ../applications/audio/tonelib-zoom { };
 
+  tonelib-metal = callPackage ../applications/audio/tonelib-metal { };
+
   tony = libsForQt514.callPackage ../applications/audio/tony { };
 
   toot = callPackage ../applications/misc/toot { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
