### PR TITLE
ocamlPackages.cmdliner: Use the upstream Makefile build rules

### DIFF
--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -1,33 +1,18 @@
 { lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, result }:
 
-let
-  pname = "cmdliner";
-in
-
-assert lib.versionAtLeast ocaml.version "4.01.0";
-
-let param =
-  if lib.versionAtLeast ocaml.version "4.03" then {
-    version = "1.0.4";
-    sha256 = "1h04q0zkasd0mw64ggh4y58lgzkhg6yhzy60lab8k8zq9ba96ajw";
-  } else {
-    version = "1.0.2";
-    sha256 = "18jqphjiifljlh9jg8zpl6310p3iwyaqphdkmf89acyaix0s4kj1";
-  }
-; in
+assert (lib.versionAtLeast ocaml.version "4.03");
 
 stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-${pname}-${version}";
-  inherit (param) version;
+  pname = "cmdliner";
+  version = "1.0.4";
 
   src = fetchurl {
     url = "https://erratique.ch/software/${pname}/releases/${pname}-${version}.tbz";
-    inherit (param) sha256;
+    sha256 = "1h04q0zkasd0mw64ggh4y58lgzkhg6yhzy60lab8k8zq9ba96ajw";
   };
 
   nativeBuildInputs = [ ocaml ocamlbuild findlib topkg ];
   buildInputs = [ topkg ];
-  propagatedBuildInputs = [ result ];
 
   inherit (topkg) buildPhase installPhase;
 

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -11,10 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "1h04q0zkasd0mw64ggh4y58lgzkhg6yhzy60lab8k8zq9ba96ajw";
   };
 
-  nativeBuildInputs = [ ocaml ocamlbuild findlib topkg ];
-  buildInputs = [ topkg ];
+  nativeBuildInputs = [ ocaml ];
 
-  inherit (topkg) buildPhase installPhase;
+  makeFlags = [ "PREFIX=$(out)" ];
+  installTargets = "install install-doc";
+  installFlags = [
+    "LIBDIR=$(out)/lib/ocaml/${ocaml.version}/site-lib/${pname}"
+    "DOCDIR=$(out)/share/doc/${pname}"
+  ];
+  postInstall = ''
+    mv $out/lib/ocaml/${ocaml.version}/site-lib/${pname}/{opam,${pname}.opam}
+  '';
 
   meta = with lib; {
     homepage = "https://erratique.ch/software/cmdliner";


### PR DESCRIPTION

###### Description of changes

According to
https://github.com/dbuenzli/cmdliner/pull/147#issuecomment-1081168328,
the topkg build is deprecated.  Switch to the new recommended build instructions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

