### PR TITLE
roon-{bridge,server}: update

### DIFF
--- a/pkgs/servers/roon-bridge/default.nix
+++ b/pkgs/servers/roon-bridge/default.nix
@@ -11,24 +11,23 @@
 }:
 stdenv.mkDerivation rec {
   pname = "roon-bridge";
-  version = "1.8-880";
+  version = "1.8-918";
 
   src =
     let
       urlVersion = builtins.replaceStrings [ "." "-" ] [ "00" "00" ] version;
       inherit (stdenv.targetPlatform) system;
-      noSuchSystem = throw "Unsupposed system: ${system}";
     in
       {
         x86_64-linux = fetchurl {
           url = "http://download.roonlabs.com/builds/RoonBridge_linuxx64_${urlVersion}.tar.bz2";
-          sha256 = "sha256-YTLy3D1CQR1hlsGw2MmZtxHT82T0PCYZxD4adt2m1+o=";
+          hash = "sha256-Tx8KmGKh6BNoo2RKJm0HfPHRXiFsz+FtX5gQZ1FCEEg=";
         };
         aarch64-linux = fetchurl {
           url = "http://download.roonlabs.com/builds/RoonBridge_linuxarmv8_${urlVersion}.tar.bz2";
-          sha256 = "sha256-aCQtYMUIzwhmYJW4a8cFzIRuxyMVIkeaJH4w1Lasp3M=";
+          hash = "sha256-UkdAs+/l9c4j8PNlAZfNNCJogjxZItcDikS+tOjYjA0=";
         };
-      }.${system} or noSuchSystem;
+      }.${system} or (throw "Unsupposed system: ${system}");
 
   dontConfigure = true;
   dontBuild = true;

--- a/pkgs/servers/roon-server/default.nix
+++ b/pkgs/servers/roon-server/default.nix
@@ -9,13 +9,14 @@
 , krb5
 , lib
 , libtasn1
+, lttng-ust_2_12
 , makeWrapper
-, stdenv
 , openssl
+, stdenv
 }:
 stdenv.mkDerivation rec {
   pname = "roon-server";
-  version = "1.8-903";
+  version = "1.8-923";
 
   src =
     let
@@ -23,7 +24,7 @@ stdenv.mkDerivation rec {
     in
     fetchurl {
       url = "http://download.roonlabs.com/builds/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-      sha256 = "sha256-FkB3sh1uwOctBOAW7eO8HFNr9a9RG3Yq4hKKscYYER4=";
+      hash = "sha256-txf8W7SoPb20S7KcQDfExPEn5dubu9JVEX89dWngYFU=";
     };
 
   dontConfigure = true;
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     freetype
     krb5
     libtasn1
+    lttng-ust_2_12
     stdenv.cc.cc.lib
   ];
 
@@ -81,10 +83,6 @@ stdenv.mkDerivation rec {
 
       mkdir -p $out/bin
       makeWrapper "$out/Server/RoonServer" "$out/bin/RoonServer" --run "cd $out"
-
-      # This is unused and depends on an ancient version of lttng-ust, so we
-      # just patch it out
-      patchelf --remove-needed liblttng-ust.so.0 $out/RoonDotnet/shared/Microsoft.NETCore.App/5.0.0/libcoreclrtraceptprovider.so
 
       runHook postInstall
     '';


### PR DESCRIPTION
- roon-server: 1.8-903 -> 1.8-923
- roon-bridge: 1.8-880 -> 1.8-918

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
