### PR TITLE
treewide: switch to `fetchFromGitHub`

### DIFF
--- a/pkgs/applications/misc/slic3r/default.nix
+++ b/pkgs/applications/misc/slic3r/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, perl, makeWrapper
+{ lib, stdenv, fetchFromGitHub, perl, makeWrapper
 , makeDesktopItem, which, perlPackages, boost
 }:
 
@@ -6,10 +6,11 @@ stdenv.mkDerivation rec {
   version = "1.3.0";
   pname = "slic3r";
 
-  src = fetchgit {
-    url = "https://github.com/alexrj/Slic3r";
+  src = fetchFromGitHub {
+    owner = "alexrj";
+    repo = "Slic3r";
     rev = version;
-    sha256 = "1pg4jxzb7f58ls5s8mygza8kqdap2c50kwlsdkf28bz1xi611zbi";
+    sha256 = "sha256-cf0QTOzhLyTcbJryCQoTVzU8kfrPV6SLpqi4s36X5N0=";
   };
 
   buildInputs =

--- a/pkgs/applications/networking/p2p/twister/default.nix
+++ b/pkgs/applications/networking/p2p/twister/default.nix
@@ -1,15 +1,15 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, autoconf, automake, libtool, pkg-config, python2
-, boost, db, openssl, geoip, libiconv, miniupnpc
-, srcOnly, fetchgit
+, boost, db, openssl, geoip, libiconv, miniupnpc, srcOnly
 }:
 
 let
   twisterHTML = srcOnly {
     name = "twister-html";
-    src = fetchgit {
-      url = "https://github.com/miguelfreitas/twister-html.git";
+    src = fetchFromGitHub {
+      owner = "miguelfreitas";
+      repo = "twister-html";
       rev = "01e7f7ca9b7e42ed90f91bc42da2c909ca5c0b9b";
-      sha256 = "0scjbin6s1kmi0bqq0dx0qyjw4n5xgmj567n0156i39f9h0dabqy";
+      sha256 = "sha256-Hi/VAEwujWhKAPaYIuvrxRIuPQa9AYwXiHUGbWxckmk=";
     };
   };
 

--- a/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/darcs-to-git/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, ruby, gnugrep, diffutils, git, darcs }:
+{ lib, stdenv, fetchFromGitHub, ruby, gnugrep, diffutils, git, darcs }:
 
 stdenv.mkDerivation {
   pname = "darcs-to-git";
   version = "2015-06-04";
 
-  src = fetchgit {
-    url = "https://github.com/purcell/darcs-to-git.git";
+  src = fetchFromGitHub {
+    owner = "purcell";
+    repo = "darcs-to-git";
     rev = "e5fee32495908fe0f7d700644c7b37347b7a0a5b";
-    sha256 = "0lxcx0x0m1cv2j4x9ykpjf6r2zg6lh5rya016x93vkmlzxm3f0ji";
+    sha256 = "sha256-UQI3av+0zj1SNwEonwuk5n2RjZN3+tSJFJuFCjrorFM=";
   };
 
   patchPhase = let

--- a/pkgs/development/compilers/ghcjs/ghcjs-base.nix
+++ b/pkgs/development/compilers/ghcjs/ghcjs-base.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, array, attoparsec, base, binary, bytestring
-, containers, deepseq, directory, dlist, fetchgit, ghc-prim
+, containers, deepseq, directory, dlist, fetchFromGitHub, ghc-prim
 , ghcjs-prim, hashable, HUnit, integer-gmp, primitive, QuickCheck
 , quickcheck-unicode, random, scientific, test-framework
 , test-framework-hunit, test-framework-quickcheck2, text, time
@@ -9,10 +9,11 @@
 mkDerivation {
   pname = "ghcjs-base";
   version = "0.2.0.3";
-  src = fetchgit {
-    url = "https://github.com/ghcjs/ghcjs-base";
-    sha256 = "15fdkjv0l7hpbbsn5238xxgzfdg61g666nzbv2sgxkwryn5rycv0";
+  src = fetchFromGitHub {
+    owner = "ghcjs";
+    repo = "ghcjs-base";
     rev = "85e31beab9beffc3ea91b954b61a5d04e708b8f2";
+    sha256 = "sha256-YDOfi/WZz/602OtbY8wL5jX3X+9oiGL1WhceCraczZU=";
   };
   libraryHaskellDepends = [
     aeson attoparsec base binary bytestring containers deepseq dlist

--- a/pkgs/development/interpreters/scsh/default.nix
+++ b/pkgs/development/interpreters/scsh/default.nix
@@ -1,14 +1,15 @@
-{ lib, stdenv, fetchgit, autoreconfHook, scheme48 }:
+{ lib, stdenv, fetchFromGitHub, autoreconfHook, scheme48 }:
 
 stdenv.mkDerivation {
   pname = "scsh";
   version = "0.7pre";
 
-  src = fetchgit {
-    url = "https://github.com/scheme/scsh.git";
+  src = fetchFromGitHub {
+    owner = "scheme";
+    repo = "scsh";
     rev = "f99b8c5293628cfeaeb792019072e3a96841104f";
+    sha256 = "sha256-vcVtqoUhozdJq1beUN8/rcI2qOJYUN+0CPSiDWGCIjI=";
     fetchSubmodules = true;
-    sha256 = "0ci2h9hhv8pl12sdyl2qwal3dhmd7zgm1pjnmd4kg8r1hnm6vidx";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/development/tools/parsing/hammer/default.nix
+++ b/pkgs/development/tools/parsing/hammer/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, glib, pkg-config, scons }:
+{ lib, stdenv, fetchFromGitHub, glib, pkg-config, scons }:
 
 stdenv.mkDerivation {
   pname = "hammer";
   version = "e7aa734";
 
-  src = fetchgit {
-    url = "https://github.com/UpstandingHackers/hammer";
-    sha256 = "01l0wbhz7dymxlndacin2vi8sqwjlw81ds2i9xyi200w51nsdm38";
+  src = fetchFromGitHub {
+    owner = "UpstandingHackers";
+    repo = "hammer";
     rev = "47f34b81e4de834fd3537dd71928c4f3cdb7f533";
+    sha256 = "sha256-aNSmbSgcABF9T1HoFhCnkmON4hY2MtUs7dW38+HigAY=";
   };
 
   nativeBuildInputs = [ pkg-config scons ];

--- a/pkgs/os-specific/linux/disk-indicator/default.nix
+++ b/pkgs/os-specific/linux/disk-indicator/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, libX11 }:
+{ lib, stdenv, fetchFromGitHub, libX11 }:
 
 stdenv.mkDerivation {
   pname = "disk-indicator";
   version = "unstable-2014-05-19";
 
-  src = fetchgit {
-    url = "https://github.com/MeanEYE/Disk-Indicator.git";
+  src = fetchFromGitHub {
+    owner = "MeanEYE";
+    repo = "Disk-Indicator";
     rev = "51ef4afd8141b8d0659cbc7dc62189c56ae9c2da";
-    sha256 = "10jx6mx9qarn21p2l2jayxkn1gmqhvck1wymgsr4jmbwxl8ra5kd";
+    sha256 = "sha256-bRaVEe18VUmyftXzMNmGuL5gZ/dKCipuEDYrnHo1XYI=";
   };
 
   buildInputs = [ libX11 ];

--- a/pkgs/tools/audio/pa-applet/default.nix
+++ b/pkgs/tools/audio/pa-applet/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, libpulseaudio, pkg-config, gtk3, glibc, autoconf, automake, libnotify, libX11, xf86inputevdev }:
+{ lib, stdenv, fetchFromGitHub, libpulseaudio, pkg-config, gtk3, glibc, autoconf, automake, libnotify, libX11, xf86inputevdev }:
 
 stdenv.mkDerivation {
   pname = "pa-applet";
   version = "unstable-2012-04-11";
 
-  src = fetchgit {
-    url = "https://github.com/fernandotcl/pa-applet.git";
+  src = fetchFromGitHub {
+    owner = "fernandotcl";
+    repo = "pa-applet";
     rev = "005f192df9ba6d2e6491f9aac650be42906b135a";
-    sha256 = "1242sdri67wnm1cd0hr40mxarkh7qs7mb9n2m0g9dbz0f4axj6wa";
+    sha256 = "sha256-ihvZFXHgr5YeqMKmVY/GB86segUkQ9BYqJYfE3PTgog=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/networking/carddav-util/default.nix
+++ b/pkgs/tools/networking/carddav-util/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, python3Packages, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, python3Packages, makeWrapper }:
 
 stdenv.mkDerivation {
   pname = "carddav";
   version = "0.1-2014-02-26";
 
-  src = fetchgit {
-    url = "https://github.com/ljanyst/carddav-util";
+  src = fetchFromGitHub {
+    owner = "ljanyst";
+    repo = "carddav-util";
     rev = "53b181faff5f154bcd180467dd04c0ce69405564";
-    sha256 = "0f0raffdy032wlnxfck6ky60r163nhqfbr311y4ry55l60s4497n";
+    sha256 = "sha256-9iRCNDC0FJ+JD2Hk5TC0w4QMjJ9mMtct5WIA35xTGTg=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/package-management/nixui/default.nix
+++ b/pkgs/tools/package-management/nixui/default.nix
@@ -1,12 +1,6 @@
-{ lib, stdenv, pkgs, fetchgit, nix, node_webkit, makeDesktopItem
+{ lib, stdenv, pkgs, fetchFromGitHub, nix, node_webkit, makeDesktopItem
 , writeScript }:
 let
-  version = "0.2.1";
-  src = fetchgit {
-    url = "https://github.com/matejc/nixui.git";
-    rev = "845a5f4a33f1d0c509c727c130d0792a5b450a38";
-    sha256 = "1ay3i4lgzs3axbby06l4vvspxi0aa9pwiil84qj0dqq1jb6isara";
-  };
   nixui = (import ./nixui.nix {
     inherit pkgs;
     inherit (stdenv.hostPlatform) system;
@@ -24,9 +18,15 @@ let
     genericName = "NixUI";
   };
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "nixui";
-  inherit version src;
+  version = "0.2.1";
+  src = fetchFromGitHub {
+    owner = "matejc";
+    repo = "nixui";
+    rev = version;
+    sha256 = "sha256-KisdzZIB4wYkJojGyG9SCsR+9d6EGuDX6mro/yiJw6s=";
+  };
   installPhase = ''
     mkdir -p $out/bin
     ln -s ${script} $out/bin/nixui


### PR DESCRIPTION
###### Description of changes
followup to  #165691

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
