### PR TITLE
autoadb: init at unstable-2020-06-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11249,6 +11249,12 @@
     githubId = 293035;
     name = "Shawn Dellysse";
   };
+  shawn8901 = {
+    email = "shawn8901@googlemail.com";
+    github = "shawn8901";
+    githubId = 12239057;
+    name = "Shawn8901";
+  };
   shazow = {
     email = "andrey.petrov@shazow.net";
     github = "shazow";

--- a/pkgs/misc/autoadb/default.nix
+++ b/pkgs/misc/autoadb/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-9Sv38dCtvbqvxSnRpq+HsIwF/rfLUVZbi0J+mltLres=";
   };
 
-  cargoSha256 = "sha256-fmNySuOW+2HKIOIqIv/8W41ZXSmq3hbi+11yZBbhW5Q=";
+  cargoSha256 = "1gzg1lhq8gp790mrc8fw8dg146k8lg20pnk45m2ssnmdka0826f7";
 
   meta = with lib; {
     description = "Execute a command whenever a device is adb-connected";

--- a/pkgs/misc/autoadb/default.nix
+++ b/pkgs/misc/autoadb/default.nix
@@ -1,0 +1,22 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "autoadb";
+  version = "20200601";
+
+  src = fetchFromGitHub {
+    owner = "rom1v";
+    repo = pname;
+    rev = "7f8402983603a9854bf618a384f679a17cd85e2d";
+    sha256 = "sha256-9Sv38dCtvbqvxSnRpq+HsIwF/rfLUVZbi0J+mltLres=";
+  };
+
+  cargoSha256 = "sha256-fmNySuOW+2HKIOIqIv/8W41ZXSmq3hbi+11yZBbhW5Q=";
+
+  meta = with lib; {
+    description = "Execute a command whenever a device is adb-connected";
+    homepage = "https://github.com/rom1v/autoadb";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ shawn8901 ];
+  };
+}

--- a/pkgs/misc/autoadb/default.nix
+++ b/pkgs/misc/autoadb/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "autoadb";
-  version = "20200601";
+  version = "unstable-2020-06-01";
 
   src = fetchFromGitHub {
     owner = "rom1v";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14385,6 +14385,8 @@ with pkgs;
 
   augeas = callPackage ../tools/system/augeas { };
 
+  autoadb = callPackage ../misc/autoadb { };
+
   inherit (callPackage ../tools/admin/ansible { })
     ansible
     ansible_2_8


### PR DESCRIPTION
###### Description of changes
Autoadb is a small helper which runs commands whenever a device is connected via adb. 
It plays very nicely in combination with scrcpy, which is already in the repository, to automatically start scrcpy when there is a new device attached.

tbh, i was not very sure where to place the import in the `top-level/all-packages.nix`. It makes sense for me to be in the same section like scrcpy. If there is a better place a hint is very welcome. 
If there is something wrong with this PR or something missing, please let me know, 
 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
