### PR TITLE
dancing-script: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13215,6 +13215,12 @@
     githubId = 34962284;
     name = "wchresta";
   };
+  wdavidw = {
+    name = "David Worms";
+    email = "david@adaltas.com";
+    github = "wdavidw";
+    githubId = 46896;
+  };
   wedens = {
     email = "kirill.wedens@gmail.com";
     name = "wedens";

--- a/pkgs/data/fonts/dancing-script/default.nix
+++ b/pkgs/data/fonts/dancing-script/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "dancing-script";
+  version = "2.0";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+
+  owner = "impallari";
+  repo = "DancingScript";
+  rev = "f7f54bc1b8836601dae8696666bfacd306f77e34";
+  sha256 = "dfFvh8h+oMhAQL9XKMrNr07VUkdQdxAsA8+q27KWWCA=";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/truetype fonts/ttf/*.ttf
+  '';
+
+  meta = with lib; {
+    description = "Dancing Script";
+    longDescription = "A lively casual script where the letters bounce and change size slightly.";
+    homepage = "https://github.com/impallari/DancingScript";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ wdavidw ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2844,6 +2844,8 @@ with pkgs;
 
   damon = callPackage ../tools/admin/damon { };
 
+  dancing-script = callPackage ../data/fonts/dancing-script { };
+
   dante = callPackage ../servers/dante { };
 
   dapr-cli = callPackage ../development/tools/dapr/cli {};


### PR DESCRIPTION
The [Dancing Script](https://github.com/impallari/DancingScript) font is a lively casual script where the letters bounce and change size slightly. Caps are big, and goes below the baseline.

Notes, version is coming from the .glyphs source file and is called 
2.000 in the readme 
https://raw.githubusercontent.com/impallari/DancingScript/master/sources/DancingScript.glyphs

###### Description of changes

This is a new module to integrate the Dancing Script font.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

