### PR TITLE
Fix treeo, treex, elegy

### DIFF
--- a/pkgs/development/python-modules/einops/default.nix
+++ b/pkgs/development/python-modules/einops/default.nix
@@ -7,6 +7,7 @@
 , nbconvert
 , jupyter
 , chainer
+, parameterized
 , pytorch
 , mxnet
 , tensorflow
@@ -15,13 +16,13 @@
 
 buildPythonPackage rec {
   pname = "einops";
-  version = "0.3.2";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "arogozhnikov";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0ix094cfh6w4bvx6ymp5dpm35y9nkaibcn1y50g6kwdp4f0473y8";
+    hash = "sha256-n4R4lcRimuOncisCTs2zJWPlqZ+W2yPkvkWAnx4R91s=";
   };
 
   checkInputs = [
@@ -33,6 +34,7 @@ buildPythonPackage rec {
     jupyter
     # For backend tests
     chainer
+    parameterized
     pytorch
     mxnet
     tensorflow

--- a/pkgs/development/python-modules/elegy/default.nix
+++ b/pkgs/development/python-modules/elegy/default.nix
@@ -22,15 +22,23 @@
 
 buildPythonPackage rec {
   pname = "elegy";
-  version = "0.8.4";
+  version = "0.8.6";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "poets-ai";
     repo = pname;
     rev = version;
-    sha256 = "11w8lgl31b52w2qri8j8cgzd30sn8i3769g8nkkshvgkjgca9r4g";
+    hash = "sha256-FZmLriYhsX+zyQKCtCjbOy6MH+AvjzHRNUyaDSXGlLI=";
   };
+
+  # The cloudpickle constraint is too strict. wandb is marked as an optional
+  # dependency but `buildPythonPackage` doesn't seem to respect that setting.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'cloudpickle = "^1.5.0"' 'cloudpickle = "*"' \
+      --replace 'wandb = { version = "^0.12.10", optional = true }' ""
+  '';
 
   nativeBuildInputs = [
     poetry

--- a/pkgs/development/python-modules/optax/default.nix
+++ b/pkgs/development/python-modules/optax/default.nix
@@ -7,19 +7,19 @@
 , lib
 , numpy
 , pytestCheckHook
+, tensorflow
+, tensorflow-datasets
 }:
 
 buildPythonPackage rec {
   pname = "optax";
-  # As of 2022-01-06, the latest stable version (0.1.0) has broken tests that are fixed
-  # in https://github.com/deepmind/optax/commit/d6633365d84eb6f2c0df0c52b630481a349ce562
-  version = "unstable-2022-01-05";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "deepmind";
     repo = pname;
-    rev = "5ec5541b3486224b22e950480ff639ceaf5098f7";
-    sha256 = "1q8cxc42a5xais2ll1l238cnn3l7w28savhgiz0lg01ilz2ysbli";
+    rev = "v${version}";
+    hash = "sha256-s/BcqzhdfWzR61MStusUPQtuT4+t8NcC5gBGiGggFqw=";
   };
 
   buildInputs = [ jaxlib ];
@@ -33,6 +33,8 @@ buildPythonPackage rec {
   checkInputs = [
     dm-haiku
     pytestCheckHook
+    tensorflow
+    tensorflow-datasets
   ];
 
   pythonImportsCheck = [
@@ -42,8 +44,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Requires `flax` which depends on `optax` creating circular dependency.
     "optax/_src/equivalence_test.py"
-    # Require `tensorflow_datasets` which isn't packaged in `nixpkgs`.
-    "examples/datasets_test.py"
+    # See https://github.com/deepmind/optax/issues/323.
     "examples/lookahead_mnist_test.py"
   ];
 

--- a/pkgs/development/python-modules/treeo/default.nix
+++ b/pkgs/development/python-modules/treeo/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , jax
 , jaxlib
 , lib
@@ -8,20 +9,30 @@
 
 buildPythonPackage rec {
   pname = "treeo";
-  version = "0.4.0";
+  # Note that there is a version 0.4.0, but it was released in error. At the
+  # time of writing (2022-03-29), v0.0.11 is the latest as reported on GitHub
+  # and PyPI.
+  version = "0.0.11";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "cgarciae";
     repo = pname;
     rev = version;
-    sha256 = "176r1kgsdlylvdrxmhnzni81p8m9cfnsn4wwn6fnmsgam2qbp76j";
+    hash = "sha256-zs3F8i+G5OX/A9wOO60xVuvnm2QqrL+dHIrC0qwH37o=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace 'typing-extensions = "^3.10.0"' 'typing-extensions = "*"'
-  '';
+  # See https://github.com/cgarciae/treex/issues/68.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/cgarciae/treeo/pull/14/commits/022915da2b3bf76406a7c79d1b4593bee7956f16.patch";
+      hash = "sha256-WGxJqqrf2g0yZe30RyG1xxbloiqj1awuf1Y4eh5y+z0=";
+    })
+    (fetchpatch {
+      url = "https://github.com/cgarciae/treeo/pull/14/commits/99f9488bd0c977780844fd79743167b0010d359b.patch";
+      hash = "sha256-oKDYs+Ah0QXkhiJysIudQ6VLIiUiIcnQisxYp6GJuTc=";
+    })
+  ];
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/treex/default.nix
+++ b/pkgs/development/python-modules/treex/default.nix
@@ -18,21 +18,23 @@
 
 buildPythonPackage rec {
   pname = "treex";
-  version = "0.6.9";
+  version = "0.6.10";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "cgarciae";
     repo = pname;
     rev = version;
-    sha256 = "1yvlldmhji12h249j14ba44hnb9x1fhrj7rh1cx2vn0vxj5wpg7x";
+    hash = "sha256-ZHfgmRNbFh8DFZkmilY0pmRNQhJFqT689I7Lu8FuFm4=";
   };
 
+  # At the time of writing (2022-03-29), rich is currently at version 11.0.0.
+  # The treeo dependency is compatible with a patch, but not marked as such in
+  # treex. See https://github.com/cgarciae/treex/issues/68.
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'rich = "^10.7.0"' 'rich = ">=10.7.0"' \
-      --replace 'PyYAML = "^5.4.1"' 'PyYAML = ">=5.4.1"' \
-      --replace 'optax = "^0.0.9"' 'optax = ">=0.0.9"'
+      --replace 'rich = "^11.2.0"' 'rich = "*"' \
+      --replace 'treeo = "^0.0.10"' 'treeo = "*"'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Description of changes
Follow up to https://github.com/NixOS/nixpkgs/pull/159933. Fix https://github.com/NixOS/nixpkgs/issues/159455.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
