### PR TITLE
u9fs: unstable-2020-11-21 -> unstable-2021-25

### DIFF
--- a/pkgs/servers/u9fs/default.nix
+++ b/pkgs/servers/u9fs/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchhg }:
+{ lib, stdenv, fetchFromBitbucket }:
 
 stdenv.mkDerivation {
   pname = "u9fs";
-  version = "unstable-2020-11-21";
+  version = "unstable-2021-01-25";
 
-  src = fetchhg {
-    url = "https://code.9front.org/hg/plan9front";
-    rev = "6eef4d6a9bce";
-    sha256 = "0irwyk8vnvx0fmz8lmbdb2jrlvas8imr61jr76a1pkwi9wpf2wv6";
+  src = fetchFromBitbucket {
+    owner = "plan9-from-bell-labs";
+    repo = "u9fs";
+    rev = "d65923fd17e8b158350d3ccd6a4e32b89b15014a";
+    sha256 = "0h06l7ciikp3gzrr550z0fyrfp3y2067dfd3rxxw0q95z4l6vhy1";
   };
 
   installPhase = ''
@@ -17,7 +18,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "Serve 9P from Unix";
-    homepage = "http://plan9.bell-labs.com/magic/man2html/4/u9fs";
+    homepage = "http://p9f.org/magic/man2html?man=u9fs&sect=4";
     license = licenses.free;
     maintainers = [ maintainers.ehmry ];
     platforms = platforms.unix;


### PR DESCRIPTION
* Use new (?) upstream over disappeared 9front hg repo, see also
  https://www.mail-archive.com/9fans@9fans.net/msg39324.html

* Link to Plan 9 Foundation's man page viewer as the Bell Labs has gone
  offine.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
