### PR TITLE
chia: 1.3.1 -> 1.3.3

### DIFF
--- a/pkgs/applications/blockchains/chia/default.nix
+++ b/pkgs/applications/blockchains/chia/default.nix
@@ -6,14 +6,14 @@
 
 let chia = python3Packages.buildPythonApplication rec {
   pname = "chia";
-  version = "1.3.1";
+  version = "1.3.5";
 
   src = fetchFromGitHub {
     owner = "Chia-Network";
     repo = "chia-blockchain";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-nH6rCzIQu5oWsdEHa+UkvbWeUGjrtpEKVEcLmSoor5k=";
+    hash = "sha256-8jVnoc7LuLdT9QdjZkIbBal49p2iSJeGtMQpNY6LBgs=";
   };
 
   postPatch = ''
@@ -43,6 +43,7 @@ let chia = python3Packages.buildPythonApplication rec {
     clvm
     clvm-rs
     clvm-tools
+    clvm-tools-rs
     colorama
     colorlog
     concurrent-log-handler

--- a/pkgs/development/python-modules/blspy/default.nix
+++ b/pkgs/development/python-modules/blspy/default.nix
@@ -13,12 +13,12 @@
 
 buildPythonPackage rec {
   pname = "blspy";
-  version = "1.0.9";
+  version = "1.0.10";
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-6keimQqwh37G9xc1Xyxlr+0n9Qgv87Np2D7Gzj6ik5Y=";
+    hash = "sha256-36i1FT9WlEHA6rZYG9DITGb32FU6m2Vb2o/fuwyZUcA=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/clvm-tools-rs/bump-cargo-lock.patch
+++ b/pkgs/development/python-modules/clvm-tools-rs/bump-cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 2e42029..1279327 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -118,7 +118,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "clvm_tools_rs"
+-version = "0.1.8"
++version = "0.1.9"
+ dependencies = [
+  "bls12_381",
+  "bytestream",

--- a/pkgs/development/python-modules/clvm-tools-rs/default.nix
+++ b/pkgs/development/python-modules/clvm-tools-rs/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, rustPlatform
+, pythonOlder
+, openssl
+, perl
+, pkgs
+}:
+
+let
+  # clvm-rs does not work with maturin 0.12
+  # https://github.com/Chia-Network/clvm_rs/commit/32fba40178a5440a1306623f47d8b0684ae2339a#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711
+  maturin_0_11 = with pkgs; rustPlatform.buildRustPackage rec {
+    pname = "maturin";
+    version = "0.11.5";
+    src = fetchFromGitHub {
+      owner = "PyO3";
+      repo = "maturin";
+      rev = "v${version}";
+      hash = "sha256-hwc6WObcJa6EXf+9PRByUtiupMMYuXThA8i/K4rl0MA=";
+    };
+    cargoHash = "sha256-qGCEfKpQwAC57LKonFnUEgLW4Cc7HFJgSyUOzHkKN9c=";
+
+
+    nativeBuildInputs = [ pkg-config ];
+
+    buildInputs = lib.optionals stdenv.isLinux [ dbus ]
+      ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security libiconv ];
+
+    # Requires network access, fails in sandbox.
+    doCheck = false;
+  };
+in
+
+buildPythonPackage rec {
+  pname = "clvm_tools_rs";
+  version = "0.1.8";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "Chia-Network";
+    repo = "clvm_tools_rs";
+    rev = version;
+    sha256 = "sha256-laECT+EkUMAvpVc/yuXT1wPyP9hTE492IgOZ5T1brtk=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    sha256 = "sha256-mlHi+WOmUIwAJIV4uA6+H2o1enmPWhAFVscJZaolf8Q=";
+  };
+
+  format = "pyproject";
+
+  nativeBuildInputs = [
+    perl # used by openssl-sys to configure
+    maturin_0_11
+  ] ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
+
+  buildInputs = [ openssl ];
+
+  pythonImportsCheck = [ "clvm_rs" ];
+
+  meta = with lib; {
+    homepage = "https://chialisp.com/";
+    description = "Rust implementation of clvm";
+    license = licenses.asl20;
+    maintainers = teams.chia.members;
+  };
+}

--- a/pkgs/development/python-modules/clvm-tools/default.nix
+++ b/pkgs/development/python-modules/clvm-tools/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "clvm_tools";
-  version = "0.4.3";
+  version = "0.4.4";
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "Chia-Network";
     repo = "clvm_tools";
     rev = version;
-    sha256 = "sha256-bWz3YCrakob/kROq+LOA+yD1wtIbInVrmDqtg4/cV4g=";
+    sha256 = "sha256-Fv7NTUEjbEDALyc+WLDQ7yJOdODZCwLobN+vUvaBWMY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1759,6 +1759,8 @@ in {
 
   clvm-tools = callPackage ../development/python-modules/clvm-tools { };
 
+  clvm-tools-rs = callPackage ../development/python-modules/clvm-tools-rs { };
+
   cma = callPackage ../development/python-modules/cma { };
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };


### PR DESCRIPTION
###### Description of changes

https://github.com/Chia-Network/chia-blockchain/releases/tag/1.3.2

Both releases are due to a [DoS vulnerability](https://github.com/advisories/GHSA-x3mh-jvjw-3xwx), however, since we inject the Nixpkgs version of openssl anyways, it's already running openssl 1.1.1n regardless. So this is not urgent.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
