### PR TITLE
 findutils: move {locate,updatedb} to a separate $locate output 

### DIFF
--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -27,7 +27,7 @@ in
 
     locate = mkOption {
       type = package;
-      default = pkgs.findutils;
+      default = pkgs.findutils.locate;
       defaultText = literalExpression "pkgs.findutils";
       example = literalExpression "pkgs.mlocate";
       description = ''

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     && (stdenv.hostPlatform.libc != "musl")
     && stdenv.hostPlatform == stdenv.buildPlatform;
 
-  outputs = [ "out" "info" ];
+  outputs = [ "out" "info" "locate"];
 
   configureFlags = [
     # "sort" need not be on the PATH as a run-time dep, so we need to tell
@@ -45,6 +45,18 @@ stdenv.mkDerivation rec {
     # https://github.com/Homebrew/homebrew-core/pull/69761#issuecomment-770268478
     "-D__nonnull\\(params\\)="
   ];
+
+  postInstall = ''
+    moveToOutput bin/locate $locate
+    moveToOutput bin/updatedb $locate
+  '';
+
+  # can't move man pages in postInstall because the multi-output hook will move them back to $out
+  postFixup = ''
+    moveToOutput share/man/man5 $locate
+    moveToOutput share/man/man1/locate.1.gz $locate
+    moveToOutput share/man/man1/updatedb.1.gz $locate
+  '';
 
   enableParallelBuilding = true;
 
@@ -62,9 +74,12 @@ stdenv.mkDerivation rec {
       The tools supplied with this package are:
 
           * find - search for files in a directory hierarchy;
+          * xargs - build and execute command lines from standard input.
+
+      The following are available in the locate output:
+
           * locate - list files in databases that match a pattern;
           * updatedb - update a file name database;
-          * xargs - build and execute command lines from standard input.
     '';
 
     platforms = lib.platforms.all;


### PR DESCRIPTION
it is not secure and most distros don't include locate in findutils
so it may be the expectation that we don't include findutils locate
either

mlocate and alternatives offer better functionality and security

Closes https://github.com/NixOS/nixpkgs/issues/53925
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
