### PR TITLE
beamerpresenter: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -1,44 +1,67 @@
-{ lib, stdenv, fetchFromGitHub, installShellFiles,
-  qmake, qtbase, qtmultimedia, wrapQtAppsHook,
-  poppler, mupdf, freetype, jbig2dec, openjpeg, gumbo,
-  renderer ? "mupdf" }:
+{ lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  cmake,
+  qtbase,
+  qtmultimedia,
+  qttools,
+  wrapQtAppsHook,
+  bash,
+  zlib,
+  gcc,
+  gnumake,
+  coreutils,
+  # only required when using poppler
+  poppler,
+  # only required when using mupdf
+  mupdf,
+  freetype,
+  jbig2dec,
+  openjpeg,
+  gumbo,
+  # choose renderer: mupdf or poppler or both (not recommended)
+  renderer ? "mupdf",
+  # choose major Qt version: "5" or "6" (only 5 is tested)
+  qt_version ? "5"}:
 
 let
   renderers = {
     mupdf.buildInputs = [ mupdf freetype jbig2dec openjpeg gumbo ];
     poppler.buildInputs = [ poppler ];
   };
-
+  use_poppler = if "${renderer}" == "poppler" || "${renderer}" == "both" then "ON" else "OFF";
+  use_mupdf = if "${renderer}" == "mupdf" || "${renderer}" == "both" then "ON" else "OFF";
 in
 
 stdenv.mkDerivation rec {
   pname = "beamerpresenter";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "stiglers-eponym";
     repo = "BeamerPresenter";
     rev = "v${version}";
-    sha256 = "sha256-+ZxllYL2wco4bG2pqInIbL9qfOoqoUJJUReqDyEBRcI=";
+    sha256 = "16v263nnnipih3lxg95rmwz0ihnvpl4n1wlj9r6zavnspzlp9dvb";
   };
 
-  nativeBuildInputs = [ qmake installShellFiles wrapQtAppsHook ];
-  buildInputs = [ qtbase qtmultimedia ] ++ renderers.${renderer}.buildInputs;
+  nativeBuildInputs = [ pkg-config installShellFiles wrapQtAppsHook ];
+  buildInputs = [ gcc cmake coreutils gnumake bash zlib qtbase qtmultimedia qttools ] ++ renderers.${renderer}.buildInputs;
 
-  qmakeFlags = [ "RENDERER=${renderer}" ];
-
-  postPatch = ''
-    shopt -s globstar
-    for f in **/*.{pro,conf,h,cpp}; do
-      substituteInPlace "$f" \
-        --replace "/usr/" "$out/" \
-        --replace "/etc/" "$out/etc/" \
-        --replace '$${GUI_CONFIG_PATH}' "$out/etc/xdg/beamerpresenter/gui.json"
-    done
-  '';
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE='Release'"
+    "-DGIT_VERSION=OFF"
+    "-DUSE_POPPLER=${use_poppler}"
+    "-DUSE_MUPDF=${use_mupdf}"
+    "-DUSE_MUJS=OFF"
+    "-DUSE_GUMBO=ON"
+    "-DUSE_TRANSLATIONS=ON"
+    "-DQT_VERSION_MAJOR=${qt_version}"
+  ];
 
   meta = with lib; {
-    description = "Modular multi screen pdf presentation software respecting your window manager";
+    description = "Modular multi screen pdf presentation viewer";
     homepage = "https://github.com/stiglers-eponym/BeamerPresenter";
     license = licenses.agpl3Plus;
     platforms = platforms.all;

--- a/pkgs/applications/office/beamerpresenter/default.nix
+++ b/pkgs/applications/office/beamerpresenter/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Modular multi screen pdf presentation viewer";
     homepage = "https://github.com/stiglers-eponym/BeamerPresenter";
-    license = licenses.agpl3Plus;
+    license = with licenses; [ agpl3 gpl3Plus ];
     platforms = platforms.all;
     maintainers = with maintainers; [ pacien ];
   };


### PR DESCRIPTION
###### Description of changes

The build system of beamerpresenter has switched from qmake to cmake in version 0.2.2.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
