### PR TITLE
.github/workflows/basic-eval.yml: try to parallelize

### DIFF
--- a/.github/workflows/basic-eval.yml
+++ b/.github/workflows/basic-eval.yml
@@ -1,3 +1,6 @@
+# act -j basic-eval --artifact-server-path artifacts
+#
+# we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
 name: Basic evaluation checks
 
 on:
@@ -10,16 +13,47 @@ on:
      - master
      - release-**
 jobs:
-  tests:
+  # create a artifact with nix dependencies so we can run the eval
+  # in parallel without having to download them 4 times
+  create-nix-dependency-artifact:
     runs-on: ubuntu-latest
-    # we don't limit this action to only NixOS repo since the checks are cheap and useful developer feedback
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v16
-    - uses: cachix/cachix-action@v10
-      with:
-        # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
-        name: nixpkgs-ci
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    # explicit list of supportedSystems is needed until aarch64-darwin becomes part of the trunk jobset
-    - run: nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "aarch64-darwin" "aarch64-linux" "x86_64-linux" "x86_64-darwin"  ]'
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v16
+      - uses: cachix/cachix-action@v10
+        with:
+          # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
+          name: nixpkgs-ci
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - run: nix copy --quiet --to file:///tmp/nix-deps -f ./pkgs/top-level/release.nix  tarball.nixpkgs-basic-release-checks.buildInputs
+      - uses: actions/upload-artifact@v3
+        with:
+          name: nix-deps
+          path: /tmp/nix-deps
+          retention-days: 1
+
+
+  basic-eval:
+    runs-on: ubuntu-latest
+    needs: create-nix-dependency-artifact
+    strategy:
+      max-parallel: 4
+      matrix:
+        supportedSystem:
+          - aarch64-darwin
+          - aarch64-linux
+          - x86_64-darwin
+          - x86_64-linux
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: nix-deps
+          path: /tmp/nix-deps
+      - uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            substituters = file://${{steps.download.outputs.download-path}} https://cache.nixos.org/
+      - name: eval - ${{ matrix.supportedSystem }}
+        run: nix-build pkgs/top-level/release.nix -A tarball.nixpkgs-basic-release-checks --arg supportedSystems '[ "${{ matrix.supportedSystem }}" ]'


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
