### PR TITLE
lxd: Add VMs support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5853,6 +5853,12 @@
     githubId = 1550265;
     name = "Dominic Steinitz";
   };
+  ifd3f = {
+    name = "Astrid Yu";
+    email = "astrid@astrid.tech";
+    github = "ifd3f";
+    githubId = 7308591;
+  };
   ifurther = {
     email = "55025025+ifurther@users.noreply.github.com";
     github = "ifurther";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -350,6 +350,7 @@ in {
   loki = handleTest ./loki.nix {};
   lvm2 = handleTest ./lvm2 {};
   lxd = handleTest ./lxd.nix {};
+  lxd-qemu = handleTest ./lxd-qemu.nix {};
   lxd-nftables = handleTest ./lxd-nftables.nix {};
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};

--- a/nixos/tests/lxd-nftables.nix
+++ b/nixos/tests/lxd-nftables.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   name = "lxd-nftables";
 
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ patryk27 ];
+    maintainers = [ patryk27 ifd3f ];
   };
 
   nodes.machine = { lib, ... }: {

--- a/nixos/tests/lxd-qemu.nix
+++ b/nixos/tests/lxd-qemu.nix
@@ -1,3 +1,8 @@
+# This tests LXD with useQemu enabled.
+# For now, it tests the same functionality, just with the modified package
+# to ensure nothing broke.
+# Eventually, we will test for VM capabilities.
+
 import ./make-test-python.nix ({ pkgs, lib, ... } :
 
 let
@@ -21,7 +26,7 @@ in {
     maintainers = [ patryk27 ifd3f ];
   };
 
-  nodes.machine = { lib, ... }: {
+  nodes.machine = { pkgs, lib, ... }: {
     virtualisation = {
       diskSize = 4096;
 
@@ -34,7 +39,6 @@ in {
 
       lxc.lxcfs.enable = true;
       lxd.enable = true;
-      lxd.package = pkgs.lxd.override { useQemu = false; };
     };
   };
 

--- a/pkgs/tools/admin/lxd/default.nix
+++ b/pkgs/tools/admin/lxd/default.nix
@@ -1,39 +1,11 @@
-{ lib
-, hwdata
-, pkg-config
-, lxc
-, buildGoModule
-, fetchurl
-, makeWrapper
-, acl
-, rsync
-, gnutar
-, xz
-, btrfs-progs
-, gzip
-, dnsmasq
-, attr
-, squashfsTools
-, iproute2
-, iptables
-, libcap
-, dqlite
-, raft-canonical
-, sqlite-replication
-, udev
-, writeShellScriptBin
-, apparmor-profiles
-, apparmor-parser
-, criu
-, bash
-, installShellFiles
-, nixosTests
-}:
-
-buildGoModule rec {
-  pname = "lxd";
+{ lib, hwdata, pkg-config, lxc, buildGoModule, fetchurl, makeWrapper, acl, rsync
+, gnutar, xz, btrfs-progs, gzip, dnsmasq, attr, squashfsTools, iproute2
+, iptables, libcap, dqlite, raft-canonical, sqlite-replication, udev
+, writeShellScriptBin, apparmor-profiles, apparmor-parser, criu, bash
+, callPackage, installShellFiles, linkFarm, qemu_kvm, qemu-utils, OVMFFull
+, nixosTests, useQemu ? true }:
+let
   version = "5.8";
-
   src = fetchurl {
     urls = [
       "https://linuxcontainers.org/downloads/lxd/lxd-${version}.tar.gz"
@@ -41,6 +13,47 @@ buildGoModule rec {
     ];
     sha256 = "sha256-mYyDYO8k4MVoNa8xfp1vH2nyuhNsDJ93s9F5hjaMftk=";
   };
+
+  binPath = [
+    acl
+    attr
+    bash
+    btrfs-progs
+    criu
+    dnsmasq
+    gnutar
+    gzip
+    iproute2
+    iptables
+    rsync
+    squashfsTools
+    xz
+
+    (writeShellScriptBin "apparmor_parser" ''
+      exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"
+    '')
+  ] ++ (lib.optionals useQemu [ qemu-utils qemu_kvm ]);
+
+  firmware = linkFarm "lxd-firmware" [
+    {
+      name = "share/OVMF/OVMF_CODE.fd";
+      path = "${OVMFFull.fd}/FV/OVMF_CODE.fd";
+    }
+    {
+      name = "share/OVMF/OVMF_VARS.fd";
+      path = "${OVMFFull.fd}/FV/OVMF_VARS.fd";
+    }
+    {
+      name = "share/OVMF/OVMF_VARS.ms.fd";
+      path = "${OVMFFull.fd}/FV/OVMF_VARS.fd";
+    }
+  ];
+
+  LXD_OVMF_PATH = "${firmware}/share/OVMF";
+
+in buildGoModule rec {
+  pname = "lxd";
+  inherit src version;
 
   vendorSha256 = null;
 
@@ -70,41 +83,39 @@ buildGoModule rec {
     export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
   '';
 
-  preCheck =
-    let skippedTests = [
+  preCheck = let
+    skippedTests = [
       "TestValidateConfig"
       "TestConvertNetworkConfig"
       "TestConvertStorageConfig"
       "TestSnapshotCommon"
       "TestContainerTestSuite"
-    ]; in
-    ''
-      # Disable tests requiring local operations
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    ];
+  in ''
+    # Disable tests requiring local operations
+    buildFlagsArray+=("-run" "[^(${
+      builtins.concatStringsSep "|" skippedTests
+    })]")
+  '';
 
   postInstall = ''
-    wrapProgram $out/bin/lxd --prefix PATH : ${lib.makeBinPath (
-      [ iptables ]
-      ++ [ acl rsync gnutar xz btrfs-progs gzip dnsmasq squashfsTools iproute2 bash criu attr ]
-      ++ [ (writeShellScriptBin "apparmor_parser" ''
-             exec '${apparmor-parser}/bin/apparmor_parser' -I '${apparmor-profiles}/etc/apparmor.d' "$@"
-           '') ]
-      )
+    wrapProgram $out/bin/lxd --prefix PATH : ${lib.makeBinPath binPath} ${
+      lib.optionalString useQemu " --set LXD_OVMF_PATH ${LXD_OVMF_PATH}"
     }
 
     installShellCompletion --bash --name lxd ./scripts/bash/lxd-client
   '';
 
-  passthru.tests.lxd = nixosTests.lxd;
-  passthru.tests.lxd-nftables = nixosTests.lxd-nftables;
+  passthru.tests = {
+    inherit (nixosTests) lxd lxd-nftables lxd-qemu;
+  };
 
   meta = with lib; {
     description = "Daemon based on liblxc offering a REST API to manage containers";
     homepage = "https://linuxcontainers.org/lxd/";
     changelog = "https://github.com/lxc/lxd/releases/tag/lxd-${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ marsam ];
+    maintainers = with maintainers; [ marsam ifd3f ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

This PR updates the changes made in #105651 by about 12 months. 

Original description:
> LXD has support for virtual machines, but this support isn't present in nixpkgs.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [x] NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### More info about testing

I ran the NixOS tests and they passed successfully.

This PR does not currently include automated tests for VMs, but I did perform manual tests. After building, I ran `sudo result/bin/lxd`, then used the `lxc` CLI to successfully launch a Fedora VM. I was additionally able to interact with `lxd-agent` and run bash inside the VM.

<details>
  <summary>Shell output</summary>

```
$ sudo lxc launch images:fedora/35/cloud testvm -s data -n br0 --vm
Creating testvm
Starting testvm

$ sudo lxc exec testvm bash
[root@testvm ~]#

$ sudo lxc info testvm
Name: testvm
Status: RUNNING
Type: virtual-machine
Architecture: x86_64
PID: 2467145
Created: 2022/04/01 11:57 PDT
Last Used: 2022/04/01 11:57 PDT

Resources:
  Processes: 18
  Disk usage:
    root: 11.55MiB
  CPU usage:
    CPU usage (in seconds): 0
  Network usage:
    enp5s0:
      Type: broadcast
      State: UP
      Host interface: tap9048ab67
      MAC address: 00:16:3e:42:a2:25
      MTU: 1500
      Bytes received: 2.27kB
      Bytes sent: 3.12kB
      Packets received: 14
      Packets sent: 25
      IP addresses:
        inet:  192.168.1.219/24 (global)
        inet6: fd73:e7aa:784e::20e/128 (global)
        inet6: fd73:e7aa:784e:0:216:3eff:fe42:a225/64 (global)
        inet6: fe80::216:3eff:fe42:a225/64 (link)
    lo:
      Type: loopback
      State: UP
      MTU: 65536
      Bytes received: 0B
      Bytes sent: 0B
      Packets received: 0
      Packets sent: 0
      IP addresses:
        inet:  127.0.0.1/8 (local)
        inet6: ::1/128 (local)
```

</details>

EDIT: I have verified that it works seamlessly on NixOS if you override the package as follows.

```nix
{
  virtualisation = {
    lxd = {
      enable = true;
      package = pkgs.lxd.override { useQemu = true; };
      recommendedSysctlSettings = true;
    };
  };
  boot.kernelModules = [ "vhost_vsock" ];
}
```