### PR TITLE
saw: init at 0.2.2

### DIFF
--- a/pkgs/tools/admin/saw/default.nix
+++ b/pkgs/tools/admin/saw/default.nix
@@ -1,0 +1,36 @@
+{ lib, buildGoModule, fetchFromGitHub, fetchpatch, testVersion, saw }:
+
+buildGoModule rec {
+  pname = "saw";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "TylerBrock";
+    repo = "saw";
+    rev = "v${version}";
+    sha256 = "n1DTUb6ZpopCWZ5ekwYI2LJQLgQwvAt3T4B2NulvxEE=";
+  };
+
+  patches = [
+    # No release has been done since project switched to go modules.
+    (fetchpatch {
+      url = "https://github.com/TylerBrock/saw/commit/0bb0a886191c3f74db88652a980bdf0891e38183.patch";
+      sha256 = "is6rgVBEGSbQq8ZYaVxLzy1N2g/9j7saVpiJCferu0M=";
+    })
+  ];
+
+  vendorSha256 = "2GTa5BEls5T1k7qQSpi6VprcTrjBmTKz7Ra5OsAJBFA=";
+
+  passthru.tests.version = testVersion {
+    package = saw;
+    command = "saw version";
+    version = "v${version}";
+  };
+
+  meta = with lib; {
+    description = "Fast, multi-purpose tool for AWS CloudWatch Logs";
+    homepage = "https://github.com/TylerBrock/saw";
+    license = licenses.mit;
+    maintainers = [ maintainers.terlar ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9792,6 +9792,8 @@ with pkgs;
 
   sasview = libsForQt5.callPackage ../applications/science/misc/sasview {};
 
+  saw = callPackage ../tools/admin/saw { };
+
   scanbd = callPackage ../tools/graphics/scanbd { };
 
   scdoc = callPackage ../tools/typesetting/scdoc { };


### PR DESCRIPTION
###### Description of changes

Add package [saw](https://github.com/TylerBrock/saw) - a fast, multi-purpose tool for AWS CloudWatch Logs.

I guess it is a bit similar to the already packaged [awslogs](https://github.com/jorgebastida/awslogs). I have not tried that one yet, so I am not fully aware of the differences.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
