### PR TITLE
dcm2niix: add support for configuring optional compile-time modules 

### DIFF
--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -43,12 +43,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "DICOM to NIfTI converter";
     longDescription = ''
-      dcm2niix is a designed to convert neuroimaging data from the
-      DICOM format to the NIfTI format.
+      dcm2niix is designed to convert neuroimaging data from the DICOM format to the NIfTI format.
     '';
     homepage = "https://www.nitrc.org/projects/dcm2nii";
     license = licenses.bsd3;
-    maintainers = [ maintainers.ashgillman ];
+    maintainers = with maintainers; [ ashgillman rbreslow ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -1,17 +1,26 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, substituteAll
 , cmake
-, git
 , openjpeg
 , libyamlcpp
-, zlib
 , batchVersion ? false
 , withJpegLs ? true
 , withOpenJpeg ? true
-, withSystemZlib ? true
+, withCloudflareZlib ? true
 }:
 
+let
+  cloudflareZlib = fetchFromGitHub {
+    owner = "ningfei";
+    repo = "zlib";
+    # HEAD revision of the gcc.amd64 branch on 2022-04-14. Reminder to update
+    # whenever bumping package version.
+    rev = "fda61188d1d4dcd21545c34c2a2f5cc9b0f5db4b";
+    sha256 = "sha256-qySFwY0VI2BQLO2XoCZeYshXEDnHh6SmJ3MvcBUROWU=";
+  };
+in
 stdenv.mkDerivation rec {
   version = "1.0.20211006";
   pname = "dcm2niix";
@@ -23,22 +32,28 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-fQAVOzynMdSLDfhcYWcaXkFW/mnv4zySGLVJNE7ql/c=";
   };
 
-  nativeBuildInputs = [ cmake git ];
+  patches = lib.optionals withCloudflareZlib [
+    (substituteAll {
+      src = ./dont-fetch-external-libs.patch;
+      inherit cloudflareZlib;
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
   buildInputs = lib.optionals batchVersion [ libyamlcpp ]
-    ++ lib.optionals withOpenJpeg [ openjpeg openjpeg.dev ]
-    ++ lib.optionals withSystemZlib [ zlib ];
+    ++ lib.optionals withOpenJpeg [ openjpeg openjpeg.dev ];
 
   cmakeFlags = lib.optionals batchVersion [
-      "-DBATCH_VERSION=ON"
-      "-DYAML-CPP_DIR=${libyamlcpp}/lib/cmake/yaml-cpp"
-    ] ++ lib.optionals withJpegLs [
-      "-DUSE_JPEGLS=ON"
-    ] ++ lib.optionals withOpenJpeg [
-      "-DUSE_OPENJPEG=ON"
-      "-DOpenJPEG_DIR=${openjpeg}/lib/${openjpeg.pname}-${lib.versions.majorMinor openjpeg.version}"
-    ] ++ lib.optionals withSystemZlib [
-      "-DZLIB_IMPLEMENTATION=System"
-    ];
+    "-DBATCH_VERSION=ON"
+    "-DYAML-CPP_DIR=${libyamlcpp}/lib/cmake/yaml-cpp"
+  ] ++ lib.optionals withJpegLs [
+    "-DUSE_JPEGLS=ON"
+  ] ++ lib.optionals withOpenJpeg [
+    "-DUSE_OPENJPEG=ON"
+    "-DOpenJPEG_DIR=${openjpeg}/lib/${openjpeg.pname}-${lib.versions.majorMinor openjpeg.version}"
+  ] ++ lib.optionals withCloudflareZlib [
+    "-DZLIB_IMPLEMENTATION=Cloudflare"
+  ];
 
   meta = with lib; {
     description = "DICOM to NIfTI converter";

--- a/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
+++ b/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
@@ -1,0 +1,36 @@
+diff --git a/SuperBuild/External-CLOUDFLARE-ZLIB.cmake b/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
+index 9f064eb..fe74df5 100644
+--- a/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
++++ b/SuperBuild/External-CLOUDFLARE-ZLIB.cmake
+@@ -1,8 +1,5 @@
+-set(CLOUDFLARE_BRANCH gcc.amd64) # Cloudflare zlib branch
+-
+ ExternalProject_Add(zlib
+-    GIT_REPOSITORY "${git_protocol}://github.com/ningfei/zlib.git"
+-    GIT_TAG "${CLOUDFLARE_BRANCH}"
++    URL file://@cloudflareZlib@
+     SOURCE_DIR cloudflare-zlib
+     BINARY_DIR cloudflare-zlib-build
+     CMAKE_ARGS
+diff --git a/SuperBuild/SuperBuild.cmake b/SuperBuild/SuperBuild.cmake
+index 2a0a956..81354a7 100644
+--- a/SuperBuild/SuperBuild.cmake
++++ b/SuperBuild/SuperBuild.cmake
+@@ -1,17 +1,3 @@
+-# Check if git exists
+-find_package(Git)
+-if(NOT GIT_FOUND)
+-    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
+-endif()
+-
+-# Use git protocol or not
+-option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
+-if(USE_GIT_PROTOCOL)
+-    set(git_protocol "git")
+-else()
+-    set(git_protocol "https")
+-endif()
+-
+ # Basic CMake build settings
+ if(NOT CMAKE_BUILD_TYPE)
+     set(CMAKE_BUILD_TYPE "Release" CACHE STRING


### PR DESCRIPTION
###### Description of changes

Right now, the dcm2niix package produces a single binary without support for dcm2niibatch, JPEG-LS, OpenJPEG, or an alternative zlib library. The [official build process](https://github.com/rordenlab/dcm2niix/blob/002ebcdb9b2a87de7b883e9ddada3963a1cc2327/.travis.yml#L29) for dcm2niix configures all these options (minus batch support). I was motivated to make these changes so my organization could process JPEG 2000 imagery using the Nix binary.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).