### PR TITLE
treewide: use lib.getLib for OpenSSL libraries

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -877,7 +877,7 @@ in
         copy_bin_and_libs ${pkgs.yubikey-personalization}/bin/ykinfo
         copy_bin_and_libs ${pkgs.openssl.bin}/bin/openssl
 
-        cc -O3 -I${pkgs.openssl.dev}/include -L${pkgs.openssl.out}/lib ${./pbkdf2-sha512.c} -o pbkdf2-sha512 -lcrypto
+        cc -O3 -I${pkgs.openssl.dev}/include -L${lib.getLib pkgs.openssl}/lib ${./pbkdf2-sha512.c} -o pbkdf2-sha512 -lcrypto
         strip -s pbkdf2-sha512
         copy_bin_and_libs pbkdf2-sha512
 

--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -126,8 +126,8 @@ stdenv.mkDerivation {
       # Work around Spotify referring to a specific minor version of
       # OpenSSL.
 
-      ln -s ${openssl.out}/lib/libssl.so $libdir/libssl.so.1.0.0
-      ln -s ${openssl.out}/lib/libcrypto.so $libdir/libcrypto.so.1.0.0
+      ln -s ${lib.getLib openssl}/lib/libssl.so $libdir/libssl.so.1.0.0
+      ln -s ${lib.getLib openssl}/lib/libcrypto.so $libdir/libcrypto.so.1.0.0
       ln -s ${nspr.out}/lib/libnspr4.so $libdir/libnspr4.so
       ln -s ${nspr.out}/lib/libplc4.so $libdir/libplc4.so
 

--- a/pkgs/applications/blockchains/snarkos/default.nix
+++ b/pkgs/applications/blockchains/snarkos/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   # Needed to get openssl-sys to use pkg-config.
   OPENSSL_NO_VENDOR = 1;
-  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_DIR="${lib.getDev openssl}";
 
   LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";

--- a/pkgs/applications/blockchains/solana/default.nix
+++ b/pkgs/applications/blockchains/solana/default.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   # checkInputs = lib.optionals stdenv.isDarwin [ pkg-config rustfmt ];
   # Needed to get openssl-sys to use pkg-config.
   # OPENSSL_NO_VENDOR = 1;
-  # OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  # OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   # OPENSSL_DIR="${lib.getDev openssl}";
   # LLVM_CONFIG_PATH="${llvm}/bin/llvm-config";
   # LIBCLANG_PATH="${llvmPackages.libclang.lib}/lib";

--- a/pkgs/applications/editors/kodestudio/default.nix
+++ b/pkgs/applications/editors/kodestudio/default.nix
@@ -57,7 +57,7 @@ in
           $out/kodestudio
       patchelf \
           --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-          --set-rpath ".:${stdenv.cc.libc}/lib:${xorg.libXinerama}/lib:${xorg.libX11}/lib:${alsa-lib}/lib:${libGL}/lib:${libGLU}/lib:${openssl.out}/lib" \
+          --set-rpath ".:${stdenv.cc.libc}/lib:${xorg.libXinerama}/lib:${xorg.libX11}/lib:${alsa-lib}/lib:${libGL}/lib:${libGLU}/lib:${lib.getLib openssl}/lib" \
           $out/resources/app/extensions/krom/Krom/linux/Krom
       patchelf \
           --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \

--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -101,7 +101,7 @@ in let
         "''${gappsWrapperArgs[@]}"
 
       # Without this, plugin_host crashes, even though it has the rpath
-      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${openssl.out}/lib/libssl.so:${bzip2.out}/lib/libbz2.so
+      wrapProgram $out/plugin_host --prefix LD_PRELOAD : ${stdenv.cc.cc.lib}/lib${lib.optionalString stdenv.is64bit "64"}/libgcc_s.so.1:${lib.getLib openssl}/lib/libssl.so:${bzip2.out}/lib/libbz2.so
     '';
   };
 in stdenv.mkDerivation (rec {

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools-csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools-csharp/default.nix
@@ -107,7 +107,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
       patchelf_add_icu_as_needed "$elf"
       patchelf --add-needed "libssl.so" "$elf"
       patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc openssl.out icu.out ]}:\$ORIGIN" \
+        --set-rpath "${lib.makeLibraryPath [ stdenv.cc.cc openssl icu.out ]}:\$ORIGIN" \
         "$elf"
     }
 

--- a/pkgs/applications/networking/irc/wraith/configure.patch
+++ b/pkgs/applications/networking/irc/wraith/configure.patch
@@ -52,7 +52,7 @@
 -fi
 -unset cf_openssl_basedir
 +SSL_INCLUDES="-I@openssl.dev@/include"
-+SSL_LIBS="-L@openssl.out@/lib"
++SSL_LIBS="-L@openssl-lib@/lib"
  
  save_CXX="$CXX"
  CXX="$CXX $SSL_INCLUDES"

--- a/pkgs/applications/networking/irc/wraith/default.nix
+++ b/pkgs/applications/networking/irc/wraith/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
   patches = [ ./configure.patch ./dlopen.patch ];
   postPatch = ''
     substituteInPlace configure        --subst-var-by openssl.dev ${openssl.dev} \
-                                       --subst-var-by openssl.out ${openssl.out}
-    substituteInPlace src/libssl.cc    --subst-var-by openssl ${openssl.out}
-    substituteInPlace src/libcrypto.cc --subst-var-by openssl ${openssl.out}
+                                       --subst-var-by openssl-lib ${lib.getLib openssl}
+    substituteInPlace src/libssl.cc    --subst-var-by openssl ${lib.getLib openssl}
+    substituteInPlace src/libcrypto.cc --subst-var-by openssl ${lib.getLib openssl}
   '';
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/applications/networking/mailreaders/mailspring/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailspring/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
       --replace dirname ${coreutils}/bin/dirname
 
     ln -s $out/share/mailspring/mailspring $out/bin/mailspring
-    ln -s ${openssl.out}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
+    ln -s ${lib.getLib openssl}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
 
     runHook postInstall
   '';

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -14,7 +14,7 @@ let
   openssl' = symlinkJoin {
     name = "openssl-backwards-compat";
     nativeBuildInputs = [ makeWrapper ];
-    paths = [ openssl.out ];
+    paths = [ (lib.getLib openssl) ];
     postBuild = ''
       ln -sf $out/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
       ln -sf $out/lib/libssl.so $out/lib/libssl.so.1.0.0

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -92,7 +92,7 @@ let
           --replace "${expat.dev}/lib" "${expat.out}/lib" \
           --replace "${zlib.dev}/lib" "${zlib.out}/lib" \
           --replace "${sqlite.dev}/lib" "${sqlite.out}/lib" \
-          --replace "${openssl.dev}/lib" "${openssl.out}/lib"
+          --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
       done
     '';
 

--- a/pkgs/development/compilers/gambit/build.nix
+++ b/pkgs/development/compilers/gambit/build.nix
@@ -86,8 +86,8 @@ gccStdenv.mkDerivation rec {
 
     # OS-specific paths are hardcoded in ./configure
     substituteInPlace config.status \
-      --replace "/usr/local/opt/openssl@1.1" "${openssl.out}" \
-      --replace "/usr/local/opt/openssl" "${openssl.out}"
+      --replace "/usr/local/opt/openssl@1.1" "${lib.getLib openssl}" \
+      --replace "/usr/local/opt/openssl" "${lib.getLib openssl}"
 
     ./config.status
   '';

--- a/pkgs/development/compilers/urweb/default.nix
+++ b/pkgs/development/compilers/urweb/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
     export CC="${gcc}/bin/gcc";
     export CCARGS="-I$out/include \
-                   -L${openssl.out}/lib \
+                   -L${lib.getLib openssl}/lib \
                    -L${libmysqlclient}/lib \
                    -L${postgresql.lib}/lib \
                    -L${sqlite.out}/lib";

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -36,8 +36,8 @@ in stdenv.mkDerivation rec {
   patches = [(substituteAll {
     src = ./0001-Fix-some-paths-for-Nix-build.patch;
     libipasir = "${libipasir}/lib/${libipasir.libname}";
-    libssl = "${openssl.out}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
-    libcrypto = "${openssl.out}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
+    libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
+    libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
   })];
 
   buildInputs = [
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     # To build community books, we need Perl and a couple of utilities:
     which perl hostname makeWrapper
     # Some of the books require one or more of these external tools:
-    openssl.out glucose minisat abc-verifier libipasir
+    glucose minisat abc-verifier libipasir
     z3 (python2.withPackages (ps: [ ps.z3 ]))
   ];
 

--- a/pkgs/development/libraries/apr-util/default.nix
+++ b/pkgs/development/libraries/apr-util/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
       substituteInPlace $f \
         --replace "${expat.dev}/lib" "${expat.out}/lib" \
         --replace "${db.dev}/lib" "${db.out}/lib" \
-        --replace "${openssl.dev}/lib" "${openssl.out}/lib"
+        --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
     done
 
     # Give apr1 access to sed for runtime invocations.

--- a/pkgs/development/libraries/aqbanking/gwenhywfar.nix
+++ b/pkgs/development/libraries/aqbanking/gwenhywfar.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
 
   configureFlags = [
     "--with-openssl-includes=${openssl.dev}/include"
-    "--with-openssl-libs=${openssl.out}/lib"
+    "--with-openssl-libs=${lib.getLib openssl}/lib"
   ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/ggz_base_libs/default.nix
+++ b/pkgs/development/libraries/ggz_base_libs/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   patchPhase = ''
     substituteInPlace configure \
       --replace "/usr/local/ssl/include" "${openssl.dev}/include" \
-      --replace "/usr/local/ssl/lib" "${openssl.out}/lib"
+      --replace "/usr/local/ssl/lib" "${lib.getLib openssl}/lib"
   '';
 
   configureFlags = [

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     sed -i $lib/lib/libarchive.la \
-      -e 's|-lcrypto|-L${openssl.out}/lib -lcrypto|' \
+      -e 's|-lcrypto|-L${lib.getLib openssl}/lib -lcrypto|' \
       -e 's|-llzo2|-L${lzo}/lib -llzo2|'
   '';
 

--- a/pkgs/development/libraries/live555/default.nix
+++ b/pkgs/development/libraries/live555/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace config.macosx-catalina \
-      --replace '/usr/lib/libssl.46.dylib' "${openssl.out}/lib/libssl.dylib" \
-      --replace '/usr/lib/libcrypto.44.dylib' "${openssl.out}/lib/libcrypto.dylib"
+      --replace '/usr/lib/libssl.46.dylib' "${lib.getLib openssl}/lib/libssl.dylib" \
+      --replace '/usr/lib/libcrypto.44.dylib' "${lib.getLib openssl}/lib/libcrypto.dylib"
     sed -i -e 's|/bin/rm|rm|g' genMakefiles
     sed -i \
       -e 's/$(INCLUDES) -I. -O2 -DSOCKLEN_T/$(INCLUDES) -I. -O2 -I. -fPIC -DRTSPCLIENT_SYNCHRONOUS_INTERFACE=1 -DSOCKLEN_T/g' \

--- a/pkgs/development/libraries/openldap/default.nix
+++ b/pkgs/development/libraries/openldap/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     rm -r libraries/*/.libs
     rm -r contrib/slapd-modules/passwd/*/.libs
     for f in $out/lib/libldap.la $out/lib/libldap_r.la; do
-      substituteInPlace "$f" --replace '-lssl' '-L${openssl.out}/lib -lssl'
+      substituteInPlace "$f" --replace '-lssl' '-L${lib.getLib openssl}/lib -lssl'
   '' + lib.optionalString withCyrusSasl ''
       substituteInPlace "$f" --replace '-lsasl2' '-L${cyrus_sasl.out}/lib -lsasl2'
   '' + ''

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -261,7 +261,7 @@ stdenv.mkDerivation {
     "-I" "${harfbuzz.dev}/include"
     "-system-pcre"
     "-openssl-linked"
-    "-L" "${openssl.out}/lib"
+    "-L" "${lib.getLib openssl}/lib"
     "-I" "${openssl.dev}/include"
     "-system-sqlite"
     ''-${if libmysqlclient != null then "plugin" else "no"}-sql-mysql''

--- a/pkgs/development/libraries/unixODBCDrivers/default.nix
+++ b/pkgs/development/libraries/unixODBCDrivers/default.nix
@@ -157,7 +157,7 @@
     '';
 
     postFixup = ''
-      patchelf --set-rpath ${lib.makeLibraryPath [ unixODBC openssl.out libkrb5 libuuid stdenv.cc.cc ]} \
+      patchelf --set-rpath ${lib.makeLibraryPath [ unixODBC openssl libkrb5 libuuid stdenv.cc.cc ]} \
         $out/lib/libmsodbcsql-${versionMajor}.${versionMinor}.so.${versionAdditional}
     '';
 

--- a/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
+++ b/pkgs/development/lisp-modules/quicklisp-to-nix-overrides.nix
@@ -64,7 +64,7 @@ in
     propagatedBuildInputs = [pkgs.openssl];
     overrides = y: (x.overrides y) // {
       prePatch = ''
-        sed 's|libssl.so|${pkgs.openssl.out}/lib/libssl.so|' -i src/reload.lisp
+        sed 's|libssl.so|${pkgs.lib.getLib pkgs.openssl}/lib/libssl.so|' -i src/reload.lisp
       '';
     };
   };

--- a/pkgs/development/python-modules/bitcoinlib/default.nix
+++ b/pkgs/development/python-modules/bitcoinlib/default.nix
@@ -17,7 +17,7 @@ in buildPythonPackage rec {
   postPatch = ''
     substituteInPlace bitcoin/core/key.py --replace \
       "ctypes.util.find_library('ssl') or 'libeay32'" \
-      "'${openssl.out}/lib/libssl.${ext}'"
+      "'${lib.getLib openssl}/lib/libssl.${ext}'"
   '';
 
   meta = {

--- a/pkgs/development/python-modules/proton-client/default.nix
+++ b/pkgs/development/python-modules/proton-client/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   # but it is not working as intended.
   #patchPhase = ''
   #  substituteInPlace proton/srp/_ctsrp.py --replace \
-  #    "ctypes.cdll.LoadLibrary('libssl.so.10')" "'${openssl.out}/lib/libssl.so'"
+  #    "ctypes.cdll.LoadLibrary('libssl.so.10')" "'${lib.getLib openssl}/lib/libssl.so'"
   #'';
   # Regarding the issue above, I'm disabling tests for now
   doCheck = false;

--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     curl
-    openssl.out
+    openssl
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   patchPhase = ''
     substituteInPlace telethon/crypto/libssl.py --replace \
-      "ctypes.util.find_library('ssl')" "'${openssl.out}/lib/libssl.so'"
+      "ctypes.util.find_library('ssl')" "'${lib.getLib openssl}/lib/libssl.so'"
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1083,12 +1083,12 @@ let
         patchShebangs configure
       '';
       PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${pkgs.openssl.out}/lib -L${pkgs.openssl.out}/lib -lssl -lcrypto";
+      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
     });
 
     websocket = old.websocket.overrideDerivation (attrs: {
       PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${pkgs.openssl.out}/lib -L${pkgs.openssl.out}/lib -lssl -lcrypto";
+      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
     });
 
     Rserve = old.Rserve.overrideDerivation (attrs: {
@@ -1193,7 +1193,7 @@ let
         patchShebangs configure
         '';
       PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include -I${pkgs.cyrus_sasl.dev}/include -I${pkgs.zlib.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${pkgs.openssl.out}/lib -L${pkgs.openssl.out}/lib -L${pkgs.cyrus_sasl.out}/lib -L${pkgs.zlib.out}/lib -lssl -lcrypto -lsasl2 -lz";
+      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -L${pkgs.cyrus_sasl.out}/lib -L${pkgs.zlib.out}/lib -lssl -lcrypto -lsasl2 -lz";
     });
 
     ps = old.ps.overrideDerivation (attrs: {

--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     # patch cl-plus-ssl to ensure that it finds libssl and libcrypto
-    sed 's|libssl.so|${openssl.out}/lib/libssl.so|' -i ext/cl-plus-ssl/src/reload.lisp
-    sed 's|libcrypto.so|${openssl.out}/lib/libcrypto.so|' -i ext/cl-plus-ssl/src/reload.lisp
+    sed 's|libssl.so|${lib.getLib openssl}/lib/libssl.so|' -i ext/cl-plus-ssl/src/reload.lisp
+    sed 's|libcrypto.so|${lib.getLib openssl}/lib/libcrypto.so|' -i ext/cl-plus-ssl/src/reload.lisp
     # patch dexador to avoid error due to dexador being loaded multiple times
     sed -i 's/defpackage/uiop:define-package/g' ext/dexador/src/dexador.lisp
   '';

--- a/pkgs/development/tools/database/prisma-engines/default.nix
+++ b/pkgs/development/tools/database/prisma-engines/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
 
   preBuild = ''
     export OPENSSL_DIR=${lib.getDev openssl}
-    export OPENSSL_LIB_DIR=${openssl.out}/lib
+    export OPENSSL_LIB_DIR=${lib.getLib openssl}/lib
 
     export PROTOC=${protobuf}/bin/protoc
     export PROTOC_INCLUDE="${protobuf}/include";

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     moveToOutput bin/nsupdate $dnsutils
 
     for f in "$lib/lib/"*.la "$dev/bin/"bind*-config; do
-      sed -i "$f" -e 's|-L${openssl.dev}|-L${openssl.out}|g'
+      sed -i "$f" -e 's|-L${openssl.dev}|-L${lib.getLib openssl}|g'
     done
   '';
 

--- a/pkgs/servers/monitoring/net-snmp/default.nix
+++ b/pkgs/servers/monitoring/net-snmp/default.nix
@@ -53,7 +53,7 @@ in stdenv.mkDerivation rec {
 
   postInstall = ''
     for f in "$lib/lib/"*.la $bin/bin/net-snmp-config $bin/bin/net-snmp-create-v3-user; do
-      sed 's|-L${openssl.dev}|-L${openssl.out}|g' -i $f
+      sed 's|-L${openssl.dev}|-L${lib.getLib openssl}|g' -i $f
     done
     mkdir $dev/bin
     mv $bin/bin/net-snmp-config $dev/bin

--- a/pkgs/servers/openxpki/default.nix
+++ b/pkgs/servers/openxpki/default.nix
@@ -53,7 +53,7 @@ perlPackages.buildPerlPackage {
   preConfigure = ''
     substituteInPlace core/server/Makefile.PL \
       --replace "my \$openssl_inc_dir = ''';" "my \$openssl_inc_dir = '${openssl.dev}/include';" \
-      --replace "my \$openssl_lib_dir = ''';" "my \$openssl_lib_dir = '${openssl.out}/lib';" \
+      --replace "my \$openssl_lib_dir = ''';" "my \$openssl_lib_dir = '${lib.getLib openssl}/lib';" \
       --replace "my \$openssl_binary  = ''';" "my \$openssl_binary  = '${openssl.bin}/bin/openssl';"
     substituteInPlace tools/vergen --replace "#!/usr/bin/perl" "#!${perl}/bin/perl"
     cp ${./vergen_revision_state} .vergen_revision_state

--- a/pkgs/servers/web-apps/lemmy/server.nix
+++ b/pkgs/servers/web-apps/lemmy/server.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
   # As of version 0.10.35 rust-openssl looks for openssl on darwin
   # with a hardcoded path to /usr/lib/libssl.x.x.x.dylib
   # https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/find_normal.rs#L115
-  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
 
   PROTOC = "${protobuf}/bin/protoc";

--- a/pkgs/stdenv/darwin/make-bootstrap-tools.nix
+++ b/pkgs/stdenv/darwin/make-bootstrap-tools.nix
@@ -80,7 +80,7 @@ in rec {
       cp ${curl_.bin}/bin/curl $out/bin
       cp -d ${curl_.out}/lib/libcurl*.dylib $out/lib
       cp -d ${libssh2.out}/lib/libssh*.dylib $out/lib
-      cp -d ${openssl.out}/lib/*.dylib $out/lib
+      cp -d ${lib.getLib openssl}/lib/*.dylib $out/lib
 
       cp -d ${gnugrep.pcre.out}/lib/libpcre*.dylib $out/lib
       cp -d ${lib.getLib libiconv}/lib/lib*.dylib $out/lib

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -46,7 +46,7 @@ py.pkgs.buildPythonApplication rec {
 
   postPatch = ''
     substituteInPlace "salt/utils/rsax931.py" \
-      --subst-var-by "libcrypto" "${openssl.out}/lib/libcrypto.so"
+      --subst-var-by "libcrypto" "${lib.getLib openssl}/lib/libcrypto.so"
     substituteInPlace requirements/base.txt \
       --replace contextvars ""
   '';

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     export BOOST_INCLUDEDIR=${boost.dev}/include
     export BOOST_LIBRARYDIR=${boost.out}/lib
     export CMAKE_INCLUDE_PATH=${openssl.dev}/include
-    export CMAKE_LIBRARY_PATH=${openssl.out}/lib
+    export CMAKE_LIBRARY_PATH=${lib.getLib openssl}/lib
 
     substituteInPlace cpp/cmake/FindValgrind.cmake \
       --replace "/usr/local" "${valgrind}"

--- a/pkgs/tools/networking/drill/default.nix
+++ b/pkgs/tools/networking/drill/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
   OPENSSL_DIR="${lib.getDev openssl}";
 
   buildInputs = lib.optionals stdenv.isLinux [

--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--with-openssl-libdir=${openssl.out}/lib"
+    "--with-openssl-libdir=${lib.getLib openssl}/lib"
     "--with-openssl-incdir=${openssl.dev}/include"
     "--enable-ignore-dns-errors"
     "--with-yielding-select=yes"

--- a/pkgs/tools/networking/ppp/default.nix
+++ b/pkgs/tools/networking/ppp/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       src = ./nix-purity.patch;
       glibc = stdenv.cc.libc.dev or stdenv.cc.libc;
       openssl_dev = openssl.dev;
-      openssl_out = openssl.out;
+      openssl_lib = lib.getLib openssl;
     })
     # Without nonpriv.patch, pppd --version doesn't work when not run as root.
     ./nonpriv.patch

--- a/pkgs/tools/networking/ppp/nix-purity.patch
+++ b/pkgs/tools/networking/ppp/nix-purity.patch
@@ -9,7 +9,7 @@ index 22837c5..6f6fff5 100644
 -CFLAGS	+= -DUSE_SRP -DOPENSSL -I/usr/local/ssl/include
 -LIBS	+= -lsrp -L/usr/local/ssl/lib
 +CFLAGS	+= -DUSE_SRP -DOPENSSL -I@openssl_dev@/include/openssl
-+LIBS	+= -lsrp -L@openssl_out@/lib
++LIBS	+= -lsrp -L@openssl_lib@/lib
  NEEDCRYPTOLIB = y
  TARGETS	+= srp-entry
  EXTRAINSTALL = $(INSTALL) -c -m 555 srp-entry $(BINDIR)/srp-entry

--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -32,7 +32,7 @@
 , withDNSTAP ? false
 , withTFO ? false
 , withRedis ? false
-# Avoid .lib depending on openssl.out
+# Avoid .lib depending on lib.getLib openssl
 # The build gets a little hacky, so in some cases we disable this approach.
 , withSlimLib ? stdenv.isLinux && !stdenv.hostPlatform.isMusl && !withDNSTAP
 , libnghttp2
@@ -110,7 +110,7 @@ stdenv.mkDerivation rec {
 
   preFixup = lib.optionalString withSlimLib
     # Build libunbound again, but only against nettle instead of openssl.
-    # This avoids gnutls.out -> unbound.lib -> openssl.out.
+    # This avoids gnutls.out -> unbound.lib -> lib.getLib openssl.
     ''
       configureFlags="$configureFlags --with-nettle=${nettle.dev} --with-libunbound-only"
       configurePhase

--- a/pkgs/tools/networking/uwimap/default.nix
+++ b/pkgs/tools/networking/uwimap/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i src/osdep/unix/Makefile -e 's,/usr/local/ssl,${openssl.dev},'
     sed -i src/osdep/unix/Makefile -e 's,^SSLCERTS=.*,SSLCERTS=/etc/ssl/certs,'
-    sed -i src/osdep/unix/Makefile -e 's,^SSLLIB=.*,SSLLIB=${openssl.out}/lib,'
+    sed -i src/osdep/unix/Makefile -e 's,^SSLLIB=.*,SSLLIB=${lib.getLib openssl}/lib,'
   '';
 
   NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ curl gtk3 libassuan libbsd libproxy libxml2 openssl p11-kit pcsclite ];
   preConfigure = ''
     mkdir openssl
-    ln -s ${openssl.out}/lib openssl
+    ln -s ${lib.getLib openssl}/lib openssl
     ln -s ${openssl.bin}/bin openssl
     ln -s ${openssl.dev}/include openssl
     export SSL_PREFIX=$(realpath openssl)

--- a/pkgs/tools/security/pcsc-safenet/default.nix
+++ b/pkgs/tools/security/pcsc-safenet/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     ln -sf libAksIfdh.so.10.0 libAksIfdh.so
     ln -sf libAksIfdh.so.10.0 libAksIfdh.so.10
 
-    ln -sf ${openssl.out}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
+    ln -sf ${lib.getLib openssl}/lib/libcrypto.so $out/lib/libcrypto.so.1.0.0
   '';
 
   dontAutoPatchelf = true;

--- a/pkgs/tools/security/quill/default.nix
+++ b/pkgs/tools/security/quill/default.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
     export IC_NNS_COMMON_PROTO_INCLUDES=${ic}/rs/nns/common/proto
     export PROTOC=${buildPackages.protobuf}/bin/protoc
     export OPENSSL_DIR=${openssl.dev}
-    export OPENSSL_LIB_DIR=${openssl.out}/lib
+    export OPENSSL_LIB_DIR=${lib.getLib openssl}/lib
   '';
 
   cargoSha256 = "sha256-YxuBABGaZ+ti31seEYR6bB+OMgrSvl1lZyu4bqdxPIk=";

--- a/pkgs/tools/security/rbw/default.nix
+++ b/pkgs/tools/security/rbw/default.nix
@@ -66,7 +66,7 @@ rustPlatform.buildRustPackage rec {
 
   preConfigure = ''
     export OPENSSL_INCLUDE_DIR="${openssl.dev}/include"
-    export OPENSSL_LIB_DIR="${openssl.out}/lib"
+    export OPENSSL_LIB_DIR="${lib.getLib openssl}/lib"
   '';
 
   postInstall = ''

--- a/pkgs/tools/system/monit/default.nix
+++ b/pkgs/tools/system/monit/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     (lib.withFeature usePAM "pam")
   ] ++ (if useSSL then [
     "--with-ssl-incl-dir=${openssl.dev}/include"
-    "--with-ssl-lib-dir=${openssl.out}/lib"
+    "--with-ssl-lib-dir=${lib.getLib openssl}/lib"
   ] else [
     "--without-ssl"
   ]) ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4709,7 +4709,7 @@ let
       sha256 = "b66fab514edf97fc32f58da257582704a210c2b35e297d5c31b7fa2ffd08e908";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.openssl.out}/lib -lcrypto";
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     meta = with lib; {
       description = "Perl wrapper around OpenSSL's AES library";
       license = with licenses; [ artistic1 gpl1Plus ];
@@ -4724,7 +4724,7 @@ let
       sha256 = "1p22znbajq91lbk2k3yg12ig7hy5b4vy8igxwqkmbm4nhgxp4ki3";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.openssl.out}/lib -lcrypto";
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
   };
 
   CryptOpenSSLGuess = buildPerlPackage {
@@ -4749,7 +4749,7 @@ let
       sha256 = "1x6ffps8q7mnawmcfq740llzy7i10g3319vap0wiw4d33fm6z1zh";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.openssl.out}/lib -lcrypto";
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
   };
 
@@ -4762,7 +4762,7 @@ let
     };
     propagatedBuildInputs = [ CryptOpenSSLRandom ];
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.openssl.out}/lib -lcrypto";
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     buildInputs = [ CryptOpenSSLGuess ];
   };
 
@@ -4774,7 +4774,7 @@ let
       sha256 = "684bd888d2ed4c748f8f6dd8e87c14afa2974b12ee01faa082ad9cfa1e321e62";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
-    NIX_CFLAGS_LINK = "-L${pkgs.openssl.out}/lib -lcrypto";
+    NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -lcrypto";
     meta = {
       homepage = "https://github.com/dsully/perl-crypt-openssl-x509";
       description = "Perl extension to OpenSSL's X509 API";
@@ -4843,7 +4843,7 @@ let
       sha256 = "0b159lw3ia5r87qsgff3qhdnz3l09xcz04rbk4ji7fbyr12wmv7q";
     };
 
-    makeMakerFlags = "--libpath=${pkgs.openssl.out}/lib --incpath=${pkgs.openssl.dev}/include";
+    makeMakerFlags = "--libpath=${lib.getLib pkgs.openssl}/lib --incpath=${pkgs.openssl.dev}/include";
     buildInputs = [ PathClass ];
     propagatedBuildInputs = [ BytesRandomSecure LWPProtocolHttps ];
   };
@@ -16739,7 +16739,7 @@ let
     doCheck = false; # Test performs network access.
     preConfigure = ''
       mkdir openssl
-      ln -s ${pkgs.openssl.out}/lib openssl
+      ln -s ${lib.getLib pkgs.openssl}/lib openssl
       ln -s ${pkgs.openssl.bin}/bin openssl
       ln -s ${pkgs.openssl.dev}/include openssl
       export OPENSSL_PREFIX=$(realpath openssl)


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
At some point, I'd like to make another attempt at #156510 ("openssl: stop static binaries referencing libs"), which was reverted in 195c7da07df.  One problem with my previous attempt is that I moved OpenSSL's libraries to a lib output, but many dependent packages were hardcoding the out output as the location of the libraries.  This patch fixes every such case I could find in the tree. It won't have any effect immediately, but will mean these packages will automatically use an OpenSSL lib output if it is reintroduced in future.

This patch should cause very few rebuilds, because it shouldn't make any change at all to most packages I'm touching.  The few rebuilds that are introduced come from when I've changed a package builder not to use variable names like openssl.out in scripts / substitution patterns, which would be confusing since they don't hardcode the output any more.

I started by making the following global replacements:

    ${pkgs.openssl.out}/lib -> ${lib.getLib pkgs.openssl}/lib
    ${openssl.out}/lib -> ${lib.getLib openssl}/lib

Then I removed the ".out" suffix when part of the argument to `lib.makeLibraryPath`, since that function uses `lib.getLib` internally.

Then I fixed up cases where openssl was part of the -L flag to the compiler/linker, since that unambigously is referring to libraries.

Then I manually investigated and fixed the following packages:

- pycurl
- citrix-workspace
- ppp
- wraith
- unbound
- gambit
- acl2

I'm reasonably confindent in my fixes for all of them.

For acl2, since the openssl library paths are manually provided above anyway, I don't think openssl is required separately as a build input at all.  Removing it doesn't make a difference to the output size, the file list, or the closure.

I've tested evaluation with the OfBorg meta checks, to protect against introducing evaluation failures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
