### PR TITLE
pluto: init at 5.6.0

### DIFF
--- a/pkgs/applications/networking/cluster/pluto/default.nix
+++ b/pkgs/applications/networking/cluster/pluto/default.nix
@@ -1,0 +1,27 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "pluto";
+  version = "5.6.0";
+
+  src = fetchFromGitHub {
+    owner = "FairwindsOps";
+    repo = "pluto";
+    rev = "v${version}";
+    sha256 = "0nr8h8vg8ifgibgw80rs4mk63bj3qhmd37lfjc89iyml4g6p9mwr";
+  };
+
+  vendorSha256 = "08x5mzypg66s54apkd7hhj6bi5pgbch9if2dbr58ksd3arkji2pv";
+
+  ldflags = [
+    "-w" "-s"
+    "-X main.version=v${version}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/FairwindsOps/pluto";
+    description = "Find deprecated Kubernetes apiVersions";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ peterromfeldhk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27958,6 +27958,8 @@ with pkgs;
 
   pleroma-bot = python3Packages.callPackage ../development/python-modules/pleroma-bot { };
 
+  pluto = callPackage ../applications/networking/cluster/pluto { };
+
   polybar = callPackage ../applications/misc/polybar { };
 
   polybarFull = callPackage ../applications/misc/polybar {


### PR DESCRIPTION
###### Description of changes

Find deprecated Kubernetes apiVersions

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

tested with:
```
[nix][k8s-context]⋊> ~/r/p/nixpkgs on peter-pluto  nix-shell -I nixpkgs=https://github.com/peterromfeldhk/nixpkgs/archive/(git rev-parse HEAD).tar.gz -p pluto kubectl --run 'pluto detect-helm'                                    10:54:45
unpacking 'https://github.com/peterromfeldhk/nixpkgs/archive/817bf77574c47ceb731e96d8eae05a7fe17d3096.tar.gz'...
NAME                                                               KIND                VERSION          REPLACEMENT   REMOVED   DEPRECATED  
prometheus-operator/prometheus-operator-kube-state-metrics         PodSecurityPolicy   policy/v1beta1                 false     true        
prometheus-operator/prometheus-operator-prometheus-node-exporter   PodSecurityPolicy   policy/v1beta1                 false     true        
prometheus-operator/prometheus-operator-alertmanager               PodSecurityPolicy   policy/v1beta1                 false     true        
prometheus-operator/prometheus-operator-operator                   PodSecurityPolicy   policy/v1beta1                 false     true        
prometheus-operator/prometheus-operator-prometheus                 PodSecurityPolicy   policy/v1beta1                 false     true
```
