### PR TITLE
nixos/jellyfin: Add dataDir and cacheDir to module

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -64,9 +64,7 @@ in
       serviceConfig = rec {
         User = cfg.user;
         Group = cfg.group;
-        StateDirectory = cfg.dataDir;
-        CacheDirectory = cfg.cacheDir;
-        ExecStart = "${cfg.package}/bin/jellyfin --datadir '${StateDirectory}' --cachedir '${CacheDirectory}'";
+        ExecStart = "${cfg.package}/bin/jellyfin --datadir '${cfg.dataDir}' --cachedir '${cfg.cacheDir}'";
         Restart = "on-failure";
 
         # Security options:

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -2,10 +2,8 @@
 
 with lib;
 
-let
-  cfg = config.services.jellyfin;
-in
-{
+let cfg = config.services.jellyfin;
+in {
   options = {
     services.jellyfin = {
       enable = mkEnableOption "Jellyfin Media Server";
@@ -34,15 +32,16 @@ in
       dataDir = mkOption {
         type = types.str;
         default = "/var/lib/jellyfin";
-        description = "This is the directory that will hold all Jellyfin data, and is also used as a default base directory.";
+        description =
+          "This is the directory that will hold all Jellyfin data, and is also used as a default base directory.";
       };
-      
+
       cacheDir = mkOption {
         type = types.str;
         default = "/var/cache/jellyfin";
         description = "This is the directory containing the server cache.";
       };
-      
+
       openFirewall = mkOption {
         type = types.bool;
         default = false;
@@ -64,7 +63,8 @@ in
       serviceConfig = rec {
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${cfg.package}/bin/jellyfin --datadir '${cfg.dataDir}' --cachedir '${cfg.cacheDir}'";
+        ExecStart =
+          "${cfg.package}/bin/jellyfin --datadir '${cfg.dataDir}' --cachedir '${cfg.cacheDir}'";
         Restart = "on-failure";
 
         # Security options:
@@ -96,7 +96,8 @@ in
 
         RestrictNamespaces = true;
         # AF_NETLINK needed because Jellyfin monitors the network connection
-        RestrictAddressFamilies = [ "AF_NETLINK" "AF_INET" "AF_INET6" "AF_UNIX" ];
+        RestrictAddressFamilies =
+          [ "AF_NETLINK" "AF_INET" "AF_INET6" "AF_UNIX" ];
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
 
@@ -104,7 +105,13 @@ in
         SystemCallErrorNumber = "EPERM";
         SystemCallFilter = [
           "@system-service"
-          "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@obsolete" "~@privileged" "~@setuid"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@keyring"
+          "~@memlock"
+          "~@obsolete"
+          "~@privileged"
+          "~@setuid"
         ];
       };
     };
@@ -116,9 +123,7 @@ in
       };
     };
 
-    users.groups = mkIf (cfg.group == "jellyfin") {
-      jellyfin = {};
-    };
+    users.groups = mkIf (cfg.group == "jellyfin") { jellyfin = { }; };
 
     networking.firewall = mkIf cfg.openFirewall {
       # from https://jellyfin.org/docs/general/networking/index.html

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -31,6 +31,18 @@ in
         description = "Group under which jellyfin runs.";
       };
 
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/jellyfin";
+        description = "This is the directory that will hold all Jellyfin data, and is also used as a default base directory.";
+      };
+      
+      cacheDir = mkOption {
+        type = types.str;
+        default = "/var/cache/jellyfin";
+        description = "This is the directory containing the server cache.";
+      };
+      
       openFirewall = mkOption {
         type = types.bool;
         default = false;
@@ -52,9 +64,9 @@ in
       serviceConfig = rec {
         User = cfg.user;
         Group = cfg.group;
-        StateDirectory = "jellyfin";
-        CacheDirectory = "jellyfin";
-        ExecStart = "${cfg.package}/bin/jellyfin --datadir '/var/lib/${StateDirectory}' --cachedir '/var/cache/${CacheDirectory}'";
+        StateDirectory = cfg.dataDir;
+        CacheDirectory = cfg.cacheDir;
+        ExecStart = "${cfg.package}/bin/jellyfin --datadir '${StateDirectory}' --cachedir '${CacheDirectory}'";
         Restart = "on-failure";
 
         # Security options:


### PR DESCRIPTION
###### Description of changes

Added two new options for Jellyfin's module: `dataDir` and `cacheDir`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
