### PR TITLE
python3Packages.ansible-later: init at 2.0.6

### DIFF
--- a/pkgs/development/python-modules/ansible-later/default.nix
+++ b/pkgs/development/python-modules/ansible-later/default.nix
@@ -1,0 +1,71 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, anyconfig
+, appdirs
+, colorama
+, flake8
+, jsonschema
+, nested-lookup
+, poetry-core
+, python-json-logger
+, pyyaml
+, toolz
+, unidiff
+, yamllint
+}:
+
+buildPythonPackage rec {
+  pname = "ansible-later";
+  version = "2.0.6";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "thegeeklab";
+    repo = "ansible-later";
+    rev = "v${version}";
+    sha256 = "sha256-vg9ryzl9ZeOGuFLL1yeJ3vGNPdo3ONmCQozY6DK6miY=";
+  };
+
+  postInstall = ''
+    rm $out/lib/python*/site-packages/LICENSE
+  '';
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'PyYAML = "6.0"' 'PyYAML = "*"' \
+      --replace 'unidiff = "0.7.3"' 'unidiff = "*"' \
+      --replace 'jsonschema = "4.4.0"' 'jsonschema = "*"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    anyconfig
+    appdirs
+    colorama
+    flake8
+    jsonschema
+    nested-lookup
+    python-json-logger
+    pyyaml
+    toolz
+    unidiff
+    yamllint
+  ];
+
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "ansiblelater" ];
+
+  meta = with lib; {
+    description = "Another best practice scanner for Ansible roles and playbooks";
+    homepage = "https://github.com/thegeeklab/ansible-later";
+    license = licenses.mit;
+    maintainers = with maintainers; [ tboerger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -522,6 +522,8 @@ in {
 
   ansible-kernel = callPackage ../development/python-modules/ansible-kernel { };
 
+  ansible-later = callPackage ../development/python-modules/ansible-later { };
+
   ansible-lint = callPackage ../development/python-modules/ansible-lint { };
 
   ansible-runner = callPackage ../development/python-modules/ansible-runner { };


### PR DESCRIPTION
###### Description of changes

Init new python module for linting Ansible roles. Depends on https://github.com/NixOS/nixpkgs/pull/165283 and https://github.com/NixOS/nixpkgs/pull/165286

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
