### PR TITLE
ocamlPackages.unionFind: init at 20220122

### DIFF
--- a/pkgs/development/ocaml-modules/unionFind/default.nix
+++ b/pkgs/development/ocaml-modules/unionFind/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitLab, buildDunePackage }:
+
+buildDunePackage rec {
+  pname = "unionFind";
+  version = "20220122";
+
+  useDune2 = true;
+  minimalOCamlVersion = "4.05";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.inria.fr";
+    owner = "fpottier";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256:0hdh56rbg8vfjd61q09cbmh8l5wmry5ykivg7gsm0v5ckkb3531r";
+  };
+
+  meta = {
+    description = "Implementations of the union-find data structure";
+    license = lib.licenses.lgpl2Only;
+    inherit (src.meta) homepage;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1410,6 +1410,8 @@ let
 
     stdint = callPackage ../development/ocaml-modules/stdint { };
 
+    unionFind = callPackage ../development/ocaml-modules/unionFind { };
+
     unstrctrd = callPackage ../development/ocaml-modules/unstrctrd { };
 
     uucd = callPackage ../development/ocaml-modules/uucd { };


### PR DESCRIPTION
###### Description of changes

OCaml implementations of the union-find data structure: https://gitlab.inria.fr/fpottier/unionfind

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
