### PR TITLE
adapt semantics of autopatchelfHook for single files

### DIFF
--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -101,7 +101,7 @@ let
         chmod -R g-w $out
 
         addAutoPatchelfSearchPath --no-recurse $out/opt/Breitbandmessung
-        autoPatchelfFile $out/opt/Breitbandmessung/breitbandmessung
+        autoPatchelf $out/opt/Breitbandmessung/breitbandmessung
 
         makeWrapper $out/opt/Breitbandmessung/breitbandmessung $out/bin/breitbandmessung \
           --prefix PATH : ${binPath}

--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -110,8 +110,14 @@ def osabi_are_compatible(wanted: str, got: str) -> bool:
 
 
 def glob(path: Path, pattern: str, recursive: bool) -> Iterator[Path]:
-    yield path
-    yield from path.rglob(pattern) if recursive else path.glob(pattern)
+    if path.is_dir():
+        return path.rglob(pattern) if recursive else path.glob(pattern)
+    else:
+        # path.glob won't return anything if the path is not a directory.
+        # We extend that behavior by matching the file name against the pattern.
+        # This allows to pass single files instead of dirs to auto_patchelf,
+        # for greater control on the files to consider.
+        return [path] if path.match(pattern) else []
 
 
 cached_paths: Set[Path] = set()
@@ -287,16 +293,21 @@ def main() -> None:
         "--no-recurse",
         dest="recursive",
         action="store_false",
-        help="Patch only the provided paths, and ignore their children")
+        help="Disable the recursive traversal of paths to patch.")
     parser.add_argument(
         "--paths", nargs="*", type=Path,
-        help="Paths whose content needs to be patched.")
+        help="Paths whose content needs to be patched."
+             " Single files and directories are accepted."
+             " Directories are traversed recursively by default.")
     parser.add_argument(
         "--libs", nargs="*", type=Path,
-        help="Paths where libraries are searched for.")
+        help="Paths where libraries are searched for."
+             " Single files and directories are accepted."
+             " Directories are not searched recursively.")
     parser.add_argument(
         "--runtime-dependencies", nargs="*", type=Path,
-        help="Paths to prepend to the runtime path of executable binaries.")
+        help="Paths to prepend to the runtime path of executable binaries."
+             " Subject to deduplication, which may imply some reordering.")
 
     print("automatically fixing dependencies for ELF files")
     args = parser.parse_args()

--- a/pkgs/build-support/setup-hooks/auto-patchelf.py
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.py
@@ -110,7 +110,8 @@ def osabi_are_compatible(wanted: str, got: str) -> bool:
 
 
 def glob(path: Path, pattern: str, recursive: bool) -> Iterator[Path]:
-    return path.rglob(pattern) if recursive else path.glob(pattern)
+    yield path
+    yield from path.rglob(pattern) if recursive else path.glob(pattern)
 
 
 cached_paths: Set[Path] = set()


### PR DESCRIPTION
###### Description of changes

This is a mass rebuild change for binary packages, albeit it will end up in a no-op (wishing for ca-derivations here).

Follow up of https://github.com/NixOS/nixpkgs/pull/149731. I think the fix is sufficiently small and innocuous, but could help a second look.

Fixes #166086.

/cc @Mic92 @aszlig @Ericson2314 @Artturin as a followup of the initial rewrite.
/cc @felschr for your opinion, and for testing if it indeed works ;-).