### PR TITLE
s-tui: 1.0.1 -> 1.1.3

### DIFF
--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -1,12 +1,18 @@
-{ lib, python3Packages }:
+{ lib
+, stdenv
+, python3Packages
+, nix-update-script
+, s-tui
+, testVersion
+}:
 
 python3Packages.buildPythonPackage rec {
   pname = "s-tui";
-  version = "1.0.1";
+  version = "1.1.3";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1gqrb2xxii43j7kszy7kvv4f6hr8ac4p0m9q8i1xs5fhsqcx186i";
+    sha256 = "sha256-t3h8d0yc7i3UvO8CVfBd3/3h3RfGN6yE6hutymOZUdA=";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -14,12 +20,16 @@ python3Packages.buildPythonPackage rec {
     psutil
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  passthru = {
+    updateScript = nix-update-script { attrPath = pname; };
+    tests = testVersion { package = s-tui; };
+  };
 
   meta = with lib; {
     homepage = "https://amanusk.github.io/s-tui/";
     description = "Stress-Terminal UI monitoring tool";
     license = licenses.gpl2;
     maintainers = with maintainers; [ infinisil ];
+    broken = stdenv.isDarwin; # https://github.com/amanusk/s-tui/issues/49
   };
 }


### PR DESCRIPTION
###### Description of changes

A few releases have happened:
 - [1.0.2](https://github.com/amanusk/s-tui/releases/tag/v1.0.2)
 - [1.1.1](https://github.com/amanusk/s-tui/releases/tag/v1.1.1)
 - [1.1.3](https://github.com/amanusk/s-tui/releases/tag/v1.1.3)

Also added an update script and a simple test. Removed `LC_ALL` since it seems to work just fine without.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
