### PR TITLE
nixos/tests/terminal-emulators: fix nonexistant `stdenv.lib` in maintainers

### DIFF
--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -112,7 +112,7 @@ let tests = {
 in mapAttrs (name: { pkg, executable ? name, cmd ? "SHELL=$command ${executable}", colourTest ? true, pinkValue ? "#FF0087", kill ? false }: makeTest
 {
   name = "terminal-emulator-${name}";
-  meta = with pkgs.stdenv.lib.maintainers; {
+  meta = with pkgs.lib.maintainers; {
     maintainers = [ jjjollyjim ];
   };
 


### PR DESCRIPTION
Fixes evaluation of tests' meta.maintainers. `stdenv.lib` was deprecated and removed in the 17 months between opening and merging #103733, and I didn't catch it when rebasing and updating it.