### PR TITLE
python3Packages.ansible-doctor: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/ansible-doctor/default.nix
+++ b/pkgs/development/python-modules/ansible-doctor/default.nix
@@ -1,0 +1,67 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+
+# pythonPackages
+, appdirs
+, colorama
+, environs
+, jinja2
+, jsonschema
+, pathspec
+, poetry-core
+, python-json-logger
+, ruamel-yaml
+}:
+
+buildPythonPackage rec {
+  pname = "ansible-doctor";
+  version = "1.2.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "thegeeklab";
+    repo = "ansible-doctor";
+    rev = "v${version}";
+    sha256 = "sha256-2Jaf7asU4c7kw9v9dUYDL4/M2Y/2qhMM3m0jqYiobUI=";
+  };
+
+  postInstall = ''
+    rm $out/lib/python*/site-packages/LICENSE
+  '';
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'environs = "9.5.0"' 'environs = "*"' \
+      --replace 'jsonschema = "4.4.0"' 'jsonschema = "*"' \
+      --replace '"ruamel.yaml" = "0.17.21"' '"ruamel.yaml" = "*"'
+  '';
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = [
+    jinja2
+    colorama
+    python-json-logger
+    pathspec
+    environs
+    jsonschema
+    appdirs
+    ruamel-yaml
+    anyconfig
+    nested-lookup
+  ];
+
+  # no tests
+  doCheck = false;
+  pythonImportsCheck = [ "ansibledoctor" ];
+
+  meta = with lib; {
+    description = "Annotation based documentation for your Ansible roles";
+    homepage = "https://github.com/thegeeklab/ansible-doctor";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ tboerger ];
+  };
+}

--- a/pkgs/development/python-modules/ansible-doctor/default.nix
+++ b/pkgs/development/python-modules/ansible-doctor/default.nix
@@ -3,6 +3,7 @@
 , lib
 
 # pythonPackages
+, anyconfig
 , appdirs
 , colorama
 , environs

--- a/pkgs/development/python-modules/ansible-doctor/default.nix
+++ b/pkgs/development/python-modules/ansible-doctor/default.nix
@@ -9,6 +9,7 @@
 , environs
 , jinja2
 , jsonschema
+, nested-lookup
 , pathspec
 , poetry-core
 , python-json-logger

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -520,6 +520,8 @@ in {
 
   ansible-core = callPackage ../development/python-modules/ansible/core.nix { };
 
+  ansible-doctor = callPackage ../development/python-modules/ansible-doctor { };
+
   ansible-kernel = callPackage ../development/python-modules/ansible-kernel { };
 
   ansible-lint = callPackage ../development/python-modules/ansible-lint { };


### PR DESCRIPTION
###### Description of changes

Init new python module for generating documentation of Ansible roles. Depends on https://github.com/NixOS/nixpkgs/pull/165283 and https://github.com/NixOS/nixpkgs/pull/165286

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
