### PR TITLE
dhcp: 4.4.2-P1 -> 4.4.3 and make client & relay support optional

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -237,7 +237,7 @@ in {
       };
 
       dhcp = mkOption {
-        type = types.enum [ "dhclient" "dhcpcd" "internal" ];
+        type = types.enum [ "dhcpcd" "internal" ];
         default = "internal";
         description = ''
           Which program (or internal library) should be used for DHCP.
@@ -497,7 +497,6 @@ in {
       "d /etc/ipsec.d 0700 root root -"
       "d /var/lib/NetworkManager-fortisslvpn 0700 root root -"
 
-      "d /var/lib/dhclient 0755 root root -"
       "d /var/lib/misc 0755 root root -" # for dnsmasq.leases
     ];
 

--- a/pkgs/os-specific/linux/pipework/default.nix
+++ b/pkgs/os-specific/linux/pipework/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper
-, bridge-utils, iproute2, lxc, openvswitch, docker, busybox, dhcpcd, dhcp
+, bridge-utils, iproute2, lxc, openvswitch, docker, busybox, dhcpcd
 }:
 
 stdenv.mkDerivation {
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   installPhase = ''
     install -D pipework $out/bin/pipework
     wrapProgram $out/bin/pipework --prefix PATH : \
-      ${lib.makeBinPath [ bridge-utils iproute2 lxc openvswitch docker busybox dhcpcd dhcp ]};
+      ${lib.makeBinPath [ bridge-utils iproute2 lxc openvswitch docker busybox dhcpcd ]};
   '';
   meta = with lib; {
     description = "Software-Defined Networking tools for LXC";

--- a/pkgs/tools/networking/dhcp/default.nix
+++ b/pkgs/tools/networking/dhcp/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "dhcp";
-  version = "4.4.2-P1";
+  version = "4.4.3";
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/dhcp/${version}/${pname}-${version}.tar.gz";
-    sha256 = "06jsr0cg5rsmyibshrpcb9za0qgwvqccashdma7mlm1rflrh8pmh";
+    sha256 = "sha256-Dj7GtMKgXsAUiHS82ZmmbQVRg3jXdCH2B/sLydATWBg=";
   };
 
   patches =
@@ -18,20 +18,6 @@ stdenv.mkDerivation rec {
       # patch, the hostname doesn't get set properly if the old
       # hostname (i.e. before reboot) is equal to the new hostname.
       ./set-hostname.patch
-
-      (fetchpatch {
-        # upstream build fix against -fno-common compilers like >=gcc-10
-        url = "https://gitlab.isc.org/isc-projects/dhcp/-/commit/6c7e61578b1b449272dbb40dd8b98d03dad8a57a.patch";
-        sha256 = "1g37ix0yf9zza8ri8bg438ygcjviniblfyb20y4gzc8lysy28m8b";
-      })
-
-      # Fix parallel build failure, the patch is pending upstream inclusion:
-      #  https://gitlab.isc.org/isc-projects/dhcp/-/merge_requests/76
-      (fetchpatch {
-        name = "parallel-make.patch";
-        url = "https://gitlab.isc.org/isc-projects/dhcp/-/commit/46d101b97c5a3b19a3f63f7b60e5f88994a64e22.patch";
-        sha256 = "1y3nsmqjzcg4bhp1xmqp47v7rkl3bpcildkx6mlrg255yvxapmdp";
-      })
     ];
 
   nativeBuildInputs = [ perl makeWrapper ];

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -12,7 +12,7 @@
 , polkit
 , gnutls
 , ppp
-, dhcp
+, dhcpcd
 , iptables
 , nftables
 , python3
@@ -96,9 +96,9 @@ stdenv.mkDerivation rec {
     "-Dresolvconf=${openresolv}/bin/resolvconf"
 
     # DHCP clients
-    "-Ddhclient=${dhcp}/bin/dhclient"
-    # Upstream prefers dhclient, so don't add dhcpcd to the closure
-    "-Ddhcpcd=no"
+    # ISC DHCP client has reached it's end of life, so stop using it
+    "-Ddhclient=no"
+    "-Ddhcpcd=${dhcpcd}/bin/dhcpcd"
     "-Ddhcpcanon=no"
 
     # Miscellaneous


### PR DESCRIPTION
###### Description of changes

https://downloads.isc.org/isc/dhcp/4.4.3/dhcp-4.4.3-RELNOTES
https://twitter.com/ISCdotORG/status/1501596200230952961

Adds `knownVulnerabilities` when `withClient` or `withRelay` are enabled as they've reached their end of life.

Related: https://github.com/NixOS/nixpkgs/issues/163472

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
