### PR TITLE
treewide: move autoconf, automake to nativeBuildInputs

### DIFF
--- a/pkgs/applications/audio/industrializer/default.nix
+++ b/pkgs/applications/audio/industrializer/default.nix
@@ -20,13 +20,11 @@ stdenv.mkDerivation rec {
     sha256 = "0vls94hqpkk8h17da6fddgqbl5dgm6250av3raimhhzwvm5r1gfi";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
 
   buildInputs = [
     alsa-lib
     audiofile
-    autoconf
-    automake
     gnome2.gtkglext
     gtk2
     libjack2

--- a/pkgs/applications/audio/pd-plugins/zexy/default.nix
+++ b/pkgs/applications/audio/pd-plugins/zexy/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "1xpgl82c2lc6zfswjsa7z10yhv5jb7a4znzh3nc7ffrzm1z8vylp";
   };
 
-  buildInputs = [ autoconf automake puredata ];
+  nativeBuildInputs = [ autoconf automake  ];
+  buildInputs = [ puredata ];
 
   preBuild = ''
     export LD=$CXX

--- a/pkgs/applications/audio/timemachine/default.nix
+++ b/pkgs/applications/audio/timemachine/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "16fgyw6jnscx9279dczv72092dddghwlp53rkfw469kcgvjhwx0z";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-    buildInputs = [ autoconf automake gtk2 libjack2
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+    buildInputs = [ gtk2 libjack2
       libsndfile
     ];
 

--- a/pkgs/applications/audio/xsynth-dssi/default.nix
+++ b/pkgs/applications/audio/xsynth-dssi/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation  rec {
     sha256 = "00nwv2pqjbmxqdc6xdm0cljq6z05lv4y6bibmhz1kih9lm0lklnk";
   };
 
-  buildInputs = [ alsa-lib autoconf automake dssi gtk2 libjack2 ladspaH
+  nativeBuildInputs = [ autoconf automake  ];
+  buildInputs = [ alsa-lib dssi gtk2 libjack2 ladspaH
     ladspaPlugins liblo pkg-config ];
 
   installPhase = ''

--- a/pkgs/applications/blockchains/cgminer/default.nix
+++ b/pkgs/applications/blockchains/cgminer/default.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
     sha256 = "0l1ms3nxnjzh4mpiadikvngcr9k3jnjqy3yna207za0va0c28dj5";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake libtool curl ncurses ocl-icd opencl-headers
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ libtool curl ncurses ocl-icd opencl-headers
     xorg.libX11 xorg.libXext xorg.libXinerama jansson libusb1 ];
 
   configureScript = "./autogen.sh";

--- a/pkgs/applications/editors/wxhexeditor/default.nix
+++ b/pkgs/applications/editors/wxhexeditor/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "08xnhaif8syv1fa0k6lc3jm7yg2k50b02lyds8w0jyzh4xi5crqj";
   };
 
-  buildInputs = [ wxGTK autoconf automake libtool python2 gettext ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ wxGTK libtool python2 gettext ];
 
   preConfigure = "patchShebangs .";
 

--- a/pkgs/applications/misc/gsimplecal/default.nix
+++ b/pkgs/applications/misc/gsimplecal/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf gtk3 ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ gtk3 ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/applications/misc/pcmanx-gtk2/default.nix
+++ b/pkgs/applications/misc/pcmanx-gtk2/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0fbwd149wny67rfhczz4cbh713a1qnswjiz7b6c2bxfcwh51f9rc";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gtk2 libXft intltool automake autoconf libtool ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ gtk2 libXft intltool libtool ];
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
+++ b/pkgs/applications/networking/instant-messengers/bitlbee-steam/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "121r92mgwv445wwxzh35n19fs5k81ihr0j19k256ia5502b1xxaq";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ bitlbee autoconf automake libtool libgcrypt ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ bitlbee libtool libgcrypt ];
 
   preConfigure = ''
     export BITLBEE_PLUGINDIR=$out/lib/bitlbee

--- a/pkgs/applications/networking/irc/bip/default.nix
+++ b/pkgs/applications/networking/irc/bip/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0q942g9lyd8pjvqimv547n6vik5759r9npw3ws3bdj4ixxqhz59w";
   };
 
-  buildInputs = [ bison flex autoconf automake openssl ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ bison flex openssl ];
 
   # includes an important security patch
   patches = [

--- a/pkgs/applications/networking/irc/irssi/fish/default.nix
+++ b/pkgs/applications/networking/irc/irssi/fish/default.nix
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
     cp src/.libs/libfish.so $out/lib/irssi/modules
   '';
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gmp automake autoconf libtool openssl glib ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ gmp libtool openssl glib ];
 
   meta = {
     homepage = "https://github.com/falsovsky/FiSH-irssi";

--- a/pkgs/applications/networking/owamp/default.nix
+++ b/pkgs/applications/networking/owamp/default.nix
@@ -4,7 +4,8 @@
 stdenv.mkDerivation rec {
   pname = "owamp";
   version = "3.5.6";
-  buildInputs = [ autoconf automake mandoc ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ mandoc ];
   src = fetchFromGitHub {
     owner = "perfsonar";
     repo = "owamp";

--- a/pkgs/applications/networking/p2p/twister/default.nix
+++ b/pkgs/applications/networking/p2p/twister/default.nix
@@ -38,9 +38,9 @@ in stdenv.mkDerivation rec {
     "--with-boost-libdir=${boostPython.out}/lib"
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
   buildInputs = [
-    autoconf automake libtool python2
+    libtool python2
     boostPython db openssl geoip miniupnpc libiconv
   ];
 

--- a/pkgs/applications/office/pinpoint/default.nix
+++ b/pkgs/applications/office/pinpoint/default.nix
@@ -8,8 +8,8 @@ stdenv.mkDerivation rec {
     url = "http://ftp.gnome.org/pub/GNOME/sources/pinpoint/0.1/${pname}-${version}.tar.xz";
     sha256 = "1jp8chr9vjlpb5lybwp5cg6g90ak5jdzz9baiqkbg0anlg8ps82s";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake clutter clutter-gst gdk-pixbuf
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ clutter clutter-gst gdk-pixbuf
                   cairo clutter-gtk ];
 
   meta = with lib; {

--- a/pkgs/applications/science/biology/kssd/default.nix
+++ b/pkgs/applications/science/biology/kssd/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-8jzYqo9LXF66pQ1EIusm+gba2VbTYpJz2K3NVlA3QxY=";
   };
 
-  buildInputs = [ zlib automake autoconf libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ zlib libtool ];
 
   installPhase = ''
       install -vD kssd $out/bin/kssd

--- a/pkgs/applications/science/electronics/gerbv/default.nix
+++ b/pkgs/applications/science/electronics/gerbv/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
     sha256 = "00jn1xhf6kblxc5gac1wvk8zm12fy6sk81nj3jwdag0z6wk3z446";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ gettext libtool automake autoconf cairo gtk2 ];
+  nativeBuildInputs = [ autoreconfHook pkg-config automake autoconf ];
+  buildInputs = [ gettext libtool cairo gtk2 ];
 
   configureFlags = ["--disable-update-desktop-database"];
 

--- a/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation rec {
     rev = "531bb33";
     sha256 = "1sv7s2ykc840cjwbfn7ayy743643x9i1lvk4cd55w9l052xvzj65";
   };
-  buildInputs = [ autoconf automake libtool gmp ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool gmp ];
   preConfigure = "./autogen.sh";
 
   meta = {

--- a/pkgs/data/misc/ddccontrol-db/default.nix
+++ b/pkgs/data/misc/ddccontrol-db/default.nix
@@ -21,10 +21,9 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs =
     [
-      autoconf
-      automake
       libtool
       intltool
     ];

--- a/pkgs/development/compilers/aldor/default.nix
+++ b/pkgs/development/compilers/aldor/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
     sha256 = "sha256-phKCghCeM+/QlxjIxfNQySo+5XMRqfOqlS9kgp07YKc=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ gmp which flex bison autoconf automake libtool jdk perl ];
+  nativeBuildInputs = [ makeWrapper autoconf automake ];
+  buildInputs = [ gmp which flex bison libtool jdk perl ];
 
   preConfigure = ''
     cd aldor ;

--- a/pkgs/development/compilers/aliceml/default.nix
+++ b/pkgs/development/compilers/aliceml/default.nix
@@ -16,9 +16,10 @@ stdenv.mkDerivation {
     sha256 = "0mgc6llbq166jmlq3alvagqsg3730670zvbwwkdgsqklw70v9355";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
     stdenv gcc glibc
-    libtool gnumake autoconf automake
+    libtool gnumake
     file which zsh m4 gtk2 zlib gmp
     gnome2.libgnomecanvas pango sqlite
     libxml2 pkg-config perl smlnj

--- a/pkgs/development/compilers/ecl/16.1.2.nix
+++ b/pkgs/development/compilers/ecl/16.1.2.nix
@@ -25,10 +25,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-LUgrGgpPvV2IFDRRcDInnYCMtkBeIt2R721zNTRGS5k=";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
     libtool
-    autoconf
-    automake
     makeWrapper
   ];
   propagatedBuildInputs = [

--- a/pkgs/development/compilers/fsharp/default.nix
+++ b/pkgs/development/compilers/fsharp/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-dgTEM2aL8lVjVMuW0+HLc+TUA39IiuBv/RfHYNURh5s=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ mono dotnetbuildhelpers autoconf automake which ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ mono dotnetbuildhelpers which ];
 
   configurePhase = ''
     sed -i '988d' src/FSharpSource.targets

--- a/pkgs/development/compilers/ios-cross-compile/9.2.nix
+++ b/pkgs/development/compilers/ios-cross-compile/9.2.nix
@@ -51,7 +51,8 @@ clangStdenv.mkDerivation rec {
       and run this installation again.
    '';
   };
-  buildInputs = [ git xz gnutar openssl automake autoconf libtool clang ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ git xz gnutar openssl libtool clang ];
   alt_wrapper = ./alt_wrapper.c;
   builder = ./9.2_builder.sh;
   meta = {

--- a/pkgs/development/compilers/x11basic/default.nix
+++ b/pkgs/development/compilers/x11basic/default.nix
@@ -14,8 +14,9 @@ stdenv.mkDerivation rec {
     sha256 = "1hpxzdqnjl1fiwgs2vrjg4kxm29c7pqwk3g1m4p5pm4x33a3d1q2";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    autoconf automake readline libX11 SDL2 bluez
+    readline libX11 SDL2 bluez
   ];
 
   preConfigure = "cd src;autoconf";

--- a/pkgs/development/interpreters/love/0.10.nix
+++ b/pkgs/development/interpreters/love/0.10.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-C/Ifd0KjmaM5Y2fxBiDNz1GQoT4GeH/vyUCiira57U4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [
     SDL2 libGLU libGL openal luajit libdevil freetype physfs libmodplug mpg123
-    libvorbis libogg libtheora autoconf which libtool automake
+    libvorbis libogg libtheora which libtool
   ];
 
   preConfigure = "$shell ./platform/unix/automagic";

--- a/pkgs/development/interpreters/love/11.nix
+++ b/pkgs/development/interpreters/love/11.nix
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "0kpdp6v8m8j0r7ppyy067shr0lfgrlh0dwb7ccws76d389vizwhb";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [
     SDL2 libGLU libGL openal luajit libdevil freetype physfs libmodplug mpg123
-    libvorbis libogg libtheora autoconf which libtool automake
+    libvorbis libogg libtheora which libtool
   ];
 
   preConfigure = "$shell ./platform/unix/automagic";

--- a/pkgs/development/libraries/dssi/default.nix
+++ b/pkgs/development/libraries/dssi/default.nix
@@ -11,9 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "0kl1hzhb7cykzkrqcqgq1dk4xcgrcxv0jja251aq4z4l783jpj7j";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs =
     [ ladspaH libjack2 liblo alsa-lib qt4 libX11 libsndfile libSM
-      libsamplerate libtool autoconf automake xorgproto libICE pkg-config
+      libsamplerate libtool xorgproto libICE pkg-config
     ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/fastjson/default.nix
+++ b/pkgs/development/libraries/fastjson/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2LyBdJR0dV1CElcGfrlmNwX52lVtx9X/Z4h/1XFjOIs=";
   };
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool ];
 
   preConfigure = ''
     sh autogen.sh

--- a/pkgs/development/libraries/givaro/3.7.nix
+++ b/pkgs/development/libraries/givaro/3.7.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
     url = "https://forge.imag.fr/frs/download.php/370/givaro-${version}.tar.gz";
     sha256 = "0lf5cnbyr27fw7klc3zabkb1979dn67jmrjz6pa3jzw2ng74x9b3";
   };
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [autoconf automake libtool gmpxx];
+  nativeBuildInputs = [ autoreconfHook autoconf automake ];
+  buildInputs = [libtool gmpxx];
   meta = {
     description = "A C++ library for arithmetic and algebraic computations";
     license = lib.licenses.cecill-b;

--- a/pkgs/development/libraries/givaro/3.nix
+++ b/pkgs/development/libraries/givaro/3.nix
@@ -6,8 +6,8 @@ stdenv.mkDerivation rec {
     url = "https://forge.imag.fr/frs/download.php/592/givaro-${version}.tar.gz";
     sha256 = "1822ksv8653a84hvcz0vxl3nk8dqz7d41ys8rplq0zjjmvb2i5yq";
   };
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [autoconf automake libtool gmpxx];
+  nativeBuildInputs = [ autoreconfHook autoconf automake ];
+  buildInputs = [libtool gmpxx];
   meta = {
     description = "A C++ library for arithmetic and algebraic computations";
     license = lib.licenses.cecill-b;

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [autoconf automake libtool];
+  nativeBuildInputs = [ autoreconfHook autoconf automake ];
+  buildInputs = [libtool];
   propagatedBuildInputs = [ gmpxx ];
 
   configureFlags = [

--- a/pkgs/development/libraries/gnet/default.nix
+++ b/pkgs/development/libraries/gnet/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1cy78kglzi235md964ikvm0rg801bx0yk9ya8zavndjnaarzqq87";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake glib libtool ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ glib libtool ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/development/libraries/gumbo/default.nix
+++ b/pkgs/development/libraries/gumbo/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0xslckwdh2i0g2qjsb6rnm8mjmbagvziz0hjlf7d1lbljfms1iw1";
   };
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/development/libraries/keybinder/default.nix
+++ b/pkgs/development/libraries/keybinder/default.nix
@@ -15,9 +15,9 @@ in stdenv.mkDerivation rec {
     sha256 = "sha256-q/+hqhvXIknT+/5oENcWSr1OuF00kaZlXFUP1fdCMlk=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [
-    autoconf automake libtool gnome.gnome-common gtk-doc gtk2
+    libtool gnome.gnome-common gtk-doc gtk2
     python pygtk lua gobject-introspection
   ];
 

--- a/pkgs/development/libraries/languagemachines/frog.nix
+++ b/pkgs/development/libraries/languagemachines/frog.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frog-v${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtar libtool autoconf-archive
                   libxml2 icu
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/frogdata.nix
+++ b/pkgs/development/libraries/languagemachines/frogdata.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "frogdata-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ libtool autoconf-archive
                 ];
 
   preConfigure = ''

--- a/pkgs/development/libraries/languagemachines/libfolia.nix
+++ b/pkgs/development/libraries/languagemachines/libfolia.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "libfolia-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtool autoconf-archive libtar libxml2 icu languageMachines.ticcutils ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtool autoconf-archive libtar libxml2 icu languageMachines.ticcutils ];
   preConfigure = "sh bootstrap.sh";
 
   # compat with icu61+ https://github.com/unicode-org/icu/blob/release-64-2/icu4c/readme.html#L554

--- a/pkgs/development/libraries/languagemachines/mbt.nix
+++ b/pkgs/development/libraries/languagemachines/mbt.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "mbt-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/ticcutils.nix
+++ b/pkgs/development/libraries/languagemachines/ticcutils.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ticcutils-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf libtool autoconf-archive libxml2
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ libtool autoconf-archive libxml2
                   # optional:
                   zlib bzip2 libtar
                   # broken but optional: boost

--- a/pkgs/development/libraries/languagemachines/timbl.nix
+++ b/pkgs/development/libraries/languagemachines/timbl.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timbl-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                 ];

--- a/pkgs/development/libraries/languagemachines/timblserver.nix
+++ b/pkgs/development/libraries/languagemachines/timblserver.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "timblserver-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtar libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtar libtool autoconf-archive
                   libxml2
                   languageMachines.ticcutils
                   languageMachines.timbl

--- a/pkgs/development/libraries/languagemachines/ucto.nix
+++ b/pkgs/development/libraries/languagemachines/ucto.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "ucto-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf bzip2 libtool autoconf-archive
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ bzip2 libtool autoconf-archive
                   icu libtar libxml2
                   languageMachines.ticcutils
                   languageMachines.libfolia

--- a/pkgs/development/libraries/languagemachines/uctodata.nix
+++ b/pkgs/development/libraries/languagemachines/uctodata.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   version = release.version;
   src = fetchurl { inherit (release) url sha256;
                    name = "uctodata-${release.version}.tar.gz"; };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf libtool autoconf-archive ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
+  buildInputs = [ libtool autoconf-archive ];
   preConfigure = "sh bootstrap.sh";
 
   meta = with lib; {

--- a/pkgs/development/libraries/lasso/default.nix
+++ b/pkgs/development/libraries/lasso/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ autoconf automake glib gobject-introspection gtk-doc libtool libxml2 libxslt openssl python27Packages.six xmlsec zlib ];
+  nativeBuildInputs = [ autoreconfHook pkg-config autoconf automake ];
+  buildInputs = [ glib gobject-introspection gtk-doc libtool libxml2 libxslt openssl python27Packages.six xmlsec zlib ];
 
   configurePhase = ''
     ./configure --with-pkg-config=$PKG_CONFIG_PATH \

--- a/pkgs/development/libraries/libHX/default.nix
+++ b/pkgs/development/libraries/libHX/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
 
   patches = [];
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool ];
 
   preConfigure = ''
     sh autogen.sh

--- a/pkgs/development/libraries/libcangjie/default.nix
+++ b/pkgs/development/libraries/libcangjie/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-j5IQ0hBefoF8p966YrfZgYCw7ht5twJhYi4l0NneukQ=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ automake autoconf libtool m4 sqlite ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ libtool m4 sqlite ];
 
   configureScript = "./autogen.sh";
 

--- a/pkgs/development/libraries/libcrafter/default.nix
+++ b/pkgs/development/libraries/libcrafter/default.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--with-libpcap=yes" ];
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool ];
 
   propagatedBuildInputs = [ libpcap ];
 

--- a/pkgs/development/libraries/libdnet/default.nix
+++ b/pkgs/development/libraries/libdnet/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "09mhbr8x66ykhf5581a5zjpplpjxibqzgkkpx689kybwg0wk1cw3";
   };
 
-  buildInputs = [ automake autoconf libtool ];
+  nativeBuildInputs = [ automake autoconf ];
+  buildInputs = [ libtool ];
 
   # .so endings are missing (quick and dirty fix)
   postInstall = ''

--- a/pkgs/development/libraries/libmx/default.nix
+++ b/pkgs/development/libraries/libmx/default.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
 
   configureScript = "sh autogen.sh";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config automake autoconf ];
   buildInputs = [
-    automake autoconf libtool
+    libtool
     intltool
     gobject-introspection glib
     gtk2 gtk-doc clutter clutter-gtk

--- a/pkgs/development/libraries/libstroke/default.nix
+++ b/pkgs/development/libraries/libstroke/default.nix
@@ -9,7 +9,8 @@ stdenv.mkDerivation rec {
     sha256 = "0bbpqzsqh9zrc6cg62f6vp1p4dzvv37blsd0gdlzdskgwvyzba8d";
   };
 
-  buildInputs = [ automake autoconf xlibsWrapper ];
+  nativeBuildInputs = [ automake autoconf ];
+  buildInputs = [ xlibsWrapper ];
 
   # libstroke ships with an ancient config.sub that doesn't know about x86_64, so regenerate it.
   # Also, modern automake doesn't like things and returns error code 63.  But it generates the file.

--- a/pkgs/development/libraries/neardal/default.nix
+++ b/pkgs/development/libraries/neardal/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
     sha256 = "12qwg7qiw2wfpaxfg2fjkmj5lls0g33xp6w433g8bnkvwlq4s29g";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ autoconf automake libtool glib readline ];
+  nativeBuildInputs = [ pkg-config makeWrapper autoconf automake ];
+  buildInputs = [ glib readline ];
 
   preConfigure = ''
     substituteInPlace "ncl/Makefile.am" --replace "noinst_PROGRAMS" "bin_PROGRAMS"

--- a/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
+++ b/pkgs/development/libraries/xcb-util-cursor/HEAD.nix
@@ -21,9 +21,8 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "dev" ];
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    autoconf
-    automake
     gnum4
     gperf
     libtool

--- a/pkgs/development/tools/misc/distcc/default.nix
+++ b/pkgs/development/tools/misc/distcc/default.nix
@@ -17,8 +17,8 @@ let
       sha256 = "0zjba1090awxkmgifr9jnjkxf41zhzc4f6mrnbayn3v6s77ca9x4";
     };
 
-  nativeBuildInputs = [ pkg-config ];
-    buildInputs = [popt avahi pkg-config python3 gtk3 autoconf automake which procps libiberty_static];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+    buildInputs = [popt avahi pkg-config python3 gtk3 which procps libiberty_static];
     preConfigure =
     ''
       export CPATH=$(ls -d ${gcc.cc}/lib/gcc/*/${gcc.cc.version}/plugin/include)

--- a/pkgs/development/tools/misc/hydra/common.nix
+++ b/pkgs/development/tools/misc/hydra/common.nix
@@ -84,7 +84,7 @@ in stdenv.mkDerivation rec {
   inherit stdenv src version patches;
 
   buildInputs =
-    [ makeWrapper autoconf automake libtool unzip nukeReferences sqlite libpqxx_6
+    [ makeWrapper libtool unzip nukeReferences sqlite libpqxx_6
       top-git mercurial /*darcs*/ subversion breezy openssl bzip2 libxslt
       perlDeps perl nix
       postgresql # for running the tests
@@ -97,7 +97,7 @@ in stdenv.mkDerivation rec {
       gzip bzip2 xz gnutar unzip git top-git mercurial /*darcs*/ gnused breezy
     ] ++ lib.optionals stdenv.isLinux [ rpm dpkg cdrkit ] );
 
-  nativeBuildInputs = [ autoreconfHook pkg-config mdbook ];
+  nativeBuildInputs = [ autoreconfHook pkg-config mdbook autoconf automake ];
 
   configureFlags = [ "--with-docbook-xsl=${docbook_xsl}/xml/xsl/docbook" ];
 

--- a/pkgs/games/garden-of-coloured-lights/default.nix
+++ b/pkgs/games/garden-of-coloured-lights/default.nix
@@ -4,7 +4,8 @@ stdenv.mkDerivation rec {
   pname = "garden-of-coloured-lights";
   version = "1.0.9";
 
-  buildInputs = [ allegro autoconf automake ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ allegro ];
 
   prePatch = ''
     noInline='s/inline //'

--- a/pkgs/games/gl-117/default.nix
+++ b/pkgs/games/gl-117/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1yvg1rp1yijv0b45cz085b29x5x0g5fkm654xdv5qwh2l6803gb4";
   };
 
-  buildInputs = [ libGLU libGL SDL freeglut SDL_mixer autoconf automake libtool ];
+  nativeBuildInputs = [ automake autoconf ];
+  buildInputs = [ libGLU libGL SDL freeglut SDL_mixer libtool ];
 
   meta = with lib; {
     description = "An air combat simulator";

--- a/pkgs/games/qqwing/default.nix
+++ b/pkgs/games/qqwing/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
       --replace "sudo " ""
   '';
 
-  buildInputs = [ perl autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ perl libtool ];
 
   makeFlags = [ "prefix=$(out)" "tgz" ];
 

--- a/pkgs/games/zangband/default.nix
+++ b/pkgs/games/zangband/default.nix
@@ -9,8 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "0kkz6f9myhjnr3308sdab8q186rd55lapvcp38w8qmakdbhc828j";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    ncurses flex bison autoconf automake m4
+    ncurses flex bison m4
   ];
 
   preConfigure = ''

--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -11,8 +11,9 @@ stdenv.mkDerivation {
     sha256 = "0w121issdjxdv5i9ksa5m23if6pz1r9ql8p894f1pqn16w0kw1ix";
   };
 
+  nativeBuildInputs = [ automake autoconf ];
   buildInputs = [
-    cups automake autoconf glib libxml2 libusb1 libtool
+    cups glib libxml2 libusb1 libtool
   ];
 
   # lgmon3's --enable-libdir flag is used soley for specifying in which

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation {
     sha256 = "06s9nl155yxmx56056y22kz1p5b2sb5fhr3gf4ddlczjkd1xch53";
   };
 
-  buildInputs = [ autoconf libtool automake
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool
                   cups popt libtiff libpng
                   ghostscript ];
 

--- a/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_4_00/default.nix
@@ -30,7 +30,8 @@ in stdenv.mkDerivation {
     sha256 = "1f6vpx1z3qa88590i5m0s49j9n90vpk81xmw6pvj0nfd3qbvzkya";
   };
 
-  buildInputs = [ autoconf libtool automake
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool
                   cups popt libtiff libpng
                   ghostscript glib libusb1 libxml2 ];
 

--- a/pkgs/os-specific/linux/conspy/default.nix
+++ b/pkgs/os-specific/linux/conspy/default.nix
@@ -10,9 +10,8 @@ stdenv.mkDerivation rec {
     curlOpts = " -A application/octet-stream ";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    autoconf
-    automake
     ncurses
   ];
 

--- a/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
+++ b/pkgs/servers/http/apache-modules/mod_auth_mellon/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0alfa8hz09jdg29bi1mvhwyr2nl0nvss2a2kybrcjvdw1fx6vijn";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config ];
-  buildInputs = [ apacheHttpd autoconf automake curl glib lasso libtool libxml2 libxslt openssl xmlsec ];
+  nativeBuildInputs = [ autoreconfHook pkg-config autoconf automake ];
+  buildInputs = [ apacheHttpd curl glib lasso libtool libxml2 libxslt openssl xmlsec ];
 
   configureFlags = ["--with-apxs2=${apacheHttpd.dev}/bin/apxs" "--exec-prefix=$out"];
 

--- a/pkgs/servers/http/spawn-fcgi/default.nix
+++ b/pkgs/servers/http/spawn-fcgi/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "07r6nwbg4881mdgp0hqh80c4x9wb7jg6cgc84ghwhfbd2abc2iq5";
   };
 
-  buildInputs = [ automake autoconf ];
+  nativeBuildInputs = [ automake autoconf ];
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/tools/X11/xinput_calibrator/default.nix
+++ b/pkgs/tools/X11/xinput_calibrator/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
 
   preConfigure = "./autogen.sh --with-gui=X11";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ xorgproto libXi autoconf automake libtool m4 xlibsWrapper ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ xorgproto libXi libtool m4 xlibsWrapper ];
 
   meta = {
     homepage = "https://github.com/tias/xinput_calibrator";

--- a/pkgs/tools/audio/mpdcron/default.nix
+++ b/pkgs/tools/audio/mpdcron/default.nix
@@ -31,9 +31,8 @@ in stdenv.mkDerivation {
     sha256 = "0vdksf6lcgmizqr5mqp0bbci259k0dj7gpmhx32md41jlmw5skaw";
   };
 
+  nativeBuildInputs = [ autoconf automake ];
   buildInputs = [
-    autoconf
-    automake
     libtool
     pkg-config
     glib

--- a/pkgs/tools/audio/pa-applet/default.nix
+++ b/pkgs/tools/audio/pa-applet/default.nix
@@ -10,9 +10,9 @@ stdenv.mkDerivation {
     sha256 = "1242sdri67wnm1cd0hr40mxarkh7qs7mb9n2m0g9dbz0f4axj6wa";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [
-    gtk3 libpulseaudio glibc automake autoconf libnotify libX11 xf86inputevdev
+    gtk3 libpulseaudio glibc libnotify libX11 xf86inputevdev
   ];
 
   preConfigure = ''

--- a/pkgs/tools/compression/pixz/default.nix
+++ b/pkgs/tools/compression/pixz/default.nix
@@ -18,10 +18,8 @@ stdenv.mkDerivation rec {
   pname = "pixz";
   version = "1.0.7";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
   buildInputs = [
-    autoconf
-    automake
     libtool
     asciidoc
     libxslt

--- a/pkgs/tools/filesystems/fuse-7z-ng/default.nix
+++ b/pkgs/tools/filesystems/fuse-7z-ng/default.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "17v1gcmg5q661b047zxjar735i4d3508dimw1x3z1pk4d1zjhp3x";
   };
 
-  nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ fuse autoconf automake ];
+  nativeBuildInputs = [ pkg-config makeWrapper autoconf automake ];
+  buildInputs = [ fuse ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/tools/filesystems/glusterfs/default.nix
+++ b/pkgs/tools/filesystems/glusterfs/default.nix
@@ -15,7 +15,7 @@ let
 
   buildInputs = [
     fuse bison flex openssl ncurses readline
-    autoconf automake libtool pkg-config zlib libaio libxml2
+    libtool pkg-config zlib libaio libxml2
     acl sqlite liburcu attr makeWrapper util-linux libtirpc gperftools
     liburing
     (python3.withPackages (pkgs: [
@@ -95,7 +95,7 @@ in stdenv.mkDerivation rec {
     "--localstatedir=/var"
   ];
 
-  nativeBuildInputs = [ rpcsvc-proto ];
+  nativeBuildInputs = [ rpcsvc-proto autoconf automake ];
 
   makeFlags = [ "DESTDIR=$(out)" ];
 

--- a/pkgs/tools/graphics/pgf/default.nix
+++ b/pkgs/tools/graphics/pgf/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vfm12cfq3an3xg0679bcwdmjq2x1bbij1iwsmm60hwmrm3zvab0";
   };
 
-  buildInputs = [ autoconf automake libtool dos2unix libpgf freeimage doxygen ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool dos2unix libpgf freeimage doxygen ];
 
   patchPhase = ''
       sed 1i'#include <inttypes.h>' -i src/PGF.cpp

--- a/pkgs/tools/graphics/povray/default.nix
+++ b/pkgs/tools/graphics/povray/default.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hy5a3q5092szk2x3s9lpn1zkszgq9bp15rxzdncxlvnanyzsasf";
   };
 
-
-  buildInputs = [ autoconf automake boost zlib libpng libjpeg libtiff xlibsWrapper SDL ];
+  nativeBuildInputs = [ automake autoconf ];
+  buildInputs = [ boost zlib libpng libjpeg libtiff xlibsWrapper SDL ];
 
   # the installPhase wants to put files into $HOME. I let it put the files
   # to $TMPDIR, so they don't get into the $out

--- a/pkgs/tools/misc/cunit/default.nix
+++ b/pkgs/tools/misc/cunit/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation rec {
   pname = "CUnit";
   version = "2.1-3";
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [autoconf automake libtool];
+  nativeBuildInputs = [ autoreconfHook autoconf automake ];
+  buildInputs = [libtool];
 
   src = fetchurl {
     url = "mirror://sourceforge/cunit/CUnit/${version}/${pname}-${version}.tar.bz2";

--- a/pkgs/tools/misc/ldapvi/default.nix
+++ b/pkgs/tools/misc/ldapvi/default.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
     sha256 = "3ef3103030ecb04d7fe80180e3fd490377cf81fb2af96782323fddabc3225030";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ openldap openssl popt glib ncurses readline cyrus_sasl autoconf automake ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ openldap openssl popt glib ncurses readline cyrus_sasl ];
 
   preConfigure = ''
     cd ldapvi

--- a/pkgs/tools/misc/ldmtool/default.nix
+++ b/pkgs/tools/misc/ldmtool/default.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
 
   configureScript = "sh autogen.sh";
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake gtk-doc lvm2 libxslt.bin
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ gtk-doc lvm2 libxslt.bin
     libtool readline gobject-introspection json-glib libuuid
   ];
 

--- a/pkgs/tools/misc/opentsdb/default.nix
+++ b/pkgs/tools/misc/opentsdb/default.nix
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ autoconf automake curl jdk nettools python2 git ];
+  nativeBuildInputs = [ makeWrapper autoconf automake ];
+  buildInputs = [ curl jdk nettools python2 git ];
 
   preConfigure = ''
     patchShebangs ./build-aux/

--- a/pkgs/tools/misc/scrub/default.nix
+++ b/pkgs/tools/misc/scrub/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ndcri2ddzqlsxvy1b607ajyd4dxpiagzx331yyi7hf3ijph129f";
   };
 
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool ];
 
   preConfigure = "./autogen.sh";
 

--- a/pkgs/tools/security/crackxls/default.nix
+++ b/pkgs/tools/security/crackxls/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
     sha256 = "0q5jl7hcds3f0rhly3iy4fhhbyh9cdrfaw7zdrazzf1wswwhyssz";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ autoconf automake openssl libgsf gmp ];
+  nativeBuildInputs = [ pkg-config autoconf automake ];
+  buildInputs = [ openssl libgsf gmp ];
 
   installPhase =
   ''

--- a/pkgs/tools/security/logkeys/default.nix
+++ b/pkgs/tools/security/logkeys/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1k6kj0913imwh53lh6hrhqmrpygqg2h462raafjsn7gbd3vkgx8n";
   };
 
-  buildInputs = [ autoconf automake which procps kbd ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ which procps kbd ];
 
   postPatch = ''
     substituteInPlace src/Makefile.am --replace 'root' '$(id -u)'

--- a/pkgs/tools/security/zzuf/default.nix
+++ b/pkgs/tools/security/zzuf/default.nix
@@ -11,7 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0li1s11xf32dafxq1jbnc8c63313hy9ry09dja2rymk9mza4x2n9";
   };
 
-  buildInputs = [ autoconf automake libtool pkg-config ];
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool pkg-config ];
 
   preConfigure = "./bootstrap";
 

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -83,8 +83,8 @@ rec {
     pname = "xmlmirror";
     version = "unstable-2016-06-05";
 
-    buildInputs = [ pkg-config autoconf automake libtool gnumake libxml2 nodejs openjdk json_c ];
-    nativeBuildInputs = [ pkg-config zlib ];
+    buildInputs = [ pkg-config libtool gnumake libxml2 nodejs openjdk json_c ];
+    nativeBuildInputs = [ pkg-config zlib autoconf automake ];
 
     src = pkgs.fetchgit {
       url = "https://gitlab.com/odfplugfest/xmlmirror.git";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
