### PR TITLE
treewide: remove obsolete kernel version checks

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -414,6 +414,12 @@
       </listitem>
       <listitem>
         <para>
+          <literal>security.klogd</literal> was removed. Logging of
+          kernel messages is handled by systemd since Linux 3.5.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           <literal>services.kubernetes.addons.dashboard</literal> was
           removed due to it being an outdated version.
         </para>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -135,6 +135,9 @@ In addition to numerous new and upgraded packages, this release has the followin
   org-contrib, refer to the ones in `pkgs.emacsPackages.elpaPackages` and
   `pkgs.emacsPackages.nongnuPackages` where the new versions will release.
 
+- `security.klogd` was removed.  Logging of kernel messages is handled
+  by systemd since Linux 3.5.
+
 - `services.kubernetes.addons.dashboard` was removed due to it being an outdated version.
 
 - `services.kubernetes.scheduler.{port,address}` now set `--secure-port` and `--bind-address` instead of `--port` and `--address`, since the former have been deprecated and are no longer functional in kubernetes>=1.23. Ensure that you are not relying on the insecure behaviour before upgrading.

--- a/nixos/modules/hardware/video/webcam/facetimehd.nix
+++ b/nixos/modules/hardware/video/webcam/facetimehd.nix
@@ -16,11 +16,6 @@ in
 
   config = mkIf cfg.enable {
 
-    assertions = singleton {
-      assertion = versionAtLeast kernelPackages.kernel.version "3.19";
-      message = "facetimehd is not supported for kernels older than 3.19";
-    };
-
     boot.kernelModules = [ "facetimehd" ];
 
     boot.blacklistedKernelModules = [ "bdc_pci" ];

--- a/nixos/modules/services/logging/klogd.nix
+++ b/nixos/modules/services/logging/klogd.nix
@@ -1,38 +1,9 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{ lib, ... }:
 
 {
-  ###### interface
-
-  options = {
-
-    services.klogd.enable = mkOption {
-      type = types.bool;
-      default = versionOlder (getVersion config.boot.kernelPackages.kernel) "3.5";
-      defaultText = literalExpression ''versionOlder (getVersion config.boot.kernelPackages.kernel) "3.5"'';
-      description = ''
-        Whether to enable klogd, the kernel log message processing
-        daemon.  Since systemd handles logging of kernel messages on
-        Linux 3.5 and later, this is only useful if you're running an
-        older kernel.
-      '';
-    };
-
-  };
-
-
-  ###### implementation
-
-  config = mkIf config.services.klogd.enable {
-    systemd.services.klogd = {
-      description = "Kernel Log Daemon";
-      wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.sysklogd ];
-      unitConfig.ConditionVirtualization = "!systemd-nspawn";
-      script =
-        "klogd -c 1 -2 -n " +
-        "-k $(dirname $(readlink -f /run/booted-system/kernel))/System.map";
-    };
-  };
+  imports = [
+    (lib.mkRemovedOptionModule [ "security" "klogd" "enable" ] ''
+      Logging of kernel messages is now handled by systemd.
+    '')
+  ];
 }

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/anbox/anbox-modules";
     license = licenses.gpl2Only;
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.4" || kernel.kernelAtLeast "5.5";
+    broken = kernel.kernelAtLeast "5.5";
     maintainers = with maintainers; [ edwtjo ];
   };
 }

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchpatch, kernel }:
 
-assert lib.versionAtLeast kernel.version "3.5";
-
 stdenv.mkDerivation rec {
   pname = "digimend";
   version = "unstable-2019-06-18";

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -42,6 +42,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "4.5" || kernel.kernelAtLeast "5.15";
+    broken = kernel.kernelAtLeast "5.15";
   };
 }

--- a/pkgs/os-specific/linux/facetimehd/default.nix
+++ b/pkgs/os-specific/linux/facetimehd/default.nix
@@ -1,9 +1,9 @@
 { stdenv, lib, fetchFromGitHub, kernel }:
 
-# facetimehd is not supported for kernels older than 3.19";
-assert lib.versionAtLeast kernel.version "3.19";
+stdenv.mkDerivation rec {
+  name = "facetimehd-${version}-${kernel.version}";
+  version = "unstable-2020-04-16";
 
-let
   # Note: When updating this revision:
   # 1. Also update pkgs/os-specific/linux/firmware/facetimehd-firmware/
   # 2. Test the module and firmware change via:
@@ -14,29 +14,11 @@ let
   #    e. see if the module loads back (apps using the camera won't
   #       recover and will have to be restarted) and the camera
   #       still works.
-  srcParams = if (lib.versionAtLeast kernel.version "4.8") then
-    { # Use mainline branch
-      version = "unstable-2020-04-16";
-      rev = "82626d4892eeb9eb704538bf0dc49a00725ff451";
-      sha256 = "118z6vjvhhcwvs4n3sgwwdagys9w718b8nkh6l9ic93732vv7cqx";
-    }
-  else
-    { # Use master branch (broken on 4.8)
-      version = "unstable-2016-05-02";
-      rev = "5a7083bd98b38ef3bd223f7ee531d58f4fb0fe7c";
-      sha256 = "0d455kajvn5xav9iilqy7s1qvsy4yb8vzjjxx7bvcgp7aj9ljvdp";
-    }
-  ;
-in
-
-stdenv.mkDerivation rec {
-  name = "facetimehd-${version}-${kernel.version}";
-  version = srcParams.version;
-
   src = fetchFromGitHub {
     owner = "patjak";
     repo = "bcwc_pcie";
-    inherit (srcParams) rev sha256;
+    rev = "82626d4892eeb9eb704538bf0dc49a00725ff451";
+    sha256 = "118z6vjvhhcwvs4n3sgwwdagys9w718b8nkh6l9ic93732vv7cqx";
   };
 
   preConfigure = ''

--- a/pkgs/os-specific/linux/kernel/gpio-utils.nix
+++ b/pkgs/os-specific/linux/kernel/gpio-utils.nix
@@ -2,8 +2,6 @@
 
 with lib;
 
-assert versionAtLeast linux.version "4.6";
-
 stdenv.mkDerivation {
   pname = "gpio-utils";
   version = linux.version;

--- a/pkgs/os-specific/linux/kernel/perf.nix
+++ b/pkgs/os-specific/linux/kernel/perf.nix
@@ -9,8 +9,6 @@
 
 with lib;
 
-assert versionAtLeast kernel.version "3.12";
-
 stdenv.mkDerivation {
   pname = "perf-linux";
   version = kernel.version;

--- a/pkgs/os-specific/linux/ply/default.nix
+++ b/pkgs/os-specific/linux/ply/default.nix
@@ -35,6 +35,5 @@ stdenv.mkDerivation rec {
     homepage = "https://wkz.github.io/ply/";
     license = [ licenses.gpl2Only ];
     maintainers = with maintainers; [ mic92 mbbx6spp ];
-    broken = lib.versionOlder kernel.version "4.0";
   };
 }

--- a/pkgs/os-specific/linux/sch_cake/default.nix
+++ b/pkgs/os-specific/linux/sch_cake/default.nix
@@ -1,7 +1,5 @@
 { stdenv, lib, fetchFromGitHub, kernel }:
 
-assert lib.versionAtLeast kernel.version "4.4";
-
 stdenv.mkDerivation {
   pname = "sch_cake";
   version = "unstable-2017-07-16";

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -1,7 +1,5 @@
 { lib, stdenv, fetchzip, kernel, perl, wireguard-tools, bc }:
 
-# module requires Linux >= 3.10 https://www.wireguard.io/install/#kernel-requirements
-assert lib.versionAtLeast kernel.version "3.10";
 # wireguard upstreamed since 5.6 https://lists.zx2c4.com/pipermail/wireguard/2019-December/004704.html
 assert lib.versionOlder kernel.version "5.6";
 

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -216,7 +216,7 @@ in {
   # to be adapted
   zfsStable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.18";
+    kernelCompatible = kernel.kernelOlder "5.18";
     latestCompatibleLinuxPackages = linuxPackages_5_17;
 
     # this package should point to the latest release.
@@ -227,7 +227,7 @@ in {
 
   zfsUnstable = common {
     # check the release notes for compatible kernels
-    kernelCompatible = kernel.kernelAtLeast "3.10" && kernel.kernelOlder "5.18";
+    kernelCompatible = kernel.kernelOlder "5.18";
     latestCompatibleLinuxPackages = linuxPackages_5_17;
 
     # this package should point to a version / git revision compatible with the latest kernel release

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -70,6 +70,6 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = with maintainers; [ maggesi spacefrogg ];
-    broken = kernel.kernelOlder "3.18" || kernel.kernelAtLeast "5.17" || kernel.isHardened;
+    broken = kernel.kernelAtLeast "5.17" || kernel.isHardened;
   };
 }

--- a/pkgs/servers/openafs/1.9/module.nix
+++ b/pkgs/servers/openafs/1.9/module.nix
@@ -59,6 +59,6 @@ in stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = [ maintainers.maggesi maintainers.spacefrogg ];
-    broken = versionOlder kernel.version "3.18" || kernel.kernelAtLeast "5.15" || kernel.isHardened;
+    broken = kernel.kernelAtLeast "5.15" || kernel.isHardened;
   };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -402,7 +402,7 @@ in {
 
     oci-seccomp-bpf-hook = if lib.versionAtLeast kernel.version "5.4" then callPackage ../os-specific/linux/oci-seccomp-bpf-hook { } else null;
 
-    perf = if lib.versionAtLeast kernel.version "3.12" then callPackage ../os-specific/linux/kernel/perf.nix { } else null;
+    perf = callPackage ../os-specific/linux/kernel/perf.nix { };
 
     phc-intel = if lib.versionAtLeast kernel.version "4.10" then callPackage ../os-specific/linux/phc-intel { } else null;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
We no longer support any Linux kernel older than 4.9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
