### PR TITLE
[staging] linux.stdenv: gcc_10 → gcc_11

### DIFF
--- a/pkgs/development/libraries/glm/default.nix
+++ b/pkgs/development/libraries/glm/default.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102823
+  NIX_CFLAGS_COMPILE = "-fno-ipa-modref";
+
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=OFF"
     "-DBUILD_STATIC_LIBS=OFF"

--- a/pkgs/development/libraries/glog/default.nix
+++ b/pkgs/development/libraries/glog/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
 
   # TODO: Re-enable Darwin tests once we're on a release that has https://github.com/google/glog/issues/709#issuecomment-960381653 fixed
   doCheck = !stdenv.isDarwin;
+  # There are some non-thread safe tests that can fail
+  enableParallelChecking = false;
   checkInputs = [ perl ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/pmdk/default.nix
+++ b/pkgs/development/libraries/pmdk/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pmdk";
-  version = "1.9.2";
+  version = "1.11.1";
 
   src = fetchFromGitHub {
     owner  = "pmem";
     repo   = "pmdk";
     rev    = "refs/tags/${version}";
-    sha256 = "0awmkj6j9y2pbqqmp9ql00s7qa3mnpppa82dfy5324lindq0z8a1";
+    hash = "sha256-8bnyLtgkKfgIjJkfY/ZS1I9aCYcrz0nrdY7m/TUVWAk=";
   };
 
   nativeBuildInputs = [ autoconf pkg-config gnum4 pandoc ];
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" "man" ];
 
   patchPhase = "patchShebangs utils";
+
+  NIX_CFLAGS_COMPILE = "-Wno-error";
 
   installPhase = ''
     make install prefix=$out

--- a/pkgs/development/libraries/rlottie/default.nix
+++ b/pkgs/development/libraries/rlottie/default.nix
@@ -1,4 +1,11 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, meson
+, ninja
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "rlottie";
@@ -10,6 +17,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "10bxr1zf9wxl55d4cw2j02r6sgqln7mbxplhhfvhw0z92fi40kr3";
   };
+
+  patches = [
+    # Fixed build with GCC 11
+    (fetchpatch {
+       url = "https://github.com/Samsung/rlottie/commit/2d7b1fa2b005bba3d4b45e8ebfa632060e8a157a.patch";
+       hash = "sha256-2JPsj0WiBMMu0N3NUYDrHumvPN2YS8nPq5Zwagx6UWE=";
+    })
+  ];
 
   nativeBuildInputs = [ meson ninja pkg-config ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5330,7 +5330,8 @@ with pkgs;
   };
 
   exempi = callPackage ../development/libraries/exempi {
-    stdenv = if stdenv.isi686 then gcc6Stdenv else stdenv;
+    stdenv = if stdenv.isi686 then gcc6Stdenv else gcc9Stdenv;
+    boost  = boost15x;
   };
 
   execline = skawarePackages.execline;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12137,6 +12137,7 @@ with pkgs;
       num =
         if (with stdenv.targetPlatform; isVc4 || libc == "relibc") then 6
         else if (stdenv.targetPlatform.isAarch64 && stdenv.isDarwin) then 11
+        else if (stdenv.targetPlatform.isx86_64 && stdenv.isLinux) then 11
         else if stdenv.targetPlatform.isAarch64 then 9
         else 10;
       numS = toString num;


### PR DESCRIPTION
###### Description of changes

Was able to build and boot into gnome 42 under kernel 5.17, seems like most packages already support gcc11 without changes; only 1 package gave issues and pinning it to a previous version was enough.

```
cat /proc/version                                                                                                                                                                                                                                                       Thu 24 Mar 2022 09:42:13 PM CST
Linux version 5.17.0 (nixbld@localhost) (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.35.2) #1-NixOS SMP PREEMPT Sun Mar 20 20:14:17 UTC 2022
```

Currently running a `home-manager switch` but those are a ton more (~4500) over the system required packages (~2600)

EDIT:

Additionally built `linux_4_9` (oldest supported LTS)

EDIT2:

Home environment also built, there are some packages that need updating but this works great so far! :3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
