### PR TITLE
ddnet: 15.9.1 -> 16.0.3

### DIFF
--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ddnet";
-  version = "16.0";
+  version = "16.0.1";
 
   src = fetchFromGitHub {
     owner = "ddnet";
     repo = pname;
     rev = version;
-    sha256 = "sha256-9X8po0qNGNzRNHZ+aDsqyomTa5WZlw74bw/ibwLfMNk=";
+    sha256 = "sha256-QbMiq4vb5yDUG0p7oYcxy4+u47okHIjVTJl/b5MimBQ=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config ];

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ddnet";
-  version = "16.0.1";
+  version = "16.0.2";
 
   src = fetchFromGitHub {
     owner = "ddnet";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QbMiq4vb5yDUG0p7oYcxy4+u47okHIjVTJl/b5MimBQ=";
+    sha256 = "sha256-zPXXBZWxO38PXMtCzXE+PykXD0hqog2VgX5P9fowSjM=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config ];

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -16,17 +16,23 @@
 , SDL2
 , sqlite
 , wavpack
+, ffmpeg
+, x264
+, vulkan-headers
+, vulkan-loader
+, glslang
+, spirv-tools
 }:
 
 stdenv.mkDerivation rec {
   pname = "ddnet";
-  version = "15.9.1";
+  version = "16.0";
 
   src = fetchFromGitHub {
     owner = "ddnet";
     repo = pname;
     rev = version;
-    sha256 = "sha256-QGtXI4Dbua5LBXSvB17tnSTGEvCCoopvg1XKBuDIEoQ=";
+    sha256 = "sha256-9X8po0qNGNzRNHZ+aDsqyomTa5WZlw74bw/ibwLfMNk=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config ];
@@ -44,6 +50,12 @@ stdenv.mkDerivation rec {
     SDL2
     sqlite
     wavpack
+    ffmpeg
+    x264
+    vulkan-loader
+    vulkan-headers
+    glslang
+    spirv-tools
   ];
 
   cmakeFlags = [

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ddnet";
-  version = "16.0.2";
+  version = "16.0.3";
 
   src = fetchFromGitHub {
     owner = "ddnet";
     repo = pname;
     rev = version;
-    sha256 = "sha256-zPXXBZWxO38PXMtCzXE+PykXD0hqog2VgX5P9fowSjM=";
+    sha256 = "sha256-9hjVAtnn+dTBNCu6E90CtjGTAStmVTsQFm2UYq68xcM=";
   };
 
   nativeBuildInputs = [ cmake ninja pkg-config ];


### PR DESCRIPTION
###### Description of changes

upstream version upgrade

ddnet now supports vulkan (which is pretty nice, see https://github.com/ddnet/ddnet/pull/4687) and requires ffmpeg and x264

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
