### PR TITLE
treewide: add meta.mainProgram to many packages

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -142,6 +142,7 @@ stdenv.mkDerivation rec {
       gpl3Plus
     ] ++ lib.optional enableVST2 unfree;
     maintainers = with maintainers; [ astro tobiasBora OPNA2608 ];
+    mainProgram = "BespokeSynth";
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/audio/spotify-tui/default.nix
+++ b/pkgs/applications/audio/spotify-tui/default.nix
@@ -31,5 +31,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/Rigellute/spotify-tui/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ jwijenbergh ];
+    mainProgram = "spt";
   };
 }

--- a/pkgs/applications/emulators/proton-caller/default.nix
+++ b/pkgs/applications/emulators/proton-caller/default.nix
@@ -19,5 +19,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/caverym/proton-caller";
     license = licenses.mit;
     maintainers = with maintainers; [ kho-dialga ];
+    mainProgram = "proton-call";
   };
 }

--- a/pkgs/applications/misc/autospotting/default.nix
+++ b/pkgs/applications/misc/autospotting/default.nix
@@ -22,6 +22,7 @@ buildGoPackage {
     description = "Automatically convert your existing AutoScaling groups to up to 90% cheaper spot instances with minimal configuration changes";
     license = licenses.free;
     maintainers = [ maintainers.costrouc ];
+    mainProgram = "AutoSpotting";
     platforms = platforms.unix;
   };
 

--- a/pkgs/applications/misc/catclock/default.nix
+++ b/pkgs/applications/misc/catclock/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation {
     homepage = "http://codefromabove.com/2014/05/catclock/";
     license = with licenses; mit;
     maintainers = with maintainers; [ ramkromberg ];
+    mainProgram = "xclock";
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/globe-cli/default.nix
+++ b/pkgs/applications/misc/globe-cli/default.nix
@@ -16,5 +16,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/adamsky/globe";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ devhell ];
+    mainProgram = "globe";
   };
 }

--- a/pkgs/applications/misc/rm-improved/default.nix
+++ b/pkgs/applications/misc/rm-improved/default.nix
@@ -19,6 +19,7 @@ rustPlatform.buildRustPackage rec {
     description = "Replacement for rm with focus on safety, ergonomics and performance";
     homepage = "https://github.com/nivekuil/rip";
     maintainers = with maintainers; [ nils-degroot ];
+    mainProgram = "rip";
     license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/applications/misc/terminal-typeracer/default.nix
+++ b/pkgs/applications/misc/terminal-typeracer/default.nix
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://gitlab.com/ttyperacer/terminal-typeracer";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ yoctocell ];
+    mainProgram = "typeracer";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "https://timewarrior.net";
     license = licenses.mit;
     maintainers = with maintainers; [ matthiasbeyer mrVanDalo ];
+    mainProgram = "timew";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/tty-solitaire/default.nix
+++ b/pkgs/applications/misc/tty-solitaire/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/mpereira/tty-solitaire";
     platforms = ncurses.meta.platforms;
     maintainers = [ maintainers.AndersonTorres ];
+    mainProgram = "ttysolitaire";
   };
 }

--- a/pkgs/applications/networking/browsers/links2/default.nix
+++ b/pkgs/applications/networking/browsers/links2/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "http://links.twibright.com/";
     description = "A small browser with some graphics support";
     maintainers = with maintainers; [ raskin ];
+    mainProgram = "links";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/applications/networking/cluster/cloudfoundry-cli/default.nix
+++ b/pkgs/applications/networking/cluster/cloudfoundry-cli/default.nix
@@ -39,6 +39,7 @@ buildGoModule rec {
     description = "The official command line client for Cloud Foundry";
     homepage = "https://github.com/cloudfoundry/cli";
     maintainers = with maintainers; [ ris ];
+    mainProgram = "cf";
     license = licenses.asl20;
   };
 }

--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -50,6 +50,7 @@ buildGoModule rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ kuznero jlesquembre ngerstle jk ricochet ];
+    mainProgram = "k3d";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/networking/cluster/kuttl/default.nix
+++ b/pkgs/applications/networking/cluster/kuttl/default.nix
@@ -26,5 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/kudobuilder/kuttl";
     license = licenses.asl20;
     maintainers = with maintainers; [ diegolelis ];
+    mainProgram = "kubectl-kuttl";
   };
 }

--- a/pkgs/applications/networking/cluster/pachyderm/default.nix
+++ b/pkgs/applications/networking/cluster/pachyderm/default.nix
@@ -20,5 +20,6 @@ buildGoPackage rec {
     homepage = "https://github.com/pachyderm/pachyderm";
     license = licenses.asl20;
     maintainers = with maintainers; [offline];
+    mainProgram = "pachctl";
   };
 }

--- a/pkgs/applications/networking/cluster/pgo-client/default.nix
+++ b/pkgs/applications/networking/cluster/pgo-client/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     changelog = "https://github.com/CrunchyData/postgres-operator/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = [ maintainers.bryanasdev000 ];
+    mainProgram = "pgo";
   };
 }

--- a/pkgs/applications/networking/cluster/tanka/default.nix
+++ b/pkgs/applications/networking/cluster/tanka/default.nix
@@ -31,6 +31,7 @@ buildGoModule rec {
     homepage = "https://tanka.dev";
     license = licenses.asl20;
     maintainers = with maintainers; [ mikefaille ];
+    mainProgram = "tk";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
+++ b/pkgs/applications/networking/cluster/tektoncd-cli/default.nix
@@ -61,5 +61,6 @@ buildGoModule rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ jk mstrangfeld vdemeester ];
+    mainProgram = "tkn";
   };
 }

--- a/pkgs/applications/networking/pjsip/default.nix
+++ b/pkgs/applications/networking/pjsip/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     homepage = "https://pjsip.org/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ olynch ];
+    mainProgram = "pjsua";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/networking/seaweedfs/default.nix
+++ b/pkgs/applications/networking/seaweedfs/default.nix
@@ -27,6 +27,7 @@ buildGoModule rec {
     description = "Simple and highly scalable distributed file system";
     homepage = "https://github.com/chrislusf/seaweedfs";
     maintainers = with maintainers; [ cmacrae raboof ];
+    mainProgram = "weed";
     license = licenses.asl20;
   };
 }

--- a/pkgs/applications/radio/flex-ncat/default.nix
+++ b/pkgs/applications/radio/flex-ncat/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     description = "FlexRadio remote control (CAT) via hamlib/rigctl protocol";
     license = licenses.mit;
     maintainers = with maintainers; [ mvs ];
+    mainProgram = "nCAT";
   };
 }

--- a/pkgs/applications/radio/rtl-ais/default.nix
+++ b/pkgs/applications/radio/rtl-ais/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/dgiardini/rtl-ais";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ mgdm ];
+    mainProgram = "rtl_ais";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
+++ b/pkgs/applications/science/astronomy/astrolabe-generator/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     description = "A Java-based tool for generating EPS files for constructing astrolabes and related tools";
     license = licenses.gpl3;
     maintainers = [ ];
+    mainProgram = "AstrolabeGenerator";
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/science/biology/bayescan/default.nix
+++ b/pkgs/applications/science/biology/bayescan/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "http://cmpg.unibe.ch/software/BayeScan";
     license = licenses.gpl3;
     maintainers = [ maintainers.bzizou ];
+    mainProgram = "bayescan_${version}";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/applications/science/biology/clustal-omega/default.nix
+++ b/pkgs/applications/science/biology/clustal-omega/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.clustal.org/omega/";
     license = licenses.gpl2;
     maintainers = [ maintainers.bzizou ];
+    mainProgram = "clustalo";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/science/biology/picard-tools/default.nix
+++ b/pkgs/applications/science/biology/picard-tools/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     homepage = "https://broadinstitute.github.io/picard/";
     maintainers = with maintainers; [ jbedo ];
+    mainProgram = "picard";
     platforms = platforms.all;
   };
 }

--- a/pkgs/applications/science/logic/symbiyosys/default.nix
+++ b/pkgs/applications/science/logic/symbiyosys/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation {
     homepage    = "https://symbiyosys.readthedocs.io/";
     license     = lib.licenses.isc;
     maintainers = with lib.maintainers; [ thoughtpolice emily ];
+    mainProgram = "sby";
     platforms   = lib.platforms.all;
   };
 }

--- a/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
@@ -50,5 +50,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/finalfusion/finalfusion-utils/";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
+    mainProgram = "finalfusion";
   };
 }

--- a/pkgs/applications/version-management/commit-formatter/default.nix
+++ b/pkgs/applications/version-management/commit-formatter/default.nix
@@ -18,5 +18,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Eliot00/commit-formatter";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ elliot ];
+    mainProgram = "git-cf";
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bfg-repo-cleaner/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3;
     maintainers = [ maintainers.changlinli ];
+    mainProgram = "bfg";
     platforms = platforms.unix;
     downloadPage = "https://mvnrepository.com/artifact/com.madgag/bfg/${version}";
   };

--- a/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/bitbucket-server-cli/default.nix
@@ -16,6 +16,7 @@ bundlerEnv rec {
     homepage    = "https://bitbucket.org/atlassian/bitbucket-server-cli";
     license     = licenses.mit;
     maintainers = with maintainers; [ jgertm nicknovitski ];
+    mainProgram = "stash";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-annex-utils/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     homepage = "http://git-annex.mysteryvortex.com/git-annex-utils.html";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ woffs ];
+    mainProgram = "gadu";
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-interactive-rebase-tool/default.nix
@@ -39,5 +39,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/MitMaro/git-interactive-rebase-tool/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ masaeedu SuperSandro2000 zowoq ];
+    mainProgram = "interactive-rebase-tool";
   };
 }

--- a/pkgs/applications/version-management/jujutsu/default.nix
+++ b/pkgs/applications/version-management/jujutsu/default.nix
@@ -56,5 +56,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/martinvonz/jj/blob/v${version}/CHANGELOG.md";
     license = licenses.asl20;
     maintainers = with maintainers; [ _0x4A6F ];
+    mainProgram = "jj";
   };
 }

--- a/pkgs/applications/virtualization/ecs-agent/default.nix
+++ b/pkgs/applications/virtualization/ecs-agent/default.nix
@@ -20,6 +20,7 @@ buildGoPackage rec {
     license     = licenses.asl20;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ copumpkin ];
+    mainProgram = "agent";
   };
 }
 

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -51,5 +51,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = teams.freedesktop.members ++ [ maintainers.mimame ];
+    mainProgram = "update-mime-database";
   };
 }

--- a/pkgs/development/beam-modules/elvis-erlang/default.nix
+++ b/pkgs/development/beam-modules/elvis-erlang/default.nix
@@ -42,5 +42,6 @@ in rebar3Relx rec {
     platforms = platforms.unix;
     license = licenses.asl20;
     maintainers = with lib.maintainers; [ dlesl ];
+    mainProgram = "elvis";
   };
 }

--- a/pkgs/development/compilers/algol68g/default.nix
+++ b/pkgs/development/compilers/algol68g/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "a68g";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/interpreters/duktape/default.nix
+++ b/pkgs/development/interpreters/duktape/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
     downloadPage = "https://duktape.org/download.html";
     license = licenses.mit;
     maintainers = [ maintainers.fgaz ];
+    mainProgram = "duk";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/interpreters/lolcode/default.nix
+++ b/pkgs/development/interpreters/lolcode/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl3;
     maintainers = [ maintainers.AndersonTorres ];
+    mainProgram = "lolcode-lci";
     platforms = lib.platforms.unix;
   };
 

--- a/pkgs/development/interpreters/trealla/default.nix
+++ b/pkgs/development/interpreters/trealla/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/infradig/trealla";
     license = licenses.mit;
     maintainers = with maintainers; [ siraben ];
+    mainProgram = "tpl";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/interpreters/yex-lang/default.nix
+++ b/pkgs/development/interpreters/yex-lang/default.nix
@@ -18,6 +18,7 @@ rustPlatform.buildRustPackage rec {
     description = "A cool functional scripting language written in rust";
     license = licenses.mit;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "yex";
     platforms = platforms.unix;
     broken = stdenv.isAarch64 && stdenv.isLinux;
   };

--- a/pkgs/development/nim-packages/tempfile/default.nix
+++ b/pkgs/development/nim-packages/tempfile/default.nix
@@ -15,5 +15,6 @@ buildNimPackage rec {
       description = "Temporary files and folders";
       license = [ lib.licenses.mit ];
       maintainers = [ maintainers.ehmry ];
+      mainProgram = "tempfile_seeder";
     };
 }

--- a/pkgs/development/python-modules/flatbuffers/default.nix
+++ b/pkgs/development/python-modules/flatbuffers/default.nix
@@ -17,5 +17,6 @@ buildPythonPackage rec {
   meta = flatbuffers.meta // {
     description = "Python runtime library for use with the Flatbuffers serialization format";
     maintainers = with lib.maintainers; [ wulfsta ];
+    mainProgram = "flatc";
   };
 }

--- a/pkgs/development/tools/bazel-gazelle/default.nix
+++ b/pkgs/development/tools/bazel-gazelle/default.nix
@@ -29,5 +29,6 @@ buildGoModule rec {
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "gazelle";
   };
 }

--- a/pkgs/development/tools/bazel-kazel/default.nix
+++ b/pkgs/development/tools/bazel-kazel/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     homepage = "https://github.com/kubernetes/repo-infra";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "kazel";
   };
 }

--- a/pkgs/development/tools/build-managers/build2/default.nix
+++ b/pkgs/development/tools/build-managers/build2/default.nix
@@ -94,5 +94,6 @@ stdenv.mkDerivation rec {
     changelog = "https://git.build2.org/cgit/build2/tree/NEWS";
     platforms = platforms.all;
     maintainers = with maintainers; [ hiro98 r-burns ];
+    mainProgram = "b";
   };
 }

--- a/pkgs/development/tools/build-managers/go-mk/default.nix
+++ b/pkgs/development/tools/build-managers/go-mk/default.nix
@@ -26,6 +26,7 @@ buildGoPackage rec {
     '';
     license = licenses.bsd2;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "mk";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -21,5 +21,6 @@ buildRustPackage rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = [lib.maintainers.nthorne];
+    mainProgram = "clog";
   };
 }

--- a/pkgs/development/tools/compile-daemon/default.nix
+++ b/pkgs/development/tools/compile-daemon/default.nix
@@ -20,6 +20,7 @@ buildGoPackage rec {
     description = "Very simple compile daemon for Go";
     license = licenses.bsd2;
     maintainers = with maintainers; [ ];
+    mainProgram = "CompileDaemon";
     inherit (src.meta) homepage;
   };
 }

--- a/pkgs/development/tools/continuous-integration/buildkite-cli/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-cli/default.nix
@@ -24,5 +24,6 @@ buildGoModule rec {
     homepage = "https://github.com/buildkite/cli";
     license = licenses.mit;
     maintainers = with maintainers; [ groodt ];
+    mainProgram = "bk";
   };
 }

--- a/pkgs/development/tools/database/pg_checksums/default.nix
+++ b/pkgs/development/tools/database/pg_checksums/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     description = "Activate/deactivate/verify checksums in offline PostgreSQL clusters";
     homepage = "https://github.com/credativ/pg_checksums";
     maintainers = [ maintainers.marsam ];
+    mainProgram = "pg_checksums_ext";
     platforms = postgresql.meta.platforms;
     license = licenses.postgresql;
   };

--- a/pkgs/development/tools/database/termdbms/default.nix
+++ b/pkgs/development/tools/database/termdbms/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     description = "A TUI for viewing and editing database files";
     license = licenses.mit;
     maintainers = with maintainers; [ izorkin ];
+    mainProgram = "sqlite3-viewer";
   };
 }

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/martinpaljak/GlobalPlatformPro";
     license = with licenses; [ lgpl3 ];
     maintainers = with maintainers; [ ekleog ];
+    mainProgram = "gp";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/go-minimock/default.nix
+++ b/pkgs/development/tools/go-minimock/default.nix
@@ -26,5 +26,6 @@ buildGoModule rec {
     description = "A golang mock generator from interfaces";
     license = licenses.mit;
     maintainers = with maintainers; [ svrana ];
+    mainProgram = "minimock";
   };
 }

--- a/pkgs/development/tools/go-mockery/default.nix
+++ b/pkgs/development/tools/go-mockery/default.nix
@@ -17,6 +17,7 @@ buildGoModule rec {
     homepage = "https://github.com/vektra/mockery";
     description = "A mock code autogenerator for Golang";
     maintainers = with maintainers; [ fbrs ];
+    mainProgram = "mockery";
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/tools/go-swagger/default.nix
+++ b/pkgs/development/tools/go-swagger/default.nix
@@ -24,5 +24,6 @@ buildGoModule rec {
     homepage = "https://github.com/go-swagger/go-swagger";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "swagger";
   };
 }

--- a/pkgs/development/tools/hjson-go/default.nix
+++ b/pkgs/development/tools/hjson-go/default.nix
@@ -17,6 +17,7 @@ buildGoPackage rec {
     src.meta // {
       description = "Utility to convert JSON to and from HJSON";
       maintainers = with maintainers; [ ehmry ];
+      mainProgram = "hjson-cli";
       license = licenses.mit;
     };
 }

--- a/pkgs/development/tools/jsonnet-bundler/default.nix
+++ b/pkgs/development/tools/jsonnet-bundler/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     homepage = "https://github.com/jsonnet-bundler/jsonnet-bundler";
     license = licenses.asl20;
     maintainers = with maintainers; [ preisschild ];
+    mainProgram = "jb";
   };
 }

--- a/pkgs/development/tools/metal-cli/default.nix
+++ b/pkgs/development/tools/metal-cli/default.nix
@@ -24,5 +24,6 @@ buildGoModule rec {
     homepage = "https://github.com/equinix/metal-cli/";
     license = licenses.mit;
     maintainers = with maintainers; [ Br1ght0ne nshalman ];
+    mainProgram = "metal";
   };
 }

--- a/pkgs/development/tools/misc/go-license-detector/default.nix
+++ b/pkgs/development/tools/misc/go-license-detector/default.nix
@@ -20,5 +20,6 @@ buildGoModule rec {
     homepage = "https://github.com/src-d/go-license-detector";
     license = licenses.asl20;
     maintainers = with maintainers; [ dtzWill ];
+    mainProgram = "license-detector";
   };
 }

--- a/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
+++ b/pkgs/development/tools/misc/nxpmicro-mfgtools/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/NXPmicro/mfgtools";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bmilanov jraygauthier ];
+    mainProgram = "uuu";
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/misc/semver-tool/default.nix
+++ b/pkgs/development/tools/misc/semver-tool/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ maintainers.qyliss ];
+    mainProgram = "semver";
   };
 }

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -70,5 +70,6 @@ stdenv.mkDerivation rec {
     license = licenses.zlib;
     platforms = platforms.unix;
     maintainers = with maintainers; [ pombeirp ];
+    mainProgram = "makensis";
   };
 }

--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -106,6 +106,7 @@ in stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.mit;
     maintainers = with maintainers; [ tesq0 ericdallo corngood ];
+    mainProgram = "omnisharp";
   };
 
 }

--- a/pkgs/development/tools/packet-sd/default.nix
+++ b/pkgs/development/tools/packet-sd/default.nix
@@ -20,5 +20,6 @@ buildGoModule rec {
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ ];
+    mainProgram = "prometheus-packet-sd";
   };
 }

--- a/pkgs/development/tools/quicktemplate/default.nix
+++ b/pkgs/development/tools/quicktemplate/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     description = "Fast, powerful, yet easy to use template engine for Go";
     license = licenses.mit;
     maintainers = with maintainers; [ chiiruno ];
+    mainProgram = "qtc";
   };
 }

--- a/pkgs/development/tools/rust/duckscript/default.nix
+++ b/pkgs/development/tools/rust/duckscript/default.nix
@@ -32,5 +32,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/sagiegurari/duckscript";
     license = licenses.asl20;
     maintainers = with maintainers; [ mkg20001 ];
+    mainProgram = "duck";
   };
 }

--- a/pkgs/development/tools/toluapp/default.nix
+++ b/pkgs/development/tools/toluapp/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
     homepage = "http://www.codenix.com/~tolua/";
     license = licenses.mit;
     maintainers = with maintainers; [ vrthra ];
+    mainProgram = "tolua++";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/development/tools/udis86/default.nix
+++ b/pkgs/development/tools/udis86/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     homepage = "http://udis86.sourceforge.net";
     license = licenses.bsd2;
     maintainers = with maintainers; [ timor ];
+    mainProgram = "udcli";
     description = ''
       Easy-to-use, minimalistic x86 disassembler library (libudis86)
     '';

--- a/pkgs/development/web/kcgi/default.nix
+++ b/pkgs/development/web/kcgi/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     platforms = platforms.all;
     maintainers = [ maintainers.leenaars ];
+    mainProgram = "kfcgi";
   };
 }

--- a/pkgs/games/liberal-crime-squad/default.nix
+++ b/pkgs/games/liberal-crime-squad/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://github.com/Kamal-Sadek/Liberal-Crime-Squad";
     maintainers = [ maintainers.rardiol ];
+    mainProgram = "crimesquad";
     license = licenses.gpl2;
     platforms = platforms.all;
   };

--- a/pkgs/games/papermc/default.nix
+++ b/pkgs/games/papermc/default.nix
@@ -32,5 +32,6 @@ in stdenv.mkDerivation {
     license     = lib.licenses.gpl3Only;
     platforms   = lib.platforms.unix;
     maintainers = with lib.maintainers; [ aaronjanse neonfuz ];
+    mainProgram = "minecraft-server";
   };
 }

--- a/pkgs/games/purpur/default.nix
+++ b/pkgs/games/purpur/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ jyooru ];
+    mainProgram = "minecraft-server";
   };
 }

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -94,5 +94,6 @@ stdenv.mkDerivation rec {
 
     platforms = platforms.unix;
     maintainers = with maintainers; [ mikroskeem m3tti ];
+    mainProgram = "quake";
   };
 }

--- a/pkgs/games/tintin/default.nix
+++ b/pkgs/games/tintin/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     homepage    = "http://tintin.sourceforge.net";
     license     = licenses.gpl2;
     maintainers = with maintainers; [ lovek323 ];
+    mainProgram = "tt++";
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/misc/lguf-brightness/default.nix
+++ b/pkgs/misc/lguf-brightness/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/periklis/lguf-brightness";
     license = licenses.lgpl21Plus;
     maintainers = with maintainers; [ periklis ];
+    mainProgram = "lguf_brightness";
     platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/misc/scimark/default.nix
+++ b/pkgs/misc/scimark/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     description = "Scientific and numerical computing benchmark (ANSI C version)";
     license = licenses.publicDomain;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "scimark4";
     platforms = platforms.all;
   };
 }

--- a/pkgs/os-specific/darwin/kwm/default.nix
+++ b/pkgs/os-specific/darwin/kwm/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     downloadPage = "https://github.com/koekeishiya/kwm/releases";
     platforms = platforms.darwin;
     maintainers = with maintainers; [ lnl7 ];
+    mainProgram = "kwmc";
     license = licenses.mit;
   };
 }

--- a/pkgs/os-specific/linux/pam_u2f/default.nix
+++ b/pkgs/os-specific/linux/pam_u2f/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ philandstuff ];
+    mainProgram = "pamu2fcfg";
   };
 }

--- a/pkgs/servers/documize-community/default.nix
+++ b/pkgs/servers/documize-community/default.nix
@@ -34,6 +34,7 @@ buildGoModule rec {
     description = "Open source Confluence alternative for internal & external docs built with Golang + EmberJS";
     license = licenses.agpl3;
     maintainers = with maintainers; [ ma27 elseym ];
+    mainProgram = "documize";
     homepage = "https://www.documize.com/";
   };
 }

--- a/pkgs/servers/http/micro-httpd/default.nix
+++ b/pkgs/servers/http/micro-httpd/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
     license     = licenses.bsd2;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ copumpkin ];
+    mainProgram = "micro_httpd";
   };
 }
 

--- a/pkgs/servers/http/webfs/default.nix
+++ b/pkgs/servers/http/webfs/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     license     = licenses.gpl2;
     platforms   = platforms.all;
     maintainers = with maintainers; [ zimbatm ];
+    mainProgram = "webfsd";
   };
 }

--- a/pkgs/servers/irker/default.nix
+++ b/pkgs/servers/irker/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
     homepage = "https://gitlab.com/esr/irker";
     license = licenses.bsd2;
     maintainers = with maintainers; [ dtzWill ];
+    mainProgram = "irkerd";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/kapowbang/default.nix
+++ b/pkgs/servers/kapowbang/default.nix
@@ -22,5 +22,6 @@ buildGoModule rec {
     description = "Expose command-line tools over HTTP";
     license = licenses.asl20;
     maintainers = with maintainers; [ nilp0inter ];
+    mainProgram = "kapow";
   };
 }

--- a/pkgs/servers/mail/clamsmtp/default.nix
+++ b/pkgs/servers/mail/clamsmtp/default.nix
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     homepage = "http://thewalter.net/stef/software/clamsmtp/";
     license = licenses.bsd3;
     maintainers = [ maintainers.ekleog ];
+    mainProgram = "clamsmtpd";
     platforms = platforms.all;
   };
 }

--- a/pkgs/servers/mail/system-sendmail/default.nix
+++ b/pkgs/servers/mail/system-sendmail/default.nix
@@ -35,5 +35,6 @@ stdenv.mkDerivation {
     '';
     platforms = platforms.unix;
     maintainers = with maintainers; [ ekleog ];
+    mainProgram = "sendmail";
   };
 }

--- a/pkgs/servers/matrix-corporal/default.nix
+++ b/pkgs/servers/matrix-corporal/default.nix
@@ -21,6 +21,7 @@ buildGoModule rec {
     homepage = "https://github.com/devture/matrix-corporal";
     description = "Reconciliator and gateway for a managed Matrix server";
     maintainers = with maintainers; [ dandellion ];
+    mainProgram = "devture-matrix-corporal";
     license = licenses.agpl3Only;
   };
 }

--- a/pkgs/servers/monitoring/zipkin/default.nix
+++ b/pkgs/servers/monitoring/zipkin/default.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = [ maintainers.hectorj ];
+    mainProgram = "zipkin-server";
   };
 }

--- a/pkgs/servers/ps3netsrv/default.nix
+++ b/pkgs/servers/ps3netsrv/default.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ makefu ];
+    mainProgram = "ps3netsrv++";
   };
 }

--- a/pkgs/servers/trezord/default.nix
+++ b/pkgs/servers/trezord/default.nix
@@ -27,6 +27,7 @@ buildGoModule rec {
     homepage = "https://trezor.io";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ canndrew jb55 prusnak mmahut _1000101 ];
+    mainProgram = "trezord-go";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/udpt/default.nix
+++ b/pkgs/servers/udpt/default.nix
@@ -23,5 +23,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ makefu ];
+    mainProgram = "udpt-rs";
   };
 }

--- a/pkgs/shells/fish/oh-my-fish/default.nix
+++ b/pkgs/shells/fish/oh-my-fish/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     maintainers = with maintainers; [ AndersonTorres ];
+    mainProgram = "omf-install";
     platforms = fish.meta.platforms;
   };
 }

--- a/pkgs/shells/powershell/default.nix
+++ b/pkgs/shells/powershell/default.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation rec {
     description = "Powerful cross-platform (Windows, Linux, and macOS) shell and scripting language based on .NET";
     homepage = "https://github.com/PowerShell/PowerShell";
     maintainers = with maintainers; [ yrashk srgom p3psi ];
+    mainProgram = "pwsh";
     platforms = [ "x86_64-darwin" "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
     license = with licenses; [ mit ];
   };

--- a/pkgs/tools/X11/runningx/default.nix
+++ b/pkgs/tools/X11/runningx/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation {
     license = lib.licenses.free;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.romildo ];
+    mainProgram = "RunningX";
   };
 }

--- a/pkgs/tools/X11/screen-message/default.nix
+++ b/pkgs/tools/X11/screen-message/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     description = "Displays a short text fullscreen in an X11 window";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.fpletz ];
+    mainProgram = "sm";
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/tools/X11/xmagnify/default.nix
+++ b/pkgs/tools/X11/xmagnify/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.com/amiloradovsky/magnify";
     license = licenses.mit;  # or GPL2+, optionally
     maintainers = with maintainers; [ amiloradovsky ];
+    mainProgram = "magnify";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/admin/aliyun-cli/default.nix
+++ b/pkgs/tools/admin/aliyun-cli/default.nix
@@ -28,5 +28,6 @@ buildGoModule rec {
     changelog = "https://github.com/aliyun/aliyun-cli/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ ornxka ];
+    mainProgram = "aliyun";
   };
 }

--- a/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
+++ b/pkgs/tools/admin/amazon-ecr-credential-helper/default.nix
@@ -18,6 +18,7 @@ buildGoPackage rec {
     homepage = "https://github.com/awslabs/amazon-ecr-credential-helper";
     license = licenses.asl20;
     maintainers = with maintainers; [ kalbasit ];
+    mainProgram = "docker-credential-ecr-login";
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/tools/admin/exoscale-cli/default.nix
+++ b/pkgs/tools/admin/exoscale-cli/default.nix
@@ -29,5 +29,6 @@ buildGoPackage rec {
     homepage    = "https://github.com/exoscale/cli";
     license     = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dramaturg ];
+    mainProgram = "exo";
   };
 }

--- a/pkgs/tools/admin/trinsic-cli/default.nix
+++ b/pkgs/tools/admin/trinsic-cli/default.nix
@@ -22,5 +22,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://trinsic.id/";
     license = licenses.asl20;
     maintainers = with maintainers; [ tmarkovski ];
+    mainProgram = "trinsic";
   };
 }

--- a/pkgs/tools/backup/zfsbackup/default.nix
+++ b/pkgs/tools/backup/zfsbackup/default.nix
@@ -21,5 +21,6 @@ buildGoPackage rec {
     homepage = "https://github.com/someone1/zfsbackup-go";
     license = licenses.mit;
     maintainers = [ maintainers.xfix ];
+    mainProgram = "zfsbackup-go";
   };
 }

--- a/pkgs/tools/compression/gzrt/default.nix
+++ b/pkgs/tools/compression/gzrt/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.urbanophile.com/arenn/hacking/gzrt/";
     description = "The gzip Recovery Toolkit";
     maintainers = with maintainers; [ ];
+    mainProgram = "gzrecover";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };

--- a/pkgs/tools/compression/lhasa/default.nix
+++ b/pkgs/tools/compression/lhasa/default.nix
@@ -19,6 +19,7 @@ stdenv.mkDerivation rec {
     license = licenses.isc;
     homepage = "http://fragglet.github.io/lhasa";
     maintainers = [ maintainers.sander ];
+    mainProgram = "lha";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/cpcsdk/idsk" ;
     license = licenses.mit;
     maintainers = [ ];
+    mainProgram = "iDSK";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/graphics/imageworsener/default.nix
+++ b/pkgs/tools/graphics/imageworsener/default.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/jsummers/${pname}/blob/${version}/changelog.txt";
     license = licenses.mit;
     maintainers = with maintainers; [ emily smitop ];
+    mainProgram = "imagew";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/asdf-vm/default.nix
+++ b/pkgs/tools/misc/asdf-vm/default.nix
@@ -80,6 +80,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://asdf-vm.com/";
     license = licenses.mit;
     maintainers = [ maintainers.c4605 ];
+    mainProgram = "asdf";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/gotify-cli/default.nix
+++ b/pkgs/tools/misc/gotify-cli/default.nix
@@ -26,5 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/gotify/cli";
     description = "A command line interface for pushing messages to gotify/server";
     maintainers = with maintainers; [ ma27 ];
+    mainProgram = "gotify";
   };
 }

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rschmitt/heatseeker";
     license = licenses.mit;
     maintainers = [ maintainers.michaelpj ];
+    mainProgram = "hs";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/hiksink/default.nix
+++ b/pkgs/tools/misc/hiksink/default.nix
@@ -35,5 +35,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/CornerBit/HikSink";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "hik_sink";
   };
 }

--- a/pkgs/tools/misc/intermodal/default.nix
+++ b/pkgs/tools/misc/intermodal/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/casey/intermodal";
     license = licenses.cc0;
     maintainers = with maintainers; [ Br1ght0ne ];
+    mainProgram = "imdl";
   };
 }

--- a/pkgs/tools/misc/lokalise2-cli/default.nix
+++ b/pkgs/tools/misc/lokalise2-cli/default.nix
@@ -24,6 +24,7 @@ buildGoModule rec {
     homepage = "https://lokalise.com";
     license = licenses.bsd3;
     maintainers = with maintainers; [ timstott ];
+    mainProgram = "lokalise2";
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/oppai-ng/default.nix
+++ b/pkgs/tools/misc/oppai-ng/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Francesco149/oppai-ng";
     license = licenses.unlicense;
     maintainers = with maintainers; [ tadeokondrak ];
+    mainProgram = "oppai";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/unclutter-xfixes/default.nix
+++ b/pkgs/tools/misc/unclutter-xfixes/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = lib.licenses.mit;
     maintainers = [ maintainers.globin ];
+    mainProgram = "unclutter";
   };
 }

--- a/pkgs/tools/networking/changetower/default.nix
+++ b/pkgs/tools/networking/changetower/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/Dc4ts/ChangeTower";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "ChangeTower";
   };
 }

--- a/pkgs/tools/networking/dnscrypt-proxy2/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy2/default.nix
@@ -21,6 +21,7 @@ buildGoModule rec {
     license = licenses.isc;
     homepage = "https://dnscrypt.info/";
     maintainers = with maintainers; [ atemu waynr ];
+    mainProgram = "dnscrypt-proxy";
     platforms = with platforms; unix;
   };
 }

--- a/pkgs/tools/networking/minio-client/default.nix
+++ b/pkgs/tools/networking/minio-client/default.nix
@@ -30,6 +30,7 @@ buildGoModule rec {
     homepage = "https://github.com/minio/mc";
     description = "A replacement for ls, cp, mkdir, diff and rsync commands for filesystems and object storage";
     maintainers = with maintainers; [ bachp eelco ];
+    mainProgram = "mc";
     platforms = platforms.unix;
     license = licenses.asl20;
   };

--- a/pkgs/tools/networking/rustcat/default.nix
+++ b/pkgs/tools/networking/rustcat/default.nix
@@ -25,5 +25,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/robiot/rustcat";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
+    mainProgram = "rcat";
   };
 }

--- a/pkgs/tools/networking/s3gof3r/default.nix
+++ b/pkgs/tools/networking/s3gof3r/default.nix
@@ -19,6 +19,7 @@ buildGoPackage rec {
     description = "Fast, concurrent, streaming access to Amazon S3, including gof3r, a CLI";
     homepage = "https://pkg.go.dev/github.com/rlmcpherson/s3gof3r";
     maintainers = with maintainers; [ ];
+    mainProgram = "gof3r";
     license = licenses.mit;
   };
 }

--- a/pkgs/tools/networking/shadowfox/default.nix
+++ b/pkgs/tools/networking/shadowfox/default.nix
@@ -27,5 +27,6 @@ buildGoModule rec {
     homepage = "https://overdodactyl.github.io/ShadowFox/";
     license = licenses.mit;
     maintainers = with maintainers; [ infinisil ];
+    mainProgram = "shadowfox-updater";
   };
 }

--- a/pkgs/tools/networking/shadowsocks-v2ray-plugin/default.nix
+++ b/pkgs/tools/networking/shadowsocks-v2ray-plugin/default.nix
@@ -18,6 +18,7 @@ buildGoModule rec {
     homepage = "https://github.com/shadowsocks/v2ray-plugin/";
     license = licenses.mit;
     maintainers = [ maintainers.ahrzb ];
+    mainProgram = "v2ray-plugin";
   };
 }
 

--- a/pkgs/tools/networking/tdns-cli/default.nix
+++ b/pkgs/tools/networking/tdns-cli/default.nix
@@ -18,5 +18,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rotty/tdns-cli";
     license = licenses.gpl3;
     maintainers = with maintainers; [ astro ];
+    mainProgram = "tdns";
   };
 }

--- a/pkgs/tools/networking/telepresence2/default.nix
+++ b/pkgs/tools/networking/telepresence2/default.nix
@@ -34,5 +34,6 @@ buildGoModule rec {
     homepage = "https://www.getambassador.io/docs/telepresence/2.1/quick-start/";
     license = licenses.asl20;
     maintainers = with maintainers; [ mausch ];
+    mainProgram = "telepresence";
   };
 }

--- a/pkgs/tools/networking/webwormhole/default.nix
+++ b/pkgs/tools/networking/webwormhole/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     homepage = "https://github.com/saljam/webwormhole";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bbigras ];
+    mainProgram = "ww";
   };
 }

--- a/pkgs/tools/networking/wg-friendly-peer-names/default.nix
+++ b/pkgs/tools/networking/wg-friendly-peer-names/default.nix
@@ -25,5 +25,6 @@ stdenv.mkDerivation {
     license = licenses.mit;
     platforms = wireguard-tools.meta.platforms;
     maintainers = with maintainers; [ mkg20001 ];
+    mainProgram = "wgg";
   };
 }

--- a/pkgs/tools/security/fulcio/default.nix
+++ b/pkgs/tools/security/fulcio/default.nix
@@ -68,5 +68,6 @@ buildGoModule rec {
     description = "A Root-CA for code signing certs - issuing certificates based on an OIDC email address";
     license = licenses.asl20;
     maintainers = with maintainers; [ lesuisse jk ];
+    mainProgram = "fulcio-server";
   };
 }

--- a/pkgs/tools/security/go365/default.nix
+++ b/pkgs/tools/security/go365/default.nix
@@ -26,5 +26,6 @@ buildGoModule rec {
     homepage = "https://github.com/optiv/Go365";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "Go365";
   };
 }

--- a/pkgs/tools/security/gosh/default.nix
+++ b/pkgs/tools/security/gosh/default.nix
@@ -25,5 +25,6 @@ buildGoModule rec {
     homepage = "https://github.com/redcode-labs/GoSH";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ] ++ teams.redcodelabs.members;
+    mainProgram = "GoSH";
   };
 }

--- a/pkgs/tools/security/jwt-cli/default.nix
+++ b/pkgs/tools/security/jwt-cli/default.nix
@@ -27,5 +27,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/mike-engel/jwt-cli";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ rycee ];
+    mainProgram = "jwt";
   };
 }

--- a/pkgs/tools/security/minio-certgen/default.nix
+++ b/pkgs/tools/security/minio-certgen/default.nix
@@ -18,5 +18,6 @@ buildGoModule rec {
     downloadPage = "https://github.com/minio/certgen";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bryanasdev000 ];
+    mainProgram = "certgen";
   };
 }

--- a/pkgs/tools/security/phrasendrescher/default.nix
+++ b/pkgs/tools/security/phrasendrescher/default.nix
@@ -24,5 +24,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.all;
     maintainers = with maintainers; [ bjornfor ];
+    mainProgram = "pd";
   };
 }

--- a/pkgs/tools/security/sheesy-cli/default.nix
+++ b/pkgs/tools/security/sheesy-cli/default.nix
@@ -37,5 +37,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/share-secrets-safely/cli/releases/tag/${version}";
     license = with licenses; [ lgpl21Only ];
     maintainers = with maintainers; [ devhell ];
+    mainProgram = "sy";
   };
 }

--- a/pkgs/tools/security/snowcrash/default.nix
+++ b/pkgs/tools/security/snowcrash/default.nix
@@ -28,5 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/redcode-labs/SNOWCRASH";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ fab ] ++ teams.redcodelabs.members;
+    mainProgram = "SNOWCRASH";
   };
 }

--- a/pkgs/tools/security/solo2-cli/default.nix
+++ b/pkgs/tools/security/solo2-cli/default.nix
@@ -45,5 +45,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/solokeys/solo2-cli";
     license = with licenses; [ asl20 mit ]; # either at your option
     maintainers = with maintainers; [ lukegb ];
+    mainProgram = "solo2";
   };
 }

--- a/pkgs/tools/system/natscli/default.nix
+++ b/pkgs/tools/system/natscli/default.nix
@@ -21,5 +21,6 @@ buildGoModule rec {
     homepage = "https://github.com/nats-io/natscli";
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ fab ];
+    mainProgram = "nats";
   };
 }

--- a/pkgs/tools/system/plan9port/default.nix
+++ b/pkgs/tools/system/plan9port/default.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation {
       ftrvxmtrx
       kovirobi
     ];
+    mainProgram = "9";
     platforms = platforms.unix;
     # TODO: revisit this when the sdk situation on x86_64-darwin changes
     broken = stdenv.isDarwin && stdenv.isx86_64;

--- a/pkgs/tools/system/tre-command/default.nix
+++ b/pkgs/tools/system/tre-command/default.nix
@@ -24,5 +24,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dduan/tre";
     license = licenses.mit;
     maintainers = [ maintainers.dduan ];
+    mainProgram = "tre";
   };
 }

--- a/pkgs/tools/text/angle-grinder/default.nix
+++ b/pkgs/tools/text/angle-grinder/default.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/rcoh/angle-grinder";
     license = licenses.mit;
     maintainers = with maintainers; [ bbigras ];
+    mainProgram = "agrind";
   };
 }

--- a/pkgs/tools/text/html-tidy/default.nix
+++ b/pkgs/tools/text/html-tidy/default.nix
@@ -28,5 +28,6 @@ stdenv.mkDerivation rec {
     homepage = "http://html-tidy.org";
     platforms = platforms.all;
     maintainers = with maintainers; [ edwtjo ];
+    mainProgram = "tidy";
   };
 }

--- a/pkgs/tools/text/igrep/default.nix
+++ b/pkgs/tools/text/igrep/default.nix
@@ -32,5 +32,6 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/konradsz/igrep/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ _0x4A6F ];
+    mainProgram = "ig";
   };
 }

--- a/pkgs/tools/text/miller/default.nix
+++ b/pkgs/tools/text/miller/default.nix
@@ -26,6 +26,7 @@ buildGoModule rec {
     homepage    = "https://github.com/johnkerl/miller";
     license     = licenses.bsd2;
     maintainers = with maintainers; [ mstarzyk ];
+    mainProgram = "mlr";
     platforms   = platforms.all;
   };
 }

--- a/pkgs/tools/video/atomicparsley/default.nix
+++ b/pkgs/tools/video/atomicparsley/default.nix
@@ -45,5 +45,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ pjones ];
+    mainProgram = "AtomicParsley";
   };
 }

--- a/pkgs/tools/virtualization/cloudmonkey/default.nix
+++ b/pkgs/tools/virtualization/cloudmonkey/default.nix
@@ -18,6 +18,7 @@ buildGoModule rec {
     homepage = "https://github.com/apache/cloudstack-cloudmonkey";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.womfoo ];
+    mainProgram = "cloudstack-cloudmonkey";
   };
 
 }


### PR DESCRIPTION
###### Description of changes

I often like to use `nix run` to use a package that's currently not installed on my system. Sometimes I run into cases where `nix run` fails due to the package's name differing from that of the executable. I've filed a few PRs manually adding `mainProgram` to few packages' `meta` attribute set to get them working with `nix run`. This is kind of annoying to do, so I got to thinking about whether there was a way I could automate this. This is my first attempt.

I created a hacky script that uses `nix-{index,locate}` to try and:
* find all packages that included a single executable in `/bin`;
* check if the single executable's name was an exact match for the packages name in `nixpkgs`; and
* if it wasn't an exact match,
  * check whether the package's `meta` attribute set contained a `mainProgram` attribute; and
  * if it didn't, adds the `mainProgram` attribute, set to the name of the single executable.

I excluded packages defined in places like `pkgs/development/{libraries,haskell-modules}` and a few others to reduce false positives.

I then manually looked through the diff to sanity check the changes, spot checking many with `nix run` (especially the ones that looked the most suspect) and removed a few where the single executable didn't really make sense to define as the `mainProgram`.

This process will have missed a bunch of cases, e.g.,
* cases where the package has a single executable, but it was wrapped, so a second executable was present in `/bin` with the suffix "-wrapped";
* cases where my in-place substitution with `sed` failed; 
* among many others.

But even at that, this PR should enable `nix run` to work with 143 additional packages. 
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
