### PR TITLE
cups-brother-mfcl2750dw: init at 4.0.0-1

### DIFF
--- a/pkgs/misc/cups/drivers/mfcl2750dw/default.nix
+++ b/pkgs/misc/cups/drivers/mfcl2750dw/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, perl
+, gnused
+, ghostscript
+, file
+, coreutils
+, gnugrep
+, which
+}:
+
+let
+  arches = [ "x86_64" "i686" "armv7l" ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-mfcl2750dw";
+  version = "4.0.0-1";
+
+  nativeBuildInputs = [ dpkg makeWrapper autoPatchelfHook ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103566/mfcl2750dwpdrv-${version}.i386.deb";
+    hash = "sha256-3uDwzLQTF8r1tsGZ7ChGhk4ryQmVsZYdUaj9eFaC0jc=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  '' + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/MFCL2750DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches) + ''
+
+      # bundled scripts don't understand the arch subdirectories for some reason
+      ln -s \
+        "$out/opt/brother/Printers/MFCL2750DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+        "$out/opt/brother/Printers/MFCL2750DW/lpd/"
+
+      # Fix global references and replace auto discovery mechanism with hardcoded values
+      substituteInPlace $out/opt/brother/Printers/MFCL2750DW/lpd/lpdfilter \
+        --replace /opt "$out/opt" \
+        --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/MFCL2750DW\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"MFCL2750DW\"; #"
+
+      # Make sure all executables have the necessary runtime dependencies available
+      find "$out" -executable -and -type f | while read file; do
+        wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+      done
+
+      # Symlink filter and ppd into a location where CUPS will discover it
+      mkdir -p $out/lib/cups/filter
+      mkdir -p $out/share/cups/model
+
+      ln -s \
+        $out/opt/brother/Printers/MFCL2750DW/lpd/lpdfilter \
+        $out/lib/cups/filter/brother_lpdwrapper_MFCL2750DW
+
+      ln -s \
+        $out/opt/brother/Printers/MFCL2750DW/cupswrapper/brother-MFCL2750DW-cups-en.ppd \
+        $out/share/cups/model/
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    homepage = "http://www.brother.com/";
+    description = "Brother MFC-L2750DW printer driver";
+    license = licenses.unfree;
+    platforms = builtins.map (arch: "${arch}-linux") arches;
+    maintainers = [ maintainers.lovesegfault ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33277,6 +33277,8 @@ with pkgs;
 
   cups-brother-hll2350dw = callPackage  ../misc/cups/drivers/hll2350dw { };
 
+  cups-brother-mfcl2750dw = callPackage  ../misc/cups/drivers/mfcl2750dw { };
+
   cups-drv-rastertosag-gdi = callPackage ../misc/cups/drivers/cups-drv-rastertosag-gdi { };
 
   # this driver ships with pre-compiled 32-bit binary libraries


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
