### PR TITLE
s25rttr: init at 0.9.5

### DIFF
--- a/pkgs/games/s25rttr/cmake_file_placeholder.patch
+++ b/pkgs/games/s25rttr/cmake_file_placeholder.patch
@@ -1,0 +1,34 @@
+From fad6d134f6174048353a56fedc5cbec7b8c163a5 Mon Sep 17 00:00:00 2001
+From: Shawn8901 <shawn8901@googlemail.com>
+Date: Wed, 30 Mar 2022 19:38:28 +0200
+Subject: [PATCH] Added a cmake option control if a placeholder file should be
+ witten install phase
+
+This option enables the possibility for a package maintainer to let RTTR_GAMEDIR to a place
+which is not in control of the packaging system. Thats needed when RTTR_GAMEDIR should point
+to a directory which is not the package, but the packaging system prevents writes on package build time.
+
+As the usecase is special for some packaging systems and not indended for daily use its marked as advanced option.
+---
+ CMakeLists.txt | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4562487ef..688d873bb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,7 +384,11 @@ if(NOT WIN32)
+ endif()
+ 
+ # Placeholder for S2 installation
+-install(FILES "${RTTR_S2_PLACEHOLDER_PATH}" DESTINATION "${RTTR_GAMEDIR}")
++option(RTTR_INSTALL_PLACEHOLDER "Install a placeholder file to the location the S2 game files should be copied to." ON)
++mark_as_advanced(RTTR_INSTALL_PLACEHOLDER)
++if(RTTR_INSTALL_PLACEHOLDER)
++    install(FILES "${RTTR_S2_PLACEHOLDER_PATH}" DESTINATION "${RTTR_GAMEDIR}")
++endif()
+ 
+ ################################################################################
+ # Postbuild
+-- 
+2.35.1

--- a/pkgs/games/s25rttr/default.nix
+++ b/pkgs/games/s25rttr/default.nix
@@ -1,0 +1,72 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, git
+, cmake
+, pkg-config
+, boost
+, bzip2
+, curl
+, gettext
+, libiconv
+, miniupnpc
+, SDL2
+, SDL2_mixer
+, libsamplerate
+}:
+
+stdenv.mkDerivation rec {
+  pname = "s25rttr";
+  version = "0.9.5";
+
+  message = ''
+    Copy the S2 folder of the Settler 2 Gold Edition to /var/lib/s25rttr/S2/".
+  '';
+
+  src = fetchFromGitHub {
+    owner = "Return-To-The-Roots";
+    repo = "s25client";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    leaveDotGit = true;
+    sha256 = "sha256-+89F6LtY6nEJEgVM1R5qiPhG6CLEKymowzEowuLCfUM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    git
+    boost
+    bzip2
+    curl
+    gettext
+    libiconv
+    miniupnpc
+    SDL2
+    SDL2_mixer
+    libsamplerate
+  ];
+
+  patches = [ ./cmake_file_placeholder.patch ];
+
+  cmakeBuildType = "Release";
+
+  cmakeFlags = [
+    "-DRTTR_VERSION=${version}"
+    "-DRTTR_USE_SYSTEM_LIBS=ON"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DRTTR_INSTALL_PLACEHOLDER=OFF"
+    "-DRTTR_GAMEDIR=/var/lib/s25rttr/S2/"
+  ];
+
+  meta = with lib; {
+    description = "Return To The Roots (Settlers II(R) Clone)";
+    homepage = "https://www.rttr.info/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ shawn8901 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31625,6 +31625,12 @@ with pkgs;
 
   rrootage = callPackage ../games/rrootage { };
 
+  s25rttr = callPackage ../games/s25rttr {
+    SDL2 = SDL2.override {
+      withStatic = true;
+    };
+  };
+
   space-cadet-pinball = callPackage ../games/space-cadet-pinball {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };


### PR DESCRIPTION
###### Description of changes

RTTR is a settler 2 clone, which re-implements the game to bring classical settler 2 to modern OS and also adds a lot of (optional) things to the game, like multiplayer and other game changes, while keeping "old" game experience in mind.

The game itself requires the user to own a original copy of the game (to be more specific Settler 2 Gold Edition), as its using the originals games assets. 
The files have to be placed at a specific folder by the enduser.
The game will exit with a console message if the game files are not placed at the expected directory. 

Upstream places the game files in the application directory of the game itself, which is not possible for nix users as the store is read only.
Preloading the files to the store and depending on them should result in a variant which will never be build by hydra, which is a non-optimal user experience.
So in a discussion with NoobZ and me on the unofficial nixos discord and another discussion between a person from upstream (s25rttr) and me, i came to the solution presented here. 

The game directory points to `/var/lib/s25rttr/S2`. That place may be not optimal, but i dont see another predictable folder where to look for the files, as long as its not definable on runtime.
The game does not need S2 proprietary files on compile time, they are just loaded on game start. 
So building it with hydra should be fine.

The game itself builds fine that way and is also in a usable state. I have tested some minutes in single player and joined a multiplayer session opened with upstream builds (started local with steam-run).

Every feedback is welcome, if someone has a better idea for the game-data solution, i would be happy to test it out.

The package just needs SDL2 withStatic=true due https://github.com/NixOS/nixpkgs/pull/149601 not being merged, and the CMake plugin searches for libSDL2main.a to read out the versions.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
