### PR TITLE
argononed: init at unstable-2022-03-26

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8252,6 +8252,17 @@
     githubId = 1776903;
     name = "Andrew Abbott";
   };
+  misterio77 = {
+    email = "eu@misterio.me";
+    github = "misterio77";
+    githubId = 5727578;
+    matrix = "@misterio:matrix.org";
+    name = "Gabriel Fontes";
+    keys = [{
+      longkeyid = "rsa3072/0x245CAB70B4C225E9";
+      fingerprint = "7088 C742 1873 E0DB 97FF  17C2 245C AB70 B4C2 25E9";
+    }];
+  };
   mitchmindtree = {
     email = "mail@mitchellnordine.com";
     github = "mitchmindtree";

--- a/pkgs/misc/drivers/argononed/default.nix
+++ b/pkgs/misc/drivers/argononed/default.nix
@@ -1,0 +1,48 @@
+{ lib, stdenv, fetchFromGitLab, dtc, installShellFiles }:
+
+stdenv.mkDerivation rec {
+  pname = "argononed";
+  version = "unstable-2022-03-26";
+
+  src = fetchFromGitLab {
+    owner = "DarkElvenAngel";
+    repo = pname;
+    rev = "97c4fa07fc2c09ffc3bd86e0f6319d50fa639578";
+    sha256 = "sha256-5/xUYbprRiwD+FN8V2cUpHxnTbBkEsFG2wfsEXrCrgQ=";
+  };
+
+  patches = [ ./fix-hardcoded-reboot-poweroff-paths.patch ];
+
+  postPatch = ''
+    patchShebangs configure
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ dtc ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 build/argononed $out/bin/argononed
+    install -Dm755 build/argonone-cli $out/bin/argonone-cli
+    install -Dm755 build/argonone-shutdown $out/lib/systemd/system-shutdown/argonone-shutdown
+    install -Dm644 build/argonone.dtbo $out/boot/overlays/argonone.dtbo
+
+    install -Dm644 OS/_common/argononed.service $out/lib/systemd/system/argononed.service
+    install -Dm644 OS/_common/argononed.logrotate $out/etc/logrotate.d/argononed
+    install -Dm644 LICENSE $out/share/argononed/LICENSE
+
+    installShellCompletion --bash --name argonone-cli OS/_common/argonone-cli-complete.bash
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/DarkElvenAngel/argononed";
+    description = "A replacement daemon for the Argon One Raspberry Pi case";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.misterio77 ];
+  };
+}

--- a/pkgs/misc/drivers/argononed/fix-hardcoded-reboot-poweroff-paths.patch
+++ b/pkgs/misc/drivers/argononed/fix-hardcoded-reboot-poweroff-paths.patch
@@ -1,0 +1,18 @@
+--- a/src/argononed.c
++++ b/src/argononed.c
+@@ -783,13 +783,13 @@
+     {
+         log_message(LOG_DEBUG, "EXEC REBOOT");
+         sync();
+-        system("/sbin/reboot");
++        system("/run/current-system/sw/bin/reboot");
+     }
+     if (count >= 39 && count <= 41)
+     {
+         log_message(LOG_DEBUG, "EXEC SHUTDOWN");
+         sync();
+-        system("/sbin/poweroff");
++        system("/run/current-system/sw/bin/poweroff");
+     }
+ #else
+     log_message(LOG_INFO,"Daemon Ready");

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33306,6 +33306,8 @@ with pkgs;
     swt = swt_jdk8;
   };
 
+  argononed = callPackage ../misc/drivers/argononed { };
+
   attract-mode = callPackage ../applications/emulators/attract-mode { };
 
   autotiling = python3Packages.callPackage ../misc/autotiling { };


### PR DESCRIPTION
###### Description of changes

Argon One Daemon is a replacement daemon for the Argon One Raspberry Pi Cases (fan control, power button).

I have been using this for quite some time now (together with a module implementation I plan on upstreaming soonish), and works flawlessly.

###### Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).