### PR TITLE
teleport: fix exec srv command not found

### DIFF
--- a/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
+++ b/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
@@ -16,10 +16,10 @@ index 253fbafef..815a2e1e0 100644
  
  const (
 -	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
-+	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin:/run/current-system/sw/bin"
++	defaultPath          = "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"
  	defaultEnvPath       = "PATH=" + defaultPath
 -	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-+	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
++	defaultRootPath      = "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"
  	defaultEnvRootPath   = "PATH=" + defaultRootPath
  	defaultTerm          = "xterm"
  	defaultLoginDefsPath = "/etc/login.defs"

--- a/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
+++ b/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
@@ -16,10 +16,10 @@ index 253fbafef..815a2e1e0 100644
  
  const (
 -	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
-+	defaultPath          = "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"
++	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin:/run/current-system/sw/bin"
  	defaultEnvPath       = "PATH=" + defaultPath
 -	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-+	defaultRootPath      = "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/bin:/bin"
++	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
  	defaultEnvRootPath   = "PATH=" + defaultRootPath
  	defaultTerm          = "xterm"
  	defaultLoginDefsPath = "/etc/login.defs"

--- a/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
+++ b/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
@@ -16,10 +16,10 @@ index 253fbafef..815a2e1e0 100644
  
  const (
 -	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
-+	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin:/run/current-system/sw/bin"
++	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/run/wrappers/bin"
  	defaultEnvPath       = "PATH=" + defaultPath
 -	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-+	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
++	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/run/wrappers/bin"
  	defaultEnvRootPath   = "PATH=" + defaultRootPath
  	defaultTerm          = "xterm"
  	defaultLoginDefsPath = "/etc/login.defs"

--- a/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
+++ b/pkgs/servers/teleport/0001-fix-add-nix-path-to-exec-env.patch
@@ -1,0 +1,28 @@
+From e3651ca79c0edb66c04e0d3381f3b0b6f76d37d2 Mon Sep 17 00:00:00 2001
+From: 5aaee9 <jiduye@gmail.com>
+Date: Thu, 24 Mar 2022 17:34:38 +0800
+Subject: [PATCH] fix: add nix path to exec env
+
+---
+ lib/srv/exec.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/srv/exec.go b/lib/srv/exec.go
+index 253fbafef..815a2e1e0 100644
+--- a/lib/srv/exec.go
++++ b/lib/srv/exec.go
+@@ -41,9 +41,9 @@ import (
+ )
+ 
+ const (
+-	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
++	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin:/run/current-system/sw/bin"
+ 	defaultEnvPath       = "PATH=" + defaultPath
+-	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
++	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin"
+ 	defaultEnvRootPath   = "PATH=" + defaultRootPath
+ 	defaultTerm          = "xterm"
+ 	defaultLoginDefsPath = "/etc/login.defs"
+-- 
+2.32.0 (Apple Git-132)
+

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -60,6 +60,7 @@ buildGoModule rec {
     ./tsh.patch
     # https://github.com/NixOS/nixpkgs/issues/132652
     ./test.patch
+    ./0001-fix-add-nix-path-to-exec-env.patch
   ];
 
   # Reduce closure size for client machines


### PR DESCRIPTION
###### Description of changes

Exec commands using teleport will result command not found because it's hardcoded PATH env.

This patch add `/run/current-system/sw/bin` to default run path

<details>
<summary>Before Patch</summary>

```bash
ssh root@somehost.teleport -- whoami
fish: Unknown command: mktemp
/nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/share/fish/functions/psub.fish (line 1):
mktemp $tmpdir/.psub.XXXXXXXXXX
^
in command substitution
	called on line 37 of file /nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/share/fish/functions/psub.fish
in function 'psub'
	called on line 1 of file -
in command substitution
	called on line 1 of file -
from sourcing file -
	called on line 12 of file /etc/fish/config.fish
from sourcing file /etc/fish/config.fish
	called on line 43 of file /nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/etc/fish/config.fish
from sourcing file /nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/etc/fish/config.fish
	called during startup
/nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/share/fish/functions/psub.fish (line 37): Unknown command
        set filename (mktemp $tmpdir/.psub.XXXXXXXXXX)
                     ^
in function 'psub'
	called on line 1 of file -
in command substitution
	called on line 1 of file -
from sourcing file -
	called on line 12 of file /etc/fish/config.fish
from sourcing file /etc/fish/config.fish
	called on line 43 of file /nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/etc/fish/config.fish
from sourcing file /nix/store/yyxfq3pmbp5i4dk143p4m517avri3fhk-fish-3.4.0/etc/fish/config.fish
	called during startup
fish: Unknown command: whoami
```
</details>

After this patch

```
ssh root@somehost.teleport -- whoami
root
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
