### PR TITLE
python3Packages.openapi-core: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/openapi-core/default.nix
+++ b/pkgs/development/python-modules/openapi-core/default.nix
@@ -1,34 +1,40 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, isodate
-, dictpath
-, openapi-spec-validator
-, openapi-schema-validator
-, six
-, lazy-object-proxy
 , attrs
-, werkzeug
-, parse
-, more-itertools
-, pytestCheckHook
-, falcon
-, flask
+, buildPythonPackage
+, dictpath
 , django
 , djangorestframework
-, responses
+, falcon
+, fetchFromGitHub
+, flask
+, isodate
+, lazy-object-proxy
 , mock
+, more-itertools
+, openapi-schema-validator
+, openapi-spec-validator
+, parse
+, pytestCheckHook
+, pythonOlder
+, responses
+, six
+, webob
+, werkzeug
+, python
 }:
 
 buildPythonPackage rec {
   pname = "openapi-core";
   version = "0.14.2";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "p1c2u";
     repo = "openapi-core";
     rev = version;
-    sha256 = "1npsibyf8zx6z230yl19kyap8g25kqvgm7z1w6rm6jxv58yqsp7r";
+    hash = "sha256-+VyNPSq7S1Oz4eGf+jaeRTx0lZ8pUA+G+KZ/5PyK+to=";
   };
 
   postPatch = ''
@@ -36,31 +42,34 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    isodate
-    dictpath
-    openapi-spec-validator
-    openapi-schema-validator
-    six
-    lazy-object-proxy
     attrs
-    werkzeug
-    parse
+    dictpath
+    isodate
+    lazy-object-proxy
     more-itertools
+    openapi-schema-validator
+    openapi-spec-validator
+    parse
+    six
+    werkzeug
   ];
 
   checkInputs = [
-    pytestCheckHook
-    falcon
-    flask
     django
     djangorestframework
-    responses
+    falcon
+    flask
     mock
+    pytestCheckHook
+    responses
+    webob
   ];
 
   disabledTestPaths = [
     # AttributeError: 'str' object has no attribute '__name__'
     "tests/integration/validation"
+    # Unable to detect SECRET_KEY and ROOT_URLCONF
+    "tests/integration/contrib/test_django.py"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/pathable/default.nix
+++ b/pkgs/development/python-modules/pathable/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, poetry-core
+}:
+
+buildPythonPackage rec {
+  pname = "pathable";
+  version = "0.4.0";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "p1c2u";
+    repo = pname;
+    rev = version;
+    hash = "sha256-3qekweG+o7f6nm1cnCEHrWYn/fQ42GZrZkPwGbZcU38=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    sed -i "/--cov/d" pyproject.toml
+  '';
+
+  pythonImportsCheck = [
+    "pathable"
+  ];
+
+  meta = with lib; {
+    description = "Library for object-oriented paths";
+    homepage = "https://github.com/p1c2u/pathable";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5974,6 +5974,8 @@ in {
 
   path-and-address = callPackage ../development/python-modules/path-and-address { };
 
+  pathable = callPackage ../development/python-modules/pathable { };
+
   pathlib2 = callPackage ../development/python-modules/pathlib2 { };
 
   pathlib = callPackage ../development/python-modules/pathlib { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Fix build (https://hydra.nixos.org/build/170869593)

Fixes #165853

The next `openapi-core` release requires `pathable`.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
