### PR TITLE
flywheel-cli: init at 16.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10283,6 +10283,16 @@
     githubId = 16487165;
     name = "Rafael Basso";
   };
+  rbreslow = {
+    name = "Rocky Breslow";
+    email = "1774125+rbreslow@users.noreply.github.com";
+    github = "rbreslow";
+    githubId = 1774125;
+    keys = [{
+      longkeyid = "ed25519/0xA0D32ACCA38B88ED";
+      fingerprint = "B5B7 BCA0 EE6F F31E 263A  69E3 A0D3 2ACC A38B 88ED";
+    }];
+  };
   rbrewer = {
     email = "rwb123@gmail.com";
     github = "rbrewer123";

--- a/pkgs/applications/science/biology/flywheel-cli/default.nix
+++ b/pkgs/applications/science/biology/flywheel-cli/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
+
+let
+  inherit (stdenv.targetPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  os = {
+    x86_64-darwin = "darwin";
+    x86_64-linux = "linux";
+  }.${system} or throwSystem;
+
+  sha256 = {
+    x86_64-darwin = "sha256-OIyEu3Hsobui9s5+T9nC10SxMw0MhgmTA4SN9Ridyzo=";
+    x86_64-linux = "sha256-SxBjRd95hoh2zwX6IDnkZnTWVduQafPHvnWw8qTuM78=";
+  }.${system} or throwSystem;
+in
+stdenv.mkDerivation rec {
+  pname = "flywheel-cli";
+  version = "16.2.0";
+
+  src = fetchurl {
+    url = "https://storage.googleapis.com/flywheel-dist/cli/${version}/fw-${os}_amd64-${version}.zip";
+    inherit sha256;
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip ${src}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/bin ./${os}_amd64/fw
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Library and command line interface for interacting with a Flywheel site";
+    homepage = "https://gitlab.com/flywheel-io/public/python-cli";
+    license = licenses.mit;
+    maintainers = with maintainers; [ rbreslow ];
+    platforms = [ "x86_64-darwin" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32209,6 +32209,8 @@ with pkgs;
 
   febio-studio = libsForQt5.callPackage ../applications/science/biology/febio-studio { };
 
+  flywheel-cli = callPackage ../applications/science/biology/flywheel-cli { };
+
   hisat2 = callPackage ../applications/science/biology/hisat2 { };
 
   htslib = callPackage ../development/libraries/science/biology/htslib { };


### PR DESCRIPTION
###### Description of changes

[Flywheel](https://flywheel.io/) is a platform for managing biomedical research data. At @d3b-center, we use it for cataloging DICOM and NIfTI images.

From the Flywheel docs:

> Flywheel's CLI is a tool for [uploading existing data into Flywheel](https://docs.flywheel.io/hc/en-us/articles/360034339933) and [downloading data from Flywheel](https://docs.flywheel.io/hc/en-us/articles/360016090074) to work with offline. The Flywheel CLI is also required to [start jobs](https://docs.flywheel.io/hc/articles/360008285193#UUID-ac584bd6-3657-6b5f-70f1-3d7e9191b4cb) and [build gears](https://docs.flywheel.io/hc/articles/360008285193#UUID-ac584bd6-3657-6b5f-70f1-3d7e9191b4cb).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).