### PR TITLE
[Backport release-21.11] keycloak: add support for plugins

### DIFF
--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -809,7 +809,7 @@ in
               export JAVA_OPTS=-Djboss.server.config.user.dir=/run/keycloak/configuration
               add-user-keycloak.sh -u admin -p '${cfg.initialAdminPassword}'
             ''
-            + lib.optionalString (cfg.plugins != []) (lib.concatStringsSep "\n" (map (pl: "install_plugin ${lib.escapeShellArg pl}") cfg.plugins))
+            + lib.optionalString (cfg.plugins != []) (lib.concatStringsSep "\n" (map (pl: "install_plugin ${lib.escapeShellArg pl}") cfg.plugins)) + "\n"
             + optionalString (cfg.sslCertificate != null && cfg.sslCertificateKey != null) ''
               pushd /run/keycloak/ssl/
               cat "$CREDENTIALS_DIRECTORY/ssl_cert" <(echo) \

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -128,6 +128,14 @@ in
         '';
       };
 
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [];
+        description = ''
+          Keycloak plugin jar, ear files or derivations with them
+        '';
+      };
+
       database = {
         type = mkOption {
           type = enum [ "mysql" "postgresql" ];
@@ -785,6 +793,14 @@ in
 
               umask u=rwx,g=,o=
 
+              install_plugin() {
+                if [ -d "$1" ]; then
+                  find "$1" -type f \( -iname \*.ear -o -iname \*.jar \) -exec install -m 0500 -o keycloak -g keycloak "{}" "/run/keycloak/deployments/" \;
+                else
+                  install -m 0500 -o keycloak -g keycloak "$1" "/run/keycloak/deployments/"
+                fi
+              }
+
               install -m 0600 ${cfg.package}/standalone/configuration/*.properties /run/keycloak/configuration
               install -T -m 0600 ${keycloakConfig} /run/keycloak/configuration/standalone.xml
 
@@ -792,7 +808,9 @@ in
 
               export JAVA_OPTS=-Djboss.server.config.user.dir=/run/keycloak/configuration
               add-user-keycloak.sh -u admin -p '${cfg.initialAdminPassword}'
-            '' + optionalString (cfg.sslCertificate != null && cfg.sslCertificateKey != null) ''
+            ''
+            + lib.optionalString (cfg.plugins != []) (lib.concatStringsSep "\n" (map (pl: "install_plugin ${lib.escapeShellArg pl}") cfg.plugins))
+            + optionalString (cfg.sslCertificate != null && cfg.sslCertificateKey != null) ''
               pushd /run/keycloak/ssl/
               cat "$CREDENTIALS_DIRECTORY/ssl_cert" <(echo) \
                   "$CREDENTIALS_DIRECTORY/ssl_key" <(echo) \

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -16,8 +16,7 @@ let
       };
 
       nodes = {
-        keycloak = { ... }: {
-
+        keycloak = { config, ... }: {
           security.pki.certificateFiles = [
             certs.ca.cert
           ];
@@ -36,6 +35,9 @@ let
               username = "bogus";
               passwordFile = pkgs.writeText "dbPassword" "wzf6vOCbPp6cqTH";
             };
+            plugins = with config.services.keycloak.package.plugins; [
+              keycloak-discord
+            ];
           };
 
           environment.systemPackages = with pkgs; [

--- a/nixos/tests/keycloak.nix
+++ b/nixos/tests/keycloak.nix
@@ -37,6 +37,7 @@ let
             };
             plugins = with config.services.keycloak.package.plugins; [
               keycloak-discord
+              keycloak-metrics-spi
             ];
           };
 
@@ -104,8 +105,21 @@ let
           ### Realm Setup ###
 
           # Get an admin interface access token
+          keycloak.succeed("""
+              curl -sSf -d 'client_id=admin-cli' \
+                   -d 'username=admin' \
+                   -d 'password=${initialAdminPassword}' \
+                   -d 'grant_type=password' \
+                   '${frontendUrl}/realms/master/protocol/openid-connect/token' \
+                   | jq -r '"Authorization: bearer " + .access_token' >admin_auth_header
+          """)
+
+          # Register the metrics SPI
           keycloak.succeed(
-              "curl -sSf -d 'client_id=admin-cli' -d 'username=admin' -d 'password=${initialAdminPassword}' -d 'grant_type=password' '${frontendUrl}/realms/master/protocol/openid-connect/token' | jq -r '\"Authorization: bearer \" + .access_token' >admin_auth_header"
+              "${pkgs.jre}/bin/keytool -import -alias snakeoil -file ${certs.ca.cert} -storepass aaaaaa -keystore cacert.jks -noprompt",
+              "KC_OPTS='-Djavax.net.ssl.trustStore=cacert.jks -Djavax.net.ssl.trustStorePassword=aaaaaa' ${pkgs.keycloak}/bin/kcadm.sh config credentials --server '${frontendUrl}' --realm master --user admin --password '${initialAdminPassword}'",
+              "KC_OPTS='-Djavax.net.ssl.trustStore=cacert.jks -Djavax.net.ssl.trustStorePassword=aaaaaa' ${pkgs.keycloak}/bin/kcadm.sh update events/config -s 'eventsEnabled=true' -s 'adminEventsEnabled=true' -s 'eventsListeners+=metrics-listener'",
+              "curl -sSf '${frontendUrl}/realms/master/metrics' | grep '^keycloak_admin_event_UPDATE'"
           )
 
           # Publish the realm, including a test OIDC client and user

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -31,6 +31,7 @@ javaPackages.mavenfod rec {
   };
 
   mvnSha256 = "7Sm1hAoi5xc4MLONOD8ySLLkpao0qmlMRRva/8zR210=";
+  mvnParameters = "-P desktop,all-platforms";
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -16,9 +16,10 @@
 , maven
 , webkitgtk
 , glib-networking
+, javaPackages
 }:
 
-stdenv.mkDerivation rec {
+javaPackages.mavenfod rec {
   pname = "dbeaver";
   version = "21.2.5"; # When updating also update fetchedMavenDeps.sha256
 
@@ -29,31 +30,7 @@ stdenv.mkDerivation rec {
     sha256 = "bLZYwf6dtbzS0sWKfQQzv4NqRQZqLkJaT24eW3YOsdQ=";
   };
 
-  fetchedMavenDeps = stdenv.mkDerivation {
-    name = "dbeaver-${version}-maven-deps";
-    inherit src;
-
-    buildInputs = [
-      maven
-    ];
-
-    buildPhase = "mvn package -Dmaven.repo.local=$out/.m2 -P desktop,all-platforms";
-
-    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''
-      find $out -type f \
-        -name \*.lastUpdated -or \
-        -name resolver-status.properties -or \
-        -name _remote.repositories \
-        -delete
-    '';
-
-    # don't do any fixup
-    dontFixup = true;
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "7Sm1hAoi5xc4MLONOD8ySLLkpao0qmlMRRva/8zR210=";
-  };
+  mvnSha256 = "7Sm1hAoi5xc4MLONOD8ySLLkpao0qmlMRRva/8zR210=";
 
   nativeBuildInputs = [
     copyDesktopItems
@@ -87,14 +64,6 @@ stdenv.mkDerivation rec {
       categories = "Development;";
     })
   ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    mvn package --offline -Dmaven.repo.local=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)/.m2 -P desktop,all-platforms
-
-    runHook postBuild
-  '';
 
   installPhase =
     let

--- a/pkgs/development/java-modules/maven-fod.nix
+++ b/pkgs/development/java-modules/maven-fod.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, maven
+}:
+
+{ src
+, patches ? []
+, pname
+, version
+, mvnSha256 ? "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+, mvnHash ? "sha256-${mvnSha256}"
+, mvnFetchExtraArgs ? {}
+, ...
+} @args:
+
+# originally extracted from dbeaver
+# created to allow using maven packages in the same style as rust
+
+stdenv.mkDerivation (rec {
+  fetchedMavenDeps = stdenv.mkDerivation ({
+    name = "${pname}-${version}-maven-deps";
+    inherit src;
+
+    buildInputs = [
+      maven
+    ];
+
+    buildPhase = ''
+      mvn package -Dmaven.repo.local=$out/.m2 -P desktop,all-platforms
+    '';
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    installPhase = ''
+      find $out -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
+    '';
+
+    # don't do any fixup
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHash = mvnHash;
+  } // mvnFetchExtraArgs);
+
+  buildPhase = ''
+    runHook preBuild
+
+    mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
+    mvn package --offline "-Dmaven.repo.local=$mvnDeps/.m2" -P desktop,all-platforms
+
+    runHook postBuild
+  '';
+} // args)

--- a/pkgs/development/java-modules/maven-fod.nix
+++ b/pkgs/development/java-modules/maven-fod.nix
@@ -10,6 +10,7 @@
 , mvnSha256 ? "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 , mvnHash ? "sha256-${mvnSha256}"
 , mvnFetchExtraArgs ? {}
+, mvnParameters ? ""
 , ...
 } @args:
 
@@ -26,7 +27,7 @@ stdenv.mkDerivation (rec {
     ];
 
     buildPhase = ''
-      mvn package -Dmaven.repo.local=$out/.m2 -P desktop,all-platforms
+      mvn package -Dmaven.repo.local=$out/.m2 ${mvnParameters}
     '';
 
     # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -1,0 +1,4 @@
+{ callPackage }:
+
+{
+}

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -2,4 +2,5 @@
 
 {
   scim-for-keycloak = callPackage ./scim-for-keycloak {};
+  keycloak-discord = callPackage ./keycloak-discord {};
 }

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -1,4 +1,5 @@
 { callPackage }:
 
 {
+  scim-for-keycloak = callPackage ./scim-for-keycloak {};
 }

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -3,4 +3,5 @@
 {
   scim-for-keycloak = callPackage ./scim-for-keycloak {};
   keycloak-discord = callPackage ./keycloak-discord {};
+  keycloak-metrics-spi = callPackage ./keycloak-metrics-spi {};
 }

--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchzip, makeWrapper, jre, writeText, nixosTests
 , postgresql_jdbc ? null, mysql_jdbc ? null
+, callPackage
 }:
 
 let
@@ -55,7 +56,10 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/jboss-cli.sh --set JAVA_HOME ${jre}
   '';
 
-  passthru.tests = nixosTests.keycloak;
+  passthru = {
+    tests = nixosTests.keycloak;
+    plugins = callPackage ./all-plugins.nix {};
+  };
 
   meta = with lib; {
     homepage    = "https://www.keycloak.org/";

--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -51,9 +51,11 @@ stdenv.mkDerivation rec {
       ln -s ${mkModuleXml "com.mysql" "mysql-connector-java.jar"} $module_path/com/mysql/main/module.xml
     ''}
 
-    wrapProgram $out/bin/standalone.sh --set JAVA_HOME ${jre}
-    wrapProgram $out/bin/add-user-keycloak.sh --set JAVA_HOME ${jre}
-    wrapProgram $out/bin/jboss-cli.sh --set JAVA_HOME ${jre}
+    for script in add-user-keycloak.sh add-user.sh domain.sh elytron-tool.sh jboss-cli.sh jconsole.sh jdr.sh standalone.sh wsconsume.sh wsprovide.sh; do
+      wrapProgram $out/bin/$script --set JAVA_HOME ${jre}
+    done
+    wrapProgram $out/bin/kcadm.sh --prefix PATH : ${jre}/bin
+    wrapProgram $out/bin/kcreg.sh --prefix PATH : ${jre}/bin
   '';
 
   passthru = {

--- a/pkgs/servers/keycloak/keycloak-discord/default.nix
+++ b/pkgs/servers/keycloak/keycloak-discord/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, lib
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "keycloak-discord";
+  version = "0.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/wadahiro/keycloak-discord/releases/download/v${version}/keycloak-discord-ear-${version}.ear";
+    sha256 = "0fswhbnxc80dpfqf5y6j29dxk3vcnm4kki6qdk22qliasvpw5n9c";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install "$src" "$out/${pname}-ear-${version}.ear"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/wadahiro/keycloak-discord";
+    description = "Keycloak Social Login extension for Discord";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/servers/keycloak/keycloak-discord/default.nix
+++ b/pkgs/servers/keycloak/keycloak-discord/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
+    mkdir -p "$out"
     install "$src" "$out/${pname}-ear-${version}.ear"
   '';
 

--- a/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
+++ b/pkgs/servers/keycloak/keycloak-metrics-spi/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "keycloak-metrics-spi";
+  version = "2.5.3";
+
+  src = fetchurl {
+    url = "https://github.com/aerogear/keycloak-metrics-spi/releases/download/${version}/keycloak-metrics-spi-${version}.jar";
+    sha256 = "15lsy8wjw6nlfdfhllc45z9l5474p0lsghrwzzsssvd68bw54gwv";
+  };
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out
+    install "$src" "$out"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/aerogear/keycloak-metrics-spi";
+    description = "Keycloak Service Provider that adds a metrics endpoint";
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ benley ];
+  };
+}

--- a/pkgs/servers/keycloak/scim-for-keycloak/default.nix
+++ b/pkgs/servers/keycloak/scim-for-keycloak/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, maven
+, javaPackages
+}:
+
+javaPackages.mavenfod rec {
+  pname = "scim-for-keycloak";
+  version = "kc-15-b2"; # When updating also update mvnHash
+
+  src = fetchFromGitHub {
+    owner = "Captain-P-Goldfish";
+    repo = "scim-for-keycloak";
+    rev = version;
+    sha256 = "K34c7xISjEETI3jFkRLdZ0C8pZHTWtPtrrIzwC76Tv0=";
+  };
+
+  mvnHash = "sha256-L1i9Fn9l6Xun6usvqiDLtMkMscQMEcqgaWXV3OUKrwQ=";
+
+  nativeBuildInputs = [
+    maven
+  ];
+
+  installPhase = ''
+    EAR=$(find -iname "*.ear")
+    install -D "$EAR" "$out/$(basename $EAR)"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Captain-P-Goldfish/scim-for-keycloak";
+    description = "A third party module that extends Keycloak with SCIM functionality";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mkg20001 ];
+  };
+}

--- a/pkgs/servers/keycloak/scim-for-keycloak/default.nix
+++ b/pkgs/servers/keycloak/scim-for-keycloak/default.nix
@@ -16,7 +16,7 @@ javaPackages.mavenfod rec {
     sha256 = "K34c7xISjEETI3jFkRLdZ0C8pZHTWtPtrrIzwC76Tv0=";
   };
 
-  mvnHash = "sha256-L1i9Fn9l6Xun6usvqiDLtMkMscQMEcqgaWXV3OUKrwQ=";
+  mvnHash = "sha256-kDYhXTEOAWH/dcRJalKtbwBpoxcD1aX9eqcRKs6ewbE=";
 
   nativeBuildInputs = [
     maven

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -5,8 +5,11 @@ with pkgs;
 let
   mavenbuild = callPackage ../development/java-modules/build-maven-package.nix { };
   fetchMaven = callPackage ../development/java-modules/m2install.nix { };
+
+  mavenfod = callPackage ../development/java-modules/maven-fod.nix { };
+
 in {
-  inherit mavenbuild fetchMaven;
+  inherit mavenbuild mavenfod fetchMaven;
 
   mavenPlugins = recurseIntoAttrs (callPackage ../development/java-modules/mavenPlugins.nix { });
 


### PR DESCRIPTION
###### Description of changes

Backport #140406 to release-21.11

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
