### PR TITLE
ocamlPackages.janeStreet: 0.14 -> 0.15

### DIFF
--- a/pkgs/development/compilers/ligo/default.nix
+++ b/pkgs/development/compilers/ligo/default.nix
@@ -46,6 +46,7 @@ coq.ocamlPackages.buildDunePackage rec {
     yojson
     getopt
     core
+    core_unix
     pprint
     linenoise
 
@@ -82,6 +83,8 @@ coq.ocamlPackages.buildDunePackage rec {
   ];
 
   doCheck = false; # Tests fail, but could not determine the reason
+
+  patches = [ ./ligo.patch ]; # fix for core >= 0.15.0
 
   meta = with lib; {
     homepage = "https://ligolang.org/";

--- a/pkgs/development/compilers/ligo/ligo.patch
+++ b/pkgs/development/compilers/ligo/ligo.patch
@@ -1,0 +1,134 @@
+diff --git a/ligo.opam b/ligo.opam
+index d561c74d1..3a8d34feb 100644
+--- a/ligo.opam
++++ b/ligo.opam
+@@ -10,7 +10,9 @@ license: "MIT"
+ # If you change the dependencies, run `opam lock` in the root
+ depends: [
+   # Jane Street Core
+-  "core"
++  "core" { >= "v0.14.0" & < "v0.16.0" }
++  "core_kernel" { >= "v0.14.0" & "v0.16.0" }
++  "core_unix" { >= "v0.14.0" & "v0.16.0" }
+   # Tooling
+   "odoc" { build }
+   "ocamlfind" { build }
+diff --git a/ligo.opam.locked b/ligo.opam.locked
+index b4501cc76..c8ed8a41f 100644
+--- a/ligo.opam.locked
++++ b/ligo.opam.locked
+@@ -50,8 +50,9 @@ depends: [
+   "conf-rust" {= "0.1"}
+   "conf-which" {= "1"}
+   "coq" {= "8.13.2"}
+-  "core" {= "v0.14.1"}
+-  "core_kernel" {= "v0.14.2"}
++  "core" {= "v0.15.0"}
++  "core_kernel" {= "v0.15.0"}
++  "core_unix" {= "v0.15.0"}
+   "cppo" {= "1.6.8"}
+   "csexp" {= "1.5.1"}
+   "cstruct" {= "6.0.1"}
+diff --git a/src/bin/cli.ml b/src/bin/cli.ml
+index a6fc13e0d..ef5177868 100644
+--- a/src/bin/cli.ml
++++ b/src/bin/cli.ml
+@@ -12,7 +12,7 @@ let entry_point =
+ let source_file =
+     let name = "SOURCE_FILE" in
+     let _doc = "the path to the smart contract file." in
+-    Command.Param.(anon (name %: Filename.arg_type))
++    Command.Param.(anon (name %: Filename_unix.arg_type))
+ 
+ let package_name =
+   let name = "PACKAGE_NAME" in
+@@ -662,7 +662,7 @@ let main = Command.group ~preserve_subcommand_order:() ~summary:"the LigoLANG co
+   ]
+ 
+ let run ?argv () =
+-  Command.run ~version:Version.version ?argv main;
++  Command_unix.run ~version:Version.version ?argv main;
+   (* Effect to error code *)
+   match !return with
+     Done -> 0;
+@@ -677,4 +677,3 @@ let run ?argv () =
+     match exn with
+     | Failure msg -> message msg
+     | exn -> message (Exn.to_string exn)
+-  
+diff --git a/src/bin/cli_helpers.ml b/src/bin/cli_helpers.ml
+index b64a17d53..8c4c43dde 100644
+--- a/src/bin/cli_helpers.ml
++++ b/src/bin/cli_helpers.ml
+@@ -66,7 +66,7 @@ let run_command (cmd : command) =
+     (fun p -> Lwt.map  
+       (fun status -> 
+         match status with
+-          Caml.Unix.WEXITED 0 -> Ok ()
++          Caml_unix.WEXITED 0 -> Ok ()
+         | _ -> Error ("unknown error"))
+         p#status) in
+   Lwt_main.run status
+\ No newline at end of file
+diff --git a/src/bin/dune b/src/bin/dune
+index 295c056f3..08d980439 100644
+--- a/src/bin/dune
++++ b/src/bin/dune
+@@ -11,7 +11,9 @@
+   repl
+   install
+   cli_helpers
+-  ligo_api)
++  ligo_api
++  core_unix.command_unix
++  core_unix.filename_unix)
+  (modules cli version))
+ 
+ (library
+diff --git a/src/main/interpreter/dune b/src/main/interpreter/dune
+index c55e24a88..f9762a297 100644
+--- a/src/main/interpreter/dune
++++ b/src/main/interpreter/dune
+@@ -4,4 +4,4 @@
+  (instrumentation
+   (backend bisect_ppx))
+  (libraries tezos-011-PtHangz2-test-helpers ast_aggregated ligo_interpreter
+-   main_errors ligo_compile build fuzz ligo_run self_ast_typed))
++   main_errors ligo_compile build fuzz ligo_run self_ast_typed core_unix.sys_unix))
+diff --git a/src/main/interpreter/interpreter.ml b/src/main/interpreter/interpreter.ml
+index b0379029c..530e08c3a 100644
+--- a/src/main/interpreter/interpreter.ml
++++ b/src/main/interpreter/interpreter.ml
+@@ -2,6 +2,7 @@ open Simple_utils.Trace
+ open Simple_utils
+ open Ligo_interpreter.Types
+ open Ligo_interpreter.Combinators
++module Sys = Sys_unix
+ 
+ module AST = Ast_aggregated
+ 
+diff --git a/vendors/ligo-utils/simple-utils/dune b/vendors/ligo-utils/simple-utils/dune
+index ca9f2bf5c..62c39087b 100644
+--- a/vendors/ligo-utils/simple-utils/dune
++++ b/vendors/ligo-utils/simple-utils/dune
+@@ -6,6 +6,7 @@
+   (libraries
+     ;; Third party
+    core
++   core_kernel.caml_unix
+    yojson
+    result
+    unix
+diff --git a/vendors/ligo-utils/simple-utils/snippet.ml b/vendors/ligo-utils/simple-utils/snippet.ml
+index 658f115f2..f23000590 100644
+--- a/vendors/ligo-utils/simple-utils/snippet.ml
++++ b/vendors/ligo-utils/simple-utils/snippet.ml
+@@ -1,7 +1,7 @@
+ (* used to show code snippets in error messages *)
+ 
+ let print_code ppf (l:Region.t) (input_line: unit -> string) =
+-  let dumb =String.equal (Caml.Unix.getenv "TERM") "dumb" in
++  let dumb =String.equal (Caml_unix.getenv "TERM") "dumb" in
+   let start = l#start#line in
+   let start_column = l#start#offset `Byte in
+   let stop = l#stop#line in

--- a/pkgs/development/ocaml-modules/bap/default.nix
+++ b/pkgs/development/ocaml-modules/bap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl
+{ lib, stdenv, fetchFromGitHub, fetchurl, fetchpatch
 , ocaml, findlib, ocamlbuild, ocaml_oasis
 , bitstring, camlzip, cmdliner, core_kernel, ezjsonm, fileutils, ocaml_lwt, ocamlgraph, ocurl, re, uri, zarith, piqi, piqi-ocaml, uuidm, llvm, frontc, ounit, ppx_jane, parsexp
 , utop, libxml2, ncurses
@@ -64,7 +64,13 @@ stdenv.mkDerivation rec {
   disableIda = "--disable-ida";
   disableGhidra = "--disable-ghidra";
 
-  patches = [ ./curses_is_ncurses.patch ];
+  patches = [
+    ./curses_is_ncurses.patch
+    (fetchpatch {
+      url = "https://github.com/BinaryAnalysisPlatform/bap/commit/8b1bba30ebb551256a5b15122e70d07f40184039.patch";
+      sha256 = "0il0ik5f6nyqyrlln3n43mz1zpqq34lfnhmp10wdsah4ck2dy75h";
+    })
+  ];
 
   preConfigure = ''
     substituteInPlace oasis/elf-loader --replace bitstring.ppx ppx_bitstring

--- a/pkgs/development/ocaml-modules/biocaml/default.nix
+++ b/pkgs/development/ocaml-modules/biocaml/default.nix
@@ -4,7 +4,7 @@
 
 buildDunePackage rec {
   pname = "biocaml";
-  version = "0.11.1";
+  version = "0.11.2";
 
   useDune2 = true;
 
@@ -14,7 +14,12 @@ buildDunePackage rec {
     owner = "biocaml";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "1il84vvypgkhdyc2j5fmgh14a58069s6ijbd5dvyl2i7jdxaazji";
+    sha256 = "01yw12yixs45ya1scpb9jy2f7dw1mbj7741xib2xpq3kkc1hc21s";
+  };
+
+  patches = fetchpatch {
+    url = "https://github.com/biocaml/biocaml/commit/3ef74d0eb4bb48d2fb7dd8b66fb3ad8fe0aa4d78.patch";
+    sha256 = "0rcvf8gwq7sz15mghl9ing722rl2zpnqif9dfxrnpdxiv0rl0731";
   };
 
   buildInputs = [ ppx_jane ppx_sexp_conv ];

--- a/pkgs/development/ocaml-modules/bistro/default.nix
+++ b/pkgs/development/ocaml-modules/bistro/default.nix
@@ -1,10 +1,13 @@
 { lib
 , ocaml
+, fetchpatch
 , fetchFromGitHub
 , buildDunePackage
 , base64
 , bos
 , core
+, core_kernel
+, core_unix
 , lwt_react
 , ocamlgraph
 , ppx_sexp_conv
@@ -15,21 +18,23 @@
 
 buildDunePackage rec {
   pname = "bistro";
-  version = "unstable-2021-11-13";
+  version = "unstable-2022-05-07";
 
   useDune2 = true;
 
   src = fetchFromGitHub {
     owner = "pveber";
     repo = pname;
-    rev = "fb285b2c6d8adccda3c71e2293bceb01febd6624";
-    sha256 = "sha256-JChDU1WH8W9Czkppx9SHiVIu9/7QFWJy2A89oksp0Ek=";
+    rev = "d363bd2d8257babbcb6db15bd83fd6465df7c268";
+    sha256 = "0g11324j1s2631zzf7zxc8s0nqd4fwvcni0kbvfpfxg96gy2wwfm";
   };
 
   propagatedBuildInputs = [
     base64
     bos
     core
+    core_kernel
+    core_unix
     lwt_react
     ocamlgraph
     ppx_sexp_conv

--- a/pkgs/development/ocaml-modules/cohttp/async.nix
+++ b/pkgs/development/ocaml-modules/cohttp/async.nix
@@ -1,4 +1,6 @@
 { lib
+, fetchpatch
+, fetchurl
 , buildDunePackage
 , ppx_sexp_conv
 , base
@@ -47,12 +49,20 @@ buildDunePackage {
     ipaddr
   ];
 
-  doCheck = true;
+  # Examples don't compile with core 0.15.  See https://github.com/mirage/ocaml-cohttp/pull/864.
+  doCheck = false;
   checkInputs = [
     ounit
     mirage-crypto
     core
   ];
+
+  # Compatibility with core 0.15.  No longer needed after updating cohttp to 5.0.0.
+  patches = fetchpatch {
+    url = "https://github.com/mirage/ocaml-cohttp/commit/5a7124478ed31c6b1fa6a9a50602c2ec839083b5.patch";
+    sha256 = "0i99rl8604xqwb6d0yzk9ws4dflbn0j4hv2nba2qscbqrrn22rw3";
+  };
+  patchFlags = "-p1 -F3";
 
   meta = cohttp.meta // {
     description = "CoHTTP implementation for the Async concurrency library";

--- a/pkgs/development/ocaml-modules/faraday/async.nix
+++ b/pkgs/development/ocaml-modules/faraday/async.nix
@@ -1,8 +1,13 @@
-{ buildDunePackage, faraday, core, async }:
+{ buildDunePackage, fetchpatch, faraday, core, async }:
 
 buildDunePackage rec {
   pname = "faraday-async";
   inherit (faraday) version src useDune2;
+
+  patches = fetchpatch {
+    url = "https://github.com/inhabitedtype/faraday/commit/31c3fc7f91ecca0f1deea10b40fd5e33bcd35f75.patch";
+    sha256 = "05z5gk7hxq7qvwg6f73hdhfcnx19p1dq6wqh8prx667y8zsaq2zj";
+  };
 
   minimumOCamlVersion = "4.08";
 

--- a/pkgs/development/ocaml-modules/hack_parallel/default.nix
+++ b/pkgs/development/ocaml-modules/hack_parallel/default.nix
@@ -1,5 +1,5 @@
-{ lib, fetchFromGitHub, buildDunePackage, core, core_kernel, pkg-config, sqlite
-}:
+{ lib, fetchFromGitHub, buildDunePackage, core, core_unix, pkg-config
+, sqlite }:
 buildDunePackage rec {
   pname = "hack_parallel";
   version = "1.0.1";
@@ -13,9 +13,11 @@ buildDunePackage rec {
     sha256 = "0qjlkw35r4q2cm0n2x0i73zvx1xgrp6axaia2nm8zxpm49mid629";
   };
 
+  patches = [ ./hack_parallel.patch ];
+
   nativeBuildInputs = [ pkg-config ];
 
-  propagatedBuildInputs = [ core core_kernel sqlite ];
+  propagatedBuildInputs = [ core core_unix sqlite ];
 
   meta = {
     description =

--- a/pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch
+++ b/pkgs/development/ocaml-modules/hack_parallel/hack_parallel.patch
@@ -1,0 +1,68 @@
+diff --git a/src/heap/sharedMem.ml b/src/heap/sharedMem.ml
+index 600e272..511b724 100644
+--- a/src/heap/sharedMem.ml
++++ b/src/heap/sharedMem.ml
+@@ -521,7 +521,7 @@ end = struct
+ 
+     let stack: t option ref = ref None
+ 
+-    let has_local_changes () = Core_kernel.Option.is_some (!stack)
++    let has_local_changes () = Core.Option.is_some (!stack)
+ 
+     let rec mem stack_opt key =
+       match stack_opt with
+diff --git a/src/interface/memory.ml b/src/interface/memory.ml
+index 3554b17..09aa1f5 100644
+--- a/src/interface/memory.ml
++++ b/src/interface/memory.ml
+@@ -66,10 +66,10 @@ let get_heap_handle () =
+ 
+ 
+ let heap_use_ratio () =
+-  Core_kernel.Float.of_int (SharedMemory.heap_size ()) /.
+-  Core_kernel.Float.of_int initial_heap_size
++  Core.Float.of_int (SharedMemory.heap_size ()) /.
++  Core.Float.of_int initial_heap_size
+ 
+ 
+ let slot_use_ratio () =
+   let { SharedMemory.used_slots; slots; _ } = SharedMemory.hash_stats () in
+-  Core_kernel.Float.of_int used_slots /. Core_kernel.Float.of_int slots
++  Core.Float.of_int used_slots /. Core.Float.of_int slots
+diff --git a/src/interface/scheduler.ml b/src/interface/scheduler.ml
+index 9b8282a..b5d41b5 100644
+--- a/src/interface/scheduler.ml
++++ b/src/interface/scheduler.ml
+@@ -48,7 +48,7 @@ let map_reduce
+     | Some exact_size when exact_size > 0 ->
+       (List.length work / exact_size) + 1
+     | _ ->
+-      let bucket_multiplier = Core_kernel.Int.min bucket_multiplier (1 + (List.length work / 400)) in
++      let bucket_multiplier = Core.Int.min bucket_multiplier (1 + (List.length work / 400)) in
+       number_of_workers * bucket_multiplier
+   in
+   MultiWorker.call
+diff --git a/src/utils/dune b/src/utils/dune
+index 50a4c42..45e4a5a 100644
+--- a/src/utils/dune
++++ b/src/utils/dune
+@@ -15,6 +15,7 @@
+     sysinfo)
+   (libraries
+     core
++    core_unix
+     str
+     hack_parallel.collections
+     hack_parallel.disk
+diff --git a/src/utils/hh_logger.ml b/src/utils/hh_logger.ml
+index 4c99f05..8075ed5 100644
+--- a/src/utils/hh_logger.ml
++++ b/src/utils/hh_logger.ml
+@@ -9,6 +9,7 @@
+ *)
+ 
+ open Core
++module Unix = Core_unix
+ 
+ let timestamp_string () =
+   let open Unix in

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -535,7 +535,7 @@ with self;
     pname = "ppx_css";
     hash = "09dpmj3f3m3z1ji9hq775iqr3cfmv5gh7q9zlblizj4wx4y0ibyi";
     meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
-    propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex_2 ];
+    propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex ];
   };
 
   ppx_disable_unused_warnings = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -410,6 +410,13 @@ with self;
     hash = "1lxqsj5k3v8p7g802vj1xc6bs5wrfpszh3q61xvpcd42pf3ahma9";
     meta.description = "Compile-time configuration for Jane Street libraries";
     buildInputs = [ dune-configurator ppx_assert stdio ];
+    patches = [
+      # remove on next release
+      (fetchpatch {
+        url = "https://github.com/janestreet/jst-config/commit/e5fdac6e5df9ba93e014a4d2db841fdbf209446f.patch";
+        sha256 = "sha256-8hVC76z5ilYD/++xRHVswy/l+zzDt63jH4hfSJ/rPaA=";
+      })
+    ];
   };
 
   ocaml-compiler-libs = janePackage {

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -1,0 +1,1000 @@
+{ self
+, fetchpatch
+, lib
+, openssl
+, patdiff
+, zstd
+}:
+
+with self;
+
+{
+
+  abstract_algebra = janePackage {
+    pname = "abstract_algebra";
+    minimumOCamlVersion = "4.08";
+    hash = "12imf6ibm7qb8r1fpqnrl20x2z14zl3ri1vzg0z8qby9l8bv2fbd";
+    meta.description = "A small library describing abstract algebra concepts";
+    propagatedBuildInputs = [ base ppx_jane ];
+  };
+
+  accessor = janePackage {
+    pname = "accessor";
+    minimumOCamlVersion = "4.09";
+    hash = "17rzf0jpc9s3yrxcnn630jhgsw5mrnrhwbfh62hqxqanascc5rxh";
+    meta.description = "A library that makes it nicer to work with nested functional data structures";
+    propagatedBuildInputs = [ higher_kinded ];
+  };
+
+  accessor_async = janePackage {
+    pname = "accessor_async";
+    minimumOCamlVersion = "4.09";
+    hash = "17r6af55ms0i496jsfx0xpdm336c2vhyf49b3s8s1gpz521wrgmc";
+    meta.description = "Accessors for Async types, for use with the Accessor library";
+    propagatedBuildInputs = [ accessor_core async_kernel ];
+  };
+
+  accessor_base = janePackage {
+    pname = "accessor_base";
+    minimumOCamlVersion = "4.09";
+    hash = "1qvq005vxf6n1c7swzb4bzcqdh471bfb9gcmdj4m57xg85xznc1n";
+    meta.description = "Accessors for Base types, for use with the Accessor library";
+    propagatedBuildInputs = [ ppx_accessor ];
+  };
+
+  accessor_core = janePackage {
+    minimumOCamlVersion = "4.09";
+    pname = "accessor_core";
+    hash = "0zrs5zbyrhfbah73g22l19bw1mmljhyb3l2mrwcxgbjq9pqp0k9v";
+    meta.description = "Accessors for Core types, for use with the Accessor library";
+    propagatedBuildInputs = [ accessor_base core_kernel ];
+  };
+
+  async = janePackage {
+    pname = "async";
+    hash = "0pykmnsil754jsnr8gss91ykyjvivngx4ii0ih3nsg1x2jl9xmy2";
+    meta.description = "Monadic concurrency library";
+    propagatedBuildInputs = [ async_rpc_kernel async_unix textutils ];
+    doCheck = false; # we don't have netkit_sockets
+  };
+
+  async_extra = janePackage {
+    pname = "async_extra";
+    hash = "0pxp0b4shz9krsj8xfzajv8a1mijgf0xdgxrn2abdqrz3rvj6pig";
+    meta.description = "Monadic concurrency library";
+    propagatedBuildInputs = [ async_kernel ];
+  };
+
+  async_find = janePackage {
+    pname = "async_find";
+    hash = "119988nkcnw6l6wch4llqkvsrawv2gkbn5q4hngpdwvnw0g0aapv";
+    meta.description = "Directory traversal with Async";
+    propagatedBuildInputs = [ async ];
+  };
+
+  async_inotify = janePackage {
+    pname = "async_inotify";
+    hash = "1nxz6bijp7liy18ljrxg92v2m8v8fqcs1pmzg9kbcf0d4vij8j2p";
+    meta.description = "Async wrapper for inotify";
+    propagatedBuildInputs = [ async_find inotify ];
+  };
+
+  async_interactive = janePackage {
+    pname = "async_interactive";
+    hash = "00hr2lhs8p3hwnyllmns59rwlpimc5b7r6v4zn6cmpb1riblaxqp";
+    meta.description = "Utilities for building simple command-line based user interfaces";
+    propagatedBuildInputs = [ async ];
+  };
+
+  async_js = janePackage {
+    pname = "async_js";
+    hash = "184j077bz686k5lrqswircnrdqldb316ngpzq7xri1pcsl39sy3q";
+    meta.description = "A small library that provide Async support for JavaScript platforms";
+    buildInputs = [ js_of_ocaml-ppx ];
+    propagatedBuildInputs = [ async_rpc_kernel js_of_ocaml uri-sexp ];
+  };
+
+  async_kernel = janePackage {
+    pname = "async_kernel";
+    hash = "01if6c8l2h64v7sk56xr8acnmj6g9whxcjrzzzvczspq88hq2bfh";
+    meta.description = "Monadic concurrency library";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  async_rpc_kernel = janePackage {
+    pname = "async_rpc_kernel";
+    hash = "1b5rp5yam03ir4f1sixpzjg1zdqmkb7lvnaa82kac4fzk80gfrfr";
+    meta.description = "Platform-independent core of Async RPC library";
+    propagatedBuildInputs = [ async_kernel protocol_version_header ];
+  };
+
+  async_rpc_websocket = janePackage {
+    pname = "async_rpc_websocket";
+    hash = "1n93jhkz5r76xcc40c4i4sxcyfz1dbppz8sjfxpwcwjyi6lyhp1p";
+    meta.description = "Library to serve and dispatch Async RPCs over websockets";
+    propagatedBuildInputs = [ async_rpc_kernel async_websocket cohttp_async_websocket ];
+  };
+
+  async_sendfile = janePackage {
+    pname = "async_sendfile";
+    hash = "0lnagdxfnac4z29narphf2ab5a23ys883zmc45r96rssfx82i3fs";
+    meta.description = "Thin wrapper around [Linux_ext.sendfile] to send full files";
+    propagatedBuildInputs = [ async_unix ];
+  };
+
+  async_shell = janePackage {
+    pname = "async_shell";
+    hash = "07iwlyrc4smk6hsnz89cz2ihp670mllq0y9wbdafvagm1y1p62vx";
+    meta.description = "Shell helpers for Async";
+    propagatedBuildInputs = [ async shell ];
+  };
+
+  async_smtp = janePackage {
+    pname = "async_smtp";
+    hash = "1m00j7wcb0blipnc1m6by70gd96a1k621b4dgvgffp8as04a461r";
+    meta.description = "SMTP client and server";
+    propagatedBuildInputs = [ async_extra async_inotify async_sendfile async_shell async_ssl email_message resource_cache re2_stable sexp_macro ];
+  };
+
+  async_ssl = janePackage {
+    pname = "async_ssl";
+    hash = "1b7f7p3xj4jr2n2dxy2lp7a9k7944w6x2nrg6524clvcsd1ax4hn";
+    meta.description = "Async wrappers for SSL";
+    buildInputs = [ dune-configurator ];
+    propagatedBuildInputs = [ async ctypes openssl ];
+    # in ctypes.foreign 0.18.0 threaded and unthreaded have been merged
+    postPatch = ''
+      substituteInPlace bindings/dune \
+        --replace "ctypes.foreign.threaded" "ctypes.foreign"
+    '';
+  };
+
+  async_unix = janePackage {
+    pname = "async_unix";
+    hash = "0z4fgpn93iw0abd7l9kac28qgzgc5qr2x0s1n2zh49lsdn02n6ys";
+    meta.description = "Monadic concurrency library";
+    propagatedBuildInputs = [ async_kernel core_unix ];
+  };
+
+  async_websocket = janePackage {
+    pname = "async_websocket";
+    hash = "16ixqfnx9jp77bvx11dlzsq0pzfpyiif60hl2q06zncyswky9xgb";
+    meta.description = "A library that implements the websocket protocol on top of Async";
+    propagatedBuildInputs = [ async cryptokit ];
+  };
+
+  base = janePackage {
+    pname = "base";
+    hash = "1qyycqqr4dijvxm4hhy79c964wd91kpsfvb89kna1qwgllg0hrpj";
+    minimumOCamlVersion = "4.10";
+    meta.description = "Full standard library replacement for OCaml";
+    buildInputs = [ dune-configurator ];
+    propagatedBuildInputs = [ sexplib0 ];
+    checkInputs = [ alcotest ];
+  };
+
+  base_bigstring = janePackage {
+    pname = "base_bigstring";
+    hash = "1hv3hw2fwqmkrxms1g6rw3c18mmla1z5bva3anx45mnff903iv4q";
+    minimumOCamlVersion = "4.08";
+    meta.description = "String type based on [Bigarray], for use in I/O and C-bindings";
+    propagatedBuildInputs = [ int_repr ppx_jane ];
+  };
+
+  base_quickcheck = janePackage {
+    pname = "base_quickcheck";
+    hash = "0q73kfr67cz5wp4qn4rq3lpa922hqmvwdiinnans0js65fvlgqsi";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Randomized testing framework, designed for compatibility with Base";
+    propagatedBuildInputs = [ ppx_base ppx_fields_conv ppx_let ppx_sexp_value splittable_random ];
+  };
+
+  bignum = janePackage {
+    pname = "bignum";
+    hash = "12q3xcv78b4s9srnc17jbyn53d5drmwmyvgp62p7nk3fs4f7cr4f";
+    propagatedBuildInputs = [ core_kernel zarith zarith_stubs_js ];
+    meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
+  };
+
+  bin_prot = janePackage {
+    pname = "bin_prot";
+    hash = "1qfqglscc25wwnjx7byqmjcnjww1msnr8940gyg8h93wdq43fjnh";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "A binary protocol generator";
+    propagatedBuildInputs = [ ppx_compare ppx_custom_printf ppx_fields_conv ppx_optcomp ppx_variants_conv ];
+  };
+
+  bonsai = janePackage {
+    pname = "bonsai";
+    hash = "150zx2g1dmhyrxwqq8j7f2m3hjpmk5bk182ihx2gdbarhw1ainpm";
+    meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
+    buildInputs = [ ppx_pattern_bind ];
+    nativeBuildInputs = [ js_of_ocaml-compiler ocaml-embed-file ];
+    propagatedBuildInputs = [
+      async
+      async_extra
+      async_rpc_websocket
+      cohttp-async
+      core_bench
+      fuzzy_match
+      incr_dom
+      js_of_ocaml-ppx
+      patdiff
+      ppx_css
+      ppx_typed_fields
+      profunctor
+      textutils
+    ];
+    patches = [ ./bonsai_jsoo_4_0.patch ];
+  };
+
+  cinaps = janePackage {
+    pname = "cinaps";
+    version = "0.15.1";
+    hash = "0g856cxmxg4vicwslhqldplkpwi158s2d62vwzv26xg5m6wjn9rg";
+    minimumOCamlVersion = "4.04";
+    meta.description = "Trivial metaprogramming tool";
+    propagatedBuildInputs = [ re ];
+    doCheck = false; # fails because ppx_base doesn't include ppx_js_style
+  };
+
+  cohttp_async_websocket = janePackage {
+    pname = "cohttp_async_websocket";
+    hash = "0d0smavnxpnwrmhlcf3b5a3cm3n9kz1y8fh6l28xv6zrn4sc7ik8";
+    meta.description = "Websocket library for use with cohttp and async";
+    propagatedBuildInputs = [ async_websocket cohttp-async ppx_jane uri-sexp ];
+  };
+
+  core = janePackage {
+    pname = "core";
+    hash = "1m2ybvlz9zlb2d0jc0j7wdgd18mx9sh3ds2ylkv0cfjx1pzi0l25";
+    meta.description = "Industrial strength alternative to OCaml's standard library";
+    buildInputs = [ jst-config ];
+    propagatedBuildInputs = [ base base_bigstring base_quickcheck ppx_jane time_now ];
+    doCheck = false; # circular dependency with core_kernel
+  };
+
+  core_bench = janePackage {
+    pname = "core_bench";
+    hash = "0v6lm9vz6y1qd7h8pg9l5jsy8qr74vlk1nd4qzchld4jhwq7mbdi";
+    meta.description = "Benchmarking library";
+    propagatedBuildInputs = [ textutils ];
+  };
+
+  core_extended = janePackage {
+    pname = "core_extended";
+    hash = "0sx79hc1y1daczib2p4nbyw4aqnznmdd83knrhs5q153j7lnlalx";
+    meta.description = "Extra components that are not as closely vetted or as stable as Core";
+    propagatedBuildInputs = [ core_unix record_builder ];
+  };
+
+  core_kernel = janePackage {
+    pname = "core_kernel";
+    hash = "05mb4vbf293iq1xx4acyrmi9cgcw6capwrsa54ils62alby6w6yq";
+    meta.description = "System-independent part of Core";
+    buildInputs = [ jst-config ];
+    propagatedBuildInputs = [ base_bigstring core int_repr sexplib ];
+    doCheck = false; # we don't have quickcheck_deprecated
+  };
+
+  core_unix = janePackage {
+    pname = "core_unix";
+    hash = "1xzxqzg23in5ivz0v3qshzpr4w92laayscqj9im7jylh2ar1xi0a";
+    meta.description = "Unix-specific portions of Core";
+    buildInputs = [ jst-config ];
+    propagatedBuildInputs = [ core_kernel expect_test_helpers_core ocaml_intrinsics ppx_jane timezone spawn ];
+    postPatch = ''
+      patchShebangs unix_pseudo_terminal/src/discover.sh
+    '';
+  };
+
+  csvfields = janePackage {
+    pname = "csvfields";
+    hash = "0z47pq17bw776hzvk48ypbd92ps9vlvl86mnhw3j6cqx4ahbjik3";
+    propagatedBuildInputs = [ core num ];
+    meta.description = "Runtime support for ppx_xml_conv and ppx_csv_conv";
+  };
+
+  delimited_parsing = janePackage {
+    pname = "delimited_parsing";
+    hash = "0d050v58zzi8c4qiwxbfcyrdw6zvncnnl3qj79qi0yq4xkg7820r";
+    propagatedBuildInputs = [ async core_extended ];
+    meta.description = "Parsing of character (e.g., comma) separated and fixed-width values";
+  };
+
+  ecaml = janePackage {
+    pname = "ecaml";
+    hash = "08g2bl06vkn3bkqzkmvk2646aqb6jj4a7n3wgzpcx1c2gl3iw5i6";
+    meta.description = "Library for writing Emacs plugin in OCaml";
+    propagatedBuildInputs = [ async expect_test_helpers_core ];
+  };
+
+  email_message = janePackage {
+    pname = "email_message";
+    hash = "00h66l2g5rjaay0hbyqy4v9i866g779miriwv20h9k4mliqdq7in";
+    meta.description = "E-mail message parser";
+    propagatedBuildInputs = [ angstrom async base64 cryptokit magic-mime re2 ];
+  };
+
+  expect_test_helpers_async = janePackage {
+    pname = "expect_test_helpers_async";
+    hash = "14v4966p5dmqgjb9sgrvnsixv0w0bagicn8v44g9mf9d88z8pfym";
+    meta.description = "Async helpers for writing expectation tests";
+    propagatedBuildInputs = [ async expect_test_helpers_core ];
+  };
+
+  expect_test_helpers_core = janePackage {
+    pname = "expect_test_helpers_core";
+    hash = "0bxs3g0zzym8agfcbpg5lmrh6hcb86z861bq40xhhfwqf4pzdbfa";
+    meta.description = "Helpers for writing expectation tests";
+    propagatedBuildInputs = [ core_kernel sexp_pretty ];
+  };
+
+  fieldslib = janePackage {
+    pname = "fieldslib";
+    hash = "0xwf9mdxlyr3f0vv5y82cyw2bsckwl8rwf6jm6bai1gqpgxjq756";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values";
+    propagatedBuildInputs = [ base ];
+  };
+
+  fuzzy_match = janePackage {
+    pname = "fuzzy_match";
+    hash = "0s5w81698b07l5m11nwx8xbjcpmp54dnf5fcrnlva22jrlsf14h4";
+    meta.description = "A library for fuzzy string matching";
+    propagatedBuildInputs = [ core ppx_jane ];
+  };
+
+  higher_kinded = janePackage {
+    pname = "higher_kinded";
+    minimumOCamlVersion = "4.09";
+    hash = "0rafxxajqswi070h8sinhjna0swh1hc6d7i3q7y099yj3wlr2y1l";
+    meta.description = "A library with an encoding of higher kinded types in OCaml";
+    propagatedBuildInputs = [ base ppx_jane ];
+  };
+
+  incr_dom = janePackage {
+    pname = "incr_dom";
+    hash = "1sija9w2im8vdp61h387w0mww9hh7jgkgsjcccps4lbv936ac7c1";
+    meta.description = "A library for building dynamic webapps, using Js_of_ocaml";
+    buildInputs = [ js_of_ocaml-ppx ];
+    propagatedBuildInputs = [ async_js incr_map incr_select virtual_dom ];
+    patches = [ ./incr_dom_jsoo_4_0.patch ];
+  };
+
+  incr_map = janePackage {
+    pname = "incr_map";
+    hash = "0aq8wfylvq68him92vzh1fqmr7r0lfwc5cdiqr10r5x032vzpnii";
+    meta.description = "Helpers for incremental operations on map like data structures";
+    buildInputs = [ ppx_pattern_bind ];
+    propagatedBuildInputs = [ abstract_algebra incremental ];
+  };
+
+  incr_select = janePackage {
+    pname = "incr_select";
+    hash = "0qm2i4hb5jh2ra95kq881s4chkwbd2prvql1c0nahd63h829m57l";
+    meta.description = "Handling of large set of incremental outputs from a single input";
+    propagatedBuildInputs = [ incremental ];
+  };
+
+  incremental = janePackage {
+    pname = "incremental";
+    hash = "1dp30mhljnbcxqimydwbmxx0x4y4xnb55gyhldm1f5qrwdxdl747";
+    meta.description = "Library for incremental computations";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  int_repr = janePackage {
+    pname = "int_repr";
+    hash = "0ph88ym3s9dk30n17si2xam40sp8wv1xffw5cl3bskc2vfya1nvl";
+    meta.description = "Integers of various widths";
+    propagatedBuildInputs = [ base ppx_jane ];
+  };
+
+  jane-street-headers = janePackage {
+    pname = "jane-street-headers";
+    hash = "1lzk3w66x4429n2j75lwm55xafc46mywgdrbh9nc9jwqwgzf0wwx";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Jane Street C header files";
+  };
+
+  jsonaf = janePackage {
+    pname = "jsonaf";
+    hash = "1j9rn8vsvfpgmdpmdqb5qhvss5171j8n3ii1bcgnavqinchbvqa6";
+    meta.description = "A library for parsing, manipulating, and serializing data structured as JSON";
+    propagatedBuildInputs = [ base ppx_jane angstrom faraday ];
+  };
+
+  jst-config = janePackage {
+    pname = "jst-config";
+    hash = "1lxqsj5k3v8p7g802vj1xc6bs5wrfpszh3q61xvpcd42pf3ahma9";
+    meta.description = "Compile-time configuration for Jane Street libraries";
+    buildInputs = [ dune-configurator ppx_assert stdio ];
+  };
+
+  ocaml-compiler-libs = janePackage {
+    pname = "ocaml-compiler-libs";
+    version = "0.12.4";
+    minimumOCamlVersion = "4.04.1";
+    hash = "00if2f7j9d8igdkj4rck3p74y17j6b233l91mq02drzrxj199qjv";
+    meta.description = "OCaml compiler libraries repackaged";
+  };
+
+  ocaml-embed-file = janePackage {
+    pname = "ocaml-embed-file";
+    hash = "1nzgc0q05f0j3q1kwfpyhhhpgwrfjvmkqqifrkrm4y7d1i44bfnw";
+    propagatedBuildInputs = [ async ppx_jane ];
+    meta.description = "Files contents as module constants";
+  };
+
+  ocaml_intrinsics = janePackage {
+    pname = "ocaml_intrinsics";
+    minimumOCamlVersion = "4.08";
+    hash = "1fdfl78b8br0j9w4046i0fmmaqn4cgl06q94rsniyagx9747pnsr";
+    meta.description = "Intrinsics";
+    buildInputs = [ dune-configurator ];
+    doCheck = false; # test rules broken
+  };
+
+  parsexp = janePackage {
+    pname = "parsexp";
+    hash = "1grzpxi39318vcqhwf723hqh11k68irh59zb3dyg9lw8wjn7752a";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "S-expression parsing library";
+    propagatedBuildInputs = [ base sexplib0 ];
+  };
+
+  patience_diff = janePackage {
+    pname = "patience_diff";
+    hash = "17yrhn4qfi31m8g1ygb3m6i9z4fqd8f60fn6viazgx06s3x4xp3v";
+    meta.description = "Diff library using Bram Cohen's patience diff algorithm";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  posixat = janePackage {
+    pname = "posixat";
+    hash = "1xgycwa0janrfn9psb7xrm0820blr82mqf1lvjy9ipqalj7v9w1f";
+    minimumOCamlVersion = "4.07";
+    propagatedBuildInputs = [ ppx_optcomp ppx_sexp_conv ];
+    meta.description = "Binding to the posix *at functions";
+  };
+
+  ppx_accessor = janePackage {
+    pname = "ppx_accessor";
+    minimumOCamlVersion = "4.09";
+    hash = "0qv51if1nk0zff2v6q946h8ac7bpd5xa4ivyixl9g4h2mk29w4qb";
+    meta.description = "[@@deriving] plugin to generate accessors for use with the Accessor libraries";
+    propagatedBuildInputs = [ accessor ];
+  };
+
+  ppx_assert = janePackage {
+    pname = "ppx_assert";
+    hash = "0dic250q3flrjs3i70a2qqqnhqqj75ddlixpy7hdfghjw32azw90";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Assert-like extension nodes that raise useful errors on failure";
+    propagatedBuildInputs = [ ppx_cold ppx_compare ppx_here ppx_sexp_conv ];
+  };
+
+  ppx_base = janePackage {
+    pname = "ppx_base";
+    hash = "13rfmy2fxvwi7z5l1mai474ri5anqjm8q4hs7dblplsjjd9m5ld1";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Base set of ppx rewriters";
+    propagatedBuildInputs = [ ppx_cold ppx_enumerate ppx_hash ];
+  };
+
+  ppx_bench = janePackage {
+    pname = "ppx_bench";
+    hash = "0bc0gbm922417wqisafxh35jslcp7xy1s0h0a1q32rhx0ivxx3g6";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Syntax extension for writing in-line benchmarks in ocaml code";
+    propagatedBuildInputs = [ ppx_inline_test ];
+  };
+
+  ppx_bin_prot = janePackage {
+    pname = "ppx_bin_prot";
+    hash = "1280wsls061fmvmdysjqn3lv4mnkyg400jnjf4jyfr14s33h1ad5";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Generation of bin_prot readers and writers from types";
+    propagatedBuildInputs = [ bin_prot ppx_here ];
+    doCheck = false; # circular dependency with ppx_jane
+  };
+
+  ppx_cold = janePackage {
+    pname = "ppx_cold";
+    hash = "0x7xgpvy0l28k971xy08ibhr4w9nh8d9zvxc6jfxxx4fbfcv5gca";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Expands [@cold] into [@inline never][@specialise never][@local never]";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_compare = janePackage {
+    pname = "ppx_compare";
+    hash = "1wjwqkr71p61vjidbr80l93y4kkad7xsfyp04w8qfqrj7h5nm625";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Generation of comparison functions from types";
+    propagatedBuildInputs = [ ppxlib base ];
+  };
+
+  ppx_custom_printf = janePackage {
+    pname = "ppx_custom_printf";
+    hash = "1k8nmq6kwqz2wpkm9ymq749dz1vd8lxrjc711knp1wyz5935hnsv";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Printf-style format-strings for user-defined string conversion";
+    propagatedBuildInputs = [ ppx_sexp_conv ];
+  };
+
+  ppx_css = janePackage {
+    pname = "ppx_css";
+    hash = "09dpmj3f3m3z1ji9hq775iqr3cfmv5gh7q9zlblizj4wx4y0ibyi";
+    meta.description = "A ppx that takes in css strings and produces a module for accessing the unique names defined within";
+    propagatedBuildInputs = [ core_kernel ppxlib js_of_ocaml js_of_ocaml-ppx sedlex_2 ];
+  };
+
+  ppx_disable_unused_warnings = janePackage {
+    pname = "ppx_disable_unused_warnings";
+    hash = "0sb5i4v7p9df2bxk66rjs30k9fqdrwsq1jgykjv6wyrx2d9bv955";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_enumerate = janePackage {
+    pname = "ppx_enumerate";
+    hash = "1i0f6jv5cappw3idd70wpg76d7x6mvxapa89kri1bwz47hhg4pkz";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Generate a list containing all values of a finite type";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_expect = janePackage {
+    pname = "ppx_expect";
+    hash = "134dl5qhjxsj2mcmrx9f3m0iys0n5mjfpz9flj8zn8d2jir43776";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Cram like framework for OCaml";
+    propagatedBuildInputs = [ ppx_here ppx_inline_test re ];
+    doCheck = false; # test build rules broken
+  };
+
+  ppx_fields_conv = janePackage {
+    pname = "ppx_fields_conv";
+    hash = "094wsnw7fcwgl9xg6vkjb0wbgpn9scsp847yhdd184sz9v1amz14";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Generation of accessor and iteration functions for ocaml records";
+    propagatedBuildInputs = [ fieldslib ppxlib ];
+  };
+
+  ppx_fixed_literal = janePackage {
+    pname = "ppx_fixed_literal";
+    hash = "10siwcqrqa4gh0mg6fkaby0jjskc01r81pcblc67h3vmbjjh08j9";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Simpler notation for fixed point literals";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_hash = janePackage {
+    pname = "ppx_hash";
+    hash = "15agkwavadllzxdv4syjna02083nfnap8qs4yqf5s0adjw73fzyg";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "A ppx rewriter that generates hash functions from type expressions and definitions";
+    propagatedBuildInputs = [ ppx_compare ppx_sexp_conv ];
+  };
+
+  ppx_here = janePackage {
+    pname = "ppx_here";
+    hash = "0jv81k8x18q8rxdyfwavrvx8yq9k5m3abpmgdg6zipx2ajcjzvag";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Expands [%here] into its location";
+    propagatedBuildInputs = [ ppxlib ];
+    doCheck = false; # test build rules broken
+  };
+
+  ppx_ignore_instrumentation = janePackage {
+    pname = "ppx_ignore_instrumentation";
+    hash = "16fgig88g3jr0m3i636fr52h29h1yzhi8nhnl4029zn808kcdyj2";
+    minimumOCamlVersion = "4.08";
+    meta.description = "Ignore Jane Street specific instrumentation extensions";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_inline_test = janePackage {
+    pname = "ppx_inline_test";
+    hash = "1a0gaj9p6gbn5j7c258mnzr7yjlq0hqi3aqqgyj1g2dbk1sxdbjz";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Syntax extension for writing in-line tests in ocaml code";
+    propagatedBuildInputs = [ ppxlib time_now ];
+    doCheck = false; # test build rules broken
+  };
+
+  ppx_jane = janePackage {
+    pname = "ppx_jane";
+    hash = "1p6847gdfnnj6qpa4yh57s6wwpsl7rfgy0q7993chz24h9mhz5lk";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Standard Jane Street ppx rewriters";
+    propagatedBuildInputs = [ base_quickcheck ppx_bin_prot ppx_disable_unused_warnings ppx_expect ppx_fixed_literal ppx_ignore_instrumentation ppx_log ppx_module_timer ppx_optcomp ppx_optional ppx_pipebang ppx_stable ppx_string ppx_typerep_conv ppx_variants_conv ];
+  };
+
+  ppx_js_style = janePackage {
+    pname = "ppx_js_style";
+    hash = "0q2p9pvmlncgv0hprph95xiv7s6q44ynvp4yl4dckf1qx68rb3ba";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Code style checker for Jane Street Packages";
+    propagatedBuildInputs = [ octavius ppxlib ];
+  };
+
+  ppx_let = janePackage {
+    pname = "ppx_let";
+    hash = "04v3fq0vnvvavxbc7hfsrg8732pwxbyw8pjl3xfplqdqci6fj15n";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Monadic let-bindings";
+    propagatedBuildInputs = [ ppxlib ppx_here ];
+  };
+
+  ppx_log = janePackage {
+    pname = "ppx_log";
+    hash = "08i9gz3f4w3bmlrfdw7ja9awsfkhhldz03bnnc4hijfmn8sawzi0";
+    minimumOCamlVersion = "4.08.0";
+    meta.description = "Ppx_sexp_message-like extension nodes for lazily rendering log messages";
+    propagatedBuildInputs = [ base ppx_here ppx_sexp_conv ppx_sexp_message sexplib ];
+  };
+
+  ppx_module_timer = janePackage {
+    pname = "ppx_module_timer";
+    hash = "0lzi5hxi10p89ddqbrc667267f888kqslal76gfhmszyk60n20av";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Ppx rewriter that records top-level module startup times";
+    propagatedBuildInputs = [ time_now ];
+  };
+
+  ppx_optcomp = janePackage {
+    pname = "ppx_optcomp";
+    hash = "0ypivfipi8fcr9pqyvl2ajpcivmr1irdwwv248i4x6mggpc2pl0b";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Optional compilation for OCaml";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_optional = janePackage {
+    pname = "ppx_optional";
+    hash = "0amxwxhkyzamgnxx400qhvxzqr3m4sazhhkc516lm007pynv7xq2";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Pattern matching on flat options";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_pattern_bind = janePackage {
+    pname = "ppx_pattern_bind";
+    hash = "01nfdk9yvk92r7sjl4ngxfsx8fyqh2dsjxz0i299nszv9jc4rn4f";
+    minimumOCamlVersion = "4.07";
+    meta.description = "A ppx for writing fast incremental bind nodes in a pattern match";
+    propagatedBuildInputs = [ ppx_let ];
+  };
+
+  ppx_pipebang = janePackage {
+    pname = "ppx_pipebang";
+    hash = "0sm5dghyalhws3hy1cc2ih36az1k4q02hcgj6l26gwyma3y4irvq";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "A ppx rewriter that inlines reverse application operators `|>` and `|!`";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_python = janePackage {
+    pname = "ppx_python";
+    hash = "1d2wf0rkvxg07q6xq2zmxh6hmvnwlsmny3mm92jsg1s7bdl39gap";
+    meta.description = "A [@@deriving] plugin to generate Python conversion functions ";
+    propagatedBuildInputs = [ ppx_base ppxlib pyml ];
+  };
+
+  ppx_sexp_conv = janePackage {
+    pname = "ppx_sexp_conv";
+    minimumOCamlVersion = "4.04.2";
+    hash = "1fyf7hgxprn7pj58rmmrfpv938a0avpzvvk6wzihpmfm6whgbdm8";
+    meta.description = "[@@deriving] plugin to generate S-expression conversion functions";
+    propagatedBuildInputs = [ ppxlib sexplib0 base ];
+  };
+
+  ppx_sexp_message = janePackage {
+    pname = "ppx_sexp_message";
+    hash = "0a7hx50bkkc5n5msc3zzc4ixnp7674x3mallknb9j31jnd8l90nj";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "A ppx rewriter for easy construction of s-expressions";
+    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+  };
+
+  ppx_sexp_value = janePackage {
+    pname = "ppx_sexp_value";
+    hash = "0kz83j9v6yz3v8c6vr9ilhkcci4hhjd6i6r6afnx72jh6i7d3hnv";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "A ppx rewriter that simplifies building s-expressions from ocaml values";
+    propagatedBuildInputs = [ ppx_here ppx_sexp_conv ];
+  };
+
+  ppx_stable = janePackage {
+    pname = "ppx_stable";
+    hash = "1as0v0x8c9ilyhngax55lvwyyi4a2wshyan668v0f2s1608cwb1l";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Stable types conversions generator";
+    propagatedBuildInputs = [ ppxlib ];
+  };
+
+  ppx_string = janePackage {
+    pname = "ppx_string";
+    minimumOCamlVersion = "4.04.2";
+    hash = "1dp5frk6cig5m3m5rrh2alw63snyf845x7zlkkaljip02pqcbw1s";
+    meta.description = "Ppx extension for string interpolation";
+    propagatedBuildInputs = [ ppx_base ppxlib stdio ];
+  };
+
+  ppx_typed_fields = janePackage {
+    pname = "ppx_typed_fields";
+    hash = "0hxililjgy4jh66b4xmphrfhv6qpp7dz7xbz3islp357hf18niqy";
+    meta.description = "GADT-based field accessors and utilities";
+    propagatedBuildInputs = [ core ppx_jane ppxlib ];
+  };
+
+  ppx_typerep_conv = janePackage {
+    pname = "ppx_typerep_conv";
+    minimumOCamlVersion = "4.04.2";
+    hash = "1q1lzykpm83ra4l5jh4rfddhd3c96kx4s4rvx0w4b51z1qk56zam";
+    meta.description = "Generation of runtime types from type declarations";
+    propagatedBuildInputs = [ ppxlib typerep ];
+  };
+
+  ppx_variants_conv = janePackage {
+    pname = "ppx_variants_conv";
+    minimumOCamlVersion = "4.04.2";
+    hash = "1dh0bw9dn246k00pymf59yjkl6x6bxd76lkk9b5xpq2692wwlc3s";
+    meta.description = "Generation of accessor and iteration functions for ocaml variant types";
+    propagatedBuildInputs = [ variantslib ppxlib ];
+  };
+
+  profunctor = janePackage {
+    pname = "profunctor";
+    hash = "151vk0cagjwn0isnnwryn6gmvnpds4dyj1in9jvv5is8yij203gg";
+    meta.description = "A library providing a signature for simple profunctors and traversal of a record";
+    propagatedBuildInputs = [ base ppx_jane record_builder ];
+  };
+
+  protocol_version_header = janePackage {
+    pname = "protocol_version_header";
+    hash = "0s638cwf1357gg754rc4306654hhrhzqaqm2lp3yv5vj3ml8p4qy";
+    meta.description = "Protocol versioning";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  pythonlib = janePackage {
+    pname = "pythonlib";
+    hash = "0p88vmp19zmr0r58dz6sawsmbn4yi2vyymad2c82kp93kg66nm1v";
+    meta.description = "A library to help writing wrappers around ocaml code for python";
+    patches = lib.optional (lib.versionAtLeast ocaml.version "4.13") ./pythonlib.patch;
+    propagatedBuildInputs = [ ppx_expect ppx_let ppx_python stdio typerep ];
+  };
+
+  re2 = janePackage {
+    pname = "re2";
+    hash = "0z1cajd8abrryf3gz322jpynba79nv4a2kmmcdz0314ran5w68v3";
+    meta.description = "OCaml bindings for RE2, Google's regular expression library";
+    propagatedBuildInputs = [ core_kernel ];
+    prePatch = ''
+      substituteInPlace src/re2_c/dune --replace 'CXX=g++' 'CXX=c++'
+      substituteInPlace src/dune --replace '(cxx_flags (:standard \ -pedantic) (-I re2_c/libre2))' '(cxx_flags (:standard \ -pedantic) (-I re2_c/libre2) (-x c++))'
+    '';
+  };
+
+  re2_stable = janePackage {
+    pname = "re2_stable";
+    version = "0.14.0";
+    hash = "0kjc0ff6b3509s3b9n4q8ilb06d5fngdh3z58cm95vg7zkcas9w3";
+    meta.description = "Re2_stable adds an incomplete but stable serialization of Re2";
+    propagatedBuildInputs = [ core re2 ];
+  };
+
+  record_builder = janePackage {
+    pname = "record_builder";
+    hash = "004nqcmwll0vy47mb3d3jlk21cc6adcjy62dkv2k966n9jkh472h";
+    meta.description = "A library which provides traversal of records with an applicative";
+    propagatedBuildInputs = [ base ppx_jane ];
+  };
+
+  resource_cache = janePackage {
+    pname = "resource_cache";
+    hash = "13wzx8ixgbb7jj5yrps890irw2wvkchnihsn7rfrcvnvrjzzjshm";
+    meta.description = "General resource cache";
+    propagatedBuildInputs = [ async_rpc_kernel ];
+  };
+
+  sexp = janePackage {
+    pname = "sexp";
+    hash = "00xlsymm1mpgs8cqkb6c36vh5hfw0saghvwiqh7jry65qc5nvv9z";
+    propagatedBuildInputs = [
+      async
+      core
+      csvfields
+      jsonaf
+      re2
+      sexp_diff
+      sexp_macro
+      sexp_pretty
+      sexp_select
+    ];
+    meta.description = "S-expression swiss knife";
+  };
+
+  sexp_diff = janePackage {
+    pname = "sexp_diff";
+    hash = "1p5xwhj634ij4a0m5k6a3abddi5315y7is1a6ha1lifdz3v985ll";
+    propagatedBuildInputs = [ core_kernel ];
+    meta.description = "Code for computing the diff of two sexps";
+  };
+
+  sexp_macro = janePackage {
+    pname = "sexp_macro";
+    hash = "1l5dsv9gawmf5dg3rf8sxphp9qs3n4n038nlmf9rxzypzyn112k8";
+    propagatedBuildInputs = [ async sexplib ];
+    meta.description = "Sexp macros";
+  };
+
+  sexp_pretty = janePackage {
+    pname = "sexp_pretty";
+    hash = "1p1jspwjvrhm8li22xl0n8wngs12d9g7nc1svk6xc32jralnxblg";
+    minimumOCamlVersion = "4.07";
+    meta.description = "S-expression pretty-printer";
+    propagatedBuildInputs = [ ppx_base re sexplib ];
+  };
+
+  sexp_select = janePackage {
+    pname = "sexp_select";
+    hash = "0mmvga9w3gbb2gd1h4l8f1c3l2lrpn1zld2a8xgqyfqfff3vg31p";
+    minimumOCamlVersion = "4.07";
+    propagatedBuildInputs = [ base ppx_jane ];
+    meta.description = "A library to use CSS-style selectors to traverse sexp trees";
+  };
+
+  sexplib0 = janePackage {
+    pname = "sexplib0";
+    hash = "0jag0bz2173b0n7hx013fhghydhh92arqjlrcnf5x025bw8nz66v";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Library containing the definition of S-expressions and some base converters";
+  };
+
+  sexplib = janePackage {
+    pname = "sexplib";
+    hash = "05h34fm3p0179xivc14bixc50pzc8zws46l5gsq310kpm37srq3c";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Library for serializing OCaml values to and from S-expressions";
+    propagatedBuildInputs = [ num parsexp ];
+  };
+
+  shell = janePackage {
+    pname = "shell";
+    hash = "1vzdif7w9y1kw2qynlfixwphdgiflrf43j0fzinjp9f56vlhghhy";
+    meta.description = "Yet another implementation of fork&exec and related functionality";
+    buildInputs = [ jst-config ];
+    propagatedBuildInputs = [ textutils ];
+    checkInputs = [ ounit ];
+    # This currently fails with dune
+    strictDeps = false;
+  };
+
+  shexp = janePackage {
+    pname = "shexp";
+    hash = "05iswnhi92f4yvrh76j3254bvls6fbrdb56mv6vc6mi5f8z4l79i";
+    minimumOCamlVersion = "4.07";
+    propagatedBuildInputs = [ posixat spawn ];
+    meta.description = "Process library and s-expression based shell";
+  };
+
+  spawn = janePackage {
+    pname = "spawn";
+    minimumOCamlVersion = "4.02.3";
+    hash = "1fjr91psas5zmk1hxvxh0dchhn0pkyzlr4gg232f5g9vdgissi0p";
+    meta.description = "Spawning sub-processes";
+    buildInputs = [ ppx_expect ];
+  };
+
+  splay_tree = janePackage {
+    pname = "splay_tree";
+    hash = "1jxfh7f2hjrms5pm2cy1cf6ivphgiqqvyyr9hdcz8d3vi612p4dm";
+    meta.description = "A splay tree implementation";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  splittable_random = janePackage {
+    pname = "splittable_random";
+    hash = "0ap5z4z1aagz4z02q9642cbl25jzws9lbc2x5xkpyjlc0qcm9v3m";
+    meta.description = "PRNG that can be split into independent streams";
+    propagatedBuildInputs = [ base ppx_assert ppx_bench ppx_sexp_message ];
+  };
+
+  stdio = janePackage {
+    pname = "stdio";
+    hash = "0g00b00kpjcadikq2asng35w7kvd24q9ldkiylwmn3gv3lrbipa8";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Standard IO library for OCaml";
+    propagatedBuildInputs = [ base ];
+  };
+
+  textutils = janePackage {
+    pname = "textutils";
+    hash = "1wass49h645wql9b7nck2iqlkf4648dkxvlvxixr7z80zcnb5rxr";
+    meta.description = "Text output utilities";
+    propagatedBuildInputs = [ core_unix textutils_kernel ];
+  };
+
+  textutils_kernel = janePackage {
+    pname = "textutils_kernel";
+    hash = "068g11d98wsb5a6ds0p5xybdmx5nx9bxa0k11dmh3l57kn4c169x";
+    meta.description = "Text output utilities";
+    propagatedBuildInputs = [ core ppx_jane uutf ];
+  };
+
+  time_now = janePackage {
+    pname = "time_now";
+    hash = "1pa0hyh470j9jylii4983qagb6hq2dz6s0q2fnrcph9qbw83bc0c";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Reports the current time";
+    buildInputs = [ jst-config ppx_optcomp ];
+    propagatedBuildInputs = [ jane-street-headers base ppx_base ];
+  };
+
+  timezone = janePackage {
+    pname = "timezone";
+    hash = "00a007aji5rbz42kgbq1w90py6fm9k9akycs5abkcfll5rd0cbhx";
+    meta.description = "Time-zone handling";
+    propagatedBuildInputs = [ core_kernel ];
+  };
+
+  topological_sort = janePackage {
+    pname = "topological_sort";
+    hash = "0iqhp8n6g5n1ng80brjpav54229lykm2c1fc104s58lk3rqfvj9v";
+    meta.description = "Topological sort algorithm";
+    propagatedBuildInputs = [ ppx_jane stdio ];
+  };
+
+  typerep = janePackage {
+    pname = "typerep";
+    hash = "1qxfi01qim0hrgd6d0bgvpxg36i99mmm8cw4wqpr9kxyqvgzv26z";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Typerep is a library for runtime types";
+    propagatedBuildInputs = [ base ];
+  };
+
+  variantslib = janePackage {
+    pname = "variantslib";
+    hash = "033ns8ph6bd8g5cdfryjfcnrnzkdshppjyw5kl7cvszjfrz33ij7";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Part of Jane Street's Core library";
+    propagatedBuildInputs = [ base ];
+  };
+
+  vcaml = janePackage {
+    pname = "vcaml";
+    hash = "12fd29x9dgf4f14xrx7z4y1bm1wbfynrs3jismjbiqnckfpbqrib";
+    meta.description = "OCaml bindings for the Neovim API";
+    propagatedBuildInputs = [ angstrom-async async_extra expect_test_helpers_async faraday ];
+  };
+
+  virtual_dom = janePackage {
+    pname = "virtual_dom";
+    hash = "15xia9v4ighzm0gv3vbqk9nvg47cvzqmfnl2zr67yxv4b98kyzv3";
+    meta.description = "OCaml bindings for the virtual-dom library";
+    buildInputs = [ js_of_ocaml-ppx ];
+    propagatedBuildInputs = [ core_kernel gen_js_api js_of_ocaml lambdasoup tyxml ];
+  };
+
+  zarith_stubs_js = janePackage {
+    pname = "zarith_stubs_js";
+    hash = "119xgr3kla9q1bvs4a5z2ivbmsrz4db3a9z0gf77ryqg4i22ywvl";
+    minimumOCamlVersion = "4.04.2";
+    meta.description = "Javascripts stubs for the Zarith library";
+  };
+
+  zstandard = janePackage {
+    pname = "zstandard";
+    hash = "1blkv35g5q1drkc6zmc4m027gjz6vfdadra1kw1xkp1wlc2l4v3k";
+    meta.description = "OCaml bindings to Zstandard";
+    buildInputs = [ ppx_jane ];
+    propagatedBuildInputs = [ core_kernel ctypes zstd ];
+  };
+
+}

--- a/pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch
+++ b/pkgs/development/ocaml-modules/janestreet/bonsai_jsoo_4_0.patch
@@ -1,0 +1,13 @@
+diff --git a/web_ui/element_size_hooks/visibility_tracker.ml b/web_ui/element_size_hooks/visibility_tracker.ml
+index 2e5dbe0..61df433 100644
+--- a/web_ui/element_size_hooks/visibility_tracker.ml
++++ b/web_ui/element_size_hooks/visibility_tracker.ml
+@@ -23,8 +23,6 @@ let get_conservative_vis_bounds (element : Dom_html.element Js.t) : Bounds.t opt
+   and client_height = client_bounds##.height
+   and window_height = Dom_html.window##.innerHeight
+   and window_width = Dom_html.window##.innerWidth in
+-  let%bind.Option window_height = Js.Optdef.to_option window_height in
+-  let%bind.Option window_width = Js.Optdef.to_option window_width in
+   let window_height = Float.of_int window_height
+   and window_width = Float.of_int window_width
+   and client_width = Js.Optdef.get client_width (Fn.const 0.0)

--- a/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/janePackage_0_15.nix
@@ -1,0 +1,31 @@
+{ lib, fetchFromGitHub, buildDunePackage, defaultVersion ? "0.15.0" }:
+
+{ pname
+, version ? defaultVersion
+, hash
+, minimumOCamlVersion ? "4.11"
+, doCheck ? true
+, buildInputs ? []
+, strictDeps ? true
+, ...}@args:
+
+buildDunePackage (args // {
+  useDune2 = true;
+  inherit version buildInputs strictDeps;
+
+  inherit minimumOCamlVersion;
+
+  src = fetchFromGitHub {
+    owner = "janestreet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = hash;
+  };
+
+  inherit doCheck;
+
+  meta = {
+    license = lib.licenses.mit;
+    homepage = "https://github.com/janestreet/${pname}";
+  } // args.meta;
+})

--- a/pkgs/development/ocaml-modules/janestreet/pythonlib.patch
+++ b/pkgs/development/ocaml-modules/janestreet/pythonlib.patch
@@ -1,0 +1,22 @@
+diff --git a/src/type.ml b/src/type.ml
+index 8a9e648..3f3b0e9 100644
+--- a/src/type.ml
++++ b/src/type.ml
+@@ -31,12 +31,12 @@ let of_type_desc type_desc ~env =
+     | Tunivar _ -> Or_error.error_string "not handled: Tunivar"
+     | Tvariant _ -> Or_error.error_string "not handled: Tvariant"
+     | Tnil -> Or_error.error_string "not handled: Tnil"
+-    | Tobject (_, _) -> Or_error.error_string "not handled: Tobject"
+-    | Tfield (_, _, _, _) -> Or_error.error_string "not handled: Tfield"
+-    | Tpackage (_, _, _) -> Or_error.error_string "not handled: Tpackage"
+-    | Tpoly (_, _) -> Or_error.error_string "not handled: Tpoly"
++    | Tobject _ -> Or_error.error_string "not handled: Tobject"
++    | Tfield _ -> Or_error.error_string "not handled: Tfield"
++    | Tpackage _ -> Or_error.error_string "not handled: Tpackage"
++    | Tpoly _ -> Or_error.error_string "not handled: Tpoly"
+     | Tlink e -> walk e.desc
+-    | Tsubst e -> walk e.desc
++    | Tsubst (e, _) -> walk e.desc
+     | Ttuple es ->
+       let%bind tuple = List.map es ~f:(fun e -> walk e.desc) |> Or_error.all in
+       (match tuple with

--- a/pkgs/development/ocaml-modules/phylogenetics/default.nix
+++ b/pkgs/development/ocaml-modules/phylogenetics/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildDunePackage
-, fetchurl
+, fetchFromGitHub
 , ppx_deriving
 , bppsuite
 , alcotest
@@ -16,17 +16,14 @@
 
 buildDunePackage rec {
   pname = "phylogenetics";
-  version = "0.1.0";
+  version = "unstable-2022-05-06";
 
-  src = fetchurl {
-    url = "https://github.com/biocaml/phylogenetics/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "sha256:064ldljzh17h8pp0c27xd1pf6c50yhccw2g3hddzhk07a95q8v16";
+  src = fetchFromGitHub {
+    owner = "biocaml";
+    repo = pname;
+    rev = "cd7c624d0f98e31b02933ca4511b9809b26d35b5";
+    sha256 = "sha256:0w0xyah3hj05hxg1rsa40hhma3dm1cyq0zvnjrihhf22laxap7ga";
   };
-
-  # Ensure compatibility with printbox ≥ 0.6
-  preConfigure = ''
-    substituteInPlace lib/dune --replace printbox printbox-text
-  '';
 
   minimalOCamlVersion = "4.08";
 

--- a/pkgs/development/ocaml-modules/tls/default.nix
+++ b/pkgs/development/ocaml-modules/tls/default.nix
@@ -6,11 +6,11 @@
 
 buildDunePackage rec {
   pname = "tls";
-  version = "0.15.2";
+  version = "0.15.3";
 
   src = fetchurl {
-    url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-v${version}.tbz";
-    sha256 = "b76371757249bbeabb12c333de4ea2a09c095767bdbbc83322538c0da1fc1e36";
+    url = "https://github.com/mirleft/ocaml-tls/releases/download/v${version}/tls-${version}.tbz";
+    sha256 = "0nj6fhgrirn8ky4hb24m3ilhr41ynzgk6bqmjs17g8rdibwmdd2x";
   };
 
   minimumOCamlVersion = "4.08";

--- a/pkgs/development/tools/comby/comby.patch
+++ b/pkgs/development/tools/comby/comby.patch
@@ -1,0 +1,1025 @@
+diff --git a/comby-kernel.opam b/comby-kernel.opam
+index 828c5a3..00f6c3d 100644
+--- a/comby-kernel.opam
++++ b/comby-kernel.opam
+@@ -20,7 +20,7 @@ build: [
+ depends: [
+   "dune" {>= "2.8.0"}
+   "ocaml" {>= "4.08.1"}
+-  "core_kernel"
++  "core_kernel" {>= "v0.15.0"}
+   "mparser" {>= "1.3"}
+   "mparser-pcre"
+   "ppx_deriving"
+diff --git a/comby-semantic.opam b/comby-semantic.opam
+index cb9dcc7..443749f 100644
+--- a/comby-semantic.opam
++++ b/comby-semantic.opam
+@@ -20,7 +20,7 @@ build: [
+ depends: [
+   "dune" {>= "2.8.0"}
+   "ocaml" {>= "4.08.1"}
+-  "core_kernel"
++  "core_kernel" {>= "v0.15.0"}
+   "ppx_deriving"
+   "lwt"
+   "cohttp"
+diff --git a/comby.opam b/comby.opam
+index 98bdc19..d45892c 100644
+--- a/comby.opam
++++ b/comby.opam
+@@ -31,7 +31,7 @@ depends: [
+   "cohttp-lwt-unix"
+   "comby-kernel" {= "1.7.0"}
+   "comby-semantic" {= "1.7.0"}
+-  "core"
++  "core" {>= "v0.15.0"}
+   "hack_parallel" {arch != "arm32" & arch != "arm64"}
+   "lwt"
+   "lwt_react"
+diff --git a/dune b/dune
+index 53b1312..a71571a 100644
+--- a/dune
++++ b/dune
+@@ -1,6 +1,8 @@
+ (env
+  (dev
+-  (flags (:standard -w A-3-4-32-34-37-39-40-41-42-44-45-48-49-50-57-60-66-67)))
++  (flags
++   (:standard -w A-3-4-32-34-37-39-40-41-42-44-45-48-49-50-57-60-66-67)))
+  (release
+-  (flags (:standard -w A-3-4-32-34-37-39-40-41-42-44-45-48-49-50-57-60-66-67))
+- (ocamlopt_flags (-O3))))
++  (flags
++   (:standard -w A-3-4-32-34-37-39-40-41-42-44-45-48-49-50-57-60-66-67))
++  (ocamlopt_flags (-O3))))
+diff --git a/lib/app/configuration/command_configuration.ml b/lib/app/configuration/command_configuration.ml
+index eed8420..aea4dfa 100644
+--- a/lib/app/configuration/command_configuration.ml
++++ b/lib/app/configuration/command_configuration.ml
+@@ -16,21 +16,21 @@ type 'a next =
+ 
+ let fold_directory ?(sorted=false) root ~init ~f =
+   let rec aux acc absolute_path depth =
+-    if Sys.is_file absolute_path = `Yes then
++    if Sys_unix.is_file absolute_path = `Yes then
+       match f acc ~depth ~absolute_path ~is_file:true with
+       | Continue acc
+       | Skip acc -> acc
+-    else if Sys.is_directory absolute_path = `Yes then
++    else if Sys_unix.is_directory absolute_path = `Yes then
+       match f acc ~depth ~absolute_path ~is_file:false with
+       | Skip acc -> acc
+       | Continue acc ->
+         let dir_contents =
+           if Option.is_some (Sys.getenv "COMBY_TEST") || sorted then
+-            Sys.ls_dir absolute_path
++            Sys_unix.ls_dir absolute_path
+             |> List.sort ~compare:String.compare
+             |> List.rev
+           else
+-            Sys.ls_dir absolute_path
++            Sys_unix.ls_dir absolute_path
+         in
+         List.fold dir_contents ~init:acc ~f:(fun acc subdir ->
+             aux acc (Filename.concat absolute_path subdir) (depth + 1))
+@@ -50,8 +50,8 @@ let parse_source_directories
+   let exact_file_paths, file_patterns =
+     List.partition_map file_filters ~f:(fun path ->
+         let is_exact path =
+-          (String.contains path '/' && Sys.is_file path = `Yes)
+-          || (Sys.is_file ("." ^/ path) = `Yes) (* See if it matches something in the current directory *)
++          (String.contains path '/' && Sys_unix.is_file path = `Yes)
++          || (Sys_unix.is_file ("." ^/ path) = `Yes) (* See if it matches something in the current directory *)
+         in
+         if is_exact path then Either.First path else Either.Second path)
+   in
+@@ -167,8 +167,8 @@ let parse_templates ?metasyntax ?(warn_for_missing_file_in_dir = false) paths =
+   let f acc ~depth:_ ~absolute_path ~is_file =
+     let is_leaf_directory absolute_path =
+       not is_file &&
+-      Sys.ls_dir absolute_path
+-      |> List.for_all ~f:(fun path -> Sys.is_directory (absolute_path ^/ path) = `No)
++      Sys_unix.ls_dir absolute_path
++      |> List.for_all ~f:(fun path -> Sys_unix.is_directory (absolute_path ^/ path) = `No)
+     in
+     if is_leaf_directory absolute_path then
+       match parse_directory absolute_path with
+@@ -178,7 +178,7 @@ let parse_templates ?metasyntax ?(warn_for_missing_file_in_dir = false) paths =
+       Continue acc
+   in
+   List.concat_map paths ~f:(fun path ->
+-      if Sys.is_directory path = `Yes then
++      if Sys_unix.is_directory path = `Yes then
+         fold_directory path ~sorted:true ~init:[] ~f
+       else
+         parse_toml ?metasyntax path)
+@@ -421,7 +421,7 @@ let parse_metasyntax metasyntax_path =
+   match metasyntax_path with
+   | None -> Matchers.Metasyntax.default_metasyntax
+   | Some metasyntax_path ->
+-    match Sys.file_exists metasyntax_path with
++    match Sys_unix.file_exists metasyntax_path with
+     | `No | `Unknown ->
+       Format.eprintf "Could not open file: %s@." metasyntax_path;
+       exit 1
+@@ -470,12 +470,12 @@ let emit_errors { input_options; output_options; _ } =
+     ; Option.is_some input_options.directory_depth
+       && Option.value_exn (input_options.directory_depth) < 0
+     , "-depth must be 0 or greater."
+-    ; Sys.is_directory input_options.target_directory = `No
++    ; Sys_unix.is_directory input_options.target_directory = `No
+     , "Directory specified with -d or -directory is not a directory."
+     ; output_options.json_only_diff && not output_options.json_lines
+     , "-json-only-diff can only be supplied with -json-lines."
+     ; Option.is_some output_options.interactive_review &&
+-      (not (String.equal input_options.target_directory (Sys.getcwd ())))
++      (not (String.equal input_options.target_directory (Sys_unix.getcwd ())))
+     , "Please remove the -d option and `cd` to the directory where you want to \
+        review from. The -review, -editor, or -default-no options should only be run \
+        at the root directory of the project files to patch."
+@@ -483,11 +483,11 @@ let emit_errors { input_options; output_options; _ } =
+          match input_options.templates with
+          | Some inputs ->
+            List.find_map inputs ~f:(fun input ->
+-               if Sys.is_file input = `Yes then
++               if Sys_unix.is_file input = `Yes then
+                  (match Toml.Parser.from_filename input with
+                   | `Error (s, _) -> Some s
+                   | _ -> None)
+-               else if not (Sys.is_directory input = `Yes) then
++               else if not (Sys_unix.is_directory input = `Yes) then
+                  Some (Format.sprintf "Directory %S specified with -templates is not a directory." input)
+                else
+                  None)
+@@ -599,7 +599,7 @@ let filter_zip_entries file_filters exclude_directory_prefix exclude_file_prefix
+ 
+ let syntax custom_matcher_path =
+   match
+-    Sys.file_exists custom_matcher_path with
++    Sys_unix.file_exists custom_matcher_path with
+   | `No | `Unknown ->
+     Format.eprintf "Could not open file: %s@." custom_matcher_path;
+     exit 1
+@@ -783,7 +783,7 @@ let create
+     | Directory ->
+       let target_directory =
+         if target_directory = "." then
+-          Filename.realpath target_directory
++          Filename_unix.realpath target_directory
+         else
+           target_directory
+       in
+diff --git a/lib/app/configuration/dune b/lib/app/configuration/dune
+index e0f9748..e417cfe 100644
+--- a/lib/app/configuration/dune
++++ b/lib/app/configuration/dune
+@@ -1,6 +1,21 @@
+ (library
+-  (name configuration)
+-  (public_name comby.configuration)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
+-  (libraries comby-kernel comby-semantic comby.patdiff comby.camlzip core yojson ppx_deriving_yojson toml lwt lwt.unix tar tar-unix))
++ (name configuration)
++ (public_name comby.configuration)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving.show ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
++ (libraries
++  comby-kernel
++  comby-semantic
++  comby.patdiff
++  comby.camlzip
++  core
++  core_unix.sys_unix
++  yojson
++  ppx_deriving_yojson
++  toml
++  lwt
++  lwt.unix
++  tar
++  tar-unix))
+diff --git a/lib/app/configuration/external_semantic.ml b/lib/app/configuration/external_semantic.ml
+index bdc7051..ac69b1b 100644
+--- a/lib/app/configuration/external_semantic.ml
++++ b/lib/app/configuration/external_semantic.ml
+@@ -2,13 +2,10 @@ open Core_kernel
+ 
+ open Comby_semantic
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ let lsif_hover ~name:_ ~filepath ~line ~column =
+-  String.chop_prefix_if_exists filepath ~prefix:(Sys.getcwd ()) |> fun filepath_relative_root ->
++  String.chop_prefix_if_exists filepath ~prefix:(Sys_unix.getcwd ()) |> fun filepath_relative_root ->
+   if debug then Format.printf "File relative root: %s@." filepath;
+   if debug then Format.printf "Querying type at %d::%d@." line column;
+   let context =
+diff --git a/lib/app/dune b/lib/app/dune
+index 2ed553c..a91f826 100644
+--- a/lib/app/dune
++++ b/lib/app/dune
+@@ -1,9 +1,8 @@
+ (library
+-  (name comby)
+-  (public_name comby)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
+-  (libraries 
+-   core 
+-   comby-kernel
+-   comby.pipeline))
++ (name comby)
++ (public_name comby)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
++ (libraries core comby-kernel comby.pipeline))
+diff --git a/lib/app/interactive/dune b/lib/app/interactive/dune
+index 815aff5..63c1757 100644
+--- a/lib/app/interactive/dune
++++ b/lib/app/interactive/dune
+@@ -1,5 +1,12 @@
+ (library
+-  (name interactive)
+-  (public_name comby.interactive)
+-  (preprocess (pps ppx_sexp_conv))
+-  (libraries comby-kernel comby.configuration core shell.filename_extended lwt lwt.unix))
++ (name interactive)
++ (public_name comby.interactive)
++ (preprocess
++  (pps ppx_sexp_conv))
++ (libraries
++  comby-kernel
++  comby.configuration
++  core
++  shell.filename_extended
++  lwt
++  lwt.unix))
+diff --git a/lib/app/interactive/interactive.ml b/lib/app/interactive/interactive.ml
+index d4bf200..b27105a 100644
+--- a/lib/app/interactive/interactive.ml
++++ b/lib/app/interactive/interactive.ml
+@@ -1,5 +1,6 @@
+ open Core
+ open Lwt
++module Unix = Core_unix
+ 
+ open Configuration
+ 
+@@ -37,6 +38,7 @@ module Diff = struct
+           ~big_enough:line_big_enough
+           ~prev
+           ~next
++          ()
+       | Some prog ->
+         let compare x y =
+           let cmd = sprintf "%s %S %S" prog x y in
+@@ -52,7 +54,7 @@ module Diff = struct
+             let compare = compare
+           end)
+         in
+-        P.get_hunks ~transform ~context ~big_enough:line_big_enough ~prev ~next
++        P.get_hunks ~transform ~context ~big_enough:line_big_enough ~prev ~next ()
+     in
+     match float_tolerance with
+     | None -> hunks
+diff --git a/lib/app/pipeline/dune b/lib/app/pipeline/dune
+index 3369b9e..e6ec880 100644
+--- a/lib/app/pipeline/dune
++++ b/lib/app/pipeline/dune
+@@ -1,11 +1,23 @@
+ (library
+-  (name pipeline)
+-  (public_name comby.pipeline)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_sexp_conv ppx_deriving_yojson))
+-  (libraries comby-kernel comby.statistics comby.configuration comby.interactive comby.camlzip core core.uuid yojson ppx_deriving_yojson parany
+-    (select parallel_hack.ml from
+-      (hack_parallel -> parallel_hack.available.ml)
+-      (!hack_parallel -> parallel_hack.parany_fallback.ml)) 
+-  ))
+-
++ (name pipeline)
++ (public_name comby.pipeline)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_sexp_conv ppx_deriving_yojson))
++ (libraries
++  comby-kernel
++  comby.statistics
++  comby.configuration
++  comby.interactive
++  comby.camlzip
++  core
++  core_unix.uuid
++  yojson
++  ppx_deriving_yojson
++  parany
++  (select
++   parallel_hack.ml
++   from
++   (hack_parallel -> parallel_hack.available.ml)
++   (!hack_parallel -> parallel_hack.parany_fallback.ml))))
+diff --git a/lib/app/pipeline/parallel_hack.available.ml b/lib/app/pipeline/parallel_hack.available.ml
+index a901eea..ad33070 100644
+--- a/lib/app/pipeline/parallel_hack.available.ml
++++ b/lib/app/pipeline/parallel_hack.available.ml
+@@ -1,4 +1,5 @@
+ open Core
++module Unix = Core_unix
+ 
+ open Hack_parallel
+ 
+diff --git a/lib/app/statistics/dune b/lib/app/statistics/dune
+index b14d5b1..12aff7f 100644
+--- a/lib/app/statistics/dune
++++ b/lib/app/statistics/dune
+@@ -1,6 +1,8 @@
+ (library
+-  (name statistics)
+-  (public_name comby.statistics)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving_yojson))
+-  (libraries yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))
++ (name statistics)
++ (public_name comby.statistics)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving_yojson))
++ (libraries yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))
+diff --git a/lib/app/vendored/camlzip/dune b/lib/app/vendored/camlzip/dune
+index 56ea8ff..1c67be1 100644
+--- a/lib/app/vendored/camlzip/dune
++++ b/lib/app/vendored/camlzip/dune
+@@ -7,7 +7,9 @@
+  ; as long as the unix parts are not needed, but I want it to 
+  ; compile executables for tests
+  (libraries unix)
+- (foreign_stubs (language c) (names zlibstubs))
++ (foreign_stubs
++  (language c)
++  (names zlibstubs))
+  (c_library_flags
+   (:include c_flags.sexp)
+   (:include c_library_flags.sexp)))
+@@ -21,7 +23,9 @@
+ 
+ (env
+  (dev
+-  (flags (:standard -w A-3-4-27-29-32-34-35-39-40-41-42-44-45-48-49-50-57-60)))
++  (flags
++   (:standard -w A-3-4-27-29-32-34-35-39-40-41-42-44-45-48-49-50-57-60)))
+  (release
+-  (flags (:standard -w A-3-4-27-29-32-34-35-39-40-41-42-44-45-48-49-50-57-60))
+- (ocamlopt_flags (-O3))))
++  (flags
++   (:standard -w A-3-4-27-29-32-34-35-39-40-41-42-44-45-48-49-50-57-60))
++  (ocamlopt_flags (-O3))))
+diff --git a/lib/app/vendored/patdiff/kernel/src/dune b/lib/app/vendored/patdiff/kernel/src/dune
+index 7a6353d..b79cba2 100644
+--- a/lib/app/vendored/patdiff/kernel/src/dune
++++ b/lib/app/vendored/patdiff/kernel/src/dune
+@@ -1,3 +1,6 @@
+-(library (name patdiff_kernel) (public_name comby.patdiff_kernel)
++(library
++ (name patdiff_kernel)
++ (public_name comby.patdiff_kernel)
+  (libraries core_kernel.composition_infix core_kernel patience_diff re)
+- (preprocess (pps ppx_jane)))
++ (preprocess
++  (pps ppx_jane)))
+diff --git a/lib/app/vendored/patdiff/kernel/src/patdiff_core.ml b/lib/app/vendored/patdiff/kernel/src/patdiff_core.ml
+index 4f53a0b..88ee0e3 100644
+--- a/lib/app/vendored/patdiff/kernel/src/patdiff_core.ml
++++ b/lib/app/vendored/patdiff/kernel/src/patdiff_core.ml
+@@ -138,6 +138,7 @@ module Make (Output_impls : Output_impls) = struct
+       ~big_enough:line_big_enough
+       ~prev
+       ~next
++      ()
+   ;;
+ 
+   type word_or_newline =
+@@ -345,6 +346,7 @@ module Make (Output_impls : Output_impls) = struct
+       ~big_enough:word_big_enough
+       ~prev:prev_pieces
+       ~next:next_pieces
++      ()
+   ;;
+ 
+   let ranges_are_just_whitespace (ranges : _ Patience_diff.Range.t list) =
+diff --git a/lib/app/vendored/patdiff/lib/src/compare_core.ml b/lib/app/vendored/patdiff/lib/src/compare_core.ml
+index fafb201..8b40d09 100644
+--- a/lib/app/vendored/patdiff/lib/src/compare_core.ml
++++ b/lib/app/vendored/patdiff/lib/src/compare_core.ml
+@@ -1,5 +1,6 @@
+ open! Core
+ open! Import
++module Unix = Core_unix
+ 
+ let lines_of_contents contents =
+   let lines = Array.of_list (String.split_lines contents) in
+@@ -100,6 +101,7 @@ let compare_lines (config : Configuration.t) ?prev_diff ?next_diff ~prev ~next (
+         ~big_enough:line_big_enough
+         ~prev
+         ~next
++        ()
+     | Some prog ->
+       let compare x y =
+         let cmd = sprintf "%s %S %S" prog x y in
+@@ -116,7 +118,7 @@ let compare_lines (config : Configuration.t) ?prev_diff ?next_diff ~prev ~next (
+           let compare = compare
+         end)
+       in
+-      P.get_hunks ~transform ~context ~big_enough:line_big_enough ~prev ~next
++      P.get_hunks ~transform ~context ~big_enough:line_big_enough ~prev ~next ()
+   in
+   let hunks =
+     match config.float_tolerance with
+@@ -361,7 +363,7 @@ let rec diff_dirs_internal (config : Configuration.t) ~prev_dir ~next_dir ~file_
+       | None -> Fn.const true
+       | Some file_filter -> file_filter
+     in
+-    Sys.ls_dir (File_name.real_name_exn dir)
++    Sys_unix.ls_dir (File_name.real_name_exn dir)
+     |> List.filter ~f:(fun x ->
+       let x = File_name.real_name_exn dir ^/ x in
+       match Unix.stat x with
+diff --git a/lib/app/vendored/patdiff/lib/src/compare_core.mli b/lib/app/vendored/patdiff/lib/src/compare_core.mli
+index e919512..caa8dcb 100644
+--- a/lib/app/vendored/patdiff/lib/src/compare_core.mli
++++ b/lib/app/vendored/patdiff/lib/src/compare_core.mli
+@@ -1,5 +1,6 @@
+ open! Core
+ open! Import
++module Unix = Core_unix
+ 
+ val diff_files
+   :  Configuration.t
+diff --git a/lib/app/vendored/patdiff/lib/src/configuration.ml b/lib/app/vendored/patdiff/lib/src/configuration.ml
+index 6879daa..7d59706 100644
+--- a/lib/app/vendored/patdiff/lib/src/configuration.ml
++++ b/lib/app/vendored/patdiff/lib/src/configuration.ml
+@@ -481,7 +481,7 @@ let rec load_exn' ~set config_file =
+        | Error _another_exn -> raise exn
+        | Ok c ->
+          (let new_file = config_file ^ ".new" in
+-          match Sys.file_exists new_file with
++          match Sys_unix.file_exists new_file with
+           | `Yes | `Unknown -> ()
+           | `No ->
+             (try Sexp.save_hum new_file (On_disk.V1.sexp_of_t c) with
+@@ -564,7 +564,7 @@ let get_config ?filename () =
+       (* ~/.patdiff exists *)
+       Option.bind (Sys.getenv "HOME") ~f:(fun home ->
+         let f = home ^/ ".patdiff" in
+-        match Sys.file_exists f with
++        match Sys_unix.file_exists f with
+         | `Yes -> Some f
+         | `No | `Unknown -> None)
+   in
+diff --git a/lib/app/vendored/patdiff/lib/src/dune b/lib/app/vendored/patdiff/lib/src/dune
+index 007acad..b6a0f80 100644
+--- a/lib/app/vendored/patdiff/lib/src/dune
++++ b/lib/app/vendored/patdiff/lib/src/dune
+@@ -1,4 +1,13 @@
+-(library (name patdiff) (public_name comby.patdiff)
+- (libraries core_kernel.composition_infix core core.linux_ext comby.patdiff_kernel
++(library
++ (name patdiff)
++ (public_name comby.patdiff)
++ (libraries
++  core_kernel.composition_infix
++  core
++  core_unix
++  core_unix.linux_ext
++  core_unix.sys_unix
++  comby.patdiff_kernel
+   patience_diff)
+- (preprocess (pps ppx_jane)))
++ (preprocess
++  (pps ppx_jane)))
+diff --git a/lib/app/vendored/patdiff/lib/src/html_output.ml b/lib/app/vendored/patdiff/lib/src/html_output.ml
+index 3d08f91..93ae8af 100644
+--- a/lib/app/vendored/patdiff/lib/src/html_output.ml
++++ b/lib/app/vendored/patdiff/lib/src/html_output.ml
+@@ -1,5 +1,6 @@
+ open! Core
+ open! Import
++module Unix = Core_unix
+ 
+ include Patdiff_kernel.Html_output.Private.Make (struct
+     let mtime file =
+diff --git a/lib/kernel/dune b/lib/kernel/dune
+index 0961dad..07a929b 100644
+--- a/lib/kernel/dune
++++ b/lib/kernel/dune
+@@ -1,10 +1,12 @@
+ (library
+-  (name comby_kernel)
+-  (public_name comby-kernel)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
+-  (libraries 
+-   core_kernel
+-   comby-kernel.match
+-   comby-kernel.matchers
+-   comby-kernel.replacement))
++ (name comby_kernel)
++ (public_name comby-kernel)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
++ (libraries
++  core_kernel
++  comby-kernel.match
++  comby-kernel.matchers
++  comby-kernel.replacement))
+diff --git a/lib/kernel/match/dune b/lib/kernel/match/dune
+index 03b120a..4d48b61 100644
+--- a/lib/kernel/match/dune
++++ b/lib/kernel/match/dune
+@@ -1,6 +1,12 @@
+ (library
+-  (name match)
+-  (public_name comby-kernel.match)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson))
+-  (libraries core_kernel yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))
++ (name match)
++ (public_name comby-kernel.match)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving.eq ppx_sexp_conv ppx_deriving_yojson))
++ (libraries
++  core_kernel
++  yojson
++  ppx_deriving_yojson
++  ppx_deriving_yojson.runtime))
+diff --git a/lib/kernel/matchers/alpha.ml b/lib/kernel/matchers/alpha.ml
+index e31094d..01adb52 100644
+--- a/lib/kernel/matchers/alpha.ml
++++ b/lib/kernel/matchers/alpha.ml
+@@ -13,20 +13,11 @@ module R = MakeRegexp(Regexp)
+ let configuration_ref = ref (Configuration.create ())
+ let weaken_delimiter_hole_matching = false
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+-let debug_hole =
+-  match Sys.getenv "DEBUG_COMBY_HOLE" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug_hole = Sys.getenv "DEBUG_COMBY_HOLE" |> Option.is_some
+ 
+-let debug_position =
+-  match Sys.getenv "DEBUG_COMBY_POS" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug_position = Sys.getenv "DEBUG_COMBY_POS" |> Option.is_some
+ 
+ let f _ = return Types.Unit
+ 
+@@ -147,7 +138,7 @@ module Make (Lang : Types.Language.S) (Meta : Types.Metasyntax.S) (Ext : Types.E
+         ]
+       >>= fun _ -> f Types.Unit
+ 
+-    let sequence_chain (plist : ('c, Match.t) parser sexp_list) : ('c, Match.t) parser =
++    let sequence_chain (plist : ('c, Match.t) parser list) : ('c, Match.t) parser =
+       List.fold plist ~init:(return Types.Unit) ~f:(>>)
+ 
+     let with_debug_matcher s tag =
+diff --git a/lib/kernel/matchers/dune b/lib/kernel/matchers/dune
+index 12ed326..4625458 100644
+--- a/lib/kernel/matchers/dune
++++ b/lib/kernel/matchers/dune
+@@ -1,6 +1,18 @@
+ (library
+-  (name matchers)
+-  (public_name comby-kernel.matchers)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
+-  (libraries comby-kernel.replacement comby-kernel.parsers comby-kernel.match comby-kernel.vangstrom core_kernel mparser mparser-pcre re yojson ppx_deriving_yojson))
++ (name matchers)
++ (public_name comby-kernel.matchers)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_here ppx_sexp_conv ppx_sexp_message ppx_deriving_yojson))
++ (libraries
++  comby-kernel.replacement
++  comby-kernel.parsers
++  comby-kernel.match
++  comby-kernel.vangstrom
++  core_kernel
++  mparser
++  mparser-pcre
++  re
++  yojson
++  ppx_deriving_yojson))
+diff --git a/lib/kernel/matchers/evaluate.ml b/lib/kernel/matchers/evaluate.ml
+index 9ea71a0..288f79a 100644
+--- a/lib/kernel/matchers/evaluate.ml
++++ b/lib/kernel/matchers/evaluate.ml
+@@ -3,10 +3,7 @@ open Core_kernel
+ open Match
+ open Types.Ast
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ type result = bool * Match.environment option
+ 
+diff --git a/lib/kernel/matchers/omega.ml b/lib/kernel/matchers/omega.ml
+index eeec516..1eb3ccc 100644
+--- a/lib/kernel/matchers/omega.ml
++++ b/lib/kernel/matchers/omega.ml
+@@ -32,15 +32,9 @@ let push_source_ref : string ref = ref ""
+ 
+ let filepath_ref : string option ref = ref None
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+-let rewrite =
+-  match Sys.getenv "REWRITE" with
+-  | exception Not_found -> false
+-  | _ -> true
++let rewrite = Sys.getenv "REWRITE" |> Option.is_some
+ 
+ let actual = Buffer.create 10
+ 
+diff --git a/lib/kernel/matchers/preprocess.ml b/lib/kernel/matchers/preprocess.ml
+index 84f3ed0..b6d10e7 100644
+--- a/lib/kernel/matchers/preprocess.ml
++++ b/lib/kernel/matchers/preprocess.ml
+@@ -1,9 +1,6 @@
+ open Core_kernel
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ let append_rule (module Parser : Types.Rule.S) rule parent_rule =
+   let open Option in
+diff --git a/lib/kernel/matchers/regexp.ml b/lib/kernel/matchers/regexp.ml
+index ef0bd59..906820b 100644
+--- a/lib/kernel/matchers/regexp.ml
++++ b/lib/kernel/matchers/regexp.ml
+@@ -3,7 +3,7 @@ open Vangstrom
+ let debug =
+   match Sys.getenv "DEBUG_COMBY" with
+   | exception Not_found -> false
+-  | _ -> true
++  | (_ : string) -> true
+ 
+ module type Regexp_engine_intf = sig
+   type t
+diff --git a/lib/kernel/matchers/rewrite.ml b/lib/kernel/matchers/rewrite.ml
+index 32c4740..2fc28db 100644
+--- a/lib/kernel/matchers/rewrite.ml
++++ b/lib/kernel/matchers/rewrite.ml
+@@ -4,10 +4,7 @@ open Core_kernel
+ open Match
+ open Replacement
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ let counter =
+   let uuid_for_id_counter = ref 0 in
+diff --git a/lib/kernel/matchers/template.ml b/lib/kernel/matchers/template.ml
+index 423a07f..136236c 100644
+--- a/lib/kernel/matchers/template.ml
++++ b/lib/kernel/matchers/template.ml
+@@ -4,10 +4,7 @@ open Core_kernel
+ open Match
+ open Types.Template
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ module Make (Metasyntax : Types.Metasyntax.S) (External : Types.External.S) : Types.Template.S = struct
+ 
+diff --git a/lib/kernel/parsers/dune b/lib/kernel/parsers/dune
+index 28b020c..0cc1fa5 100644
+--- a/lib/kernel/parsers/dune
++++ b/lib/kernel/parsers/dune
+@@ -1,6 +1,8 @@
+ (library
+-  (name parsers)
+-  (public_name comby-kernel.parsers)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_sexp_conv))
+-  (libraries core_kernel comby-kernel.vangstrom mparser))
++ (name parsers)
++ (public_name comby-kernel.parsers)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_sexp_conv))
++ (libraries core_kernel comby-kernel.vangstrom mparser))
+diff --git a/lib/kernel/replacement/dune b/lib/kernel/replacement/dune
+index 3e62de6..485b716 100644
+--- a/lib/kernel/replacement/dune
++++ b/lib/kernel/replacement/dune
+@@ -1,6 +1,13 @@
+ (library
+-  (name replacement)
+-  (public_name comby-kernel.replacement)
+-  (instrumentation (backend bisect_ppx))
+-  (preprocess (pps ppx_deriving_yojson))
+-  (libraries comby-kernel.match core_kernel yojson ppx_deriving_yojson ppx_deriving_yojson.runtime))
++ (name replacement)
++ (public_name comby-kernel.replacement)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving_yojson))
++ (libraries
++  comby-kernel.match
++  core_kernel
++  yojson
++  ppx_deriving_yojson
++  ppx_deriving_yojson.runtime))
+diff --git a/lib/semantic/dune b/lib/semantic/dune
+index 9a244d3..186a2ed 100644
+--- a/lib/semantic/dune
++++ b/lib/semantic/dune
+@@ -1,11 +1,8 @@
+ (library
+-   (name comby_semantic)
+-   (public_name comby-semantic)
+-   (instrumentation (backend bisect_ppx))
+-   (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
+-   (libraries
+-      core_kernel
+-      lwt
+-      cohttp
+-      cohttp-lwt-unix
+-      yojson))
++ (name comby_semantic)
++ (public_name comby-semantic)
++ (instrumentation
++  (backend bisect_ppx))
++ (preprocess
++  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv))
++ (libraries core_kernel lwt cohttp cohttp-lwt-unix yojson))
+diff --git a/lib/semantic/lsif.ml b/lib/semantic/lsif.ml
+index 49747bc..d6b3e19 100644
+--- a/lib/semantic/lsif.ml
++++ b/lib/semantic/lsif.ml
+@@ -3,10 +3,7 @@ open Lwt
+ open Cohttp
+ open Cohttp_lwt_unix
+ 
+-let debug =
+-  match Sys.getenv "DEBUG_COMBY" with
+-  | exception Not_found -> false
+-  | _ -> true
++let debug = Sys.getenv "DEBUG_COMBY" |> Option.is_some
+ 
+ module Formatting = struct
+   type t =
+diff --git a/src/dune b/src/dune
+index 444a5a3..f006195 100644
+--- a/src/dune
++++ b/src/dune
+@@ -1,10 +1,17 @@
+ (executables
+- (libraries comby core ppx_deriving_yojson ppx_deriving_yojson.runtime
+-    (select if_hack_parallel.ml from
+-      (hack_parallel -> if_hack_parallel.available.ml)
+-      (!hack_parallel -> if_hack_parallel.unavailable.ml))
+- )
+- (preprocess (pps ppx_deriving_yojson ppx_let ppx_deriving.show ppx_sexp_conv))
++ (libraries
++  comby
++  core
++  core_unix.command_unix
++  ppx_deriving_yojson
++  ppx_deriving_yojson.runtime
++  (select
++   if_hack_parallel.ml
++   from
++   (hack_parallel -> if_hack_parallel.available.ml)
++   (!hack_parallel -> if_hack_parallel.unavailable.ml)))
++ (preprocess
++  (pps ppx_deriving_yojson ppx_let ppx_deriving.show ppx_sexp_conv))
+  (modules main if_hack_parallel)
+  (modes byte exe)
+  (names main))
+@@ -20,4 +27,5 @@
+ (install
+  (package comby)
+  (section bin)
+- (files (main.exe as comby)))
++ (files
++  (main.exe as comby)))
+diff --git a/src/main.ml b/src/main.ml
+index 5cad346..48784d1 100644
+--- a/src/main.ml
++++ b/src/main.ml
+@@ -1,4 +1,5 @@
+ open Core
++module Unix = Core_unix
+ open Command.Let_syntax
+ 
+ open Comby_kernel
+@@ -47,7 +48,7 @@ let substitute_environment_only_and_exit metasyntax_path anonymous_arguments jso
+     match metasyntax_path with
+     | None -> Matchers.Metasyntax.default_metasyntax
+     | Some metasyntax_path ->
+-      match Sys.file_exists metasyntax_path with
++      match Sys_unix.file_exists metasyntax_path with
+       | `No | `Unknown ->
+         Format.eprintf "Could not open file: %s@." metasyntax_path;
+         exit 1
+@@ -95,7 +96,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
+     and verbose = flag "verbose" no_arg ~doc:(Format.sprintf "Log to %s" verbose_out_file)
+     and rule = flag "rule" (optional_with_default "where true" string) ~doc:"rule Apply rules to matches."
+     and match_timeout = flag "timeout" (optional_with_default 3 int) ~doc:"seconds Set match timeout on a source. Default: 3 seconds"
+-    and target_directory = flag "directory" ~aliases:["d"] (optional_with_default (Sys.getcwd ()) string) ~doc:(Format.sprintf "path Run recursively on files in a directory relative to the root. Default is current directory: %s" @@ Sys.getcwd ())
++    and target_directory = flag "directory" ~aliases:["d"] (optional_with_default (Sys_unix.getcwd ()) string) ~doc:(Format.sprintf "path Run recursively on files in a directory relative to the root. Default is current directory: %s" @@ Sys_unix.getcwd ())
+     and directory_depth = flag "depth" (optional int) ~doc:"n Depth to recursively descend into directories"
+     and templates = flag "templates" ~aliases:["config"; "configuration"] (optional (Arg_type.comma_separated string)) ~doc:"paths CSV of directories containing templates, or TOML configuration files"
+     and file_filters = flag "extensions" ~aliases:["e"; "file-extensions"; "f"] (optional (Arg_type.comma_separated string)) ~doc:"extensions Comma-separated extensions to include, like \".go\" or \".c,.h\". It is just a file suffix, so you can use it to filter file names like \"main.go\". The extension will be used to infer a matcher, unless -custom-matcher or -matcher is specified"
+@@ -146,7 +147,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
+       | l ->
+         List.map l ~f:(fun pattern ->
+             if String.contains pattern '/' then
+-              match Filename.realpath pattern with
++              match Filename_unix.realpath pattern with
+               | exception Unix.Unix_error _ ->
+                 Format.eprintf
+                   "No such file or directory: %s. Comby interprets \
+@@ -203,7 +204,7 @@ let base_command_parameters : (unit -> 'result) Command.Param.t =
+     let omega = omega || omega_env in
+     let fast_offset_conversion_env = Option.is_some @@ Sys.getenv "FAST_OFFSET_CONVERSION_COMBY" in
+     let fast_offset_conversion = fast_offset_conversion_env || fast_offset_conversion in
+-    let arch = Unix.Utsname.machine (Core.Unix.uname ()) in
++    let arch = Unix.Utsname.machine (Unix.uname ()) in
+     let compute_mode = match sequential, parany, arch with
+       | true, _, _ -> `Sequential
+       | _, true, _
+@@ -301,7 +302,7 @@ let parse_comby_dot_file () =
+ 
+ let () =
+   If_hack_parallel.check_entry_point ();
+-  Command.run default_command ~version:"1.7.1" ~extend:(fun _ ->
+-      match Sys.file_exists ".comby" with
++  Command_unix.run default_command ~version:"1.7.1" ~extend:(fun _ ->
++      match Sys_unix.file_exists ".comby" with
+       | `Yes -> parse_comby_dot_file ()
+       | _ -> [])
+diff --git a/test/alpha/dune b/test/alpha/dune
+index d7e5532..020677c 100644
+--- a/test/alpha/dune
++++ b/test/alpha/dune
+@@ -1,17 +1,14 @@
+ (library
+  (name alpha_test_integration)
+  (package comby)
+- (modules
+-  test_special_matcher_cases
+-  test_substring_disabled)
++ (modules test_special_matcher_cases test_substring_disabled)
+  (inline_tests)
+- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
+- (libraries
+-  comby
+-  cohttp-lwt-unix
+-  core
+-  camlzip))
++ (preprocess
++  (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
++ (libraries comby cohttp-lwt-unix core camlzip))
+ 
+ (alias
+-(name runtest)
+-(deps (source_tree example) (source_tree example/src/.ignore-me)))
++ (name runtest)
++ (deps
++  (source_tree example)
++  (source_tree example/src/.ignore-me)))
+diff --git a/test/common/dune b/test/common/dune
+index aa83b0c..3793242 100644
+--- a/test/common/dune
++++ b/test/common/dune
+@@ -34,16 +34,14 @@
+   test_regex_holes
+   test_template_constraints
+   test_custom_metasyntax
+-  test_rewrite_attributes
+-  )
++  test_rewrite_attributes)
+  (inline_tests)
+- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
+- (libraries
+-  comby
+-  cohttp-lwt-unix
+-  core
+-  camlzip))
++ (preprocess
++  (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
++ (libraries comby cohttp-lwt-unix core camlzip))
+ 
+ (alias
+-(name runtest)
+-(deps (source_tree example) (source_tree example/src/.ignore-me)))
++ (name runtest)
++ (deps
++  (source_tree example)
++  (source_tree example/src/.ignore-me)))
+diff --git a/test/common/test_cli.ml b/test/common/test_cli.ml
+index 3606367..d5d0c0b 100644
+--- a/test/common/test_cli.ml
++++ b/test/common/test_cli.ml
+@@ -1,7 +1,10 @@
+ open Core
+ open Camlzip
+ 
++module Filename = Filename_unix
++module Sys = Sys_unix
+ module Time = Core_kernel.Time_ns.Span
++module Unix = Core_unix
+ 
+ let binary_path = "../../../../comby"
+ 
+diff --git a/test/common/test_cli_helper.ml b/test/common/test_cli_helper.ml
+index 5791ee6..18372ae 100644
+--- a/test/common/test_cli_helper.ml
++++ b/test/common/test_cli_helper.ml
+@@ -1,6 +1,7 @@
+ open Core
+ 
+ module Time = Core_kernel.Time_ns.Span
++module Unix = Core_unix
+ 
+ let binary_path = "../../../../comby"
+ 
+diff --git a/test/omega/dune b/test/omega/dune
+index 3b31a7e..bf68dcb 100644
+--- a/test/omega/dune
++++ b/test/omega/dune
+@@ -2,20 +2,19 @@
+  (name omega_test_integration)
+  (package comby)
+  (modules
+-;
+-; TODO
+-;
++  ;
++  ; TODO
++  ;
+   test_optional_holes
+   test_special_matcher_cases
+   test_substring_disabled)
+  (inline_tests)
+- (preprocess (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
+- (libraries
+-  comby
+-  cohttp-lwt-unix
+-  core
+-  camlzip))
++ (preprocess
++  (pps ppx_expect ppx_sexp_message ppx_deriving_yojson))
++ (libraries comby cohttp-lwt-unix core camlzip))
+ 
+ (alias
+-(name runtest)
+-(deps (source_tree example) (source_tree example/src/.ignore-me)))
++ (name runtest)
++ (deps
++  (source_tree example)
++  (source_tree example/src/.ignore-me)))

--- a/pkgs/development/tools/comby/default.nix
+++ b/pkgs/development/tools/comby/default.nix
@@ -26,6 +26,8 @@ let
         sha256 = "0k60hj8wcrvrk0isr210vnalylkd63ria1kgz5n49inl7w1hfwpv";
       };
 
+      patches = [ ./comby.patch ];
+
       nativeBuildInputs = [
         ocamlPackages.ppx_deriving
         ocamlPackages.ppx_deriving_yojson
@@ -35,6 +37,7 @@ let
 
       buildInputs = [
         ocamlPackages.core
+        ocamlPackages.core_kernel
         ocamlPackages.ocaml_pcre
         ocamlPackages.mparser
         ocamlPackages.mparser-pcre

--- a/pkgs/tools/misc/flitter/default.nix
+++ b/pkgs/tools/misc/flitter/default.nix
@@ -20,11 +20,17 @@ ocamlPackages.buildDunePackage rec {
     sha256 = "1k3m7bjq5yrrq7vhnbdykni65dsqhq6knnv9wvwq3svb3n07z4w3";
   };
 
+  # compatibility with core >= 0.15
+  patches = [ ./flitter.patch ];
+
   # https://github.com/alexozer/flitter/issues/28
   postPatch = ''
-    for f in src/colors.ml src/duration.ml src/event_loop.ml src/splits.ml; do
+    for f in src/*.ml; do
       substituteInPlace "$f" \
-        --replace 'Unix.gettimeofday' 'Caml_unix.gettimeofday'
+        --replace 'Unix.gettimeofday' 'Caml_unix.gettimeofday' \
+        --replace 'Core_kernel' 'Core' \
+        --replace 'sexp_option' 'option[@sexp.option]' \
+        --replace 'sexp_list' 'list[@sexp.list]'
     done
   '';
 
@@ -33,7 +39,7 @@ ocamlPackages.buildDunePackage rec {
   ];
 
   buildInputs = with ocamlPackages; [
-    core
+    core_unix
     lwt_ppx
     sexp_pretty
     color

--- a/pkgs/tools/misc/flitter/flitter.patch
+++ b/pkgs/tools/misc/flitter/flitter.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dune b/src/dune
+index a50b09a..54cc770 100644
+--- a/src/dune
++++ b/src/dune
+@@ -1,7 +1,7 @@
+ (library
+   (name flitter)
+   (wrapped false)
+-  (libraries core lwt.unix notty notty.unix re color sexp_pretty)
++  (libraries core core_kernel.caml_unix lwt.unix notty notty.unix re color sexp_pretty)
+   (preprocess (pps lwt_ppx ppx_sexp_conv))
+   )
+ 

--- a/pkgs/tools/misc/patdiff/default.nix
+++ b/pkgs/tools/misc/patdiff/default.nix
@@ -4,8 +4,8 @@ with ocamlPackages;
 
 janePackage {
   pname = "patdiff";
-  hash = "1yslj6xxyv8rx8y5s1civ1zq8y6vvxmkszdds958zdm1p1ign54r";
-  buildInputs = [ core patience_diff ocaml_pcre ];
+  hash = "0623a7n5r659rkxbp96g361mvxkcgc6x9lcbkm3glnppplk5kxr9";
+  propagatedBuildInputs = [ core_unix patience_diff ocaml_pcre ];
   meta = {
     description = "File Diff using the Patience Diff algorithm";
   };

--- a/pkgs/tools/typesetting/satysfi/default.nix
+++ b/pkgs/tools/typesetting/satysfi/default.nix
@@ -50,6 +50,8 @@ in
       $out/share/satysfi
     '';
 
+    DUNE_PROFILE = "release";
+
     nativeBuildInputs = [ ruby dune_2 ];
 
     buildInputs = [ camlpdf otfm yojson-with-position ] ++ (with ocamlPackages; [

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1535,14 +1535,21 @@ let
     # Jane Street
 
     janePackage =
-      if lib.versionOlder "4.08" ocaml.version
+      if lib.versionOlder "4.10.2" ocaml.version
+      then callPackage ../development/ocaml-modules/janestreet/janePackage_0_15.nix {}
+      else if lib.versionOlder "4.08" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/janePackage_0_14.nix {}
       else if lib.versionOlder "4.07" ocaml.version
       then callPackage ../development/ocaml-modules/janestreet/janePackage_0_12.nix {}
       else callPackage ../development/ocaml-modules/janestreet/janePackage.nix {};
 
     janeStreet =
-    if lib.versionOlder "4.08" ocaml.version
+    if lib.versionOlder "4.10.2" ocaml.version
+    then import ../development/ocaml-modules/janestreet/0.15.nix {
+      inherit self;
+      inherit (pkgs) fetchpatch lib openssl patdiff zstd;
+    }
+    else if lib.versionOlder "4.08" ocaml.version
     then import ../development/ocaml-modules/janestreet/0.14.nix {
       inherit self;
       inherit (pkgs) fetchpatch lib openssl zstd;


### PR DESCRIPTION
###### Description of changes

- Major breaking change: the library Core_kernel is no more.  The opam packages core and core_kernel have been shuffled around, so core is now platform-independent, and the Unix-dependent parts are now in core_unix.  See https://discuss.ocaml.org/t/goodbye-core-kernel/8393
- Package sexp_diff_kernel was renamed sexp_diff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
