### PR TITLE
python39Packages.pyeclib: 1.6.0 -> unstable-2022-03-11, python39Packages.python-novaclient: 17.6.0 -> 17.7.0

### DIFF
--- a/pkgs/development/python-modules/pyeclib/default.nix
+++ b/pkgs/development/python-modules/pyeclib/default.nix
@@ -1,12 +1,14 @@
-{ lib, stdenv, buildPythonPackage, fetchPypi, liberasurecode, six }:
+{ lib, stdenv, buildPythonPackage, fetchFromGitHub, liberasurecode, six }:
 
 buildPythonPackage rec {
   pname = "pyeclib";
-  version = "1.6.0";
+  version = "unstable-2022-03-11";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-gBHjHuia5/uZymkWZgyH4BCEZqmWK9SXowAQIJdOO7E=";
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "pyeclib";
+    rev = "b50040969a03f7566ffcb468336e875d21486113";
+    sha256 = "sha256-nYYjocStC0q/MC6pum3J4hlXiu/R5xODwIE97Ho3iEY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/python-novaclient/default.nix
+++ b/pkgs/development/python-modules/python-novaclient/default.nix
@@ -16,11 +16,11 @@
 
 buildPythonPackage rec {
   pname = "python-novaclient";
-  version = "17.6.0";
+  version = "17.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-yRDCCFMQ2mNfs0NYXxBwcS/w+cs8j3nUTKPWMsTyMPU=";
+    sha256 = "sha256-Trwn9M4GwVW46ZGkRGO5NYWW5oVs8XHJr43HVo2Gi+0=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
this fixes python 3.9 and 3.10 support

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
