### PR TITLE
gsettings-desktop-schemas: clear out broken dark background URL

### DIFF
--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation rec {
     cat - > $out/share/glib-2.0/schemas/remove-backgrounds.gschema.override <<- EOF
       [org.gnome.desktop.background]
       picture-uri='''
+      picture-uri-dark='''
 
       [org.gnome.desktop.screensaver]
       picture-uri='''

--- a/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
+++ b/pkgs/development/libraries/gsettings-desktop-schemas/default.nix
@@ -39,12 +39,17 @@ stdenv.mkDerivation rec {
     patchShebangs build-aux/meson/post-install.py
   '';
 
-  # meson installs the schemas to share/glib-2.0/schemas
-  # We add the override file there too so it will be compiled and later moved by
-  # glib's setup hook.
   preInstall = ''
+    # Meson installs the schemas to share/glib-2.0/schemas
+    # We add the override file there too so it will be compiled and later moved by
+    # glib's setup hook.
     mkdir -p $out/share/glib-2.0/schemas
     cat - > $out/share/glib-2.0/schemas/remove-backgrounds.gschema.override <<- EOF
+      # These paths are supposed to refer to gnome-backgrounds
+      # but since we do not use FHS, they are broken.
+      # And we do not want to hardcode the correct paths
+      # since then every GTK app would pull in gnome-backgrounds.
+      # Let’s just override the broken paths so that people are not confused.
       [org.gnome.desktop.background]
       picture-uri='''
       picture-uri-dark='''


### PR DESCRIPTION
###### Description of changes

Fixes broken background in GNOME 42 in dark mode. Also needs a [module change](https://github.com/NixOS/nixpkgs/pull/166096).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
