### PR TITLE
python39Packages.bcrypt: remove unused dependencies

### DIFF
--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,9 +1,18 @@
-{ lib, buildPythonPackage, isPyPy, fetchPypi, pythonOlder
-, cffi, pytestCheckHook, six }:
+{ lib
+, buildPythonPackage
+, isPyPy
+, fetchPypi
+, pythonOlder
+, cffi
+, pytestCheckHook
+, six
+}:
 
 buildPythonPackage rec {
-  version = "3.2.0";
   pname = "bcrypt";
+  version = "3.2.0";
+  format = "setuptools";
+
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
@@ -11,16 +20,28 @@ buildPythonPackage rec {
     sha256 = "5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29";
   };
 
-  propagatedBuildInputs = [ six ] ++ lib.optional (!isPyPy) cffi;
+  propagatedBuildInputs = [
+    six
+  ] ++ lib.optional (!isPyPy) [
+    cffi
+  ];
 
-  propagatedNativeBuildInputs = lib.optional (!isPyPy) cffi;
+  propagatedNativeBuildInputs = lib.optional (!isPyPy) [
+    cffi
+  ];
 
-  checkInputs = [ pytestCheckHook ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "bcrypt"
+  ];
 
   meta = with lib; {
-    maintainers = with maintainers; [ domenkozar ];
     description = "Modern password hashing for your software and your servers";
-    license = licenses.asl20;
     homepage = "https://github.com/pyca/bcrypt/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ domenkozar ];
   };
 }

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, isPyPy, fetchPypi, pythonOlder
-, cffi, pycparser, mock, pytest, py, six }:
+, cffi, pytestCheckHook, six }:
 
 buildPythonPackage rec {
   version = "3.2.0";
@@ -11,11 +11,11 @@ buildPythonPackage rec {
     sha256 = "5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29";
   };
 
-  buildInputs = [ pycparser mock pytest py ];
-
   propagatedBuildInputs = [ six ] ++ lib.optional (!isPyPy) cffi;
 
   propagatedNativeBuildInputs = lib.optional (!isPyPy) cffi;
+
+  checkInputs = [ pytestCheckHook ];
 
   meta = with lib; {
     maintainers = with maintainers; [ domenkozar ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
