### PR TITLE
dconf-editor: Respect NIX_GSETTINGS_OVERRIDES_DIR variable

### DIFF
--- a/pkgs/desktops/gnome/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome/core/dconf-editor/default.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Vxr0x9rU8Em1PmzXKLea3fCMJ92ra8V7OW0hGGbueeM=";
   };
 
+  patches = [
+    # Look for compiled schemas in NIX_GSETTINGS_OVERRIDES_DIR
+    # environment variable, to match what we patched GLib to do.
+    ./schema-override-variable.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/desktops/gnome/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome/core/dconf-editor/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , meson
 , ninja
 , vala
@@ -31,6 +32,12 @@ stdenv.mkDerivation rec {
     # Look for compiled schemas in NIX_GSETTINGS_OVERRIDES_DIR
     # environment variable, to match what we patched GLib to do.
     ./schema-override-variable.patch
+
+    # Fix build with Meson 0.61.0
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/dconf-editor/-/commit/56474378568e6ff4af8aa912810323e808c1d977.patch";
+      sha256 = "iFyJcskqcmvz7tp1Z9jM9f8WvAhD0L9Vx1hu2c402MA=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/dconf-editor/schema-override-variable.patch
+++ b/pkgs/desktops/gnome/core/dconf-editor/schema-override-variable.patch
@@ -1,0 +1,14 @@
+diff --git a/editor/source-manager.vala b/editor/source-manager.vala
+index 27b2b17a..87f7ba86 100644
+--- a/editor/source-manager.vala
++++ b/editor/source-manager.vala
+@@ -121,6 +121,9 @@ private class SourceManager : Object
+             source = try_prepend_dir (source, Path.build_filename (system_data_dirs [i], "glib-2.0", "schemas"));
+         string user_data_dir = GLib.Environment.get_user_data_dir ();
+         source = try_prepend_dir (source, Path.build_filename (user_data_dir, "glib-2.0", "schemas"));
++        string? nix_var_schema_dir = GLib.Environment.get_variable ("NIX_GSETTINGS_OVERRIDES_DIR");
++        if (nix_var_schema_dir != null)
++            source = try_prepend_dir (source, (!) nix_var_schema_dir);
+         string? var_schema_dir = GLib.Environment.get_variable ("GSETTINGS_SCHEMA_DIR");
+         if (var_schema_dir != null)
+             source = try_prepend_dir (source, (!) var_schema_dir);


### PR DESCRIPTION
###### Description of changes

We patch GLib to recognize `NIX_GSETTINGS_OVERRIDES_DIR` environment variable as a high priority source of settings schemas (#31683). This is used by NixOS modules for desktop environments like GNOME to set default values for stuff like background image.

Since dconf-editor uses custom GSettingsSchemaSource, it bypassed that patch, leading to the dconf-editor showing different values from what other apps using the GLib’s default source saw.

Let’s mirror our GLib patch in dconf-editor to fix that.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
