### PR TITLE
WIP: nixos-rebuild test suite

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -3,6 +3,7 @@
 , coreutils
 , gnused
 , gnugrep
+, jq
 , nix
 , lib
 , nixosTests
@@ -19,7 +20,7 @@ substituteAll {
   nix_x86_64_linux = fallback.x86_64-linux;
   nix_i686_linux = fallback.i686-linux;
   nix_aarch64_linux = fallback.aarch64-linux;
-  path = lib.makeBinPath [ coreutils gnused gnugrep ];
+  path = lib.makeBinPath [ coreutils gnused gnugrep jq ];
 
   # run some a simple installer tests to make sure nixos-rebuild still works for them
   passthru.tests = {

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -34,10 +34,15 @@ remoteSudo=
 verboseScript=
 # comma separated list of vars to preserve when using sudo
 preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
+testInstrumented="$NIXOS_REBUILD_TEST_INSTRUMENTED"
 
 # log the given argument to stderr
 log() {
-    echo "$@" >&2
+    if [ -n "$testInstrumented" ]; then
+        jq '{ tag: "log", argv: $ARGS.positional }' --compact-output --null-input --args -- "$@" >&2
+    else
+        echo "$@" >&2
+    fi
 }
 
 while [ "$#" -gt 0 ]; do
@@ -156,13 +161,22 @@ fi
 # log the given argument to stderr if verbose mode is on
 logVerbose() {
     if [ -n "$verboseScript" ]; then
-      echo "$@" >&2
+        if [ -n "$testInstrumented" ]; then
+            jq '{ tag: "log_verbose", argv: $ARGS.positional }' --compact-output --null-input --args -- "$@" >&2
+        else
+            echo "$@" >&2
+        fi
     fi
 }
 
 # Run a command, logging it first if verbose mode is on
 runCmd() {
-    logVerbose "$" "$@"
+    # if we are instrumented for testing, print the command
+    if [ -n "$testInstrumented" ]; then
+        jq '{ tag: "run_command", argv: $ARGS.positional }' --compact-output --null-input --args -- "$@" >&2
+    else
+        logVerbose "$" "$@"
+    fi
     "$@"
 }
 

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -35,6 +35,11 @@ verboseScript=
 # comma separated list of vars to preserve when using sudo
 preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
 
+# log the given argument to stderr
+log() {
+    echo "$@" >&2
+}
+
 while [ "$#" -gt 0 ]; do
     i="$1"; shift 1
     case "$i" in
@@ -46,7 +51,7 @@ while [ "$#" -gt 0 ]; do
         action="$i"
         ;;
       --install-grub)
-        echo "$0: --install-grub deprecated, use --install-bootloader instead" >&2
+        log "$0: --install-grub deprecated, use --install-bootloader instead"
         export NIXOS_INSTALL_BOOTLOADER=1
         ;;
       --install-bootloader)
@@ -90,7 +95,7 @@ while [ "$#" -gt 0 ]; do
         ;;
       --profile-name|-p)
         if [ -z "$1" ]; then
-            echo "$0: ‘--profile-name’ requires an argument"
+            log "$0: ‘--profile-name’ requires an argument"
             exit 1
         fi
         if [ "$1" != system ]; then
@@ -128,7 +133,7 @@ while [ "$#" -gt 0 ]; do
         lockFlags+=("$i" "$j" "$k")
         ;;
       *)
-        echo "$0: unknown option \`$i'"
+        log "$0: unknown option \`$i'"
         exit 1
         ;;
     esac
@@ -235,7 +240,7 @@ nixBuild() {
             NIX_SSHOPTS=$SSHOPTS runCmd nix-copy-closure --to "$buildHost" "$drv"
             buildHostCmd nix-store -r "$drv" "${buildArgs[@]}"
         else
-            echo "nix-instantiate failed"
+            log "nix-instantiate failed"
             exit 1
         fi
   fi
@@ -286,7 +291,7 @@ nixFlakeBuild() {
             NIX_SSHOPTS=$SSHOPTS runCmd nix "${flakeFlags[@]}" copy --derivation --to "ssh://$buildHost" "$drv"
             buildHostCmd nix-store -r "$drv" "${buildArgs[@]}"
         else
-            echo "nix eval failed"
+            log "nix eval failed"
             exit 1
         fi
     fi
@@ -421,13 +426,13 @@ prebuiltNix() {
     elif [[ "$machine" = aarch64 ]]; then
         echo @nix_aarch64_linux@
     else
-        echo "$0: unsupported platform"
+        log "$0: unsupported platform"
         exit 1
     fi
 }
 
 if [[ -n $buildNix && -z $flake ]]; then
-    echo "building Nix..." >&2
+    log "building Nix..."
     nixDrv=
     if ! nixDrv="$(runCmd nix-instantiate '<nixpkgs/nixos>' --add-root "$tmpDir/nix.drv" --indirect -A config.nix.package.out "${extraBuildFlags[@]}")"; then
         if ! nixDrv="$(runCmd nix-instantiate '<nixpkgs>' --add-root "$tmpDir/nix.drv" --indirect -A nix "${extraBuildFlags[@]}")"; then
@@ -436,7 +441,7 @@ if [[ -n $buildNix && -z $flake ]]; then
             fi
             if ! runCmd nix-store -r "$nixStorePath" --add-root "${tmpDir}/nix" --indirect \
                 --option extra-binary-caches https://cache.nixos.org/; then
-                echo "warning: don't know how to get latest Nix" >&2
+                log "warning: don't know how to get latest Nix"
             fi
             # Older version of nix-store -r don't support --add-root.
             [ -e "$tmpDir/nix" ] || ln -sf "$nixStorePath" "$tmpDir/nix"
@@ -446,7 +451,7 @@ if [[ -n $buildNix && -z $flake ]]; then
                 if ! buildHostCmd nix-store -r "$remoteNixStorePath" \
                   --option extra-binary-caches https://cache.nixos.org/ >/dev/null; then
                     remoteNix=
-                    echo "warning: don't know how to get latest Nix" >&2
+                    log "warning: don't know how to get latest Nix"
                 fi
             fi
         fi
@@ -486,7 +491,7 @@ fi
 # or "boot"), or just build it and create a symlink "result" in the
 # current directory (for "build" and "test").
 if [ -z "$rollback" ]; then
-    echo "building the system configuration..." >&2
+    log "building the system configuration..."
     if [[ "$action" = switch || "$action" = boot ]]; then
         if [[ -z $flake ]]; then
             pathToConfig="$(nixBuild '<nixpkgs/nixos>' --no-out-link -A system "${extraBuildFlags[@]}")"
@@ -543,7 +548,7 @@ fi
 # default and/or activate it now.
 if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = dry-activate ]]; then
     if ! targetHostCmd "$pathToConfig/bin/switch-to-configuration" "$action"; then
-        echo "warning: error(s) occurred while switching to the new configuration" >&2
+        log "warning: error(s) occurred while switching to the new configuration"
         exit 1
     fi
 fi

--- a/pkgs/os-specific/linux/nixos-rebuild/tests/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/tests/default.nix
@@ -1,0 +1,14 @@
+{ pkgs, writers, nixos-rebuild }:
+
+let
+  writer = name: script:
+    writers.makePythonWriter pkgs.python310 pkgs.python3Packages name {
+      flakeIgnore = ["E201" "E202" "E231" "E302" "E305" "E501" "E999"];
+    } script;
+
+in
+  writers.writeDash "foo" ''
+    NIXOS_REBUILD_TEST_INSTRUMENTED=1 \
+      ${nixos-rebuild}/bin/nixos-rebuild dry-build 2>&1 \
+        | ${writer "nixos-rebuild-tests" ./nixos-rebuild-tests.py}
+  ''

--- a/pkgs/os-specific/linux/nixos-rebuild/tests/nixos-rebuild-tests.py
+++ b/pkgs/os-specific/linux/nixos-rebuild/tests/nixos-rebuild-tests.py
@@ -1,0 +1,30 @@
+import json
+import sys
+import unittest
+
+def read_json_lines(f):
+    """read lines that are a json object"""
+    for line in f:
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            # ignore lines that are not json
+            pass
+
+class BasicTest(unittest.TestCase):
+    def test_basic(self):
+        tests = [
+            log_message_exact(self, "building the system configuration..."),
+            run_command_exact(self, ['nix-build', '<nixpkgs/nixos>', '-A', 'system', '-k', '--dry-run']),
+        ]
+        # this is a generator, so a second test won’t get anything atm
+        for (j, test) in zip(read_json_lines(sys.stdin), tests):
+            test(j)
+
+def run_command_exact(test, argv):
+    return lambda j: test.assertEqual({ "tag": "run_command", "argv": argv }, j)
+
+def log_message_exact(test, msg):
+    return lambda j: test.assertEqual({ "tag": "log", "argv": [msg]}, j)
+
+unittest.main()


### PR DESCRIPTION
I’d like to change nixos-rebuild to python at one point, because the complexity of the shell script has gone out of bounds, and there is no good way of refactoring bash scripts in a rigorous way.

The first step towards that is building a strong test suite which captures many (if not most) of the current branching.

The strategy here is to instrument nixos-rebuild to print json-strings, which can be read by the test suite and matched on.