### PR TITLE
[21.11] libarchive: 3.5.2 -> 3.5.3

### DIFF
--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -15,13 +15,13 @@ assert xarSupport -> libxml2 != null;
 
 stdenv.mkDerivation rec {
   pname = "libarchive";
-  version = "3.5.2";
+  version = "3.5.3";
 
   src = fetchFromGitHub {
     owner = "libarchive";
     repo = "libarchive";
     rev = "v${version}";
-    sha256 = "sha256-H00UJ+ON1kBc19BgWBBKmO8f23oAg2mk7o9hhDhn50Q=";
+    sha256 = "1q4ij55yirrbrk5iwnh3r90ayq92n02shxc4qkyf73h8zqlfrcj7";
   };
 
   outputs = [ "out" "lib" "dev" ];

--- a/pkgs/development/libraries/libarchive/default.nix
+++ b/pkgs/development/libraries/libarchive/default.nix
@@ -6,6 +6,9 @@
   # builds fine on windows, but libarchive has trouble linking windows
   # things it depends on for some reason.
   xarSupport ? stdenv.hostPlatform.isUnix,
+
+  # for passthru.tests
+  cmake, nix, samba
 }:
 
 assert xarSupport -> libxml2 != null;
@@ -48,6 +51,10 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  passthru.tests = {
+    inherit cmake nix samba;
+  };
 
   meta = {
     description = "Multi-format archive and compression library";


### PR DESCRIPTION
###### Description of changes
#132136
#138679
#142981
https://nvd.nist.gov/vuln/detail/CVE-2021-36976

This bump looks like it's really nothing but security fixes.

Also cherry-picked #159900 to ease testing.

Fixed in master with #159465

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
