### PR TITLE
nixos/_1password{,-gui}: cleanup

### DIFF
--- a/nixos/modules/programs/_1password-gui.nix
+++ b/nixos/modules/programs/_1password-gui.nix
@@ -3,67 +3,66 @@
 with lib;
 
 let
+
   cfg = config.programs._1password-gui;
 
-in {
+in
+{
   options = {
     programs._1password-gui = {
-      enable = mkEnableOption "The 1Password Desktop application with browser integration";
+      enable = mkEnableOption "the 1Password GUI application";
 
-      groupId = mkOption {
-        type = types.int;
+      gid = mkOption {
+        type = types.addCheck types.int (x: x >= 1000);
         example = literalExpression "5000";
         description = ''
-          The GroupID to assign to the onepassword group, which is needed for browser integration. The group ID must be 1000 or greater.
-          '';
+          The gid to assign to the onepassword group, which is needed for browser integration.
+          It must be 1000 or greater.
+        '';
       };
 
       polkitPolicyOwners = mkOption {
         type = types.listOf types.str;
-        default = [];
-        example = literalExpression "[\"user1\" \"user2\" \"user3\"]";
+        default = [ ];
+        example = literalExpression ''["user1" "user2" "user3"]'';
         description = ''
-          A list of users who should be able to integrate 1Password with polkit-based authentication mechanisms. By default, no users will have such access.
-          '';
+          A list of users who should be able to integrate 1Password with polkit-based authentication mechanisms.
+        '';
       };
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs._1password-gui;
-        defaultText = literalExpression "pkgs._1password-gui";
-        example = literalExpression "pkgs._1password-gui";
-        description = ''
-          The 1Password derivation to use. This can be used to upgrade from the stable release that we keep in nixpkgs to the betas.
-          '';
+      package = mkPackageOption pkgs "1Password GUI" {
+        default = [ "_1password-gui" ];
       };
     };
   };
 
-  config = let
-    package = cfg.package.override {
-      polkitPolicyOwners = cfg.polkitPolicyOwners;
-    };
-  in mkIf cfg.enable {
-    environment.systemPackages = [ package ];
-    users.groups.onepassword.gid = cfg.groupId;
+  config =
+    let
+      package = cfg.package.override {
+        polkitPolicyOwners = cfg.polkitPolicyOwners;
+      };
+    in
+    mkIf cfg.enable {
+      environment.systemPackages = [ package ];
+      users.groups.onepassword.gid = cfg.gid;
 
-    security.wrappers = {
-      "1Password-BrowserSupport" =
-        { source = "${cfg.package}/share/1password/1Password-BrowserSupport";
+      security.wrappers = {
+        "1Password-BrowserSupport" = {
+          source = "${package}/share/1password/1Password-BrowserSupport";
           owner = "root";
           group = "onepassword";
           setuid = false;
           setgid = true;
         };
 
-      "1Password-KeyringHelper" =
-        { source = "${cfg.package}/share/1password/1Password-KeyringHelper";
+        "1Password-KeyringHelper" = {
+          source = "${package}/share/1password/1Password-KeyringHelper";
           owner = "root";
           group = "onepassword";
           setuid = true;
           setgid = true;
         };
-    };
+      };
 
-  };
+    };
 }

--- a/nixos/modules/programs/_1password.nix
+++ b/nixos/modules/programs/_1password.nix
@@ -3,35 +3,33 @@
 with lib;
 
 let
+
   cfg = config.programs._1password;
-in {
+
+in
+{
   options = {
     programs._1password = {
-      enable = mkEnableOption "The 1Password CLI tool with biometric unlock and integration with the 1Password GUI.";
+      enable = mkEnableOption "the 1Password CLI tool";
 
-      groupId = mkOption {
-        type = types.int;
+      gid = mkOption {
+        type = types.addCheck types.int (x: x >= 1000);
         example = literalExpression "5001";
         description = ''
-          The GroupID to assign to the onepassword-cli group, which is needed for integration with the 1Password GUI. The group ID must be 1000 or greater.
+          The gid to assign to the onepassword-cli group, which is needed for integration with the 1Password GUI.
+          It must be 1000 or greater.
         '';
       };
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs._1password;
-        defaultText = literalExpression "pkgs._1password";
-        example = literalExpression "pkgs._1password";
-        description = ''
-          The 1Password CLI derivation to use.
-        '';
+      package = mkPackageOption pkgs "1Password CLI" {
+        default = [ "_1password" ];
       };
     };
   };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
-    users.groups.onepassword-cli.gid = cfg.groupId;
+    users.groups.onepassword-cli.gid = cfg.gid;
 
     security.wrappers = {
       "op" = {


### PR DESCRIPTION
###### Description of changes

Slightly opinionated cleanup of the new 1Password NixOS modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

cc @savannidgerinel @Enzime 
