### PR TITLE
jsoncpp: enable static and USING_SECURE_MEMORY

### DIFF
--- a/pkgs/development/libraries/jsoncpp/default.nix
+++ b/pkgs/development/libraries/jsoncpp/default.nix
@@ -1,4 +1,13 @@
-{ lib, stdenv, fetchFromGitHub, cmake, python3, validatePkgConfig, fetchpatch }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, python3
+, validatePkgConfig
+, fetchpatch
+, secureMemory ? false
+, enableStatic ? stdenv.hostPlatform.isStatic
+}:
 
 stdenv.mkDerivation rec {
   pname = "jsoncpp";
@@ -30,6 +39,10 @@ stdenv.mkDerivation rec {
     export sourceRoot=${src.name}
   '';
 
+  postPatch = lib.optionalString secureMemory ''
+    sed -i 's/#define JSONCPP_USING_SECURE_MEMORY 0/#define JSONCPP_USING_SECURE_MEMORY 1/' include/json/version.h
+  '';
+
   # Hack to be able to run the test, broken because we use
   # CMAKE_SKIP_BUILD_RPATH to avoid cmake resetting rpath on install
   preBuild = if stdenv.isDarwin then ''
@@ -42,10 +55,21 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_STATIC_LIBS=OFF"
     "-DBUILD_OBJECT_LIBS=OFF"
     "-DJSONCPP_WITH_CMAKE_PACKAGE=ON"
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DJSONCPP_WITH_TESTS=OFF";
+  ]
+    # the test's won't compile if secureMemory is used because there is no
+    # comparison operators and conversion functions between
+    # std::basic_string<..., Json::SecureAllocator<char>> vs.
+    # std::basic_string<..., [default allocator]>
+    ++ lib.optional ((stdenv.buildPlatform != stdenv.hostPlatform) || secureMemory) "-DJSONCPP_WITH_TESTS=OFF"
+    ++ lib.optional (!enableStatic) "-DBUILD_STATIC_LIBS=OFF";
+
+  # this is fixed and no longer necessary in 1.9.5 but there they use
+  # memset_s without switching to a different c++ standard in the cmake files
+  postInstall = lib.optionalString enableStatic ''
+    (cd $out/lib && ln -sf libjsoncpp_static.a libjsoncpp.a)
+  '';
 
   meta = with lib; {
     homepage = "https://github.com/open-source-parsers/jsoncpp";


### PR DESCRIPTION
###### Description of changes

Enable static builds and the `USING_SECURE_MEMORY` functionality (both options are disabled by default)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
