### PR TITLE
boost17x: 1.77 -> 1.78

### DIFF
--- a/pkgs/development/libraries/boost/1.78.nix
+++ b/pkgs/development/libraries/boost/1.78.nix
@@ -8,7 +8,7 @@ callPackage ./generic.nix (args // rec {
       "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
       "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
     ];
-    # SHA256 from http://www.boost.org/users/history/version_1_77_0.html
+    # SHA256 from http://www.boost.org/users/history/version_1_78_0.html
     sha256 = "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc";
   };
 })

--- a/pkgs/development/libraries/boost/1.78.nix
+++ b/pkgs/development/libraries/boost/1.78.nix
@@ -12,3 +12,4 @@ callPackage ./generic.nix (args // rec {
     sha256 = "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc";
   };
 })
+

--- a/pkgs/development/libraries/boost/1.78.nix
+++ b/pkgs/development/libraries/boost/1.78.nix
@@ -1,0 +1,14 @@
+{ callPackage, fetchurl, fetchpatch, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+  version = "1.78.0";
+
+  src = fetchurl {
+    urls = [
+      "mirror://sourceforge/boost/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+      "https://dl.bintray.com/boostorg/release/${version}/source/boost_${builtins.replaceStrings ["."] ["_"] version}.tar.bz2"
+    ];
+    # SHA256 from http://www.boost.org/users/history/version_1_77_0.html
+    sha256 = "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc";
+  };
+})

--- a/pkgs/development/libraries/boost/default.nix
+++ b/pkgs/development/libraries/boost/default.nix
@@ -45,4 +45,5 @@ in {
   boost174 = makeBoost ./1.74.nix;
   boost175 = makeBoost ./1.75.nix;
   boost177 = makeBoost ./1.77.nix;
+  boost178 = makeBoost ./1.78.nix;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16376,11 +16376,12 @@ with pkgs;
     boost174
     boost175
     boost177
+    boost178
   ;
 
   boost15x = boost159;
   boost16x = boost169;
-  boost17x = boost177;
+  boost17x = boost178;
   boost = boost17x;
 
   boost_process = callPackage ../development/libraries/boost-process { };


### PR DESCRIPTION
###### Description of changes

Added the December 2021 release of Boost, 1.78.0. This PR not only adds a new package, `pkgs.boost178`, but also moves the indirect package `pkgs.boost17x` to point to the new library. This later change is more substantive as there are many other derivations that depend on this meta-package.

###### Things done

- Built on platform(s)
  - [ x ] x86_64-linux
I ran `nix-build -A pkgs.boost178 .` from the local clone of nixpkgs and got a proper result.

I was not able to run `nixpkgs-review` in a reasonable amount of time (was ongoing for many hours) so this check is left undone.
