### PR TITLE
kicost: init at 1.1.15

### DIFF
--- a/pkgs/applications/science/electronics/kicost/default.nix
+++ b/pkgs/applications/science/electronics/kicost/default.nix
@@ -1,0 +1,35 @@
+{ lib, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "kicost";
+  version = "1.1.15";
+
+  src = python3.pkgs.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-JPwhE3qew0DzBHVfVuQyW5tLJE6QNBE2P2x34WDSaUc=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    lxml
+    XlsxWriter
+    tqdm
+    requests
+    validators
+    wxPython_4_1
+    colorama
+    pyyaml
+    kicost-digikey-api-v3
+  ];
+
+  # Test artifacts missing in source distribution
+  doCheck = false;
+  pythonImportsCheck = [ "kicost" ];
+
+  meta = with lib; {
+    description = "Build cost spreadsheet for a KiCad project";
+    homepage = "https://hildogjr.github.io/KiCost";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
+++ b/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
@@ -1,0 +1,35 @@
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, inflection, requests
+, urllib3, six, certifi, pyopenssl, tldextract, python-dateutil }:
+
+buildPythonPackage rec {
+  pname = "kicost-digikey-api-v3";
+  version = "0.1.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "kicost_digikey_api_v3";
+    sha256 = "sha256-tOHiv1CbcfCgWjqZ29DchAfxVgemKZviEbHVZA34ZAw=";
+  };
+
+  propagatedBuildInputs = [
+    inflection
+    requests
+    urllib3
+    six
+    certifi
+    pyopenssl
+    tldextract
+    python-dateutil
+  ];
+
+  # Tests missing in source distribution
+  doCheck = false;
+  pythonImportsCheck = [ "kicost_digikey_api_v3" ];
+
+  meta = with lib; {
+    description = "KiCost plugin for the Digikey PartSearch API";
+    homepage = "https://github.com/set-soft/kicost-digikey-api-v3";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36215,6 +36215,8 @@ with pkgs;
     with3d = false;
   };
 
+  kicost = callPackage ../applications/science/electronics/kicost { };
+
   librepcb = libsForQt5.callPackage ../applications/science/electronics/librepcb { };
 
   ngspice = callPackage ../applications/science/electronics/ngspice { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5052,6 +5052,8 @@ self: super: with self; {
     python3 = python;
   }).src;
 
+  kicost-digikey-api-v3 = callPackage ../development/python-modules/kicost-digikey-api-v3 { };
+
   kinparse = callPackage ../development/python-modules/kinparse { };
 
   kiss-headers = callPackage ../development/python-modules/kiss-headers { };


### PR DESCRIPTION
###### Description of changes

Build cost spreadsheet for a KiCad project.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).