### PR TITLE
resilio-sync: 2.7.2 -> 2.7.3

### DIFF
--- a/pkgs/applications/networking/resilio-sync/default.nix
+++ b/pkgs/applications/networking/resilio-sync/default.nix
@@ -1,25 +1,25 @@
 { lib, stdenv, fetchurl, ... }:
 
-let
-  arch = {
-    x86_64-linux = "x64";
-    i686-linux = "i386";
-    aarch64-linux = "arm64";
-  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-  libPath = lib.makeLibraryPath [ stdenv.cc.libc ];
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "resilio-sync";
-  version = "2.7.2";
+  version = "2.7.3";
 
-  src = fetchurl {
-    url = "https://download-cdn.resilio.com/${version}/linux-${arch}/resilio-sync_${arch}.tar.gz";
-    sha256 = {
-      x86_64-linux = "0gar5lzv1v4yqmypwqsjnfb64vffzn8mw9vnjr733fgf1pmr57hf";
-      i686-linux   = "1bws7r86h1vysjkhyvp2zk8yvxazmlczvhjlcayldskwq48iyv6w";
-      aarch64-linux = "0j8wk5cf8bcaaqxi8gnqf1mpv8nyfjyr4ibls7jnn2biqq767af2";
-    }.${stdenv.hostPlatform.system};
-  };
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://download-cdn.resilio.com/${version}/linux-x64/resilio-sync_x64.tar.gz";
+      sha256 = "sha256-DYQs9KofHkvtlsRQHRLwQHoHwSZkr40Ih0RVAw2xv3M=";
+    };
+
+    i686-linux = fetchurl {
+      url = "https://download-cdn.resilio.com/${version}/linux-i386/resilio-sync_i386.tar.gz";
+      sha256 = "sha256-PFKVBs0KthG4tuvooHkAciPhNQP0K8oi2LyoRUs5V7I=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://download-cdn.resilio.com/${version}/linux-arm64/resilio-sync_arm64.tar.gz";
+      sha256 = "sha256-o2DlYOBTkFhQMEDJySlVSNlVqLNbBzacyv2oTwxrXto=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   dontStrip = true; # Don't strip, otherwise patching the rpaths breaks
   sourceRoot = ".";
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
     install -D rslsync "$out/bin/rslsync"
     patchelf \
       --interpreter "$(< $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath ${libPath} "$out/bin/rslsync"
+      --set-rpath ${lib.makeLibraryPath [ stdenv.cc.libc ]} "$out/bin/rslsync"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

<https://help.resilio.com/hc/en-us/articles/206216855-Resilio-Sync-change-log>

>  Use sha-256 signed certificate for WebUI for new installations
>  Add .icloud to default IgnoreList
>  Deprecated: support for WindowsServers for Sync Home Free and Pro
>  Fixed non-clickable "Can't download file" error
>  Fixed improper reporting the error about missing access permissions
>  Fixed false positive "No free space" error on WD NAS
>  Fixed crashes on QNAP and Synology in some cases
>  Fixed crash caused by mix of composed and decomposed symbols in filenames
>  Fixed crash when syncing streams from NTFS formatted drive on macOS
>   Fixed losing history log entries after update
>  Fixed generating sample configuration file
>  Fixed Finder Extensions getting enabled again after Sync restart on macOS
>  Other core and UI fixes

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
