### PR TITLE
glib: Add support for GNOME Console

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation rec {
     # Add support for the GNOME’s default terminal emulator.
     # https://gitlab.gnome.org/GNOME/glib/-/issues/2618
     ./gnome-console-support.patch
+    # Do the same for Pantheon’s terminal emulator.
+    ./elementary-terminal-support.patch
 
     # GLib contains many binaries used for different purposes;
     # we will install them to different outputs:

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation rec {
     ./glib-appinfo-watch.patch
     ./schema-override-variable.patch
 
+    # Add support for the GNOME’s default terminal emulator.
+    # https://gitlab.gnome.org/GNOME/glib/-/issues/2618
+    ./gnome-console-support.patch
+
     # GLib contains many binaries used for different purposes;
     # we will install them to different outputs:
     # 1. Tools for desktop environment ($bin)

--- a/pkgs/development/libraries/glib/elementary-terminal-support.patch
+++ b/pkgs/development/libraries/glib/elementary-terminal-support.patch
@@ -1,0 +1,16 @@
+diff --git a/gio/gdesktopappinfo.c b/gio/gdesktopappinfo.c
+index a441bfec9..6bcd3e690 100644
+--- a/gio/gdesktopappinfo.c
++++ b/gio/gdesktopappinfo.c
+@@ -2678,6 +2678,11 @@ prepend_terminal_to_vector (int    *argc,
+             if (check != NULL)
+               pass_cmd_as_single_arg = TRUE;
+           }
++          if (check == NULL) {
++            check = g_find_program_in_path ("io.elementary.terminal");
++            if (check != NULL)
++              pass_cmd_as_single_arg = TRUE;
++          }
+           if (check == NULL)
+             check = g_find_program_in_path ("tilix");
+           if (check == NULL)

--- a/pkgs/development/libraries/glib/gnome-console-support.patch
+++ b/pkgs/development/libraries/glib/gnome-console-support.patch
@@ -1,0 +1,55 @@
+diff --git a/gio/gdesktopappinfo.c b/gio/gdesktopappinfo.c
+index 60d6debb2..a441bfec9 100644
+--- a/gio/gdesktopappinfo.c
++++ b/gio/gdesktopappinfo.c
+@@ -2627,6 +2627,7 @@ prepend_terminal_to_vector (int    *argc,
+   int i, j;
+   char **term_argv = NULL;
+   int term_argc = 0;
++  gboolean pass_cmd_as_single_arg = FALSE;
+   char *check;
+   char **the_argv;
+ 
+@@ -2672,6 +2673,11 @@ prepend_terminal_to_vector (int    *argc,
+         }
+       else
+         {
++          if (check == NULL) {
++            check = g_find_program_in_path ("kgx");
++            if (check != NULL)
++              pass_cmd_as_single_arg = TRUE;
++          }
+           if (check == NULL)
+             check = g_find_program_in_path ("tilix");
+           if (check == NULL)
+@@ -2697,14 +2703,27 @@ prepend_terminal_to_vector (int    *argc,
+         }
+     }
+ 
+-  real_argc = term_argc + *argc;
++  real_argc = term_argc + (pass_cmd_as_single_arg ? 1 : *argc);
+   real_argv = g_new (char *, real_argc + 1);
+ 
+   for (i = 0; i < term_argc; i++)
+     real_argv[i] = term_argv[i];
+ 
+-  for (j = 0; j < *argc; j++, i++)
+-    real_argv[i] = (char *)the_argv[j];
++  if (pass_cmd_as_single_arg) {
++    char **quoted_argv = g_new (char *, *argc + 1);
++
++    for (j = 0; j < *argc; j++) {
++      quoted_argv[j] = g_shell_quote (the_argv[j]);
++      g_free (the_argv[j]);
++    }
++    quoted_argv[j] = NULL;
++
++    real_argv[i++] = g_strjoinv (" ", quoted_argv);
++    g_strfreev (quoted_argv);
++  } else {
++    for (j = 0; j < *argc; j++, i++)
++      real_argv[i] = (char *)the_argv[j];
++  }
+ 
+   real_argv[i] = NULL;
+ 


### PR DESCRIPTION
###### Description of changes

GNOME Console (aka King’s Cross) is the default terminal emulator in GNOME 42. Let’s make GLib aware of it so that apps relying on it (e.g. GNOME Shell) can launch terminal apps like htop.

This is a downstream patch since GLib does not want to add any more terminal emulators: https://gitlab.gnome.org/GNOME/glib/-/issues/2618

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
