### PR TITLE
python39Packages.pytest-xdist: add hook to add flags

### DIFF
--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -29,6 +29,12 @@ buildPythonPackage rec {
   checkInputs = [ pytestCheckHook filelock pexpect ];
   propagatedBuildInputs = [ execnet pytest-forked psutil ];
 
+  pytestFlagsArray = [
+    # pytest can already use xdist at this point
+    "--numprocesses=$NIX_BUILD_CORES"
+    "--forked"
+  ];
+
   # access file system
   disabledTests = [
     "test_distribution_rsyncdirs_example"
@@ -40,6 +46,8 @@ buildPythonPackage rec {
     # flakey
     "test_internal_errors_propagate_to_controller"
   ];
+
+  setupHook = ./setup-hook.sh;
 
   meta = with lib; {
     description = "Pytest xdist plugin for distributed testing and loop-on-failing modes";

--- a/pkgs/development/python-modules/pytest-xdist/default.nix
+++ b/pkgs/development/python-modules/pytest-xdist/default.nix
@@ -9,6 +9,7 @@
 , pytest
 , pytest-forked
 , psutil
+, pexpect
 }:
 
 buildPythonPackage rec {
@@ -25,7 +26,7 @@ buildPythonPackage rec {
   buildInputs = [
     pytest
   ];
-  checkInputs = [ pytestCheckHook filelock ];
+  checkInputs = [ pytestCheckHook filelock pexpect ];
   propagatedBuildInputs = [ execnet pytest-forked psutil ];
 
   # access file system

--- a/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
+++ b/pkgs/development/python-modules/pytest-xdist/setup-hook.sh
@@ -1,0 +1,7 @@
+pytestXdistHook() {
+    pytestFlagsArray+=("--numprocesses=$NIX_BUILD_CORES" "--forked" )
+}
+
+if [ -z "${dontUsePytestXdist-}" ] && [ -z "${dontUsePytestCheck-}" ]; then
+    addEnvHooks "$hostOffset" pytestXdistHook
+fi


### PR DESCRIPTION
many of our packages have pytest-xdist in their inputs however
oftentimes the required flags aren't added to pytest flags
since we dont use tox and other frameworks

some examples of improvements
(my pc has ryzen 9 5900x)
hypothesis 11m:15s on hydra -> <1m on my pc
hypothesmith 8m on my pc -> <1m on my pc

the whole graph from pytest-xdist (tested by adding postPatch with true to xdist)
time nix build ".#python3Packages.hypothesmith"
19m:57s -> 9m:13s



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
