### PR TITLE
nodePackages.postcss-cli: fix execution of binary

### DIFF
--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -343,6 +343,7 @@ let
         wrapProgram "$out/bin/postcss" \
           --prefix NODE_PATH : ${self.postcss}/lib/node_modules \
           --prefix NODE_PATH : ${self.autoprefixer}/lib/node_modules
+        ln -s '${self.postcss}/lib/node_modules/postcss' "$out/lib/node_modules/postcss"
       '';
       passthru.tests = {
         simple-execution = pkgs.callPackage ./package-tests/postcss-cli.nix {

--- a/pkgs/development/node-packages/default.nix
+++ b/pkgs/development/node-packages/default.nix
@@ -349,7 +349,10 @@ let
           inherit (self) postcss-cli;
         };
       };
-      meta.mainProgram = "postcss";
+      meta = {
+        mainProgram = "postcss";
+        maintainers = with lib.maintainers; [ Luflosi ];
+      };
     };
 
     prisma = super.prisma.override rec {


### PR DESCRIPTION
###### Description of changes
Without this change, executing the postcss binary results in the following error:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'postcss'

Thanks to https://github.com/NixOS/nixpkgs/issues/145618#issuecomment-1051347961 I finally managed to fix this. For some reason `wrapProgram` is still needed though.
The test currently doesn't pass with or without the changes in this PR. I'll fix it some other time

Fixes https://github.com/NixOS/nixpkgs/issues/145618.
Also add myself as a maintainer.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).