### PR TITLE
kanidm: init at 1.1.0-alpha.7

### DIFF
--- a/pkgs/servers/kanidm/default.nix
+++ b/pkgs/servers/kanidm/default.nix
@@ -1,0 +1,54 @@
+{ lib, fetchFromGitHub, rustPlatform, openssl, pam, pkg-config, sqlite, udev }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kanidm";
+  version = "1.1.0-alpha.7";
+
+  src = fetchFromGitHub {
+    owner = "kanidm";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-C+ITINRQLJjC8sL2PKvnnHHdLQ3y5OWz0wNMDfmn2vw=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl pam sqlite udev ];
+
+  KANIDM_BUILD_PROFILE = "nixpkgs_profile";
+
+  preBuild = ''
+    cat > ./profiles/nixpkgs_profile.toml <<EOF
+      web_ui_pkg_path = "${placeholder "out"}/share/webui/pkg"
+      # Valid options are none, native, x86_64_v1, x86_64_v3
+      cpu_flags = "none"
+    EOF
+  '';
+
+  cargoBuildFlags = [
+    # Only package things we care about, i.e. don't package orca (load testing tool)
+    # https://github.com/kanidm/kanidm/blob/5cb429904df2ad21a5a97037ce9197f03d8eb470/Cargo.toml#L7-L20
+    # This sequence of packages gets 100% of the kanidm commands, and no orca, at the time of writing
+    "--package" "kanidm"
+    "--package" "kanidm_tools"
+    "--package" "kanidm_unix_int"
+  ];
+
+  cargoSha256 = "sha256-Cm3gNm3amUsJxDPsXDsGr+lFnN+H6XzIp4UmiUIdofM=";
+
+  postInstall = ''
+    mkdir -p $out/share/webui/
+    cp --recursive ./kanidmd_web_ui/pkg $out/share/webui/pkg
+  '';
+
+  preCheck = ''
+    # Use the default build profile so the tests can find the web ui
+    unset KANIDM_BUILD_PROFILE
+  '';
+
+  meta = with lib; {
+    description = "A simple, secure and fast identity management platform ";
+    license = with licenses; [ mpl20 ];
+    maintainers = with maintainers; [ euank ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21526,6 +21526,8 @@ with pkgs;
 
   keycloak = callPackage ../servers/keycloak { };
 
+  kanidm = callPackage ../servers/kanidm { };
+
   knot-dns = callPackage ../servers/dns/knot-dns { };
   knot-resolver = callPackage ../servers/dns/knot-resolver { };
 


### PR DESCRIPTION
###### Description of changes

This packages the current alpha release of kanidm, including the work-in-progress web UI (which was the only bit of packaging that had to deviate from standard `buildRustPackage` stuff).

You can learn more about kanidm here: https://github.com/kanidm/kanidm#kanidm

This adds just the package (which includes the kanidm cli, notably, a useful tool for interacting with hosted kanidm servers).

In a future PR, I plan to also add a NixOS module for running the kanidm server.

There's additional packaging work that could be done, notably nixos `pam`, `nsswitch`, and ssh key integration options, but I also think those can be done in a future PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
    Yes, verified the kanidm server ran (with the upstream './examples/insecure_server.toml' config), and verified the web UI worked correctly.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
