### PR TITLE
Cryptography vectors

### DIFF
--- a/pkgs/development/interpreters/python/fetchpypi.nix
+++ b/pkgs/development/interpreters/python/fetchpypi.nix
@@ -20,9 +20,9 @@ let
 
   in compute (builtins.removeAttrs attrs ["format"]);
 
-in makeOverridable( {format ? "setuptools", sha256 ? "", hash ? "", ... } @attrs:
+in makeOverridable( {format ? "setuptools", name ? "", sha256 ? "", hash ? "", ... } @attrs:
   let
     url = computeUrl (builtins.removeAttrs attrs ["sha256" "hash"]) ;
   in fetchurl {
-    inherit url sha256 hash;
+    inherit name url sha256 hash;
   })

--- a/pkgs/development/interpreters/python/fetchpypi.nix
+++ b/pkgs/development/interpreters/python/fetchpypi.nix
@@ -14,9 +14,9 @@ let
     # Fetch a source tarball.
       "mirror://pypi/${builtins.substring 0 1 pname}/${pname}/${pname}-${version}.${extension}";
 
-    compute = (if format == "wheel" then computeWheelUrl
+    compute = if format == "wheel" then computeWheelUrl
       else if format == "setuptools" then computeSourceUrl
-      else throw "Unsupported format ${format}");
+      else throw "Unsupported format ${format}";
 
   in compute (builtins.removeAttrs attrs ["format"]);
 

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -3,10 +3,12 @@
 buildPythonPackage rec {
   pname = "cryptography_vectors";
   # The test vectors must have the same version as the cryptography package:
-  version = cryptography.version;
+  inherit (cryptography) version;
 
-  src = fetchPypi {
-    inherit pname version;
+  src = fetchPypi rec {
+    pname = "cryptography_vectors";
+    inherit version;
+    name = "${pname}-${version}.tar.gz";
     sha256 = "19gs051jbsixxwhlfs4xdxpzg8w1vypzpz3w56bp9x01qwzfbdy6";
   };
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
