### PR TITLE
dbeaver: use overridden maven in javaPackages.mavenfod

### DIFF
--- a/pkgs/applications/misc/dbeaver/default.nix
+++ b/pkgs/applications/misc/dbeaver/default.nix
@@ -19,9 +19,11 @@
 , javaPackages
 }:
 
-javaPackages.mavenfod rec {
+(javaPackages.mavenfod.override {
+  inherit maven; # use overridden maven version (see dbeaver's entry in all-packages.nix)
+}) rec {
   pname = "dbeaver";
-  version = "22.0.1"; # When updating also update fetchedMavenDeps.sha256
+  version = "22.0.1"; # When updating also update mvnSha256
 
   src = fetchFromGitHub {
     owner = "dbeaver";
@@ -30,35 +32,8 @@ javaPackages.mavenfod rec {
     sha256 = "sha256-IG5YWwq3WVzQBvAslQ9Z2Ou6ADzf4n9NkQCtH4Jgkac=";
   };
 
-
-  mvnSha256 = "7Sm1hAoi5xc4MLONOD8ySLLkpao0qmlMRRva/8zR210=";
+  mvnSha256 = "WAB15d4UvUOkBXT7K/hvAZWOE3V1Lpl/tr+AFNBM4FI=";
   mvnParameters = "-P desktop,all-platforms";
-
-  fetchedMavenDeps = stdenv.mkDerivation {
-    name = "dbeaver-${version}-maven-deps";
-    inherit src;
-
-    buildInputs = [
-      maven
-    ];
-
-    buildPhase = "mvn package -Dmaven.repo.local=$out/.m2 ${mvnParameters}";
-
-    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
-    installPhase = ''
-      find $out -type f \
-        -name \*.lastUpdated -or \
-        -name resolver-status.properties -or \
-        -name _remote.repositories \
-        -delete
-    '';
-
-    # don't do any fixup
-    dontFixup = true;
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "sha256-WAB15d4UvUOkBXT7K/hvAZWOE3V1Lpl/tr+AFNBM4FI=";
-  };
 
   nativeBuildInputs = [
     copyDesktopItems

--- a/pkgs/development/java-modules/maven-fod.nix
+++ b/pkgs/development/java-modules/maven-fod.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (rec {
     runHook preBuild
 
     mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
-    mvn package --offline "-Dmaven.repo.local=$mvnDeps/.m2" -P desktop,all-platforms
+    mvn package --offline "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnParameters}
 
     runHook postBuild
   '';


### PR DESCRIPTION
###### Description of changes

This fixes the error described in #166048 since dbeaver won't build under Java 17 by overriding the `maven` argument of `javaPackages.mavenfod` to be the Java 11 `maven` defined in dbeaver's `all-packages.nix` entry.

Also replaced the `-P desktop,all-platforms` in mavenfod's `buildPhase` to be `${mvnParameters}` (was missed in https://github.com/NixOS/nixpkgs/pull/140406#discussion_r721166445).

fixes #166048

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
