### PR TITLE
python310Packages.pyqldb: init at 3.2.2

### DIFF
--- a/pkgs/development/python-modules/amazon-ion/default.nix
+++ b/pkgs/development/python-modules/amazon-ion/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, jsonconversion, six, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "amazon-ion";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    pname = "amazon.ion";
+    inherit version;
+    sha256 = "sha256-vtztUHSnGoPYozhwvigxEdieVtbKNfV4B5yZ4MHaWGw=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  '';
+
+  propagatedBuildInputs = [ jsonconversion six ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "amazon.ion" ];
+
+  meta = with lib; {
+    description = "A Python implementation of Amazon Ion";
+    homepage = "https://github.com/amzn/ion-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.terlar ];
+  };
+}

--- a/pkgs/development/python-modules/ionhash/default.nix
+++ b/pkgs/development/python-modules/ionhash/default.nix
@@ -1,0 +1,38 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, amazon-ion, six, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "ionhash";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "amzn";
+    repo = "ion-hash-python";
+    rev = "v${version}";
+    sha256 = "sha256-mXOLKXauWwwIA/LnF4qyZsBiF/QM+rF9MmE2ewmozYo=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/amzn/ion-hash-python/commit/5cab56d694ecc176e394bb455c2d726ba1514ce0.patch";
+      sha256 = "sha256-P5QByNafgxI//e3m+b0oG00+rVymCsT/J4dOZSk3354=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner'," ""
+  '';
+
+  propagatedBuildInputs = [ amazon-ion six ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "ionhash" ];
+
+  meta = with lib; {
+    description = "Python implementation of Amazon Ion Hash";
+    homepage = "https://github.com/amzn/ion-hash-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.terlar ];
+  };
+}

--- a/pkgs/development/python-modules/jsonconversion/default.nix
+++ b/pkgs/development/python-modules/jsonconversion/default.nix
@@ -1,0 +1,26 @@
+{ lib, buildPythonPackage, fetchPypi, pytestCheckHook, numpy }:
+
+buildPythonPackage rec {
+  pname = "jsonconversion";
+  version = "0.2.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-4hMY0N/Px+g5zn3YzNfDWPyi8Pglvd/c2N9SeC4JoZ0=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner'" ""
+  '';
+
+  checkInputs = [ pytestCheckHook numpy ];
+
+  pythonImportsCheck = [ "jsonconversion" ];
+
+  meta = with lib; {
+    description = "This python module helps converting arbitrary Python objects into JSON strings and back";
+    homepage = "https://pypi.org/project/jsonconversion/";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.terlar ];
+  };
+}

--- a/pkgs/development/python-modules/pyqldb/default.nix
+++ b/pkgs/development/python-modules/pyqldb/default.nix
@@ -1,0 +1,32 @@
+{ lib, buildPythonPackage, fetchFromGitHub, boto3, amazon-ion, ionhash, pytestCheckHook }:
+
+buildPythonPackage rec {
+  pname = "pyqldb";
+  version = "3.2.2";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "amazon-qldb-driver-python";
+    rev = "v${version}";
+    sha256 = "sha256-TKf43+k428h8T6ye6mJrnK9D4J1xpIu0QacM7lWJF7w=";
+  };
+
+  propagatedBuildInputs = [ boto3 amazon-ion ionhash ];
+
+  checkInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    export AWS_DEFAULT_REGION=us-east-1
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  pythonImportsCheck = [ "pyqldb" ];
+
+  meta = with lib; {
+    description = "Python driver for Amazon QLDB";
+    homepage = "https://github.com/awslabs/amazon-qldb-driver-python";
+    license = licenses.asl20;
+    maintainers = [ maintainers.terlar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4296,6 +4296,8 @@ in {
 
   json5 = callPackage ../development/python-modules/json5 { };
 
+  jsonconversion = callPackage ../development/python-modules/jsonconversion { };
+
   jsondate = callPackage ../development/python-modules/jsondate { };
 
   jsondiff = callPackage ../development/python-modules/jsondiff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -470,6 +470,8 @@ in {
 
   altair = callPackage ../development/python-modules/altair { };
 
+  amazon-ion = callPackage ../development/python-modules/amazon-ion { };
+
   amazon_kclpy = callPackage ../development/python-modules/amazon_kclpy { };
 
   ambee = callPackage ../development/python-modules/ambee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7480,6 +7480,8 @@ in {
 
   pypytools = callPackage ../development/python-modules/pypytools { };
 
+  pyqldb = callPackage ../development/python-modules/pyqldb { };
+
   pyqrcode = callPackage ../development/python-modules/pyqrcode { };
 
   pyqt-builder = callPackage ../development/python-modules/pyqt-builder { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4090,6 +4090,8 @@ in {
 
   iocapture = callPackage ../development/python-modules/iocapture { };
 
+  ionhash = callPackage ../development/python-modules/ionhash { };
+
   iotawattpy = callPackage ../development/python-modules/iotawattpy { };
 
   iowait = callPackage ../development/python-modules/iowait { };


### PR DESCRIPTION
###### Description of changes

This adds the Python package pyqldb with it's dependencies.

This package is the official Amazon QLDB Python Driver and more information can be found in the repository hosting the code:
https://github.com/awslabs/amazon-qldb-driver-python

This is especially useful as there is not other way that I know of to automate setting up QLDB tables etc.

This might be hard to test without actually having a QLDB database, but if you are able to set one up, you could run something like this:
```python
#! /usr/bin/env nix-shell
#! nix-shell -I nixpkgs=./. -i python -p python3 python3Packages.pyqldb

import botocore
import sys
import time
from pyqldb.driver.qldb_driver import QldbDriver


def main(ledger, region, table):
    qldb_driver = QldbDriver(ledger_name=ledger, region_name=region)
    timeout_sec = 5
    sleep_sec = 1

    try:
        print(f"Creating table {table}...", file=sys.stderr, end="", flush=True)
        qldb_driver.execute_lambda(
            lambda executor: executor.execute_statement(f"CREATE TABLE {table}")
        )

        waited_sec = 0
        success = False
        while not success and waited_sec < timeout_sec:
            waited_sec += sleep_sec
            try:
                qldb_driver.execute_lambda(
                    lambda executor: executor.execute_statement(
                        f"SELECT * FROM {table}"
                    )
                )
                success = True
            except (botocore.exceptions.ClientError) as e:
                print(".", file=sys.stderr, end="")
                time.sleep(sleep_sec)

                if success:
                    print("OK", file=sys.stderr)
                else:
                    print("ERROR", file=sys.stderr)
                    sys.exit(
                        f"Failed to select from database after creation within {timeout_sec}s"
                    )
    except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError) as e:
        print("ERROR", file=sys.stderr)
        sys.exit(e)


if __name__ == "__main__":
    main("my-ledger", "us-east-1", "my_table")
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
