### PR TITLE
gnuastro: init at 0.17

### DIFF
--- a/pkgs/applications/science/astronomy/gnuastro/default.nix
+++ b/pkgs/applications/science/astronomy/gnuastro/default.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, libtool
+, cfitsio, curl, ghostscript, gsl, libgit2, libjpeg, libtiff, lzlib, wcslib }:
+
+stdenv.mkDerivation rec {
+  pname = "gnuastro";
+  version = "0.17";
+
+  src = fetchurl {
+    url = "mirror://gnu/gnuastro/gnuastro-${version}.tar.gz";
+    sha256 = "sha256-xBvtM8wkDOqXg/Q2dNfPR0R0ZgRm4QiPJZoLDKivaPU=";
+  };
+
+  nativeBuildInputs = [ libtool ];
+
+  buildInputs = [
+    cfitsio
+    curl
+    ghostscript
+    gsl
+    libgit2
+    libjpeg
+    libtiff
+    lzlib
+    wcslib
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "GNU astronomy utilities and library";
+    homepage = "https://www.gnu.org/software/gnuastro/";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ sikmir ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6254,6 +6254,8 @@ with pkgs;
 
   gpp = callPackage ../development/tools/gpp { };
 
+  gnuastro = callPackage ../applications/science/astronomy/gnuastro { };
+
   gpredict = callPackage ../applications/science/astronomy/gpredict {
     hamlib = hamlib_4;
   };


### PR DESCRIPTION
###### Description of changes

> The [**GNU Astronomy Utilities (Gnuastro)**](https://www.gnu.org/software/gnuastro/) is an official GNU package consisting of various programs and library functions for the manipulation and analysis of astronomical data.

[![Packaging status](https://repology.org/badge/tiny-repos/gnuastro.svg)](https://repology.org/project/gnuastro/versions)

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
