### PR TITLE
ircdog: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/applications/networking/irc/ircdog/default.nix
+++ b/pkgs/applications/networking/irc/ircdog/default.nix
@@ -5,21 +5,22 @@
 
 buildGoPackage rec {
   pname = "ircdog";
-  version = "0.2.1";
+  version = "0.3.0";
 
-  goPackagePath = "github.com/goshuirc/ircdog";
+  goPackagePath = "github.com/ergochat/ircdog";
 
   src = fetchFromGitHub {
     owner = "goshuirc";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ppbznlkv7vajfbimxbyiq5y6pkfhm6ylhl408rwq1bawl28hpkl";
+    sha256 = "sha256-x3ihWLgVYu17vG1xQTgIr4TSkeZ467TZBV1fPTPnZgw=";
     fetchSubmodules = true;
   };
 
   meta = with lib; {
     description = "ircdog is a simple wrapper over the raw IRC protocol that can respond to pings, and interprets formatting codes";
-    homepage = "https://github.com/goshuirc/ircdog";
+    homepage = "https://github.com/ergochat/ircdog";
+    changelog = "https://github.com/ergochat/ircdog/releases/tag/v${version}";
     license = licenses.isc;
     maintainers = with maintainers; [ hexa ];
   };


### PR DESCRIPTION
https://github.com/ergochat/ircdog/releases/tag/v0.3.0

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
