### PR TITLE
ksmbd-tools: init at 3.4.5

### DIFF
--- a/pkgs/os-specific/linux/ksmbd-tools/default.nix
+++ b/pkgs/os-specific/linux/ksmbd-tools/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, glib
+, libkrb5
+, libnl
+, libtool
+, pkg-config
+, withKerberos ? false
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ksmbd-tools";
+  version = "3.4.5";
+
+  src = fetchFromGitHub {
+    owner = "cifsd-team";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-sSCLXNdVUAdk+GnFlVx/BsAzyfz0KDdugJ1isrOztgs=";
+  };
+
+  buildInputs = [ glib libnl ] ++ lib.optional withKerberos libkrb5;
+
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
+
+  preConfigure = "./autogen.sh";
+
+  configureFlags = lib.optional withKerberos "--enable-krb5";
+
+  meta = with lib; {
+    description = "Userspace utilities for the ksmbd kernel SMB server";
+    homepage = "https://www.kernel.org/doc/html/latest/filesystems/cifs/ksmbd.html";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ elohmeier ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1301,6 +1301,8 @@ with pkgs;
 
   kanata-with-cmd = callPackage ../tools/system/kanata { withCmd = true; };
 
+  ksmbd-tools = callPackage ../os-specific/linux/ksmbd-tools { };
+
   ksnip = libsForQt5.callPackage ../tools/misc/ksnip { };
 
   kubevirt = callPackage ../tools/virtualization/kubevirt { };


### PR DESCRIPTION
###### Description of changes

This adds the ksmbd-tools for the new in-kernel SMB server implementation, which was added in Linux 5.15.
See https://www.kernel.org/doc/html/latest/filesystems/cifs/ksmbd.html for details.
Closes #141225.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
