### PR TITLE
gnome.gnome-tetravex: fix build with meson 0.61

### DIFF
--- a/pkgs/desktops/gnome/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-tetravex/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, fetchpatch
 , pkg-config
 , gnome
 , gtk3
@@ -23,6 +24,17 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/gnome-tetravex/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "06wihvqp2p52zd2dnknsc3rii69qib4a30yp15h558xrg44z3k8z";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # data/meson.build:37:0: ERROR: Function does not take positional arguments.
+    # data/meson.build:59:0: ERROR: Function does not take positional arguments.
+    # Taken from https://gitlab.gnome.org/GNOME/gnome-tetravex/-/merge_requests/20
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-tetravex/-/commit/80912d06f5e588f6aca966fa516103275e58d94e.patch";
+      sha256 = "2+nFw5sJzbInibKaq3J10Ufbl3CnZWlgnUtzRTZ5G0I=";
+    })
+  ];
 
   nativeBuildInputs = [
     wrapGAppsHook

--- a/pkgs/desktops/gnome/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-tetravex/default.nix
@@ -1,6 +1,18 @@
-{ lib, stdenv, fetchurl, pkg-config, gnome, gtk3, wrapGAppsHook
-, libxml2, gettext, itstool, meson, ninja, python3
-, vala, desktop-file-utils
+{ stdenv
+, lib
+, fetchurl
+, pkg-config
+, gnome
+, gtk3
+, wrapGAppsHook
+, libxml2
+, gettext
+, itstool
+, meson
+, ninja
+, python3
+, vala
+, desktop-file-utils
 }:
 
 stdenv.mkDerivation rec {
@@ -12,14 +24,20 @@ stdenv.mkDerivation rec {
     sha256 = "06wihvqp2p52zd2dnknsc3rii69qib4a30yp15h558xrg44z3k8z";
   };
 
-  passthru = {
-    updateScript = gnome.updateScript { packageName = "gnome-tetravex"; attrPath = "gnome.gnome-tetravex"; };
-  };
-
   nativeBuildInputs = [
-    wrapGAppsHook itstool libxml2 gnome.adwaita-icon-theme
-    pkg-config gettext meson ninja python3 vala desktop-file-utils
+    wrapGAppsHook
+    itstool
+    libxml2
+    gnome.adwaita-icon-theme
+    pkg-config
+    gettext
+    meson
+    ninja
+    python3
+    vala
+    desktop-file-utils
   ];
+
   buildInputs = [
     gtk3
   ];
@@ -28,6 +46,13 @@ stdenv.mkDerivation rec {
     chmod +x build-aux/meson_post_install.py
     patchShebangs build-aux/meson_post_install.py
   '';
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "gnome-tetravex";
+      attrPath = "gnome.gnome-tetravex";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://wiki.gnome.org/Apps/Tetravex";


### PR DESCRIPTION
###### Description of changes
Going to assume there is no plan to patch meson and try to patch things that are not bumped in GNOME 42 PR.

Patch taken from open-for-a-month-but-still-not-merged PR https://gitlab.gnome.org/GNOME/gnome-tetravex/-/merge_requests/20

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (with meson 0.61)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
