### PR TITLE
python3Packages.pyroute2-core: 0.6.8 -> 0.6.9

### DIFF
--- a/pkgs/development/python-modules/pyroute2-core/default.nix
+++ b/pkgs/development/python-modules/pyroute2-core/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-core";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.core";
     inherit version;
-    hash = "sha256-gkvr1FgFWI1eurjbuUYhYj0D4eZTIBsDMRXSWrKiCP4=";
+    hash = "sha256-lH0Mi2nR4jqawvpvVfn79U0AflxE8lU1VLKvqAEXDOo=";
   };
 
   # pyroute2 sub-modules have no tests

--- a/pkgs/development/python-modules/pyroute2-ethtool/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ethtool/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ethtool";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.ethtool";
     inherit version;
-    hash = "sha256-+/B+YQOluzyGYmnwAZonsjgZeiZPYl8LhJ9OjnvV/64=";
+    hash = "sha256-6o75plLeSle6ZFgoIZGKLCjx1hg4Z2okOq2RqAT2g8E=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ipdb/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ipdb/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ipdb";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.ipdb";
     inherit version;
-    hash = "sha256-sjlJ1eBoMQaJzEF/4Qk9ZwZB0s/yvR5wUUDP3UWBA50=";
+    hash = "sha256-sJ9Zzlrh9FWVWL7StyHpPPuXo6TtNLz2/lQBCl53Wrk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ipset/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ipset/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ipset";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.ipset";
     inherit version;
-    hash = "sha256-j2vEQyfuuMH0QRtXw6acX9AMureQwgeS+Ap7m2uP9OY=";
+    hash = "sha256-icEMJno03WKUdIYTZ6BIAo9lm43RwMjxNXcoSkYF81M=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-ndb/default.nix
+++ b/pkgs/development/python-modules/pyroute2-ndb/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-ndb";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.ndb";
     inherit version;
-    hash = "sha256-90DAbXCkoIFUbWZotKYkCSGsQvb7LrEpf6xGCviP40w=";
+    hash = "sha256-ASk6ycw3dQNMV4xmaxPAHDL1KtrY1JGQ5yJYcJ+OgUE=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-nftables/default.nix
+++ b/pkgs/development/python-modules/pyroute2-nftables/default.nix
@@ -6,12 +6,12 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-nftables";
-  version = "0.6.8";
+  version = "0.6.9";
 
   src = fetchPypi {
     pname = "pyroute2.nftables";
     inherit version;
-    sha256 = "sha256-SNebxs0mCFEI4bejuLMeU3wrO8KZZT1frnfQw8Gko6E=";
+    sha256 = "sha256-8BLz8IIobmrGb64PhXz1XWfl3KJTOhOL+j1C4/jlXuI=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-nslink/default.nix
+++ b/pkgs/development/python-modules/pyroute2-nslink/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-nslink";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.nslink";
     inherit version;
-    hash = "sha256-bTGzXouEdVUFaT5mxGfonFu3aOMxZKRTDMaHFciofec=";
+    hash = "sha256-WZjRexKn1FWXj+5KZxqZXB0aZmnd0ECKWt3hvVDdz4w=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2-protocols/default.nix
+++ b/pkgs/development/python-modules/pyroute2-protocols/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "pyroute2-protocols";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "pyroute2.protocols";
     inherit version;
-    hash = "sha256-l07CEwZzDxym+QAnKFFEpX690RStOA+rAwMXiEd7FOs=";
+    hash = "sha256-7vP4rbid2cVGKlYUM5qsmYXQhUfvIWoaDXYnxSUnSJY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyroute2/default.nix
+++ b/pkgs/development/python-modules/pyroute2/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "pyroute2";
-  version = "0.6.8";
+  version = "0.6.9";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-WhqjvCwKrUUBLKvjpva7pc94UIZvTf7j705Bt2DHyKQ=";
+    hash = "sha256-PRxNGnH7VpyrV49V9xNO8C1I6LMYK05+ZrKndWKO2vs=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Update to latest upstream release 0.6.8
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
