### PR TITLE
python39Packages.sortedcontainers: enable tests, replace SuperSandro2…

### DIFF
--- a/pkgs/development/python-modules/sortedcontainers/default.nix
+++ b/pkgs/development/python-modules/sortedcontainers/default.nix
@@ -1,24 +1,39 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, pytestCheckHook
 }:
 
-buildPythonPackage rec {
-  pname = "sortedcontainers";
-  version = "2.4.0";
+let
+  sortedcontainers = buildPythonPackage rec {
+    pname = "sortedcontainers";
+    version = "2.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88";
+    src = fetchFromGitHub {
+      owner = "grantjenks";
+      repo = "python-sortedcontainers";
+      rev = "v${version}";
+      sha256 = "sha256-YRbSM2isWi7AzfquFvuZBlpEMNUnBJTBLBn0/XYVHKQ=";
+    };
+
+    doCheck = false;
+
+    checkInputs = [
+      pytestCheckHook
+    ];
+
+    pythonImportsCheck = [ "sortedcontainers" ];
+
+    passthru.tests = {
+      pytest = sortedcontainers.overridePythonAttrs (_: { doCheck = true; });
+    };
+
+    meta = with lib; {
+      description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet";
+      homepage = "https://grantjenks.com/docs/sortedcontainers/";
+      license = licenses.asl20;
+      maintainers = with maintainers; [ SuperSandro2000 ];
+    };
   };
-
-  # pypi tarball does not come with tests
-  doCheck = false;
-
-  meta = {
-    description = "Python Sorted Container Types: SortedList, SortedDict, and SortedSet";
-    homepage = "http://www.grantjenks.com/docs/sortedcontainers/";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ costrouc ];
-  };
-}
+in
+sortedcontainers


### PR DESCRIPTION
…000 as maintainer

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
