### PR TITLE
libunwind: fix for aarch64 and non-4K pages

### DIFF
--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoreconfHook, xz, buildPackages }:
+{ stdenv, lib, fetchurl, fetchpatch, autoreconfHook, xz, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "libunwind";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "mirror://savannah/libunwind/${pname}-${version}.tar.gz";
     sha256 = "sha256-SmrsZmmR+0XQiJxErt6K1usQgHHDVU/N/2cfnJR5SXY=";
   };
+
+  patches = [
+    # Fix for aarch64 and non-4K pages. Remove once upgraded past 1.6.2.
+    (fetchpatch {
+      url = "https://github.com/libunwind/libunwind/commit/e85b65cec757ef589f28957d0c6c21c498a03bdf.patch";
+      sha256 = "sha256-z2Hpg98D4UMmrE/LC596RFcyxRTvDjD4k7llDPfz1NI=";
+    })
+  ];
 
   postPatch = if stdenv.cc.isClang then ''
     substituteInPlace configure.ac --replace "-lgcc_s" ""

--- a/pkgs/development/libraries/libunwind/default.nix
+++ b/pkgs/development/libraries/libunwind/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     # Fix for aarch64 and non-4K pages. Remove once upgraded past 1.6.2.
     (fetchpatch {
       url = "https://github.com/libunwind/libunwind/commit/e85b65cec757ef589f28957d0c6c21c498a03bdf.patch";
-      sha256 = "sha256-z2Hpg98D4UMmrE/LC596RFcyxRTvDjD4k7llDPfz1NI=";
+      sha256 = "1lnlygvhqrdrjgw303pg2k2k4ms4gaghpjsgmhk47q83vy1yjwfg";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds an upstream patch which fixes libunwind for aarch64 systems with 16K or 64K pages. Although such systems are quite rare, the X server crashes on startup without this patch, so adding it is vital to a graphical NixOS experience.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
