### PR TITLE
gotools: 2021-01-13 -> 0.1.10

### DIFF
--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -1,14 +1,13 @@
 { lib, buildGoModule, fetchgit }:
 
 buildGoModule rec {
-  pname = "gotools-unstable";
-  version = "2021-01-13";
-  rev = "8b4aab62c064010e8e875d2e5a8e63a96fefc87d";
+  pname = "gotools";
+  version = "0.1.10";
 
   src = fetchgit {
-    inherit rev;
+    rev = "v${version}";
     url = "https://go.googlesource.com/tools";
-    sha256 = "1cmnm9fl2a6hiplj8s6x0l3czcw4xh3j3lvzbgccnp1l8kz8q2vm";
+    sha256 = "sha256-r71+//VhayW18uvMl/ls/8KYNbZ7uDZw3SWoqPL3Xqk=";
   };
 
   # The gopls folder contains a Go submodule which causes a build failure.
@@ -25,7 +24,7 @@ buildGoModule rec {
     rm -rf gopls
   '';
 
-  vendorSha256 = "18qpjmmjpk322fvf81cafkpl3spv7hpdpymhympmld9isgzggfyz";
+  vendorSha256 = "sha256-UJIXG8WKzazNTXoqEFlT/umC40F6z2Q5I8RfxnMbsPM=";
 
   doCheck = false;
 
@@ -53,4 +52,11 @@ buildGoModule rec {
   # Do not copy this without a good reason for enabling
   # In this case tools is heavily coupled with go itself and embeds paths.
   allowGoReference = true;
+
+  meta = with lib; {
+    description = "Additional tools for Go development";
+    homepage = "http://go.googlesource.com/tools";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ danderson ];
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23089,7 +23089,9 @@ with pkgs;
 
   gotest = callPackage ../development/tools/gotest { };
 
-  gotools = callPackage ../development/tools/gotools { };
+  gotools = callPackage ../development/tools/gotools {
+    buildGoModule = buildGo118Module;
+  };
 
   gotop = callPackage ../tools/system/gotop { };
 


### PR DESCRIPTION
###### Description of changes

Adds tool support for parsing files that use Go 1.18 generics. In particular, goimports no longer chokes on generic-ful files.

The package needs to be built with Go 1.18, which is not yet the default in nixpkgs. However, the generics changes to the syntax are backwards compatible, so the 1.18-ful gotools is still perfectly happy operating on <1.18 source code.


With that said, gotools and the Go toolchain are pretty tightly coupled, in terms of things like language parsing and module semantics. Go hasn't had a major language change in years, so having a single gotools and multiple go toolchains has worked fine so far... But maybe it's time to ship gotools_1_17, gotools_1_18 and so forth, so that these tools stay more in lockstep with the toolchain? I haven't done this here, because there's no _breaking_ changes, so using bleeding edge gotools should still work fine for users of older Go versions, but I thought I'd bring it up in case that's something we want to do in future.

I've tested this build by using the built goimports in emacs, and it functions correctly in both Go 1.18 + generics source files and Go 1.17 files.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
