### PR TITLE
aeskeyfind: init at 1.0

### DIFF
--- a/pkgs/tools/security/aeskeyfind/default.nix
+++ b/pkgs/tools/security/aeskeyfind/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Locates 128-bit and 256-bit AES keys in a captured memory image";
     homepage = "https://citp.princeton.edu/our-work/memory/";
-    license = bsd3;
+    license = licenses.bsd3;
     maintainers = with maintainers; [ fedx-sudo ];
   };
 

--- a/pkgs/tools/security/aeskeyfind/default.nix
+++ b/pkgs/tools/security/aeskeyfind/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "aeskeyfind";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://citpsite.s3.amazonaws.com/memory-content/src/aeskeyfind-${version}.tar.gz";
+    sha256 = "sha256-FBflwbYehruVJ9sfW+4ZlaDuqCR12zy8iA4Ev3Bgg+Q=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp aeskeyfind $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Locates 128-bit and 256-bit AES keys in a captured memory image";
+    homepage = "https://citp.princeton.edu/our-work/memory/";
+    license = bsd3;
+    maintainers = with maintainers; [ fedx-sudo ];
+  };
+
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -190,6 +190,8 @@ with pkgs;
 
   aesfix = callPackage ../tools/security/aesfix { };
 
+  aeskeyfind = callPackage ../tools/security/aeskeyfind { };
+
   astrolog = callPackage ../applications/science/astronomy/astrolog { };
 
   atkinson-hyperlegible = callPackage ../data/fonts/atkinson-hyperlegible { };


### PR DESCRIPTION
###### Description of changes
Init pentesting tool aeskeyfind. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done
Add aeskeyfind another security tool and recommended to be used with my last PR aeskfix. 

Relevant issue: https://github.com/NixOS/nixpkgs/issues/81418
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
