### PR TITLE
ydotool: minor fixes

### DIFF
--- a/pkgs/tools/wayland/ydotool/default.nix
+++ b/pkgs/tools/wayland/ydotool/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, scdoc }:
+{ lib, stdenv, fetchFromGitHub, cmake, scdoc, util-linux }:
 
 stdenv.mkDerivation rec {
   pname = "ydotool";
@@ -11,10 +11,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-maXXGCqB8dkGO8956hsKSwM4HQdYn6z1jBFENQ9sKcA=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [
-    scdoc
-  ];
+  nativeBuildInputs = [ cmake scdoc ];
+
+  # fix call of /usr/bin/kill in the systemd service
+  # this is used for reloading the service
+  postInstall = ''
+    substituteInPlace ${placeholder "out"}/lib/systemd/user/ydotool.service \
+      --replace /usr/bin/kill "${util-linux}/bin/kill"
+  '';
 
   meta = with lib; {
     inherit (src.meta) homepage;

--- a/pkgs/tools/wayland/ydotool/default.nix
+++ b/pkgs/tools/wayland/ydotool/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ReimuNotMoe/ydotool";
     description = "Generic Linux command-line automation tool";
     license = licenses.agpl3Plus;
     maintainers = with maintainers; [ willibutz kraem ];

--- a/pkgs/tools/wayland/ydotool/default.nix
+++ b/pkgs/tools/wayland/ydotool/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake scdoc ];
 
-  # fix call of /usr/bin/kill in the systemd service
-  # this is used for reloading the service
   postInstall = ''
     substituteInPlace ${placeholder "out"}/lib/systemd/user/ydotool.service \
       --replace /usr/bin/kill "${util-linux}/bin/kill"


### PR DESCRIPTION
###### Description of changes

- Fix the ExecReload= on the systemd service to point to the proper
  `kill` binary to send the HUP signal for ydotoold to reload.
- Don't use pkg-config (it doesn't seem to be necessary).
- move `scdoc` to `nativeBuildInputs=` as it is executed during
  the build process to create the manapages, so it should be
  installed in the native build-machine arch.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
