### PR TITLE
gnome.gedit: 41.0 -> 42.0

### DIFF
--- a/pkgs/desktops/gnome/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome/apps/gedit/default.nix
@@ -5,6 +5,7 @@
 , python3
 , pkg-config
 , gtk3
+, gtk-mac-integration
 , glib
 , adwaita-icon-theme
 , libpeas
@@ -59,6 +60,8 @@ stdenv.mkDerivation rec {
     gtksourceview4
     libpeas
     libsoup
+  ] ++ lib.optionals stdenv.isDarwin [
+    gtk-mac-integration
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome/apps/gedit/default.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gedit";
-  version = "41.0";
+  version = "42.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "epsYsViAjRiSmJFl83BsTxooKXkHmrdFinnTwkrU3rU=";
+    sha256 = "qHmR9Clh609qvNuqu3hHYMI66u765jY9PiGmHpxFhDc=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/gedit/-/compare/41.0...42.0

* [Revert "gedit-dirs: remove get_user_cache_dir() (no longer used)"](https://gitlab.gnome.org/GNOME/gedit/-/commit/ba2662ff9ee99ef0d85023b06053792fd3eb9272)
* Rename display name back to gedit
* Build fix ([for macOS](https://gitlab.gnome.org/GNOME/gedit/-/commit/d142898dad42ea5efe9bf93bbae58a0edefcc61b))
* Translation updates

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
