### PR TITLE
python3Packages.voluptuous: 0.12.2 -> 0.13.0

### DIFF
--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "aioguardian";
-  version = "2022.03.0";
+  version = "2022.03.1";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-Dgmef+4KteMMIBqoM+KCosh0yTgaqGHHyO1LguwoDfQ=";
+    sha256 = "sha256-UiRTyUAoTcohRkTBF5Jvd/uY2zAbHV5z4HC8Oc0QNTs=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "aioguardian";
-  version = "2021.11.0";
+  version = "2022.03.0";
 
   src = fetchFromGitHub {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-jQIRACm0d0a5mQqlwxSTgLZfJFvGLWuJTb/MacppmS4=";
+    sha256 = "sha256-Dgmef+4KteMMIBqoM+KCosh0yTgaqGHHyO1LguwoDfQ=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/idasen/default.nix
+++ b/pkgs/development/python-modules/idasen/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "newAM";
     repo = "idasen";
     rev = "v${version}";
-    sha256 = "sha256-s8CnYMUVl2VbGbVxICSaKH5DxTA+NP/zPX1z7vfMqi4=";
+    hash = "sha256-s8CnYMUVl2VbGbVxICSaKH5DxTA+NP/zPX1z7vfMqi4=";
   };
 
   nativeBuildInputs = [
@@ -39,7 +39,14 @@ buildPythonPackage rec {
     pytest-asyncio
   ];
 
-  pythonImportsCheck = [ "idasen" ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'voluptuous = "^0.12"' 'voluptuous = "*"'
+  '';
+
+  pythonImportsCheck = [
+    "idasen"
+  ];
 
   meta = with lib; {
     description = "Python API and CLI for the ikea IDÅSEN desk";

--- a/pkgs/development/python-modules/python-awair/default.nix
+++ b/pkgs/development/python-modules/python-awair/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "python-awair";
-  version = "0.2.2";
+  version = "0.2.3";
   format = "pyproject";
   disabled = pythonOlder "3.6";
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "ahayworth";
     repo = "python_awair";
     rev = version;
-    sha256 = "sha256-5+s1aSvt+rXyumvf/qZ58Uvmq0p45mu23Djbwgih3qI=";
+    sha256 = "sha256-Roqmwamv/2/O87jfyymCGgRlw/woUhCNIuM9MLT3+Cw=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/simplisafe-python/default.nix
+++ b/pkgs/development/python-modules/simplisafe-python/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "simplisafe-python";
-  version = "2022.03.1";
+  version = "2022.03.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-VrCVZeE4CDPt6RfckTUC9UJnoxHVeoNAxD67OefSa2o=";
+    sha256 = "sha256-WWpGRgmjOBCdsxESEpfZEigK7mfutromx6EEr/C/cO0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/simplisafe-python/default.nix
+++ b/pkgs/development/python-modules/simplisafe-python/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "simplisafe-python";
-  version = "2022.03.0";
+  version = "2022.03.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = pname;
     rev = version;
-    sha256 = "sha256-B4Tg122S2lJaBXBKUSN2ndt5EOiC5HyORTQXofZKUpw=";
+    sha256 = "sha256-VrCVZeE4CDPt6RfckTUC9UJnoxHVeoNAxD67OefSa2o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/voluptuous/default.nix
+++ b/pkgs/development/python-modules/voluptuous/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "voluptuous";
-  version = "0.12.2";
+  version = "0.13.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-TbGsUHnbkkmCDUnIkctGYKb4yuNQSRIQq850H6v1ZRM=";
+    sha256 = "sha256-yuakUmtDS2QoFrNKAOEYbVpfXgyUirlNKpGOAeWHQGY=";
   };
 
   checkInputs = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -30,6 +30,7 @@ let
   defaultOverrides = [
     # Override the version of some packages pinned in Home Assistant's setup.py and requirements_all.txt
     (mkOverride "python-slugify" "4.0.1" "sha256-aaUXdm4AwSaOW7/A0BCgqFCN4LGNMK1aH/NX+K5yQnA=")
+    (mkOverride "voluptuous" "0.12.2" "sha256-TbGsUHnbkkmCDUnIkctGYKb4yuNQSRIQq850H6v1ZRM=")
 
     # pytest-aiohttp>0.3.0 breaks home-assistant tests
     (self: super: {


### PR DESCRIPTION
###### Description of changes
https://github.com/alecthomas/voluptuous/releases/tag/0.13.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
