### PR TITLE
wolfram-engine: init at 13.0.1

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/wolfram/default.nix
+++ b/pkgs/applications/editors/jupyter-kernels/wolfram/default.nix
@@ -1,0 +1,22 @@
+{ callPackage
+, wolfram-engine
+}:
+
+# To test:
+# $(nix-build -E 'with import ./. {}; jupyter.override { definitions = { wolfram = wolfram-for-jupyter-kernel.definition; }; }')/bin/jupyter-notebook
+let kernel = callPackage ./kernel.nix {};
+in {
+  definition = {
+    displayName = "Wolfram Language ${wolfram-engine.version}";
+    argv = [
+      "${wolfram-engine}/bin/wolfram"
+      "-script"
+      "${kernel}/share/Wolfram/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl"
+      "{connection_file}"
+      "ScriptInstall" # suppresses prompt
+    ];
+    language = "Wolfram Language";
+    logo32 = "${wolfram-engine}/share/icons/hicolor/32x32/apps/wolfram-wolframlanguage.png";
+    logo64 = "${wolfram-engine}/share/icons/hicolor/64x64/apps/wolfram-wolframlanguage.png";
+  };
+}

--- a/pkgs/applications/editors/jupyter-kernels/wolfram/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/wolfram/kernel.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "wolfram-for-jupyter-kernel";
+  version = "0.9.2";
+
+  src = fetchFromGitHub {
+    owner = "WolframResearch";
+    repo = "WolframLanguageForJupyter";
+    rev = "v${version}";
+    sha256 = "19d9dvr0bv7iy0x8mk4f576ha7z7h7id39nyrggwf9cp7gymxf47";
+  };
+
+  dontConfigure = true;
+
+  installPhase = ''
+    patchShebangs ./configure-jupyter.wls
+    mkdir -p $out/share/Wolfram
+    cp -r {WolframLanguageForJupyter,images,extras,LICENSE} $out/share/Wolfram
+  '';
+
+  # no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Jupyter kernel for Wolfram Language.";
+    homepage = "https://github.com/WolframResearch/WolframLanguageForJupyter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/science/math/wolfram-engine/default.nix
+++ b/pkgs/applications/science/math/wolfram-engine/default.nix
@@ -1,0 +1,143 @@
+{ lib
+, stdenv
+, autoPatchelfHook
+, requireFile
+, callPackage
+, makeWrapper
+, alsa-lib
+, dbus
+, fontconfig
+, freetype
+, gcc
+, glib
+, installShellFiles
+, libssh2
+, ncurses
+, opencv4
+, openssl
+, unixODBC
+, xkeyboard_config
+, xorg
+, zlib
+, libxml2
+, libuuid
+, lang ? "en"
+, libGL
+, libGLU
+}:
+
+let
+  l10n = import ./l10ns.nix {
+    lib = lib;
+    inherit requireFile lang;
+  };
+  dirName = "WolframEngine";
+in
+stdenv.mkDerivation rec {
+  inherit (l10n) version name src;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    installShellFiles
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    fontconfig
+    freetype
+    gcc.cc
+    gcc.libc
+    glib
+    libssh2
+    ncurses
+    opencv4
+    openssl
+    stdenv.cc.cc.lib
+    unixODBC
+    xkeyboard_config
+    libxml2
+    libuuid
+    zlib
+    libGL
+    libGLU
+  ] ++ (with xorg; [
+    libX11
+    libXext
+    libXtst
+    libXi
+    libXmu
+    libXrender
+    libxcb
+    libXcursor
+    libXfixes
+    libXrandr
+    libICE
+    libSM
+  ]);
+
+  # some bundled libs are found through LD_LIBRARY_PATH
+  autoPatchelfIgnoreMissingDeps = true;
+
+  ldpath = lib.makeLibraryPath buildInputs
+    + lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
+      (":" + lib.makeSearchPathOutput "lib" "lib64" buildInputs);
+
+  unpackPhase = ''
+    # find offset from file
+    offset=$(${stdenv.shell} -c "$(grep -axm1 -e 'offset=.*' $src); echo \$offset" $src)
+    dd if="$src" ibs=$offset skip=1 | tar -xf -
+    cd Unix
+  '';
+
+  installPhase = ''
+    cd Installer
+    sed -i -e 's/^PATH=/# PATH=/' -e 's/=`id -[ug]`/=0/' MathInstaller
+
+    # Installer wants to write default config in HOME
+    export HOME=$(mktemp -d)
+
+    # Fix the installation script
+    patchShebangs MathInstaller
+    substituteInPlace MathInstaller \
+      --replace "`hostname`" "" \
+      --replace "chgrp" "# chgrp" \
+      --replace "chown" ": # chown"
+
+    # Install the desktop items
+    export XDG_DATA_HOME="$out/share"
+
+    ./MathInstaller -auto -createdir=y -execdir=$out/bin -targetdir=$out/libexec/${dirName} -silent
+
+    # Fix library paths
+    cd $out/libexec/${dirName}/Executables
+    for path in MathKernel WolframKernel math mcc wolfram; do
+      makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}"
+    done
+
+    # ... and xkeyboard config path for Qt
+    for path in WolframPlayer wolframplayer; do
+      makeWrapper $out/libexec/${dirName}/Executables/$path $out/bin/$path \
+        --set LD_LIBRARY_PATH "${zlib}/lib:${stdenv.cc.cc.lib}/lib:${libssh2}/lib:\''${LD_LIBRARY_PATH}" \
+        --set QT_XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb"
+    done
+
+    # Install man pages
+    installManPage $out/libexec/${dirName}/SystemFiles/SystemDocumentation/Unix/*
+  '';
+
+  # This is primarily an IO bound build; there's little benefit to building remotely.
+  preferLocalBuild = true;
+
+  # Stripping causes the program to core dump.
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Wolfram Engine computational software system";
+    homepage = "https://www.wolfram.com/engine/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ fbeffa ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/science/math/wolfram-engine/l10ns.nix
+++ b/pkgs/applications/science/math/wolfram-engine/l10ns.nix
@@ -1,0 +1,51 @@
+{ lib
+, requireFile
+, lang
+, majorVersion ? null
+}:
+
+let allVersions = with lib; flip map
+  # N.B. Versions in this list should be ordered from newest to oldest.
+  [
+    {
+      version = "13.0.1";
+      lang = "en";
+      language = "English";
+      sha256 = "1rrxi7d51m02407k719fq829jzanh550wr810i22n3irhk8axqga";
+      installer = "WolframEngine_13.0.1_LINUX.sh";
+    }
+    {
+      version = "13.0.0";
+      lang = "en";
+      language = "English";
+      sha256 = "10cpwllz9plxz22iqdh6xgkxqphl9s9nq8ax16pafjll6j9kqy1q";
+      installer = "WolframEngine_13.0.0_LINUX.sh";
+    }
+  ]
+  ({ version, lang, language, sha256, installer }: {
+    inherit version lang;
+    name = "wolfram-engine-${version}" + optionalString (lang != "en") "-${lang}";
+    src = requireFile {
+      name = installer;
+      message = ''
+        This nix expression requires that ${installer} is
+        already part of the store. Download the file from
+        https://www.wolfram.com/engine/ and add it to the nix store
+        with nix-store --add-fixed sha256 <FILE>.
+      '';
+      inherit sha256;
+    };
+  });
+minVersion =
+  with lib;
+  if majorVersion == null
+  then elemAt (builtins.splitVersion (elemAt allVersions 0).version) 0
+  else majorVersion;
+maxVersion = toString (1 + builtins.fromJSON minVersion);
+in
+with lib;
+findFirst (l: (l.lang == lang
+               && l.version >= minVersion
+               && l.version < maxVersion))
+          (throw "Version ${minVersion} in language ${lang} not supported")
+          allVersions

--- a/pkgs/applications/science/math/wolfram-engine/notebook.nix
+++ b/pkgs/applications/science/math/wolfram-engine/notebook.nix
@@ -1,0 +1,9 @@
+{ lib, stdenv, writeScriptBin, jupyter, wolfram-for-jupyter-kernel }:
+
+let
+  wolfram-jupyter = jupyter.override { definitions = { wolfram = wolfram-for-jupyter-kernel.definition; }; };
+in
+  writeScriptBin "wolfram-notebook" ''
+    #! ${stdenv.shell}
+    ${wolfram-jupyter}/bin/jupyter-notebook
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32635,6 +32635,8 @@ with pkgs;
 
   trilinos-mpi = callPackage ../development/libraries/science/math/trilinos { withMPI = true; };
 
+  wolfram-engine = callPackage ../applications/science/math/wolfram-engine { };
+
   ipopt = callPackage ../development/libraries/science/math/ipopt { };
 
   gmsh = callPackage ../applications/science/math/gmsh { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32637,6 +32637,10 @@ with pkgs;
 
   wolfram-engine = callPackage ../applications/science/math/wolfram-engine { };
 
+  wolfram-for-jupyter-kernel = callPackage ../applications/editors/jupyter-kernels/wolfram { };
+
+  wolfram-notebook = callPackage ../applications/science/math/wolfram-engine/notebook.nix { };
+
   ipopt = callPackage ../development/libraries/science/math/ipopt { };
 
   gmsh = callPackage ../applications/science/math/gmsh { };


### PR DESCRIPTION
###### Description of changes

Add the Wolfram Engine and a corresponding Jupyter kernel.

The `wolfram-engine` derivation is based on the `mathematica` one and requires manual download of the installer from the Wolfram web site.  That's because it can not be redistributed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
