### PR TITLE
gpu-screen-recorder: init at 1.0.0

### DIFF
--- a/pkgs/applications/video/gpu-screen-recorder/default.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, fetchgit, makeWrapper, pkg-config, cudatoolkit, glew, libX11
+, libXcomposite, glfw, libpulseaudio, ffmpeg }:
+
+stdenv.mkDerivation rec {
+  pname = "gpu-screen-recorder";
+  version = "1.0.0";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder";
+    rev = "36fd4516db06bcb192e49055319d1778bbed0322";
+    sha256 = "sha256-hYEHM4FOYcPmQ5Yxh520PKy8HiD+G0xv9hrn8SmA07w=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glew
+    libX11
+    libXcomposite
+    glfw
+    libpulseaudio
+    ffmpeg
+  ];
+
+  postPatch = ''
+    substituteInPlace ./build.sh \
+      --replace '/opt/cuda/targets/x86_64-linux/include' '${cudatoolkit}/targets/x86_64-linux/include' \
+      --replace '/usr/lib64/libcuda.so' '${cudatoolkit}/targets/x86_64-linux/lib/stubs/libcuda.so'
+  '';
+
+  buildPhase = ''
+    ./build.sh
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin/ gpu-screen-recorder
+    wrapProgram $out/bin/gpu-screen-recorder --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib
+  '';
+
+  meta = with lib; {
+    description = "A screen recorder that has minimal impact on system performance by recording a window using the GPU only";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder/about/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ babbaj ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/video/gpu-screen-recorder/fix-nvfbc-check.patch
+++ b/pkgs/applications/video/gpu-screen-recorder/fix-nvfbc-check.patch
@@ -1,0 +1,38 @@
+diff --git a/build.sh b/build.sh
+index 05603db..8c38b31 100755
+--- a/build.sh
++++ b/build.sh
+@@ -2,5 +2,5 @@
+ 
+ dependencies="gtk+-3.0 x11 xrandr libpulse"
+ includes="$(pkg-config --cflags $dependencies)"
+-libs="$(pkg-config --libs $dependencies)"
++libs="$(pkg-config --libs $dependencies) -ldl"
+ g++ -o gpu-screen-recorder-gtk -O2 src/main.cpp -s $includes $libs
+diff --git a/src/main.cpp b/src/main.cpp
+index ae2078f..9dcdce1 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -15,6 +15,7 @@
+ #include <pwd.h>
+ #include <libgen.h>
+ #include <functional>
++#include <dlfcn.h>
+ 
+ typedef struct {
+     Display *display;
+@@ -830,7 +831,13 @@ static void audio_input_change_callback(GtkComboBox *widget, gpointer userdata)
+ }
+ 
+ static bool is_nv_fbc_installed() {
+-    return access("/usr/lib/libnvidia-fbc.so.1", F_OK) == 0 || access("/usr/local/lib/libnvidia-fbc.so.1", F_OK) == 0;
++    auto handle = dlopen("libnvidia-fbc.so.1", RTLD_LAZY);
++    if (handle) {
++        dlclose(handle);
++        return true;
++    } else {
++        return false;
++    }
+ }
+ 
+ static GtkWidget* create_common_settings_page(GtkStack *stack, GtkApplication *app) {

--- a/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
+++ b/pkgs/applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix
@@ -1,0 +1,46 @@
+{ stdenv, lib, fetchgit, pkg-config, makeWrapper, gtk3, libX11, libXrandr
+, libpulseaudio, gpu-screen-recorder }:
+
+stdenv.mkDerivation rec {
+  pname = "gpu-screen-recorder-gtk";
+  version = "0.1.0";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-gtk";
+    rev = "4c317abd0531f8e155fbbbcd32850bbeebbf2ead";
+    sha256 = "sha256-5W6qmUMP31ndRDxMHuQ/XnZysPQgaie0vVlMTzfODU4=";
+  };
+
+  patches = [ ./fix-nvfbc-check.patch ];
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk3
+    libX11
+    libXrandr
+    libpulseaudio
+  ];
+
+  buildPhase = ''
+    ./build.sh
+  '';
+
+  installPhase = ''
+    install -Dt $out/bin/ gpu-screen-recorder-gtk
+    install -Dt $out/share/applications/ gpu-screen-recorder-gtk.desktop
+
+    wrapProgram $out/bin/gpu-screen-recorder-gtk --prefix PATH : ${lib.makeBinPath [ gpu-screen-recorder ]}
+  '';
+
+  meta = with lib; {
+    description = "GTK frontend for gpu-screen-recorder.";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-gtk/about/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ babbaj ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26380,6 +26380,10 @@ with pkgs;
 
   gpsprune = callPackage ../applications/misc/gpsprune { };
 
+  gpu-screen-recorder = callPackage ../applications/video/gpu-screen-recorder { };
+
+  gpu-screen-recorder-gtk = callPackage ../applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix { };
+
   gpxlab = libsForQt5.callPackage ../applications/misc/gpxlab { };
 
   gpxsee = libsForQt5.callPackage ../applications/misc/gpxsee { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A simple screen recorder for nvenc with little CPU overhead.
https://git.dec05eba.com/gpu-screen-recorder/about/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
