### PR TITLE
emacs.pkgs.control-lock: Add package

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/control-lock/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/control-lock/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchurl }:
+
+stdenv.mkDerivation {
+  name = "control-lock";
+
+  src = fetchurl {
+    url = "http://emacswiki.org/emacs/download/control-lock.el";
+    sha256 = "1vjpiagiy581qy2ljkbp0w12gvdqzx2lg0778z93262jf55ycai4";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -d $out/share/emacs/site-lisp
+    install $src $out/share/emacs/site-lisp/control-lock.el
+  '';
+
+  meta = {
+    description = "Like caps-lock, but for your control key.  Give your pinky a rest!";
+    homepage = "https://www.emacswiki.org/emacs/control-lock.el";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/applications/editors/emacs/elisp-packages/control-lock/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/control-lock/default.nix
@@ -4,8 +4,8 @@ stdenv.mkDerivation {
   name = "control-lock";
 
   src = fetchurl {
-    url = "http://emacswiki.org/emacs/download/control-lock.el";
-    sha256 = "1vjpiagiy581qy2ljkbp0w12gvdqzx2lg0778z93262jf55ycai4";
+    url = "https://github.com/emacsmirror/emacswiki.org/blob/185fdc34fb1e02b43759ad933d3ee5646b0e78f8/control-lock.el";
+    sha256 = "1b5xcgq2r565pr1c14dwrmn1fl05p56infapa5pqvajv2kpfla7h";
   };
 
   dontUnpack = true;

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages.nix
@@ -190,6 +190,8 @@
 
   perl-completion = callPackage ./perl-completion { };
 
+  control-lock = callPackage ./control-lock { };
+
   plz = callPackage ./plz { };
 
   pod-mode = callPackage ./pod-mode { };


### PR DESCRIPTION
###### Description of changes

Add emacs package that allows to caps-lock like behavior for control key (with cursor change of color)

###### Things done
- Built on platform(s)
  - [X] x86_64-linux

I have just tested it by running 
$ nixos-rebuild switch  -I nixpkgs=/path/to/my/nixpkgs/checkout/nixpkgs