### PR TITLE
Space cadet pinball: fix non-darwin builds

### DIFF
--- a/pkgs/games/space-cadet-pinball/default.nix
+++ b/pkgs/games/space-cadet-pinball/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchzip
-, cmake, SDL2, SDL2_mixer
+, cmake, SDL2, SDL2_mixer, Cocoa
 , unrar-wrapper, makeWrapper
 , fetchpatch
 }:
@@ -38,7 +38,16 @@ stdenv.mkDerivation rec {
     SDL2_mixer
     cmake
     makeWrapper
-  ];
+  ] ++ lib.optional stdenv.isDarwin Cocoa;
+
+  # Darwin needs a custom installphase since it is excluded from the cmake install
+  # https://github.com/k4zmu2a/SpaceCadetPinball/blob/0f88e43ba261bc21fa5c3ef9d44969a2a079d0de/CMakeLists.txt#L221
+  installPhase = lib.optionalString stdenv.isDarwin ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install ../bin/SpaceCadetPinball $out/bin
+    runHook postInstall
+  '';
 
   postInstall = ''
     mkdir -p $out/lib/SpaceCadetPinball
@@ -57,5 +66,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ unfree mit ];
     maintainers = [ maintainers.hqurve ];
     platforms = platforms.all;
+    mainProgram = "SpaceCadetPinball";
   };
 }

--- a/pkgs/games/space-cadet-pinball/default.nix
+++ b/pkgs/games/space-cadet-pinball/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, fetchzip
-, cmake, SDL2, SDL2_mixer, Cocoa
+, cmake, SDL2, SDL2_mixer
 , unrar-wrapper, makeWrapper
 , fetchpatch
 }:
@@ -38,21 +38,15 @@ stdenv.mkDerivation rec {
     SDL2_mixer
     cmake
     makeWrapper
-    Cocoa
   ];
 
-  preBuild = ''
+  postInstall = ''
     mkdir -p $out/lib/SpaceCadetPinball
-    mkdir -p $out/bin
-  '';
-
-  installPhase = ''
     install ${assets}/*.{DAT,DOC,MID,BMP,INF} ${assets}/Sounds/*.WAV $out/lib/SpaceCadetPinball
 
     # Assets are loaded from the directory of the program is stored in
     # https://github.com/k4zmu2a/SpaceCadetPinball/blob/de13d4e326b2dfa8e6dfb59815c0a8b9657f942d/SpaceCadetPinball/winmain.cpp#L119
-    cp ../bin/SpaceCadetPinball $out/bin
-    cp $out/bin/SpaceCadetPinball $out/lib/SpaceCadetPinball
+    mv $out/bin/SpaceCadetPinball $out/lib/SpaceCadetPinball
     makeWrapper $out/lib/SpaceCadetPinball/SpaceCadetPinball $out/bin/SpaceCadetPinball
   '';
 
@@ -63,6 +57,5 @@ stdenv.mkDerivation rec {
     license = with licenses; [ unfree mit ];
     maintainers = [ maintainers.hqurve ];
     platforms = platforms.all;
-    mainProgram = "SpaceCadetPinball";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31682,7 +31682,9 @@ with pkgs;
 
   rrootage = callPackage ../games/rrootage { };
 
-  space-cadet-pinball = callPackage ../games/space-cadet-pinball { };
+  space-cadet-pinball = callPackage ../games/space-cadet-pinball {
+    inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
 
   starsector = callPackage ../games/starsector {
     openjdk = openjdk8;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31682,9 +31682,7 @@ with pkgs;
 
   rrootage = callPackage ../games/rrootage { };
 
-  space-cadet-pinball = callPackage ../games/space-cadet-pinball {
-    inherit (darwin.apple_sdk.frameworks) Cocoa;
-  };
+  space-cadet-pinball = callPackage ../games/space-cadet-pinball { };
 
   starsector = callPackage ../games/starsector {
     openjdk = openjdk8;


### PR DESCRIPTION
###### Description of changes

Refactor changes made in https://github.com/NixOS/nixpkgs/pull/166506 to be compatible with non-darwin systems.

The custom installPhase works on linux and hence I expect it to also work on darwin. This custom installphase is needed since the darwin is specifically excluded from the cmakeLists install https://github.com/k4zmu2a/SpaceCadetPinball/blob/0f88e43ba261bc21fa5c3ef9d44969a2a079d0de/CMakeLists.txt#L221
However, I believe we should keep the install phase which uses cmake since it also installs icons and desktop files which are useful for linux users.

Also, I'm unsure if to squash both commits into one.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
