### PR TITLE
treewide: replace defunct git://github.com urls with https://

### DIFF
--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -286,7 +286,7 @@ Sample output1:
 "reload" = buildVimPluginFrom2Nix { # created by nix#NixDerivation
   name = "reload";
   src = fetchgit {
-    url = "git://github.com/xolox/vim-reload";
+    url = "https://github.com/xolox/vim-reload";
     rev = "0a601a668727f5b675cb1ddc19f6861f3f7ab9e1";
     sha256 = "0vb832l9yxj919f5hfg6qj6bn9ni57gnjd3bj7zpq7d4iv2s4wdh";
   };

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -81,6 +81,6 @@ rapidjson,https://github.com/xpol/lua-rapidjson.git,,,,,
 readline,,,,,,
 say,https://github.com/Olivine-Labs/say.git,,,,,
 std._debug,https://github.com/lua-stdlib/_debug.git,,,,,
-std.normalize,git://github.com/lua-stdlib/normalize.git,,,,,
+std.normalize,https://github.com/lua-stdlib/normalize.git,,,,,
 stdlib,,,,41.2.2,,vyp
 vstruct,https://github.com/ToxicFrog/vstruct.git,,,,,

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -64,7 +64,7 @@ in {
         description = "Factory Steps";
         default = [];
         example = [
-          "steps.Git(repourl='git://github.com/buildbot/pyflakes.git', mode='incremental')"
+          "steps.Git(repourl='https://github.com/buildbot/pyflakes.git', mode='incremental')"
           "steps.ShellCommand(command=['trial', 'pyflakes'])"
         ];
       };
@@ -74,7 +74,7 @@ in {
         description = "List of Change Sources.";
         default = [];
         example = [
-          "changes.GitPoller('git://github.com/buildbot/pyflakes.git', workdir='gitpoller-workdir', branch='master', pollinterval=300)"
+          "changes.GitPoller('https://github.com/buildbot/pyflakes.git', workdir='gitpoller-workdir', branch='master', pollinterval=300)"
         ];
       };
 

--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   pname = "slic3r";
 
   src = fetchgit {
-    url = "git://github.com/alexrj/Slic3r";
+    url = "https://github.com/alexrj/Slic3r";
     rev = version;
     sha256 = "1pg4jxzb7f58ls5s8mygza8kqdap2c50kwlsdkf28bz1xi611zbi";
   };

--- a/pkgs/applications/networking/p2p/twister/default.nix
+++ b/pkgs/applications/networking/p2p/twister/default.nix
@@ -7,7 +7,7 @@ let
   twisterHTML = srcOnly {
     name = "twister-html";
     src = fetchgit {
-      url = "git://github.com/miguelfreitas/twister-html.git";
+      url = "https://github.com/miguelfreitas/twister-html.git";
       rev = "01e7f7ca9b7e42ed90f91bc42da2c909ca5c0b9b";
       sha256 = "0scjbin6s1kmi0bqq0dx0qyjw4n5xgmj567n0156i39f9h0dabqy";
     };

--- a/pkgs/applications/science/math/sage/README.md
+++ b/pkgs/applications/science/math/sage/README.md
@@ -17,7 +17,7 @@ If the build broke as a result of a package update, try those solutions in order
 - fix the problem yourself. First clone the sagemath source and then check out the sage version you want to patch:
 
 ```
-[user@localhost ~]$ git clone git://github.com/sagemath/sage.git
+[user@localhost ~]$ git clone https://github.com/sagemath/sage.git
 [user@localhost ~]$ cd sage
 [user@localhost sage]$ git checkout 8.2 # substitute the relevant version here
 ```
@@ -41,7 +41,7 @@ You can [login the sage trac using GitHub](https://trac.sagemath.org/login). You
 Here's the gist, assuming you want to use ssh key authentication. First, [add your public ssh key](https://trac.sagemath.org/prefs/sshkeys). Then:
 
 ```
-[user@localhost ~]$ git clone git://github.com/sagemath/sage.git
+[user@localhost ~]$ git clone https://github.com/sagemath/sage.git
 [user@localhost ~]$ cd sage
 [user@localhost sage]$ git remote add trac git@trac.sagemath.org:sage.git -t master
 [user@localhost sage]$ git checkout -b u/gh-<your-github-username>/<your-branch-name> develop

--- a/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "2015-06-04";
 
   src = fetchgit {
-    url = "git://github.com/purcell/darcs-to-git.git";
+    url = "https://github.com/purcell/darcs-to-git.git";
     rev = "e5fee32495908fe0f7d700644c7b37347b7a0a5b";
     sha256 = "0lxcx0x0m1cv2j4x9ykpjf6r2zg6lh5rya016x93vkmlzxm3f0ji";
   };

--- a/pkgs/applications/video/byzanz/default.nix
+++ b/pkgs/applications/video/byzanz/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "byzanz";
 
   src = fetchgit {
-    url = "https://github.com/GNOME/byzanz";
+    url = "https://gitlab.gnome.org/Archive/byzanz";
     rev = "1875a7f6a3903b83f6b1d666965800f47db9286a";
     sha256 = "0a72fw2mxl8vdcdnzy0bwis4jk28pd7nc8qgr4vhyw5pd48dynvh";
   };

--- a/pkgs/applications/video/byzanz/default.nix
+++ b/pkgs/applications/video/byzanz/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   pname = "byzanz";
 
   src = fetchgit {
-    url = "git://github.com/GNOME/byzanz";
+    url = "https://github.com/GNOME/byzanz";
     rev = "1875a7f6a3903b83f6b1d666965800f47db9286a";
     sha256 = "0a72fw2mxl8vdcdnzy0bwis4jk28pd7nc8qgr4vhyw5pd48dynvh";
   };

--- a/pkgs/development/compilers/ghcjs/ghcjs-base.nix
+++ b/pkgs/development/compilers/ghcjs/ghcjs-base.nix
@@ -10,7 +10,7 @@ mkDerivation {
   pname = "ghcjs-base";
   version = "0.2.0.3";
   src = fetchgit {
-    url = "git://github.com/ghcjs/ghcjs-base";
+    url = "https://github.com/ghcjs/ghcjs-base";
     sha256 = "15fdkjv0l7hpbbsn5238xxgzfdg61g666nzbv2sgxkwryn5rycv0";
     rev = "85e31beab9beffc3ea91b954b61a5d04e708b8f2";
   };

--- a/pkgs/development/interpreters/scsh/default.nix
+++ b/pkgs/development/interpreters/scsh/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "0.7pre";
 
   src = fetchgit {
-    url = "git://github.com/scheme/scsh.git";
+    url = "https://github.com/scheme/scsh.git";
     rev = "f99b8c5293628cfeaeb792019072e3a96841104f";
     fetchSubmodules = true;
     sha256 = "0ci2h9hhv8pl12sdyl2qwal3dhmd7zgm1pjnmd4kg8r1hnm6vidx";

--- a/pkgs/development/tools/parsing/hammer/default.nix
+++ b/pkgs/development/tools/parsing/hammer/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "e7aa734";
 
   src = fetchgit {
-    url = "git://github.com/UpstandingHackers/hammer";
+    url = "https://github.com/UpstandingHackers/hammer";
     sha256 = "01l0wbhz7dymxlndacin2vi8sqwjlw81ds2i9xyi200w51nsdm38";
     rev = "47f34b81e4de834fd3537dd71928c4f3cdb7f533";
   };

--- a/pkgs/os-specific/linux/disk-indicator/default.nix
+++ b/pkgs/os-specific/linux/disk-indicator/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "unstable-2014-05-19";
 
   src = fetchgit {
-    url = "git://github.com/MeanEYE/Disk-Indicator.git";
+    url = "https://github.com/MeanEYE/Disk-Indicator.git";
     rev = "51ef4afd8141b8d0659cbc7dc62189c56ae9c2da";
     sha256 = "10jx6mx9qarn21p2l2jayxkn1gmqhvck1wymgsr4jmbwxl8ra5kd";
   };

--- a/pkgs/tools/audio/pa-applet/default.nix
+++ b/pkgs/tools/audio/pa-applet/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "unstable-2012-04-11";
 
   src = fetchgit {
-    url = "git://github.com/fernandotcl/pa-applet.git";
+    url = "https://github.com/fernandotcl/pa-applet.git";
     rev = "005f192df9ba6d2e6491f9aac650be42906b135a";
     sha256 = "1242sdri67wnm1cd0hr40mxarkh7qs7mb9n2m0g9dbz0f4axj6wa";
   };

--- a/pkgs/tools/networking/carddav-util/default.nix
+++ b/pkgs/tools/networking/carddav-util/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation {
   version = "0.1-2014-02-26";
 
   src = fetchgit {
-    url = "git://github.com/ljanyst/carddav-util";
+    url = "https://github.com/ljanyst/carddav-util";
     rev = "53b181faff5f154bcd180467dd04c0ce69405564";
     sha256 = "0f0raffdy032wlnxfck6ky60r163nhqfbr311y4ry55l60s4497n";
   };

--- a/pkgs/tools/package-management/nixui/default.nix
+++ b/pkgs/tools/package-management/nixui/default.nix
@@ -3,7 +3,7 @@
 let
   version = "0.2.1";
   src = fetchgit {
-    url = "git://github.com/matejc/nixui.git";
+    url = "https://github.com/matejc/nixui.git";
     rev = "845a5f4a33f1d0c509c727c130d0792a5b450a38";
     sha256 = "1ay3i4lgzs3axbby06l4vvspxi0aa9pwiil84qj0dqq1jb6isara";
   };

--- a/pkgs/tools/package-management/nixui/default.nix
+++ b/pkgs/tools/package-management/nixui/default.nix
@@ -10,7 +10,7 @@ let
   nixui = (import ./nixui.nix {
     inherit pkgs;
     inherit (stdenv.hostPlatform) system;
-  })."nixui-git://github.com/matejc/nixui.git#0.2.1";
+  })."nixui-git+https://github.com/matejc/nixui.git#0.2.1";
   script = writeScript "nixui" ''
     #! ${stdenv.shell}
     export PATH="${nix}/bin:\$PATH"

--- a/pkgs/tools/package-management/nixui/node-packages.nix
+++ b/pkgs/tools/package-management/nixui/node-packages.nix
@@ -70,12 +70,12 @@ let
   };
 in
 {
-  "nixui-git://github.com/matejc/nixui.git#0.2.1" = nodeEnv.buildNodePackage {
+  "nixui-git+https://github.com/matejc/nixui.git#0.2.1" = nodeEnv.buildNodePackage {
     name = "nixui";
     packageName = "nixui";
     version = "0.2.1";
     src = fetchgit {
-      url = "git://github.com/matejc/nixui.git";
+      url = "https://github.com/matejc/nixui.git";
       rev = "845a5f4a33f1d0c509c727c130d0792a5b450a38";
       sha256 = "2a2b1dcd9201e306242688c6c86f520ac47ef5de841ae0d7ea6ae8ff2889c3ab";
     };

--- a/pkgs/tools/package-management/nixui/pkg.json
+++ b/pkgs/tools/package-management/nixui/pkg.json
@@ -1,3 +1,3 @@
 [
-  { "nixui": "git://github.com/matejc/nixui.git#0.2.1" }
+  { "nixui": "git+https://github.com/matejc/nixui.git#0.2.1" }
 ]

--- a/pkgs/tools/security/onlykey/default.nix
+++ b/pkgs/tools/security/onlykey/default.nix
@@ -20,7 +20,7 @@ let
     elem;
 
   # this must be updated anytime this package is updated.
-  onlykeyPkg = "onlykey-git://github.com/trustcrypto/OnlyKey-App.git#v${version}";
+  onlykeyPkg = "onlykey-git+https://github.com/trustcrypto/OnlyKey-App.git#v${version}";
 
   # define a shortcut to get to onlykey.
   onlykey = self."${onlykeyPkg}";

--- a/pkgs/tools/security/onlykey/node-packages.nix
+++ b/pkgs/tools/security/onlykey/node-packages.nix
@@ -6316,12 +6316,12 @@ let
   };
 in
 {
-  "onlykey-git://github.com/trustcrypto/OnlyKey-App.git#v5.3.3" = nodeEnv.buildNodePackage {
+  "onlykey-git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.3" = nodeEnv.buildNodePackage {
     name = "OnlyKey";
     packageName = "OnlyKey";
     version = "5.3.3";
     src = fetchgit {
-      url = "git://github.com/trustcrypto/OnlyKey-App.git";
+      url = "https://github.com/trustcrypto/OnlyKey-App.git";
       rev = "0bd08ef5828d9493cd4c5f4909e9a4fc4c59a494";
       sha256 = "d2386369fd9d9b7d5ea5d389434848c33fa34e26d713d439e8e2f2e447237bb0";
     };

--- a/pkgs/tools/security/onlykey/package.json
+++ b/pkgs/tools/security/onlykey/package.json
@@ -1,3 +1,3 @@
 [
-  {"onlykey": "git://github.com/trustcrypto/OnlyKey-App.git#v5.3.3"}
+  {"onlykey": "git+https://github.com/trustcrypto/OnlyKey-App.git#v5.3.3"}
 ]


### PR DESCRIPTION
###### Description of changes

Fix #165246

Github has removed support for git://github.com and recommends https://github.com instead.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
