### PR TITLE
lfimg: init at 87b1f6b

### DIFF
--- a/pkgs/tools/graphics/epub-thumbnailer/default.nix
+++ b/pkgs/tools/graphics/epub-thumbnailer/default.nix
@@ -1,0 +1,33 @@
+{ lib, python3Packages, fetchFromGitHub }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "epub-thumbnailer";
+  version = "486111b";
+
+  src = fetchFromGitHub {
+    owner = "marianosimone";
+    repo = pname;
+    rev = version;
+    sha256 = "0mv0zd74g4xfi2pvl8k0z6qvf1987lwk47ia8cyr51capk95p4rp";
+  };
+
+  dontBuild = true;
+  doCheck = false;
+
+  propagatedBuildInputs = with python3Packages; [ pillow ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/epub-thumbnailer.py $out/bin/epub-thumbnailer
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/marianosimone/epub-thumbnailer";
+    description = "Script to extract the cover of an epub book and create a thumbnail for it";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ atila ];
+  };
+}

--- a/pkgs/tools/misc/lfimg/default.nix
+++ b/pkgs/tools/misc/lfimg/default.nix
@@ -1,0 +1,57 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, ueberzug
+, lf
+, makeWrapper
+, ffmpegthumbnailer
+, imagemagick
+, wkhtmltopdf
+, epub-thumbnailer
+, poppler_utils
+, chafa
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "lfimg";
+  version = "87b1f6b";
+
+  src = fetchFromGitHub {
+    owner = "cirala";
+    repo = pname;
+    rev = version;
+    sha256 = "0ykjhvl3yd8mwaf1vpz6wa0zph7ahn5pw88dk8vy62wm0d6aajgg";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 lfrun $out/bin/lfrun
+
+    wrapProgram $out/bin/lfrun \
+        --prefix PATH : ${lib.makeBinPath [
+            ueberzug
+            lf
+            ffmpegthumbnailer
+            imagemagick
+            wkhtmltopdf
+            epub-thumbnailer
+            poppler_utils
+            chafa
+          ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/cirala/lfimg";
+    description = "Image preview support for lf (list files) using Überzug";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ atila ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7198,6 +7198,8 @@ with pkgs;
 
   lf = callPackage ../tools/misc/lf {};
 
+  lfimg = callPackage ../tools/misc/lfimg { };
+
   lha = callPackage ../tools/archivers/lha { };
 
   lhasa = callPackage ../tools/compression/lhasa {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5056,6 +5056,8 @@ with pkgs;
 
   epubcheck = callPackage ../tools/text/epubcheck { };
 
+  epub-thumbnailer = callPackage ../tools/graphics/epub-thumbnailer { };
+
   luckybackup = libsForQt5.callPackage ../tools/backup/luckybackup {
     ssh = openssh;
   };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a script to enable image preview for the file manager lf, using ueberzug. Hope it helps other people.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
