### PR TITLE
bless: fix build with meson 0.61

### DIFF
--- a/pkgs/applications/editors/bless/default.nix
+++ b/pkgs/applications/editors/bless/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
 , pkg-config
 , mono
@@ -12,6 +13,7 @@
 , libxslt
 , docbook_xsl
 , python3
+, itstool
 }:
 
 stdenv.mkDerivation rec {
@@ -47,6 +49,7 @@ stdenv.mkDerivation rec {
     libxslt
     docbook_xsl
     python3
+    itstool
   ];
 
   preFixup = ''

--- a/pkgs/applications/editors/bless/default.nix
+++ b/pkgs/applications/editors/bless/default.nix
@@ -27,11 +27,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-rS+vJX0y9v1TiPsRfABroHiTuENQKEOxNsyKwagRuHM=";
   };
 
-  postPatch = ''
-    sed "s|get_option('tests')|false|g" -i meson.build
-    patchShebangs .
-  '';
-
   buildInputs = [
     gtk-sharp-2_0
     mono
@@ -51,6 +46,14 @@ stdenv.mkDerivation rec {
     python3
     itstool
   ];
+
+  mesonFlags = [
+    "-Dtests=false" # requires NUnit
+  ];
+
+  postPatch = ''
+    patchShebangs .
+  '';
 
   preFixup = ''
     MPATH="${gtk-sharp-2_0}/lib/mono/gtk-sharp-2.0:${glib.out}/lib:${gtk2-x11}/lib:${gtk-sharp-2_0}/lib"


### PR DESCRIPTION
###### Description of changes

```
doc/user/meson.build:73:6: ERROR: Program 'itstool' not found or not executable
```

https://hydra.nixos.org/build/171063401/nixlog/1
https://github.com/mesonbuild/meson/commit/26c1869a142a

Adding itstool to nativeBuildInputs [following what freebsd is doing](https://cgit.freebsd.org/ports/commit/?id=683aee272ea8309a83f48cdaa467cfcddb69a7b6
)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (with and without meson 0.61)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
