### PR TITLE
eiciel: init at 0.9.13.1

### DIFF
--- a/pkgs/tools/filesystems/eiciel/default.nix
+++ b/pkgs/tools/filesystems/eiciel/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, acl
+, gnome
+, gtkmm3
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eiciel";
+  version = "0.9.13.1";
+
+  outputs = [ "out" "nautilusExtension" ];
+
+  src = fetchFromGitHub {
+    owner = "rofirrim";
+    repo = "eiciel";
+    rev = version;
+    sha256 = "0rhhw0h1hyg5kvxhjxkdz03vylgax6912mg8j4lvcz6wlsa4wkvj";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    acl
+    gtkmm3
+    gnome.nautilus
+  ];
+
+  mesonFlags = [
+    "-Dnautilus-extension-dir=${placeholder "nautilusExtension"}/lib/nautilus/extensions-3.0"
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build --replace "compiler.find_library('libacl')" "compiler.find_library('acl')"
+    chmod +x img/install_icons.sh
+    patchShebangs img/install_icons.sh
+  '';
+
+  meta = with lib; {
+    description = "Graphical editor for ACLs and extended attributes";
+    homepage = "https://rofi.roger-ferrer.org/eiciel/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sersorrel ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33310,6 +33310,8 @@ with pkgs;
 
   dosbox-staging = callPackage ../applications/emulators/dosbox-staging { };
 
+  eiciel = callPackage ../tools/filesystems/eiciel { };
+
   emu2 = callPackage ../applications/emulators/emu2 { };
 
   apt = callPackage ../tools/package-management/apt { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Eiciel is a viewer/editor for ACLs and xattrs. It integrates with Nautilus, but also works standalone. https://rofi.roger-ferrer.org/eiciel/

I don't know if the Nautilus integration works; I installed eiciel and nautilus with nix-env and it doesn't seem to work, I don't know if that's because I packaged it wrong or if it's because I would have to install them both system-wide. I copied the method from https://github.com/NixOS/nixpkgs/blob/66be55b715edbc42f879b4bcccafe86d7f6bff10/pkgs/applications/networking/dropbox/cli.nix.

The "help" button doesn't seem to do anything, I don't know why that is – https://github.com/rofirrim/eiciel/commit/96fbd782cdfa4c47d7f6b91789e92a62614f7e6b looks relevant, and isn't included in a release yet, but building from that doesn't seem to fix it, so maybe I don't have some help viewer installed on my system.

Closes #165947

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
