### PR TITLE
linode-cli: Remove update check

### DIFF
--- a/pkgs/tools/virtualization/linode-cli/default.nix
+++ b/pkgs/tools/virtualization/linode-cli/default.nix
@@ -33,6 +33,10 @@ buildPythonApplication rec {
     inherit sha256;
   };
 
+  patches = [
+    ./remove-update-check.patch
+  ];
+
   # remove need for git history
   prePatch = ''
     substituteInPlace setup.py \

--- a/pkgs/tools/virtualization/linode-cli/remove-update-check.patch
+++ b/pkgs/tools/virtualization/linode-cli/remove-update-check.patch
@@ -1,0 +1,11 @@
+--- a/linodecli/cli.py
++++ b/linodecli/cli.py
+@@ -555,7 +555,7 @@
+         if self.debug_request:
+             self.print_response_debug_info(result)
+ 
+-        if not self.suppress_warnings:
++        if False:
+             # check the major/minor version API reported against what we were built
+             # with to see if an upgrade should be available
+             api_version_higher = False


### PR DESCRIPTION
Upon every API call, this program will check the API version and make a
request to PyPi to check the latest version and, if not latest, will
show a warning like

> The API responded with version 1.2.4, which is newer than the CLI's
> version of 1.2.3.  Please update the CLI to get access to the newest
> features.  You can update with a simple `pip install --upgrade
> linode-cli`

This is not really useful with Nix, as the update message is wrong. And
connecting to a third-party on each usage is not desired, either.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
