### PR TITLE
lib/trivial: actually expose warnIfNot and throwIf

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,7 @@ let
       stringLength sub substring tail trace;
     inherit (self.trivial) id const pipe concat or and bitAnd bitOr bitXor
       bitNot boolToString mergeAttrs flip mapNullable inNixShell isFloat min max
-      importJSON importTOML warn warnIf throwIfNot checkListOfEnum
+      importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction toFunction


### PR DESCRIPTION
Can't believe I forgot this.