### PR TITLE
minecraft-fabric-servers: init at 1.14.4 to 1.18.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6299,6 +6299,13 @@
     githubId = 66669;
     name = "Jeff Zellner";
   };
+  K1aymore = {
+    name = "Carl Klay";
+    email = "klaymorer@protonmail.com";
+    matrix = "@klaymore:klaymore.me";
+    github = "K1aymore";
+    githubId = 75699983;
+  };
   k4leg = {
     name = "k4leg";
     email = "python.bogdan@gmail.com";

--- a/pkgs/games/minecraft-fabric-servers/default.nix
+++ b/pkgs/games/minecraft-fabric-servers/default.nix
@@ -1,0 +1,24 @@
+{ callPackage, lib, javaPackages }:
+let
+  versions = lib.importJSON ./versions.json;
+
+  latestVersion = lib.last (builtins.sort lib.versionOlder (builtins.attrNames versions));
+  escapeVersion = builtins.replaceStrings [ "." ] [ "-" ];
+
+  getJavaVersion = v: (builtins.getAttr "openjdk${toString v}" javaPackages.compiler).headless;
+
+  packages = lib.mapAttrs'
+    (version: value: {
+      name = "vanilla-${escapeVersion version}";
+      value = callPackage ./derivation.nix {
+        inherit (value) version url sha1;
+        jre_headless = getJavaVersion (if value.javaVersion == null then 8 else value.javaVersion); # versions <= 1.6 will default to 8
+      };
+    })
+    versions;
+in
+lib.recurseIntoAttrs (
+  packages // {
+    vanilla = builtins.getAttr "vanilla-${escapeVersion latestVersion}" packages;
+  }
+)

--- a/pkgs/games/minecraft-fabric-servers/default.nix
+++ b/pkgs/games/minecraft-fabric-servers/default.nix
@@ -10,7 +10,7 @@ let
 
   packages = lib.mapAttrs'
     (version: value: {
-      name = "vanilla-${escapeVersion version}";
+      name = "fabric-${escapeVersion version}";
       value = callPackage ./derivation.nix {
         inherit (value) version url sha256;
         jre_headless = getJavaVersion (if value.javaVersion == null then 8 else value.javaVersion); # versions <= 1.6 will default to 8
@@ -20,6 +20,6 @@ let
 in
 lib.recurseIntoAttrs (
   packages // {
-    vanilla = builtins.getAttr "vanilla-${escapeVersion latestVersion}" packages;
+    fabric = builtins.getAttr "fabric-${escapeVersion latestVersion}" packages;
   }
 )

--- a/pkgs/games/minecraft-fabric-servers/default.nix
+++ b/pkgs/games/minecraft-fabric-servers/default.nix
@@ -1,5 +1,6 @@
 { callPackage, lib, javaPackages }:
 let
+  # from https://fabricmc.net/use/server/
   versions = lib.importJSON ./versions.json;
 
   latestVersion = lib.last (builtins.sort lib.versionOlder (builtins.attrNames versions));
@@ -11,7 +12,7 @@ let
     (version: value: {
       name = "vanilla-${escapeVersion version}";
       value = callPackage ./derivation.nix {
-        inherit (value) version url sha1;
+        inherit (value) version url sha256;
         jre_headless = getJavaVersion (if value.javaVersion == null then 8 else value.javaVersion); # versions <= 1.6 will default to 8
       };
     })

--- a/pkgs/games/minecraft-fabric-servers/derivation.nix
+++ b/pkgs/games/minecraft-fabric-servers/derivation.nix
@@ -1,0 +1,36 @@
+{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha1 }:
+stdenv.mkDerivation {
+  pname = "minecraft-server";
+  inherit version;
+
+  src = fetchurl { inherit url sha1; };
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/minecraft
+    cp -v $src $out/lib/minecraft/server.jar
+
+    cat > $out/bin/minecraft-server << EOF
+    #!/bin/sh
+    exec ${jre_headless}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    EOF
+
+    chmod +x $out/bin/minecraft-server
+  '';
+
+  dontUnpack = true;
+
+  passthru = {
+    tests = { inherit (nixosTests) minecraft-server; };
+    updateScript = ./update.py;
+  };
+
+  meta = with lib; {
+    description = "Minecraft Server";
+    homepage = "https://minecraft.net";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice tomberek costrouc jyooru ];
+  };
+}

--- a/pkgs/games/minecraft-fabric-servers/derivation.nix
+++ b/pkgs/games/minecraft-fabric-servers/derivation.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation {
     homepage = "https://fabricmc.net";
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ thoughtpolice tomberek costrouc jyooru ];
+    maintainers = with maintainers; [ K1aymore ];
   };
 }

--- a/pkgs/games/minecraft-fabric-servers/derivation.nix
+++ b/pkgs/games/minecraft-fabric-servers/derivation.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha256 }:
 stdenv.mkDerivation {
-  pname = "minecraft-server";
+  pname = "minecraft-fabric-server";
   inherit version;
 
   src = fetchurl { inherit url sha256; };
@@ -9,11 +9,11 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/bin $out/lib/minecraft
-    cp -v $src $out/lib/minecraft/server.jar
+    cp -v $src $out/lib/minecraft/fabric-server.jar
 
     cat > $out/bin/minecraft-server << EOF
     #!/bin/sh
-    exec ${jre_headless}/bin/java \$@ -jar $out/lib/minecraft/server.jar nogui
+    exec ${jre_headless}/bin/java \$@ -jar $out/lib/minecraft/fabric-server.jar nogui
     EOF
 
     chmod +x $out/bin/minecraft-server
@@ -26,8 +26,8 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = "Minecraft Server";
-    homepage = "https://minecraft.net";
+    description = "Minecraft 1.18.2 server with Fabric modloader";
+    homepage = "https://fabricmc.net";
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice tomberek costrouc jyooru ];

--- a/pkgs/games/minecraft-fabric-servers/derivation.nix
+++ b/pkgs/games/minecraft-fabric-servers/derivation.nix
@@ -1,9 +1,9 @@
-{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha1 }:
+{ lib, stdenv, fetchurl, nixosTests, jre_headless, version, url, sha256 }:
 stdenv.mkDerivation {
   pname = "minecraft-server";
   inherit version;
 
-  src = fetchurl { inherit url sha1; };
+  src = fetchurl { inherit url sha256; };
 
   preferLocalBuild = true;
 
@@ -23,7 +23,6 @@ stdenv.mkDerivation {
 
   passthru = {
     tests = { inherit (nixosTests) minecraft-server; };
-    updateScript = ./update.py;
   };
 
   meta = with lib; {

--- a/pkgs/games/minecraft-fabric-servers/derivation.nix
+++ b/pkgs/games/minecraft-fabric-servers/derivation.nix
@@ -26,7 +26,8 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = "Minecraft 1.18.2 server with Fabric modloader";
+    description = "Minecraft server with Fabric modloader. Set
+      services.minecraft-server.package = pkgs.minecraftFabricServers.fabric-1-(14|15|16|17|18);";
     homepage = "https://fabricmc.net";
     license = licenses.unfreeRedistributable;
     platforms = platforms.unix;

--- a/pkgs/games/minecraft-fabric-servers/versions.json
+++ b/pkgs/games/minecraft-fabric-servers/versions.json
@@ -1,0 +1,104 @@
+{
+  "1.18": {
+    "url": "https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar",
+    "sha1": "c8f83c5655308435b3dcf03c06d9fe8740a77469",
+    "version": "1.18.2",
+    "javaVersion": 17
+  },
+  "1.17": {
+    "url": "https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar",
+    "sha1": "a16d67e5807f57fc4e550299cf20226194497dc2",
+    "version": "1.17.1",
+    "javaVersion": 16
+  },
+  "1.16": {
+    "url": "https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar",
+    "sha1": "1b557e7b033b583cd9f66746b7a9ab1ec1673ced",
+    "version": "1.16.5",
+    "javaVersion": 8
+  },
+  "1.15": {
+    "url": "https://launcher.mojang.com/v1/objects/bb2b6b1aefcd70dfd1892149ac3a215f6c636b07/server.jar",
+    "sha1": "bb2b6b1aefcd70dfd1892149ac3a215f6c636b07",
+    "version": "1.15.2",
+    "javaVersion": 8
+  },
+  "1.14": {
+    "url": "https://launcher.mojang.com/v1/objects/3dc3d84a581f14691199cf6831b71ed1296a9fdf/server.jar",
+    "sha1": "3dc3d84a581f14691199cf6831b71ed1296a9fdf",
+    "version": "1.14.4",
+    "javaVersion": 8
+  },
+  "1.13": {
+    "url": "https://launcher.mojang.com/v1/objects/3737db93722a9e39eeada7c27e7aca28b144ffa7/server.jar",
+    "sha1": "3737db93722a9e39eeada7c27e7aca28b144ffa7",
+    "version": "1.13.2",
+    "javaVersion": 8
+  },
+  "1.12": {
+    "url": "https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar",
+    "sha1": "886945bfb2b978778c3a0288fd7fab09d315b25f",
+    "version": "1.12.2",
+    "javaVersion": 8
+  },
+  "1.11": {
+    "url": "https://launcher.mojang.com/v1/objects/f00c294a1576e03fddcac777c3cf4c7d404c4ba4/server.jar",
+    "sha1": "f00c294a1576e03fddcac777c3cf4c7d404c4ba4",
+    "version": "1.11.2",
+    "javaVersion": 8
+  },
+  "1.10": {
+    "url": "https://launcher.mojang.com/v1/objects/3d501b23df53c548254f5e3f66492d178a48db63/server.jar",
+    "sha1": "3d501b23df53c548254f5e3f66492d178a48db63",
+    "version": "1.10.2",
+    "javaVersion": 8
+  },
+  "1.9": {
+    "url": "https://launcher.mojang.com/v1/objects/edbb7b1758af33d365bf835eb9d13de005b1e274/server.jar",
+    "sha1": "edbb7b1758af33d365bf835eb9d13de005b1e274",
+    "version": "1.9.4",
+    "javaVersion": 8
+  },
+  "1.8": {
+    "url": "https://launcher.mojang.com/v1/objects/b58b2ceb36e01bcd8dbf49c8fb66c55a9f0676cd/server.jar",
+    "sha1": "b58b2ceb36e01bcd8dbf49c8fb66c55a9f0676cd",
+    "version": "1.8.9",
+    "javaVersion": 8
+  },
+  "1.7": {
+    "url": "https://launcher.mojang.com/v1/objects/4cec86a928ec171fdc0c6b40de2de102f21601b5/server.jar",
+    "sha1": "4cec86a928ec171fdc0c6b40de2de102f21601b5",
+    "version": "1.7.9",
+    "javaVersion": 8
+  },
+  "1.6": {
+    "url": "https://launcher.mojang.com/v1/objects/050f93c1f3fe9e2052398f7bd6aca10c63d64a87/server.jar",
+    "sha1": "050f93c1f3fe9e2052398f7bd6aca10c63d64a87",
+    "version": "1.6.4",
+    "javaVersion": null
+  },
+  "1.5": {
+    "url": "https://launcher.mojang.com/v1/objects/f9ae3f651319151ce99a0bfad6b34fa16eb6775f/server.jar",
+    "sha1": "f9ae3f651319151ce99a0bfad6b34fa16eb6775f",
+    "version": "1.5.2",
+    "javaVersion": null
+  },
+  "1.4": {
+    "url": "https://launcher.mojang.com/v1/objects/2f0ec8efddd2f2c674c77be9ddb370b727dec676/server.jar",
+    "sha1": "2f0ec8efddd2f2c674c77be9ddb370b727dec676",
+    "version": "1.4.7",
+    "javaVersion": null
+  },
+  "1.3": {
+    "url": "https://launcher.mojang.com/v1/objects/3de2ae6c488135596e073a9589842800c9f53bfe/server.jar",
+    "sha1": "3de2ae6c488135596e073a9589842800c9f53bfe",
+    "version": "1.3.2",
+    "javaVersion": null
+  },
+  "1.2": {
+    "url": "https://launcher.mojang.com/v1/objects/d8321edc9470e56b8ad5c67bbd16beba25843336/server.jar",
+    "sha1": "d8321edc9470e56b8ad5c67bbd16beba25843336",
+    "version": "1.2.5",
+    "javaVersion": null
+  }
+}

--- a/pkgs/games/minecraft-fabric-servers/versions.json
+++ b/pkgs/games/minecraft-fabric-servers/versions.json
@@ -1,104 +1,32 @@
 {
   "1.18": {
-    "url": "https://launcher.mojang.com/v1/objects/c8f83c5655308435b3dcf03c06d9fe8740a77469/server.jar",
-    "sha1": "c8f83c5655308435b3dcf03c06d9fe8740a77469",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.18.2/0.13.3/0.10.2/server/jar",
+    "sha256": "3c4cd6ba235d3dc9602ed60923bd75749ca7e48e58cc7f6c1f58fc07d64b3291",
     "version": "1.18.2",
     "javaVersion": 17
   },
   "1.17": {
-    "url": "https://launcher.mojang.com/v1/objects/a16d67e5807f57fc4e550299cf20226194497dc2/server.jar",
-    "sha1": "a16d67e5807f57fc4e550299cf20226194497dc2",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.17.1/0.13.3/0.10.2/server/jar",
+    "sha256": "79c32a225287bfd8da350b857dc5262fcf8f9058d03d54427068b70b273b6e33",
     "version": "1.17.1",
     "javaVersion": 16
   },
   "1.16": {
-    "url": "https://launcher.mojang.com/v1/objects/1b557e7b033b583cd9f66746b7a9ab1ec1673ced/server.jar",
-    "sha1": "1b557e7b033b583cd9f66746b7a9ab1ec1673ced",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.16.5/0.13.3/0.10.2/server/jar",
+    "sha256": "f001f3cfa0ef00905505c76341bb5c9dc0ce1397294991f6a6bc84dc209cf336",
     "version": "1.16.5",
     "javaVersion": 8
   },
   "1.15": {
-    "url": "https://launcher.mojang.com/v1/objects/bb2b6b1aefcd70dfd1892149ac3a215f6c636b07/server.jar",
-    "sha1": "bb2b6b1aefcd70dfd1892149ac3a215f6c636b07",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.15.2/0.13.3/0.10.2/server/jar",
+    "sha256": "dd73ca2dbd43812a9bf86053a8fc6ca05777e495e95b8673003c7925e23f56d3",
     "version": "1.15.2",
     "javaVersion": 8
   },
   "1.14": {
-    "url": "https://launcher.mojang.com/v1/objects/3dc3d84a581f14691199cf6831b71ed1296a9fdf/server.jar",
-    "sha1": "3dc3d84a581f14691199cf6831b71ed1296a9fdf",
+    "url": "https://meta.fabricmc.net/v2/versions/loader/1.14.4/0.13.3/0.10.2/server/jar",
+    "sha256": "12b47dd4abc278ba8e42ed978ed8343d1712215c907f03e14256379b886a116e",
     "version": "1.14.4",
     "javaVersion": 8
-  },
-  "1.13": {
-    "url": "https://launcher.mojang.com/v1/objects/3737db93722a9e39eeada7c27e7aca28b144ffa7/server.jar",
-    "sha1": "3737db93722a9e39eeada7c27e7aca28b144ffa7",
-    "version": "1.13.2",
-    "javaVersion": 8
-  },
-  "1.12": {
-    "url": "https://launcher.mojang.com/v1/objects/886945bfb2b978778c3a0288fd7fab09d315b25f/server.jar",
-    "sha1": "886945bfb2b978778c3a0288fd7fab09d315b25f",
-    "version": "1.12.2",
-    "javaVersion": 8
-  },
-  "1.11": {
-    "url": "https://launcher.mojang.com/v1/objects/f00c294a1576e03fddcac777c3cf4c7d404c4ba4/server.jar",
-    "sha1": "f00c294a1576e03fddcac777c3cf4c7d404c4ba4",
-    "version": "1.11.2",
-    "javaVersion": 8
-  },
-  "1.10": {
-    "url": "https://launcher.mojang.com/v1/objects/3d501b23df53c548254f5e3f66492d178a48db63/server.jar",
-    "sha1": "3d501b23df53c548254f5e3f66492d178a48db63",
-    "version": "1.10.2",
-    "javaVersion": 8
-  },
-  "1.9": {
-    "url": "https://launcher.mojang.com/v1/objects/edbb7b1758af33d365bf835eb9d13de005b1e274/server.jar",
-    "sha1": "edbb7b1758af33d365bf835eb9d13de005b1e274",
-    "version": "1.9.4",
-    "javaVersion": 8
-  },
-  "1.8": {
-    "url": "https://launcher.mojang.com/v1/objects/b58b2ceb36e01bcd8dbf49c8fb66c55a9f0676cd/server.jar",
-    "sha1": "b58b2ceb36e01bcd8dbf49c8fb66c55a9f0676cd",
-    "version": "1.8.9",
-    "javaVersion": 8
-  },
-  "1.7": {
-    "url": "https://launcher.mojang.com/v1/objects/4cec86a928ec171fdc0c6b40de2de102f21601b5/server.jar",
-    "sha1": "4cec86a928ec171fdc0c6b40de2de102f21601b5",
-    "version": "1.7.9",
-    "javaVersion": 8
-  },
-  "1.6": {
-    "url": "https://launcher.mojang.com/v1/objects/050f93c1f3fe9e2052398f7bd6aca10c63d64a87/server.jar",
-    "sha1": "050f93c1f3fe9e2052398f7bd6aca10c63d64a87",
-    "version": "1.6.4",
-    "javaVersion": null
-  },
-  "1.5": {
-    "url": "https://launcher.mojang.com/v1/objects/f9ae3f651319151ce99a0bfad6b34fa16eb6775f/server.jar",
-    "sha1": "f9ae3f651319151ce99a0bfad6b34fa16eb6775f",
-    "version": "1.5.2",
-    "javaVersion": null
-  },
-  "1.4": {
-    "url": "https://launcher.mojang.com/v1/objects/2f0ec8efddd2f2c674c77be9ddb370b727dec676/server.jar",
-    "sha1": "2f0ec8efddd2f2c674c77be9ddb370b727dec676",
-    "version": "1.4.7",
-    "javaVersion": null
-  },
-  "1.3": {
-    "url": "https://launcher.mojang.com/v1/objects/3de2ae6c488135596e073a9589842800c9f53bfe/server.jar",
-    "sha1": "3de2ae6c488135596e073a9589842800c9f53bfe",
-    "version": "1.3.2",
-    "javaVersion": null
-  },
-  "1.2": {
-    "url": "https://launcher.mojang.com/v1/objects/d8321edc9470e56b8ad5c67bbd16beba25843336/server.jar",
-    "sha1": "d8321edc9470e56b8ad5c67bbd16beba25843336",
-    "version": "1.2.5",
-    "javaVersion": null
   }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31424,6 +31424,7 @@ with pkgs;
 
   minecraftServers = import ../games/minecraft-servers { inherit callPackage lib javaPackages; };
   minecraft-server = minecraftServers.vanilla; # backwards compatibility
+  minecraftFabricServers = import ../games/minecraft-fabric-servers { inherit callPackage lib javaPackages; };
 
   moon-buggy = callPackage ../games/moon-buggy { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31425,6 +31425,7 @@ with pkgs;
   minecraftServers = import ../games/minecraft-servers { inherit callPackage lib javaPackages; };
   minecraft-server = minecraftServers.vanilla; # backwards compatibility
   minecraftFabricServers = import ../games/minecraft-fabric-servers { inherit callPackage lib javaPackages; };
+  minecraft-fabric-server = minecraftServers.fabric; # default to latest version
 
   moon-buggy = callPackage ../games/moon-buggy { };
 


### PR DESCRIPTION
###### Description of changes

Added a package for Minecraft servers with the Fabric modloader.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Ran `sudo nixos-rebuild test -I nixpkgs=<directory> --fast` with `services.minecraft-server.package = pkgs.minecraftFabricServers.fabric;`

Also tested with `services.minecraft-server.package = pkgs.minecraftFabricServers.fabric-1-14;` to test installing different Minecraft versions.