### PR TITLE
devito: init at unstable-2022-04-22

### DIFF
--- a/pkgs/development/python-modules/codepy/default.nix
+++ b/pkgs/development/python-modules/codepy/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytools
+, appdirs
+, six
+, cgen
+}:
+
+buildPythonPackage rec {
+  pname = "codepy";
+  version = "2019.1";
+
+  src = fetchFromGitHub {
+    owner = "inducer";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-viMfB/nDrvDA/IGRZEX+yXylxbbmqbh/fgdYXBzK0zM=";
+  };
+
+  buildInputs = [ pytools six cgen ];
+  propagatedBuildInputs = [ appdirs ];
+
+  pythonImportsCheck = [ "codepy" ];
+
+  # Tests are broken
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = "https://github.com/inducer/codepy";
+    description = "Generate and execute native code at run time, from Python";
+    license = licenses.mit;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/development/python-modules/contexttimer/default.nix
+++ b/pkgs/development/python-modules/contexttimer/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, mock
+, fetchpatch
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "contexttimer";
+  version = "unstable-2019-03-30";
+
+  src = fetchFromGitHub {
+    owner = "brouberol";
+    repo = "contexttimer";
+    rev = "a866f420ed4c10f29abf252c58b11f9db6706100";
+    sha256 = "sha256-Fc1vK1KSZWgBPtBf5dVydF6dLHEGAOslWMV0FLRdj8w=";
+  };
+
+  patches = [
+  # https://github.com/brouberol/contexttimer/pull/16
+    (fetchpatch {
+      url = "https://github.com/brouberol/contexttimer/commit/dd65871f3f25a523a47a74f2f5306c57048592b0.patch";
+      hash = "sha256-vNBuFXvuvb6hWPzg4W4iyKbd4N+vofhxsKydEkc25E4=";
+    })
+  ];
+
+  pythonImportCheck = [ "contexttimer" ];
+
+  checkInputs = [ mock ];
+
+  checkPhase = ''
+    ${python.interpreter} -m unittest tests/test_timer.py
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/brouberol/contexttimer";
+    description = "A timer as a context manager";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/development/python-modules/devito/default.nix
+++ b/pkgs/development/python-modules/devito/default.nix
@@ -1,0 +1,100 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, anytree
+, nbval
+, sympy
+, scipy
+, cached-property
+, psutil
+, py-cpuinfo
+, cgen
+, click
+, multidict
+, distributed
+, pyrevolve
+, codepy
+, pytestCheckHook
+, matplotlib
+, pytest-xdist
+}:
+
+buildPythonPackage rec {
+  pname = "devito";
+  version = "unstable-2022-04-22";
+
+  src = fetchFromGitHub {
+    owner = "devitocodes";
+    repo = "devito";
+    rev = "7cb52eded4038c1a0ee92cfd04d3412c48f2fb7c";
+    sha256 = "sha256-QdQRCGmXaubPPnmyJo2ha0mW5P1akRZhXZVW2TNM5yY=";
+  };
+
+  postPatch = ''
+    # Removing unecessary dependencies
+    sed -e "s/flake8.*//g" \
+        -e "s/codecov.*//g" \
+        -e "s/pytest.*//g" \
+        -e "s/pytest-runner.*//g" \
+        -e "s/pytest-cov.*//g" \
+        -i requirements.txt
+
+    # Relaxing dependencies requirements
+    sed -e "s/>.*//g" \
+        -e "s/<.*//g" \
+        -i requirements.txt
+  '';
+
+  checkInputs = [ pytestCheckHook pytest-xdist matplotlib ];
+
+  # I've had to disable the following tests since they fail while using nix-build, but they do pass
+  # outside the build. They mostly related to the usage of MPI in a sandboxed environment.
+  disabledTests = [
+    "test_assign_parallel"
+    "test_gs_parallel"
+    "test_if_parallel"
+    "test_if_halo_mpi"
+    "test_cache_blocking_structure_distributed"
+    "test_mpi"
+    "test_codegen_quality0"
+    "test_new_distributor"
+    "test_subdomainset_mpi"
+    "test_init_omp_env_w_mpi"
+    "test_mpi_nocomms"
+  ];
+
+  disabledTestPaths = [
+    "tests/test_pickle.py"
+    "tests/test_benchmark.py"
+    "tests/test_mpi.py"
+    "tests/test_autotuner.py"
+    "tests/test_data.py"
+    "tests/test_dse.py"
+    "tests/test_gradient.py"
+  ];
+
+  propagatedBuildInputs = [
+    anytree
+    cached-property
+    cgen
+    click
+    codepy
+    distributed
+    nbval
+    multidict
+    psutil
+    py-cpuinfo
+    pyrevolve
+    scipy
+    sympy
+  ];
+
+  pythonImportsCheck = [ "devito" ];
+
+  meta = with lib; {
+    homepage = "https://www.devitoproject.org/";
+    description = "Code generation framework for automated finite difference computation";
+    license = licenses.mit;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/development/python-modules/pyrevolve/default.nix
+++ b/pkgs/development/python-modules/pyrevolve/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, contexttimer
+, versioneer
+, cython
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pyrevolve";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "devitocodes";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-5a4zvyf2vfz8aI6vFMI2vxekYrcUi/YuPFvZnUOx+Zs=";
+  };
+
+  nativeBuildInputs = [ versioneer cython ];
+  propagatedBuildInputs = [ contexttimer ];
+
+  checkInputs = [ pytest numpy ];
+  # Using approach bellow bcs the tests fail with the pytestCheckHook, throwing the following error
+  # ImportError: cannot import name 'crevolve' from partially initialized module 'pyrevolve'
+  # (most likely due to a circular import)
+  checkPhase = ''
+    pytest
+  '';
+
+  pythonImportsCheck = [ "pyrevolve" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/devitocodes/pyrevolve";
+    description = "Python library to manage checkpointing for adjoints";
+    license = licenses.epl10;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2181,6 +2181,8 @@ in {
 
   detect-secrets = callPackage ../development/python-modules/detect-secrets { };
 
+  devito = callPackage ../development/python-modules/devito { };
+
   devolo-home-control-api = callPackage ../development/python-modules/devolo-home-control-api { };
 
   devolo-plc-api = callPackage ../development/python-modules/devolo-plc-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6349,6 +6349,8 @@ in {
 
   pypoolstation = callPackage ../development/python-modules/pypoolstation { };
 
+  pyrevolve = callPackage ../development/python-modules/pyrevolve { };
+
   pyrfxtrx = callPackage ../development/python-modules/pyrfxtrx { };
 
   pyrogram = callPackage ../development/python-modules/pyrogram { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1779,6 +1779,8 @@ in {
 
   codecov = callPackage ../development/python-modules/codecov { };
 
+  codepy = callPackage ../development/python-modules/codepy { };
+
   codespell = callPackage ../development/python-modules/codespell { };
 
   cogapp = callPackage ../development/python-modules/cogapp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1867,6 +1867,8 @@ in {
 
   contextvars = callPackage ../development/python-modules/contextvars { };
 
+  contexttimer = callPackage ../development/python-modules/contexttimer { };
+
   convertdate = callPackage ../development/python-modules/convertdate { };
 
   cookiecutter = callPackage ../development/python-modules/cookiecutter { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I implemented this package because I going to need it for my job. Devito is a domain specific language API that allows for code generation of partial differential equations solutions, and is highly optimized for both CPU and GPU.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
