### PR TITLE
xfce.orage: 4.12.1 -> 4.16.0

### DIFF
--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -1,25 +1,34 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkg-config, intltool, dbus-glib, gtk2, libical, libnotify, tzdata
-, popt, libxfce4ui, xfce4-panel, withPanelPlugin ? true, wrapGAppsHook, xfce }:
+{ lib
+, mkXfceDerivation
+, dbus-glib
+, gtk3
+, libical
+, libnotify
+, libxfce4ui
+, popt
+, tzdata
+, xfce4-panel
+, withPanelPlugin ? true
+}:
 
-assert withPanelPlugin -> libxfce4ui != null && xfce4-panel != null;
-
-let
-  inherit (lib) optionals;
-in
-
-stdenv.mkDerivation rec {
+mkXfceDerivation {
+  category = "apps";
   pname = "orage";
-  version = "4.12.1";
+  version = "4.16.0";
+  odd-unstable = false;
+  sha256 = "sha256-Q2vTjfhbhG7TrkGeU5oVBB+UvrV5QFtl372wgHU4cxw=";
 
-  src = fetchurl {
-    url = "https://archive.xfce.org/src/apps/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-PPmqRBroPIaIhl+CIXAlzfPrqhUszkVxd3uMKqjdkGI=";
-  };
-
-  nativeBuildInputs = [ pkg-config intltool wrapGAppsHook ];
-
-  buildInputs = [ dbus-glib gtk2 libical libnotify popt ]
-    ++ optionals withPanelPlugin [ libxfce4ui xfce4-panel ];
+  buildInputs = [
+    dbus-glib
+    gtk3
+    libical
+    libnotify
+    libxfce4ui
+    popt
+  ]
+  ++ lib.optionals withPanelPlugin [
+    xfce4-panel
+  ];
 
   postPatch = ''
     substituteInPlace src/parameters.c        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
@@ -27,27 +36,13 @@ stdenv.mkDerivation rec {
     substituteInPlace tz_convert/tz_convert.c --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';
 
-  postConfigure = "rm -rf libical"; # ensure pkgs.libical is used instead of one included in the orage sources
-
-  patches = [
-    # Fix build with libical 3.0
-    (fetchpatch {
-      name = "fix-libical3.patch";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/libical3.patch?h=orage-4.10";
-      sha256 = "sha256-bsnQMGmeo4mRNGM/7UYXez2bNopXMHRFX7VFVg0IGtE=";
-    })
-  ];
-
-  passthru.updateScript = xfce.archiveUpdater {
-    category = "apps";
-    inherit pname version;
-  };
+  postConfigure = ''
+    # ensure pkgs.libical is used instead of one included in the orage sources
+    rm -rf libical
+  '';
 
   meta = with lib; {
-    description = "Simple calendar application with reminders";
-    homepage = "https://git.xfce.org/archive/orage/";
-    license = licenses.gpl2Plus;
-    platforms = platforms.linux;
+    description = "Simple calendar application for Xfce";
     maintainers = with maintainers; [ ] ++ teams.xfce.members;
   };
 }


### PR DESCRIPTION
###### Description of changes

- Update to version [4.16.0](https://gitlab.xfce.org/apps/orage/-/blob/master/NEWS)
- Development has restarted and now there is a new upstream release - Initial release for Gtk3
- Use `mkXfceDerivation`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
