### PR TITLE
imlib2: 1.7.5 -> 1.8.1

### DIFF
--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -2,7 +2,7 @@
 # Image file formats
 , libjpeg, libtiff, giflib, libpng, libwebp
 # imlib2 can load images from ID3 tags.
-, libid3tag
+, libid3tag, librsvg, libheif
 , freetype , bzip2, pkg-config
 , x11Support ? true, xlibsWrapper ? null
 }:
@@ -21,8 +21,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     libjpeg libtiff giflib libpng libwebp
-    bzip2 freetype libid3tag
-  ] ++ optional x11Support xlibsWrapper;
+    bzip2 freetype libid3tag libheif
+  ] ++ optional x11Support xlibsWrapper
+  # Compilation error on Darwin with librsvg. For more information see:
+  # https://github.com/NixOS/nixpkgs/pull/166452#issuecomment-1090725613
+  ++ optional (!stdenv.isDarwin) librsvg;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/libraries/imlib2/default.nix
+++ b/pkgs/development/libraries/imlib2/default.nix
@@ -12,11 +12,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "imlib2";
-  version = "1.7.5";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/enlightenment/${pname}-${version}.tar.xz";
-    hash = "sha256-RY2DAKp6bUzjU1GDi7pdn9+wiES9WxU8WTjs/kP/Ngo=";
+    hash = "sha256-Ui4ecOZbwO3f4gdhfRXJo5VmKnwJBmHaqiwpT7fZ/ao=";
   };
 
   buildInputs = [


### PR DESCRIPTION
###### Description of changes



###### Things done



- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


