### PR TITLE
cryptowatch-desktop: init at 0.5.0

### DIFF
--- a/pkgs/applications/finance/cryptowatch/default.nix
+++ b/pkgs/applications/finance/cryptowatch/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, fetchurl
+, autoPatchelfHook
+, wrapGAppsHook
+, dbus
+, libGL
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, udev
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cryptowatch-desktop";
+  version = "0.5.0";
+
+  src = fetchurl {
+    url = "https://cryptowat.ch/desktop/download/linux/${version}";
+    sha256 = "0lr5fsd0f44b1v9f2dvx0a0lmz9dyivyz5d98qx2gcv3jkngw34v";
+  };
+
+  unpackPhase = "unzip $src";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook
+    unzip
+  ];
+
+  buildInputs = [
+    dbus
+    udev
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    install -m755 -D cryptowatch_desktop $out/bin/cryptowatch_desktop
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL libX11 libXcursor libXrandr libXi ]}"
+    )
+  '';
+
+  meta = with lib; {
+    homepage = "https://cryptowat.ch";
+    description = "Application for visualising real-time cryptocurrency market data";
+    platforms = platforms.linux;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ livnev ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -335,6 +335,8 @@ with pkgs;
 
   crow-translate = libsForQt5.callPackage ../applications/misc/crow-translate { };
 
+  cryptowatch-desktop = callPackage ../applications/finance/cryptowatch { };
+
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };
 
   dhallPackageToNix = callPackage ../build-support/dhall/package-to-nix.nix { };


### PR DESCRIPTION
###### Description of changes

[cryptowat.ch](https://cryptowat.ch/apps/desktop) is a desktop application, distributed as a binary for Linux, for displaying real-time cryptocurrency market data.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
