### PR TITLE
nixos/1password-gui: init at 8.6.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -118,6 +118,7 @@
   ./misc/version.nix
   ./misc/wordlist.nix
   ./misc/nixops-autoluks.nix
+  ./programs/_1password-gui.nix
   ./programs/adb.nix
   ./programs/appgate-sdp.nix
   ./programs/atop.nix

--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -1,0 +1,69 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs._1password-gui;
+
+in {
+  options = {
+    programs._1password-gui = {
+      enable = mkEnableOption "The 1Password Desktop application with browser integration";
+
+      groupId = mkOption {
+        type = types.int;
+        example = literalExpression "5000";
+        description = ''
+          The GroupID to assign to the onepassword group, which is needed for browser integration. The group ID must be 1000 or greater.
+          '';
+      };
+
+      polkitPolicyOwners = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = literalExpression "[\"user1\" \"user2\" \"user3\"]";
+        description = ''
+          A list of users who should be able to integrate 1Password with polkit-based authentication mechanisms. By default, no users will have such access.
+          '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs._1password-gui;
+        defaultText = literalExpression "pkgs._1password-gui";
+        example = literalExpression "pkgs._1password-gui";
+        description = ''
+          The 1Password derivation to use. This can be used to upgrade from the stable release that we keep in nixpkgs to the betas.
+          '';
+      };
+    };
+  };
+
+  config = let
+    package = cfg.package.override {
+      polkitPolicyOwners = cfg.polkitPolicyOwners;
+    };
+  in mkIf cfg.enable {
+    environment.systemPackages = [ package ];
+    users.groups.onepassword.gid = cfg.groupId;
+
+    security.wrappers = {
+      "1Password-BrowserSupport" =
+        { source = "${cfg.package}/share/1password/1Password-BrowserSupport";
+          owner = "root";
+          group = "onepassword";
+          setuid = false;
+          setgid = true;
+        };
+
+      "1Password-KeyringHelper" =
+        { source = "${cfg.package}/share/1password/1Password-KeyringHelper";
+          owner = "root";
+          group = "onepassword";
+          setuid = true;
+          setgid = true;
+        };
+    };
+
+  };
+}

--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -101,6 +101,7 @@ in stdenv.mkDerivation rec {
         mkdir -p $out/share/polkit-1/actions
         substitute com.1password.1Password.policy.tpl $out/share/polkit-1/actions/com.1password.1Password.policy --replace "\''${POLICY_OWNERS}" "${policyOwners}"
         '') + ''
+
       # Icons
       cp -a resources/icons $out/share
 


### PR DESCRIPTION
###### Description of changes

This adds an OS-level module for 1Password. 1Password's Browser Integration feature requires setgid and setuid programs, which on NixOS can only be handled in the global configuration. This has the benefit of ensuring that the system admin is aware of setgid and setui programs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
