### PR TITLE
python39Packages.ansible-lint: 5.3.2 -> 6.0.2

### DIFF
--- a/pkgs/development/python-modules/ansible-compat/default.nix
+++ b/pkgs/development/python-modules/ansible-compat/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, ansible
+, flaky
+, pytest-mock
+, pytestCheckHook
+, pyyaml
+, setuptools-scm
+, subprocess-tee
+}:
+
+buildPythonPackage rec {
+  pname = "ansible-compat";
+  version = "2.0.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-xlGZXcMj7xRbq4V/7mVA/ryIH7cbf+r+gWPUnicxY6U=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    pyyaml
+    subprocess-tee
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export PATH=$PATH:$out/bin
+  '';
+
+  checkInputs = [
+    ansible
+    flaky
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # require network
+    "test_prepare_environment_with_collections"
+    "test_prerun_reqs_v1"
+    "test_prerun_reqs_v2"
+    "test_require_collection_wrong_version"
+    "test_require_collection"
+    "test_install_collection"
+    "test_install_collection_dest"
+    "test_upgrade_collection"
+    "test_require_collection_no_cache_dir"
+    "test_runtime"
+  ];
+
+  pythonImportsCheck = [ "ansible_compat" ];
+
+  meta = with lib; {
+    description = "A python package containing functions that help interacting with various versions of Ansible";
+    homepage = "https://github.com/ansible/ansible-compat";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -520,6 +520,8 @@ in {
 
   ansible-base = callPackage ../development/python-modules/ansible/base.nix { };
 
+  ansible-compat = callPackage ../development/python-modules/ansible-compat { };
+
   ansible-core = callPackage ../development/python-modules/ansible/core.nix { };
 
   ansible-doctor = callPackage ../development/python-modules/ansible-doctor { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
