### PR TITLE
dynablaster-revenge: Init at unstable-2022-04-15

### DIFF
--- a/pkgs/games/dynablaster-revenge/default.nix
+++ b/pkgs/games/dynablaster-revenge/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, lib
+, mkDerivation
+, fetchFromGitHub
+, qtbase
+, qmake
+, wrapQtAppsHook
+, libGLU
+, SDL2
+, alsa-lib
+
+, isServer ? false
+}:
+
+mkDerivation rec {
+  pname = "dynablaster-revenge"
+    + lib.optionalString isServer "-server";
+  version = "unstable-2022-04-15";
+
+  src = fetchFromGitHub {
+    owner = "varnholt";
+    repo = "dynablaster_revenge";
+    rev = "08fb11fb2d5dd94e1ea0e447d95cccb375dfc7e5";
+    sha256 = "1apc4751l1gscbg8rlmpym2lp9dsvak8sa6s7zy10yg1h6k6c004";
+  };
+
+  postUnpack = ''
+    export sourceRoot=$sourceRoot/${if isServer then "server" else "client"}
+  '';
+
+  postPatch = lib.optionalString isServer ''
+    substituteInPlace server.pro \
+      --replace 'TARGET = server' 'TARGET = ${meta.mainProgram}'
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qtbase
+  ] ++ lib.optionals (!isServer) ([
+    libGLU
+    SDL2
+  ] ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+  ]);
+
+  installPhase = ''
+    runHook preInstall
+
+  '' + (if stdenv.isDarwin then ''
+    mkdir -p $out/{Applications,bin}
+    mv {,$out/Applications/}${meta.mainProgram}.app
+    ln -s $out/{Applications/${meta.mainProgram}.app/Contents/MacOS,bin}/${meta.mainProgram}
+  '' else ''
+    install -Dm755 {,$out/bin/}${meta.mainProgram}
+  '') + lib.optionalString (!isServer) ''
+    mkdir -p $out/share/dynablaster
+    cp -R data $out/share/dynablaster/
+  '' + ''
+
+    runHook postInstall
+  '';
+
+  preFixup = lib.optionalString (!isServer) ''
+    qtWrapperArgs+=(
+      --run "cd $out/share/dynablaster"
+    )
+  '';
+
+  meta = with lib; {
+    description = "This is a remake of the game Dynablaster, released by Hudson Soft in 1991"
+      + lib.optionalString isServer " (dedicated server)";
+    mainProgram = "dynablaster" + lib.optionalString isServer "-server";
+    homepage = "https://github.com/varnholt/dynablaster_revenge";
+    maintainers = with maintainers; [ luz ];
+    license = with licenses; [ cc-by-nc-40 ];
+    platforms = platforms.all;
+    broken = (!isServer) && (
+      # Missing audio backend code, unplayable even when patched
+      stdenv.isDarwin ||
+      # https://github.com/varnholt/dynablaster_revenge/issues/6
+      stdenv.isAarch64
+    );
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3014,6 +3014,11 @@ with pkgs;
     enableSSH = true;
   };
 
+  dynablaster-revenge = libsForQt5.callPackage ../games/dynablaster-revenge { };
+  dynablaster-revenge-server = libsForQt5.callPackage ../games/dynablaster-revenge {
+    isServer = true;
+  };
+
   dynamic-colors = callPackage ../tools/misc/dynamic-colors { };
 
   dyncall = callPackage ../development/libraries/dyncall { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
