### PR TITLE
oras: init at 0.12.0

### DIFF
--- a/pkgs/development/tools/oras/default.nix
+++ b/pkgs/development/tools/oras/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "oras";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "oras-project";
+    repo = "oras";
+    rev = "v${version}";
+    sha256 = "sha256-6W7vmWFjULIJnOVtgSrCEKw/83W8jNSbM0AF4LZZR6U=";
+  };
+  vendorSha256 = "sha256-3UKsH4Jbq7G5PRwhn5lW0NR80jhmuzT9daa++v2sFWk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/oras-project/oras/internal/version.Version=${version}"
+    "-X github.com/oras-project/oras/internal/version.BuildMetadata="
+    "-X github.com/oras-project/oras/internal/version.GitTreeState=clean"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/oras --help
+    $out/bin/oras version | grep "${version}"
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://oras.land/";
+    changelog = "https://github.com/oras-project/oras/releases/tag/v${version}";
+    description = "The ORAS project provides a way to push and pull OCI Artifacts to and from OCI Registries";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19615,6 +19615,8 @@ with pkgs;
 
   optparse-bash = callPackage ../development/libraries/optparse-bash { };
 
+  oras = callPackage ../development/tools/oras { };
+
   orcania = callPackage ../development/libraries/orcania { };
 
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package oras cli for nixpkgs

This tool is now the go-to tool for grabbing the trivy db for an airgapped system and OCI based storage for other stuff is growing: signing and provenance with cosign etc, package storage with brew, etc

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
