### PR TITLE
unicode-emoji: 12.1 -> 14.0; cldr-common: init at 40.0; ibus: update for Emoji 14

### DIFF
--- a/pkgs/data/misc/cldr-annotations/default.nix
+++ b/pkgs/data/misc/cldr-annotations/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchzip }:
+
+let
+  version = "40.0";
+in fetchzip rec {
+  name = "cldr-annotations-${version}";
+
+  url = "https://unicode.org/Public/cldr/40/cldr-common-${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/unicode/cldr
+    unzip -d $out/share/unicode/cldr $downloadedFile 'common/annotations/*' 'common/annotationsDerived/*'
+  '';
+
+  sha256 = "sha256-L4NSMNFYKJWV3qKQhio9eMABtDlLieT9VeMZfzeAkbM=";
+
+  meta = with lib; {
+    description = "Names and keywords for Unicode characters from the Common Locale Data Repository";
+    homepage = "https://cldr.unicode.org";
+    license = licenses.unicode-dfs-2016;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ DeeUnderscore ];
+  };
+}

--- a/pkgs/data/misc/unicode-emoji/default.nix
+++ b/pkgs/data/misc/unicode-emoji/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  version = "12.1";
+  version = "14.0";
 
   fetchData = { file, sha256 }: fetchurl {
     url = "https://www.unicode.org/Public/emoji/${version}/${file}";
@@ -19,25 +19,17 @@ let
   };
 
   srcs = {
-    emoji-data = fetchData {
-      file = "emoji-data.txt";
-      sha256 = "17gfm5a28lsymx36prbjy2g0b27gf3rcgggy0yxdshbxwf6zpf9k";
-    };
     emoji-sequences = fetchData {
       file = "emoji-sequences.txt";
-      sha256 = "1fckw5hfyvz5jfp2jczzx8qcs79vf0zyq0z2942230j99arq70vc";
+      sha256 = "sha256-4helD/0oe+UmNIuVxPx/P0R9V10EY/RccewdeemeGxE=";
     };
     emoji-test = fetchData {
       file = "emoji-test.txt";
-      sha256 = "0w29lva7gp9g9lf7bz1i24qdalvf440bcq8npsbwr3cpp7na95kh";
-    };
-    emoji-variation-sequences = fetchData {
-      file = "emoji-variation-sequences.txt";
-      sha256 = "0akpib3cinr8xcs045hda5wnpfj6qfdjlkzmq5vgdc50gyhrd2z3";
+      sha256 = "sha256-DDOVhnFzfvowINzBZ7dGYMZnL4khyRWVzrLL95djsUg=";
     };
     emoji-zwj-sequences = fetchData {
       file = "emoji-zwj-sequences.txt";
-      sha256 = "0s2mvy1nr2v1x0rr1fxlsv8ly1vyf9978rb4hwry5vnr678ls522";
+      sha256 = "sha256-owlGLICFkyEsIHz/DUZucxjBmgVO40A69BCJPbIYDA0=";
     };
   };
 in

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -21,7 +21,7 @@
 , gtk-doc
 , runCommand
 , isocodes
-, cldr-emoji-annotation
+, cldr-annotations
 , unicode-character-database
 , unicode-emoji
 , python3
@@ -106,7 +106,7 @@ stdenv.mkDerivation rec {
     "--enable-gtk4"
     "--enable-install-tests"
     "--with-unicode-emoji-dir=${unicode-emoji}/share/unicode/emoji"
-    "--with-emoji-annotation-dir=${cldr-emoji-annotation}/share/unicode/cldr/common/annotations"
+    "--with-emoji-annotation-dir=${cldr-annotations}/share/unicode/cldr/common/annotations"
     "--with-ucd-dir=${unicode-character-database}/share/unicode"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23690,6 +23690,8 @@ with pkgs;
 
   chonburi-font = callPackage ../data/fonts/chonburi { };
 
+  cldr-annotations = callPackage ../data/misc/cldr-annotations { };
+
   cldr-emoji-annotation = callPackage ../data/misc/cldr-emoji-annotation { };
 
   clearlooks-phenix = callPackage ../data/themes/clearlooks-phenix { };


### PR DESCRIPTION
###### Description of changes
The goal of this PR is to get ibus to support Emoji 14 in its emoji picker. To this end, this PR:
* bumps `unicode-emoji` to 14.0
* adds `cldr-common`. The ibus package currently uses `cldr-emoji-annotations`, which is no longer maintained (per [the README](https://github.com/fujiwarat/cldr-emoji-annotation/blob/master/README)). As the README suggests, I switched over to upstream CLDR tarballs.

I built the ibus with the changes and tested out its emoji picker, but I didn't rebuild all the packages (~50) dependent on ibus. 

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
