### PR TITLE
maintainers/scripts/remove-old-aliases.py: add option to only operate on

### DIFF
--- a/maintainers/scripts/remove-old-aliases.py
+++ b/maintainers/scripts/remove-old-aliases.py
@@ -28,6 +28,11 @@ def process_args() -> argparse.Namespace:
         default=1,
         help="operate on aliases older than $year-$month",
     )
+    arg_parser.add_argument(
+        "--only-throws",
+        action="store_true",
+        help="only operate on throws. e.g remove throws older than $date",
+    )
     arg_parser.add_argument("--file", required=True, type=Path, help="alias file")
     arg_parser.add_argument(
         "--dry-run", action="store_true", help="don't modify files, only print results"
@@ -36,7 +41,7 @@ def process_args() -> argparse.Namespace:
 
 
 def get_date_lists(
-    txt: list[str], cutoffdate: datetimedate
+    txt: list[str], cutoffdate: datetimedate, only_throws: bool
 ) -> tuple[list[str], list[str], list[str]]:
     """get a list of lines in which the date is older than $cutoffdate"""
     date_older_list: list[str] = []
@@ -57,7 +62,11 @@ def get_date_lists(
                 except ValueError:
                     continue
 
-        if my_date is None or my_date > cutoffdate or "preserve, reason:" in line.lower():
+        if (
+            my_date is None
+            or my_date > cutoffdate
+            or "preserve, reason:" in line.lower()
+        ):
             continue
 
         if "=" not in line:
@@ -67,7 +76,7 @@ def get_date_lists(
             print(f"RESOLVE MANUALLY {line}")
         elif "throw" in line:
             date_older_throw_list.append(line)
-        else:
+        elif not only_throws:
             date_older_list.append(line)
 
     return (
@@ -160,6 +169,7 @@ def main() -> None:
     """main"""
     args = process_args()
 
+    only_throws = args.only_throws
     aliasfile = Path(args.file).absolute()
     cutoffdate = (datetime.strptime(f"{args.year}-{args.month}-01", "%Y-%m-%d")).date()
 
@@ -170,13 +180,12 @@ def main() -> None:
     date_older_throw_list: list[str] = []
 
     date_older_list, date_sep_line_list, date_older_throw_list = get_date_lists(
-        txt, cutoffdate
+        txt, cutoffdate, only_throws
     )
 
     converted_to_throw: list[tuple[str, str]] = []
-    converted_to_throw = convert_to_throw(date_older_list)
-
     if date_older_list:
+        converted_to_throw = convert_to_throw(date_older_list)
         print(" Will be converted to throws. ".center(100, "-"))
         for l_n in date_older_list:
             print(l_n)


### PR DESCRIPTION
throws

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
