### PR TITLE
nixos/networkd: add `wait-online` options

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1318,6 +1318,35 @@
       </listitem>
       <listitem>
         <para>
+          A new option group
+          <literal>systemd.network.wait-online</literal> was added, with
+          options to configure
+          <literal>systemd-networkd-wait-online.service</literal>:
+        </para>
+        <itemizedlist spacing="compact">
+          <listitem>
+            <para>
+              <literal>anyInterface</literal> allows specifying that the
+              network should be considered online when <emphasis>at
+              least one</emphasis> interface is online (useful on
+              laptops)
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>timeout</literal> defines how long to wait for
+              the network to come online
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>extraArgs</literal> for everything else
+            </para>
+          </listitem>
+        </itemizedlist>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>influxdb2</literal> package was split into
           <literal>influxdb2-server</literal> and
           <literal>influxdb2-cli</literal>, matching the split that took

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -478,6 +478,11 @@ In addition to numerous new and upgraded packages, this release has the followin
   still under heavy development and behavior is not always flawless.
   Furthermore, not all Electron apps use the latest Electron versions.
 
+- A new option group `systemd.network.wait-online` was added, with options to configure `systemd-networkd-wait-online.service`:
+  - `anyInterface` allows specifying that the network should be considered online when *at least one* interface is online (useful on laptops)
+  - `timeout` defines how long to wait for the network to come online
+  - `extraArgs` for everything else
+
 - The `influxdb2` package was split into `influxdb2-server` and
   `influxdb2-cli`, matching the split that took place upstream. A
   combined `influxdb2` package is still provided in this release for


### PR DESCRIPTION
Expose a few options to configure `systemd-networkd-wait-online.service`. Tested locally.
