### PR TITLE
sshuttle: 1.0.5 -> 1.1.0, add SuperSandro2000 as maintainer

### DIFF
--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -11,11 +11,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sshuttle";
-  version = "1.0.5";
+  version = "1.1.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "fd8c691aac2cb80933aae7f94d9d9e271a820efc5c48e73408f1a90da426a1bd";
+    sha256 = "sha256-IfuRvfOStQ5422uNdelbc6ydr9Nh4mV+eE5nRWEhkxU=";
   };
 
   patches = [ ./sudo.patch ];
@@ -27,9 +27,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [ makeWrapper python3Packages.setuptools-scm ];
 
-  propagatedBuildInputs = [ python3Packages.psutil ];
-
-  checkInputs = with python3Packages; [ mock pytestCheckHook flake8 ];
+  checkInputs = with python3Packages; [ pytestCheckHook ];
 
   postInstall = ''
     wrapProgram $out/bin/sshuttle \
@@ -45,6 +43,6 @@ python3Packages.buildPythonApplication rec {
       Works with Linux and Mac OS and supports DNS tunneling.
     '';
     license = licenses.lgpl21;
-    maintainers = with maintainers; [ domenkozar carlosdagos ];
+    maintainers = with maintainers; [ domenkozar carlosdagos SuperSandro2000 ];
   };
 }

--- a/pkgs/tools/security/sshuttle/sudo.patch
+++ b/pkgs/tools/security/sshuttle/sudo.patch
@@ -5,7 +5,7 @@ index cab5b1c..e89f8a6 100644
 @@ -192,7 +192,7 @@ class FirewallClient:
  
          self.auto_nets = []
-         python_path = os.path.dirname(os.path.dirname(__file__))
+
 -        argvbase = ([sys.executable, sys.argv[0]] +
 +        argvbase = ([sys.argv[0]] +
                      ['-v'] * (helpers.verbose or 0) +


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
