### PR TITLE
python3Packages.sip: fix builds of dependents on non-x86 Linux

### DIFF
--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -10,6 +10,13 @@ buildPythonPackage rec {
     sha256 = "a1cf8431a8eb9392b3ff6dc61d832d0447bfdcae5b3e4256a5fa74dbc25b0734";
   };
 
+  patches = [
+    # on non-x86 Linux platforms, sip incorrectly detects the manylinux version
+    # and PIP will refuse to install the resulting wheel.
+    # remove once upstream fixes this, hopefully in 6.5.2
+    ./fix-manylinux-version.patch
+  ];
+
   propagatedBuildInputs = [ packaging toml ];
 
   # There aren't tests

--- a/pkgs/development/python-modules/sip/fix-manylinux-version.patch
+++ b/pkgs/development/python-modules/sip/fix-manylinux-version.patch
@@ -1,0 +1,19 @@
+diff --git a/sipbuild/project.py b/sipbuild/project.py
+--- a/sipbuild/project.py
++++ b/sipbuild/project.py
+@@ -336,13 +336,13 @@ class Project(AbstractProject, Configurable):
+             # We expect a two part tag so leave anything else unchanged.
+             parts = platform_tag.split('-')
+             if len(parts) == 2:
+-                if self.minimum_glibc_version > (2, 17):
++                if self.minimum_glibc_version > (2, 17) or parts[1] not in {"x86_64", "i686", "aarch64", "armv7l", "ppc64", "ppc64le", "s390x"}:
+                     # PEP 600.
+                     parts[0] = 'manylinux'
+                     parts.insert(1,
+                             '{}.{}'.format(self.minimum_glibc_version[0],
+                                     self.minimum_glibc_version[1]))
+-                elif self.minimum_glibc_version > (2, 12):
++                elif self.minimum_glibc_version > (2, 12) or parts[1] not in {"x86_64", "i686"}:
+                     # PEP 599.
+                     parts[0] = 'manylinux2014'
+                 elif self.minimum_glibc_version > (2, 5):


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes PyQt5 on aarch64 and thus issue #163589. I haven't fully tested all dependents on staging, but PyQt5 builds correctly now and qutebrowser builds and runs on master.

I have sent an email to the PyQt5 list informing them of this issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
