### PR TITLE
python39Packages.mock: remove no longer required dependencies, enable…

### DIFF
--- a/pkgs/development/python-modules/mock/default.nix
+++ b/pkgs/development/python-modules/mock/default.nix
@@ -1,31 +1,30 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, isPy27
-, funcsigs
-, six
-, pbr
+, fetchpatch
 , python
+, pythonOlder
 , pytest
 }:
 
 buildPythonPackage rec {
   pname = "mock";
   version = "4.0.3";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc";
   };
 
-  propagatedBuildInputs = [ six pbr ] ++ lib.optionals isPy27 [ funcsigs ];
-
-  # On PyPy for Python 2.7 in particular, Mock's tests have a known failure.
-  # Mock upstream has a decoration to disable the failing test and make
-  # everything pass, but it is not yet released. The commit:
-  # https://github.com/testing-cabal/mock/commit/73bfd51b7185#diff-354f30a63fb0907d4ad57269548329e3L12
-  #doCheck = !(python.isPyPy && python.isPy27);
-  doCheck = false; # Infinite recursion pytest
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/testing-cabal/mock/commit/f3e3d82aab0ede7e25273806dc0505574d85eae2.patch";
+      sha256 = "sha256-wPrv1/WeICZHn31UqFlICFsny2knvn3+Xg8BZoaGbwQ=";
+    })
+  ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover
@@ -37,8 +36,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Mock objects for Python";
-    homepage = "http://python-mock.sourceforge.net/";
+    homepage = "https://github.com/testing-cabal/mock";
     license = licenses.bsd2;
   };
-
 }


### PR DESCRIPTION
… and fix tests, update homepage

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
