### PR TITLE
glade: fix build with meson 0.61

### DIFF
--- a/pkgs/development/tools/glade/default.nix
+++ b/pkgs/development/tools/glade/default.nix
@@ -1,6 +1,8 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , gettext
 , fetchurl
+, fetchpatch
 , python3
 , meson
 , ninja
@@ -29,6 +31,22 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/glade/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1dxsiz9ahqkxg2a1dw9sbd8jg59y5pdz4c1gvnbmql48gmj8gz4q";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # data/meson.build:4:5: ERROR: Function does not take positional arguments.
+    # Taken from https://gitlab.gnome.org/GNOME/glade/-/merge_requests/117
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/glade/-/commit/61304b2e8bac8ded76643cb7c3e781f73881dd2b.patch";
+      sha256 = "9x6RK8Wgnm8bDxeBLV3PlUkUuH2706Ba9kwE5S87DgE=";
+    })
+    # help/meson.build:6:6: ERROR: Tried to create target "help-glade-da-update-po", but a target of that name already exists.
+    # Taken from https://gitlab.gnome.org/GNOME/glade/-/merge_requests/117
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/glade/-/commit/04ba6f969f716fbfe3c7feb7e4bab8678cc1e9eb.patch";
+      sha256 = "j3XfF7P6rndL+0PWqnp+QYph7Ba6bgcp4Pkikr2wuJA=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson


### PR DESCRIPTION
###### Description of changes

Not part of GNOME 42 PR and no new release so far.

Patch taken from open-for-two-month-but-still-not-merged PR https://gitlab.gnome.org/GNOME/glade/-/merge_requests/117


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (with meson 0.62.0 <- not typo)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
