### PR TITLE
moonraker: unstable-2021-12-05 -> unstable-2022-03-10

### DIFF
--- a/nixos/modules/services/misc/moonraker.nix
+++ b/nixos/modules/services/misc/moonraker.nix
@@ -128,6 +128,9 @@ in {
         exec ${pkg}/bin/moonraker -c ${cfg.configDir}/moonraker-temp.cfg
       '';
 
+      # Needs `ip` command
+      path = [ pkgs.iproute2 ];
+
       serviceConfig = {
         WorkingDirectory = cfg.stateDir;
         Group = cfg.group;

--- a/nixos/modules/services/misc/moonraker.nix
+++ b/nixos/modules/services/misc/moonraker.nix
@@ -79,12 +79,32 @@ in {
           for supported values.
         '';
       };
+
+      allowSystemControl = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to allow Moonraker to perform system-level operations.
+
+          Moonraker exposes APIs to perform system-level operations, such as
+          reboot, shutdown, and management of systemd units. See the
+          <link xlink:href="https://moonraker.readthedocs.io/en/latest/web_api/#machine-commands">documentation</link>
+          for details on what clients are able to do.
+        '';
+      };
     };
   };
 
   config = mkIf cfg.enable {
     warnings = optional (cfg.settings ? update_manager)
       ''Enabling update_manager is not supported on NixOS and will lead to non-removable warnings in some clients.'';
+
+    assertions = [
+      {
+        assertion = cfg.allowSystemControl -> config.security.polkit.enable;
+        message = "services.moonraker.allowSystemControl requires polkit to be enabled (security.polkit.enable).";
+      }
+    ];
 
     users.users = optionalAttrs (cfg.user == "moonraker") {
       moonraker = {
@@ -137,5 +157,22 @@ in {
         User = cfg.user;
       };
     };
+
+    security.polkit.extraConfig = lib.optionalString cfg.allowSystemControl ''
+      // nixos/moonraker: Allow Moonraker to perform system-level operations
+      //
+      // This was enabled via services.moonraker.allowSystemControl.
+      polkit.addRule(function(action, subject) {
+        if ((action.id == "org.freedesktop.systemd1.manage-units" ||
+             action.id == "org.freedesktop.login1.power-off" ||
+             action.id == "org.freedesktop.login1.power-off-multiple-sessions" ||
+             action.id == "org.freedesktop.login1.reboot" ||
+             action.id == "org.freedesktop.login1.reboot-multiple-sessions" ||
+             action.id.startsWith("org.freedesktop.packagekit.")) &&
+             subject.user == "${cfg.user}") {
+          return polkit.Result.YES;
+        }
+      });
+    '';
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -307,6 +307,7 @@ in
   molly-brown = handleTest ./molly-brown.nix {};
   mongodb = handleTest ./mongodb.nix {};
   moodle = handleTest ./moodle.nix {};
+  moonraker = handleTest ./moonraker.nix {};
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   moosefs = handleTest ./moosefs.nix {};

--- a/nixos/tests/moonraker.nix
+++ b/nixos/tests/moonraker.nix
@@ -1,0 +1,45 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "moonraker";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ zhaofengli ];
+  };
+
+  nodes = {
+    printer = { config, pkgs, ... }: {
+      security.polkit.enable = true;
+
+      services.moonraker = {
+        enable = true;
+        allowSystemControl = true;
+
+        settings = {
+          authorization = {
+            trusted_clients = [ "127.0.0.0/8" "::1/128" ];
+          };
+        };
+      };
+
+      services.klipper = {
+        enable = true;
+
+        user = "moonraker";
+        group = "moonraker";
+
+        # No mcu configured so won't even enter `ready` state
+        settings = {};
+      };
+    };
+  };
+
+  testScript = ''
+    printer.start()
+
+    printer.wait_for_unit("klipper.service")
+    printer.wait_for_unit("moonraker.service")
+    printer.wait_until_succeeds("curl http://localhost:7125/printer/info | grep -v 'Not Found' >&2", timeout=30)
+
+    with subtest("Check that we can perform system-level operations"):
+        printer.succeed("curl -X POST http://localhost:7125/machine/services/stop?service=klipper | grep ok >&2")
+        printer.wait_until_succeeds("systemctl --no-pager show klipper.service | grep ActiveState=inactive", timeout=10)
+  '';
+})

--- a/pkgs/development/python-modules/preprocess-cancellation/default.nix
+++ b/pkgs/development/python-modules/preprocess-cancellation/default.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, buildPythonPackage, pythonOlder, poetry-core
+, pytestCheckHook, pytest-cov
+, shapely }:
+
+buildPythonPackage rec {
+  pname = "preprocess-cancellation";
+  version = "0.2.0";
+  disabled = pythonOlder "3.6"; # >= 3.6
+  format = "pyproject";
+
+  # No tests in PyPI
+  src = fetchFromGitHub {
+    owner = "kageurufu";
+    repo = "cancelobject-preprocessor";
+    rev = version;
+    hash = "sha256-mn3/etXA5dkL+IsyxwD4/XjU/t4/roYFVyqQxlLOoOI=";
+  };
+
+  nativeBuildInputs = [ poetry-core ];
+
+  propagatedBuildInputs = [ shapely ];
+
+  checkInputs = [ pytestCheckHook pytest-cov ];
+
+  meta = with lib; {
+    description = "Klipper GCode Preprocessor for Object Cancellation";
+    homepage = "https://github.com/kageurufu/cancelobject-preprocessor";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ zhaofengli ];
+  };
+}

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/lib/klipper
     cp -r ./* $out/lib/klipper
 
+    # Moonraker expects `config_examples` and `docs` to be available
+    # under `klipper_path`
+    cp -r $src/docs $out/lib/docs
+    cp -r $src/config $out/lib/config
+
     chmod 755 $out/lib/klipper/klippy.py
     runHook postInstall
   '';

--- a/pkgs/servers/moonraker/default.nix
+++ b/pkgs/servers/moonraker/default.nix
@@ -3,7 +3,7 @@
 let
   pythonEnv = python3.withPackages (packages: with packages; [
     tornado
-    pyserial
+    pyserial-asyncio
     pillow
     lmdb
     streaming-form-data
@@ -12,16 +12,21 @@ let
     libnacl
     paho-mqtt
     pycurl
+    zeroconf
+    preprocess-cancellation
+    jinja2
+    dbus-next
+    apprise
   ]);
 in stdenvNoCC.mkDerivation rec {
   pname = "moonraker";
-  version = "unstable-2021-12-05";
+  version = "unstable-2022-03-10";
 
   src = fetchFromGitHub {
     owner = "Arksine";
     repo = "moonraker";
-    rev = "ac73036857cc1ca83df072dd94bf28eb9d0ed8b0";
-    sha256 = "Oqjt0z4grt+hdQ4t7KQSwkkCeRGoFFedJsTpMHwMm34=";
+    rev = "ee312ee9c6597c8d077d7c3208ccea4e696c97ca";
+    sha256 = "l0VOQIfKgZ/Je4z+SKhWMgYzxye8WKs9W1GkNs7kABo=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/servers/moonraker/default.nix
+++ b/pkgs/servers/moonraker/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub, python3, makeWrapper, unstableGitUpdater }:
+{ lib, stdenvNoCC, fetchFromGitHub, python3, makeWrapper, unstableGitUpdater, nixosTests }:
 
 let
   pythonEnv = python3.withPackages (packages: with packages; [
@@ -39,7 +39,10 @@ in stdenvNoCC.mkDerivation rec {
       --add-flags "$out/lib/moonraker/moonraker.py"
   '';
 
-  passthru.updateScript = unstableGitUpdater { url = meta.homepage; };
+  passthru = {
+    updateScript = unstableGitUpdater { url = meta.homepage; };
+    tests.moonraker = nixosTests.moonraker;
+  };
 
   meta = with lib; {
     description = "API web server for Klipper";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6458,6 +6458,8 @@ in {
 
   premailer = callPackage ../development/python-modules/premailer { };
 
+  preprocess-cancellation = callPackage ../development/python-modules/preprocess-cancellation { };
+
   preshed = callPackage ../development/python-modules/preshed { };
 
   pretend = callPackage ../development/python-modules/pretend { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Supersedes #163796.

`services.moonraker.allowSystemControl` is added to grant permissions to Moonraker so API clients can perform some machine-level operations (e.g., reboot, shut down, start/stop/restart klipper).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
