### PR TITLE
[21.11] pdns-recursor: apply CVE-2022-27227 patch

### DIFF
--- a/pkgs/servers/dns/pdns-recursor/default.nix
+++ b/pkgs/servers/dns/pdns-recursor/default.nix
@@ -12,6 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "1avvs1wpck0rahx80xnnaw94hdrfbhi1jdvgg1zpac26mzab4kdd";
   };
 
+  patches = [
+    # Patch for CVE-2022-27227
+    (fetchurl {
+      url = "https://downloads.powerdns.com/patches/2022-01/rec-4.5.7-ixfr.diff";
+      sha256 = "12d43ld6fh4j2iaidjjvrl1x71zscm4frr2sa2dx4749dwia41a1";
+     })
+  ];
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     boost openssl systemd


### PR DESCRIPTION
###### Description of changes

Security patch for DoS vulnerability.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux NixOS
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested with `pdns-recursor.tests`
- [x] Tested compilation of all packages that depend on this change
- [ ] Tested basic functionality of all binary files
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
