### PR TITLE
pdfminer: fix missing package version

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -80,6 +80,12 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  postPatch = ''
+    # https://github.com/ocrmypdf/OCRmyPDF/issues/933
+    substituteInPlace setup.cfg \
+      --replace "pdfminer.six!=20200720,>=20191110,<=20211012" "pdfminer.six!=20200720,>=20191110,<=20220319"
+  '';
+
   pythonImportsCheck = [
     "ocrmypdf"
   ];

--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -21,6 +21,12 @@ buildPythonPackage rec {
     done
   '';
 
+  postPatch = ''
+    # Verion is not stored in repo, gets added by a GitHub action after tag is created
+    # https://github.com/pdfminer/pdfminer.six/pull/727
+    substituteInPlace pdfminer/__init__.py --replace "__VERSION__" ${version}
+  '';
+
   checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pdfx/default.nix
+++ b/pkgs/development/python-modules/pdfx/default.nix
@@ -13,7 +13,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "chardet==4.0.0" "chardet"
+      --replace "chardet==4.0.0" "chardet" \
+      --replace "pdfminer.six==20201018" "pdfminer.six"
   '';
 
   propagatedBuildInputs = [ pdfminer chardet ];

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -131,6 +131,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
+      --replace "pdfminer.six >= 20200101" "pdfminer.six" \
       --replace "pluggy >= 0.12.0, < 1.0" "pluggy" \
       --replace "pygmars >= 0.7.0" "pygmars" \
       --replace "license_expression >= 21.6.14" "license_expression"


### PR DESCRIPTION
###### Description of changes

1. The new version of `pdfminer` doesn't include the actual version in the repo any more, and the tests don't appear to be included in the PyPi package, so the version ends up detected as `VERSION`.
2. Fix dependencies broken by https://github.com/NixOS/nixpkgs/pull/164911

```
Requirement already satisfied: pdfminer.six in /nix/store/rvmigdjvg6bvjbdzq23waw4mz4f5hrnc-python3.9-pdfminer_six-20220319/lib/python3.9/site-packages (from ocrmypdf==13.4.1) (-VERSION-)
```

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).