### PR TITLE
kube3d: 5.3.0 -> 5.4.1

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -1,16 +1,28 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, k3sVersion ? "1.22.2-k3s2" }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, k3sVersion ? null
+}:
 
+let
+  hasVPrefix = ver: (builtins.elemAt (lib.stringToCharacters ver) 0) == "v";
+  k3sVersionSet =
+    if k3sVersion != null then
+      if hasVPrefix k3sVersion then throw "k3sVersion should not have a v prefix" else true
+    else
+      false;
+in
 buildGoModule rec {
   pname = "kube3d";
-  version = "5.3.0";
+  version = "5.4.1";
 
   src = fetchFromGitHub {
-    owner = "rancher";
+    owner = "k3d-io";
     repo = "k3d";
     rev = "v${version}";
-    sha256 = "sha256-ZuUjk1wb7iRZX+OpjLJHp1T0WYNjCHU6DpYF4V/heVc=";
+    sha256 = "sha256-DVQrD4JMei9yRFzuiVb6AcydEupNSlpgYLfGWWRiaao=";
   };
-
   vendorSha256 = null;
 
   nativeBuildInputs = [ installShellFiles ];
@@ -18,10 +30,14 @@ buildGoModule rec {
   excludedPackages = [ "tools" "docgen" ];
 
   ldflags =
-    let t = "github.com/rancher/k3d/v5/version"; in
-    [ "-s" "-w" "-X ${t}.Version=v${version}" "-X ${t}.K3sVersion=v${k3sVersion}" ];
+    let t = "github.com/k3d-io/k3d/v5/version"; in
+    [ "-s" "-w" "-X ${t}.Version=v${version}" ] ++ lib.optionals k3sVersionSet [ "-X ${t}.K3sVersion=v${k3sVersion}" ];
 
-  doCheck = false;
+   preCheck = ''
+    # skip test that uses networking
+    substituteInPlace version/version_test.go \
+      --replace "TestGetK3sVersion" "SkipGetK3sVersion"
+  '';
 
   postInstall = ''
     installShellCompletion --cmd k3d \
@@ -34,13 +50,13 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/k3d --help
-    $out/bin/k3d --version | grep -e "k3d version v${version}" -e "k3s version v${k3sVersion}"
+    $out/bin/k3d --version | grep -e "k3d version v${version}" ${lib.optionalString k3sVersionSet "-e \"k3s version v${k3sVersion}\""}
     runHook postInstallCheck
   '';
 
   meta = with lib; {
-    homepage = "https://github.com/rancher/k3d";
-    changelog = "https://github.com/rancher/k3d/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/k3d-io/k3d/";
+    changelog = "https://github.com/k3d-io/k3d/blob/v${version}/CHANGELOG.md";
     description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container - k3d";
     longDescription = ''
       k3s is the lightweight Kubernetes distribution by Rancher: rancher/k3s
@@ -51,5 +67,6 @@ buildGoModule rec {
     license = licenses.mit;
     maintainers = with maintainers; [ kuznero jlesquembre ngerstle jk ricochet ];
     platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "k3d";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump kube3d to `5.4.1`


Also:

Updated github location after the move

Fall back on default k3sVersion in the code - The k3d code regularly updates the default k3s version wihin the code. We can set it by hand when we need to if there's a certain version we should use but at the moment we seem to update it at random. k3d also has some capability to query the latest version via the network or have it overriden via the cli

Added some validation to the k3sVersion that can be overriden - prevent double `v` prefix

Added mainProgram to meta


Testing the validation:

```
λ nix-build -A kube3d
# or
λ nix-build -E 'with import ./. {}; kube3d'

# overrides
λ nix-build -E 'with import ./. {}; kube3d.override { k3sVersion = "1.23.4+k3s1"; }'

λ nix-build -E 'with import ./. {}; kube3d.override { k3sVersion = "v1.23.4+k3s1"; }'

```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
