### PR TITLE
patatt: init at 0.4.9

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -607,6 +607,11 @@ in mkLicense lset) ({
     fullName = "Enlightenment License (e16)";
   };
 
+  mit0 = {
+    spdxId = "MIT-0";
+    fullName = "MIT No Attribution";
+  };
+
   mpl10 = {
     spdxId = "MPL-1.0";
     fullName = "Mozilla Public License 1.0";

--- a/pkgs/development/tools/patatt/default.nix
+++ b/pkgs/development/tools/patatt/default.nix
@@ -1,0 +1,28 @@
+{ lib, python3Packages }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "patatt";
+  version = "0.4.9";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-qHhNxgP43vBSjrHp2Ygzq5J/f6YyBD4VDTp9S1ud6zo=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pynacl
+  ];
+
+  meta = with lib; {
+    homepage = "https://git.kernel.org/pub/scm/utils/patatt/patatt.git/about/";
+    license = licenses.mit0;
+    description = "Add cryptographic attestation to patches sent via email";
+    longDescription = ''
+      This utility allows an easy way to add end-to-end cryptographic
+      attestation to patches sent via mail.  It does so by adapting the
+      DKIM email signature standard to include cryptographic
+      signatures via the X-Developer-Signature email header.
+    '';
+    maintainers = with maintainers; [ yoctocell ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8886,6 +8886,8 @@ with pkgs;
 
   patchage = callPackage ../applications/audio/patchage { };
 
+  patatt = callPackage ../development/tools/patatt { };
+
   pcapfix = callPackage ../tools/networking/pcapfix { };
 
   pbzip2 = callPackage ../tools/compression/pbzip2 { };


### PR DESCRIPTION
- lib.licenses: add MIT-0
- patatt: init at 0.4.9

###### Description of changes

Patatt is also needed to update b4 to the newest version.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
