### PR TITLE
lib/modules: Document `_module.args`

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -691,7 +691,7 @@ runTests {
 
         locs = filter (o: ! o.internal) (optionAttrSetToDocList options);
       in map (o: o.loc) locs;
-    expected = [ [ "foo" ] [ "foo" "<name>" "bar" ] [ "foo" "bar" ] ];
+    expected = [ [ "_module" "args" ] [ "foo" ] [ "foo" "<name>" "bar" ] [ "foo" "bar" ] ];
   };
 
   testCartesianProductOfEmptySet = {

--- a/nixos/lib/make-options-doc/mergeJSON.py
+++ b/nixos/lib/make-options-doc/mergeJSON.py
@@ -48,7 +48,9 @@ overrides = pivot(json.load(open(sys.argv[2 + optOffset], 'r')))
 
 # fix up declaration paths in lazy options, since we don't eval them from a full nixpkgs dir
 for (k, v) in options.items():
-    v.value['declarations'] = list(map(lambda s: f'nixos/modules/{s}', v.value['declarations']))
+    # The _module options are not declared in nixos/modules
+    if v.value['loc'][0] != "_module":
+        v.value['declarations'] = list(map(lambda s: f'nixos/modules/{s}', v.value['declarations']))
 
 # merge both descriptions
 for (k, v) in overrides.items():


### PR DESCRIPTION
###### Description of changes

Documents the `_module.args` option, motivated by [many usages in Flakes](https://discourse.nixos.org/t/accessing-flake-outputs-in-the-flake-itself/14662/6?u=infinisil), especially with the [deprecation of extraArgs](https://github.com/NixOS/nixpkgs/pull/148315)

<details>
<summary>Click for screenshot of the documentation</summary>

![Screen Shot 2022-03-24 at 14 33 07](https://user-images.githubusercontent.com/20525370/159927397-b6b2179f-38df-4b82-a937-87f2a55fd0bb.png)

</details>

Ping @roberth

###### Things done

- [x] Built the manual with `nix-build nixos/release.nix -A manualHTML.x86_64-linux` and checked the resulting `result/share/doc/nixos/options.html`