### PR TITLE
prometheus-cpp: fix use with CMake and clean up

### DIFF
--- a/pkgs/development/libraries/prometheus-cpp/default.nix
+++ b/pkgs/development/libraries/prometheus-cpp/default.nix
@@ -21,22 +21,20 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ gbenchmark civetweb gtest zlib curl ];
-
+  buildInputs = [ gbenchmark gtest zlib curl ];
+  propagatedBuildInputs = [ civetweb ];
   strictDeps = true;
 
   cmakeFlags = [
     "-DUSE_THIRDPARTY_LIBRARIES=OFF"
-    "-DCIVETWEB_INCLUDE_DIR=${civetweb.dev}/include"
-    "-DCIVETWEB_CXX_LIBRARY=${civetweb}/lib/libcivetweb${stdenv.targetPlatform.extensions.sharedLibrary}"
     "-DBUILD_SHARED_LIBS=ON"
   ];
 
-  NIX_LDFLAGS = "-ldl";
+  outputs = [ "out" "dev" ];
 
   postInstall = ''
-    mkdir -p $out/lib/pkgconfig
-    substituteAll ${./prometheus-cpp.pc.in} $out/lib/pkgconfig/prometheus-cpp.pc
+    mkdir -p $dev/lib/pkgconfig
+    substituteAll ${./prometheus-cpp.pc.in} $dev/lib/pkgconfig/prometheus-cpp.pc
   '';
 
   meta = {


### PR DESCRIPTION
The derivation did not properly propagate it's
dependency on civetweb, causing dependent CMake
derivations not to find it. So just move it to
propagatedBuildInputs instead of messing with
the cmakeFlags.

Also, split off "dev" so we don't carry around
the headers as a runtime dependency.