### PR TITLE
mictray: init at 0.2.5

### DIFF
--- a/pkgs/tools/audio/mictray/default.nix
+++ b/pkgs/tools/audio/mictray/default.nix
@@ -1,0 +1,53 @@
+{ fetchFromGitHub
+, gtk3
+, lib
+, libgee
+, libnotify
+, meson
+, ninja
+, pkg-config
+, pulseaudio
+, stdenv
+, vala
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mictray";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "Junker";
+    repo = "mictray";
+    rev = "1f879aeda03fbe87ae5a761f46c042e09912e1c0";
+    sha256 = "0achj6r545c1sigls79c8qdzryz3sgldcyzd3pwak1ymim9i9c74";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    libgee
+    libnotify
+    pulseaudio
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/Junker/mictray";
+    description = "System tray application for microphone";
+    longDescription = ''
+      MicTray is a Lightweight system tray application which lets you control the microphone state and volume.
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.anpryl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34991,4 +34991,6 @@ with pkgs;
   honeytail = callPackage ../servers/tracing/honeycomb/honeytail { };
 
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
+
+  mictray = callPackage ../tools/audio/mictray { };
 }


### PR DESCRIPTION
###### Description of changes

Adding new package [mitray](https://github.com/Junker/mictray). It is a tray tool to control microphone state and volume from system tray.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
