### PR TITLE
python39Packages.flask-sqlalchemy: update homepage, switch to pytestCheckHook, normalize pname

### DIFF
--- a/pkgs/development/python-modules/flask-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/flask-sqlalchemy/default.nix
@@ -1,24 +1,21 @@
-{ lib, buildPythonPackage, fetchPypi, flask, mock, sqlalchemy, pytest }:
+{ lib, buildPythonPackage, fetchPypi, flask, mock, sqlalchemy, pytestCheckHook }:
 
 buildPythonPackage rec {
-  pname = "Flask-SQLAlchemy";
+  pname = "flask-sqlalchemy";
   version = "2.5.1";
 
   src = fetchPypi {
-    inherit pname version;
+  pname = "Flask-SQLAlchemy";
+    inherit version;
     sha256 = "2bda44b43e7cacb15d4e05ff3cc1f8bc97936cc464623424102bfc2c35e95912";
   };
 
   propagatedBuildInputs = [ flask sqlalchemy ];
-  checkInputs = [ mock pytest ];
-
-  checkPhase = ''
-    pytest
-  '';
+  checkInputs = [ mock pytestCheckHook ];
 
   meta = with lib; {
     description = "SQLAlchemy extension for Flask";
-    homepage = "http://flask-sqlalchemy.pocoo.org/";
+    homepage = "https://flask-sqlalchemy.palletsprojects.com/";
     license = licenses.bsd3;
     maintainers = with maintainers; [ gerschtli ];
   };


### PR DESCRIPTION


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
