### PR TITLE
config.allowAliases: Define as option

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/default.nix
+++ b/pkgs/applications/editors/kakoune/plugins/default.nix
@@ -18,7 +18,7 @@ let
     inherit buildKakounePluginFrom2Nix;
   };
 
-  aliases = lib.optionalAttrs (config.allowAliases or true) (import ./aliases.nix lib plugins);
+  aliases = lib.optionalAttrs config.allowAliases (import ./aliases.nix lib plugins);
 
 in
 

--- a/pkgs/applications/editors/vim/plugins/default.nix
+++ b/pkgs/applications/editors/vim/plugins/default.nix
@@ -35,7 +35,7 @@ let
     inherit llvmPackages luaPackages;
   };
 
-  aliases = if (config.allowAliases or true) then (import ./aliases.nix lib) else final: prev: {};
+  aliases = if config.allowAliases then (import ./aliases.nix lib) else final: prev: {};
 
   extensible-self = lib.makeExtensible
     (extends aliases

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2329,7 +2329,7 @@ let
   # then apply extension specific modifcations to packages.
 
   # overlays will be applied left to right, overrides should come after aliases.
-  overlays = lib.optionals (config.allowAliases or true) [ aliases ];
+  overlays = lib.optionals config.allowAliases [ aliases ];
 
   toFix = lib.foldl' (lib.flip lib.extends) baseExtensions overlays;
 in

--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -68,7 +68,7 @@ let
       archived = date: throw "the provider has been archived by upstream on ${date}";
       removed = date: throw "removed from nixpkgs on ${date}";
     in
-    lib.optionalAttrs (config.allowAliases or false) {
+    lib.optionalAttrs config.allowAliases {
       arukas = archived "2022/01";
       chef = archived "2022/01";
       cherryservers = archived "2022/01";

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -1,7 +1,7 @@
 { pkgs, config, buildPackages, lib, stdenv, libiconv, mkNugetDeps, mkNugetSource, gawk, gnused, gixy }:
 
 let
-  aliases = if (config.allowAliases or true) then (import ./aliases.nix lib) else prev: {};
+  aliases = if config.allowAliases then (import ./aliases.nix lib) else prev: {};
 
   writers = with lib; rec {
   # Base implementation for non-compiled executables.

--- a/pkgs/desktops/gnome-2/default.nix
+++ b/pkgs/desktops/gnome-2/default.nix
@@ -62,7 +62,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     autoreconfHook = pkgs.autoreconfHook269;
   };
 
-} // lib.optionalAttrs (config.allowAliases or true) {
+} // lib.optionalAttrs config.allowAliases {
   inherit (pkgs)
     # GTK Libs
     glib glibmm atk atkmm cairo pango pangomm gdk_pixbuf gtkmm2 libcanberra-gtk2

--- a/pkgs/desktops/gnome/default.nix
+++ b/pkgs/desktops/gnome/default.nix
@@ -276,7 +276,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   gnome-autoar = callPackage ./misc/gnome-autoar { };
 
   gnome-packagekit = callPackage ./misc/gnome-packagekit { };
-}) // lib.optionalAttrs (config.allowAliases or true) {
+}) // lib.optionalAttrs config.allowAliases {
 #### Legacy aliases. They need to be outside the scope or they will shadow the attributes from parent scope.
 
   gnome-desktop = pkgs.gnome-desktop; # added 2022-03-16

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -69,7 +69,7 @@ in rec {
     (lib.attrValues)
     (mapReadableNames)
     # Add some aliases
-    (extensions: extensions // lib.optionalAttrs (config.allowAliases or true) {
+    (extensions: extensions // lib.optionalAttrs config.allowAliases {
       unite-shell = gnomeExtensions.unite; # added 2021-01-19
       arc-menu = gnomeExtensions.arcmenu; # added 2021-02-14
       disable-unredirect = gnomeExtensions.disable-unredirect-fullscreen-windows; # added 2021-11-20

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -226,7 +226,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   # Please call these packages in pkgs/top-level/all-packages.nix instead of this file.
   # https://github.com/NixOS/nixpkgs/issues/115222#issuecomment-906868654
 
-}) // lib.optionalAttrs (config.allowAliases or true) {
+}) // lib.optionalAttrs config.allowAliases {
 
   ### ALIASES
 

--- a/pkgs/desktops/plasma-5/default.nix
+++ b/pkgs/desktops/plasma-5/default.nix
@@ -166,7 +166,7 @@ let
         parachute = callPackage ./3rdparty/kwin/scripts/parachute.nix { };
       };
 
-    } // lib.optionalAttrs (config.allowAliases or true) {
+    } // lib.optionalAttrs config.allowAliases {
       ksysguard = throw "ksysguard has been replaced with plasma-systemmonitor";
       plasma-phone-components = throw "'plasma-phone-components' has been renamed to/replaced by 'plasma-mobile'";
     };

--- a/pkgs/desktops/xfce/default.nix
+++ b/pkgs/desktops/xfce/default.nix
@@ -156,7 +156,7 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   xfce4-pulseaudio-plugin = callPackage ./panel-plugins/xfce4-pulseaudio-plugin { };
 
-} // lib.optionalAttrs (config.allowAliases or true) {
+} // lib.optionalAttrs config.allowAliases {
   #### ALIASES - added 2018-01
 
   terminal = xfce4-terminal;

--- a/pkgs/development/idris-modules/default.nix
+++ b/pkgs/development/idris-modules/default.nix
@@ -205,7 +205,7 @@
 
     yampa = callPackage ./yampa.nix {};
 
-  } // builtins_ // pkgs.lib.optionalAttrs (config.allowAliases or true) {
+  } // builtins_ // pkgs.lib.optionalAttrs config.allowAliases {
     # removed packages
     protobuf = throw "idrisPackages.protobuf has been removed: abandoned by upstream"; # Added 2022-02-06
   };

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -75,7 +75,7 @@ with pkgs;
           optionalExtensions = cond: as: if cond then as else [];
           python2Extension = import ../../../top-level/python2-packages.nix;
           extensions = lib.composeManyExtensions ((optionalExtensions (!self.isPy3k) [python2Extension]) ++ [ overrides ]);
-          aliases = self: super: lib.optionalAttrs (config.allowAliases or true) (import ../../../top-level/python-aliases.nix lib self super);
+          aliases = self: super: lib.optionalAttrs config.allowAliases (import ../../../top-level/python-aliases.nix lib self super);
         in lib.makeScopeWithSplicing
           pkgs.splicePackages
           pkgs.newScope

--- a/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
+++ b/pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {}
 , nodejs ? pkgs.nodejs
 , yarn ? pkgs.yarn
-, allowAliases ? pkgs.config.allowAliases or true
+, allowAliases ? pkgs.config.allowAliases
 }:
 
 let

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -32,6 +32,24 @@ let
       feature = "run <literal>checkPhase</literal> by default";
     };
 
+    allowAliases = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to expose old attribute names for compatibility.
+
+        The recommended setting is to enable this, as it
+        improves backward compatibity, easing updates.
+
+        The only reason to disable aliases is for continuous
+        integration purposes. For instance, Nixpkgs should
+        not depend on aliases in its internal code. Projects
+        that aren't Nixpkgs should be cautious of instantly
+        removing all usages of aliases, as migrating too soon
+        can break compatibility with the stable Nixpkgs releases.
+      '';
+    };
+
   };
 
 in {

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -153,7 +153,7 @@ let self = rec {
   trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
 
   trakt = callPackage ../applications/video/kodi/addons/trakt { };
-}; in self // lib.optionalAttrs (config.allowAliases or true) {
+}; in self // lib.optionalAttrs config.allowAliases {
   # deprecated or renamed packages
 
   controllers = throw "kodi.packages.controllers has been replaced with kodi.packages.controller-topology-project - a package which contains a large number of controller profiles." { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -476,7 +476,7 @@ in {
 
     can-isotp = callPackage ../os-specific/linux/can-isotp { };
 
-  } // lib.optionalAttrs (config.allowAliases or false) {
+  } // lib.optionalAttrs config.allowAliases {
     ati_drivers_x11 = throw "ati drivers are no longer supported by any kernel >=4.1"; # added 2021-05-18;
   });
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25392,7 +25392,7 @@ let
     };
   };
 
-} // lib.optionalAttrs (config.allowAliases or true) {
+} // lib.optionalAttrs config.allowAliases {
   autodie = null; # part of Perl
   AutoLoader = null; # part of Perl 5.22
   constant = null; # part of Perl 5.22

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -152,7 +152,7 @@ let
       res self super;
     in res;
 
-  aliases = self: super: lib.optionalAttrs (config.allowAliases or true) (import ./aliases.nix lib self super);
+  aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);
 
   # stdenvOverrides is used to avoid having multiple of versions
   # of certain dependencies that were used in bootstrapping the


### PR DESCRIPTION

###### Motivation and description

This simplifies usages and makes the default value consistent.

In a few cases, the default value was interpreted to be `false`,
but this is useless, because virtually nobody will explicitly
set `allowAliases = true;`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
