### PR TITLE
kubent: init at 0.5.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubent/default.nix
+++ b/pkgs/applications/networking/cluster/kubent/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "kubent";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "doitintl";
+    repo = "kube-no-trouble";
+    rev = "${version}";
+    sha256 = "0pwb9g1hhfqn3rl87fg6sf07m7aviadljb05bbnd241hhlcyslv6";
+  };
+
+  vendorSha256 = "1z4cvk936l7011fbimsgpw89yqzyikw9jb4184l37mnj9hl5wpcp";
+
+  ldflags = [
+    "-w" "-s"
+    "-X main.version=v${version}"
+  ];
+
+  subPackages = [ "cmd/kubent" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/doitintl/kube-no-trouble";
+    description = "Easily check your cluster for use of deprecated APIs";
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterromfeldhk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27109,6 +27109,8 @@ with pkgs;
 
   kubemqctl = callPackage ../applications/networking/cluster/kubemqctl { };
 
+  kubent = callPackage ../applications/networking/cluster/kubent { };
+
   kubeseal = callPackage ../applications/networking/cluster/kubeseal { };
 
   kubernix = callPackage ../applications/networking/cluster/kubernix { };


### PR DESCRIPTION
###### Description of changes

Easily check your k8s cluster for use of deprecated APIs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

tested with:
```
⋊> ~/r/p/nixpkgs on peter-kubent  nix-shell -I nixpkgs=https://github.com/peterromfeldhk/nixpkgs/archive/(git rev-parse HEAD).tar.gz -p kubent --run 'kubent info'                                                                  10:25:45
10:25AM INF >>> Kube No Trouble `kubent` <<<
10:25AM INF version v0.5.1 (git sha dev)
10:25AM INF Initializing collectors and retrieving data
10:25AM INF Retrieved 0 resources from collector name=Cluster
10:25AM ERR Failed to retrieve data from collector error=Unauthorized name="Helm v2"
10:25AM ERR Failed to retrieve data from collector error="list: failed to list: Unauthorized" name="Helm v3"
10:25AM INF Loaded ruleset name=custom.rego.tmpl
10:25AM INF Loaded ruleset name=deprecated-1-16.rego
10:25AM INF Loaded ruleset name=deprecated-1-22.rego
10:25AM INF Loaded ruleset name=deprecated-1-25.rego
```
