### PR TITLE
octoprint: fix build due to black

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -34,6 +34,47 @@ let
         (mkOverride "markdown" "3.1.1" "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a")
         (mkOverride "markupsafe" "1.1.1" "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b")
 
+        # black uses hash, not sha256 identifier. Newer black version requires newer click version
+        (
+          self: super: {
+            black = super.black.overridePythonAttrs (oldAttrs: rec {
+              version = "21.12b0";
+              src = oldAttrs.src.override {
+                inherit version;
+                hash = "sha256-d7gPaTpWni5SeVhFljTxjfmwuiYluk4MLV2lvkLm8rM=";
+              };
+              doCheck = false;
+            });
+          }
+        )
+
+        # tests need network
+        (
+          self: super: {
+            curio = super.curio.overridePythonAttrs (oldAttrs: rec {
+              disabledTests = [
+                "test_timeout"
+                "test_ssl_outgoing"
+              ];
+            });
+          }
+        )
+
+        # tests need network
+        (
+          self: super: {
+            trio = super.trio.overridePythonAttrs (oldAttrs: rec {
+              disabledTests = [
+                "test_local_address_real"
+              ];
+              disabledTestPaths = [
+                "trio/tests/test_exports.py"
+                "trio/tests/test_socket.py"
+              ];
+            });
+          }
+        )
+
         # Requires flask<2, cannot mkOverride because tests need to be disabled
         (
           self: super: {
@@ -400,7 +441,7 @@ let
                 homepage = "https://octoprint.org/";
                 description = "The snappy web interface for your 3D printer";
                 license = licenses.agpl3Only;
-                maintainers = with maintainers; [ abbradar gebner WhittlesJr ];
+                maintainers = with maintainers; [ abbradar gebner WhittlesJr gador ];
               };
             };
           }


### PR DESCRIPTION
This is a quick fix for the build error described in #165323 

Signed-off-by: florian on nixos (Florian Brandes) <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
