### PR TITLE
openconnect-sso: Init at 4430cb09ae

### DIFF
--- a/pkgs/tools/networking/openconnect-sso/default.nix
+++ b/pkgs/tools/networking/openconnect-sso/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, openconnect
+, python3
+, python3Packages
+, poetry2nix
+, substituteAll
+, qt5
+}@attrs:
+
+let
+  src = builtins.fetchGit {
+      url = "https://github.com/vlaci/openconnect-sso";
+      ref = "master";
+      rev = "4430cb09aefe15108e5f3b40b94ed792fbe9548b";
+  };
+
+  input = builtins.removeAttrs (attrs // { wrapQtAppsHook = qt5.wrapQtAppsHook; }) [ "qt5" ];
+in
+  import (src + /nix/openconnect-sso.nix) input
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10974,6 +10974,8 @@ with pkgs;
     openssl = null;
   };
 
+  openconnect-sso = callPackage ../tools/networking/openconnect-sso { };
+
   globalprotect-openconnect = libsForQt5.callPackage ../tools/networking/globalprotect-openconnect { };
 
   ding-libs = callPackage ../tools/misc/ding-libs { };


### PR DESCRIPTION
###### Description of changes

This adds [openconnect-sso](https://github.com/vlaci/openconnect-sso).

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).