### PR TITLE
ntfy-sh: init at 1.18.1

### DIFF
--- a/pkgs/tools/misc/ntfy-sh/default.nix
+++ b/pkgs/tools/misc/ntfy-sh/default.nix
@@ -1,7 +1,7 @@
-{ lib, buildGoModule, fetchFromGitHub, ... }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
-  pname = "ntfysh";
+  pname = "ntfy-sh";
   version = "1.18.1";
 
   src = fetchFromGitHub {
@@ -23,7 +23,6 @@ buildGoModule rec {
     description = "Send push notifications to your phone or desktop via PUT/POST";
     homepage = "https://ntfy.sh";
     license = licenses.asl20;
-    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ arjan-s ];
   };
 }

--- a/pkgs/tools/misc/ntfysh/default.nix
+++ b/pkgs/tools/misc/ntfysh/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildGoModule, fetchFromGitHub, ... }:
+
+buildGoModule rec {
+  pname = "ntfysh";
+  version = "1.18.1";
+
+  src = fetchFromGitHub {
+    owner = "binwiederhier";
+    repo = "ntfy";
+    rev = "v${version}";
+    sha256 = "sha256-rXdkNJYpQ8s2BeFRR4fSIuCrdq60me4B3wee64ei8qM=";
+  };
+
+  vendorSha256 = "sha256-7b3cQczQLUZ//5ubKvq8s9U75qJpJaieLN+kzjXIyHg=";
+
+  doCheck = false;
+
+  preBuild = ''
+    make server-deps-static-sites
+  '';
+
+  meta = with lib; {
+    description = "Send push notifications to your phone or desktop via PUT/POST";
+    homepage = "https://ntfy.sh";
+    license = licenses.asl20;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ arjan-s ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8490,6 +8490,8 @@ with pkgs;
 
   ntfy = callPackage ../tools/misc/ntfy {};
 
+  ntfysh = callPackage ../tools/misc/ntfysh {};
+
   ntirpc = callPackage ../development/libraries/ntirpc { };
 
   ntopng = callPackage ../tools/networking/ntopng { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8490,7 +8490,7 @@ with pkgs;
 
   ntfy = callPackage ../tools/misc/ntfy {};
 
-  ntfysh = callPackage ../tools/misc/ntfysh {};
+  ntfy-sh = callPackage ../tools/misc/ntfy-sh {};
 
   ntirpc = callPackage ../development/libraries/ntirpc { };
 


### PR DESCRIPTION
###### Description of changes
This PR adds the package `ntfysh`, which provides the binary `ntfy` (details on https://ntfy.sh). The upstream author has decided that a name clash with another existing package is okay, so I'm not sure what to do here. For now, it has the same binary name as package `ntfy` already provides. Please let me know if this isn't okay.
Closes https://github.com/NixOS/nixpkgs/issues/153892
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
