### PR TITLE
rdma-core: Fix pkg-config files

### DIFF
--- a/pkgs/os-specific/linux/rdma-core/default.nix
+++ b/pkgs/os-specific/linux/rdma-core/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_SHAREDSTATEDIR=/var/lib"
   ];
 
+  patches = [
+    # this has been fixed in master. As soon as it gets into a release, this
+    # patch won't apply anymore and can be removed.
+    ./pkg-config-template.patch
+  ];
+
   postPatch = ''
     substituteInPlace srp_daemon/srp_daemon.sh.in \
       --replace /bin/rm rm

--- a/pkgs/os-specific/linux/rdma-core/pkg-config-template.patch
+++ b/pkgs/os-specific/linux/rdma-core/pkg-config-template.patch
@@ -1,0 +1,14 @@
+diff -ru source/buildlib/template.pc.in source-fixed/buildlib/template.pc.in
+--- source/buildlib/template.pc.in	1970-01-01 01:00:01.000000000 +0100
++++ source-fixed/buildlib/template.pc.in	2022-03-30 22:29:12.988625941 +0200
+@@ -1,7 +1,6 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: lib@PC_LIB_NAME@
+ Description: RDMA Core Userspace Library


### PR DESCRIPTION
###### Description of changes

This patch fixes double-appearance of the nix store path in the generated pkg-config file.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
