### PR TITLE
nixos/prowlarr: add a module similar to sonarr/radarr/lidarr

### DIFF
--- a/nixos/modules/services/misc/prowlarr.nix
+++ b/nixos/modules/services/misc/prowlarr.nix
@@ -11,15 +11,37 @@ in
     services.prowlarr = {
       enable = mkEnableOption "Prowlarr";
 
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/prowlarr";
+        description = "The directory where Prowlarr stores its data files.";
+      };
+
       openFirewall = mkOption {
         type = types.bool;
         default = false;
         description = "Open ports in the firewall for the Prowlarr web interface.";
       };
+
+      user = mkOption {
+        type = types.str;
+        default = "prowlarr";
+        description = "User account under which Prowlarr runs.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "prowlarr";
+        description = "Group under which Prowlarr runs.";
+      };
     };
   };
 
   config = mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
+    ];
+
     systemd.services.prowlarr = {
       description = "Prowlarr";
       after = [ "network.target" ];
@@ -27,15 +49,29 @@ in
 
       serviceConfig = {
         Type = "simple";
-        DynamicUser = true;
-        StateDirectory = "prowlarr";
-        ExecStart = "${pkgs.prowlarr}/bin/Prowlarr -nobrowser -data=/var/lib/prowlarr";
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = "${pkgs.prowlarr}/bin/Prowlarr -nobrowser -data=${cfg.dataDir}";
         Restart = "on-failure";
       };
     };
 
     networking.firewall = mkIf cfg.openFirewall {
       allowedTCPPorts = [ 9696 ];
+    };
+
+    users.users = mkIf (cfg.user == "prowlarr") {
+      prowlarr = {
+        group = cfg.group;
+        home = "/var/lib/prowlarr";
+        uid = config.ids.uids.prowlarr;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "prowlarr") {
+      prowlarr = {
+        gid = config.ids.gids.prowlarr;
+      };
     };
   };
 }


### PR DESCRIPTION
###### Description of changes

I have added more options to the prowlarr package which is pretty much similar to the other modules from the *rr universe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
