### PR TITLE
prometheus-node-exporter: fix build on darwin

### DIFF
--- a/pkgs/servers/monitoring/prometheus/node-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/node-exporter.nix
@@ -1,4 +1,7 @@
-{ lib, buildGoModule, fetchFromGitHub, nixosTests }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub, nixosTests
+  # darwin
+  , CoreFoundation, IOKit
+}:
 
 buildGoModule rec {
   pname = "node_exporter";
@@ -16,6 +19,13 @@ buildGoModule rec {
 
   # FIXME: tests fail due to read-only nix store
   doCheck = false;
+
+  buildInputs = lib.optionals stdenv.isDarwin [ CoreFoundation IOKit ];
+  # upstream currently doesn't work with the version of the macOS SDK
+  # we're building against in nix-darwin without a patch.
+  # this patch has been submitted upstream at https://github.com/prometheus/node_exporter/pull/2327
+  # and only needs to be carried until it lands in a new release.
+  patches = lib.optionals stdenv.isDarwin [ ./node-exporter/node-exporter-darwin.patch ];
 
   excludedPackages = [ "docs/node-mixin" ];
 

--- a/pkgs/servers/monitoring/prometheus/node-exporter/node-exporter-darwin.patch
+++ b/pkgs/servers/monitoring/prometheus/node-exporter/node-exporter-darwin.patch
@@ -1,0 +1,17 @@
+diff --git a/collector/powersupplyclass_darwin.go b/collector/powersupplyclass_darwin.go
+index a070f64..01d7f18 100644
+--- a/collector/powersupplyclass_darwin.go
++++ b/collector/powersupplyclass_darwin.go
+@@ -18,9 +18,11 @@ package collector
+ 
+ /*
+ #cgo LDFLAGS: -framework IOKit -framework CoreFoundation
++#include <CoreFoundation/CFNumber.h>
++#include <CoreFoundation/CFRunLoop.h>
++#include <CoreFoundation/CFString.h>
+ #include <IOKit/ps/IOPowerSources.h>
+ #include <IOKit/ps/IOPSKeys.h>
+-#include <CoreFoundation/CFArray.h>
+ 
+ // values collected from IOKit Power Source APIs
+ // Functions documentation available at

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22004,7 +22004,9 @@ with pkgs;
   prometheus-nextcloud-exporter = callPackage ../servers/monitoring/prometheus/nextcloud-exporter.nix { };
   prometheus-nginx-exporter = callPackage ../servers/monitoring/prometheus/nginx-exporter.nix { };
   prometheus-nginxlog-exporter = callPackage ../servers/monitoring/prometheus/nginxlog-exporter.nix { };
-  prometheus-node-exporter = callPackage ../servers/monitoring/prometheus/node-exporter.nix { };
+  prometheus-node-exporter = callPackage ../servers/monitoring/prometheus/node-exporter.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
+  };
   prometheus-openldap-exporter = callPackage ../servers/monitoring/prometheus/openldap-exporter.nix { };
   prometheus-openvpn-exporter = callPackage ../servers/monitoring/prometheus/openvpn-exporter.nix { };
   prometheus-pihole-exporter = callPackage ../servers/monitoring/prometheus/pihole-exporter.nix {  };


### PR DESCRIPTION
###### Description of changes

this adds a small patch to fix node_exporter on darwin. code was written that works with the commercial macos SDK but not against ours due to slightly different includes, seemingly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
