### PR TITLE
Revert "gmailctl: 0.10.0 -> unstable-2022-03-24"

### DIFF
--- a/pkgs/applications/networking/gmailctl/default.nix
+++ b/pkgs/applications/networking/gmailctl/default.nix
@@ -6,16 +6,14 @@
 
 buildGoModule rec {
   pname = "gmailctl";
-  version = "unstable-2022-03-24";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "mbrt";
     repo = "gmailctl";
-    rev = "484bb689866987580e0576165180ef06375a543f";
-    sha256 = "sha256-hIoS64QEDJ1qq3KJ2H8HjgQl8SxuIo+xz7Ot8CdjjQA=";
+    rev = "v${version}";
+    sha256 = "sha256-JuE8+OW+qM6tir4A25tN2GTXQIkcKVE4uKbZNSTcNlA=";
   };
-
-  vendorSha256 = "sha256-KWM20a38jZ3/a45313kxY2LaCQyiNMEdfdIV78phrBo=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -27,6 +25,8 @@ buildGoModule rec {
       --fish <($out/bin/gmailctl completion fish) \
       --zsh <($out/bin/gmailctl completion zsh)
   '';
+
+  vendorSha256 = "sha256-nAczO439tRiQU9f9LbJVENJiURVRnBAInwUp699RxOY=";
 
   doCheck = false;
 


### PR DESCRIPTION
This reverts commit de5a0ee6fc3899d8dfd120e7659a7b74a728acec - PR https://github.com/NixOS/nixpkgs/pull/165955 .

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
