### PR TITLE
Add a list of subsystem maintainers for release

### DIFF
--- a/maintainers/scripts/feature-freeze-teams.pl
+++ b/maintainers/scripts/feature-freeze-teams.pl
@@ -1,0 +1,98 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i perl -p perl -p perlPackages.JSON perlPackages.LWPUserAgent perlPackages.LWPProtocolHttps perlPackages.TermReadKey
+
+# This script generates a list of teams to ping for the Feature Freeze announcement on Discourse.
+# It's intended to be used by Release Managers before creating such posts.
+#
+# The script interactively reads a GitHub username and a corresponding GitHub Personal Access token.
+# This is required to access the GitHub Teams API so the token needs at least the read:org privilege.
+
+## no critic (InputOutput::RequireCheckedSyscalls, InputOutput::ProhibitBacktickOperators)
+use strict;
+use warnings;
+use Carp;
+use Cwd 'abs_path';
+use File::Basename;
+use JSON qw(decode_json);
+use LWP::UserAgent;
+use Term::ReadKey qw(ReadLine ReadMode);
+
+sub github_team_members {
+    my ($team_name, $username, $token) = @_;
+    my @ret;
+
+    my $req = HTTP::Request->new('GET', "https://api.github.com/orgs/NixOS/teams/$team_name/members", [ 'Accept' => 'application/vnd.github.v3+json' ]);
+    $req->authorization_basic($username, $token);
+    my $response = LWP::UserAgent->new->request($req);
+
+    if ($response->is_success) {
+        my $content = decode_json($response->decoded_content);
+        foreach (@{$content}) {
+            push @ret, $_->{'login'};
+        }
+    } else {
+        print {*STDERR} "!! Requesting members of GitHub Team '$team_name' failed: $response->status_line";
+    }
+
+    return \@ret;
+}
+
+# Read GitHub credentials
+print {*STDERR} 'GitHub username: ';
+my $github_user = ReadLine(0);
+ReadMode('noecho');
+print {*STDERR} 'GitHub personal access token (no echo): ';
+my $github_token = ReadLine(0);
+ReadMode('restore');
+print {*STDERR} "\n";
+chomp $github_user;
+chomp $github_token;
+
+# Read nix output
+my $nix_version = `nix --version`;
+my $out;
+my $lib_path = abs_path(dirname(__FILE__)) . '../../../lib';
+if ($nix_version =~ m/2[.]3[.]/msx) {
+    $out = `nix eval --json '(import $lib_path).teams'` || croak 'nix eval failed';
+} else {
+    $out = `nix --extra-experimental-features nix-command eval --json --impure --expr '(import $lib_path).teams'` || croak('nix eval failed');
+}
+my $data = decode_json($out);
+
+# Process teams
+print {*STDERR} "\n";
+while (my ($team_nix_key, $team_config) = each %{$data}) {
+    # Ignore teams that don't want to be or can't be pinged
+    if (not defined $team_config->{enableFeatureFreezePing} or not $team_config->{enableFeatureFreezePing}) {
+        next;
+    }
+    if (not defined $team_config->{shortName}) {
+        print {*STDERR} "!! The team with the nix key '$team_nix_key' has no shortName set - ignoring";
+        next;
+    }
+    #  Team name
+    print {*STDERR} "$team_config->{shortName}:";
+    # GitHub Teams
+    my @github_members;
+    if (defined $team_config->{githubTeams}) {
+        foreach (@{$team_config->{githubTeams}}) {
+            print {*STDERR} " \@NixOS/${_}";
+            push @github_members, @{github_team_members($_, $github_user, $github_token)};
+        }
+    }
+    my %github_members = map { $_ => 1 } @github_members;
+    # Members
+    if (defined $team_config->{members}) {
+        foreach (@{$team_config->{members}}) {
+            my %user = %{$_};
+            my $github_handle = $user{'github'};
+            # Ensure we don't ping team members twice (as team member and directly)
+            if (defined $github_members{$github_handle}) {
+                next;
+            }
+            print {*STDERR} " \@$github_handle";
+        }
+    }
+
+    print {*STDERR} "\n";
+}

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -3,12 +3,19 @@
       # Required
       members = [ maintainer1 maintainer2 ];
       scope = "Maintain foo packages.";
+      shortName = "foo";
+      # Optional
+      enableFeatureFreezePing = true;
+      githubTeams = [ "my-subsystem" ];
     };
 
   where
 
   - `members` is the list of maintainers belonging to the group,
   - `scope` describes the scope of the group.
+  - `shortName` short human-readable name
+  - `enableFeatureFreezePing` will ping this team during the Feature Freeze announcements on releases
+  - `githubTeams` will ping specified GitHub teams as well
 
   More fields may be added in the future.
 
@@ -27,6 +34,7 @@ with lib.maintainers; {
       m1cr0man
     ];
     scope = "Maintain ACME-related packages and modules.";
+    shortName = "ACME";
   };
 
   bazel = {
@@ -41,6 +49,8 @@ with lib.maintainers; {
       ylecornec
     ];
     scope = "Bazel build tool & related tools https://bazel.build/";
+    shortName = "Bazel";
+    enableFeatureFreezePing = true;
   };
 
   beam = {
@@ -53,7 +63,32 @@ with lib.maintainers; {
       minijackson
       yurrriq
     ];
+    githubTeams = [
+      "beam"
+    ];
     scope = "Maintain BEAM-related packages and modules.";
+    shortName = "BEAM";
+    enableFeatureFreezePing = true;
+  };
+
+  blockchains = {
+    members = [
+      mmahut
+      RaghavSood
+    ];
+    scope = "Maintain Blockchain packages and modules.";
+    shortName = "Blockchains";
+    enableFeatureFreezePing = true;
+  };
+
+  c = {
+    members = [
+      matthewbauer
+      mic92
+    ];
+    scope = "Maintain C libraries and tooling.";
+    shortName = "C";
+    enableFeatureFreezePing = true;
   };
 
   cinnamon = {
@@ -61,6 +96,8 @@ with lib.maintainers; {
       mkg20001
     ];
     scope = "Maintain Cinnamon desktop environment and applications made by the LinuxMint team.";
+    shortName = "Cinnamon";
+    enableFeatureFreezePing = true;
   };
 
   chia = {
@@ -68,6 +105,41 @@ with lib.maintainers; {
       lourkeur
     ];
     scope = "Maintain the Chia blockchain and its dependencies";
+    shortName = "Chia Blockchain";
+  };
+
+  cleanup = {
+    members = [
+      ajs124
+    ];
+    scope = "Cleaning of the nixpkgs source tree.";
+    shortName = "Cleanup";
+    enableFeatureFreezePing = true;
+  };
+
+  coq = {
+    members = [
+      cohencyril
+      Zimmi48
+      # gares has no entry in the maintainers list
+      siraben
+      vbgl
+    ];
+    scope = "Maintain the Coq theorem prover and related packages.";
+    shortName = "Coq";
+    enableFeatureFreezePing = true;
+  };
+
+  darwin = {
+    members = [
+      toonn
+    ];
+    githubTeams = [
+      "darwin-maintainers"
+    ];
+    scope = "Maintain Darwin compatibility of packages and Darwin-only packages.";
+    shortName = "Darwin";
+    enableFeatureFreezePing = true;
   };
 
   deshaw = {
@@ -76,6 +148,7 @@ with lib.maintainers; {
       limeytexan
     ];
     scope = "Group registration for D. E. Shaw employees who collectively maintain packages.";
+    shortName = "Shaw employees";
   };
 
   determinatesystems = {
@@ -85,11 +158,63 @@ with lib.maintainers; {
       grahamc
     ];
     scope = "Group registration for packages maintained by Determinate Systems.";
+    shortName = "Determinate Systems employees";
+  };
+
+  dhall = {
+    members = [
+      Gabriel439
+      ehmry
+    ];
+    scope = "Maintain Dhall and related packages.";
+    shortName = "Dhall";
+    enableFeatureFreezePing = true;
+  };
+
+  docker = {
+    members = [
+      roberth
+      utdemir
+    ];
+    scope = "Maintain Docker and related tools.";
+    shortName = "DockerTools";
+    enableFeatureFreezePing = true;
+  };
+
+  docs = {
+    members = [
+      ryantm
+    ];
+    scope = "Maintain nixpkgs/NixOS documentation and tools for building it.";
+    shortName = "Docs";
+    enableFeatureFreezePing = true;
+  };
+
+  emacs = {
+    members = [
+      adisbladis
+    ];
+    scope = "Maintain the Emacs editor and packages.";
+    shortName = "Emacs";
+    enableFeatureFreezePing = true;
+  };
+
+  # Dummy group for the "everyone else" section
+  feature-freeze-everyone-else = {
+    members = [ ];
+    githubTeams = [
+      "nixpkgs-committers"
+      "release-engineers"
+    ];
+    scope = "Dummy team for the #everyone else' section during feture freezes, not to be used as package maintainers!";
+    shortName = "Everyone else";
+    enableFeatureFreezePing = true;
   };
 
   freedesktop = {
     members = [ jtojnar ];
     scope = "Maintain Freedesktop.org packages for graphical desktop.";
+    shortName = "freedesktop.org packaging";
   };
 
   gcc = {
@@ -99,6 +224,7 @@ with lib.maintainers; {
       ericson2314
     ];
     scope = "Maintain GCC (GNU Compiler Collection) compilers";
+    shortName = "GCC";
   };
 
   golang = {
@@ -113,6 +239,8 @@ with lib.maintainers; {
       zowoq
     ];
     scope = "Maintain Golang compilers.";
+    shortName = "Go";
+    enableFeatureFreezePing = true;
   };
 
   gnome = {
@@ -122,7 +250,12 @@ with lib.maintainers; {
       dasj19
       maxeaubrey
     ];
+    githubTeams = [
+      "gnome"
+    ];
     scope = "Maintain GNOME desktop environment and platform.";
+    shortName = "GNOME";
+    enableFeatureFreezePing = true;
   };
 
   haskell = {
@@ -132,7 +265,12 @@ with lib.maintainers; {
       maralorn
       sternenseemann
     ];
+    githubTeams = [
+      "haskell"
+    ];
     scope = "Maintain Haskell packages and infrastructure.";
+    shortName = "Haskell";
+    enableFeatureFreezePing = true;
   };
 
   home-assistant = {
@@ -143,6 +281,7 @@ with lib.maintainers; {
       mic92
     ];
     scope = "Maintain the Home Assistant ecosystem";
+    shortName = "Home Assistant";
   };
 
   iog = {
@@ -154,6 +293,7 @@ with lib.maintainers; {
       nrdxp
     ];
     scope = "Input-Output Global employees, which maintain critical software";
+    shortName = "Input-Output Global employees";
   };
 
   jitsi = {
@@ -164,6 +304,7 @@ with lib.maintainers; {
       yuka
     ];
     scope = "Maintain Jitsi.";
+    shortName = "Jitsi";
   };
 
   kubernetes = {
@@ -175,6 +316,7 @@ with lib.maintainers; {
       zowoq
     ];
     scope = "Maintain the Kubernetes package and module";
+    shortName = "Kubernetes";
   };
 
   kodi = {
@@ -187,6 +329,7 @@ with lib.maintainers; {
       sephalon
     ];
     scope = "Maintain Kodi and related packages.";
+    shortName = "Kodi";
   };
 
   linux-kernel = {
@@ -197,6 +340,17 @@ with lib.maintainers; {
       qyliss
     ];
     scope = "Maintain the Linux kernel.";
+    shortName = "Linux Kernel";
+  };
+
+  marketing = {
+    members = [
+      garbas
+      tomberek
+    ];
+    scope = "Marketing of Nix/NixOS/nixpkgs.";
+    shortName = "Marketing";
+    enableFeatureFreezePing = true;
   };
 
   mate = {
@@ -205,6 +359,7 @@ with lib.maintainers; {
       romildo
     ];
     scope = "Maintain Mate desktop environment and related packages.";
+    shortName = "MATE";
   };
 
   matrix = {
@@ -218,6 +373,40 @@ with lib.maintainers; {
       sumnerevans
     ];
     scope = "Maintain the ecosystem around Matrix, a decentralized messenger.";
+    shortName = "Matrix";
+  };
+
+  mobile = {
+    members = [
+      samueldr
+    ];
+    scope = "Maintain Mobile NixOS.";
+    shortName = "Mobile";
+    enableFeatureFreezePing = true;
+  };
+
+  nix = {
+    members = [
+      Profpatsch
+      eelco
+      grahamc
+      pierron
+    ];
+    scope = "Maintain the Nix package manager.";
+    shortName = "Nix/nix-cli ecosystem";
+    enableFeatureFreezePing = true;
+  };
+
+  nixos-modules = {
+    members = [
+      ericson2314
+      infinisil
+      qyliss
+      roberth
+    ];
+    scope = "Maintain nixpkgs module system internals.";
+    shortName = "NixOS Modules / internals";
+    enableFeatureFreezePing = true;
   };
 
   openstack = {
@@ -226,6 +415,7 @@ with lib.maintainers; {
       SuperSandro2000
     ];
     scope = "Maintain the ecosystem around OpenStack";
+    shortName = "OpenStack";
   };
 
   pantheon = {
@@ -233,7 +423,21 @@ with lib.maintainers; {
       davidak
       bobby285271
     ];
+    githubTeams = [
+      "pantheon"
+    ];
     scope = "Maintain Pantheon desktop environment and platform.";
+    shortName = "Pantheon";
+    enableFeatureFreezePing = true;
+  };
+
+  perl = {
+    members = [
+      sgo
+    ];
+    scope = "Maintain the Perl interpreter and Perl packages.";
+    shortName = "Perl";
+    enableFeatureFreezePing = true;
   };
 
   php = {
@@ -245,7 +449,12 @@ with lib.maintainers; {
       ma27
       talyz
     ];
+    githubTeams = [
+      "php"
+    ];
     scope = "Maintain PHP related packages and extensions.";
+    shortName = "PHP";
+    enableFeatureFreezePing = true;
   };
 
   podman = {
@@ -255,7 +464,54 @@ with lib.maintainers; {
       vdemeester
       zowoq
     ];
+    githubTeams = [
+      "podman"
+    ];
     scope = "Maintain Podman and CRI-O related packages and modules.";
+    shortName = "Podman";
+    enableFeatureFreezePing = true;
+  };
+
+  postgres = {
+    members = [
+      thoughtpolice
+    ];
+    scope = "Maintain the PostgreSQL package and plugins along with the NixOS module.";
+    shortName = "PostgreSQL";
+    enableFeatureFreezePing = true;
+  };
+
+  python = {
+    members = [
+      fridh
+      hexa
+      jonringer
+    ];
+    scope = "Maintain the Python interpreter and related packages.";
+    shortName = "Python";
+    enableFeatureFreezePing = true;
+  };
+
+  qt-kde = {
+    members = [
+      ttuegel
+    ];
+    githubTeams = [
+      "qt-kde"
+    ];
+    scope = "Maintain the KDE desktop environment and Qt.";
+    shortName = "Qt / KDE";
+    enableFeatureFreezePing = true;
+  };
+
+  r = {
+    members = [
+      bcdarwin
+      jbedo
+    ];
+    scope = "Maintain the R programming language and related packages.";
+    shortName = "R";
+    enableFeatureFreezePing = true;
   };
 
   redcodelabs = {
@@ -265,6 +521,38 @@ with lib.maintainers; {
       wintrmvte
     ];
     scope = "Maintain Red Code Labs related packages and modules.";
+    shortName = "Red Code Labs";
+  };
+
+  release = {
+    members = [ ];
+    githubTeams = [
+      "nixos-release-managers"
+    ];
+    scope = "Manage the current nixpkgs/NixOS release.";
+    shortName = "Release";
+    enableFeatureFreezePing = true;
+  };
+
+  ruby = {
+    members = [
+      marsam
+    ];
+    scope = "Maintain the Ruby interpreter and related packages.";
+    shortName = "Ruby";
+    enableFeatureFreezePing = true;
+  };
+
+  rust = {
+    members = [
+      andir
+      lnl7
+      mic92
+      zowoq
+    ];
+    scope = "Maintain the Rust compiler toolchain and nixpkgs integration.";
+    shortName = "Rust";
+    enableFeatureFreezePing = true;
   };
 
   sage = {
@@ -275,6 +563,7 @@ with lib.maintainers; {
       collares
     ];
     scope = "Maintain SageMath and the dependencies that are likely to break it.";
+    shortName = "SageMath";
   };
 
   sphinx = {
@@ -282,6 +571,7 @@ with lib.maintainers; {
       SuperSandro2000
     ];
     scope = "Maintain Sphinx related packages.";
+    shortName = "Sphinx";
   };
 
   serokell = {
@@ -291,6 +581,26 @@ with lib.maintainers; {
       mkaito
     ];
     scope = "Group registration for Serokell employees who collectively maintain packages.";
+    shortName = "Serokell employees";
+  };
+
+  systemd = {
+    members = [ ];
+    githubTeams = [
+      "systemd"
+    ];
+    scope = "Maintain systemd for NixOS.";
+    shortName = "systemd";
+    enableFeatureFreezePing = true;
+  };
+
+  tests = {
+    members = [
+      tfc
+    ];
+    scope = "Maintain the NixOS VM test runner.";
+    shortName = "NixOS tests";
+    enableFeatureFreezePing = true;
   };
 
   tts = {
@@ -299,6 +609,18 @@ with lib.maintainers; {
       mic92
     ];
     scope = "coqui-ai TTS (formerly Mozilla TTS) and leaf packages";
+    shortName = "coqui-ai TTS";
+  };
+
+  vim = {
+    members = [
+      jonringer
+      softinio
+      teto
+    ];
+    scope = "Maintain the vim and neovim text editors and related packages.";
+    shortName = "Vim/Neovim";
+    enableFeatureFreezePing = true;
   };
 
   xfce = {
@@ -306,5 +628,6 @@ with lib.maintainers; {
       romildo
     ];
     scope = "Maintain Xfce desktop environment and related packages.";
+    shortName = "Xfce";
   };
 }


### PR DESCRIPTION
While I would be happy with a list like this, @mweinelt and @vcunat raised concerns if this would be better integrated with the teams list.
I agree with them for most of this list, but there are also parts of the list where I think this model would not hold very well, especially the first section.

This issue is a draft and hopefully we can start a discussion and come to a solution people like.
I'm not against merging the list into the teams list but we need to find a way to structure it properly and a script to render a textual version of the list for posting on Discourse.

cc @jonringer @tomberek @Mic92, maybe you have some ideas