### PR TITLE
vokoscreen-ng: 3.0.8 -> 3.1.0

### DIFF
--- a/pkgs/applications/video/vokoscreen-ng/default.nix
+++ b/pkgs/applications/video/vokoscreen-ng/default.nix
@@ -6,6 +6,7 @@
 , qttools
 , gstreamer
 , libX11
+, wayland
 , pulseaudio
 , qtbase
 , qtmultimedia
@@ -19,13 +20,13 @@
 mkDerivation rec {
 
   pname = "vokoscreen-ng";
-  version = "3.0.8";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "vkohaupt";
     repo = "vokoscreenNG";
     rev = version;
-    sha256 = "1302663hyp2xxhaavhfky24a2p9gz23i3rykmrc6c1n23h24snri";
+    sha256 = "sha256-DIZ50JJhLFgPdBKhGCM5JPxz2hiWNGYVqtzY8/omq/s=";
   };
 
   patches = [
@@ -40,6 +41,7 @@ mkDerivation rec {
   buildInputs = [
     gstreamer
     libX11
+    wayland
     pulseaudio
     qtbase
     qtmultimedia

--- a/pkgs/applications/video/vokoscreen-ng/linux-support-installation-target.patch
+++ b/pkgs/applications/video/vokoscreen-ng/linux-support-installation-target.patch
@@ -1,9 +1,8 @@
-Seulement dans b: patch.patch
-Seulement dans b: ..rej
-diff --color -ur a/src/vokoscreenNG.pro b/src/vokoscreenNG.pro
---- a/src/vokoscreenNG.pro	2021-02-03 15:00:57.377401016 +0100
-+++ b/src/vokoscreenNG.pro	2021-02-03 15:09:18.141905863 +0100
-@@ -160,7 +160,32 @@
+diff --git a/src/vokoscreenNG.pro b/src/vokoscreenNG.pro
+index d43ed30..4e45448 100644
+--- a/src/vokoscreenNG.pro
++++ b/src/vokoscreenNG.pro
+@@ -153,6 +153,31 @@ include(version/version.pri)
  # systrayAlternative
  include(systrayAlternative/systrayAlternative.pri)
  
@@ -31,10 +30,8 @@ diff --color -ur a/src/vokoscreenNG.pro b/src/vokoscreenNG.pro
 +
 +  INSTALLS += target icon desktop appdata
 +}
++
  # ciscoOpenh264
  win32:include(ciscoOpenh264/ciscoOpenh264.pri)
  
--unix:include(wayland/wayland.pri)
-\ Pas de fin de ligne à la fin du fichier
-+unix:include(wayland/wayland.pri)
-+
+


### PR DESCRIPTION
###### Description of changes

https://linuxecke.volkoh.de/vokoscreen/vokoscreen-changes.html

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
