### PR TITLE
ocamlPackages.{macaddr,ipaddr}: 5.2.0 -> 5.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/cstruct.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "ipaddr-cstruct";
 
-  inherit (ipaddr) version src useDune2 minimumOCamlVersion;
+  inherit (ipaddr) version src;
 
   propagatedBuildInputs = [ ipaddr cstruct ];
 

--- a/pkgs/development/ocaml-modules/ipaddr/default.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/default.nix
@@ -6,7 +6,7 @@
 buildDunePackage rec {
   pname = "ipaddr";
 
-  inherit (macaddr) version src useDune2 minimumOCamlVersion;
+  inherit (macaddr) version src;
 
   propagatedBuildInputs = [ macaddr domain-name stdlib-shims ];
 

--- a/pkgs/development/ocaml-modules/ipaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/ipaddr/sexp.nix
@@ -5,7 +5,7 @@
 buildDunePackage rec {
   pname = "ipaddr-sexp";
 
-  inherit (ipaddr) version src useDune2 minimumOCamlVersion;
+  inherit (ipaddr) version src;
 
   propagatedBuildInputs = [ ipaddr ];
 

--- a/pkgs/development/ocaml-modules/macaddr/cstruct.nix
+++ b/pkgs/development/ocaml-modules/macaddr/cstruct.nix
@@ -5,9 +5,7 @@
 buildDunePackage {
   pname = "macaddr-cstruct";
 
-  inherit (macaddr) version src minimumOCamlVersion;
-
-  useDune2 = true;
+  inherit (macaddr) version src;
 
   propagatedBuildInputs = [ macaddr cstruct ];
 

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -6,9 +6,7 @@ buildDunePackage rec {
   pname = "macaddr";
   version = "5.3.0";
 
-  useDune2 = true;
-
-  minimumOCamlVersion = "4.04";
+  minimalOCamlVersion = "4.04";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-${version}.tbz";

--- a/pkgs/development/ocaml-modules/macaddr/default.nix
+++ b/pkgs/development/ocaml-modules/macaddr/default.nix
@@ -4,15 +4,15 @@
 
 buildDunePackage rec {
   pname = "macaddr";
-  version = "5.2.0";
+  version = "5.3.0";
 
   useDune2 = true;
 
   minimumOCamlVersion = "4.04";
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-v${version}.tbz";
-    sha256 = "f98d237cc1f783a0ba7dff0c6c69b5f519fec056950e3e3e7c15e5511ee5b7ec";
+    url = "https://github.com/mirage/ocaml-ipaddr/releases/download/v${version}/ipaddr-${version}.tbz";
+    sha256 = "0mdp38mkvk2f5h2q7nb9fc70a8hyssblnl7kam0d8r5lckgrx5rn";
   };
 
   checkInputs = [ ppx_sexp_conv ounit ];

--- a/pkgs/development/ocaml-modules/macaddr/sexp.nix
+++ b/pkgs/development/ocaml-modules/macaddr/sexp.nix
@@ -5,9 +5,7 @@
 buildDunePackage {
   pname = "macaddr-sexp";
 
-  inherit (macaddr) version src minimumOCamlVersion;
-
-  useDune2 = true;
+  inherit (macaddr) version src;
 
   propagatedBuildInputs = [ ppx_sexp_conv ];
 


### PR DESCRIPTION
###### Description of changes

* Add `with_port_of_string` function
* **breaking-change** Be restrictive on `Ipaddr.of_string`
  Before this release, `Ipaddr.of_string` accepts remaining bytes and returns
  a valid value such as `"127.0.0.1aaaa"` is valid. Now, `ipaddr` does not
  accept a string with remaining bytes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
