### PR TITLE
fetchpatch: add throwBool, reason, condition, path

### DIFF
--- a/pkgs/build-support/fetchpatch/default.nix
+++ b/pkgs/build-support/fetchpatch/default.nix
@@ -15,6 +15,10 @@ in
 , excludes ? []
 , includes ? []
 , revert ? false
+, throwBool ? false
+, reason ? ""
+, condition ? true
+, path ? ""
 , postFetch ? ""
 , ...
 }@args:
@@ -27,57 +31,63 @@ let
   };
 in let
   inherit (args') stripLen extraPrefix;
+in let
+  fetch = if !condition then ""
+  else if builtins.isPath path then path
+  else fetchurl ({
+    postFetch = ''
+      tmpfile="$TMPDIR/patch"
+
+      if [ ! -s "$out" ]; then
+        echo "error: Fetched patch file '$out' is empty!" 1>&2
+        exit 1
+      fi
+
+      "${patchutils}/bin/lsdiff" \
+        ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
+        "$out" \
+      | sort -u | sed -e 's/[*?]/\\&/g' \
+      | xargs -I{} \
+        "${patchutils}/bin/filterdiff" \
+        --include={} \
+        --strip=${toString stripLen} \
+        ${lib.optionalString (extraPrefix != null) ''
+            --addoldprefix=a/${lib.escapeShellArg extraPrefix} \
+            --addnewprefix=b/${lib.escapeShellArg extraPrefix} \
+        ''} \
+        --clean "$out" > "$tmpfile"
+
+      if [ ! -s "$tmpfile" ]; then
+        echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
+        echo "Did you maybe fetch a HTML representation of a patch instead of a raw patch?" 1>&2
+        echo "Fetched file was:" 1>&2
+        cat "$out" 1>&2
+        exit 1
+      fi
+
+      ${patchutils}/bin/filterdiff \
+        -p1 \
+        ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
+        ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
+        "$tmpfile" > "$out"
+
+      if [ ! -s "$out" ]; then
+        echo "error: Filtered patch '$out' is empty (while the original patch file was not)!" 1>&2
+        echo "Check your includes and excludes." 1>&2
+        echo "Normalized patch file was:" 1>&2
+        cat "$tmpfile" 1>&2
+        exit 1
+      fi
+    '' + lib.optionalString revert ''
+      ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
+      mv "$tmpfile" "$out"
+    '' + postFetch;
+  } // builtins.removeAttrs args [
+    "relative" "stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch" "reason" "throwBool" "condition" "path"
+  ]);
 in
-lib.throwIfNot (excludes == [] || includes == [])
-  "fetchpatch: cannot use excludes and includes simultaneously"
-fetchurl ({
-  postFetch = ''
-    tmpfile="$TMPDIR/patch"
-
-    if [ ! -s "$out" ]; then
-      echo "error: Fetched patch file '$out' is empty!" 1>&2
-      exit 1
-    fi
-
-    "${patchutils}/bin/lsdiff" \
-      ${lib.optionalString (relative != null) "-p1 -i ${lib.escapeShellArg relative}/'*'"} \
-      "$out" \
-    | sort -u | sed -e 's/[*?]/\\&/g' \
-    | xargs -I{} \
-      "${patchutils}/bin/filterdiff" \
-      --include={} \
-      --strip=${toString stripLen} \
-      ${lib.optionalString (extraPrefix != null) ''
-          --addoldprefix=a/${lib.escapeShellArg extraPrefix} \
-          --addnewprefix=b/${lib.escapeShellArg extraPrefix} \
-      ''} \
-      --clean "$out" > "$tmpfile"
-
-    if [ ! -s "$tmpfile" ]; then
-      echo "error: Normalized patch '$tmpfile' is empty (while the fetched file was not)!" 1>&2
-      echo "Did you maybe fetch a HTML representation of a patch instead of a raw patch?" 1>&2
-      echo "Fetched file was:" 1>&2
-      cat "$out" 1>&2
-      exit 1
-    fi
-
-    ${patchutils}/bin/filterdiff \
-      -p1 \
-      ${builtins.toString (builtins.map (x: "-x ${lib.escapeShellArg x}") excludes)} \
-      ${builtins.toString (builtins.map (x: "-i ${lib.escapeShellArg x}") includes)} \
-      "$tmpfile" > "$out"
-
-    if [ ! -s "$out" ]; then
-      echo "error: Filtered patch '$out' is empty (while the original patch file was not)!" 1>&2
-      echo "Check your includes and excludes." 1>&2
-      echo "Normalized patch file was:" 1>&2
-      cat "$tmpfile" 1>&2
-      exit 1
-    fi
-  '' + lib.optionalString revert ''
-    ${patchutils}/bin/interdiff "$out" /dev/null > "$tmpfile"
-    mv "$tmpfile" "$out"
-  '' + postFetch;
-} // builtins.removeAttrs args [
-  "relative" "stripLen" "extraPrefix" "excludes" "includes" "revert" "postFetch"
-])
+  lib.throwIfNot (excludes == [] || includes == [])
+    "fetchpatch: cannot use excludes and includes simultaneously"
+  lib.throwIf (throwBool && reason == "") "to use throwBool a reason why the patch is required is needed"
+  lib.throwIf throwBool "patch '${reason}' is no longer required"
+  fetch

--- a/pkgs/games/nudoku/default.nix
+++ b/pkgs/games/nudoku/default.nix
@@ -12,11 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Pull upstream fix for ncurses-6.3
     (fetchpatch {
       name = "ncurses-6.3.patch";
       url = "https://github.com/jubalh/nudoku/commit/93899a0fd72e04b9f257e5f54af53466106b5959.patch";
       sha256 = "1h3za0dnx8fk3vshql5mhcici8aw8j0vr7ra81p3r1rii4c479lm";
+      reason = "${pname}: upstream fix for ncurses-6.3";
+      throwBool = lib.versionAtLeast version "2.1.1";
     })
   ];
 
@@ -38,4 +39,3 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ dtzWill ];
   };
 }
-


### PR DESCRIPTION
NOTE: i will write tests and docs later for now i want feedback about the namings
to view the diff well, click the `hide whitespace changes` button

`throwBool = lib.versionAtLeast version "2.1.0";`
so people won't forget to remove conditional patches

`condition = stdenv.isAarch64;`
so no `lib.optional` needed so we can evaluate the throwBool

reason = "${pname}: upstream fix for ncurses-6.3";
so we dont have to use comments

`path = ./some.patch;`
to allow using the above options with vendored patches

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
