### PR TITLE
hut: unstable-2022-03-02 -> 0.1.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/hut/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/hut/default.nix
@@ -2,21 +2,20 @@
 , buildGoModule
 , fetchFromSourcehut
 , scdoc
-, unstableGitUpdater
 }:
 
-buildGoModule {
+buildGoModule rec {
   pname = "hut";
-  version = "unstable-2022-03-02";
+  version = "0.1.0";
 
   src = fetchFromSourcehut {
     owner = "~emersion";
     repo = "hut";
-    rev = "55ad2fbd9ceeeb9e7dc203c15476fa785f1209e0";
-    sha256 = "sha256-j2IVwCm7iq3JKccPL8noRBhqw+V+4qfcpAwV65xhZk0=";
+    rev = "v${version}";
+    sha256 = "sha256-2YUrDPulpLQQGw31nEasHoQ/AppECg7acwwqu6JDT5U=";
   };
 
-  vendorSha256 = "sha256-zdQvk0M1a+Y90pnhqIpKxLJnlVJqMoSycewTep2Oux4=";
+  vendorSha256 = "sha256-EmokL3JlyM6C5/NOarCAJuqNsDO2tgHwqQdv0rAk+Xk=";
 
   nativeBuildInputs = [
     scdoc
@@ -31,8 +30,6 @@ buildGoModule {
   preInstall = ''
     make $makeFlags install
   '';
-
-  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     homepage = "https://sr.ht/~emersion/hut/";


### PR DESCRIPTION
###### Description of changes


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is Symbol’s value as variable is void: sandbox\ set in Symbol’s value as variable is void: nix\.conf\? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using Symbol’s value as variable is void: nix-shell\. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in Symbol’s value as variable is void: \./result/bin/)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `\nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).