### PR TITLE
platformio-core: expose unwrapped platformio as platformio-core

### DIFF
--- a/pkgs/development/embedded/platformio/chrootenv.nix
+++ b/pkgs/development/embedded/platformio/chrootenv.nix
@@ -4,9 +4,9 @@ let
   pio-pkgs = pkgs:
     let
       python = pkgs.python3;
-      platformio = python.pkgs.callPackage ./core.nix { inherit version src; };
     in
     (with pkgs; [
+      platformio-core
       zlib
       git
       xdg-user-dirs
@@ -15,7 +15,6 @@ let
       setuptools
       pip
       bottle
-      platformio
     ]);
 
 in

--- a/pkgs/development/embedded/platformio/default.nix
+++ b/pkgs/development/embedded/platformio/default.nix
@@ -1,4 +1,4 @@
-{ newScope, fetchFromGitHub }:
+{ newScope, fetchFromGitHub, python3Packages }:
 
 let
   callPackage = newScope self;
@@ -14,6 +14,8 @@ let
   };
 
   self = {
+    platformio-core = python3Packages.callPackage ./core.nix { inherit version src; };
+
     platformio-chrootenv = callPackage ./chrootenv.nix { inherit version src; };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11105,7 +11105,8 @@ with pkgs;
   };
 
   platformioPackages = dontRecurseIntoAttrs (callPackage ../development/embedded/platformio { });
-  platformio = platformioPackages.platformio-chrootenv;
+  platformio = if stdenv.isLinux then platformioPackages.platformio-chrootenv else platformioPackages.platformio-core;
+  platformio-core = platformioPackages.platformio-core;
 
   platinum-searcher = callPackage ../tools/text/platinum-searcher { };
 


### PR DESCRIPTION
PlatformIO is a pure python package that is in turn a package
manager. In a pure NixOS environment, this means that any downloaded
binary packages will not run. To make Platform IO usable, there's a
chrootenv wrapper. However, in a mixed environment like other linux or
darwin, the pure python version will work, and in the case of darwin
only the pure version will work, since the chrootenv wrapper is not
supported.

To handle the above use cases we have:

 * platformio -- unwrapped on darwin, wrapped on linux. Should always
                 provide a functional platformio.

 * platformio-core -- always unwrapped (like "bintools-unwrapped") for
                      when the wrapper is explicitly not required. For
                      example, on other linux where the chrootenv is
                      not supported.

###### Description of changes

I want to expose `platformio-core` for use on darwin, but I don't mind too much how it's exposed. This change seems reasonable to me.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
