### PR TITLE
nixos/zathura: init

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1786,6 +1786,13 @@
           generating host-global NNCP configuration.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          Added a module which allows configuration of zathura
+          <literal>programs.zathura</literal>, it follows the same
+          options as the home manager module.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -618,4 +618,6 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - The `programs.nncp` options were added for generating host-global NNCP configuration.
 
+- Added a module which allows configuration of zathura `programs.zathura`, it follows the same options as the home manager module.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/programs/zathura.nix
+++ b/nixos/modules/programs/zathura.nix
@@ -1,0 +1,70 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.programs.zathura;
+
+  formatLine = n: v:
+    let
+      formatValue = v:
+        if isBool v then (if v then "true" else "false") else toString v;
+    in ''set ${n}	"${formatValue v}"'';
+
+in {
+
+  options.programs.zathura = {
+    enable = mkEnableOption ''
+      Zathura, a highly customizable and functional document viewer
+      focused on keyboard interaction'';
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.zathura;
+      defaultText = "pkgs.zathura";
+      description = "The Zathura package to use";
+    };
+
+    options = mkOption {
+      default = { };
+      type = with types; attrsOf (either str (either bool int));
+      description = ''
+        Add <option>:set</option> command options to zathura and make
+        them permanent. See
+        <citerefentry>
+          <refentrytitle>zathurarc</refentrytitle>
+          <manvolnum>5</manvolnum>
+        </citerefentry>
+        for the full list of options.
+      '';
+      example = {
+        default-bg = "#000000";
+        default-fg = "#FFFFFF";
+      };
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Additional commands for zathura that will be added to the
+        <filename>zathurarc</filename> file.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ cfg.package ];
+
+      etc.zathurarc.source =
+        pkgs.writeText "zathurarc" (concatStringsSep "\n" ([ ]
+          ++ optional (cfg.extraConfig != "") cfg.extraConfig
+          ++ mapAttrsToList formatLine cfg.options) + "\n");
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ alexnortung ];
+}


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This commit adds zathura as a module for nixos.
It allows for setting options and extra config on a system level.

Credit to the [home manager module](https://github.com/nix-community/home-manager/blob/master/modules/programs/zathura.nix#blob-path) which this pull request is heavily inspired on.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
