### PR TITLE
GNOME updates 2022-04-01

### DIFF
--- a/pkgs/desktops/gnome/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome/core/gucharmap/default.nix
@@ -45,7 +45,7 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "gucharmap";
-  version = "14.0.2";
+  version = "14.0.3";
 
   outputs = [ "out" "lib" "dev" "devdoc" ];
 
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
     owner = "GNOME";
     repo = pname;
     rev = version;
-    sha256 = "sha256-gyOm/S0ae0kX4AFUiglqyGRGB8C/KUuaG/dr/Wf1ug0=";
+    sha256 = "sha256-xO34CR+SWxtHuP6G8m0jla0rivVp3ddrsODNo50MhHw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/sushi/default.nix
+++ b/pkgs/desktops/gnome/core/sushi/default.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "sushi";
-  version = "41.0";
+  version = "41.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/sushi/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "m3UlaQzkNmJO+gpgV3NJNDLNDva49GSYLouETtqYmO4=";
+    sha256 = "JifbYWLnV3hZDAfhZbLzbqJNEjGlE7FkAj/G3fx1xKM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/games/aisleriot/default.nix
+++ b/pkgs/desktops/gnome/games/aisleriot/default.nix
@@ -10,7 +10,7 @@
 , librsvg
 , libxml2
 , desktop-file-utils
-, guile_3_0
+, guile
 , libcanberra-gtk3
 , ninja
 , appstream-glib
@@ -19,14 +19,14 @@
 
 stdenv.mkDerivation rec {
   pname = "aisleriot";
-  version = "3.22.21";
+  version = "3.22.22";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = pname;
     rev = version;
-    sha256 = "sha256-dpzuePxSoJcwUlj314r5G9A8aF1Yz49r+DxNTfA8/Ks=";
+    sha256 = "sha256-Jr4XEj6h+gI1gNqoJ/cJ3cDBB4mSbpzvOUQkwGxkLPs=";
   };
 
   nativeBuildInputs = [
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     librsvg
-    guile_3_0
+    guile
     libcanberra-gtk3
   ];
 

--- a/pkgs/desktops/gnome/games/five-or-more/default.nix
+++ b/pkgs/desktops/gnome/games/five-or-more/default.nix
@@ -1,5 +1,20 @@
-{ lib, stdenv, fetchurl, meson, ninja, pkg-config, gnome, gtk3, wrapGAppsHook
-, librsvg, libgnome-games-support, gettext, itstool, libxml2, python3, vala }:
+{ stdenv
+, lib
+, fetchurl
+, meson
+, ninja
+, pkg-config
+, gnome
+, gtk3
+, wrapGAppsHook
+, librsvg
+, libgnome-games-support
+, gettext
+, itstool
+, libxml2
+, python3
+, vala
+}:
 
 stdenv.mkDerivation rec {
   pname = "five-or-more";
@@ -11,11 +26,22 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    meson ninja pkg-config gettext itstool libxml2 python3 wrapGAppsHook
+    meson
+    ninja
+    pkg-config
+    gettext
+    itstool
+    libxml2
+    python3
+    wrapGAppsHook
     vala
   ];
+
   buildInputs = [
-    gtk3 librsvg libgnome-games-support gnome.adwaita-icon-theme
+    gtk3
+    librsvg
+    libgnome-games-support
+    gnome.adwaita-icon-theme
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome/games/five-or-more/default.nix
+++ b/pkgs/desktops/gnome/games/five-or-more/default.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "five-or-more";
-  version = "3.32.2";
+  version = "3.32.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "19pf8wzbf3ciqf2k4bj9sddvyhckfd62x86pnqr6s8h4vn9jc6ii";
+    sha256 = "LRDXLu/esyS0R9YyrwwySW4l/BWjwB230vAMm1HQnvQ=";
   };
 
   nativeBuildInputs = [
@@ -41,7 +41,6 @@ stdenv.mkDerivation rec {
     gtk3
     librsvg
     libgnome-games-support
-    gnome.adwaita-icon-theme
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### gnome.aisleriot: 3.22.21 → 3.22.22

https://gitlab.gnome.org/GNOME/aisleriot/-/compare/3.22.21...3.22.22

- Look for themes in .local/share/aisleriot/cards. ([#268](https://gitlab.gnome.org/GNOME/aisleriot/-/issues/268))
- Fix build with default guile version we use. ([#925](https://gitlab.gnome.org/GNOME/aisleriot/-/issues/925))

###### gnome.five-or-more: 3.32.2 → 3.32.3

https://gitlab.gnome.org/GNOME/five-or-more/-/compare/3.32.2...3.32.3

- Fix build with latest vala ([#26](https://gitlab.gnome.org/GNOME/five-or-more/issues/26))

###### gnome.gucharmap: 14.0.2 → 14.0.3

https://gitlab.gnome.org/GNOME/gucharmap/-/compare/14.0.2...14.0.3

- Just translations

###### gnome.sushi: 41.0 → 41.1

https://gitlab.gnome.org/GNOME/sushi/-/compare/41.0...41.1

- [text: Allow right-clicks to show context menu for GtkSourceView](https://gitlab.gnome.org/GNOME/sushi/-/commit/c771ecc4bf9f25d9397b74a06af30719d5b79865)
- [html: enable web process sandbox](https://gitlab.gnome.org/GNOME/sushi/-/commit/3fcb670f738591196dc3f461999fadc4c4646c86)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
