### PR TITLE
cvc5: init at 1.0.0 & symfpu: init at 8fbe139b

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11271,6 +11271,12 @@
     githubId = 1151264;
     name = "Sebastian Graf";
   };
+  shadaj = {
+    email = "shadaj@users.noreply.github.com";
+    github = "shadaj";
+    githubId = 543055;
+    name = "Shadaj Laddad";
+  };
   shahrukh330 = {
     email = "shahrukh330@gmail.com";
     github = "shahrukh330";

--- a/pkgs/applications/science/logic/cvc5/default.nix
+++ b/pkgs/applications/science/logic/cvc5/default.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitHub, pkg-config, cmake, cadical, symfpu, gmp, git, python3, gtest, libantlr3c, antlr3_4, boost, jdk }:
+
+stdenv.mkDerivation rec {
+  pname = "cvc5";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner  = "cvc5";
+    repo   = "cvc5";
+    rev    = "cvc5-${version}";
+    sha256 = "03sxqwmlajffmv7lncqs1bx8gyihkpnikk87q9wjrd4776n13ign";
+  };
+
+  nativeBuildInputs = [ pkg-config cmake ];
+  buildInputs = [ cadical.dev symfpu gmp git python3 python3.pkgs.toml gtest libantlr3c antlr3_4 boost jdk ];
+
+  preConfigure = ''
+    patchShebangs ./src/
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Production"
+    "-DBUILD_SHARED_LIBS=1"
+    "-DANTLR3_JAR=${antlr3_4}/lib/antlr/antlr-3.4-complete.jar"
+  ];
+
+  meta = with lib; {
+    description = "A high-performance theorem prover and SMT solver";
+    homepage    = "https://cvc5.github.io";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ shadaj ];
+  };
+}

--- a/pkgs/applications/science/logic/symfpu/default.nix
+++ b/pkgs/applications/science/logic/symfpu/default.nix
@@ -1,0 +1,26 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "symfpu";
+  version = "unstable-2019-05-17";
+
+  src = fetchFromGitHub {
+    owner  = "martin-cs";
+    repo   = "symfpu";
+    rev    = "8fbe139bf0071cbe0758d2f6690a546c69ff0053";
+    sha256 = "1jf5lkn67q136ppfacw3lsry369v7mdr1rhidzjpbz18jfy9zl9q";
+  };
+
+  installPhase = ''
+    mkdir -p $out/symfpu
+    cp -r * $out/symfpu/
+  '';
+
+  meta = with lib; {
+    description = "A (concrete or symbolic) implementation of IEEE-754 / SMT-LIB floating-point";
+    homepage    = "https://github.com/martin-cs/symfpu";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ shadaj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32770,6 +32770,8 @@ with pkgs;
     jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
   };
 
+  cvc5 = callPackage ../applications/science/logic/cvc5 { };
+
   drat-trim = callPackage ../applications/science/logic/drat-trim {};
 
   ekrhyper = callPackage ../applications/science/logic/ekrhyper {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32934,6 +32934,8 @@ with pkgs;
 
   symbiyosys = callPackage ../applications/science/logic/symbiyosys {};
 
+  symfpu = callPackage ../applications/science/logic/symfpu {};
+
   mcy = callPackage ../applications/science/logic/mcy {};
 
   lingeling = callPackage ../applications/science/logic/lingeling {};


### PR DESCRIPTION
###### Description of changes

Adds the CVC5 package (an SMT solver), along with its dependency symfpu (which provides symbolic floating point APIs).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
