### PR TITLE
mate: fix inactive settings and make session work without display managers

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -4,17 +4,6 @@ with lib;
 
 let
 
-  addToXDGDirs = p: ''
-    if [ -d "${p}/share/gsettings-schemas/${p.name}" ]; then
-      export XDG_DATA_DIRS=$XDG_DATA_DIRS''${XDG_DATA_DIRS:+:}${p}/share/gsettings-schemas/${p.name}
-    fi
-
-    if [ -d "${p}/lib/girepository-1.0" ]; then
-      export GI_TYPELIB_PATH=$GI_TYPELIB_PATH''${GI_TYPELIB_PATH:+:}${p}/lib/girepository-1.0
-      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}${p}/lib
-    fi
-  '';
-
   xcfg = config.services.xserver;
   cfg = xcfg.desktopManager.mate;
 
@@ -48,24 +37,8 @@ in
       pkgs.mate.mate-session-manager
     ];
 
-    services.xserver.displayManager.sessionCommands = ''
-      if test "$XDG_CURRENT_DESKTOP" = "MATE"; then
-          export XDG_MENU_PREFIX=mate-
-
-          # Let caja find extensions
-          export CAJA_EXTENSION_DIRS=$CAJA_EXTENSION_DIRS''${CAJA_EXTENSION_DIRS:+:}${config.system.path}/lib/caja/extensions-2.0
-
-          # Let caja extensions find gsettings schemas
-          ${concatMapStrings (p: ''
-          if [ -d "${p}/lib/caja/extensions-2.0" ]; then
-              ${addToXDGDirs p}
-          fi
-          '') config.environment.systemPackages}
-
-          # Add mate-control-center paths to some XDG variables because its schemas are needed by mate-settings-daemon, and mate-settings-daemon is a dependency for mate-control-center (that is, they are mutually recursive)
-          ${addToXDGDirs pkgs.mate.mate-control-center}
-      fi
-    '';
+    # Let caja find extensions
+    environment.sessionVariables.CAJA_EXTENSION_DIRS = [ "${config.system.path}/lib/caja/extensions-2.0" ];
 
     # Let mate-panel find applets
     environment.sessionVariables."MATE_PANEL_APPLETS_DIR" = "${config.system.path}/share/mate-panel/applets";
@@ -83,7 +56,6 @@ in
         pkgs.gtk3.out
         pkgs.shared-mime-info
         pkgs.xdg-user-dirs # Update user dirs as described in https://freedesktop.org/wiki/Software/xdg-user-dirs/
-        pkgs.mate.mate-settings-daemon
         pkgs.yelp # for 'Contents' in 'Help' menus
       ])
       config.environment.mate.excludePackages;

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchurl, pkg-config, gettext, gtk3, gupnp, mate, imagemagick, wrapGAppsHook, mateUpdateScript }:
+{ lib, stdenv, fetchurl, pkg-config, gettext, gtk3, gupnp, mate, imagemagick, wrapGAppsHook, mateUpdateScript
+, glib, substituteAll }:
 
 stdenv.mkDerivation rec {
   pname = "caja-extensions";
@@ -23,7 +24,22 @@ stdenv.mkDerivation rec {
     imagemagick
   ];
 
+  patches = [
+    (substituteAll {
+      src = ./hardcode-gsettings.patch;
+      CAJA_GSETTINGS_PATH = glib.getSchemaPath mate.caja;
+      TERM_GSETTINGS_PATH = glib.getSchemaPath mate.mate-terminal;
+    })
+  ];
+
   postPatch = ''
+    substituteInPlace open-terminal/caja-open-terminal.c --subst-var-by \
+      GSETTINGS_PATH ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+    substituteInPlace sendto/caja-sendto-command.c --subst-var-by \
+      GSETTINGS_PATH ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+    substituteInPlace wallpaper/caja-wallpaper-extension.c --subst-var-by \
+      GSETTINGS_PATH ${glib.makeSchemaPath "$out" "${pname}-${version}"}
+
     for f in image-converter/caja-image-{resizer,rotator}.c; do
       substituteInPlace $f --replace "/usr/bin/convert" "${imagemagick}/bin/convert"
     done

--- a/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
+++ b/pkgs/desktops/mate/caja-extensions/hardcode-gsettings.patch
@@ -1,0 +1,169 @@
+diff --git a/open-terminal/caja-open-terminal.c b/open-terminal/caja-open-terminal.c
+index e14a9bf..691afab 100644
+--- a/open-terminal/caja-open-terminal.c
++++ b/open-terminal/caja-open-terminal.c
+@@ -135,8 +135,18 @@ desktop_opens_home_dir (void)
+ {
+ 	gboolean result;
+ 	GSettings* settings;
+-
+-	settings = g_settings_new (COT_SCHEMA);
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
++
++    schema_source = g_settings_schema_source_new_from_directory("@GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             COT_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	result = g_settings_get_boolean (settings, COT_DESKTOP_KEY);
+ 	g_object_unref (settings);
+ 	return result;
+@@ -147,8 +157,18 @@ set_desktop_opens_home_dir (gboolean val)
+ {
+ 	gboolean result;
+ 	GSettings* settings;
+-
+-	settings = g_settings_new (COT_SCHEMA);
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
++
++    schema_source = g_settings_schema_source_new_from_directory("@GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             COT_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	result = g_settings_set_boolean (settings, COT_DESKTOP_KEY, val);
+ 	g_object_unref (settings);
+ 	return result;
+@@ -159,8 +179,18 @@ desktop_is_home_dir (void)
+ {
+ 	gboolean result;
+ 	GSettings* settings;
+-
+-	settings = g_settings_new (CAJA_SCHEMA);
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
++
++    schema_source = g_settings_schema_source_new_from_directory("@CAJA_GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             CAJA_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	result = g_settings_get_boolean (settings, CAJA_DESKTOP_KEY);
+ 	g_object_unref (settings);
+ 	return result;
+@@ -171,8 +201,18 @@ default_terminal_application (void)
+ {
+ 	gchar *result;
+ 	GSettings* settings;
+-
+-	settings = g_settings_new (TERM_SCHEMA);
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
++
++    schema_source = g_settings_schema_source_new_from_directory("@TERM_GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             TERM_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	result = g_settings_get_string (settings, TERM_EXEC_KEY);
+ 	g_object_unref (settings);
+ 
+@@ -189,8 +229,18 @@ set_default_terminal_application (const gchar* exec)
+ {
+ 	gboolean result;
+ 	GSettings* settings;
+-
+-	settings = g_settings_new (TERM_SCHEMA);
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
++
++    schema_source = g_settings_schema_source_new_from_directory("@TERM_GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             TERM_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	result = g_settings_set_string (settings, TERM_EXEC_KEY, exec);
+ 	g_object_unref (settings);
+ 	return result;
+diff --git a/sendto/caja-sendto-command.c b/sendto/caja-sendto-command.c
+index 8181db6..579dc81 100644
+--- a/sendto/caja-sendto-command.c
++++ b/sendto/caja-sendto-command.c
+@@ -801,6 +801,8 @@ caja_sendto_init (void)
+ int main (int argc, char **argv)
+ {
+ 	GOptionContext *context;
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
+ 	GError *error = NULL;
+ 
+ #ifdef ENABLE_NLS
+@@ -818,7 +820,15 @@ int main (int argc, char **argv)
+ 		return 1;
+ 	}
+ 
+-	settings = g_settings_new ("org.mate.Caja.Sendto");
++    schema_source = g_settings_schema_source_new_from_directory("@GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             "org.mate.Caja.Sendto",
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 	caja_sendto_init ();
+ 	if (caja_sendto_plugin_init () == FALSE) {
+ 		GtkWidget *error_dialog;
+diff --git a/wallpaper/caja-wallpaper-extension.c b/wallpaper/caja-wallpaper-extension.c
+index 3119e9f..4f80c88 100644
+--- a/wallpaper/caja-wallpaper-extension.c
++++ b/wallpaper/caja-wallpaper-extension.c
+@@ -47,6 +47,8 @@ set_wallpaper_callback (CajaMenuItem *item,
+ {
+     GList *files;
+     GSettings *settings;
++    GSettingsSchemaSource* schema_source;
++    GSettingsSchema* schema;
+     CajaFileInfo *file;
+     gchar *uri;
+     gchar *filename;
+@@ -57,7 +59,15 @@ set_wallpaper_callback (CajaMenuItem *item,
+     uri = caja_file_info_get_uri (file);
+     filename = g_filename_from_uri(uri, NULL, NULL);
+ 
+-    settings = g_settings_new (WP_SCHEMA);
++    schema_source = g_settings_schema_source_new_from_directory("@GSETTINGS_PATH@",
++                                                                g_settings_schema_source_get_default(),
++                                                                TRUE, NULL);
++    schema = g_settings_schema_source_lookup(schema_source,
++                                             WP_SCHEMA,
++                                             FALSE);
++    settings = g_settings_new_full(schema, NULL, NULL);
++    g_settings_schema_source_unref(schema_source);
++    g_settings_schema_unref(schema);
+ 
+     g_settings_set_string (settings, WP_FILE_KEY, filename);
+ 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -42,6 +42,7 @@ let
     mate-sensors-applet = callPackage ./mate-sensors-applet { };
     mate-session-manager = callPackage ./mate-session-manager { };
     mate-settings-daemon = callPackage ./mate-settings-daemon { };
+    mate-settings-daemon-wrapped = callPackage ./mate-settings-daemon/wrapped.nix { };
     mate-screensaver = callPackage ./mate-screensaver { };
     mate-system-monitor = callPackage ./mate-system-monitor { };
     mate-terminal = callPackage ./mate-terminal { };
@@ -70,6 +71,7 @@ let
       mate-polkit
       mate-session-manager
       mate-settings-daemon
+      mate-settings-daemon-wrapped
       mate-themes
     ];
 

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, pkg-config, gettext, itstool, libxml2, dbus-glib
-, libxklavier, libcanberra-gtk3, librsvg, libappindicator-gtk3
+, libxklavier, libcanberra-gtk3, librsvg, libappindicator-gtk3, glib
 , desktop-file-utils, dconf, gtk3, polkit, mate, hicolor-icon-theme, wrapGAppsHook
 , mateUpdateScript
 }:
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
     gappsWrapperArgs+=(
       # WM keyboard shortcuts
       --prefix XDG_DATA_DIRS : "${mate.marco}/share"
+      # Desktop font, works only when passed after gtk3 schemas in the wrapper for some reason
+      --prefix XDG_DATA_DIRS : "${glib.getSchemaDataDirPath mate.caja}"
     )
   '';
 

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -37,6 +37,13 @@ stdenv.mkDerivation rec {
     "INTROSPECTION_TYPELIBDIR=$(out)/lib/girepository-1.0"
   ];
 
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # Workspace switcher settings, works only when passed after gtk3 schemas in the wrapper for some reason
+      --prefix XDG_DATA_DIRS : "${glib.getSchemaDataDirPath mate.marco}"
+    )
+  '';
+
   enableParallelBuilding = true;
 
   passthru.updateScript = mateUpdateScript { inherit pname version; };

--- a/pkgs/desktops/mate/mate-settings-daemon/wrapped.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/wrapped.nix
@@ -1,0 +1,22 @@
+{ stdenv, mate, glib, wrapGAppsHook }:
+
+stdenv.mkDerivation {
+  pname = "${mate.mate-settings-daemon.pname}-wrapped";
+  version = mate.mate-settings-daemon.version;
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [ glib mate.mate-control-center ];
+  dontWrapGApps = true;
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/etc/xdg/autostart
+    cp ${mate.mate-settings-daemon}/etc/xdg/autostart/mate-settings-daemon.desktop $out/etc/xdg/autostart
+  '';
+  postFixup = ''
+    mkdir -p $out/libexec
+    makeWrapper ${mate.mate-settings-daemon}/libexec/mate-settings-daemon $out/libexec/mate-settings-daemon \
+      "''${gappsWrapperArgs[@]}"
+    substituteInPlace $out/etc/xdg/autostart/mate-settings-daemon.desktop \
+      --replace "${mate.mate-settings-daemon}/libexec/mate-settings-daemon" "$out/libexec/mate-settings-daemon"
+  '';
+  meta = mate.mate-settings-daemon.meta // { priority = -10; };
+}


### PR DESCRIPTION
###### Description of changes

This fixes multiple problems in MATE I'm aware of:
1. Inactive desktop font setting in mate-appearance-properties
2. Inactive settings in the workspace switcher applet
3. Unusable session if run without a display manager (mate-settings-daemon crashes in a cycle), fixed with a wrapped package to avoid infinite recursion (mate-control-center depends on mate-settings-daemon)
4. caja-extensions is patched to hardcode gsettings schema paths to get rid of the displayManager.sessionCommands script and make the session truly independent from display managers

An interesting thing is that just adding caja/marco to mate-control-center/mate-panel didn't work, it works only if their gsettings schema paths are specified after gtk3 ones in the wrapper and adding them to buildInputs never allows to do so.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
