### PR TITLE
deltachat-desktop: update react-string-replace to 1.0.0

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -81,6 +81,9 @@ in nodejs-14_x.pkgs.deltachat-desktop.override rec {
 
     npm prune --production
 
+    install -D $out/lib/node_modules/deltachat-desktop/build/icon.png \
+      $out/share/icons/hicolor/scalable/apps/deltachat.png
+
     awk '!/^#/ && NF' build/packageignore_list \
       | xargs -I {} sh -c "rm -rf {}" || true
 
@@ -90,10 +93,6 @@ in nodejs-14_x.pkgs.deltachat-desktop.override rec {
       ln -sf ${roboto}/share/fonts/truetype/$(basename $font) \
         $out/lib/node_modules/deltachat-desktop/html-dist/fonts
     done
-
-    mkdir -p $out/share/icons/hicolor/scalable/apps
-    ln -s $out/lib/node_modules/deltachat-desktop/build/icon.png \
-      $out/share/icons/hicolor/scalable/apps/deltachat.png
 
     makeWrapper ${electronExec} $out/bin/deltachat \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher${stdenv.hostPlatform.extensions.sharedLibrary} \

--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/package.json
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.2",
     "react-qr-reader": "^2.2.1",
     "react-qr-svg": "^2.1.0",
-    "react-string-replace": "^0.4.4",
+    "react-string-replace": "^1.0.0",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",


### PR DESCRIPTION
###### Motivation
This reduces the closure size by 4.9 MiB.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
