### PR TITLE
fnc: init at 0.10

### DIFF
--- a/pkgs/applications/version-management/fnc/default.nix
+++ b/pkgs/applications/version-management/fnc/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, stdenv, zlib, ncurses }:
+{ lib, fetchurl, stdenv, zlib, ncurses, libiconv }:
 
 stdenv.mkDerivation rec {
   pname = "fnc";
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1phqxh0afky7q2qmhgjlsq1awbv4254yd8wpzxlww4p7a57cp0lk";
   };
 
-  buildInputs = [ zlib ncurses ];
+  buildInputs = [ zlib ncurses ] ++
+	(lib.optional stdenv.isDarwin libiconv);
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/version-management/fnc/default.nix
+++ b/pkgs/applications/version-management/fnc/default.nix
@@ -1,0 +1,40 @@
+{ lib, fetchurl, stdenv, zlib, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "fnc";
+  version = "0.10";
+
+  src = fetchurl {
+    url = "https://fnc.bsdbox.org/tarball/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1phqxh0afky7q2qmhgjlsq1awbv4254yd8wpzxlww4p7a57cp0lk";
+  };
+
+  buildInputs = [ zlib ncurses ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+    test "$($out/bin/fnc --version)" = '${pname} ${version}'
+    runHook postInstallCheck
+  '';
+
+  meta = with lib; {
+    description = "Interactive ncurses browser for Fossil repositories";
+    longDescription = ''
+      An interactive ncurses browser for Fossil repositories.
+
+      fnc uses libfossil to create a fossil ui experience in the terminal.
+    '';
+    homepage = "https://fnc.bsdbox.org";
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ abbe ];
+  };
+}

--- a/pkgs/applications/version-management/fnc/default.nix
+++ b/pkgs/applications/version-management/fnc/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib ncurses ] ++
-	(lib.optional stdenv.isDarwin libiconv);
+    (lib.optional stdenv.isDarwin libiconv);
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/applications/version-management/fnc/default.nix
+++ b/pkgs/applications/version-management/fnc/default.nix
@@ -5,12 +5,11 @@ stdenv.mkDerivation rec {
   version = "0.10";
 
   src = fetchurl {
-    url = "https://fnc.bsdbox.org/tarball/${version}/${pname}-${version}.tar.gz";
+    url = "https://fnc.bsdbox.org/tarball/${version}/fnc-${version}.tar.gz";
     sha256 = "1phqxh0afky7q2qmhgjlsq1awbv4254yd8wpzxlww4p7a57cp0lk";
   };
 
-  buildInputs = [ zlib ncurses ] ++
-    (lib.optional stdenv.isDarwin libiconv);
+  buildInputs = [ libiconv ncurses zlib ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25655,6 +25655,8 @@ with pkgs;
 
   fmsynth = callPackage ../applications/audio/fmsynth { };
 
+  fnc = callPackage ../applications/version-management/fnc { };
+
   focuswriter = libsForQt5.callPackage ../applications/editors/focuswriter { };
 
   foliate = callPackage ../applications/office/foliate { };


### PR DESCRIPTION
###### Description of changes

[fnc](https://fnc.bsdbox.org) is a read-only interactive ncurses based viewer for [Fossil](https://fossil-scm.org/) repositories.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
