### PR TITLE
xfce4-screensaver: init at 4.16.0

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1613,6 +1613,13 @@
       </listitem>
       <listitem>
         <para>
+          <literal>services.xserver.desktopManager.xfce</literal> now
+          includes Xfce’s screen locker,
+          <literal>xfce4-screensaver</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>hadoop</literal> package has added support for
           <literal>aarch64-linux</literal> and
           <literal>aarch64-darwin</literal> as of 3.3.1

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -576,6 +576,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The polkit service, available at `security.polkit.enable`, is now disabled by default. It will automatically be enabled through services and desktop environments as needed.
 
+- `services.xserver.desktopManager.xfce` now includes Xfce's screen locker, `xfce4-screensaver`.
+
 - The `hadoop` package has added support for `aarch64-linux` and `aarch64-darwin` as of 3.3.1 ([#158613](https://github.com/NixOS/nixpkgs/pull/158613)).
 
 - The `R` package now builds again on `aarch64-darwin` ([#158992](https://github.com/NixOS/nixpkgs/pull/158992)).

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -99,6 +99,7 @@ in
       ristretto
       xfce4-appfinder
       xfce4-notifyd
+      xfce4-screensaver
       xfce4-screenshooter
       xfce4-session
       xfce4-settings
@@ -168,5 +169,6 @@ in
       xfce4-notifyd
     ];
 
+    security.pam.services.xfce4-screensaver.unixAuth = true;
   };
 }

--- a/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screensaver/default.nix
@@ -1,0 +1,49 @@
+{ mkXfceDerivation
+, dbus-glib
+, garcon
+, glib
+, gtk3
+, libX11
+, libXScrnSaver
+, libXrandr
+, libwnck
+, libxfce4ui
+, libxklavier
+, pam
+, systemd
+, xfconf
+, lib
+}:
+
+mkXfceDerivation {
+  category = "apps";
+  pname = "xfce4-screensaver";
+  version = "4.16.0";
+
+  sha256 = "1vblqhhzhv85yd5bz1xg14yli82ys5qrjdcabg3l53glbk61n99p";
+
+  buildInputs = [
+    dbus-glib
+    garcon
+    glib
+    gtk3
+    libX11
+    libXScrnSaver
+    libXrandr
+    libwnck
+    libxfce4ui
+    libxklavier
+    pam
+    systemd
+    xfconf
+  ];
+
+  configureFlags = [ "--without-console-kit" ];
+
+  makeFlags = [ "DBUS_SESSION_SERVICE_DIR=$(out)/etc" ];
+
+  meta =  {
+    description = "Screensaver for Xfce";
+    maintainers = with lib.maintainers; [ symphorien ];
+  };
+}

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -82,6 +82,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4-terminal = callPackage ./applications/xfce4-terminal { };
 
+  xfce4-screensaver = callPackage ./applications/xfce4-screensaver { };
+
   xfce4-screenshooter = callPackage ./applications/xfce4-screenshooter {
     inherit (pkgs.gnome) libsoup;
   };


### PR DESCRIPTION
A simple screen saver and locker for the Xfce desktop environment.

###### Description of changes

reopening of #146665

<!--


For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
