### PR TITLE
tree-wide: fix unused installCheckPhase's (or be explicit about disabling them)

### DIFF
--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
 
   installCheckInputs = [ perl ];
 
-  doInstallCheck = doCheck;
+  doInstallCheck = false; # minor test failure, see https://github.com/NixOS/nixpkgs/pull/166730#issuecomment-1090671531 .
 
   installCheckPhase = ''
     # copy tests to allow writing results

--- a/pkgs/applications/science/electronics/verilog/default.nix
+++ b/pkgs/applications/science/electronics/verilog/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
 
   installCheckInputs = [ perl ];
 
+  doInstallCheck = doCheck;
+
   installCheckPhase = ''
     # copy tests to allow writing results
     export TESTDIR=$(mktemp -d)

--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -71,6 +71,8 @@ stdenv.mkDerivation rec {
     substituteInPlace meson.build --replace '>= 1.0.0-alpha.1' '>= 1.0.0'
   '';
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     $out/bin/kooha --help
   '';

--- a/pkgs/applications/video/kooha/default.nix
+++ b/pkgs/applications/video/kooha/default.nix
@@ -71,7 +71,11 @@ stdenv.mkDerivation rec {
     substituteInPlace meson.build --replace '>= 1.0.0-alpha.1' '>= 1.0.0'
   '';
 
-  doInstallCheck = true;
+  doCheck = true;
+
+  # thread 'main' panicked at 'Unable to start GTK4.: BoolError { message: "Failed to
+  # initialize GTK", filename: "/build/kooha-2.0.1-vendor.tar.gz/gtk4/src/rt.rs", function: "gtk4::rt", line: 120 }', src/main.rs:37:17
+  doInstallCheck = false;
 
   installCheckPhase = ''
     $out/bin/kooha --help

--- a/pkgs/build-support/replace-secret/replace-secret.nix
+++ b/pkgs/build-support/replace-secret/replace-secret.nix
@@ -10,6 +10,7 @@ stdenv.mkDerivation {
     patchShebangs $out
     runHook postInstall
   '';
+  doInstallCheck = true;
   installCheckPhase = ''
     install -m 0600 ${./test/input_file} long_test
     $out/bin/replace-secret "replace this" ${./test/passwd} long_test

--- a/pkgs/development/compilers/llvm/10/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/10/lldb/default.nix
@@ -69,8 +69,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/11/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/11/lldb/default.nix
@@ -69,8 +69,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/12/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/12/lldb/default.nix
@@ -85,8 +85,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/13/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/13/lldb/default.nix
@@ -85,8 +85,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/14/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/14/lldb/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
-  doInstallCheck = true;
+  doInstallCheck = false; # python bits are broken, see #166604
 
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then

--- a/pkgs/development/compilers/llvm/14/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/14/lldb/default.nix
@@ -90,8 +90,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/8/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/8/lldb/default.nix
@@ -62,8 +62,11 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/9/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/9/lldb/default.nix
@@ -59,8 +59,11 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/compilers/llvm/git/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/git/lldb/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
-  doInstallCheck = true;
+  doInstallCheck = false; # python bits are broken, see #166604
 
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then

--- a/pkgs/development/compilers/llvm/git/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/git/lldb/default.nix
@@ -90,8 +90,11 @@ stdenv.mkDerivation (rec {
 
   doCheck = false;
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     if [ ! -e "$lib/${python3.sitePackages}/lldb/_lldb.so" ] ; then
+        echo 'ERROR: python files not installed where expected!'
         return 1;
     fi
   '';

--- a/pkgs/development/interpreters/clojure/babashka.nix
+++ b/pkgs/development/interpreters/clojure/babashka.nix
@@ -17,6 +17,8 @@ buildGraalvmNativeImage rec {
     "--native-image-info"
   ];
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
     $out/bin/bb --version | grep '${version}'
     $out/bin/bb '(+ 1 2)' | grep '3'

--- a/pkgs/development/libraries/science/math/fenics/default.nix
+++ b/pkgs/development/libraries/science/math/fenics/default.nix
@@ -218,6 +218,7 @@ let
       "-DDOLFIN_ENABLE_SLEPC=OFF"
       "-DDOLFIN_ENABLE_TRILINOS=OFF"
     ];
+    doInstallCheck = false; # make: *** No rule to make target 'runtests'.  Stop.
     installCheckPhase = ''
       source $out/share/dolfin/dolfin.conf
       make runtests

--- a/pkgs/development/tools/jbang/default.nix
+++ b/pkgs/development/tools/jbang/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
+  doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/jbang --version 2>&1 | grep -q "${version}"
   '';

--- a/pkgs/development/tools/scalafix/default.nix
+++ b/pkgs/development/tools/scalafix/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
       --add-flags "-cp $CLASSPATH scalafix.cli.Cli"
   '';
 
+  doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/${baseName} --version | grep -q "${version}"
   '';

--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/${baseName} --version | grep -q "${version}"
   '';

--- a/pkgs/games/chiaki/default.nix
+++ b/pkgs/games/chiaki/default.nix
@@ -52,6 +52,7 @@ mkDerivation rec {
 
   doCheck = true;
 
+  doInstallCheck = false; # error, can't connect to display
   installCheckPhase = "$out/bin/chiaki --help";
 
   meta = with lib; {

--- a/pkgs/servers/owncast/default.nix
+++ b/pkgs/servers/owncast/default.nix
@@ -39,10 +39,12 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ bash which ffmpeg ]}
   '';
 
+  doInstallCheck = true;
+
   installCheckPhase = ''
-    runHook preCheck
+    runHook preInstallCheck
     $out/bin/owncast --help
-    runHook postCheck
+    runHook postInstallCheck
   '';
 
   passthru.tests.owncast = nixosTests.testOwncast;


### PR DESCRIPTION
###### Description of changes

LLDB's:

See #166604.
Enable the installCheckPhase that is meant to catch this problem.
Mark the broken LLDB's as broken until they're fixed (14/git).

For the rest:

For each, I checked:
* If they built as-is
* Ensured they didn't fail when adding 'exit 1' to `installCheckPhase`
* Ensured did fail when adding `doInstallCheck` with `exit 1` present
* Ensured built with original `installCheckPhase` with `doInstallCheck`

I found these using some quick ripgrep incantation, and manually
skipped over the packages that were built using python builders as they
handle installCheckPhase themselves.
EDIT: oops they might warrant review later too, not sure what `installCheckPhase` does for them, since `checkPhase` is mapped to it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->