### PR TITLE
session-desktop-appimage: refactor - added desktop entry

### DIFF
--- a/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
+++ b/pkgs/applications/networking/instant-messengers/session-desktop-appimage/default.nix
@@ -1,15 +1,53 @@
 { lib
+, makeDesktopItem
+, copyDesktopItems
+, stdenvNoCC
 , fetchurl
 , appimageTools
 }:
 
-appimageTools.wrapType2 rec {
-  pname = "session-desktop-appimage";
+let
   version = "1.7.9";
+  pname = "session-desktop-appimage";
+
   src = fetchurl {
     url = "https://github.com/oxen-io/session-desktop/releases/download/v${version}/session-desktop-linux-x86_64-${version}.AppImage";
     sha256 = "ca7754e59146633b71e66b02a90cff87e4f2574e57ff831ca4a5f983b7e2fbef";
   };
+  appimage = appimageTools.wrapType2 {
+    inherit version pname src;
+  };
+  appimage-contents = appimageTools.extractType2 {
+    inherit version pname src;
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit version pname;
+  src = appimage;
+
+  nativeBuildInputs = [ copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Session";
+      desktopName = "Session";
+      comment = "Onion routing based messenger";
+      exec = "${appimage}/bin/session-desktop-appimage-${version}";
+      icon = "${appimage-contents}/session-desktop.png";
+      terminal = false;
+      type = "Application";
+      categories = [ "Network" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    cp -r bin $out/bin
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "Onion routing based messenger";


### PR DESCRIPTION
###### Description of changes

This pull request adds an icon and desktop entry to `session-desktop-appimage`.

Related to #165808

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
