### PR TITLE
apc-temp-fetch: init at 0.0.1

### DIFF
--- a/pkgs/tools/networking/apc-temp-fetch/default.nix
+++ b/pkgs/tools/networking/apc-temp-fetch/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, pythonOlder
+, requests
+}:
+
+buildPythonApplication rec {
+  pname = "apc-temp-fetch";
+  version = "0.0.1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchPypi {
+    pname = "APC-Temp-fetch";
+    inherit version;
+    hash = "sha256-2hNrTrYQadNJWzj7/dDou+a6uI+Ksyrbru9rBqIHXaM=";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "APC_Temp_fetch"
+  ];
+
+  meta = with lib; {
+    description = "unified temperature fetcher interface to several UPS network adapters";
+    homepage = "https://github.com/YZITE/APC_Temp_fetch";
+    license = licenses.asl20;
+    maintainers = [ maintainers.zseri ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4387,6 +4387,8 @@ with pkgs;
 
   apple-music-electron = callPackage ../applications/audio/apple-music-electron { };
 
+  apc-temp-fetch = with python3.pkgs; callPackage ../tools/networking/apc-temp-fetch { };
+
   arping = callPackage ../tools/networking/arping { };
 
   arpoison = callPackage ../tools/networking/arpoison { };


### PR DESCRIPTION
###### Description of changes

A cli application for fetching battery temperature from different network-attached UPS devices.
(written by myself, but I wasn't able to come up with any good way to unit-test it)
Doesn't contain any "native" compiled python extensions, thus pure python.
Also exports a python module which allows access to all extracted information (some UPS status pages are easily parsable and usually contain more info than just battery temperature)

Side note about dependencies: I'm not entirely sure if `nativeBuildInputs = [setuptools];` is the correct way to integrate setuptools. Currently this package doesn't contain tests, otherwise I would've added `pytestCheckHook` to `checkInputs`.

I also noticed that the executables are wrapped to mangle `PATH`, even though this is (in this case) completely unnecessary, because no part of the cli executes any subprocesses afaik. (#58130)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
