### PR TITLE
octoprint: 1.7.3 -> 1.8.0rc5

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -167,6 +167,7 @@ let
                     "wrapt"
                     "zeroconf"
                     "Flask-Login"
+                    "werkzeug"
                   ];
                 in
                 ''

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -14,75 +14,6 @@ let
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) (
       [
-         (
-           self: super: {
-             sentry-sdk = super.sentry-sdk.overrideAttrs (oldAttrs: rec {
-               disabledTests = oldAttrs.disabledTests ++ lib.optionals (stdenv.buildPlatform != "x86_64-linux") [
-                 "test_leaks"
-               ];
-               disabledTestPaths = [
-                 # Don't test integrations
-                 "tests/integrations"
-                 # test crashes on aarch64
-                 "tests/test_transport.py"
-               ];
-             });
-           }
-         )
-
-        # All test fail on aarch64
-        (
-          self: super: {
-            azure-core = super.azure-core.overridePythonAttrs (oldAttrs: rec {
-              doCheck = stdenv.buildPlatform == "x86_64-linux";
-            });
-          }
-        )
-
-        # needs network
-        (
-          self: super: {
-            falcon = super.falcon.overridePythonAttrs (oldAttrs: rec {
-              #pytestFlagsArray = [ "-W ignore::DeprecationWarning" ];
-              disabledTestPaths = oldAttrs.disabledTestPaths or [] ++ [
-                "tests/asgi/test_asgi_servers.py"
-              ];
-            });
-          }
-        )
-
-        # update broke some tests
-        (
-          self: super: {
-            sanic = super.sanic.overridePythonAttrs (oldAttrs: rec {
-              disabledTestPaths = oldAttrs.disabledTestPaths or [] ++ [
-                "test_cli.py"
-                "test_cookies.py"
-                # requires network
-                "test_worker.py"
-              ];
-            });
-          }
-        )
-
-         (
-          self: super: {
-            flask-restful = super.flask-restful.overridePythonAttrs (oldAttrs: rec {
-              # remove werkzeug patch
-              patches = [];
-            });
-          }
-        )
-
-        (
-          self: super: {
-            trytond = super.trytond.overridePythonAttrs (oldAttrs: rec {
-              # remove werkzeug patch
-              patches = [];
-            });
-          }
-        )
-
         # Built-in dependency
         (
           self: super: {
@@ -123,14 +54,14 @@ let
           self: super: {
             octoprint-pisupport = self.buildPythonPackage rec {
               pname = "OctoPrint-PiSupport";
-              version = "2022.3.1";
+              version = "2022.3.28";
               format = "setuptools";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint-PiSupport";
                 rev = version;
-                sha256 = "fuDIvmz9u4f1Kptm6pd9TfQd9DVKiak4THUd66QpRO4=";
+                sha256 = "yzE/jz604nX/CHcW3aa7goH1ey8qZ7rLw31SMfNKJZM=";
               };
 
               # requires octoprint itself during tests
@@ -143,13 +74,13 @@ let
           self: super: {
             octoprint = self.buildPythonPackage rec {
               pname = "OctoPrint";
-              version = "1.8.0rc2";
+              version = "1.8.0rc5";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint";
                 rev = version;
-                sha256 = "sha256-0DX9xQ/yhrVPQD14DhGlIS7ikMJAF4p+uJaQ3MUcaKs=";
+                sha256 = "sha256-FeT45w6VXaFV4BsuOMk58nxxiu9jhCNnA2F7Uh/3sB0=";
               };
 
               propagatedBuildInputs = with super; [

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -9,216 +9,26 @@
 , packageOverrides ? self: super: { }
 }:
 let
-  mkOverride = attrname: version: sha256:
-    self: super: {
-      ${attrname} = super.${attrname}.overridePythonAttrs (
-        oldAttrs: {
-          inherit version;
-          src = oldAttrs.src.override {
-            inherit version sha256;
-          };
-        }
-      );
-    };
 
   py = python3.override {
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) (
       [
-        # the following dependencies are non trivial to update since later versions introduce backwards incompatible
-        # changes that might affect plugins, or due to other observed problems
-        (mkOverride "click" "7.1.2" "d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a")
-        (mkOverride "flask-babel" "1.0.0" "0gmb165vkwv5v7dxsxa2i3zhafns0fh938m2zdcrv4d8z5l099yn")
-        (mkOverride "itsdangerous" "1.1.0" "321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19")
-        (mkOverride "jinja2" "2.11.3" "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6")
-        (mkOverride "markdown" "3.1.1" "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
-        (mkOverride "markupsafe" "1.1.1" "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
-
-        # black uses hash, not sha256 identifier. Newer black version requires newer click version
-        (
-          self: super: {
-            black = super.black.overridePythonAttrs (oldAttrs: rec {
-              version = "21.12b0";
-              src = oldAttrs.src.override {
-                inherit version;
-                hash = "sha256-d7gPaTpWni5SeVhFljTxjfmwuiYluk4MLV2lvkLm8rM=";
-              };
-              doCheck = false;
-            });
-          }
-        )
-
-        # tests need network
-        (
-          self: super: {
-            curio = super.curio.overridePythonAttrs (oldAttrs: rec {
-              disabledTests = [
-                "test_timeout"
-                "test_ssl_outgoing"
-              ];
-            });
-          }
-        )
-
-        # tests need network
-        (
-          self: super: {
-            trio = super.trio.overridePythonAttrs (oldAttrs: rec {
-              disabledTests = [
-                "test_local_address_real"
-              ];
-              disabledTestPaths = [
-                "trio/tests/test_exports.py"
-                "trio/tests/test_socket.py"
-              ];
-            });
-          }
-        )
-
-        # Requires flask<2, cannot mkOverride because tests need to be disabled
-        (
-          self: super: {
-            flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-              version = "1.1.4";
-              src = oldAttrs.src.override {
-                inherit version;
-                sha256 = "15ni4xlm57a15f5hipp8w0c9zba20179bvfns2392fiq1lcbdghg";
-              };
-              doCheck = false;
-            });
-          }
-        )
-
-        # Requires werkezug<2, cannot mkOverride because tests need to be disabled
-        (
-          self: super: {
-            werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
-              version = "1.0.1";
-              src = oldAttrs.src.override {
-                inherit version;
-                sha256 = "6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c";
-              };
-              doCheck = false;
-            });
-          }
-        )
-
-        # Requires unidecode>=0.04.14,<0.05. Upstream changed the source naming between releases
-        (
-          self: super: {
-            unidecode = super.unidecode.overridePythonAttrs (oldAttrs: rec {
-              version = "0.04.21";
-              src = fetchFromGitHub {
-                owner = "avian2";
-                repo = "unidecode";
-                rev = "release-${version}";
-                sha256 = "0p5bkibv0xm1265dlfrz3zq3k9bbx07gl8zyq8mvvb8hi7p5lifg";
-              };
-            });
-          }
-        )
-
-        # Requires websocket-client <1.0, >=0.57. Cannot do mkOverride b/c differing underscore/hyphen in pypi source name
-        (
-          self: super: {
-            websocket-client = super.websocket-client.overridePythonAttrs (
-              oldAttrs: rec {
-                version = "0.59.0";
-                src = oldAttrs.src.override {
-                  inherit version;
-                  sha256 = "0p0cz2mdissq7iw1n7jrmsfir0jfmgs1dvnpnrx477ffx9hbsxnk";
-                };
-                propagatedBuildInputs = with self; [
-                  six
-                  pysocks
-                ];
-                disabledTests = [
-                  "testConnect" # requires network access
-                ];
-              }
-            );
-          }
-        )
-
-        # Octoprint needs zeroconf >=0.24 <0.25. This can't be done via mkOverride, because in zeroconf 0.32
-        # the super package was migrated to fetchFromGitHub.
-        (
-          self: super: {
-            zeroconf = super.zeroconf.overrideAttrs (oldAttrs: rec {
-              version = "0.24.5";
-              src = super.fetchPypi {
-                inherit (oldAttrs) pname;
-                inherit version;
-                sha256 = "0jpgd0rk91si93857mjrizan5gc42kj1q4fi4160qgk68la88fl9";
-              };
-              pythonImportsCheck = [
-                "zeroconf"
-              ];
-              buildInputs = with self; [
-                pytestCheckHook
-                nose
-              ];
-              pytestFlagsArray = [ "zeroconf/test.py" ];
-            });
-          }
-        )
-
-        # Octoprint pulls in celery indirectly but has no support for the up-to-date releases
-        (
-          self: super: {
-            celery = super.celery.overrideAttrs (oldAttrs: rec {
-              version = "5.0.0";
-              src = oldAttrs.src.override {
-                inherit version;
-                hash = "sha256-MTkw/d3nA9jjcCmjBL+RQpzRGu72PFfebayp2Vjh8lU=";
-              };
-              disabledTestPaths = [
-                "t/unit/backends/test_mongodb.py"
-                "t/unit/backends/test_cassandra.py"
-              ];
-            });
-          }
-        )
-
-        # Octoprint would allow later sentry-sdk releases but not later click releases
-        (
-          self: super: {
-            sentry-sdk = super.sentry-sdk.overrideAttrs (oldAttrs: rec {
-              pname = "sentry-sdk";
-              version = "1.4.3";
-
-              src = fetchFromGitHub {
-                owner = "getsentry";
-                repo = "sentry-python";
-                rev = version;
-                sha256 = "sha256-vdE6eqELMM69CWHaNYhF0HMCTV3tQsJlMHAA96oCy8c=";
-              };
-              disabledTests = [
-                "test_apply_simulates_delivery_info"
-                "test_auto_enabling_integrations_catches_import_error"
-                "test_leaks"
-              ];
-              disabledTestPaths = [
-                # Don't test integrations
-                "tests/integrations"
-                # test crashes on aarch64
-                "tests/test_transport.py"
-              ];
-            });
-          }
-        )
-
-        # Octoprint fails due to a newly added test in pytest-httpbin
-        # see https://github.com/NixOS/nixpkgs/issues/159864
-        (
-          self: super: {
-            pytest-httpbin = super.pytest-httpbin.overridePythonAttrs (oldAttrs: rec {
-              disabledTests = [
-                "test_redirect_location_is_https_for_secure_server"
-              ];
-            });
-          }
-        )
+         (
+           self: super: {
+             sentry-sdk = super.sentry-sdk.overrideAttrs (oldAttrs: rec {
+               disabledTests = oldAttrs.disabledTests ++ lib.optionals (stdenv.buildPlatform != "x86_64-linux") [
+                 "test_leaks"
+               ];
+               disabledTestPaths = [
+                 # Don't test integrations
+                 "tests/integrations"
+                 # test crashes on aarch64
+                 "tests/test_transport.py"
+               ];
+             });
+           }
+         )
 
         # All test fail on aarch64
         (
@@ -313,14 +123,14 @@ let
           self: super: {
             octoprint-pisupport = self.buildPythonPackage rec {
               pname = "OctoPrint-PiSupport";
-              version = "2021.10.28";
+              version = "2022.3.1";
               format = "setuptools";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint-PiSupport";
                 rev = version;
-                sha256 = "01bpvv1sn3113fdpw6b90c2rj8lqay118x609yy64z9ccm93khl9";
+                sha256 = "fuDIvmz9u4f1Kptm6pd9TfQd9DVKiak4THUd66QpRO4=";
               };
 
               # requires octoprint itself during tests
@@ -333,13 +143,13 @@ let
           self: super: {
             octoprint = self.buildPythonPackage rec {
               pname = "OctoPrint";
-              version = "1.7.3";
+              version = "1.8.0rc2";
 
               src = fetchFromGitHub {
                 owner = "OctoPrint";
                 repo = "OctoPrint";
                 rev = version;
-                sha256 = "sha256-U6g7WysHHOlZ4p5BM4tw3GGAxQmxv6ltYgAp1rO/eCg=";
+                sha256 = "sha256-0DX9xQ/yhrVPQD14DhGlIS7ikMJAF4p+uJaQ3MUcaKs=";
               };
 
               propagatedBuildInputs = with super; [
@@ -387,7 +197,7 @@ let
                 werkzeug
                 wrapt
                 zeroconf
-                zipstream-new
+                zipstream-ng
               ] ++ lib.optionals stdenv.isDarwin [
                 py.pkgs.appdirs
               ];


### PR DESCRIPTION
Update octoprint to the most recent [version](https://github.com/OctoPrint/OctoPrint/releases).

Most notably, support for python2 was dropped. This also allows the removal of many of the version overrides (which were necessary due to the python2 compatibility). 

This is the ~~rc2~~ rc5 release of octoprint, so not the final release. Due to a recent update, octoprint cannot be build as of now. This update fixes #165323 and #167718 and I felt it more sensible than adding yet another overwrite. 

Signed-off-by: florian on nixos (Florian Brandes) <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
