### PR TITLE
Device-Tree-Overlays broke with linux 5.17 due to some dts w/o compatible

### DIFF
--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -13,7 +13,7 @@ with lib; {
         | xargs -0 cp -v --no-preserve=mode --target-directory $out --parents
 
       for dtb in $(find $out -type f -name '*.dtb'); do
-        dtbCompat="$( fdtget -t s $dtb / compatible )"
+        dtbCompat="$( fdtget -t s $dtb / compatible || (echo INCOMPATIBLE; echo Error was caused by $dtb >&2) )"
 
         ${flip (concatMapStringsSep "\n") overlays (o: ''
         overlayCompat="$( fdtget -t s ${o.dtboFile} / compatible )"


### PR DESCRIPTION
###### Description of changes

Device-tree overlays broke with the 5.17 kernel, as it adds a few dts files, that did not state the `/ compatible` string, that is used by the builder that applies the overlays.

I have added a fallback compatibility string of `INCOMPATIBLE` in case none was found in the dts. Also I added some output to stderr for future debuging possibilities.

I am rather unsure, if this is intended by the kernel developers, or they left it out by accident, but I believe we should make the code more resilient nevertheless. Even if it is "fixed" in upcoming releases, I would like to also handle it on our end, so it would work fine if it ever happened again.

The files added by the kernel, that do not contain the `/ compatible` are:
* freescale/fsl-ls1028a-qds-13bb.dts
* freescale/fsl-ls1028a-qds-65bb.dts
* freescale/fsl-ls1028a-qds-7777.dts
* freescale/fsl-ls1028a-qds-85bb.dts
* freescale/fsl-ls1028a-qds-899b.dts
* freescale/fsl-ls1028a-qds-9999.dts

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
