### PR TITLE
cosmopolitan: 0.3 -> unstable-2022-03-22

### DIFF
--- a/pkgs/development/libraries/cosmopolitan/ioctl.patch
+++ b/pkgs/development/libraries/cosmopolitan/ioctl.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/python/python.mk b/third_party/python/python.mk
+index f18c15060..b17455bca 100644
+--- a/third_party/python/python.mk
++++ b/third_party/python/python.mk
+@@ -1818,7 +1818,6 @@ THIRD_PARTY_PYTHON_PYTEST_PYMAINS =						\
+ 	third_party/python/Lib/test/test_int_literal.py				\
+ 	third_party/python/Lib/test/test_bisect.py				\
+ 	third_party/python/Lib/test/test_pyexpat.py				\
+-	third_party/python/Lib/test/test_ioctl.py				\
+ 	third_party/python/Lib/test/test_getopt.py				\
+ 	third_party/python/Lib/test/test_sort.py				\
+ 	third_party/python/Lib/test/test_slice.py				\


### PR DESCRIPTION
###### Description of changes
update cosmopolitan library. Going to unstable version beyond 1.0 because 1.0 does not build (see previous attempt: https://github.com/NixOS/nixpkgs/pull/127217)

###### Things done
using built-in gcc instead of Nix-provided. Retained the relevant lines in comment to aid future updates. This simplified patches and was the only variant I could make work to pass the getrandom test. Added additional necessary binaries.

Closes: https://github.com/NixOS/nixpkgs/pull/127217


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).