### PR TITLE
ocamlPackages.{ocsigen,eliom}: updates

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -16,17 +16,18 @@
 , js_of_ocaml-tyxml
 , lwt_ppx
 , ocamlnet
+, ocsipersist
 }:
 
 stdenv.mkDerivation rec {
   pname = "eliom";
-  version = "8.9.0";
+  version = "9.4.0";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "eliom";
     rev = version;
-    sha256 = "sha256-VNxzpVpXEGlixyjadbW0GjL83jcKV5TWd46UReNYO6w=";
+    sha256 = "sha256:1yn8mqxv9yz51x81j8wv1jn7l7crm8azp1m2g4zn5nz2s4nmfv6q";
   };
 
   nativeBuildInputs = [
@@ -49,12 +50,17 @@ stdenv.mkDerivation rec {
     lwt_ppx
     lwt_react
     ocsigen_server
+    ocsipersist
     ppx_deriving
   ];
 
   strictDeps = true;
 
-  installPhase = "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR";
+  installPhase = ''
+    runHook preInstall
+    opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
+    runHook postInstall
+  '';
 
   setupHook = [ ./setup-hook.sh ];
 

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -2,7 +2,7 @@
 , bigstringaf, lwt, cstruct, mirage-crypto, zarith, mirage-crypto-ec, ptime, mirage-crypto-rng, mtime, ca-certs
 , cohttp, cohttp-lwt-unix, hmap
 , lwt_log, ocaml_pcre, cryptokit, xml-light, ipaddr
-, pgocaml, camlzip, ocaml_sqlite3
+, camlzip
 , makeWrapper
 }:
 
@@ -17,7 +17,7 @@ let caml_ld_library_path =
 ; in
 
 buildDunePackage rec {
-  version = "4.0.1";
+  version = "5.0.1";
   pname = "ocsigenserver";
 
   useDune2 = true;
@@ -27,11 +27,11 @@ buildDunePackage rec {
     owner = "ocsigen";
     repo = "ocsigenserver";
     rev = version;
-    sha256 = "0pid4irkmdmx1d6n2rvcvx5mnljl3hazzdqc3bql72by35izfac6";
+    sha256 = "sha256:1vzza33hd41740dqrx4854rqpyd8wv7kwpsvvmlpck841i9lh8h5";
   };
 
   nativeBuildInputs = [ makeWrapper which ];
-  buildInputs = [ lwt_react pgocaml camlzip ocaml_sqlite3 ];
+  buildInputs = [ lwt_react camlzip ];
 
   propagatedBuildInputs = [ cohttp cohttp-lwt-unix cryptokit hmap ipaddr lwt_log lwt_ssl
     ocaml_pcre xml-light

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation rec {
   pname = "ocaml${ocaml.version}-ocsigen-start";
-  version = "4.3.0";
+  version = "4.5.0";
 
   nativeBuildInputs = [ ocaml findlib eliom ];
   propagatedBuildInputs = [ pgocaml_ppx safepass ocsigen-toolkit yojson resource-pooling cohttp-lwt-unix ocamlnet ];
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = "ocsigen-start";
     rev = version;
-    sha256 = "0lkl59dwzyqq2lyr46fyjr27ms0fp9h59xfsn37faaavdd7v0h98";
+    sha256 = "sha256:1n94r8rbkzxbgcz5w135n6f2cwpc91bdvf7yslcdq4cn713rncmq";
   };
 
   preInstall = ''

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -5,7 +5,7 @@
 stdenv.mkDerivation rec {
  pname = "ocsigen-toolkit";
  name = "ocaml${ocaml.version}-${pname}-${version}";
- version = "3.0.1";
+ version = "3.1.1";
 
  propagatedBuildInputs = [ calendar js_of_ocaml-ppx_deriving_json eliom ];
  nativeBuildInputs = [ ocaml findlib opaline eliom ];
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "ocsigen";
     repo = pname;
     rev = version;
-    sha256 = "1yx50ja2wcs5vfy4rk9szgwccpnihkjn14i4ywchx4yr4ppr00fm";
+    sha256 = "sha256:1fm0vvccmjib9yj5m2760vhzb4z3392swlprp51az53g3vk4q218";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/ocsipersist/default.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/default.nix
@@ -1,0 +1,20 @@
+{ buildDunePackage, ocsipersist-lib
+, ocsipersist-pgsql
+, ocsipersist-sqlite
+}:
+
+buildDunePackage {
+  pname = "ocsipersist";
+  inherit (ocsipersist-lib) src version useDune2;
+
+  buildInputs = [
+    ocsipersist-pgsql
+    ocsipersist-sqlite
+  ];
+
+  propagatedBuildInputs = [ ocsipersist-lib ];
+
+  meta = ocsipersist-lib.meta // {
+    description = "Persistent key/value storage (for Ocsigen) using multiple backends";
+  };
+}

--- a/pkgs/development/ocaml-modules/ocsipersist/lib.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/lib.nix
@@ -1,0 +1,27 @@
+{ lib, buildDunePackage, fetchFromGitHub
+, lwt_ppx, lwt
+}:
+
+buildDunePackage rec {
+  pname = "ocsipersist-lib";
+  version = "1.1.0";
+
+  useDune2 = true;
+
+  src = fetchFromGitHub {
+    owner = "ocsigen";
+    repo = "ocsipersist";
+    rev = version;
+    sha256 = "sha256:1d6kdcfjvrz0dl764mnyxc477aa57rvmzkg154qc915w2y1nbz9a";
+  };
+
+  buildInputs = [ lwt_ppx ];
+  propagatedBuildInputs = [ lwt ];
+
+  meta = {
+    description = "Persistent key/value storage (for Ocsigen) - support library";
+    license = lib.licenses.lgpl21Only;
+    maintainers = [ lib.maintainers.vbgl ];
+    inherit (src.meta) homepage;
+  };
+}

--- a/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
@@ -1,0 +1,24 @@
+{ buildDunePackage, ocsipersist-lib
+, lwt_log
+, ocsigen_server
+, pgocaml
+, xml-light
+}:
+
+buildDunePackage {
+  pname = "ocsipersist-pgsql";
+  inherit (ocsipersist-lib) version src useDune2;
+
+  propagatedBuildInputs = [
+    lwt_log
+    ocsigen_server
+    ocsipersist-lib
+    pgocaml
+    xml-light
+  ];
+
+  meta = ocsipersist-lib.meta // {
+    description = "Persistent key/value storage (for Ocsigen) using PostgreSQL";
+  };
+}
+

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
@@ -1,0 +1,23 @@
+{ buildDunePackage, ocsipersist-lib
+, lwt_log
+, ocaml_sqlite3
+, ocsigen_server
+, xml-light
+}:
+
+buildDunePackage {
+  pname = "ocsipersist-sqlite";
+  inherit (ocsipersist-lib) version src useDune2;
+
+  propagatedBuildInputs = [
+    lwt_log
+    ocaml_sqlite3
+    ocsigen_server
+    ocsipersist-lib
+    xml-light
+  ];
+
+  meta = ocsipersist-lib.meta // {
+    description = "Persistent key/value storage (for Ocsigen) using SQLite";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -982,6 +982,14 @@ let
 
     ocsigen-toolkit = callPackage ../development/ocaml-modules/ocsigen-toolkit { };
 
+    ocsipersist = callPackage ../development/ocaml-modules/ocsipersist {};
+
+    ocsipersist-lib = callPackage ../development/ocaml-modules/ocsipersist/lib.nix { };
+
+    ocsipersist-pgsql = callPackage ../development/ocaml-modules/ocsipersist/pgsql.nix { };
+
+    ocsipersist-sqlite = callPackage ../development/ocaml-modules/ocsipersist/sqlite.nix { };
+
     octavius = callPackage ../development/ocaml-modules/octavius { };
 
     odate = callPackage ../development/ocaml-modules/odate { };


### PR DESCRIPTION
###### Description of changes

Moves the `ocsipersist` library out of `ocsigenserver`.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
