### PR TITLE
brave: 1.36.116 -> 1.36.122

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,11 +91,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.36.116";
+  version = "1.36.122";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "whGV0VgCm6JSyrcFQTKbM35b/qLQdBmChTrYuyC+OlI=";
+    sha256 = "aBHoEu1egRPMpeUBgRl2V5J3op1Ju+CvprG14dIWc8M=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes
https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#136122

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).