### PR TITLE
openshift: 4.1 -> 4.10

### DIFF
--- a/pkgs/applications/networking/cluster/openshift/default.nix
+++ b/pkgs/applications/networking/cluster/openshift/default.nix
@@ -1,84 +1,68 @@
-{ lib, fetchFromGitHub, buildGoPackage, which, go-bindata, rsync, util-linux
-, coreutils, libkrb5, ncurses, clang, installShellFiles
-, components ? [
-  "cmd/oc"
-  "cmd/openshift"
-  ]
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, libkrb5
+, git
+, installShellFiles
+, testVersion
+, openshift
 }:
 
-with lib;
-
-let
-  version = "4.1.0";
-  ver = lib.elemAt (lib.splitVersion version);
-  versionMajor = ver 0;
-  versionMinor = ver 1;
-  versionPatch = ver 2;
-  gitCommit = "b4261e0";
-  # version is in vendor/k8s.io/kubernetes/pkg/version/base.go
-  k8sversion = "v1.11.1";
-  k8sgitcommit = "b1b2997";
-  k8sgitMajor = "0";
-  k8sgitMinor = "1";
-in buildGoPackage rec {
-  pname = "openshift-origin";
-  inherit version;
+buildGoModule rec {
+  pname = "openshift";
+  version = "4.10.0";
+  gitCommit = "346b183";
 
   src = fetchFromGitHub {
     owner = "openshift";
-    repo = "origin";
-    rev = "v${version}";
-    sha256 = "16bc6ljm418kxz92gz8ldm82491mvlqamrvigyr6ff72rf7ml7ba";
+    repo = "oc";
+    rev = "release-4.10";
+    sha256 = "Pdq3OwT5P7vvB70X+GVglT9CdJbhkm35nvEGurO1HPc=";
   };
 
-  goPackagePath = "github.com/openshift/origin";
+  vendorSha256 = null;
 
   buildInputs = [ libkrb5 ];
 
-  nativeBuildInputs = [
-    clang
-    go-bindata
-    installShellFiles
-    ncurses
-    rsync
-    which
-  ];
+  nativeBuildInputs = [ installShellFiles ];
 
   patchPhase = ''
     patchShebangs ./hack
   '';
 
   buildPhase = ''
-    cd go/src/${goPackagePath}
     # Openshift build require this variables to be set
     # unless there is a .git folder which is not the case with fetchFromGitHub
-    echo "OS_GIT_VERSION=v${version}" >> os-version-defs
-    echo "OS_GIT_TREE_STATE=clean" >> os-version-defs
-    echo "OS_GIT_MAJOR=${versionMajor}" >> os-version-defs
-    echo "OS_GIT_MINOR=${versionMinor}" >> os-version-defs
-    echo "OS_GIT_PATCH=${versionPatch}" >> os-version-defs
-    echo "OS_GIT_COMMIT=${gitCommit}" >> os-version-defs
-    echo "KUBE_GIT_VERSION=${k8sversion}" >> os-version-defs
-    echo "KUBE_GIT_COMMIT=${k8sgitcommit}" >> os-version-defs
-    echo "KUBE_GIT_MAJOR=${k8sgitMajor}" >> os-version-defs
-    echo "KUBE_GIT_MINOR=${k8sgitMinor}" >> os-version-defs
-    export OS_VERSION_FILE="os-version-defs"
-    export CC=clang
-    make all WHAT='${concatStringsSep " " components}'
+    export SOURCE_GIT_COMMIT=${gitCommit}
+    export SOURCE_GIT_TAG=v${version}
+    export SOURCE_GIT_TREE_STATE=clean
+
+    make all
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -a "_output/local/bin/$(go env GOOS)/$(go env GOARCH)/"* "$out/bin/"
+    cp oc $out/bin
+
+    mkdir -p man
+    ./genman man oc
+    installManPage man/*.1
+
     installShellCompletion --bash contrib/completions/bash/*
     installShellCompletion --zsh contrib/completions/zsh/*
   '';
+
+  passthru.tests.version = testVersion {
+    package = openshift;
+    command = "oc version";
+    version = "v${version}";
+  };
 
   meta = with lib; {
     description = "Build, deploy, and manage your applications with Docker and Kubernetes";
     license = licenses.asl20;
     homepage = "http://www.openshift.org";
-    maintainers = with maintainers; [offline bachp moretea];
+    maintainers = with maintainers; [ offline bachp moretea stehessel ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Update openshift client from 4.1 (almost three years old) to latest version.

The CLI tool `oc` has been separated into a new repository `openshift/oc`.

I also tried to simplify the derivation by using buildGoModule and
removing some  unnecessary environment variables. Also added man
pages and a passthru test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
