### PR TITLE
Add `formats.javaProperties`

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -32,6 +32,20 @@ type of this option should represent the format. The most common formats
 have a predefined type and string generator already declared under
 `pkgs.formats`:
 
+`pkgs.formats.javaProperties` { *`comment`* ? `"Generated with Nix"` }
+
+:   A function taking an attribute set with values
+
+    `comment`
+
+    :   A string to put at the start of the
+        file in a comment. It can have multiple
+        lines.
+
+    It returns the `type`: `attrsOf str` and a function
+    `generate` to build a Java `.properties` file, taking
+    care of the correct escaping, etc.
+
 `pkgs.formats.json` { }
 
 :   A function taking an empty attribute set (for future extensibility)

--- a/nixos/doc/manual/from_md/development/settings-options.section.xml
+++ b/nixos/doc/manual/from_md/development/settings-options.section.xml
@@ -55,6 +55,38 @@
     <variablelist>
       <varlistentry>
         <term>
+          <literal>pkgs.formats.javaProperties</literal> {
+          <emphasis><literal>comment</literal></emphasis> ?
+          <literal>&quot;Generated with Nix&quot;</literal> }
+        </term>
+        <listitem>
+          <para>
+            A function taking an attribute set with values
+          </para>
+          <variablelist>
+            <varlistentry>
+              <term>
+                <literal>comment</literal>
+              </term>
+              <listitem>
+                <para>
+                  A string to put at the start of the file in a comment.
+                  It can have multiple lines.
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+          <para>
+            It returns the <literal>type</literal>:
+            <literal>attrsOf str</literal> and a function
+            <literal>generate</literal> to build a Java
+            <literal>.properties</literal> file, taking care of the
+            correct escaping, etc.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
           <literal>pkgs.formats.json</literal> { }
         </term>
         <listitem>

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -31,6 +31,9 @@ rec {
   */
 
 
+  inherit (import ./formats/java-properties/default.nix { inherit lib pkgs; })
+    javaProperties;
+
   json = {}: {
 
     type = with lib.types; let

--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -1,6 +1,6 @@
 { lib, pkgs }:
 {
-  javaProperties = {}: {
+  javaProperties = { comment ? "Generated with Nix" }: {
     type = lib.types.attrsOf lib.types.str;
 
     generate = name: value:
@@ -76,10 +76,15 @@
 
           inputEncoding = "UTF-8";
 
+          inherit comment;
+
         } ''
-        jq -r --arg hash '#' "$jqCode" "$valuePath" \
-          | iconv --from-code "$inputEncoding" --to-code JAVA \
-          > "$out"
+        (
+          echo "$comment" | while read -r ln; do echo "# $ln"; done
+          echo
+          jq -r --arg hash '#' "$jqCode" "$valuePath" \
+            | iconv --from-code "$inputEncoding" --to-code JAVA \
+        ) > "$out"
       '';
   };
 }

--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -1,0 +1,85 @@
+{ lib, pkgs }:
+{
+  javaProperties = {}: {
+    type = lib.types.attrsOf lib.types.str;
+
+    generate = name: value:
+      pkgs.runCommandLocal name
+        {
+          # Requirements
+          # ============
+          #
+          #  1. Strings in Nix carry over to the same
+          #     strings in Java => need proper escapes
+          #  2. Generate files quickly
+          #      - A JVM would have to match the app's
+          #        JVM to avoid build closure bloat
+          #      - Even then, JVM startup would slow
+          #        down config generation.
+          #
+          #
+          # Implementation
+          # ==============
+          #
+          # Escaping has two steps
+          #
+          # 1. jq
+          #    Escape known separators, in order not
+          #    to break up the keys and values.
+          #    This handles typical whitespace correctly,
+          #    but may produce garbage for other control
+          #    characters.
+          #
+          # 2. iconv
+          #    Escape >ascii code points to java escapes,
+          #    as .properties files are supposed to be
+          #    encoded in ISO 8859-1. It's an old format.
+          #    UTF-8 behavior may exist in some apps and
+          #    libraries, but we can't rely on this in
+          #    general.
+
+          passAsFile = [ "value" ];
+          value = builtins.toJSON value;
+          nativeBuildInputs = [
+            pkgs.jq
+            pkgs.libiconvReal
+          ];
+
+          jqCode =
+            let
+              main = ''
+                to_entries
+                  | .[]
+                  | "\(
+                      .key
+                      | ${commonEscapes}
+                      | gsub(" "; "\\ ")
+                      | gsub("="; "\\=")
+                    ) = \(
+                      .value
+                      | ${commonEscapes}
+                      | gsub("^ "; "\\ ")
+                      | gsub("\\n "; "\n\\ ")
+                    )"
+              '';
+              # Most escapes are equal for both keys and values.
+              commonEscapes = ''
+                gsub("\\\\"; "\\\\")
+                | gsub("\\n"; "\\n\\\n")
+                | gsub("#"; "\\#")
+                | gsub("!"; "\\!")
+                | gsub("\\t"; "\\t")
+                | gsub("\r"; "\\r")
+              '';
+            in
+            main;
+
+          inputEncoding = "UTF-8";
+
+        } ''
+        jq -r --arg hash '#' "$jqCode" "$valuePath" \
+          | iconv --from-code "$inputEncoding" --to-code JAVA \
+          > "$out"
+      '';
+  };
+}

--- a/pkgs/pkgs-lib/formats/java-properties/test/Main.java
+++ b/pkgs/pkgs-lib/formats/java-properties/test/Main.java
@@ -1,0 +1,27 @@
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+class Main {
+    public static void main (String args[]) {
+        try {
+            InputStream input = new FileInputStream(args[0]);
+            Properties prop = new Properties();
+            prop.load(input);
+            SortedSet<String> keySet = new TreeSet(prop.keySet());
+            for (String key : keySet) {
+                System.out.println("KEY");
+                System.out.println(key);
+                System.out.println("VALUE");
+                System.out.println(prop.get(key));
+                System.out.println("");
+            }
+        } catch (Exception e) {
+          e.printStackTrace();
+          System.err.println(e.toString());
+          System.exit(1);
+        }
+    }
+}

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -1,0 +1,85 @@
+{ fetchurl
+, formats
+, glibcLocales
+, jdk
+, lib
+, stdenv
+}:
+let
+  inherit (lib) concatStrings attrValues mapAttrs;
+
+  javaProperties = formats.javaProperties { };
+
+  input = {
+    foo = "bar";
+    "empty value" = "";
+    "typical.dot.syntax" = "com.sun.awt";
+    "" = "empty key's value";
+    "1" = "2 3";
+    "#" = "not a comment # still not";
+    "!" = "not a comment!";
+    "!a" = "still not! a comment";
+    "!b" = "still not ! a comment";
+    "dos paths" = "C:\\Program Files\\Nix For Windows\\nix.exe";
+    "a \t\nb" = " c";
+    "angry \t\nkey" = ''
+      multi
+      ${"\tline\r"}
+       space-
+        indented
+      trailing-space${" "}
+      trailing-space${"  "}
+      value
+    '';
+    "this=not" = "bad";
+    "nor = this" = "bad";
+    "all stuff" = "foo = bar";
+    "unicode big brain" = "e = mc□";
+    "ütf-8" = "dûh";
+    # NB: Some editors (vscode) show this _whole_ line in right-to-left order
+    "الجبر" = "أكثر من مجرد أرقام";
+  };
+
+in
+stdenv.mkDerivation {
+  name = "pkgs.formats.javaProperties-test-${jdk.name}";
+  nativeBuildInputs = [
+    jdk
+    glibcLocales
+  ];
+
+  # technically should go through the type.merge first, but that's tested
+  # in tests/formats.nix.
+  properties = javaProperties.generate "example.properties" input;
+
+  # Expected output as printed by Main.java
+  passAsFile = [ "expected" ];
+  expected = concatStrings (attrValues (
+    mapAttrs
+      (key: value:
+        ''
+          KEY
+          ${key}
+          VALUE
+          ${value}
+
+        ''
+      )
+      input
+  ));
+
+  src = lib.sourceByRegex ./. [
+    ".*\.java"
+  ];
+  LANG = "C.UTF-8";
+  buildPhase = ''
+    javac Main.java
+  '';
+  doCheck = true;
+  checkPhase = ''
+    cat -v $properties
+    java Main $properties >actual
+    diff -U3 $expectedPath actual
+  '';
+  installPhase = "touch $out";
+}

--- a/pkgs/pkgs-lib/tests/default.nix
+++ b/pkgs/pkgs-lib/tests/default.nix
@@ -1,7 +1,45 @@
 # Call nix-build on this file to run all tests in this directory
-{ pkgs ? import ../../.. {} }:
+
+# This produces a link farm derivation with the original attrs
+# merged on top of it.
+# You can run parts of the "hierarchy" with for example:
+#     nix-build -A java-properties
+# See `structured` below.
+
+{ pkgs ? import ../../.. { } }:
 let
-  formats = import ./formats.nix { inherit pkgs; };
-in pkgs.linkFarm "nixpkgs-pkgs-lib-tests" [
-  { name = "formats"; path = import ./formats.nix { inherit pkgs; }; }
-]
+  inherit (pkgs.lib) mapAttrs mapAttrsToList isDerivation mergeAttrs foldl' attrValues recurseIntoAttrs;
+
+  structured = {
+    formats = import ./formats.nix { inherit pkgs; };
+    java-properties = recurseIntoAttrs {
+      jdk8 = pkgs.callPackage ../formats/java-properties/test { jdk = pkgs.jdk8; };
+      jdk11 = pkgs.callPackage ../formats/java-properties/test { jdk = pkgs.jdk11_headless; };
+      jdk17 = pkgs.callPackage ../formats/java-properties/test { jdk = pkgs.jdk17_headless; };
+    };
+  };
+
+  flatten = prefix: as:
+    foldl'
+      mergeAttrs
+      { }
+      (attrValues
+        (mapAttrs
+          (k: v:
+            if isDerivation v
+            then { "${prefix}${k}" = v; }
+            else if v?recurseForDerivations
+            then flatten "${prefix}${k}-" (removeAttrs v [ "recurseForDerivations" ])
+            else builtins.trace v throw "expected derivation or recurseIntoAttrs")
+          as
+        )
+      );
+in
+
+# It has to be a link farm for inclusion in the hydra unstable jobset.
+pkgs.linkFarm "pkgs-lib-formats-tests"
+  (mapAttrsToList
+    (k: v: { name = k; path = v; })
+    (flatten "" structured)
+  )
+// structured

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -168,4 +168,21 @@ in runBuildTests {
       level4 = "deep"
     '';
   };
+
+  # See also java-properties/default.nix for more complete tests
+  testJavaProperties = {
+    drv = evalFormat formats.javaProperties {} {
+      foo = "bar";
+      "1" = "2";
+      "ütf 8" = "dûh";
+      # NB: Some editors (vscode) show this _whole_ line in right-to-left order
+      "الجبر" = "أكثر من مجرد أرقام";
+    };
+    expected = ''
+      1 = 2
+      foo = bar
+      \u00fctf\ 8 = d\u00fbh
+      \u0627\u0644\u062c\u0628\u0631 = \u0623\u0643\u062b\u0631 \u0645\u0646 \u0645\u062c\u0631\u062f \u0623\u0631\u0642\u0627\u0645
+    '';
+  };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -179,6 +179,8 @@ in runBuildTests {
       "الجبر" = "أكثر من مجرد أرقام";
     };
     expected = ''
+      # Generated with Nix
+
       1 = 2
       foo = bar
       \u00fctf\ 8 = d\u00fbh

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -69,4 +69,6 @@ with pkgs;
   dhall = callPackage ./dhall { };
 
   makeWrapper = callPackage ./make-wrapper {};
+
+  pkgs-lib = recurseIntoAttrs (import ../pkgs-lib/tests { inherit pkgs; });
 }


### PR DESCRIPTION
###### Motivation

`.properties` is a deceivingly complicated format.

This PR adds a format with a quick generator that should cover most corner cases.

It also wires the `pkgs-lib` tests into `pkgs.tests` for ofborg to pick them up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
