### PR TITLE
bin-paste: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14749,6 +14749,15 @@
     githubId = 3889405;
     name = "vyp";
   };
+  w4 = {
+    email = "jordan@doyle.la";
+    github = "w4";
+    githubId = 5258114;
+    name = "Jordan Doyle";
+    keys = [{
+      fingerprint = "327D 73A1 FEF2 CDA5 1140  1183 1EA6 BAE6 F66D C49A";
+    }];
+  };
   wackbyte = {
     name = "wackbyte";
     email = "wackbyte@pm.me";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1087,6 +1087,7 @@
   ./services/web-apps/atlassian/confluence.nix
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
+  ./services/web-apps/bin-paste.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/code-server.nix

--- a/nixos/modules/services/web-apps/bin-paste.nix
+++ b/nixos/modules/services/web-apps/bin-paste.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.bin-paste;
+
+in {
+  options.services.bin-paste = {
+    enable = mkEnableOption "bin-paste";
+    bindAddress = mkOption {
+      default = "[::]:8000";
+      description = "Address and port to listen on";
+      type = types.str;
+    };
+    package = mkOption {
+      default = pkgs.bin;
+      defaultText = "pkgs.bin-paste";
+      description = "Which bin derivation to use";
+      type = types.package;
+    };
+    maxPasteSize = mkOption {
+      default = 32768;
+      description = "Max allowed size of an individual paste";
+      type = types.int;
+    };
+    bufferSize = mkOption {
+      default = 1000;
+      description = "Maximum amount of pastes to store at a time";
+      type = types.int;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.bin-paste = {
+      enable = true;
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${cfg.package}/bin/bin --buffer-size ${toString cfg.bufferSize} --max-paste-size ${toString cfg.maxPasteSize} ${cfg.bindAddress}";
+        Restart = "on-failure";
+
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        PrivateMounts = true;
+        ProtectHome = true;
+        ProtectClock = true;
+        ProtectProc = "noaccess";
+        ProcSubset = "pid";
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        SystemCallFilter = [ "@system-service" "~@privileged" ];
+      };
+    };
+  };
+}

--- a/pkgs/servers/bin-paste/default.nix
+++ b/pkgs/servers/bin-paste/default.nix
@@ -20,5 +20,6 @@ rustPlatform.buildRustPackage rec {
     description = "Paste bin";
     homepage = "https://github.com/w4/bin";
     license = licenses.wtfpl;
+    maintainers = [ maintainers.w4 ];
   };
 }

--- a/pkgs/servers/bin-paste/default.nix
+++ b/pkgs/servers/bin-paste/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, rustPlatform, fetchFromGitHub, llvmPackages, Security }:
+rustPlatform.buildRustPackage rec {
+  pname = "bin-paste";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "w4";
+    repo = "bin";
+    rev = "v${version}";
+    sha256 = "1g67k9m4aflhf2sb2xggh896xgp9vh7n2z0w5kxql0p3xa0shsi9";
+  };
+
+  cargoSha256 = "1v2ks2vdr5knn6kri0d03rvzx1mkv5qhv7xphsxpwfyykhbc0j7h";
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ Security ];
+
+  meta = with lib; {
+    description = "Paste bin";
+    homepage = "https://github.com/w4/bin";
+    license = licenses.wtfpl;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23639,6 +23639,10 @@ with pkgs;
 
   bftpd = callPackage ../servers/ftp/bftpd {};
 
+  bin-paste = callPackage ../servers/bin-paste {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+
   bind = callPackage ../servers/dns/bind { };
   dnsutils = bind.dnsutils;
   dig = bind.dnsutils;


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the `bin` package and service, a barebones pastebin that can run with no configuration. The "official" https://bin.gy/ is currently running with this derivation but there has been a couple of requests to move this to Nixpkgs.

https://github.com/w4/bin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
