### PR TITLE
nushell: 0.44.0 -> 0.60.0

### DIFF
--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -18,16 +18,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nushell";
-  version = "0.44.0";
+  version = "0.60.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "sha256-LMG72XfDHA9dKiBbaB09v0rDdUKRy/Czu/lsYw6jUog=";
+    sha256 = "1qfqn2q2bam0jrr4yqq9rb29k8qj9w9g0j9x4n8h0zp28vn7c2bq";
   };
 
-  cargoSha256 = "sha256-wgaRTf+ZQ7alibCdeCjSQhhR9MC77qM1n0jakDgr114=";
+  cargoSha256 = "sha256-gZ9r1Ryp5a7MjG9yM0pGCBYtM4GylZg7Sg9wCiB+SW0=";
+
 
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ];

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -29,7 +29,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoSha256 = "sha256-gZ9r1Ryp5a7MjG9yM0pGCBYtM4GylZg7Sg9wCiB+SW0=";
 
-
   nativeBuildInputs = [ pkg-config ]
     ++ lib.optionals (withExtraFeatures && stdenv.isLinux) [ python3 ];
 

--- a/pkgs/shells/nushell/use-system-zstd-lib.diff
+++ b/pkgs/shells/nushell/use-system-zstd-lib.diff
@@ -1,32 +1,32 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 8833c3e5..0c90d2fe 100644
+index 4261c06..6d6e537 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -3188,6 +3188,7 @@ dependencies = [
-  "nu_plugin_xpath",
+@@ -2166,6 +2166,7 @@ dependencies = [
   "rstest",
   "serial_test",
+  "tempfile",
 + "zstd-sys",
  ]
-
+ 
  [[package]]
-@@ -6954,4 +6955,5 @@ checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
+@@ -4962,4 +4963,5 @@ checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
  dependencies = [
   "cc",
   "libc",
 + "pkg-config",
  ]
 diff --git a/Cargo.toml b/Cargo.toml
-index 89e8a311..4cc2331a 100644
+index e214da1..b78919a 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -63,6 +63,9 @@ serial_test = "0.5.1"
- hamcrest2 = "0.3.0"
- rstest = "0.10.0"
-
+@@ -67,6 +69,9 @@ hamcrest2 = "0.3.0"
+ rstest = "0.12.0"
+ itertools = "0.10.3"
+ 
 +# Specify that the indirect dependency ztsd-sys should pick up the system zstd C library
 +zstd-sys = { version = "1", features = [ "pkg-config" ] }
 +
- [build-dependencies]
-
- [features]
+ [target.'cfg(windows)'.build-dependencies]
+ embed-resource = "1"
+ 


### PR DESCRIPTION
Nushell 0.60 was released on Mar, 22nd. This upgrades nushell for nixpkgs to
that version.

For release notes see https://www.nushell.sh/blog/2022-03-22-nushell_0_60.html

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
