### PR TITLE
Deprecate global pam options

### DIFF
--- a/nixos/modules/security/oath.nix
+++ b/nixos/modules/security/oath.nix
@@ -12,6 +12,10 @@ with lib;
         type = types.bool;
         default = false;
         description = ''
+          DEPRECATED, please use <literal>security.pam.services.*.oathAuth</literal>
+          instead, as this option is very coarse-grained.
+          I.e. <literal>security.pam.services.login.oathAuth = true</literal>
+
           Enable the OATH (one-time password) PAM module.
         '';
       };

--- a/nixos/modules/security/pam_usb.nix
+++ b/nixos/modules/security/pam_usb.nix
@@ -18,6 +18,10 @@ in
         type = types.bool;
         default = false;
         description = ''
+          DEPRECATED, please use <literal>security.pam.services.*.usbAuth</literal>
+          instead, as this option is very coarse-grained.
+          I.e. <literal>security.pam.services.login.usbAuth = true</literal>
+
           Enable USB login for all login systems that support it.  For
           more information, visit <link
           xlink:href="https://github.com/aluzzardi/pam_usb/wiki/Getting-Started#setting-up-devices-and-users" />.
@@ -29,6 +33,12 @@ in
   };
 
   config = mkIf (cfg.enable || anyUsbAuth) {
+
+    warnings =  optional config.security.pam.usb.enable ''
+      DEPRECATED, please use `security.pam.services.<name>.usbAuth`
+      instead, as this option is very coarse-grained.
+      I.e. `security.pam.services.login.usbAuth = true`
+    '';
 
     # Make sure pmount and pumount are setuid wrapped.
     security.wrappers = {


### PR DESCRIPTION
###### Description of changes

Fix #166076.

The following options would be deprecated by this:
- [X] `security.pam.p11.enable` (safe)
- [X] `security.pam.u2f.enable` (safe)
- [X] `security.pam.yubico.enable` (safe)
- [X] `security.pam.usb.enable` (safe)
- [X] `security.pam.enableOTPW` (safe)
- [ ] `services.fprintd.enable`
- [X] `security.pam.oath.enable` (safe)
- [ ] `(security.pam.mount.enable)`


Implications:
- Options marked with `(safe)` can easily be replaced as they only serve as a default value for an option in `security.pam.services.<name>` and add packages to `environment.systemPackages`. The latter is replaced by including the necessary packages if any service uses them.

There are still open questions.
- How should `services.fprintd.enable` be handled. This option can't really be deprecated as it has effects other than just functioning as a default value for PAM services. Changing the default value for `security.pam.services.<name>.fprintAuth` would likely surprise some people and (worst case) log them out of their devices.
- Is `security.pam.mount.enable` relevant in this context? Why would one use this instead of `security.pam.services.login.pamMount`?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
