### PR TITLE
[21.11] mime-types: unrot url

### DIFF
--- a/pkgs/data/misc/mime-types/default.nix
+++ b/pkgs/data/misc/mime-types/default.nix
@@ -4,7 +4,7 @@ let
   version = "9";
 in fetchzip rec {
   name = "mime-types-${version}";
-  url = "https://mirrors.kernel.org/gentoo/distfiles/${name}.tar.bz2";
+  url = "https://oss.neverware.com/app-misc/mime-types/${name}.tar.bz2";
   postFetch = ''
     mkdir -p $out/etc
     tar xjvf $downloadedFile --directory=$out/etc --strip-components=1


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #164680

Gentoo mirrors no longer distribute this file. This updates it to a surviving URL ([comment](https://github.com/NixOS/nixpkgs/issues/164680#issuecomment-1072522099)).

This is not a backport of something from master. Later versions of nixpkgs have already replaced mime-types with mailcap.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - no, built in nixos docker image, which sets `sandbox = false`
- [ ] Tested, as applicable:
  - I just built it in nix repl
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - no, but this is a fixed-output derivation so that shouldn't affect anything
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - n/a
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
  - no user-facing changes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
