### PR TITLE
arc-theme: 20211018 -> 20220223

### DIFF
--- a/pkgs/data/themes/arc/default.nix
+++ b/pkgs/data/themes/arc/default.nix
@@ -3,36 +3,33 @@
 , sassc
 , meson
 , ninja
-, pkg-config
-, gtk3
 , glib
 , gnome
 , gtk-engine-murrine
-, optipng
 , inkscape
 , cinnamon
+, makeFontsConf
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "arc-theme";
-  version = "20211018";
+  version = "20220223";
 
   src = fetchFromGitHub {
     owner = "jnsh";
     repo = pname;
     rev = version;
-    sha256 = "1rrxm5b7l8kq1h0lm08ck54xljzm8w573mxx904n3rhdg3ri9d63";
+    sha256 = "sha256-qsZdXDNxT1/gIlkUsC1cfVrULApC+dHreBXXjVTJQiA=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
-    pkg-config
     sassc
-    optipng
     inkscape
-    gtk3
     glib # for glib-compile-resources
+    python3
   ];
 
   propagatedUserEnvPkgs = [
@@ -40,17 +37,23 @@ stdenv.mkDerivation rec {
     gtk-engine-murrine
   ];
 
-  preBuild = ''
-    # Shut up inkscape's warnings about creating profile directory
-    export HOME="$NIX_BUILD_ROOT"
+  postPatch = ''
+    patchShebangs meson/install-file.py
   '';
 
+  preBuild = ''
+    # Shut up inkscape's warnings about creating profile directory
+    export HOME="$TMPDIR"
+  '';
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
   mesonFlags = [
-    "-Dthemes=cinnamon,gnome-shell,gtk2,gtk3,plank,xfwm,metacity"
-    "-Dvariants=light,darker,dark,lighter"
+    # "-Dthemes=cinnamon,gnome-shell,gtk2,gtk3,plank,xfwm,metacity"
+    # "-Dvariants=light,darker,dark,lighter"
     "-Dcinnamon_version=${cinnamon.cinnamon-common.version}"
     "-Dgnome_shell_version=${gnome.gnome-shell.version}"
-    "-Dgtk3_version=${gtk3.version}"
     # You will need to patch gdm to make use of this.
     "-Dgnome_shell_gresource=true"
   ];


### PR DESCRIPTION
###### Description of changes

- Update to latest release
- Added FONTCONFIG_FILE to avoid "Fontconfig error: Cannot load default config file: No such file: (null)"
- Removed Parameter mesonFlag gtk3_version (upstream deleted)
- Cleanup (build all themes/variants)

###### Things done
`[ERROR] Fontconfig error: No writable cache directories`
This error occurs up to seven times per asset, I tired to fix it with [makeFontCache](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/fontconfig/make-fonts-cache.nix) but it seems to not help.

Then I came across that this is maybe not the point why the build is failing, but this should be:
`[ERROR] Running custom install script '/build/source/meson/install-file.py /build/source/build/common/cinnamon/cinnamon.css $MESON_INSTALL_DESTDIR_PREFIX/share/themes/Arc/cinnamon/cinnamon.css'`

I tried set `$MESON_INSTALL_DESTDIR_PREFIX `as I couldn't see it in the build summary but it does not work either.

Full build-log: [arc-build.log](https://github.com/NixOS/nixpkgs/files/8321867/arc-build.log)

Not directly related, but it made debugging harder: `nix log /nix/store/jgjlpxizwm0w29wx09v2y5c0gq5m75lg-arc-theme-20220223.drv` -> `error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override. Maybe there is another way to get the logs without having to enable experimental-features?

Do you have recommendations/tips on this?

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
