### PR TITLE
unigine-heaven: init at 4.0

### DIFF
--- a/pkgs/applications/graphics/unigine-heaven/default.nix
+++ b/pkgs/applications/graphics/unigine-heaven/default.nix
@@ -1,0 +1,107 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, libX11
+, libXext
+, libXrandr
+, freetype
+, fontconfig
+, libXrender
+, libXinerama
+, autoPatchelfHook
+, libglvnd
+, openal
+, imagemagick
+, makeDesktopItem
+}:
+let
+  version = "4.0";
+
+  arch =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      "x64"
+    else if stdenv.hostPlatform.system == "i686-linux" then
+      "x86"
+    else
+      throw "Unsupported platform ${stdenv.hostPlatform.system}";
+
+  desktopItem = makeDesktopItem {
+    name = "Heaven";
+    exec = "heaven";
+    genericName = "A GPU Stress test tool from the UNIGINE";
+    icon = "Heaven";
+    desktopName = "Heaven Benchmark";
+  };
+in
+stdenv.mkDerivation
+{
+  pname = "unigine-heaven";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://assets.unigine.com/d/Unigine_Heaven-${version}.run";
+    sha256 = "19rndwwxnb9k2nw9h004hyrmr419471s0fp25yzvvc6rkd521c0v";
+  };
+
+  installPhase =
+    ''
+      sh $src --target $name
+
+      mkdir -p $out/lib/unigine/heaven/bin
+      mkdir -p $out/bin
+      mkdir -p $out/share/applications/
+      mkdir -p $out/share/icons/hicolor
+
+      install -m 0755 $name/bin/browser_${arch} $out/lib/unigine/heaven/bin
+      install -m 0755 $name/bin/libApp{Stereo,Surround,Wall}_${arch}.so $out/lib/unigine/heaven/bin
+      install -m 0755 $name/bin/libGPUMonitor_${arch}.so $out/lib/unigine/heaven/bin
+      install -m 0755 $name/bin/libQt{Core,Gui,Network,WebKit,Xml}Unigine_${arch}.so.4 $out/lib/unigine/heaven/bin
+      install -m 0755 $name/bin/libUnigine_${arch}.so $out/lib/unigine/heaven/bin
+      install -m 0755 $name/bin/heaven_${arch} $out/lib/unigine/heaven/bin
+      install -m 0755 $name/heaven $out/bin/heaven
+
+      cp -R $name/data $name/documentation $out/lib/unigine/heaven
+
+      wrapProgram $out/bin/heaven --prefix LD_LIBRARY_PATH : ${libglvnd}/lib:$out/bin:${openal}/lib --run "cd $out/lib/unigine/heaven/"
+
+      convert $out/lib/unigine/heaven/data/launcher/icon.png -resize 128x128 $out/share/icons/Heaven.png
+      for RES in 16 24 32 48 64 128 256
+      do
+          mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+          convert $out/lib/unigine/heaven/data/launcher/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Heaven.png
+      done
+
+      ln -s ${desktopItem}/share/applications/* $out/share/applications
+    '';
+
+  nativeBuildInputs =
+    [
+      autoPatchelfHook
+      makeWrapper
+      imagemagick
+    ];
+
+  buildInputs =
+    [
+      libX11
+      stdenv.cc.cc
+      libXext
+      libXrandr
+      freetype
+      fontconfig
+      libXrender
+      libXinerama
+    ];
+
+  dontUnpack = true;
+
+  meta =
+    {
+      description = "The Unigine Heaven GPU benchmarking tool";
+      homepage = "https://benchmark.unigine.com/heaven";
+      license = lib.licenses.unfree;
+      maintainers = [ lib.maintainers.BarinovMaxim ];
+      platforms = [ "x86_64-linux" "i686-linux" ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29667,6 +29667,8 @@ with pkgs;
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
+  unigine-heaven = callPackage ../applications/graphics/unigine-heaven { };
+
   unipicker = callPackage ../applications/misc/unipicker { };
 
   unison = callPackage ../applications/networking/sync/unison {


### PR DESCRIPTION
###### Description of changes

I want to add a new package. It's Unigine Heaven benchmarking GPU tool.

###### Motivation for this change
I want to add a new package. It's Unigine Heaven benchmarking GPU tool. People will be able to install this benchmarking tool on nixos.

###### Things done
unigine_heaven.nix downloads the program from official site and unpacks it. Then applies autopatchelfhook and creates an executable file in $out/bin to add to environment

- Built on platform(s)
  - [x] x86_64-linux


