### PR TITLE
gnome.gnome-logs: 3.36.0 → 42.0

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -117,6 +117,7 @@ with lib.maintainers; {
 
   gnome = {
     members = [
+      bobby285271
       hedning
       jtojnar
       dasj19

--- a/pkgs/desktops/gnome/apps/gnome-logs/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-logs/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -10,6 +10,7 @@
 , wrapGAppsHook
 , gettext
 , itstool
+, libhandy
 , libxml2
 , libxslt
 , docbook_xsl
@@ -21,20 +22,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-logs";
-  version = "3.36.0";
+  version = "42.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-logs/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0w1nfdxbv3f0wnhmdy21ydvr4swfc108hypda561p7l9lrhnnxj4";
+    url = "mirror://gnome/sources/gnome-logs/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    sha256 = "TV5FFp1r9DkC16npoHk8kW65LaumuoWzXI629nLNq9c=";
   };
-
-  patches = [
-    # https://gitlab.gnome.org/GNOME/gnome-logs/-/issues/52
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-logs/-/commit/b42defceefc775220b525f665a3b662ab9593b81.patch";
-      sha256 = "1s0zscmhwy7r0xff17wh8ik8x9xw1vrkipw5vl5i770bxnljps8n";
-    })
-  ];
 
   nativeBuildInputs = [
     python3
@@ -53,9 +46,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gtk3
+    libhandy
     systemd
     gsettings-desktop-schemas
-    gnome.adwaita-icon-theme
   ];
 
   mesonFlags = [
@@ -80,7 +73,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wiki.gnome.org/Apps/Logs";
     description = "A log viewer for the systemd journal";
     maintainers = teams.gnome.members;
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/gnome-logs/-/compare/gnome-logs-3.36.0...gnome-logs-42.0

* Opt-in to dark mode user preference
* Rounded window corners using libhandy
* Add feature to open journal files directly
* Port to GtkFileChooserNative
* Add several keyboard shortcuts to help overlay
* Window sizing improvements
* Small fixes
* Appdata name improvement

(Contact me on matrix `@bobby285271:matrix.org` if you are feeling uncomfortable with 066634e509988232b435cf2e64c778ec4508a4b4? To clarify I am still happy to maintain Pantheon)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
