### PR TITLE
various GNOME packages: fix build with meson 0.61

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-books/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-books/default.nix
@@ -1,8 +1,10 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , meson
 , ninja
 , gettext
 , fetchurl
+, fetchpatch
 , evince
 , gjs
 , pkg-config
@@ -34,6 +36,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "0c41l8m2di8h39bmk2fnhpwglwp6qhljmwqqbihzp4ay9976zrc5";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://gitlab.gnome.org/GNOME/gnome-books/-/merge_requests/62
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-books/-/commit/2663dcdaaaa71f067a4c2d0005eecc0fdf940bf5.patch";
+      sha256 = "v2mLzrxSWrkJ0N6seR8jNXX14FsneEPuE9ELLVUe6+E=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
@@ -1,17 +1,52 @@
-{ lib, stdenv, gettext, libxml2, libhandy, fetchurl, pkg-config, libcanberra-gtk3
-, gtk3, glib, meson, ninja, python3, wrapGAppsHook, appstream-glib, desktop-file-utils
-, gnome, gsettings-desktop-schemas }:
+{ stdenv
+, lib
+, gettext
+, libxml2
+, libhandy
+, fetchurl
+, pkg-config
+, libcanberra-gtk3
+, gtk3
+, glib
+, meson
+, ninja
+, python3
+, wrapGAppsHook
+, appstream-glib
+, desktop-file-utils
+, gnome
+, gsettings-desktop-schemas
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-screenshot";
   version = "41.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "Stt97JJkKPdCY9V5ZnPPFC5HILbnaPVGio0JM/mMlZc=";
   };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    appstream-glib
+    libxml2
+    desktop-file-utils
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    glib
+    libcanberra-gtk3
+    libhandy
+    gnome.adwaita-icon-theme
+    gsettings-desktop-schemas
+  ];
 
   doCheck = true;
 
@@ -19,12 +54,6 @@ in stdenv.mkDerivation rec {
     chmod +x build-aux/postinstall.py # patchShebangs requires executable file
     patchShebangs build-aux/postinstall.py
   '';
-
-  nativeBuildInputs = [ meson ninja pkg-config gettext appstream-glib libxml2 desktop-file-utils python3 wrapGAppsHook ];
-  buildInputs = [
-    gtk3 glib libcanberra-gtk3 libhandy gnome.adwaita-icon-theme
-    gsettings-desktop-schemas
-  ];
 
   passthru = {
     updateScript = gnome.updateScript {
@@ -34,10 +63,10 @@ in stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    homepage = "https://en.wikipedia.org/wiki/GNOME_Screenshot";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-screenshot";
     description = "Utility used in the GNOME desktop environment for taking screenshots";
     maintainers = teams.gnome.members;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-screenshot/default.nix
@@ -4,6 +4,7 @@
 , libxml2
 , libhandy
 , fetchurl
+, fetchpatch
 , pkg-config
 , libcanberra-gtk3
 , gtk3
@@ -26,6 +27,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "Stt97JJkKPdCY9V5ZnPPFC5HILbnaPVGio0JM/mMlZc=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://gitlab.gnome.org/GNOME/gnome-screenshot/-/issues/186
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-screenshot/-/commit/b60dad3c2536c17bd201f74ad8e40eb74385ed9f.patch";
+      sha256 = "Js83h/3xxcw2hsgjzGa5lAYFXVrt6MPhXOTh5dZTx/w=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/desktops/gnome/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome/devtools/devhelp/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchurl
+, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -28,6 +30,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/devhelp/${lib.versions.major version}/${pname}-${version}.tar.xz";
     sha256 = "7KqQsPTaqPsgMPbcaQv1M/+Zp3NDf+Dhis/oLZl/YNI=";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://gitlab.gnome.org/GNOME/devhelp/-/issues/59
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/devhelp/-/commit/281bade14c1925cf9e7329fa8e9cf2d82512c66f.patch";
+      sha256 = "LmHoeQ0zJwOhuasAUYy8FfpDnEO+UNfEb293uKttYKo=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/desktops/gnome/games/gnome-2048/default.nix
+++ b/pkgs/desktops/gnome/games/gnome-2048/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, fetchpatch
 , wrapGAppsHook
 , meson
 , vala
@@ -22,6 +23,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/gnome-2048/${lib.versions.majorMinor version}/gnome-2048-${version}.tar.xz";
     sha256 = "0s5fg4z5in1h39fcr69j1qc5ynmg7a8mfprk3mc3c0csq3snfwz2";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # https://gitlab.gnome.org/GNOME/gnome-2048/-/merge_requests/21
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-2048/-/commit/194e22699f7166a016cd39ba26dd719aeecfc868.patch";
+      sha256 = "Qpn/OJJwblRm5Pi453aU2HwbrNjsf+ftmSnns/5qZ9E=";
+    })
+  ];
 
   nativeBuildInputs = [
     itstool


### PR DESCRIPTION
###### Description of changes

https://hydra.nixos.org/eval/1751498?filter=aarch64-linux&compare=1751214&full=1#tabs-now-fail


No new release so far

  - https://repology.org/project/devhelp/versions
  - https://repology.org/project/gnome-books/versions
  - https://repology.org/project/gnome-screenshot/versions
  - https://repology.org/project/gnome-2048/versions


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
