### PR TITLE
nixos-rebuild: use log instead of echo, always print to stderr

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -35,6 +35,11 @@ verboseScript=
 # comma separated list of vars to preserve when using sudo
 preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
 
+# log the given argument to stderr
+log() {
+    echo "$@" >&2
+}
+
 while [ "$#" -gt 0 ]; do
     i="$1"; shift 1
     case "$i" in
@@ -46,7 +51,7 @@ while [ "$#" -gt 0 ]; do
         action="$i"
         ;;
       --install-grub)
-        echo "$0: --install-grub deprecated, use --install-bootloader instead" >&2
+        log "$0: --install-grub deprecated, use --install-bootloader instead"
         export NIXOS_INSTALL_BOOTLOADER=1
         ;;
       --install-bootloader)
@@ -90,7 +95,7 @@ while [ "$#" -gt 0 ]; do
         ;;
       --profile-name|-p)
         if [ -z "$1" ]; then
-            echo "$0: ‘--profile-name’ requires an argument"
+            log "$0: ‘--profile-name’ requires an argument"
             exit 1
         fi
         if [ "$1" != system ]; then
@@ -128,7 +133,7 @@ while [ "$#" -gt 0 ]; do
         lockFlags+=("$i" "$j" "$k")
         ;;
       *)
-        echo "$0: unknown option \`$i'"
+        log "$0: unknown option \`$i'"
         exit 1
         ;;
     esac
@@ -235,7 +240,7 @@ nixBuild() {
             NIX_SSHOPTS=$SSHOPTS runCmd nix-copy-closure --to "$buildHost" "$drv"
             buildHostCmd nix-store -r "$drv" "${buildArgs[@]}"
         else
-            echo "nix-instantiate failed"
+            log "nix-instantiate failed"
             exit 1
         fi
   fi
@@ -286,7 +291,7 @@ nixFlakeBuild() {
             NIX_SSHOPTS=$SSHOPTS runCmd nix "${flakeFlags[@]}" copy --derivation --to "ssh://$buildHost" "$drv"
             buildHostCmd nix-store -r "$drv" "${buildArgs[@]}"
         else
-            echo "nix eval failed"
+            log "nix eval failed"
             exit 1
         fi
     fi
@@ -421,13 +426,13 @@ prebuiltNix() {
     elif [[ "$machine" = aarch64 ]]; then
         echo @nix_aarch64_linux@
     else
-        echo "$0: unsupported platform"
+        log "$0: unsupported platform"
         exit 1
     fi
 }
 
 if [[ -n $buildNix && -z $flake ]]; then
-    echo "building Nix..." >&2
+    log "building Nix..."
     nixDrv=
     if ! nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then
         if ! nixDrv="$(runCmd nix-instantiate '<nixpkgs>' --add-root "$tmpDir/nix.drv" --indirect -A nix "${extraBuildFlags[@]}")"; then
@@ -436,7 +441,7 @@ if [[ -n $buildNix && -z $flake ]]; then
             fi
             if ! runCmd nix-store -r "$nixStorePath" --add-root "${tmpDir}/nix" --indirect \
                 --option extra-binary-caches https://cache.nixos.org/; then
-                echo "warning: don't know how to get latest Nix" >&2
+                log "warning: don't know how to get latest Nix"
             fi
             # Older version of nix-store -r don't support --add-root.
             [ -e "$tmpDir/nix" ] || ln -sf "$nixStorePath" "$tmpDir/nix"
@@ -446,7 +451,7 @@ if [[ -n $buildNix && -z $flake ]]; then
                 if ! buildHostCmd nix-store -r "$remoteNixStorePath" \
                   --option extra-binary-caches https://cache.nixos.org/ >/dev/null; then
                     remoteNix=
-                    echo "warning: don't know how to get latest Nix" >&2
+                    log "warning: don't know how to get latest Nix"
                 fi
             fi
         fi
@@ -486,7 +491,7 @@ fi
 # or "boot"), or just build it and create a symlink "result" in the
 # current directory (for "build" and "test").
 if [ -z "$rollback" ]; then
-    echo "building the system configuration..." >&2
+    log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
@@ -543,7 +548,7 @@ fi
 # default and/or activate it now.
 if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = dry-activate ]]; then
     if ! targetHostCmd "$pathToConfig/bin/switch-to-configuration" "$action"; then
-        echo "warning: error(s) occurred while switching to the new configuration" >&2
+        log "warning: error(s) occurred while switching to the new configuration"
         exit 1
     fi
 fi


### PR DESCRIPTION
Introduces a `log()` function, similar to `logVerbose()`, to replace
usage of `echo` for logging.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
