### PR TITLE
pythonPackages.cryptography-vectors: normalise attr name

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -1,11 +1,11 @@
 { lib
 , stdenv
+, callPackage
 , buildPythonPackage
 , fetchPypi
 , rustPlatform
 , setuptools-rust
 , openssl
-, cryptography_vectors
 , Security
 , packaging
 , six
@@ -20,6 +20,9 @@
 , hypothesis
 }:
 
+let
+  cryptography-vectors = callPackage ./vectors.nix { };
+in
 buildPythonPackage rec {
   pname = "cryptography";
   version = "36.0.2"; # Also update the hash in vectors.nix
@@ -55,7 +58,7 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    cryptography_vectors
+    cryptography-vectors
     hypothesis
     iso8601
     pretend

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -1,12 +1,13 @@
 { buildPythonPackage, fetchPypi, lib, cryptography }:
 
 buildPythonPackage rec {
-  pname = "cryptography_vectors";
-  # The test vectors must have the same version as the cryptography package:
+  pname = "cryptography-vectors";
+  # The test vectors must have the same version as the cryptography package
   inherit (cryptography) version;
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "cryptography_vectors";
+    inherit version;
     sha256 = "sha256-KnkkRJoDAl+vf4dUpvQgAAHKshBzSmzmrB9r2s06aOQ=";
   };
 

--- a/pkgs/development/python2-modules/cryptography/default.nix
+++ b/pkgs/development/python2-modules/cryptography/default.nix
@@ -1,10 +1,11 @@
-{ lib, stdenv
+{ lib
+, stdenv
+, callPackage
 , buildPythonPackage
 , fetchPypi
 , isPy27
 , ipaddress
 , openssl
-, cryptography_vectors
 , darwin
 , packaging
 , six
@@ -18,6 +19,9 @@
 , enum34
 }:
 
+let
+  cryptography-vectors = callPackage ./vectors.nix { };
+in
 buildPythonPackage rec {
   pname = "cryptography";
   version = "3.3.2"; # Also update the hash in vectors-3.3.nix
@@ -36,18 +40,19 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [ openssl ]
-             ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
+    ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   propagatedBuildInputs = [
     packaging
     six
   ] ++ lib.optionals (!isPyPy) [
     cffi
   ] ++ lib.optionals isPy27 [
-    ipaddress enum34
+    ipaddress
+    enum34
   ];
 
   checkInputs = [
-    cryptography_vectors
+    cryptography-vectors
     hypothesis
     iso8601
     pretend

--- a/pkgs/development/python2-modules/cryptography/vectors.nix
+++ b/pkgs/development/python2-modules/cryptography/vectors.nix
@@ -1,12 +1,13 @@
 { buildPythonPackage, fetchPypi, lib, cryptography }:
 
 buildPythonPackage rec {
-  pname = "cryptography_vectors";
+  pname = "cryptography-vectors";
   # The test vectors must have the same version as the cryptography package:
   version = cryptography.version;
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "cryptography_vectors";
+    inherit version;
     sha256 = "1yhaps0f3h2yjb6lmz953z1l1d84y9swk4k3gj9nqyk4vbx5m7cc";
   };
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -43,6 +43,7 @@ mapAliases ({
   class-registry = phx-class-registry; # added 2021-10-05
   ConfigArgParse = configargparse; # added 2021-03-18
   cozy = throw "cozy was removed because it was not actually https://pypi.org/project/Cozy/."; # added 2022-01-14
+  cryptography_vectors = "cryptography_vectors is no longer exposed in python*Packages because it is used for testing cryptography only."; # Added 2022-03-23
   dateutil = python-dateutil; # added 2021-07-03
   demjson = throw "demjson has been removed, it was using setuptools 2to3 translation feature, which has been removed in setuptools 58"; # added 2022-01-18
   detox = throw "detox is no longer maintained, and was broken since may 2019"; # added 2020-07-04

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1920,8 +1920,6 @@ in {
     inherit (pkgs.darwin.apple_sdk.frameworks) Security;
   };
 
-  cryptography_vectors = callPackage ../development/python-modules/cryptography/vectors.nix { };
-
   crytic-compile = callPackage ../development/python-modules/crytic-compile { };
 
   csrmesh  = callPackage ../development/python-modules/csrmesh { };

--- a/pkgs/top-level/python2-packages.nix
+++ b/pkgs/top-level/python2-packages.nix
@@ -30,8 +30,6 @@ with self; with super; {
 
   cryptography = callPackage ../development/python2-modules/cryptography { };
 
-  cryptography_vectors = callPackage ../development/python2-modules/cryptography-vectors { };
-
   decorator = callPackage ../development/python2-modules/decorator { };
 
   enum = callPackage ../development/python2-modules/enum { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
