### PR TITLE
bluespec: 2021.07 -> 2022.01

### DIFF
--- a/pkgs/development/compilers/bluespec/default.nix
+++ b/pkgs/development/compilers/bluespec/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchurl
 , autoconf
 , automake
 , fontconfig
@@ -18,20 +19,27 @@
 , gmp-static
 , verilog
 , asciidoctor
-, tex }:
+, tex
+, which
+}:
 
 let
   ghcWithPackages = ghc.withPackages (g: (with g; [ old-time regex-compat syb split ]));
 
 in stdenv.mkDerivation rec {
   pname = "bluespec";
-  version = "2021.07";
+  version = "2022.01";
 
   src = fetchFromGitHub {
     owner = "B-Lang-org";
     repo = "bsc";
     rev = version;
-    sha256 = "0gw8wyp65lpkyfhv3laazz9qypdl8qkp1j7cqp0gv11592a9p5qw";
+    sha256 = "sha256-ivTua3MLa8akma3MGkhsqwSdwswYX916kywKdlj7TqY=";
+  };
+
+  yices-src = fetchurl {
+    url = "https://github.com/B-Lang-org/bsc/releases/download/${version}/yices-src-for-bsc-${version}.tar.gz";
+    sha256 = "sha256-ey5yIIVFZyG4EnYGqbIJqmxK1rZ70FWM0Jz+2hIoGXE=";
   };
 
   enableParallelBuilding = true;
@@ -43,8 +51,7 @@ in stdenv.mkDerivation rec {
 
   postUnpack = ''
     mkdir -p $sourceRoot/src/vendor/yices/v2.6/yices2
-    # XXX: only works because yices.src isn't a tarball.
-    cp -av ${yices.src}/* $sourceRoot/src/vendor/yices/v2.6/yices2
+    tar -C $sourceRoot/src/vendor/yices/v2.6/yices2 -xf ${yices-src}
     chmod -R +rwX $sourceRoot/src/vendor/yices/v2.6/yices2
   '';
 
@@ -68,6 +75,7 @@ in stdenv.mkDerivation rec {
     libX11 # tcltk
     tcl
     tk
+    which
     xorg.libXft
     zlib
   ];


### PR DESCRIPTION
Current bsc releases ship a tarball of the expected version of the yices
source, so switch to using that rather than gamble on the nixpkgs yices
version.

Signed-off-by: David Anderson <dave@natulte.net>

###### Description of changes

Upstream release, and switching to using the vendored yices version.

I switched to using the vendored yices on the idea that bsc has been tested against that, but I'm not married to the idea. Happy to switch back to "whatever yices nixpkgs ships" if that's the preferred way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
