### PR TITLE
pxz: use upstream's Makefile

### DIFF
--- a/pkgs/tools/compression/pxz/default.nix
+++ b/pkgs/tools/compression/pxz/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitHub, xz }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, testVersion
+, pxz
+, xz
+}:
 
 stdenv.mkDerivation rec {
   pname = "pxz";
@@ -8,24 +14,27 @@ stdenv.mkDerivation rec {
     owner = "jnovy";
     repo = "pxz";
     rev = "124382a6d0832b13b7c091f72264f8f3f463070a";
-    sha256 = "15mmv832iqsqwigidvwnf0nyivxf0y8m22j2szy4h0xr76x4z21m";
+    hash = "sha256-NYhPujm5A0j810IKUZEHru/oLXCW7xZf5FjjKAbatZY=";
   };
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '`date +%Y%m%d`' '19700101'
+
+    substituteInPlace pxz.c \
+      --replace 'XZ_BINARY "xz"' 'XZ_BINARY "${lib.getBin xz}/bin/xz"'
+  '';
 
   buildInputs = [ xz ];
 
-  buildPhase = ''
-    gcc -o pxz pxz.c -llzma \
-        -fopenmp -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -O2 \
-        -DPXZ_BUILD_DATE=\"nixpkgs\" \
-        -DXZ_BINARY=\"${xz.bin}/bin/xz\" \
-        -DPXZ_VERSION=\"${version}\"
-  '';
+  makeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "out"}/share/man"
+  ];
 
-  installPhase = ''
-    mkdir -p $out/bin $out/share/man/man1
-    cp pxz $out/bin
-    cp pxz.1 $out/share/man/man1
-  '';
+  passthru.tests.version = testVersion {
+    package = pxz;
+  };
 
   meta = with lib; {
     homepage = "https://jnovy.fedorapeople.org/pxz/";
@@ -39,6 +48,7 @@ stdenv.mkDerivation rec {
       resources to speed up compression time with minimal possible influence
       on compression ratio
     '';
+    mainProgram = "pxz";
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/tools/compression/pxz/default.nix
+++ b/pkgs/tools/compression/pxz/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "pxz";
-  version = "4.999.9beta+git";
+  version = "4.999.9beta";
 
   src = fetchFromGitHub {
     owner = "jnovy";
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     rev = "124382a6d0832b13b7c091f72264f8f3f463070a";
     hash = "sha256-NYhPujm5A0j810IKUZEHru/oLXCW7xZf5FjjKAbatZY=";
   };
+
+  patches = [ ./flush-stdout-help-version.patch ];
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/tools/compression/pxz/flush-stdout-help-version.patch
+++ b/pkgs/tools/compression/pxz/flush-stdout-help-version.patch
@@ -1,0 +1,32 @@
+From bba741ccd0f0a65cd9bfdd81504ebe5840fd37ad Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 22 Mar 2022 08:01:10 -0500
+Subject: [PATCH] pxz: flush stdout before exec'ing xz, ensure our messages are
+ printed
+
+Without this, they're presently dropped on my system when pxz
+is piped to something, as in `pxz --help|less` or `pxz --version|cat`.
+---
+ pxz.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/pxz.c b/pxz.c
+index 4240b6e..3b53cfa 100644
+--- a/pxz.c
++++ b/pxz.c
+@@ -184,10 +184,12 @@ void parse_args( int argc, char **argv, char **envp ) {
+ 					"  -D, --context-size  per-thread compression context size as a multiple\n"
+ 					"                      of dictionary size. Default is 3.\n\n"
+ 					"Usage and other options are same as in XZ:\n\n");
++				fflush(stdout);
+ 				run_xz(argv, envp);
+ 				break;
+ 			case 'V':
+ 				printf("Parallel PXZ "PXZ_VERSION" (build "PXZ_BUILD_DATE")\n");
++				fflush(stdout);
+ 				run_xz(argv, envp);
+ 				break;
+ 			case 'g':
+-- 
+2.35.1
+


### PR DESCRIPTION
###### Description of changes


Cleanup that I've had sitting around for ages.

Instead of using custom build and install phases, just use upstream's.

At the same time, get rid of a build date in the binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
