### PR TITLE
aardvark-dns, netavark: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/tools/networking/aardvark-dns/default.nix
+++ b/pkgs/tools/networking/aardvark-dns/default.nix
@@ -5,26 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "aardvark-dns";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-6O/7GoGH0xNbTfIFeD5VLrifNFpHcxxG0bdq/YQb3Ew=";
+    sha256 = "sha256-d4YSCVZkNung4frgAeP46E9Ptpnu9y0HwmPRADo4t0U=";
   };
 
-  cargoHash = "sha256-YdHIyCJ00MKH8PL0osOqQIMwaws3+cOUwvhvA8mOp84=";
-
-  preBuild = ''
-    rm build.rs
-
-    export \
-      VERGEN_BUILD_SEMVER="${version}" \
-      VERGEN_BUILD_TIMESTAMP="$SOURCE_DATE_EPOCH" \
-      VERGEN_GIT_SHA="${src.rev}" \
-      VERGEN_RUSTC_HOST_TRIPLE=""
-  '';
+  cargoHash = "sha256-fu7ZopS55IzzeO7uzLx1wVHQ8A1Ff+9f7FagoZPerxk=";
 
   meta = with lib; {
     description = "Authoritative dns server for A/AAAA container records";

--- a/pkgs/tools/networking/netavark/default.nix
+++ b/pkgs/tools/networking/netavark/default.nix
@@ -7,29 +7,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "netavark";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-r9NoPDFCqmzESxlovs91j0OyunGDmfWJXN+U1f0w2QQ=";
+    sha256 = "sha256-2ElEhKit/XysRsUw+dg7SnhDl+Zf+FJb5pIYpq1ALNs=";
   };
 
-  cargoHash = "sha256-/N9oKzcAwaxI2BbeoYZ2quN+Z3UO67ecpogK2SRG9Dw=";
-
-  preBuild = ''
-    substituteInPlace Cargo.toml \
-      --replace 'build = "build.rs"' ""
-
-    rm build.rs
-
-    export \
-      VERGEN_BUILD_SEMVER="${version}" \
-      VERGEN_BUILD_TIMESTAMP="$SOURCE_DATE_EPOCH" \
-      VERGEN_GIT_SHA="${src.rev}" \
-      VERGEN_RUSTC_HOST_TRIPLE=""
-  '';
+  cargoHash = "sha256-w3qz4ygjIvn+Rxd1JEVO6Ax08leuuJvC4Bk7VygbBh4=";
 
   nativeBuildInputs = [ installShellFiles mandown ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
