### PR TITLE
gitlab: 14.9.1 -> 14.9.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,14 +1,14 @@
 {
-  "version": "14.9.1",
-  "repo_hash": "0jkhvglisaj3h9ls8q8wrxnnp4xp3zggc8vmwg6jqqjsmbpi332h",
-  "yarn_hash": "1bq1ka0nlb2nkjx70qpwpm8x6crbkfj0c8m39pwwc42j8wn10r9g",
+  "version": "14.9.2",
+  "repo_hash": "sha256-+tZN6isOb7LtUVwGshx9TP+P42sftJmQGVk1L9UJqcY=",
+  "yarn_hash": "1mya6y0cb9x8491gpf7f1i7qi2rb0l7d9g5yzj44vvy3mb4rcqaj",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v14.9.1-ee",
+  "rev": "v14.9.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "14.9.1",
-    "GITLAB_PAGES_VERSION": "1.56.0",
+    "GITALY_SERVER_VERSION": "14.9.2",
+    "GITLAB_PAGES_VERSION": "1.56.1",
     "GITLAB_SHELL_VERSION": "13.24.0",
-    "GITLAB_WORKHORSE_VERSION": "14.9.1"
+    "GITLAB_WORKHORSE_VERSION": "14.9.2"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -11,7 +11,7 @@ let
     gemdir = ./.;
   };
 
-  version = "14.9.1";
+  version = "14.9.2";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/v${lib.versions.major version}";
 in
 
@@ -23,7 +23,7 @@ buildGoModule {
     owner = "gitlab-org";
     repo = "gitaly";
     rev = "v${version}";
-    sha256 = "sha256-mk6JZuu6b2r/OqRI4ZUf8AV/ObRKhTIQT9bQE8sH894=";
+    sha256 = "sha256-eEo+WZ2N/5bLfvwJCNf9qt+h/V5dIVqCjVJeomzw/Ps=";
   };
 
   vendorSha256 = "sha256-kEjgWA/Task23PScPYrqdDu3vdVR/FJl7OilUug/Bds=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "14.9.1";
+  version = "14.9.2";
 
   src = fetchFromGitLab {
     owner = data.owner;

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
@@ -67,7 +67,7 @@ gem 'akismet', '~> 3.0'
 gem 'invisible_captcha', '~> 1.1.0'
 
 # Two-factor authentication
-gem 'devise-two-factor', '~> 4.0.0'
+gem 'devise-two-factor', '~> 4.0.2'
 gem 'rqrcode-rails3', '~> 0.1.7'
 gem 'attr_encrypted', '~> 3.1.0'
 gem 'u2f', '~> 0.2.1'

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -263,11 +263,11 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-two-factor (4.0.0)
-      activesupport (< 6.2)
+    devise-two-factor (4.0.2)
+      activesupport (< 7.1)
       attr_encrypted (>= 1.3, < 4, != 2)
       devise (~> 4.0)
-      railties (< 6.2)
+      railties (< 7.1)
       rotp (~> 6.0)
     diff-lcs (1.4.4)
     diff_match_patch (0.1.0)
@@ -1450,7 +1450,7 @@ DEPENDENCIES
   derailed_benchmarks
   device_detector
   devise (~> 4.7.2)
-  devise-two-factor (~> 4.0.0)
+  devise-two-factor (~> 4.0.2)
   diff_match_patch (~> 0.1.0)
   diffy (~> 3.3)
   discordrb-webhooks (~> 3.4)

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -1088,10 +1088,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "148pfr6g8dwikdq3994gsid2a3n6p5h4z1a1dzh1898shr5f9znc";
+      sha256 = "04f5rb8fg4cvzm32v413z3h53wc0fgxg927q8rqd546hdrlx4j35";
       type = "gem";
     };
-    version = "4.0.0";
+    version = "4.0.2";
   };
   diff-lcs = {
     groups = ["default" "development" "test"];


### PR DESCRIPTION
https://about.gitlab.com/releases/2022/03/31/critical-security-release-gitlab-14-9-2-released/

Fixes: CVE-2022-1162, CVE-2022-1175, CVE-2022-1190, CVE-2022-1185,
       CVE-2022-1148, CVE-2022-1121, CVE-2022-1120, CVE-2022-1100,
       CVE-2022-1193, CVE-2022-1105, CVE-2022-1099, CVE-2022-1174,
       CVE-2022-1188, CVE-2022-0740, CVE-2022-1189, CVE-2022-1157,
       CVE-2022-1111

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
