### PR TITLE
lib/types: addCheckDesc: init

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -752,6 +752,11 @@ rec {
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 
+    # Augment the given type with an additional type check function and a
+    # description of what the check validates.
+    addCheckDesc = desc: elemType: check: types.addCheck elemType check
+      // { description = "${elemType.description} (with check: ${desc})"; };
+
   };
 };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -436,7 +436,7 @@ Types are mainly characterized by their `check` and `merge` functions.
 
 :   The function to type check the value. Takes a value as parameter and
     return a boolean. It is possible to extend a type check with the
-    `addCheck` function ([Example: Adding a type check](#ex-extending-type-check-1)),
+    `addCheckDesc` function ([Example: Adding a type check](#ex-extending-type-check-1)),
     or to fully override the check function
     ([Example: Overriding a type check](#ex-extending-type-check-2)).
 
@@ -447,7 +447,7 @@ Types are mainly characterized by their `check` and `merge` functions.
     ```nix
     byte = mkOption {
       description = "An integer between 0 and 255.";
-      type = types.addCheck types.int (x: x >= 0 && x <= 255);
+      type = types.addCheckDesc "between 0 and 255" types.int (x: x >= 0 && x <= 255);
     };
     ```
     :::

--- a/nixos/doc/manual/from_md/development/option-types.section.xml
+++ b/nixos/doc/manual/from_md/development/option-types.section.xml
@@ -757,7 +757,7 @@ config.mod.two = { foo = 2; bar = &quot;two&quot;; };
           <para>
             The function to type check the value. Takes a value as
             parameter and return a boolean. It is possible to extend a
-            type check with the <literal>addCheck</literal> function
+            type check with the <literal>addCheckDesc</literal> function
             (<link linkend="ex-extending-type-check-1">Example: Adding a
             type check</link>), or to fully override the check function
             (<link linkend="ex-extending-type-check-2">Example:
@@ -771,7 +771,7 @@ config.mod.two = { foo = 2; bar = &quot;two&quot;; };
           <programlisting language="bash">
 byte = mkOption {
   description = &quot;An integer between 0 and 255.&quot;;
-  type = types.addCheck types.int (x: x &gt;= 0 &amp;&amp; x &lt;= 255);
+  type = types.addCheckDesc &quot;between 0 and 255&quot; types.int (x: x &gt;= 0 &amp;&amp; x &lt;= 255);
 };
 </programlisting>
           <anchor xml:id="ex-extending-type-check-2" />

--- a/nixos/modules/services/networking/multipath.nix
+++ b/nixos/modules/services/networking/multipath.nix
@@ -12,11 +12,9 @@ let
     )
   );
 
-  addCheckDesc = desc: elemType: check: types.addCheck elemType check
-    // { description = "${elemType.description} (with check: ${desc})"; };
   hexChars = stringToCharacters "0123456789abcdef";
   isHexString = s: all (c: elem c hexChars) (stringToCharacters (toLower s));
-  hexStr = addCheckDesc "hexadecimal string" types.str isHexString;
+  hexStr = types.addCheckDesc "hexadecimal string" types.str isHexString;
 
 in {
 

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -5,11 +5,8 @@ with utils;
 
 let
 
-  addCheckDesc = desc: elemType: check: types.addCheck elemType check
-    // { description = "${elemType.description} (with check: ${desc})"; };
-
   isNonEmpty = s: (builtins.match "[ \t\n]*" s) == null;
-  nonEmptyStr = addCheckDesc "non-empty" types.str isNonEmpty;
+  nonEmptyStr = types.addCheckDesc "non-empty" types.str isNonEmpty;
 
   fileSystems' = toposort fsBefore (attrValues config.fileSystems);
 
@@ -24,7 +21,7 @@ let
 
   specialFSTypes = [ "proc" "sysfs" "tmpfs" "ramfs" "devtmpfs" "devpts" ];
 
-  nonEmptyWithoutTrailingSlash = addCheckDesc "non-empty without trailing slash" types.str
+  nonEmptyWithoutTrailingSlash = types.addCheckDesc "non-empty without trailing slash" types.str
     (s: isNonEmpty s && (builtins.match ".+/" s) == null);
 
   coreFileSystemOpts = { name, config, ... }: {


### PR DESCRIPTION
It's used in only a couple places, but being able to communicate what
check was violated will help with cryptic error messages like:

    error: A definition for option `programs._1password-gui.gid' is not of type `signed integer'. Definition values:
           - In `/home/vin/workspace/vcs/nixpkgs/master/test.nix': 998

Instead, add the ability to append a nice description of the check:

    error: A definition for option `programs._1password-gui.gid' is not of type `signed integer (with check: greater than or equal to 1000)'. Definition values:
           - In `/home/vin/workspace/vcs/nixpkgs/master/test.nix': 998

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
