### PR TITLE
icon-library: fix build with meson 0.61

### DIFF
--- a/pkgs/applications/graphics/icon-library/default.nix
+++ b/pkgs/applications/graphics/icon-library/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, wrapGAppsHook
+{ lib, stdenv, fetchurl, fetchpatch, wrapGAppsHook
 , cargo, desktop-file-utils, meson, ninja, pkg-config, rustc
 , gdk-pixbuf, glib, gtk4, gtksourceview5, libadwaita
 }:
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
     url = "https://gitlab.gnome.org/World/design/icon-library/uploads/93d183b17d216bbed7b03b2f3698059c/icon-library-${version}.tar.xz";
     sha256 = "1zrcnc5dn5fgcl3vklfpbp3m0qzi2n2viw59vw5fhwkysvp670y7";
   };
+
+  patches = [
+    # Fix build with meson 0.61
+    # data/meson.build:85:0: ERROR: gnome.compile_resources takes exactly 2 arguments, but got 3.
+    # https://gitlab.gnome.org/World/design/icon-library/-/merge_requests/54
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/World/design/icon-library/-/commit/c629dbf6670f9bb0b98ff21c17110489b58f5c85.patch";
+      sha256 = "UKC1CPaM58/z0zINN794luWZdoFx1zGxETPb8VtbO3E=";
+    })
+  ];
 
   nativeBuildInputs = [
     cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook

--- a/pkgs/applications/graphics/icon-library/default.nix
+++ b/pkgs/applications/graphics/icon-library/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, wrapGAppsHook
+{ lib, stdenv, fetchurl, fetchpatch, wrapGAppsHook4
 , cargo, desktop-file-utils, meson, ninja, pkg-config, rustc
 , gdk-pixbuf, glib, gtk4, gtksourceview5, libadwaita
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook
+    cargo desktop-file-utils meson ninja pkg-config rustc wrapGAppsHook4
   ];
   buildInputs = [ gdk-pixbuf glib gtk4 gtksourceview5 libadwaita ];
 


### PR DESCRIPTION
###### Description of changes

https://hydra.nixos.org/build/171150389/nixlog/1
Filed https://gitlab.gnome.org/World/design/icon-library/-/merge_requests/54
https://mesonbuild.com/Gnome-module.html#gnomecompile_resources

```
data/meson.build:85:0: ERROR: gnome.compile_resources takes exactly 2 arguments, but got 3.
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
