### PR TITLE
pinegrow: 6.4 -> 6.5

### DIFF
--- a/pkgs/applications/editors/pinegrow/default.nix
+++ b/pkgs/applications/editors/pinegrow/default.nix
@@ -8,22 +8,22 @@
 , autoPatchelfHook
 , gsettings-desktop-schemas
 , gtk3
-, wrapGAppsHook
+, makeWrapper
 }:
 
 stdenv.mkDerivation rec {
   pname = "pinegrow";
-  version = "6.4";
+  version = "6.5";
 
   src = fetchurl {
     url = "https://download.pinegrow.com/PinegrowLinux64.${version}.zip";
-    sha256 = "0i8sg4criimrqmz0g68b8xcwcrb362ssid5jazswpa6hhwj6s5n4";
+    sha256 = "1l7cf5jgidpykaf68mzf92kywl1vxwl3fg43ibgr2rg4cnl1g82b";
   };
 
   nativeBuildInputs = [
     unzip
     autoPatchelfHook
-    wrapGAppsHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -32,6 +32,11 @@ stdenv.mkDerivation rec {
     gcc-unwrapped
     gsettings-desktop-schemas
     gtk3
+  ];
+
+  wrapProgramFlags = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gcc-unwrapped.lib gtk3 udev ]}"
+    "--prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}"
   ];
 
   sourceRoot = ".";
@@ -57,7 +62,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
-    wrapGApp "$out/opt/pinegrow/PinegrowLibrary" --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}
+    wrapProgram "$out/opt/pinegrow/PinegrowLibrary" ''${wrapProgramFlags[@]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
I noticed pinegrow doesn't start up after a change in NixOS.

Running `git bisect` I identified  8d18f29b6001756116cbb188468ef10178f44046 as the first bad commit. Within the change to auto-patchelf.sh could be the culprit (7b9fd5d1c9802131ca0a01ff08a3ff64379d2df4). 

I wasn't able to get the `wrapGAppsHook` working again and switched to `makeWrapper`. 

Now, everything should work again. The regression in 8d18f29b6001756116cbb188468ef10178f44046 also causes older pinegrow versions to not build.

Signed-off-by: florian on nixos (Florian Brandes) <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
