### PR TITLE
gitlab-runner: 14.8.2 -> 14.9.0

### DIFF
--- a/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoModule, fetchFromGitLab, fetchurl }:
 
 let
-  version = "14.8.2";
+  version = "14.9.0";
 in
 buildGoModule rec {
   inherit version;
@@ -14,17 +14,18 @@ buildGoModule rec {
     "-X ${commonPackagePath}.REVISION=v${version}"
   ];
 
-  vendorSha256 = "1aa04hbavr0bclddp5adjwwj21sp46gbhjydxc3w7vs1siw0ivq2";
+  vendorSha256 = "0ag3pmcrxksgikdcvl9rv2s3kn7l0dj41pf2m9dq0g2a1j45nydn";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     rev = "v${version}";
-    sha256 = "1zwr09lrrc3xx3sp00vs30ks0n77d7v0xkz0mz9jy2qdls9nfmrv";
+    sha256 = "0qqwg2k50cq7bc7k1389knrjq6xdbmlxd5kavyj7pg4sfapa3i8l";
   };
 
   patches = [
     ./fix-shell-path.patch
+    ./remove-bash-test.patch
   ];
 
   prePatch = ''

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/fix-shell-path.patch
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/fix-shell-path.patch
@@ -1,5 +1,5 @@
 diff --git a/shells/bash.go b/shells/bash.go
-index bd99eca1a..9873dff6b 100644
+index 18d608445..f158ffc0b 100644
 --- a/shells/bash.go
 +++ b/shells/bash.go
 @@ -3,6 +3,7 @@ package shells
@@ -10,16 +10,16 @@ index bd99eca1a..9873dff6b 100644
  	"path"
  	"runtime"
  	"strconv"
-@@ -300,7 +301,11 @@ func (b *BashShell) GetConfiguration(info common.ShellScriptInfo) (*common.Shell
- 	if info.User != "" {
- 		script.Command = "su"
- 		if runtime.GOOS == "linux" {
--			script.Arguments = append(script.Arguments, "-s", "/bin/"+b.Shell)
-+			shellPath, err := exec.LookPath(b.Shell)
-+			if err != nil {
-+				shellPath = "/bin/" + b.Shell
-+			}
-+			script.Arguments = append(script.Arguments, "-s", shellPath)
- 		}
- 		script.Arguments = append(
- 			script.Arguments,
+@@ -307,7 +308,11 @@ func (b *BashShell) GetConfiguration(info common.ShellScriptInfo) (*common.Shell
+
+ 	script.Command = "su"
+ 	if runtime.GOOS == OSLinux {
+-		script.Arguments = []string{"-s", "/bin/" + b.Shell, info.User, "-c", script.CmdLine}
++		shellPath, err := exec.LookPath(b.Shell)
++		if err != nil {
++			shellPath = "/bin/" + b.Shell
++		}
++		script.Arguments = []string{"-s", shellPath, info.User, "-c", script.CmdLine}
+ 	} else {
+ 		script.Arguments = []string{info.User, "-c", script.CmdLine}
+ 	}

--- a/pkgs/development/tools/continuous-integration/gitlab-runner/remove-bash-test.patch
+++ b/pkgs/development/tools/continuous-integration/gitlab-runner/remove-bash-test.patch
@@ -1,0 +1,80 @@
+diff --git a/shells/bash_test.go b/shells/bash_test.go
+index b8a48f85e..0e3173fc3 100644
+--- a/shells/bash_test.go
++++ b/shells/bash_test.go
+@@ -4,12 +4,9 @@
+ package shells
+ 
+ import (
+-	"runtime"
+ 	"testing"
+ 
+ 	"github.com/stretchr/testify/assert"
+-	"github.com/stretchr/testify/require"
+-	"gitlab.com/gitlab-org/gitlab-runner/common"
+ )
+ 
+ func TestBash_CommandShellEscapesLegacy(t *testing.T) {
+@@ -84,62 +81,3 @@ func TestBash_CheckForErrors(t *testing.T) {
+ 		})
+ 	}
+ }
+-
+-func TestBash_GetConfiguration(t *testing.T) {
+-	tests := map[string]struct {
+-		info common.ShellScriptInfo
+-		cmd  string
+-		args []string
+-		os   string
+-	}{
+-		`bash`: {
+-			info: common.ShellScriptInfo{Shell: "bash", Type: common.NormalShell},
+-			cmd:  "bash",
+-		},
+-		`bash -l`: {
+-			info: common.ShellScriptInfo{Shell: "bash", Type: common.LoginShell},
+-			cmd:  "bash",
+-			args: []string{"-l"},
+-		},
+-		`su -s /bin/bash foobar -c bash`: {
+-			info: common.ShellScriptInfo{Shell: "bash", User: "foobar", Type: common.NormalShell},
+-			cmd:  "su",
+-			args: []string{"-s", "/bin/bash", "foobar", "-c", "bash"},
+-			os:   OSLinux,
+-		},
+-		`su -s /bin/bash foobar -c $'bash -l'`: {
+-			info: common.ShellScriptInfo{Shell: "bash", User: "foobar", Type: common.LoginShell},
+-			cmd:  "su",
+-			args: []string{"-s", "/bin/bash", "foobar", "-c", "bash -l"},
+-			os:   OSLinux,
+-		},
+-		`su -s /bin/sh foobar -c $'sh -l'`: {
+-			info: common.ShellScriptInfo{Shell: "sh", User: "foobar", Type: common.LoginShell},
+-			cmd:  "su",
+-			args: []string{"-s", "/bin/sh", "foobar", "-c", "sh -l"},
+-			os:   OSLinux,
+-		},
+-		`su foobar -c $'bash -l'`: {
+-			info: common.ShellScriptInfo{Shell: "bash", User: "foobar", Type: common.LoginShell},
+-			cmd:  "su",
+-			args: []string{"foobar", "-c", "bash -l"},
+-			os:   "darwin",
+-		},
+-	}
+-
+-	for tn, tc := range tests {
+-		t.Run(tn, func(t *testing.T) {
+-			if tc.os != "" && tc.os != runtime.GOOS {
+-				t.Skipf("test only runs on %s", tc.os)
+-			}
+-
+-			sh := BashShell{Shell: tc.info.Shell}
+-			config, err := sh.GetConfiguration(tc.info)
+-			require.NoError(t, err)
+-
+-			assert.Equal(t, tc.cmd, config.Command)
+-			assert.Equal(t, tc.args, config.Arguments)
+-			assert.Equal(t, tn, config.CmdLine)
+-		})
+-	}
+-}


### PR DESCRIPTION
###### Description of changes
https://gitlab.com/gitlab-org/gitlab-runner/blob/v14.9.0/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
