### PR TITLE
networking.greTunnels: Add ttl option

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -535,6 +535,7 @@ let
         createGreDevice = n: v: nameValuePair "${n}-netdev"
           (let
             deps = deviceDependency v.dev;
+            ttlarg = if lib.hasPrefix "ip6" v.type then "hoplimit" else "ttl";
           in
           { description = "GRE Tunnel Interface ${n}";
             wantedBy = [ "network-setup.service" (subsystemDevice n) ];
@@ -551,6 +552,7 @@ let
               ip link add name "${n}" type ${v.type} \
                 ${optionalString (v.remote != null) "remote \"${v.remote}\""} \
                 ${optionalString (v.local != null) "local \"${v.local}\""} \
+                ${optionalString (v.ttl != null) "${ttlarg} ${toString v.ttl}"} \
                 ${optionalString (v.dev != null) "dev \"${v.dev}\""}
               ip link set "${n}" up
             '';

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -318,6 +318,8 @@ in
               Remote = gre.remote;
             }) // (optionalAttrs (gre.local != null) {
               Local = gre.local;
+            }) // (optionalAttrs (gre.ttl != null) {
+              TTL = gre.ttl;
             });
         };
         networks = mkIf (gre.dev != null) {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -1020,12 +1020,14 @@ in
             local = "10.0.0.22";
             dev = "enp4s0f0";
             type = "tap";
+            ttl = 255;
           };
           gre6Tunnel = {
             remote = "fd7a:5634::1";
             local = "fd7a:5634::2";
             dev = "enp4s0f0";
             type = "tun6";
+            ttl = 255;
           };
         }
       '';
@@ -1060,6 +1062,15 @@ in
             example = "enp4s0f0";
             description = ''
               The underlying network device on which the tunnel resides.
+            '';
+          };
+
+          ttl = mkOption {
+            type = types.nullOr types.int;
+            default = null;
+            example = 255;
+            description = ''
+              The time-to-live/hoplimit of the connection to the remote tunnel endpoint.
             '';
           };
 

--- a/nixos/tests/networking.nix
+++ b/nixos/tests/networking.nix
@@ -514,12 +514,14 @@ let
                   local = "192.168.2.1";
                   remote = "192.168.2.2";
                   dev = "eth2";
+                  ttl = 225;
                   type = "tap";
                 };
                 gre6Tunnel = {
                   local = "fd00:1234:5678:4::1";
                   remote = "fd00:1234:5678:4::2";
                   dev = "eth3";
+                  ttl = 255;
                   type = "tun6";
                 };
               };
@@ -548,12 +550,14 @@ let
                   local = "192.168.2.2";
                   remote = "192.168.2.1";
                   dev = "eth1";
+                  ttl = 225;
                   type = "tap";
                 };
                 gre6Tunnel = {
                   local = "fd00:1234:5678:4::2";
                   remote = "fd00:1234:5678:4::1";
                   dev = "eth3";
+                  ttl = 255;
                   type = "tun6";
                 };
               };
@@ -573,6 +577,7 @@ let
         ];
       testScript = { ... }:
         ''
+          import json
           start_all()
 
           with subtest("Wait for networking to be configured"):
@@ -591,6 +596,13 @@ let
               client1.wait_until_succeeds("ping -c 1 fc00::2")
 
               client2.wait_until_succeeds("ping -c 1 fc00::1")
+
+          with subtest("Test GRE tunnel TTL"):
+              links = json.loads(client1.succeed("ip -details -json link show greTunnel"))
+              assert links[0]['linkinfo']['info_data']['ttl'] == 225, "ttl not set for greTunnel"
+
+              links = json.loads(client2.succeed("ip -details -json link show gre6Tunnel"))
+              assert links[0]['linkinfo']['info_data']['ttl'] == 255, "ttl not set for gre6Tunnel"
         '';
     };
     vlan = let


### PR DESCRIPTION
###### Description of changes

Add ttl option for greTunnels, similar to what exists for `sit`.