### PR TITLE
pythonPackages.pandoc-xnos: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7242,7 +7242,7 @@
     name = "Anthony Lodi";
   };
   loicreynier = {
-    email = "loic@loireynier.fr";
+    email = "loic@loicreynier.fr";
     github = "loicreynier";
     githubId = 88983487;
     name = "Loïc Reynier";

--- a/pkgs/development/python-modules/pandoc-xnos/default.nix
+++ b/pkgs/development/python-modules/pandoc-xnos/default.nix
@@ -1,0 +1,24 @@
+{ lib, pythonPackages }:
+
+with pythonPackages;
+
+buildPythonPackage rec {
+  pname = "pandoc-xnos";
+  version = "2.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-fBhzjImeTs7Fc9xlZavY1DKB/IlNQbgnQ9Ud893iUK4=";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ pandocfilters psutil ];
+
+  meta = with lib; {
+    description = "Library for the pandoc-fignos/eqnos/tablenos/secnos Python Pandoc filters";
+    homepage = "https://github.com/tomduck/pandoc-xnos";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ loicreynier ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5888,6 +5888,8 @@ in {
 
   pandocfilters = callPackage ../development/python-modules/pandocfilters { };
 
+  pandoc-xnos = callPackage ../development/python-modules/pandoc-xnos { };
+
   panel = callPackage ../development/python-modules/panel { };
 
   panflute = callPackage ../development/python-modules/panflute { };


### PR DESCRIPTION
###### Description of changes

Add [`pandoc-xnos`](https://github.com/tomduck/pandoc-xnos) the Python library for the [`pandoc-fignos`](https://github.com/tomduck/pandoc-fignos), [`pandoc-eqnos`](https://github.com/tomduck/pandoc-eqnos), [`pandoc-tablenos`](https://github.com/tomduck/pandoc-tablenos) and [`pandoc-secnos`](https://github.com/tomduck/pandoc-secnos) Pandoc Python filters. I plan to package those filters once this library is added.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
