### PR TITLE
[21.11] nixos/default.nix: Use extendModules

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -61,7 +61,7 @@ in rec {
     args = extraArgs;
     specialArgs =
       { modulesPath = builtins.toString ../modules; } // specialArgs;
-  }) config options _module type;
+  }) config options _module type extendModules;
 
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.


### PR DESCRIPTION
(cherry picked from commit 8fd49c116bcd256263c7aad8ca5d4b7fa10d4ca2)

**All good after this cherry-pick**


**Prior to this cherry-pick**
```
❯ nixos-generate --flake .#blacklion -f iso
warning: Git tree '/home/blaggacao/src/github.com/omegadilebo/config' is dirty
warning: Git tree '/home/blaggacao/src/github.com/omegadilebo/config' is dirty
error: attribute 'extendModules' missing

       at /nix/store/1jm8g1vhr2409fm4kl9cfwy93ks8grv5-nixos-generators/share/nixos-generator/nixos-generate.nix:18:5:

           17|   if flakeUri != null then
           18|     flakeSystem.extendModules {
             |     ^
           19|       modules = [ module formatConfig ];
```
