### PR TITLE
xash3d: init at 0.19.2

### DIFF
--- a/pkgs/games/xash3d/default.nix
+++ b/pkgs/games/xash3d/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, makeWrapper
+, cmake
+, pkg-config
+, SDL2
+, fontconfig
+, fetchFromGitHub
+, python3
+}:
+{ valve ? throw ''type valve directory for example nix-env --argstr valve "/home/max/valve" -iA xash3d'' } @ args:
+let
+  hlsdk = fetchFromGitHub{
+    owner = "FWGS";
+    repo = "hlsdk-xash3d";
+    rev = "e7ef84c83db25f5b5b4c8549069135331b5ceeb2";
+    sha256 = "1x76zm5c9nz8a927197vwxskak5lm36zwnpviabwgb9ik367413w";
+  };
+  xash3d = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "FWGS";
+    repo = "xash3d";
+    rev = "v0.19.2";
+    sha256 = "03s061s13wsrljx2zdnwg2ykbxz8cpz2h0dx1wwgnlq9840f50aq";
+  };
+in
+
+stdenv.mkDerivation {
+  pname = "xash3d";
+  version = "0.19.2";
+  inherit xash3d hlsdk valve;
+
+  nativeBuildInputs = [
+    makeWrapper
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    SDL2
+    fontconfig
+  ];
+
+  configurePhase =  ''
+    cmake -DHL_SDK_DIR=$hlsdk -DXASH_SDL=yes -DXASH_VGUI=no -S $xash3d  -B $name/xash3d ${lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "-DXASH_64BIT=1"}
+    cmake -S $hlsdk -B $name/hlsdk ${lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux") "-D64BIT=1"}
+  '';
+
+  buildPhase = ''
+    make -C $name/xash3d $makeFlags
+    make -C $name/hlsdk $makeFlags
+  '';
+
+  installPhase = ''
+    install -D $name/xash3d/engine/libxash.so $out/bin/libxash.so
+    install -D $name/xash3d/game_launch/xash3d $out/bin/xash3d
+    install -D $name/xash3d/mainui/libxashmenu64.so $out/bin/libxashmenu${lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")"64"}.so
+    install -D $name/hlsdk/cl_dll/client.so $out/bin/cl_dlls/client${lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")"64"}.so
+    install -D $name/hlsdk/dlls/hl.so $out/bin/dlls/hl_i386.so
+    ln -s $valve $out/bin/valve
+    wrapProgram $out/bin/xash3d --prefix LD_LIBRARY_PATH : $out/bin
+  '';
+
+  dontUnpack = true;
+
+  meta = {
+    description = "Xash3D Engine is a custom Gold Source engine rewritten from scratch.";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35024,4 +35024,6 @@ with pkgs;
   honeytail = callPackage ../servers/tracing/honeycomb/honeytail { };
 
   honeyvent = callPackage ../servers/tracing/honeycomb/honeyvent { };
+
+  xash3d = callPackage ../games/xash3d { };
 }


### PR DESCRIPTION
###### Description of changes
I want to add a package. It's xash3d. Nixos users will be able to install xash3d and play half-life. This nix script compiles xash3d and put it in $out/bin. You'll need a "valve" directory next to xash3d binaries to play half-life so this script also creates a symlink to the directory. 
This package doesn't provide a "valve" directory so you should specify it in installation comand. For example if you have the directory in /home/max/valve then installation command will look like this
`nix-env --argstr valve "/home/max/valve" -iA xash3d`
You must specify it as string with argstr because if you specify it like a path nix will create non-writeable directory somewhere in /nix/... with files from your "valve" directory and you won't be able to play because the "valve" directory contains all your saves in 'valve/save' and you won't be able to save the game.
In the end it should look like this in $out/bin
`lrwxrwxrwx 1 root root   58 jan  1  1970 valve -> /home/max/valve`
If you want to start playing just write "xash3d" in terminal after installation.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
