### PR TITLE
python3Packages: reduce black usage to make updates easier

### DIFF
--- a/pkgs/development/python-modules/hypothesmith/default.nix
+++ b/pkgs/development/python-modules/hypothesmith/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, hypothesis, lark, libcst, black, parso, pytestCheckHook, pytest-cov, pytest-xdist }:
+{ lib, buildPythonPackage, fetchPypi, hypothesis, lark, libcst, parso, pytestCheckHook, pytest-xdist }:
 
 buildPythonPackage rec {
   pname = "hypothesmith";
@@ -10,16 +10,29 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace "lark-parser" "lark"
+    substituteInPlace setup.py \
+      --replace "lark-parser" "lark"
+
+    substituteInPlace tox.ini \
+      --replace "--cov=hypothesmith" "" \
+      --replace "--cov-branch" "" \
+      --replace "--cov-report=term-missing:skip-covered" "" \
+      --replace "--cov-fail-under=100" ""
   '';
 
   propagatedBuildInputs = [ hypothesis lark libcst ];
 
-  checkInputs = [ black parso pytestCheckHook pytest-cov pytest-xdist ];
+  checkInputs = [ parso pytestCheckHook pytest-xdist ];
 
   pytestFlagsArray = [
     "-v"
     "--numprocesses $NIX_BUILD_CORES"
+  ];
+
+  disabledTestPaths = [
+    # require black
+    "tests/test_cst.py"
+    "tests/test_syntactic.py"
   ];
 
   pythonImportsCheck = [ "hypothesmith" ];

--- a/pkgs/development/python-modules/ipython/default.nix
+++ b/pkgs/development/python-modules/ipython/default.nix
@@ -10,7 +10,6 @@
 # Runtime dependencies
 , appnope
 , backcall
-, black
 , decorator
 , jedi
 , matplotlib-inline
@@ -43,7 +42,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     backcall
-    black
     decorator
     jedi
     matplotlib-inline
@@ -83,7 +81,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "IPython: Productive Interactive Computing";
-    homepage = "http://ipython.org/";
+    homepage = "https://ipython.org/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bjornfor fridh ];
   };

--- a/pkgs/development/python-modules/typer/default.nix
+++ b/pkgs/development/python-modules/typer/default.nix
@@ -8,9 +8,6 @@
 , pytest-xdist
 , pytest-sugar
 , coverage
-, mypy
-, black
-, isort
 , pythonOlder
 }:
 
@@ -34,10 +31,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytest-sugar
     shellingham
-    coverage
-    mypy
-    black
-    isort
+    coverage # execs coverage in tests
   ];
 
   preCheck = ''


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
