### PR TITLE
dsq: init at 0.9.0

### DIFF
--- a/pkgs/tools/misc/dsq/default.nix
+++ b/pkgs/tools/misc/dsq/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildGoModule
+, runCommand
+, nix-update-script
+, dsq
+, diffutils
+}:
+
+buildGoModule rec {
+  pname = "dsq";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "multiprocessio";
+    repo = "dsq";
+    rev = version;
+    hash = "sha256-JzS94kfvgZDz4tIXa4veY3XSFeMDBN61sU8/+5V5y9Y=";
+  };
+
+  vendorSha256 = "sha256-9Exy2VLxOd4lgwbIOZ6NJ45NABO9a0rLjmZ+Cd7jjLM=";
+
+  nativeBuildInputs = [ diffutils ];
+
+  passthru = {
+    updateScript = nix-update-script { attrPath = pname; };
+
+    tests = {
+      pretty-csv = runCommand "${pname}-test" { } ''
+        mkdir "$out"
+        cat <<EOF > "$out/input.csv"
+        first,second
+        1,a
+        2,b
+        EOF
+        cat <<EOF > "$out/expected.txt"
+        +-------+--------+
+        | first | second |
+        +-------+--------+
+        |     1 | a      |
+        |     2 | b      |
+        +-------+--------+
+        EOF
+        ${dsq}/bin/dsq --pretty "$out/input.csv" 'select first, second from {}' > "$out/actual.txt"
+        diff "$out/expected.txt" "$out/actual.txt"
+      '';
+    };
+  };
+
+  meta = with lib; {
+    description = "Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more";
+    homepage = "https://github.com/multiprocessio/dsq";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ liff ];
+    # TODO: Remove once nixpkgs uses macOS SDK 10.14+ for x86_64-darwin
+    # Undefined symbols for architecture x86_64: "_SecTrustEvaluateWithError"
+    broken = stdenv.isDarwin && stdenv.isx86_64;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -341,6 +341,8 @@ with pkgs;
 
   deadnix = callPackage ../development/tools/deadnix { };
 
+  dsq = callPackage ../tools/misc/dsq { buildGoModule = buildGo118Module; };
+
   each = callPackage ../tools/text/each { };
 
   eclipse-mat = callPackage ../development/tools/eclipse-mat { };


### PR DESCRIPTION
###### Description of changes

Add a package for [dsq](https://github.com/multiprocessio/dsq), which is a “Commandline tool for running SQL queries against JSON, CSV, Excel, Parquet, and more.”

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
