### PR TITLE
shisho: init at 0.5.2

### DIFF
--- a/pkgs/tools/security/shisho/default.nix
+++ b/pkgs/tools/security/shisho/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, installShellFiles
+, rustfmt
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shisho";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "flatt-security";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-G7sHaDq+F5lXNaF1sSLUecdjZbCejJE79P4AQifKdFY=";
+    fetchSubmodules = true;
+  };
+  cargoSha256 = "sha256-xd4andytmDMOIT+3DkmUC9fkxxGJ6yRY2WSdnGB6ZwY=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    # required to build serde-sarif dependency
+    rustfmt
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd shisho \
+      --bash <($out/bin/shisho completion bash) \
+      --fish <($out/bin/shisho completion fish) \
+      --zsh <($out/bin/shisho completion zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/shisho --help
+    $out/bin/shisho --version | grep "${version}"
+
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    homepage = "https://docs.shisho.dev/shisho/";
+    changelog = "https://docs.shisho.dev/changelog/";
+    description = "Lightweight static analyzer for several programming languages";
+    longDescription = ''
+      Shisho is a lightweight static code analyzer designed for developers and
+      is the core engine for Shisho products. It is, so to speak, like a
+      pluggable and configurable linter; it gives developers a way to codify
+      your domain knowledge over your code as rules. With powerful automation
+      and integration capabilities, the rules will help you find and fix issues
+      semiautomatically.
+    '';
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ jk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3797,6 +3797,8 @@ with pkgs;
 
   shipyard = callPackage ../tools/virtualization/shipyard { };
 
+  shisho = callPackage ../tools/security/shisho { };
+
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
   simplenes = callPackage ../applications/emulators/simplenes { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package `shisho` for nixpkgs

It's an engine for finding certain code and potentially changing it similar to semgrep, written in rust, and powered in part by treesitter

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
