### PR TITLE
Always sanitize derivation name

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -756,7 +756,14 @@ rec {
        sanitizeDerivationName pkgs.hello
        => "-nix-store-2g75chlbpxlrqn15zlby2dfh8hr9qwbk-hello-2.10"
   */
-  sanitizeDerivationName = string: lib.pipe string [
+  sanitizeDerivationName =
+  let okRegex = match "^[[:alnum:]+_?=-][[:alnum:]+._?=-]*$";
+  in
+  string:
+  # First detect the common case of already valid strings, to speed those up
+  if stringLength string <= 207 && okRegex string != null
+  then unsafeDiscardStringContext string
+  else lib.pipe string [
     # Get rid of string context. This is safe under the assumption that the
     # resulting string is only used as a derivation name
     unsafeDiscardStringContext

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -757,7 +757,7 @@ rec {
        => "-nix-store-2g75chlbpxlrqn15zlby2dfh8hr9qwbk-hello-2.10"
   */
   sanitizeDerivationName =
-  let okRegex = match "^[[:alnum:]+_?=-][[:alnum:]+._?=-]*$";
+  let okRegex = match "[[:alnum:]+_?=-][[:alnum:]+._?=-]*";
   in
   string:
   # First detect the common case of already valid strings, to speed those up

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -649,6 +649,11 @@ runTests {
     expected = "foo";
   };
 
+  testSanitizeDerivationNameUnicode = testSanitizeDerivationName {
+    name = "fö";
+    expected = "f-";
+  };
+
   testSanitizeDerivationNameAscii = testSanitizeDerivationName {
     name = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
     expected = "-+--.-0123456789-=-?-ABCDEFGHIJKLMNOPQRSTUVWXYZ-_-abcdefghijklmnopqrstuvwxyz-";

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -97,7 +97,7 @@ let
     derivations and all build dependency outputs, all the way down.
   */
   allDrvOutputs = pkg:
-    let name = lib.strings.sanitizeDerivationName "allDrvOutputs-${pkg.pname or pkg.name or "unknown"}";
+    let name = "allDrvOutputs-${pkg.pname or pkg.name or "unknown"}";
     in
     pkgs.runCommand name { refs = pkgs.writeReferencesToFile pkg.drvPath; } ''
       touch $out

--- a/pkgs/build-support/test-equal-derivation.nix
+++ b/pkgs/build-support/test-equal-derivation.nix
@@ -23,7 +23,7 @@ let
   drvB = builtins.unsafeDiscardOutputDependency b.drvPath or (throw "testEqualDerivation third argument must be a package");
   name =
     if a?name
-    then lib.strings.sanitizeDerivationName "testEqualDerivation-${a.name}"
+    then "testEqualDerivation-${a.name}"
     else "testEqualDerivation";
 in
 if drvA == drvB then

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -70,8 +70,7 @@ rec {
     # name of the resulting derivation
     }: buildCommand:
     stdenv.mkDerivation ({
-      name = lib.strings.sanitizeDerivationName name;
-      inherit buildCommand;
+      inherit buildCommand name;
       passAsFile = [ "buildCommand" ]
         ++ (derivationArgs.passAsFile or []);
     }

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -219,9 +219,11 @@ else let
           # it again.
           staticMarker = lib.optionalString stdenv.hostPlatform.isStatic "-static";
         in
+        lib.strings.sanitizeDerivationName (
           if attrs ? name
           then attrs.name + hostSuffix
-          else "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}";
+          else "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
+        );
     }) // {
       builder = attrs.realBuilder or stdenv.shell;
       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
@@ -340,8 +342,9 @@ else let
   # passed to the builder and is not a dependency.  But since we
   # include it in the result, it *is* available to nix-env for queries.
   meta = {
-      # `name` above includes cross-compilation cruft (and is under assert),
-      # lets have a clean always accessible version here.
+      # `name` above includes cross-compilation cruft,
+      # is under assert, and is sanitized.
+      # Let's have a clean always accessible version here.
       name = attrs.name or "${attrs.pname}-${attrs.version}";
 
       # If the packager hasn't specified `outputsToInstall`, choose a default,


### PR DESCRIPTION
###### Description of changes

Make `mkDerivation` robust.

Fixes #166265 

~Naive change stats: https://github.com/NixOS/nixpkgs/pull/166383/checks?check_run_id=5751113354~
~2.7% total alloc, 8% call increase~

With optimization: mixed stats.

TODO
 - [x] optimize sanitizeDerivationName
 - [x] time benchmark. Normally I'd be ok to rely on mem stats alone, but I don't trust regex without a good time measurement (which ofborg can't provide)

Before

```
benchmarking ~/nix/result/bin/nix-instantiate -A nixosTests.acme
time                 16.87 s    (15.23 s .. 18.43 s)
                     0.999 R²   (0.995 R² .. 1.000 R²)
mean                 16.71 s    (16.52 s .. 16.99 s)
std dev              294.7 ms   (27.40 ms .. 373.5 ms)
variance introduced by outliers: 19% (moderately inflated)

```

After

```
benchmarking ~/nix/result/bin/nix-instantiate -A nixosTests.acme
time                 16.77 s    (16.33 s .. 17.14 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.71 s    (16.66 s .. 16.79 s)
std dev              81.45 ms   (16.44 ms .. 107.6 ms)
variance introduced by outliers: 19% (moderately inflated)

```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
