### PR TITLE
hp-uld: init at 1.00.39.12_00.15

### DIFF
--- a/pkgs/misc/cups/drivers/hp-uld/default.nix
+++ b/pkgs/misc/cups/drivers/hp-uld/default.nix
@@ -1,0 +1,96 @@
+{ lib, stdenv, fetchurl, cups, libusb-compat-0_1, libxml2 }:
+
+let
+arch = if stdenv.hostPlatform.system == "x86_64-linux"
+  then "x86_64"
+  else "i386";
+in stdenv.mkDerivation rec {
+  pname = "hp-uld";
+  version = "1.00.39.12_00.15";
+
+  src = fetchurl {
+    sha256 = "sha256-zrube2El50BmNLucKpiwFHfR4R1mx8kEdGad6ZJ7yR0=";
+    url = "https://ftp.hp.com/pub/softlib/software13/printers/CLP150/uld-hp_V${version}.tar.gz";
+  };
+
+  buildInputs = [
+    cups
+    libusb-compat-0_1
+    libxml2
+  ];
+
+  installPhase = ''
+
+    mkdir -p $out/bin
+    cp -R ${arch}/{gettext,pstosecps,rastertospl,smfpnetdiscovery,usbresetter} $out/bin
+
+    mkdir -p $out/etc/sane.d/dll.d/
+    install -m644 noarch/etc/smfp.conf $out/etc/sane.d
+    echo smfp >> $out/etc/sane.d/dll.d/smfp-scanner.conf
+
+    mkdir -p $out/lib
+    install -m755 ${arch}/libscmssc.so* $out/lib
+
+    mkdir -p $out/lib/cups/backend
+    ln -s $out/bin/smfpnetdiscovery $out/lib/cups/backend
+
+    mkdir -p $out/lib/cups/filter
+    ln -s $out/bin/{pstosecps,rastertospl} $out/lib/cups/filter
+    ln -s $ghostscript/bin/gs $out/lib/cups/filter
+
+    mkdir -p $out/lib/sane
+    install -m755 ${arch}/libsane-smfp.so* $out/lib/sane
+    ln -s libsane-smfp.so.1.0.1 $out/lib/sane/libsane-smfp.so.1
+    ln -s libsane-smfp.so.1     $out/lib/sane/libsane-smfp.so
+
+    mkdir -p $out/lib/udev/rules.d
+    (
+      OEM_FILE=noarch/oem.conf
+      INSTALL_LOG_FILE=/dev/null
+      . noarch/scripting_utils
+      . noarch/package_utils
+      . noarch/scanner-script.pkg
+      fill_full_template noarch/etc/smfp.rules.in $out/lib/udev/rules.d/60_smfp_samsung.rules
+      chmod -x $out/lib/udev/rules.d/60_smfp_samsung.rules
+    )
+
+    mkdir -p $out/share
+    cp -R noarch/share/* $out/share
+    gzip -9 $out/share/ppd/*.ppd
+    rm -r $out/share/locale/*/*/install.mo
+
+    mkdir -p $out/share/cups
+    cd $out/share/cups
+    ln -s ../ppd .
+    ln -s ppd model
+  '';
+
+  preFixup = ''
+    for bin in "$out/bin/"*; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$bin"
+      patchelf --set-rpath "$out/lib:${lib.getLib cups}/lib" "$bin"
+    done
+
+    patchelf --set-rpath "$out/lib:${lib.getLib cups}/lib" "$out/lib/libscmssc.so"
+    patchelf --set-rpath "$out/lib:${libxml2.out}/lib:${libusb-compat-0_1.out}/lib" "$out/lib/sane/libsane-smfp.so.1.0.1"
+
+    ln -s ${stdenv.cc.cc.lib}/lib/libstdc++.so.6 $out/lib/
+  '';
+
+  # all binaries are already stripped
+  dontStrip = true;
+
+  # we did this in prefixup already
+  dontPatchELF = true;
+
+  meta = with lib; {
+    description = "HP Unified Linux Driver";
+    homepage = "https://support.hp.com/us-en/drivers";
+    downloadPage = "https://support.hp.com/us-en/drivers/selfservice/swdetails/hp-laser-100-printer-series/24494339/model/24494342/swItemId/ly-227001-2";
+    license = licenses.unfree;
+
+    # Tested on linux-x86_64. Might work on linux-i386.
+    # Probably won't work on anything else.
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34169,6 +34169,8 @@ with pkgs;
 
   hll2390dw-cups = callPackage ../misc/cups/drivers/hll2390dw-cups { };
 
+  hp-uld = callPackage ../misc/cups/drivers/hp-uld { };
+
   mfcj470dw-cupswrapper = callPackage ../misc/cups/drivers/mfcj470dwcupswrapper { };
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 


### PR DESCRIPTION
###### Description of changes

Adds CUPS and sane drivers for the following products:

* HP Color Laser 15x Series
* HP Color Laser MFP 17x Series
* HP LaserJet MFP M433
* HP LaserJet MFP M436
* HP LaserJet MFP M72625 72630
* HP Laser10x Series
* HP Laser MFP 13x Series

The driver structure is identical to the `samsung-unified-linux-driver` package but with different product support. Samsung sold their driver architecture to HP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
