### PR TITLE
nmrpflash: init at 0.9.16

### DIFF
--- a/pkgs/development/embedded/nmrpflash/default.nix
+++ b/pkgs/development/embedded/nmrpflash/default.nix
@@ -1,0 +1,39 @@
+{ fetchFromGitHub
+, gcc
+, lib
+, libnl
+, libpcap
+, pkg-config
+, stdenv
+, writeShellScriptBin
+}:
+stdenv.mkDerivation rec {
+  pname = "nmrpflash";
+  version = "0.9.16";
+
+  src = fetchFromGitHub {
+    owner  = "jclehner";
+    repo   = "nmrpflash";
+    rev    = "v${version}";
+    sha256 = "sha256-0nqdbXf1syUe7o5hoNIKLruKxkNaUsGolfZzoQY15j4==";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libnl libpcap ];
+
+  PREFIX = "${placeholder "out"}";
+  STANDALONE_VERSION = "${version}";
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Netgear Unbrick Utility";
+    homepage = "https://github.com/jclehner/nmrpflash";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dadada ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15920,6 +15920,8 @@ with pkgs;
     jre_headless = jre8_headless;
   };
 
+  nmrpflash = callPackage ../development/embedded/nmrpflash { };
+
   nwjs = callPackage ../development/tools/nwjs { };
 
   nwjs-sdk = callPackage ../development/tools/nwjs {


### PR DESCRIPTION
###### Description of changes

This adds nmrpflash. A flashing and unbricking utility for Netgear devices.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
