### PR TITLE
d-spy: init at 1.2.0

### DIFF
--- a/pkgs/development/tools/misc/d-spy/default.nix
+++ b/pkgs/development/tools/misc/d-spy/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, desktop-file-utils
+, fetchpatch
+, fetchurl
+, glib
+, gtk4
+, libadwaita
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, gnome
+}:
+
+stdenv.mkDerivation rec {
+  pname = "d-spy";
+  version = "1.2.0";
+
+  outputs = [ "out" "lib" "dev" ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/dspy/${lib.versions.majorMinor version}/dspy-${version}.tar.xz";
+    sha256 = "XKL0z00w0va9m1OfuVq5YJyE1jzeynBxb50jc+O99tQ=";
+  };
+
+  patches = [
+    # Remove pointless dependencies
+    # https://gitlab.gnome.org/GNOME/d-spy/-/merge_requests/6
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/d-spy/-/commit/5a0ec8d53d006e95e93c6d6e32a381eb248b12a1.patch";
+      sha256 = "jalfdAXcH8GZ50qb2peG+2841cGan4EhwN88z5Ewf+k=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    desktop-file-utils
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      packageName = "dspy";
+      attrPath = "d-spy";
+    };
+  };
+
+  meta = with lib; {
+    description = "D-Bus exploration tool";
+    homepage = "https://gitlab.gnome.org/GNOME/d-spy";
+    license = with licenses; [
+      lgpl3Plus # library
+      gpl3Plus # app
+    ];
+    maintainers = teams.gnome.members;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14952,6 +14952,8 @@ with pkgs;
 
   dfeet = callPackage ../development/tools/misc/d-feet { };
 
+  d-spy = callPackage ../development/tools/misc/d-spy { };
+
   dfu-programmer = callPackage ../development/tools/misc/dfu-programmer { };
 
   dfu-util = callPackage ../development/tools/misc/dfu-util { };


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/d-spy

GTK4 replacement for d-feet, D-Bus exploration tool.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
