### PR TITLE
keepassxc: 2.6.6 -> 2.7.1

### DIFF
--- a/nixos/tests/keepassxc.nix
+++ b/nixos/tests/keepassxc.nix
@@ -62,7 +62,7 @@ import ./make-test-python.nix ({ pkgs, ...} :
         machine.send_key("tab")
         machine.send_chars("/home/alice/foo.keyfile")
         machine.send_key("ret")
-        # Passwords folder is displayed
-        machine.wait_for_text("Passwords")
+        # Database is unlocked (doesn't have "[Locked]" in the title anymore)
+        machine.wait_for_text("foo.kdbx - KeePassXC")
   '';
 })

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -5,34 +5,31 @@
 , darwin
 
 , asciidoctor
+, botan2
 , curl
-, glibcLocales
 , libXi
 , libXtst
 , libargon2
-, libgcrypt
-, libgpg-error
-, libsodium
-, libyubikey
+, libusb1
+, minizip
+, pcsclite
 , pkg-config
 , qrencode
 , qtbase
 , qtmacextras
 , qtsvg
 , qtx11extras
-, quazip
 , readline
 , wrapGAppsHook
 , wrapQtAppsHook
-, yubikey-personalization
 , zlib
 
 , withKeePassBrowser ? true
 , withKeePassKeeShare ? true
-, withKeePassKeeShareSecure ? true
 , withKeePassSSHAgent ? true
 , withKeePassNetworking ? true
 , withKeePassTouchID ? true
+, withKeePassYubiKey ? true
 , withKeePassFDOSecrets ? true
 
 , nixosTests
@@ -42,13 +39,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   pname = "keepassxc";
-  version = "2.6.6";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = version;
-    sha256 = "15rm3avdmc2x2n92zq6w1zbcranak4j6dds2sxmgdqi1ffc0a3ci";
+    sha256 = "sha256-BOtehDzlWhhfXj8TOFvFN4f86Hl2EC3rO4qUIl9fqq4=";
   };
 
   NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang [
@@ -66,15 +63,12 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DKEEPASSXC_BUILD_TYPE=Release"
     "-DWITH_GUI_TESTS=ON"
-    "-DWITH_XC_AUTOTYPE=ON"
     "-DWITH_XC_UPDATECHECK=OFF"
-    "-DWITH_XC_YUBIKEY=ON"
   ]
   ++ (optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
   ++ (optional withKeePassKeeShare "-DWITH_XC_KEESHARE=ON")
-  ++ (optional withKeePassKeeShareSecure "-DWITH_XC_KEESHARE_SECURE=ON")
   ++ (optional withKeePassNetworking "-DWITH_XC_NETWORKING=ON")
-  ++ (optional (withKeePassTouchID && stdenv.isDarwin) "-DWITH_XC_TOUCHID=ON")
+  ++ (optional (withKeePassYubiKey && stdenv.isLinux) "-DWITH_XC_YUBIKEY=ON")
   ++ (optional (withKeePassFDOSecrets && stdenv.isLinux) "-DWITH_XC_FDOSECRETS=ON")
   ++ (optional withKeePassSSHAgent "-DWITH_XC_SSHAGENT=ON");
 
@@ -95,26 +89,22 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl
-    glibcLocales
+    botan2
     libXi
     libXtst
     libargon2
-    libgcrypt
-    libgpg-error
-    libsodium
-    libyubikey
+    minizip
+    pcsclite
     qrencode
     qtbase
     qtsvg
     qtx11extras
     readline
-    yubikey-personalization
     zlib
   ]
-  ++ optional withKeePassKeeShareSecure quazip
+  ++ optional stdenv.isLinux libusb1
   ++ optional stdenv.isDarwin qtmacextras
-  ++ optional (stdenv.isDarwin && withKeePassTouchID)
-    darwin.apple_sdk.frameworks.LocalAuthentication;
+  ++ optional (stdenv.isDarwin && withKeePassTouchID) darwin.apple_sdk.frameworks.LocalAuthentication;
 
   passthru.tests = nixosTests.keepassxc;
 
@@ -131,5 +121,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ jonafato turion ];
     platforms = platforms.linux ++ platforms.darwin;
+    broken = stdenv.isDarwin;  # see to https://github.com/NixOS/nixpkgs/issues/172165
   };
 }

--- a/pkgs/applications/misc/keepassx/darwin.patch
+++ b/pkgs/applications/misc/keepassx/darwin.patch
@@ -8,46 +8,30 @@ index 74b1a7ff..0a713a32 100644
  elseif(APPLE AND WITH_APP_BUNDLE)
 +    set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
      set(BUNDLE_INSTALL_DIR "${PROGNAME}.app/Contents")
-     set(CMAKE_INSTALL_MANDIR "${PROGNAME}.app/Contents/Resources/man")
-     set(CLI_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
-@@ -369,12 +370,6 @@ set(CMAKE_AUTORCC ON)
+     set(CMAKE_INSTALL_MANDIR "${BUNDLE_INSTALL_DIR}/Resources/man")
+     set(CLI_INSTALL_DIR "${BUNDLE_INSTALL_DIR}/MacOS")
+@@ -470,11 +470,6 @@ set(CMAKE_AUTORCC ON)
  
  if(APPLE)
      set(CMAKE_MACOSX_RPATH TRUE)
--    find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
+-    find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ${Qt5_PREFIX}/tools/qt5/bin ENV PATH)
 -    if(NOT MACDEPLOYQT_EXE)
 -        message(FATAL_ERROR "macdeployqt is required to build on macOS")
--    else()
--        message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
 -    endif()
- elseif(MINGW)
-     find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
-     if(NOT WINDEPLOYQT_EXE)
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index f142f368..0742512d 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -351,11 +351,6 @@ if(APPLE AND WITH_APP_BUNDLE)
-     set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
-     include(CPack)
+-    message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
+     set(MACDEPLOYQT_EXTRA_BINARIES "")
+ elseif(WIN32)
+     find_program(WINDEPLOYQT_EXE windeployqt HINTS ${Qt5_PREFIX}/bin ${Qt5_PREFIX}/tools/qt5/bin ENV PATH)
+diff --git a/src/post_install/CMakeLists.txt b/src/post_install/CMakeLists.txt
+index 359c891f..a6a061a3 100644
+--- a/src/post_install/CMakeLists.txt
++++ b/src/post_install/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # The install commands in this subdirectory will be executed after all the install commands in the
+ # current scope are ran. It is required for correct functtioning of macdeployqt.
  
--    add_custom_command(TARGET ${PROGNAME}
--            POST_BUILD
--            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
--            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
--            COMMENT "Deploying app bundle")
- endif()
- 
- install(TARGETS ${PROGNAME}
-diff --git a/src/autotype/mac/CMakeLists.txt b/src/autotype/mac/CMakeLists.txt
-index 7427450a..a0a58d71 100644
---- a/src/autotype/mac/CMakeLists.txt
-+++ b/src/autotype/mac/CMakeLists.txt
-@@ -8,7 +8,6 @@ if(WITH_APP_BUNDLE)
-     add_custom_command(TARGET keepassx-autotype-cocoa
-             POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}
--            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins
-             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-             COMMENT "Deploying autotype plugin")
- else()
+-if(APPLE AND WITH_APP_BUNDLE)
++if(FALSE)
+     # Run macdeloyqt on the main app and any extra binaries and plugins as specified by the
+     # _MACDEPLOYQT_EXTRA_BINARIES global property.
+     # All install(TARGETS) calls should have already been called.


### PR DESCRIPTION
###### Description of changes
new update [blog-post](https://keepassxc.org/blog/2022-03-21-2.7.0-released/) / [tag](https://github.com/keepassxreboot/keepassxc/releases/tag/2.7.0)
has not yet been tested on darwin, but before merging someone should do it.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
