### PR TITLE
python3Packages.aspy-refactor-imports: init at 3.0.1

### DIFF
--- a/pkgs/development/python-modules/aspy-refactor-imports/default.nix
+++ b/pkgs/development/python-modules/aspy-refactor-imports/default.nix
@@ -8,8 +8,8 @@
 buildPythonPackage rec {
   pname = "aspy-refactor-imports";
   version = "3.0.1";
-
   disabled = pythonOlder "3.7";
+
   src = fetchFromGitHub {
     owner = "asottile";
     repo = "aspy.refactor_imports";

--- a/pkgs/development/python-modules/aspy-refactor-imports/default.nix
+++ b/pkgs/development/python-modules/aspy-refactor-imports/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aspy-refactor-imports";
+  version = "3.0.1";
+
+  disabled = pythonOlder "3.7";
+  src = fetchFromGitHub {
+    owner = "asottile";
+    repo = "aspy.refactor_imports";
+    rev = "v${version}";
+    sha256 = "MlCM3zNTQZJ1RWrTQG0AN28RUepWINKCeLENykbu2nw=";
+  };
+
+  pythonImportsCheck = [
+    "aspy.refactor_imports"
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  meta = with lib; {
+    description = "Utilities for refactoring imports in python-like syntax.";
+    homepage = "https://github.com/asottile/reorder_python_imports";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gador ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -658,6 +658,8 @@ in {
 
   aspell-python = callPackage ../development/python-modules/aspell-python { };
 
+  aspy-refactor-imports = callPackage ../development/python-modules/aspy-refactor-imports { };
+
   aspy-yaml = callPackage ../development/python-modules/aspy.yaml { };
 
   assertpy = callPackage ../development/python-modules/assertpy { };


### PR DESCRIPTION
Signed-off-by: florian on nixos (Florian Brandes) <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
