### PR TITLE
openconnect: 8.10 -> 8.20, unstable-2021-05-05 -> 2022-03-14, cleanup, add myself as maintainer

### DIFF
--- a/pkgs/tools/networking/openconnect/common.nix
+++ b/pkgs/tools/networking/openconnect/common.nix
@@ -1,0 +1,43 @@
+{ version
+, src
+}:
+
+{ lib
+, stdenv
+, pkg-config
+, gnutls
+, openssl
+, useOpenSSL ? false
+, gmp
+, libxml2
+, stoken
+, zlib
+, vpnc-scripts
+, PCSC
+, autoreconfHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openconnect";
+  inherit version src;
+
+  outputs = [ "out" "dev" ];
+
+  configureFlags = [
+    "--with-vpnc-script=${vpnc-scripts}/bin/vpnc-script"
+    "--disable-nls"
+    "--without-openssl-version-check"
+  ];
+
+  buildInputs = [ gmp libxml2 stoken zlib (if useOpenSSL then openssl else gnutls) ]
+    ++ lib.optional stdenv.isDarwin PCSC;
+  nativeBuildInputs = [ pkg-config autoreconfHook ];
+
+  meta = with lib; {
+    description = "VPN Client for Cisco's AnyConnect SSL VPN";
+    homepage = "https://www.infradead.org/openconnect/";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ pradeepchhetri tricktron alyaeanyx ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/tools/networking/openconnect/default.nix
+++ b/pkgs/tools/networking/openconnect/default.nix
@@ -1,58 +1,31 @@
-{ lib
-, stdenv
-, fetchurl
-, pkg-config
-, openssl ? null
-, gnutls ? null
-, p11-kit
-, gmp
-, libxml2
-, stoken
-, zlib
-, vpnc-scripts
-, PCSC
-, head ? false
-  , fetchFromGitLab
-  , autoreconfHook
-}:
+{ callPackage, fetchFromGitLab, fetchurl, darwin }:
+let
+  common = opts: callPackage (import ./common.nix opts) {
+    inherit (darwin.apple_sdk.frameworks) PCSC;
+  };
+in rec {
+  openconnect = common rec {
+    version = "8.20";
+    src = fetchurl {
+      url = "ftp://ftp.infradead.org/pub/openconnect/openconnect-${version}.tar.gz";
+      sha256 = "sha256-wUUjhMb3lrruRdTpGa4b/CgdbIiGLh9kaizFE/xE5Ys=";
+    };
+  };
 
-assert (openssl != null) == (gnutls == null);
-
-stdenv.mkDerivation rec {
-  pname = "openconnect${lib.optionalString head "-head"}";
-  version = if head then "2021-05-05" else "8.10";
-
-  src =
-    if head then fetchFromGitLab {
+  openconnect_unstable = common {
+    version = "unstable-2022-03-14";
+    src = fetchFromGitLab {
       owner = "openconnect";
       repo = "openconnect";
-      rev = "684f6db1aef78e61e01f511c728bf658c30b9114";
-      sha256 = "0waclawcymgd8sq9xbkn2q8mnqp4pd0gpyv5wrnb7i0nsv860wz8";
-    }
-    else fetchurl {
-      url = "ftp://ftp.infradead.org/pub/openconnect/${pname}-${version}.tar.gz";
-      sha256 = "1cdsx4nsrwawbsisfkldfc9i4qn60g03vxb13nzppr2br9p4rrih";
+      rev = "a27a46f1362978db9723c8730f2533516b4b31b1";
+      sha256 = "sha256-Kz98GHCyEcx7vUF+AXMLR7886+iKGKNwx1iRaYcH8ps=";
     };
+  };
 
-  outputs = [ "out" "dev" ];
-
-  configureFlags = [
-    "--with-vpnc-script=${vpnc-scripts}/bin/vpnc-script"
-    "--disable-nls"
-    "--without-openssl-version-check"
-  ];
-
-  buildInputs = [ openssl gnutls gmp libxml2 stoken zlib ]
-    ++ lib.optional stdenv.isDarwin PCSC
-    ++ lib.optional stdenv.isLinux p11-kit;
-  nativeBuildInputs = [ pkg-config ]
-    ++ lib.optional head autoreconfHook;
-
-  meta = with lib; {
-    description = "VPN Client for Cisco's AnyConnect SSL VPN";
-    homepage = "https://www.infradead.org/openconnect/";
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ pradeepchhetri tricktron ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  openconnect_openssl = openconnect.override {
+    useOpenSSL = true;
   };
 }
+
+
+

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -833,6 +833,8 @@ mapAliases ({
   openbazaar-client = throw "openbazzar-client has been removed from nixpkgs as upstream has abandoned the project"; # Added 2022-01-06
   opencascade_oce = throw "'opencascade_oce' has been renamed to/replaced by 'opencascade'"; # Converted to throw 2022-02-22
   opencl-icd = throw "'opencl-icd' has been renamed to/replaced by 'ocl-icd'"; # Converted to throw 2022-02-22
+  openconnect_head = openconnect_unstable; # Added 2022-03-29
+  openconnect_gnutls = openconnect; # Added 2022-03-29
   openconnect_pa = throw "openconnect_pa fork has been discontinued, support for GlobalProtect is now available in openconnect"; # Added 2021-05-21
   openelec-dvb-firmware = libreelec-dvb-firmware; # Added 2021-05-10
   openexr_ctl = throw "'openexr_ctl' has been renamed to/replaced by 'ctl'"; # Converted to throw 2022-02-22

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10993,23 +10993,9 @@ with pkgs;
 
   witness = callPackage ../tools/security/witness { };
 
-  openconnect = openconnect_gnutls;
+  openconnectPackages = callPackage ../tools/networking/openconnect { };
 
-  openconnect_openssl = callPackage ../tools/networking/openconnect {
-    inherit (darwin.apple_sdk.frameworks) PCSC;
-    gnutls = null;
-  };
-
-  openconnect_gnutls = callPackage ../tools/networking/openconnect {
-    inherit (darwin.apple_sdk.frameworks) PCSC;
-    openssl = null;
-  };
-
-  openconnect_head = callPackage ../tools/networking/openconnect {
-    inherit (darwin.apple_sdk.frameworks) PCSC;
-    head = true;
-    openssl = null;
-  };
+  inherit (openconnectPackages) openconnect openconnect_unstable openconnect_openssl;
 
   globalprotect-openconnect = libsForQt5.callPackage ../tools/networking/globalprotect-openconnect { };
 


### PR DESCRIPTION
###### Description of changes
* OpenConnect release: https://gitlab.com/openconnect/openconnect/-/tags
* Refactored some style issues
* changed the unstable version string according to https://nixos.org/manual/nixpkgs/stable/#sec-package-naming, kept `openconnect_head` as an alias for `openconnect_unstable` for backwards compatibility
* added myself as maintainer because my uni still uses Cisco AnyConnect VPN which is why I'll probably be using this package for the next 5 years or so

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
