### PR TITLE
brave: 1.36.122 -> 1.37.109

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,11 +91,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.36.122";
+  version = "1.37.109";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "aBHoEu1egRPMpeUBgRl2V5J3op1Ju+CvprG14dIWc8M=";
+    sha256 = "fL3vuCqUnzq38JD0bzM/DxLVb5P31iChbMVY2eax9RE=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes
https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#137109

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).