### PR TITLE
Manual: move note re: `useOSProber` option under GRUB subheading

### DIFF
--- a/nixos/doc/manual/from_md/installation/installing.chapter.xml
+++ b/nixos/doc/manual/from_md/installation/installing.chapter.xml
@@ -411,6 +411,13 @@ OK
                 specify on which disk the GRUB boot loader is to be
                 installed. Without it, NixOS cannot boot.
               </para>
+              <para>
+                If there are other operating systems running on the
+                machine before installing NixOS, the
+                <xref linkend="opt-boot.loader.grub.useOSProber" />
+                option can be set to <literal>true</literal> to
+                automatically add them to the grub menu.
+              </para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -436,13 +443,6 @@ OK
             </listitem>
           </varlistentry>
         </variablelist>
-        <para>
-          If there are other operating systems running on the machine
-          before installing NixOS, the
-          <xref linkend="opt-boot.loader.grub.useOSProber" /> option can
-          be set to <literal>true</literal> to automatically add them to
-          the grub menu.
-        </para>
         <para>
           If you need to configure networking for your machine the
           configuration options are described in

--- a/nixos/doc/manual/installation/installing.chapter.md
+++ b/nixos/doc/manual/installation/installing.chapter.md
@@ -296,6 +296,11 @@ Use the following commands:
         specify on which disk the GRUB boot loader is to be installed.
         Without it, NixOS cannot boot.
 
+    :   If there are other operating systems running on the machine before
+        installing NixOS, the [](#opt-boot.loader.grub.useOSProber)
+        option can be set to `true` to automatically add them to the grub
+        menu.
+
     UEFI systems
 
     :   You *must* set the option [](#opt-boot.loader.systemd-boot.enable)
@@ -306,11 +311,6 @@ Use the following commands:
         [`boot.loader.efi`](#opt-boot.loader.efi.canTouchEfiVariables) and
         [`boot.loader.systemd-boot`](#opt-boot.loader.systemd-boot.enable)
         as well.
-
-    If there are other operating systems running on the machine before
-    installing NixOS, the [](#opt-boot.loader.grub.useOSProber)
-    option can be set to `true` to automatically add them to the grub
-    menu.
 
     If you need to configure networking for your machine the
     configuration options are described in [](#sec-networking). In


### PR DESCRIPTION
###### Description of changes

(In the installation section of the NixOS manual) Moves a note re: `useOSProber` option under the GRUB subheading, as it only applies to GRUB and not systemd-boot.

Also, hello o/ First PR here after a couple years of dabbling in Nix on Manjaro.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).