### PR TITLE
glsl-language-server: init at 0.3.7

### DIFF
--- a/pkgs/development/tools/glsl-language-server/default.nix
+++ b/pkgs/development/tools/glsl-language-server/default.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, cmake, ninja, cli11, fmt, nlohmann_json, glslang
+, python3 }:
+
+let
+  cesanta_mongoose_6 = rec {
+    pname = "cesanta-mongoose";
+    version = "6.18";
+
+    src = fetchFromGitHub {
+      owner = "cesanta";
+      repo = "mongoose";
+      rev = version;
+      sha256 = "sha256-7r8/Z27sfs6gHTHYLoGvdNU/zG9LeLDLjyiSfPaF9VI=";
+    };
+  };
+in stdenv.mkDerivation rec {
+  pname = "glsl-language-server";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "svenstaro";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-6gXHkCHulPydxQYMCx28HaZfkha36IwfOBuAfMLCW9c=";
+  };
+
+  nativeBuildInputs = [ cmake ninja python3 ];
+
+  preConfigure = ''
+    mkdir -p externals
+    ln -s ${cli11} externals/CLI11
+    ln -s ${fmt.src} externals/fmt
+    ln -s ${nlohmann_json.src} externals/json
+    ln -s ${glslang.src} externals/glslang
+    ln -s ${cesanta_mongoose_6.src} externals/mongoose
+  '';
+
+  meta = with lib; {
+    description = "Language server implementation for GLSL";
+    homepage = "https://github.com/svenstaro/glsl-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ felschr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12714,6 +12714,8 @@ with pkgs;
 
   glslang = callPackage ../development/compilers/glslang { };
 
+  glsl-language-server = callPackage ../development/tools/glsl-language-server { };
+
   go_1_16 = callPackage ../development/compilers/go/1.16.nix ({
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   } // lib.optionalAttrs (stdenv.cc.isGNU && stdenv.isAarch64) {


### PR DESCRIPTION
###### Description of changes
Add `glsl-language-server`, a language server for the OpenGL Shading Language.

It's building & running already, but it's using libraries from its git submodule folder. I'd like to make it get these libraries from nixpkgs & add the missing ones (`mongoose`).
But if it's alright, we can also merge this PR in its current state, and I'll open a new PR to improve the dependency handling.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
