### PR TITLE
parsec: init at ???

### DIFF
--- a/pkgs/applications/misc/parsec/default.nix
+++ b/pkgs/applications/misc/parsec/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, lib
+, buildFHSUserEnv
+, parsecDrv ? null
+, dpkg
+, fetchurl
+}:
+
+let
+  parsecDrvUsed = if parsecDrv != null then parsecDrv else stdenv.mkDerivation rec {
+    name = "parsec-extracted";
+    src = fetchurl {
+      url = "https://builds.parsecgaming.com/package/parsec-linux.deb"; # Can't seem to find a link to a specific version, hopefully this wont change invalidating the derivation.
+      sha256 = "1hfdzjd8qiksv336m4s4ban004vhv00cv2j461gc6zrp37s0fwhc";
+    };
+
+    unpackPhase = "dpkg-deb -x ${src} .";
+
+    nativeBuildInputs = [
+      dpkg
+    ];
+
+    installPhase = ''
+      mkdir $out
+      cp -r ./usr/* $out
+    '';
+  };
+  fhs = buildFHSUserEnv {
+    name = "parsecd";
+
+    targetPkgs = pkgs: with pkgs; [
+      alsaLib
+      dbus
+      libGL
+      libglvnd
+      libpulseaudio
+      libva.out
+      openssl
+      udev
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXi
+    ];
+    runScript = "${parsecDrvUsed}/bin/parsecd";
+  };
+in stdenv.mkDerivation {
+  pname = "parsec";
+  version = "1.0"; # Can't seem to find versioning upstream?
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir $out/{share,bin} -p
+    cp -r ${parsecDrvUsed}/share/{applications,icons} $out/share
+    ln -s ${fhs}/bin/parsecd $out/bin/parsecd
+  '';
+  meta = with lib; {
+    homepage = "https://parsecgaming.com/";
+    description = "Remote streaming service client";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ lucasew ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27777,6 +27777,8 @@ with pkgs;
 
   ncmpcpp = callPackage ../applications/audio/ncmpcpp { };
 
+  parsec = callPackage ../applications/misc/parsec { };
+
   pragha = libsForQt5.callPackage ../applications/audio/pragha { };
 
   rofi-mpd = callPackage ../applications/audio/rofi-mpd { };


### PR DESCRIPTION
Signed-off-by: lucasew <lucas59356@gmail.com>

###### Description of changes
Added parsec

The version is ??? because parsec has a weird versioning system, the package comes with a bootstrap .so file that is updated on runtime. The bootstrap happens at `~/.parsec/parsecd-*.so` with a must-writable JSON referencing them. Hardcoding another path leads to Parsec just ignore the fact that a path is absolute and prepend ~/.parsec resolved.

It starts and logins without errors but I didn't tested running games yet, initially I though it provided a Linux server but it's only true on Windows and experimentally on MacOS.

Closes #95160 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Tested if it runs games
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
