### PR TITLE
usbrelay: init at 0.9

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -457,6 +457,7 @@
   ./services/hardware/udisks2.nix
   ./services/hardware/upower.nix
   ./services/hardware/usbmuxd.nix
+  ./services/hardware/usbrelayd.nix
   ./services/hardware/thermald.nix
   ./services/hardware/undervolt.nix
   ./services/hardware/vdr.nix

--- a/nixos/modules/services/hardware/usbrelayd.nix
+++ b/nixos/modules/services/hardware/usbrelayd.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.usbrelayd;
+in
+{
+  options.services.usbrelayd = with types; {
+    enable = mkEnableOption "USB Relay MQTT daemon";
+
+    broker = mkOption {
+      type = str;
+      description = "Hostname or IP address of your MQTT Broker.";
+      default = "127.0.0.1";
+      example = [
+        "mqtt"
+        "192.168.1.1"
+      ];
+    };
+
+    clientName = mkOption {
+      type = str;
+      description = "Name, your client connects as.";
+      default = "MyUSBRelay";
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    # TODO: Rename to .conf in upcomming release
+    environment.etc."usbrelayd.ini".text = ''
+      [MQTT]
+      BROKER = ${cfg.broker}
+      CLIENTNAME = ${cfg.clientName}
+    '';
+
+    services.udev.packages = [ pkgs.usbrelayd ];
+    systemd.packages = [ pkgs.usbrelayd ];
+    users.users.usbrelay = {
+      isSystemUser = true;
+      group = "usbrelay";
+    };
+    users.groups.usbrelay = { };
+  };
+}

--- a/pkgs/os-specific/linux/usbrelay/daemon.nix
+++ b/pkgs/os-specific/linux/usbrelay/daemon.nix
@@ -1,0 +1,36 @@
+{ stdenv, usbrelay, python3 }:
+let
+  python = python3.withPackages (ps: with ps; [ usbrelay-py paho-mqtt ]);
+in
+# This is a separate derivation, not just an additional output of
+# usbrelay, because otherwise, we have a cyclic dependency between
+# usbrelay (default.nix) and the python module (python.nix).
+stdenv.mkDerivation rec {
+  pname = "usbrelayd";
+
+  inherit (usbrelay) src version;
+
+  postPatch = ''
+    substituteInPlace 'usbrelayd.service' \
+      --replace '/usr/bin/python3' "${python}/bin/python3" \
+      --replace '/usr/sbin/usbrelayd' "$out/bin/usbrelayd"
+  '';
+
+  buildInputs = [ python ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall;
+    install -m 644 -D usbrelayd $out/bin/usbrelayd
+    install -m 644 -D usbrelayd.service $out/lib/systemd/system/usbrelayd.service
+    install -m 644 -D 50-usbrelay.rules $out/lib/udev/rules.d/50-usbrelay.rules
+    runHook postInstall
+  '';
+  # TODO for later releases: install -D usbrelayd.conf $out/etc/usbrelayd.conf # include this as an example
+
+  meta = {
+    description = "USB Relay MQTT service";
+    inherit (usbrelay.meta) homepage license maintainers platforms;
+  };
+}

--- a/pkgs/os-specific/linux/usbrelay/default.nix
+++ b/pkgs/os-specific/linux/usbrelay/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchFromGitHub, hidapi }:
+stdenv.mkDerivation rec {
+  pname = "usbrelay";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "darrylb123";
+    repo = "usbrelay";
+    rev = version;
+    sha256 = "sha256-bxME4r5W5bZKxMZ/Svi1EenqHKVWIjU6iiKaM8U6lmA=";
+  };
+
+  buildInputs = [
+    hidapi
+  ];
+
+  makeFlags = [
+    "DIR_VERSION=${version}"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = with lib; {
+    description = "Tool to control USB HID relays";
+    homepage = "https://github.com/darrylb123/usbrelay";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ wentasah ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/usbrelay/python.nix
+++ b/pkgs/os-specific/linux/usbrelay/python.nix
@@ -1,0 +1,12 @@
+{ buildPythonPackage, usbrelay }:
+
+buildPythonPackage rec {
+  pname = "usbrelay_py";
+  inherit (usbrelay) version src;
+
+  buildInputs = [ usbrelay ];
+
+  pythonImportsCheck = [ "usbrelay_py" ];
+
+  inherit (usbrelay) meta;
+}

--- a/pkgs/os-specific/linux/usbrelay/test.nix
+++ b/pkgs/os-specific/linux/usbrelay/test.nix
@@ -1,0 +1,63 @@
+# NixOS test for usbrelayd
+#
+# It is not stored in nixos/tests directory, because it requires the
+# USB relay connected to the host computer and as such, it cannot be
+# run automatically.
+#
+# Run this test as:
+#
+#     nix-build test.nix -A driverInteractive && ./result/bin/nixos-test-driver --no-interactive
+#
+# The interactive driver is required because the default
+# (non-interactive) driver uses qemu without support for passing USB
+# devices to the guest (see
+# https://discourse.nixos.org/t/hardware-dependent-nixos-tests/18564
+# for discussion of other alternatives).
+
+import ../../../../nixos/tests/make-test-python.nix ({ pkgs, ... }: {
+  name = "usbrelayd";
+
+  nodes.machine = {
+    virtualisation.qemu.options = [
+      "-device qemu-xhci"
+      "-device usb-host,vendorid=0x16c0,productid=0x05df"
+    ];
+    services.usbrelayd.enable = true;
+    systemd.services.usbrelayd = {
+      after = [ "mosquitto.service" ];
+    };
+    services.mosquitto = {
+      enable = true;
+      listeners = [{
+        acl = [ "pattern readwrite #" ];
+        omitPasswordAuth = true;
+        settings.allow_anonymous = true;
+      }];
+    };
+    environment.systemPackages = [
+      pkgs.usbrelay
+      pkgs.mosquitto
+    ];
+    documentation.nixos.enable = false; # building nixos manual takes long time
+  };
+
+  testScript = ''
+    if os.waitstatus_to_exitcode(os.system("lsusb -d 16c0:05df")) != 0:
+        print("No USB relay detected, skipping test")
+        import sys
+        sys.exit(2)
+    machine.start()
+    # usbrelayd is started by udev when an relay is detected
+    machine.wait_for_unit("usbrelayd.service")
+
+    stdout = machine.succeed("usbrelay")
+    relay_id = stdout.split(sep="_")[0]
+    assert relay_id != ""
+    import time
+    time.sleep(1)
+    machine.succeed(f"mosquitto_pub -h localhost -t cmnd/{relay_id}/1 -m ON")
+    time.sleep(1)
+    machine.succeed(f"mosquitto_pub -h localhost -t cmnd/{relay_id}/1 -m OFF")
+    print("Did you see the relay switching on and off?")
+  '';
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23515,6 +23515,9 @@ with pkgs;
     libgcrypt = null;
   };
 
+  usbrelay = callPackage ../os-specific/linux/usbrelay { };
+  usbrelayd = callPackage ../os-specific/linux/usbrelay/daemon.nix { };
+
   usbtop = callPackage ../os-specific/linux/usbtop { };
 
   usbutils = callPackage ../os-specific/linux/usbutils { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10420,6 +10420,8 @@ in {
 
   urwid-readline = callPackage ../development/python-modules/urwid-readline { };
 
+  usbrelay-py = callPackage ../os-specific/linux/usbrelay/python.nix { };
+
   usbtmc = callPackage ../development/python-modules/usbtmc { };
 
   us = callPackage ../development/python-modules/us { };


### PR DESCRIPTION
###### Description of changes

[usbrelay](https://github.com/darrylb123/usbrelay) allows controlling USB HID relays.

TODO:

- [x] Install udev rules
- [x] Add MQTT support, systemd service etc.
- [x] Add tests

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
