### PR TITLE
python3.aplpy: 2.0.3 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/aplpy/default.nix
+++ b/pkgs/development/python-modules/aplpy/default.nix
@@ -11,6 +11,7 @@
 , pyregion
 , pillow
 , scikitimage
+, cython
 , shapely
 , pytest
 , pytest-astropy
@@ -18,39 +19,18 @@
 
 buildPythonPackage rec {
   pname = "aplpy";
-  version = "2.0.3";
+  version = "2.1.0";
   format = "pyproject";
 
   src = fetchPypi {
-    pname = "APLpy";
+    pname = "aplpy";
     inherit version;
-    sha256 = "239f3d83635ca4251536aeb577df7c60df77fc4d658097b92094719739aec3f3";
+    sha256 = "sha256-KCdmBwQWt7IfHsjq7pWlbSISEpfQZDyt+SQSTDaUCV4=";
   };
-
-  patches = [
-    # Fixes compatibility with astropy-helpers. This patch has been merged into
-    # the master branch as of May 2020, and should be part of the next
-    # upstream release (v2.0.3 was tagged in Feb. 2019).
-    (fetchpatch {
-      url = "https://github.com/aplpy/aplpy/pull/448.patch";
-      sha256 = "1pnzh7ykjc8hwahzbzyryrzv5a8fddgd1bmzbhagkrn6lmvhhpvq";
-      excludes = [ "tox.ini" "azure-pipelines.yml" ".circleci/config.yml" "MANIFEST.in" ".gitignore"
-       "setup.cfg" "appveyor.yml" "readthedocs.yml" "CHANGES.rst" ".gitmodules" ".travis.yml" "astropy_helpers" ];
-    })
-    # Fix for matplotlib >= 3.4 (https://github.com/aplpy/aplpy/pull/466)
-    # Note: because of a security thing, github will refuse to serve this patch from the
-    # "normal" location
-    # (https://github.com/aplpy/aplpy/commit/56c1cc694fdea69e7da8506d3212c4495adb0ca5.patch)
-    # due to the fact that it contains the PDF magic bytes, but it will serve it from
-    # this githubusercontent domain.
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/aplpy/aplpy/pull/466/commit/56c1cc694fdea69e7da8506d3212c4495adb0ca5.patch";
-      sha256 = "0jna2n1cgfzr0a27m5z94wwph7qg25hs7lycrdb2dp3943rb35g4";
-    })
-  ];
 
   propagatedBuildInputs = [
     numpy
+    cython
     astropy
     matplotlib
     reproject


### PR DESCRIPTION
###### Description of changes

aplply 2.0.3 was failing to build on master
bumping version and removing patches ( that failed to apply ) at least fixes build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
