### PR TITLE
ocm: init at 0.1.62

### DIFF
--- a/pkgs/applications/networking/cluster/ocm/default.nix
+++ b/pkgs/applications/networking/cluster/ocm/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   # Tests expect the binary to be located in the root directory.
   preCheck = ''
-    cp $GOPATH/bin/ocm ocm
+    ln -s $GOPATH/bin/ocm ocm
   '';
 
   passthru.tests.version = testVersion {
@@ -28,6 +28,5 @@ buildGoModule rec {
     license = licenses.asl20;
     homepage = "https://github.com/openshift-online/ocm-cli";
     maintainers = with maintainers; [ stehessel ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/cluster/ocm/default.nix
+++ b/pkgs/applications/networking/cluster/ocm/default.nix
@@ -1,0 +1,33 @@
+{ lib, buildGoModule, fetchFromGitHub, testVersion, ocm }:
+
+buildGoModule rec {
+  pname = "ocm";
+  version = "0.1.62";
+
+  src = fetchFromGitHub {
+    owner = "openshift-online";
+    repo = "ocm-cli";
+    rev = "v${version}";
+    sha256 = "0kv0zcx6wdlyid37ygzg05xyyk77ybd2qcdgbswjv6crcjh1xdrd";
+  };
+
+  vendorSha256 = "sha256-nXUrbF9mcHy8G7c+ktQixBmmf6x066gpuaZ0eUsJQwc=";
+
+  # Tests expect the binary to be located in the root directory.
+  preCheck = ''
+    cp $GOPATH/bin/ocm ocm
+  '';
+
+  passthru.tests.version = testVersion {
+    package = ocm;
+    command = "ocm version";
+  };
+
+  meta = with lib; {
+    description = "CLI for the Red Hat OpenShift Cluster Manager";
+    license = licenses.asl20;
+    homepage = "https://github.com/openshift-online/ocm-cli";
+    maintainers = with maintainers; [ stehessel ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27904,6 +27904,8 @@ with pkgs;
 
   ocenaudio = callPackage ../applications/audio/ocenaudio { };
 
+  ocm = callPackage ../applications/networking/cluster/ocm { };
+
   odo = callPackage ../applications/networking/cluster/odo { };
 
   onlyoffice-bin = callPackage ../applications/office/onlyoffice-bin { };


### PR DESCRIPTION
This is a CLI tool to access the Red Hat OpenShift Cluster Manager API.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
