### PR TITLE
jimtcl: 0.79 -> 0.81

### DIFF
--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     homepage = "http://jim.tcl.tk/";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ dbohdan vrthra ];
+    maintainers = with lib.maintainers; [ dbohdan fgaz vrthra ];
   };
 }

--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -1,20 +1,30 @@
-{ lib, stdenv, fetchFromGitHub, sqlite, readline, asciidoc, SDL, SDL_gfx }:
+{ lib
+, stdenv
+, fetchFromGitHub
 
-let
-  makeSDLFlags = map (p: "-I${lib.getDev p}/include/SDL");
+, asciidoc
+, pkg-config
+, inetutils
 
-in stdenv.mkDerivation rec {
+, sqlite
+, readline
+, SDL
+, SDL_gfx
+}:
+
+stdenv.mkDerivation rec {
   pname = "jimtcl";
-  version = "0.79";
+  version = "0.81";
 
   src = fetchFromGitHub {
     owner = "msteveb";
     repo = "jimtcl";
     rev = version;
-    sha256 = "1k88hz0v3bi19xdvlp0i9nsx38imzwpjh632w7326zwbv2wldf0h";
+    sha256 = "sha256-OpM9y7fQ+18qxl3/5wUCrNA9qiCdA0vTHqLYSw2lvJs=";
   };
 
   nativeBuildInputs = [
+    pkg-config
     asciidoc
   ];
 
@@ -35,8 +45,6 @@ in stdenv.mkDerivation rec {
     "--ipv6"
   ];
 
-  NIX_CFLAGS_COMPILE = toString (makeSDLFlags [ SDL SDL_gfx ]);
-
   enableParallelBuilding = true;
 
   doCheck = true;
@@ -44,6 +52,9 @@ in stdenv.mkDerivation rec {
     # test exec2-3.2 fails depending on platform or sandboxing (?)
     rm tests/exec2.test
   '';
+
+  # test posix-1.6 needs the "hostname" command
+  checkInputs = [ inetutils ];
 
   postInstall = ''
     ln -sr $out/lib/libjim.so.${version} $out/lib/libjim.so


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->https://github.com/msteveb/jimtcl/tags

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
