### PR TITLE
kde/plasma5: 5.24.3 -> 5.24.4

### DIFF
--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.24.3/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.24.4/ -A '*.tar.xz' )

--- a/pkgs/desktops/plasma-5/kscreen.nix
+++ b/pkgs/desktops/plasma-5/kscreen.nix
@@ -3,7 +3,7 @@
   extra-cmake-modules,
   kconfig, kcmutils, kconfigwidgets, kdbusaddons, kglobalaccel, ki18n,
   kwidgetsaddons, kxmlgui, libkscreen, qtdeclarative, qtgraphicaleffects, qtsensors,
-  kwindowsystem, kdeclarative, plasma-framework
+  kwindowsystem, kdeclarative, plasma-framework, qtx11extras
 }:
 
 mkDerivation {
@@ -12,6 +12,6 @@ mkDerivation {
   buildInputs = [
     kconfig kcmutils kconfigwidgets kdbusaddons kglobalaccel ki18n
     kwidgetsaddons kxmlgui libkscreen qtdeclarative qtgraphicaleffects qtsensors
-    kwindowsystem kdeclarative plasma-framework
+    kwindowsystem kdeclarative plasma-framework qtx11extras
   ];
 }

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -4,427 +4,427 @@
 
 {
   bluedevil = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/bluedevil-5.24.3.tar.xz";
-      sha256 = "1hlyqhn14yq7960zfjwjygkpkvbmrlsanm1g1wrr7dwbmrp5dlcx";
-      name = "bluedevil-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/bluedevil-5.24.4.tar.xz";
+      sha256 = "1mph04r6l9bxml1brwifbnk6lkjxkzxx75b3g3myzijjv6f8wxw3";
+      name = "bluedevil-5.24.4.tar.xz";
     };
   };
   breeze = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/breeze-5.24.3.tar.xz";
-      sha256 = "0h19m6wmhjw8v6ys47kgzcb0h2nb9w2fcjzypnvmkvbjbkjr53sb";
-      name = "breeze-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/breeze-5.24.4.tar.xz";
+      sha256 = "01cqji6figwb95drcq9vrqlkv7xmpn2csbi2mvixbcdawqhywsg3";
+      name = "breeze-5.24.4.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/breeze-grub-5.24.3.tar.xz";
-      sha256 = "15cpmqp7klp4dhcil3i78iff4kjasfx273v36ml8y05hm8w0igjq";
-      name = "breeze-grub-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/breeze-grub-5.24.4.tar.xz";
+      sha256 = "1p154g2x1g00iam2gkv7pml1r0b91b21s8fgrfrqg5pj45ysp5bc";
+      name = "breeze-grub-5.24.4.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/breeze-gtk-5.24.3.tar.xz";
-      sha256 = "1922s17mh4ifaqbf4b7p6yj8pwd6z3qwpbf21j1fqhmdk4pvn499";
-      name = "breeze-gtk-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/breeze-gtk-5.24.4.tar.xz";
+      sha256 = "0s51azc2xmh7agbqlm9rn39c5qh6rfwyc2dq4sfv6vspm1883zmj";
+      name = "breeze-gtk-5.24.4.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/breeze-plymouth-5.24.3.tar.xz";
-      sha256 = "0nkf0ll4hcawmkd7nrh8gcf6hhbl0ajxiz2azf9njab9pv2lcz1j";
-      name = "breeze-plymouth-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/breeze-plymouth-5.24.4.tar.xz";
+      sha256 = "038pglghl40nyq6lzydijy3wnr5agvfzddjxrf6lc9m6qapqd37v";
+      name = "breeze-plymouth-5.24.4.tar.xz";
     };
   };
   discover = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/discover-5.24.3.tar.xz";
-      sha256 = "097m5njz86vi4innap1mvizas60r1qcrdzdgsid1hd6p5a92rwca";
-      name = "discover-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/discover-5.24.4.tar.xz";
+      sha256 = "0smhys51chvjh2ij4mk03cfnq09n8cq22iag1ld9j2125l5iwa99";
+      name = "discover-5.24.4.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/drkonqi-5.24.3.tar.xz";
-      sha256 = "1n6psvr3washk796zrc8ag011fwy677h2mdkw9ijx8dhrk80br0k";
-      name = "drkonqi-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/drkonqi-5.24.4.tar.xz";
+      sha256 = "1yn7yj8nwnxm1s0si2353wl17jv7c7l5dc7833ndl56phv2999x0";
+      name = "drkonqi-5.24.4.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kactivitymanagerd-5.24.3.tar.xz";
-      sha256 = "0qxf3j36dj1yklnl27znsi9qdjmn6nr779cnzms38x76dq9kxblw";
-      name = "kactivitymanagerd-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kactivitymanagerd-5.24.4.tar.xz";
+      sha256 = "0aamfgc4bdrysq7ps134pf5v4bgiwrsxffi0nb6d8zazswgkfa41";
+      name = "kactivitymanagerd-5.24.4.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kde-cli-tools-5.24.3.tar.xz";
-      sha256 = "00z8yxic5ibk05x8c25dsc4ijvk6yv0aw1iyfhnpnzmdwdydlr7y";
-      name = "kde-cli-tools-5.24.3.tar.xz";
-    };
-  };
-  kdecoration = {
-    version = "5.24.3";
-    src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kdecoration-5.24.3.tar.xz";
-      sha256 = "0dpnaf5myn1h368cnkq9g6xfm1sqmyam6bxyidbd5j3dyy1kvz5v";
-      name = "kdecoration-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kde-cli-tools-5.24.4.tar.xz";
+      sha256 = "1w2rhz32xaqhmq5lyvfmjrbssqf9f35k5fk02f05fz79yk9wir7z";
+      name = "kde-cli-tools-5.24.4.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kde-gtk-config-5.24.3.tar.xz";
-      sha256 = "0p50kf34csdrgck1y09d3lnz0r9ly0ca4778achrc59yr4qcsjzv";
-      name = "kde-gtk-config-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kde-gtk-config-5.24.4.tar.xz";
+      sha256 = "02spbx2rniiyvzj4qb6lgzj0f83k4vq53fk4i1m45438z7aslymi";
+      name = "kde-gtk-config-5.24.4.tar.xz";
+    };
+  };
+  kdecoration = {
+    version = "5.24.4";
+    src = fetchurl {
+      url = "${mirror}/stable/plasma/5.24.4/kdecoration-5.24.4.tar.xz";
+      sha256 = "05ccyb314mxf0d4ivj71l9lh13s3fqr7f4d2rmg6qshsql39569c";
+      name = "kdecoration-5.24.4.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kdeplasma-addons-5.24.3.tar.xz";
-      sha256 = "0g7jcvd6abnlzz9ibnc7phzm58pn6dv3795w4hhy47738jkhizl6";
-      name = "kdeplasma-addons-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kdeplasma-addons-5.24.4.tar.xz";
+      sha256 = "03b8d3kdzwpyqrqkmpswryksrhav3mwcnbyzdc3g2kpk2qnx68fp";
+      name = "kdeplasma-addons-5.24.4.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kgamma5-5.24.3.tar.xz";
-      sha256 = "0rwqvz14a50s43p74n19v1zzd9y8f2lylfappxmhrdyxmbgkpnk6";
-      name = "kgamma5-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kgamma5-5.24.4.tar.xz";
+      sha256 = "0z1zrw5id455idjbaqracs1vcwgs93an7w27ggfqs6i8nabrivbk";
+      name = "kgamma5-5.24.4.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/khotkeys-5.24.3.tar.xz";
-      sha256 = "1jxg91rpz09sh13fz270pxfw40qdy6p50j5xw7cpnyqlk2l5zx0p";
-      name = "khotkeys-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/khotkeys-5.24.4.tar.xz";
+      sha256 = "033dgz8wbsw2nj133hnmygz1izmcpxdn80jbjbm66nhbbyq7bb2s";
+      name = "khotkeys-5.24.4.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kinfocenter-5.24.3.tar.xz";
-      sha256 = "08z2044bl0v4ydlx2chv849y6m4py0yd4lnw76sycd14lnvsrxfj";
-      name = "kinfocenter-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kinfocenter-5.24.4.tar.xz";
+      sha256 = "0f5q6ajyd794p1z9j3il8sajlqkdcnf06xq4612qxdp49nb88nyw";
+      name = "kinfocenter-5.24.4.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kmenuedit-5.24.3.tar.xz";
-      sha256 = "1yivrdix4jiycfbw9g6pzx8zkmdq4g8g51ndc7sy3r0qxzgx1icb";
-      name = "kmenuedit-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kmenuedit-5.24.4.tar.xz";
+      sha256 = "0ril8jxqkaavc4bkpksnyxn3bww7b81gnp9bnb17acrr2nd7wyhl";
+      name = "kmenuedit-5.24.4.tar.xz";
     };
   };
   kscreen = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kscreen-5.24.3.tar.xz";
-      sha256 = "1wjbd33h8473v8i5qxdccxrsv04v6jyd7scrqdxqaln9n8ylp08f";
-      name = "kscreen-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kscreen-5.24.4.tar.xz";
+      sha256 = "0shvhymdfxw1gz49y1s79zik9kkg5qh0mqdj6dx0s6r3w6vysj1h";
+      name = "kscreen-5.24.4.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kscreenlocker-5.24.3.tar.xz";
-      sha256 = "1dh3z55hwakj11ffn2fm79vnlw7gcg1nkcxbxvcdcpq84ahpq583";
-      name = "kscreenlocker-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kscreenlocker-5.24.4.tar.xz";
+      sha256 = "1xzc80awsapsg65kk21ssp7y0jb374k1w2bb7gvzj8j40rrn48pv";
+      name = "kscreenlocker-5.24.4.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/ksshaskpass-5.24.3.tar.xz";
-      sha256 = "0ivq9nyyqm1rrm6ck26jlsh8qv9q98dz5qwvcnpgpmxb3mr1dgiv";
-      name = "ksshaskpass-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/ksshaskpass-5.24.4.tar.xz";
+      sha256 = "1pa41w793dbi3rv6mm1a4xp46n80qwdpdlwhi6z4x76hjvqx9i9l";
+      name = "ksshaskpass-5.24.4.tar.xz";
     };
   };
   ksystemstats = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/ksystemstats-5.24.3.tar.xz";
-      sha256 = "03ikpd3m0qk8cb92g63i7q9c8bks7ggf1pmmig559cmg7gbknc2c";
-      name = "ksystemstats-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/ksystemstats-5.24.4.tar.xz";
+      sha256 = "1pa7xrw5ij32bm66pn72zkzz8y70fq71n4kigm9ixc1s2glkbiwd";
+      name = "ksystemstats-5.24.4.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kwallet-pam-5.24.3.tar.xz";
-      sha256 = "0zxdrpjq8sg3qw2gfkvjs567b41labi940cq4qrix395v7251p9k";
-      name = "kwallet-pam-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kwallet-pam-5.24.4.tar.xz";
+      sha256 = "0s6z7ds42a7kba25jd7pzylw7d2mc27xgymmdrpkg2afqanf3m4r";
+      name = "kwallet-pam-5.24.4.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kwayland-integration-5.24.3.tar.xz";
-      sha256 = "1kq5vrrplbdxri8610h89apfz07a6xi1gnlvmr8gbsvas5zicvwz";
-      name = "kwayland-integration-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kwayland-integration-5.24.4.tar.xz";
+      sha256 = "1cnfb81yv6m37m2kyk523skqbk5in1kpbpxq60ivjri91sm4pryj";
+      name = "kwayland-integration-5.24.4.tar.xz";
     };
   };
   kwayland-server = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kwayland-server-5.24.3.tar.xz";
-      sha256 = "0fq61qk3cp4xg9759ylqqw5ncx9s7kayjf0bilg5m725bfhj02sn";
-      name = "kwayland-server-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kwayland-server-5.24.4.tar.xz";
+      sha256 = "1279nqhy1qyz84dkn23rvzak8bg71hbrp09jlhv9mkjdb3bhnyfi";
+      name = "kwayland-server-5.24.4.tar.xz";
     };
   };
   kwin = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kwin-5.24.3.tar.xz";
-      sha256 = "0szlrcsj4h4fa5yf27nmza7c4dyc0xcwdrihs05pl5qk5bivfkfq";
-      name = "kwin-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kwin-5.24.4.tar.xz";
+      sha256 = "1qwcd6iw6yvpchiwmvq5nwsr465jmrmscf286mjrc65im4hj6572";
+      name = "kwin-5.24.4.tar.xz";
     };
   };
   kwrited = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/kwrited-5.24.3.tar.xz";
-      sha256 = "1sgd3iik647pz2zr5cpsbwm2ll8f11xyw2jv2sfxkbiiw53qaxid";
-      name = "kwrited-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/kwrited-5.24.4.tar.xz";
+      sha256 = "0j86ih4g762a94cyzilcbigh7iv04a80bqrlxm02fbqhffv01mv2";
+      name = "kwrited-5.24.4.tar.xz";
     };
   };
   layer-shell-qt = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/layer-shell-qt-5.24.3.tar.xz";
-      sha256 = "0h3xlvmgyxyzxvazgbbn0a9l14hg5d38cl9hclnwmrnpwbn0bqax";
-      name = "layer-shell-qt-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/layer-shell-qt-5.24.4.tar.xz";
+      sha256 = "03qyf6pvk36ig6ilimq02q19frdlsmrkbng2iz3d59k15zdrz5x0";
+      name = "layer-shell-qt-5.24.4.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/libkscreen-5.24.3.tar.xz";
-      sha256 = "18777lwn5j0isc347dks25731byyfdyls79lj6hnxqb6807lz1x6";
-      name = "libkscreen-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/libkscreen-5.24.4.tar.xz";
+      sha256 = "1xv7vml5lxj1lnansisfbfym35h265ggwsyjplz76aibj5nyqv81";
+      name = "libkscreen-5.24.4.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/libksysguard-5.24.3.tar.xz";
-      sha256 = "18piiy24rd5fzvp4cnhgx0d4x4m6fnxx01zm1mx0sh676g7m31hl";
-      name = "libksysguard-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/libksysguard-5.24.4.tar.xz";
+      sha256 = "00i4l2kc02wymmiqh7wam8dp4h9hvn8nsxfv258waq7pnxzjmnkn";
+      name = "libksysguard-5.24.4.tar.xz";
     };
   };
   milou = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/milou-5.24.3.tar.xz";
-      sha256 = "06xx4afym92hfpvbiqrv7mx30bdm3dhdfn8vki5zxq2k0rv0pmri";
-      name = "milou-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/milou-5.24.4.tar.xz";
+      sha256 = "0z7kmygvjzj30llwg8gpibjja2gzc09nh9pxrpy78pa1jxnas29i";
+      name = "milou-5.24.4.tar.xz";
     };
   };
   oxygen = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/oxygen-5.24.3.tar.xz";
-      sha256 = "02j0drc24mf2pfhdgzri5sdcscq1bbj4lhhmhp6bn1v74wybv381";
-      name = "oxygen-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/oxygen-5.24.4.tar.xz";
+      sha256 = "1d3sz2qc1cz9x6g04r0scvw9fmrazfn5v3iav4cn7wdkz8x06kc0";
+      name = "oxygen-5.24.4.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-browser-integration-5.24.3.tar.xz";
-      sha256 = "1msib3c8arybqbv1vfj1ijx74a34a02hn8gvjy4sf95zcl07mc20";
-      name = "plasma-browser-integration-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-browser-integration-5.24.4.tar.xz";
+      sha256 = "1havd775d4x2y36nkba2k6vdf839dspk10mxccnk2wkhdxmzfyk7";
+      name = "plasma-browser-integration-5.24.4.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-desktop-5.24.3.tar.xz";
-      sha256 = "1lwizprs6nk6nibydwkwmpi9c7c50lvg2k188pb6ddz2sb7pwgjq";
-      name = "plasma-desktop-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-desktop-5.24.4.tar.xz";
+      sha256 = "09fhqz2sp4caabr1li1shjd8l052vp4d10ci7pwsqj8f61331qmh";
+      name = "plasma-desktop-5.24.4.tar.xz";
     };
   };
   plasma-disks = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-disks-5.24.3.tar.xz";
-      sha256 = "0nklcimxyvci3xa6nc5jxbcxds4a14vkkwihgc6xfpc7xcca0wcy";
-      name = "plasma-disks-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-disks-5.24.4.tar.xz";
+      sha256 = "1mi5fp3305kjw41zhbccxyg666gcmmrvckipjhnnnfwd3gl372ng";
+      name = "plasma-disks-5.24.4.tar.xz";
     };
   };
   plasma-firewall = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-firewall-5.24.3.tar.xz";
-      sha256 = "0r7gh3asnc5lbfsp1jb33lmgcxfpjmlrqlyz41g0wv9aj9x6pwxz";
-      name = "plasma-firewall-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-firewall-5.24.4.tar.xz";
+      sha256 = "0f9g5m2ddbp2axfxqc4d92fzg6r4z1l56i6nsry6nlz6cqky3fm2";
+      name = "plasma-firewall-5.24.4.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-integration-5.24.3.tar.xz";
-      sha256 = "031w205icblf50ps7bw7wp5q4azbqpcp4bnig2wh5d1lc8xqzvvs";
-      name = "plasma-integration-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-integration-5.24.4.tar.xz";
+      sha256 = "1d2d7cmhdhmdzs91vpc2p3fg413daqhqilp8d2qbpsks5hyrkm3k";
+      name = "plasma-integration-5.24.4.tar.xz";
     };
   };
   plasma-mobile = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-mobile-5.24.3.tar.xz";
-      sha256 = "1bwmy7xvd8wmh0snqqjh9jjgawib8ks2g30w48sqxwhplhf3da58";
-      name = "plasma-mobile-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-mobile-5.24.4.tar.xz";
+      sha256 = "1hgcnb4flw224j57fxkhaiwapymq6ccjwqj8s6jgqzc3ax0py0vr";
+      name = "plasma-mobile-5.24.4.tar.xz";
     };
   };
   plasma-nano = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-nano-5.24.3.tar.xz";
-      sha256 = "13jxhfi3c3dhg7zdyfqnsii661h1am0w9dsv82dalqvwr1mw28l5";
-      name = "plasma-nano-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-nano-5.24.4.tar.xz";
+      sha256 = "1fdq4r5zlkf3qb0a47zv3apgnqs4gqqfj8pdlcmzkyn9xykzs9vw";
+      name = "plasma-nano-5.24.4.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-nm-5.24.3.tar.xz";
-      sha256 = "1z9vzj2mbvqklnjxf2izpx9s6cq097im0kz41fy4c5cjxna4xxic";
-      name = "plasma-nm-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-nm-5.24.4.tar.xz";
+      sha256 = "0bzc48vdrnd6n9qcm8ms7wrjm2yl7h9dik32arwdxx56vb7jhv08";
+      name = "plasma-nm-5.24.4.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-pa-5.24.3.tar.xz";
-      sha256 = "0n87rb04izd0ix50iy2dgj6yzzr626vhpfk76lnqr57jz6fbx3z1";
-      name = "plasma-pa-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-pa-5.24.4.tar.xz";
+      sha256 = "09fkaq2zzicgr214zi2wf7cirffm7mwh55bivvafblp1wlavkrgz";
+      name = "plasma-pa-5.24.4.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-sdk-5.24.3.tar.xz";
-      sha256 = "0g6nypqsbmsp9msixd7p25lk58zismdamkp41f5lx3cbb49x1fpr";
-      name = "plasma-sdk-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-sdk-5.24.4.tar.xz";
+      sha256 = "1zkggp9a1yz5mwwvndizwlan6wlb2fy8n940ljnhldccl91mgwzc";
+      name = "plasma-sdk-5.24.4.tar.xz";
     };
   };
   plasma-systemmonitor = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-systemmonitor-5.24.3.tar.xz";
-      sha256 = "17a3q1az4d3xpk2ifqsj6sz7r4apxy58kk2r2l14p6s6aszhqk4h";
-      name = "plasma-systemmonitor-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-systemmonitor-5.24.4.tar.xz";
+      sha256 = "0jcsmmg0asf2npl3f1nbzazz3i8m9b34q55088k8jjakwwxqbwhz";
+      name = "plasma-systemmonitor-5.24.4.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-tests-5.24.3.tar.xz";
-      sha256 = "1x5hr465kj3dg6c335lji2lxvp7cbn86181l78qk4l75sj1ss721";
-      name = "plasma-tests-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-tests-5.24.4.tar.xz";
+      sha256 = "1ms298h9wghj9gpi7laf1dsd7s3yiycy44k4s5v4id8vfarnbs27";
+      name = "plasma-tests-5.24.4.tar.xz";
     };
   };
   plasma-thunderbolt = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-thunderbolt-5.24.3.tar.xz";
-      sha256 = "1px5vfk37ak6hj6q3ipljj2dpazdbgdsga6nbkwcfn31708c7gjj";
-      name = "plasma-thunderbolt-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-thunderbolt-5.24.4.tar.xz";
+      sha256 = "1cqabdsg8v8b00ppbabrg2gih16lf79lr5i8mqvjnc73npacvzhy";
+      name = "plasma-thunderbolt-5.24.4.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-vault-5.24.3.tar.xz";
-      sha256 = "0f5yhz7qz4bqj7mc7hv7mvh2ji82pp02c901ws5cwwsh23yrhjcd";
-      name = "plasma-vault-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-vault-5.24.4.tar.xz";
+      sha256 = "0rj9z2c52mya2fjm4bimqz5z3lj2qg764zri6bqwrgwgsjwc4s81";
+      name = "plasma-vault-5.24.4.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-workspace-5.24.3.tar.xz";
-      sha256 = "1d1a8k75q0rdbbwkx8p1i38hc6xv9kggvfm6973lh3q0pc75qk0h";
-      name = "plasma-workspace-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-workspace-5.24.4.tar.xz";
+      sha256 = "0w7cnawnpcg5zk9bycjcnc8yfz21whrhd9h2z7hizgfnj2q403jv";
+      name = "plasma-workspace-5.24.4.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plasma-workspace-wallpapers-5.24.3.tar.xz";
-      sha256 = "0j1qqjc27grh3k02dgfb657ps11gym28lc9hzcw3qdxkf3djw9fs";
-      name = "plasma-workspace-wallpapers-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plasma-workspace-wallpapers-5.24.4.tar.xz";
+      sha256 = "0hpg7nn5wsn56my48jk225x1qb70sgf3hf8q5swwqc1xc6xzcg14";
+      name = "plasma-workspace-wallpapers-5.24.4.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/plymouth-kcm-5.24.3.tar.xz";
-      sha256 = "196nx8h54bnnrly12zvnwl22ksr9nk2mi6g39k4xmp28agw94jv5";
-      name = "plymouth-kcm-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/plymouth-kcm-5.24.4.tar.xz";
+      sha256 = "0s5h25vyk5yzipwj91rb62xzgi6aafpwikh7ibpmmh2wn71x3amr";
+      name = "plymouth-kcm-5.24.4.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.24.3";
+    version = "1-5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/polkit-kde-agent-1-5.24.3.tar.xz";
-      sha256 = "1mbr8xpjvd8w9b5nd6k8fxcnjykzzygwqk19il4wirqyh4n3k3bq";
-      name = "polkit-kde-agent-1-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/polkit-kde-agent-1-5.24.4.tar.xz";
+      sha256 = "1bc5ss6v4d7kwk1chhvpis5srs8lfypims46wgxjncyhjg2lcllm";
+      name = "polkit-kde-agent-1-5.24.4.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/powerdevil-5.24.3.tar.xz";
-      sha256 = "047h4lz8d1kdyakh5x7fr3kpk35r38z39vm7wb974rd9hjz7alj9";
-      name = "powerdevil-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/powerdevil-5.24.4.tar.xz";
+      sha256 = "0sjlx5fhfdld1i352adi2bhyd29ja9lbmzhfxgnvmpfl6q7c0w7g";
+      name = "powerdevil-5.24.4.tar.xz";
     };
   };
   qqc2-breeze-style = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/qqc2-breeze-style-5.24.3.tar.xz";
-      sha256 = "1y21ldxwlb12kfqzxpyhdw9lkcaf5sfamwhg68r512hy785sg490";
-      name = "qqc2-breeze-style-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/qqc2-breeze-style-5.24.4.tar.xz";
+      sha256 = "1d0cgsxvnm0zza7n5hz47n28yrr35hp0vniggifncm0ag8sn0kmd";
+      name = "qqc2-breeze-style-5.24.4.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/sddm-kcm-5.24.3.tar.xz";
-      sha256 = "15n6drklwk3lmiaklw1af98qcixml4w83hngy23lwwv2lbnirl6h";
-      name = "sddm-kcm-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/sddm-kcm-5.24.4.tar.xz";
+      sha256 = "0pfqp5das7pxpmh111i2dlfqm6xzzd99bcb32bbmd9v6w2wlgwxy";
+      name = "sddm-kcm-5.24.4.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/systemsettings-5.24.3.tar.xz";
-      sha256 = "11fmjdh6v0a4gacqshhrk374i07px989p3x70w8438gr6y0n2032";
-      name = "systemsettings-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/systemsettings-5.24.4.tar.xz";
+      sha256 = "0cqm7s89jvzqz1fw32284ppnm3dc69yvc8bqqgw5jdbbjnc1z4k9";
+      name = "systemsettings-5.24.4.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.24.3";
+    version = "5.24.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.24.3/xdg-desktop-portal-kde-5.24.3.tar.xz";
-      sha256 = "06qdr7j2m9s9l60mk8vspb2173va10zdv6sinhmkhxxp78h857z6";
-      name = "xdg-desktop-portal-kde-5.24.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.24.4/xdg-desktop-portal-kde-5.24.4.tar.xz";
+      sha256 = "07nwb6ff8rnlk2play9gar52d8d44b8y412hnx9a9d4b50b4js0i";
+      name = "xdg-desktop-portal-kde-5.24.4.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

Bump KDE Plasma 5 desktop environment to 5.24.4, [released in 29 March 2022](https://kde.org/announcements/changelogs/plasma/5/5.24.3-5.24.4/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
