### PR TITLE
python3Packages.pytorchWithCuda: consistent cuda

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8365,11 +8365,12 @@ in {
       cudnn = pkgs.cudnn_8_3_cudatoolkit_11;
       cudatoolkit = cudnn.cudatoolkit;
       magma = pkgs.magma.override { inherit cudatoolkit; };
+      nccl = pkgs.nccl.override { inherit cudatoolkit; };
     in
     callPackage ../development/python-modules/pytorch
       {
         cudaSupport = pkgs.config.cudaSupport or false;
-        inherit cudnn cudatoolkit magma;
+        inherit cudnn cudatoolkit magma nccl;
       };
 
   pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8360,9 +8360,17 @@ in {
 
   pytools = callPackage ../development/python-modules/pytools { };
 
-  pytorch = callPackage ../development/python-modules/pytorch {
-    cudaSupport = pkgs.config.cudaSupport or false;
-  };
+  pytorch =
+    let
+      cudnn = pkgs.cudnn_8_3_cudatoolkit_11;
+      cudatoolkit = cudnn.cudatoolkit;
+      magma = pkgs.magma.override { inherit cudatoolkit; };
+    in
+    callPackage ../development/python-modules/pytorch
+      {
+        cudaSupport = pkgs.config.cudaSupport or false;
+        inherit cudnn cudatoolkit magma;
+      };
 
   pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix { };
 


### PR DESCRIPTION
Pytorch has been using (through unversioned attributes) cudatoolkit=10.2 (10.1 in nixpkgs-unstable)
and cudnn_7_6_cudatoolkit_10_1; the older 10.1 took priority; pytorch
1.10 requires at least 10.2, which lead to a build failure: https://github.com/NixOS/nixpkgs/issues/166403

###### Description of changes

- Calling `pytorch` with consistent cudnn and cudatoolkit versions.
- Choosing to use `cudnn_8_3_cudatoolkit_11` (cuda 11.5, atm) because this is what I expect to be the new value of the unversioned cuda*-attributes after https://github.com/NixOS/nixpkgs/pull/166533/ lands (we might be able to re-use the cache later)

This is a hotfix for pytorch to stay buildable on nixpkgs-unstable.
The longer-term solution is https://github.com/NixOS/nixpkgs/pull/166533.
This causes an additional magma build, but (a) we're going to provide [cache](https://hercules-ci.com/accounts/github/SomeoneSerge/derivations/%2Fnix%2Fstore%2Fmknm7lab8m5iizd2r5mbvdlswls9mbf9-magma-2.5.4.drv/log?via-job=56f6d6dc-283b-49af-9fd1-21234daba2bc), (b) with https://github.com/NixOS/nixpkgs/pull/166533/ the global magma will be using the same version of cuda and we can get rid of the ad hoc fix we introduce here
In future, we'll want to remove these custom arguments, because they make overriding (e.g. global cudnn/cuda) harder

Note that this change is "local" in the sense that it should only affect the "cuda" world, not built by hydra, but tested by [@NixOS/cuda-maintainers](https://github.com/orgs/NixOS/teams/cuda-maintainers/members). This might affect cuda-enabled pytorch on darwin, because we currently do not have any capabilities to test darwin

~~This can be merged if [113](https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/113) has fewer failures than [97](https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/97), in particular [pytorch](https://hercules-ci.com/accounts/github/SomeoneSerge/derivations/%2Fnix%2Fstore%2Fwc87lfhjknfl76az4qw0a6imckrw8vkl-python3.9-pytorch-1.10.2.drv/log?via-job=56f6d6dc-283b-49af-9fd1-21234daba2bc)~~ This should fix the configurePhase, but the later build, apparently, is going to fail: https://github.com/NixOS/nixpkgs/issues/161843. That should be addressed in a separate PR. Or maybe I should call it off and wait for the cudnn PR to get merged - I'll sleep on this thought and wait for the build


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux (waiting)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc [@NixOS/cuda-maintainers](https://github.com/orgs/NixOS/teams/cuda-maintainers/members)
cc @tscholak about cuda-enabled pytorch on darwin