### PR TITLE
firefox: allow sandbox access to graphics drivers

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -165,6 +165,14 @@ buildStdenv.mkDerivation ({
   inherit src unpackPhase meta;
 
   patches = [
+    (fetchpatch {
+      # RDD Sandbox paths for NixOS, remove with Firefox>=100
+      # https://hg.mozilla.org/integration/autoland/rev/5ac6a69a01f47ca050d90704a9791b8224d30f14
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1761692
+      name = "mozbz-1761692-rdd-sandbox-paths.patch";
+      url = "https://hg.mozilla.org/integration/autoland/raw-rev/5ac6a69a01f47ca050d90704a9791b8224d30f14";
+      hash = "sha256-+NGRUxXA7HGvPaAwvDveqRsdXof5nBIc+l4hdf7cC/Y=";
+    })
   ]
   ++ lib.optional (lib.versionAtLeast version "86") ./env_var_for_system_dir-ff86.patch
   ++ lib.optional (lib.versionAtLeast version "90" && lib.versionOlder version "95") ./no-buildconfig-ffx90.patch


### PR DESCRIPTION
Firefox uses a sandboxing model that only allows access to paths that
were previously explicitly granted. We can only add granular permissions
to a specific sandbox by patching, because setting LD_LIBRARY_PATH would
affect all of them.

To use hardware decoding via VA-API with Firefox 98.0.2 one needs to
head to `about:config` and enable `media.ffmpeg.vaapi.enabled`.

Once RFC121 has passed this should to be updated.

Closes: #157061

###### Testing

Test this change by starting firefox with `MOZ_LOG="PlatformDecoderModule:5" `, head to `about:config` and enable `media.ffmpeg.vaapi.enabled`. Then try playing video content within Firefox.

If it works you should see roughly the following

```
libva info: VA-API version 1.13.0
libva info: Trying to open /run/opengl-driver/lib/dri/radeonsi_drv_video.so
libva info: Found init function __vaDriverInit_1_13
libva info: va_openDriver() returns 0
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x3231564e -> nv12.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x30313050 -> p010le.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x36313050 -> unknown.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x30323449 -> yuv420p.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x32315659 -> yuv420p.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x56595559 -> unknown.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x32595559 -> yuyv422.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x59565955 -> uyvy422.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x41524742 -> bgra.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x41424752 -> rgba.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x58524742 -> bgr0.
[AVHWDeviceContext @ 0x7fc19f35f540] Format 0x58424752 -> rgb0.
[AVHWDeviceContext @ 0x7fc19f35f540] VAAPI driver: Mesa Gallium driver 21.3.7 for AMD Radeon RX 5700 (NAVI10, DRM 3.44.0, 5.16.15, LLVM 13.0.1).
[AVHWDeviceContext @ 0x7fc19f35f540] Driver not found in known nonstandard list, using standard behaviour.
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
