### PR TITLE
mate.mate-backgrounds: fix build with meson 0.61

### DIFF
--- a/pkgs/desktops/mate/mate-backgrounds/default.nix
+++ b/pkgs/desktops/mate/mate-backgrounds/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, meson, ninja, gettext, mateUpdateScript }:
+{ lib, stdenv, fetchurl, fetchpatch, meson, ninja, gettext, mateUpdateScript }:
 
 stdenv.mkDerivation rec {
   pname = "mate-backgrounds";
@@ -8,6 +8,15 @@ stdenv.mkDerivation rec {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0379hngy3ap1r5kmqvmzs9r710k2c9nal2ps3hq765df4ir15j8d";
   };
+
+  patches = [
+    # Fix build with meson 0.61, can be removed on next update.
+    # https://github.com/mate-desktop/mate-backgrounds/pull/39
+    (fetchpatch {
+      url = "https://github.com/mate-desktop/mate-backgrounds/commit/0096e237d420e6247a75a1c6940a818e309ac2a7.patch";
+      sha256 = "HEF8VWunFO+NCG18fZA7lbE2l8pc6Z3jcD+rSZ1Jsqg=";
+    })
+  ];
 
   nativeBuildInputs = [
     gettext


### PR DESCRIPTION


###### Description of changes

https://hydra.nixos.org/build/170802606/nixlog/1

```
abstract/meson.build:3:5: ERROR: Function does not take positional arguments.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (with and without meson 0.61)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
