### PR TITLE
nixos/ipfs: add systemd hardening

### DIFF
--- a/nixos/tests/ipfs.nix
+++ b/nixos/tests/ipfs.nix
@@ -10,6 +10,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       # Also will add a unix domain socket socket API address, see module.
       startWhenNeeded = true;
       apiAddress = "/ip4/127.0.0.1/tcp/2324";
+      dataDir = "/mnt/ipfs";
     };
   };
 
@@ -35,5 +36,9 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     machine.succeed(
         f"ipfs --api /unix/run/ipfs.sock cat /ipfs/{ipfs_hash.strip()} | grep fnord2"
     )
+
+    # Test if setting dataDir works properly with the hardened systemd unit
+    machine.succeed("test -e /mnt/ipfs/config")
+    machine.succeed("test ! -e /var/lib/ipfs/")
   '';
 })

--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -29,15 +29,23 @@ buildGoModule rec {
 
   vendorSha256 = null;
 
+  outputs = [ "out" "systemd_unit" "systemd_unit_hardened" ];
+
+  postPatch = ''
+    substituteInPlace 'misc/systemd/ipfs.service' \
+      --replace '/usr/bin/ipfs' "$out/bin/ipfs"
+    substituteInPlace 'misc/systemd/ipfs-hardened.service' \
+      --replace '/usr/bin/ipfs' "$out/bin/ipfs"
+  '';
+
   postInstall = ''
-    install --mode=444 -D misc/systemd/ipfs.service $out/etc/systemd/system/ipfs.service
-    install --mode=444 -D misc/systemd/ipfs-hardened.service $out/etc/systemd/system/ipfs-hardened.service
-    install --mode=444 -D misc/systemd/ipfs-api.socket $out/etc/systemd/system/ipfs-api.socket
-    install --mode=444 -D misc/systemd/ipfs-gateway.socket $out/etc/systemd/system/ipfs-gateway.socket
-    substituteInPlace $out/etc/systemd/system/ipfs.service \
-      --replace /usr/bin/ipfs $out/bin/ipfs
-    substituteInPlace $out/etc/systemd/system/ipfs-hardened.service \
-      --replace /usr/bin/ipfs $out/bin/ipfs
+    install --mode=444 -D 'misc/systemd/ipfs-api.socket' "$systemd_unit/etc/systemd/system/ipfs-api.socket"
+    install --mode=444 -D 'misc/systemd/ipfs-gateway.socket' "$systemd_unit/etc/systemd/system/ipfs-gateway.socket"
+    install --mode=444 -D 'misc/systemd/ipfs.service' "$systemd_unit/etc/systemd/system/ipfs.service"
+
+    install --mode=444 -D 'misc/systemd/ipfs-api.socket' "$systemd_unit_hardened/etc/systemd/system/ipfs-api.socket"
+    install --mode=444 -D 'misc/systemd/ipfs-gateway.socket' "$systemd_unit_hardened/etc/systemd/system/ipfs-gateway.socket"
+    install --mode=444 -D 'misc/systemd/ipfs-hardened.service' "$systemd_unit_hardened/etc/systemd/system/ipfs.service"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes
Use the hardened systemd unit from upstream.

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).