### PR TITLE
haskellPackages.mkDerivation: fix pkg-config cross

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -181,7 +181,8 @@ let
   ] ++ optionals (!isHaLVM) [
     "--hsc2hs-option=--cross-compile"
     (optionalString enableHsc2hsViaAsm "--hsc2hs-option=--via-asm")
-  ];
+  ] ++ optional (allPkgconfigDepends != [])
+    "--with-pkg-config=${pkg-config.targetPrefix}pkg-config";
 
   parallelBuildingFlags = "-j$NIX_BUILD_CORES" + optionalString stdenv.isLinux " +RTS -A64M -RTS";
 


### PR DESCRIPTION
###### Description of changes

When cross compiling the pkg-config binary is prefixed and cabal
needs to be made aware of this.

Note: the `--with-pkg-config` flag can't be added unconditionally
because if the package doesn't need pkg-config (thus pkg-config
is not in the PATH) cabal consider this a hard failure.

###### Things done

- [x] Tested compilation of some libraries using `libraryPkgconfigDepends`:
  - `pkgsStatic.haskellPackages.alsa-core`
  - `pkgsStatic.haskellPackages.libffi`
  - `pkgsStatic.haskellPackages.Xauth`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).