### PR TITLE
fetchpatch: add `relative`

### DIFF
--- a/doc/contributing/coding-conventions.chapter.md
+++ b/doc/contributing/coding-conventions.chapter.md
@@ -540,10 +540,11 @@ If you do need to do create this sort of patch file, one way to do so is with gi
 
 If a patch is available online but does not cleanly apply, it can be modified in some fixed ways by using additional optional arguments for `fetchpatch`:
 
+- `relative`: Similar to using `git-diff`'s `--relative` flag, only keep changes inside the specified directory, making paths relative to it.
 - `stripLen`: Remove the first `stripLen` components of pathnames in the patch.
 - `extraPrefix`: Prefix pathnames by this string.
-- `excludes`: Exclude files matching this pattern.
-- `includes`: Include only files matching this pattern.
+- `excludes`: Exclude files matching these patterns (applies after the above arguments).
+- `includes`: Include only files matching these patterns (applies after the above arguments).
 - `revert`: Revert the patch.
 
 Note that because the checksum is computed after applying these effects, using or modifying these arguments will have no effect unless the `sha256` argument is changed as well.

--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -9,7 +9,8 @@ let
   # 0.3.4 would change hashes: https://github.com/NixOS/nixpkgs/issues/25154
   patchutils = buildPackages.patchutils_0_3_3;
 in
-{ stripLen ? 0
+{ relative ? null
+, stripLen ? 0
 , extraPrefix ? null
 , excludes ? []
 , includes ? []
@@ -17,7 +18,18 @@ in
 , postFetch ? ""
 , ...
 }@args:
-
+let
+  args' = if relative != null then {
+    stripLen = 1 + lib.length (lib.splitString "/" relative) + stripLen;
+    extraPrefix = if extraPrefix != null then extraPrefix else "";
+  } else {
+    inherit stripLen extraPrefix;
+  };
+in let
+  inherit (args') stripLen extraPrefix;
+in
+lib.throwIfNot (excludes == [] || includes == [])
+  "fetchpatch: cannot use excludes and includes simultaneously"
 fetchurl ({
   postFetch = ''
     tmpfile="$TMPDIR/patch"
@@ -27,17 +39,19 @@ fetchurl ({
       exit 1
     fi
 
-    "${patchutils}/bin/lsdiff" "$out" \
-      | sort -u | sed -e 's/[*?]/\\&/g' \
-      | xargs -I{} \
-        "${patchutils}/bin/filterdiff" \
-        --include={} \
-        --strip=${toString stripLen} \
-        ${lib.optionalString (extraPrefix != null) ''
-           --addoldprefix=a/${extraPrefix} \
-           --addnewprefix=b/${extraPrefix} \
-        ''} \
-        --clean "$out" > "$tmpfile"
+    "${patchutils}/bin/lsdiff" \
+      ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
+      "$out" \
+    | sort -u | sed -e 's/[*?]/\\&/g' \
+    | xargs -I{} \
+      "${patchutils}/bin/filterdiff" \
+      --include={} \
+      --strip=${toString stripLen} \
+      ${lib.optionalString (extraPrefix != null) ''
+          --addoldprefix=a/${lib.escapeShellArg extraPrefix} \
+          --addnewprefix=b/${lib.escapeShellArg extraPrefix} \
+      ''} \
+      --clean "$out" > "$tmpfile"
 
     if [ ! -s "$tmpfile" ]; then
       echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
@@ -64,5 +78,6 @@ fetchurl ({
     ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
     mv "$tmpfile" "$out"
   '' + postFetch;
-  meta.broken = excludes != [] && includes != [];
-} // builtins.removeAttrs args ["stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"])
+} // builtins.removeAttrs args [
+  "relative" "stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"
+])

--- a/pkgs/build-support/fetchpatch/tests.nix
+++ b/pkgs/build-support/fetchpatch/tests.nix
@@ -5,4 +5,20 @@
     url = "https://github.com/facebook/zstd/pull/2724/commits/e1f85dbca3a0ed5ef06c8396912a0914db8dea6a.patch";
     sha256 = "sha256-PuYAqnJWAE+L9bsroOnnBGJhERW8LHrGSLtIEkKU9vg=";
   };
+
+  relative = invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
+    relative = "include";
+    sha256 = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
+  };
+
+  full = invalidateFetcherByDrvHash fetchpatch {
+    url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
+    relative = "test";
+    stripLen = 1;
+    extraPrefix = "foo/bar/";
+    excludes = [ "foo/bar/bernoulli_no_atomic_mp.cpp" ];
+    revert = true;
+    sha256 = "sha256-+UKmEbr2rIAweCav/hR/7d4ZrYV84ht/domTrHtm8sM=";
+  };
 }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -859,9 +859,8 @@ self: super: {
     (pkgs.fetchpatch {
       name   = "hledger-properly-escape-quotes-csv.patch";
       url    = "https://github.com/simonmichael/hledger/commit/c9a72e1615e2ddc2824f2e248456e1042eb31e1d.patch";
-      sha256 = "10knvrd5bl9nrmi27i0pm82sfr64jy04xgbjp228qywyijpr3pqv";
-      includes = [ "Hledger/Read/CsvReader.hs" ];
-      stripLen = 1;
+      relative = "hledger-lib";
+      sha256 = "sha256-gjYYo0eq1gWNAAFF3dKt9QDq0VpLnN5/648r/NXEPVE=";
     })
     super.hledger-lib;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1818,10 +1818,8 @@ self: super: {
   # Presumably to be removed at the next release
   yi-language = appendPatch (pkgs.fetchpatch {
     url = "https://github.com/yi-editor/yi/commit/0d3bcb5ba4c237d57ce33a3dc39b63c56d890765.patch";
-    sha256 = "0r4mzngs0x1akqpajzx7ssa9rax977fvj5ra8d3grfbpx6z0nm01";
-    includes = [ "yi-language.cabal" ];
-    stripLen = 2;
-    extraPrefix = "";
+    relative = "yi-language";
+    sha256 = "sha256-AVQLvul3ufxGQyoXud05qauclNanf6kunip0oJ/9lWQ=";
   }) super.yi-language;
 
   # https://github.com/ghcjs/jsaddle/issues/123

--- a/pkgs/development/libraries/CGAL/4.nix
+++ b/pkgs/development/libraries/CGAL/4.nix
@@ -18,18 +18,14 @@ stdenv.mkDerivation rec {
     (fetchpatch {
       name = "gcc-12-prereq.patch";
       url = "https://github.com/CGAL/cgal/commit/4581f1b7a8e97d1a136830e64b77cdae3546c4bf.patch";
-      sha256 = "1gzrvbrwxylv80v0m3j2s1znlysmr69lp3ggagnh38lp6423i6pq";
-      # Upstream slightly reordered directory structure since.
-      stripLen = 1;
-      # Fill patch does not apply: touches too many parts of the source.
-      includes = [ "include/CGAL/CORE/BigFloatRep.h" ];
+      relative = "CGAL_Core"; # Upstream slightly reordered directory structure since.
+      sha256 = "sha256-4+7mzGSBwAv5RHBQPAecPPKNN/LQBgvYq5mq+fHAteo=";
     })
     (fetchpatch {
       name = "gcc-12.patch";
       url = "https://github.com/CGAL/cgal/commit/6680a6e6f994b2c5b9f068eb3014d12ee1134d53.patch";
-      sha256 = "1c0h1lh8zng60yx78qc8wx714b517mil8mac87v6xr21q0b11wk7";
-      # Upstream slightly reordered directory structure since.
-      stripLen = 1;
+      relative = "CGAL_Core"; # Upstream slightly reordered directory structure since.
+      sha256 = "sha256-8kxJDT47jXI9kQNFI/ARWl9JBNS4AfU57/D0tYlgW0M=";
     })
   ];
 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -130,10 +130,8 @@ stdenv.mkDerivation {
   ++ optional (versionAtLeast version "1.73") ./cmake-paths-173.patch
   ++ optional (version == "1.77.0") (fetchpatch {
     url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
+    relative = "include";
     sha256 = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
-    stripLen = 2;
-    extraPrefix = "";
-    includes = [ "boost/math/special_functions/detail/bernoulli_details.hpp" ];
   });
 
   meta = {


### PR DESCRIPTION
Allows restricting patches to a specific subdirectory, à la `git diff --relative=subdir`.

This cannot be done (cleanly) currently because the `includes` logic happens *after* `stripLen` is applied, so we can't match on `subdir/*`. This change adds a `preIncludes` argument to make this possible, as well as a `relative` meta-argument that takes the name of a subdirectory and sets `preIncludes`, `stripLen` and `extraPrefix` accordingly.

(I turned `meta.broken` into assertions as it seems cleaner (https://github.com/NixOS/nixpkgs/pull/43538#pullrequestreview-137262799).)

As a proof of concept, I changed every instance of `fetchpatch { stripLen > 0; includes = [ ... ]; }` in nixpkgs (checked by adding a `builtins.trace` and evaluating everything) to use `relative` instead. This changes some hashes because (besides the conversion to SRI) previously people would use `stripLen` to transform `a/subdir/file` into `subdir/file`, while with `relative` you get `a/file` instead.

There might be more applications in the haskell-updates branch, and in fact the whole motivation for this was https://github.com/NixOS/nixpkgs/pull/165014#issuecomment-1075030620.

### Example

```nix
fetchpatch {
  url = "https://github.com/lambdabot/lambdabot/pull/204.patch";
  relative = "lambdabot-core";
  sha256 = "...";
}
```