### PR TITLE
keycloak: 16.1.0 -> 17.0.1 (quarkus)

### DIFF
--- a/pkgs/servers/keycloak/default.nix
+++ b/pkgs/servers/keycloak/default.nix
@@ -4,58 +4,33 @@
 }:
 
 let
-  mkModuleXml = name: jarFile: writeText "module.xml" ''
-    <?xml version="1.0" ?>
-    <module xmlns="urn:jboss:module:1.3" name="${name}">
-        <resources>
-            <resource-root path="${jarFile}"/>
-        </resources>
-        <dependencies>
-            <module name="javax.api"/>
-            <module name="javax.transaction.api"/>
-        </dependencies>
-    </module>
-  '';
+  features = [];
+  database = "dev-file";
 in
 stdenv.mkDerivation rec {
   pname   = "keycloak";
-  version = "16.1.0";
+  version = "17.0.1";
 
   src = fetchzip {
     url    = "https://github.com/keycloak/keycloak/releases/download/${version}/keycloak-${version}.zip";
-    sha256 = "sha256-QVFu3f+mwafoNUttLEVMdoZHMJjjH/TpZAGV7ZvIvh0=";
+    sha256 = "sha256-z1LfTUoK+v4oQxdyIQruFhl5O333zirSrkPoTFgVfmI=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper jre ];
+
+  buildPhase = ''
+    bash -e bin/kc.sh build --db=${database} ${lib.concatMapStrings (x: " --features "+ x) features}
+  '';
 
   installPhase = ''
     mkdir $out
     cp -r * $out
-
-    rm -rf $out/bin/*.{ps1,bat}
-
-    module_path=$out/modules/system/layers/keycloak
-    if ! [[ -d $module_path ]]; then
-        echo "The module path $module_path not found!"
-        exit 1
-    fi
-
-    ${lib.optionalString (postgresql_jdbc != null) ''
-      mkdir -p $module_path/org/postgresql/main
-      ln -s ${postgresql_jdbc}/share/java/postgresql-jdbc.jar $module_path/org/postgresql/main/
-      ln -s ${mkModuleXml "org.postgresql" "postgresql-jdbc.jar"} $module_path/org/postgresql/main/module.xml
-    ''}
-    ${lib.optionalString (mysql_jdbc != null) ''
-      mkdir -p $module_path/com/mysql/main
-      ln -s ${mysql_jdbc}/share/java/mysql-connector-java.jar $module_path/com/mysql/main/
-      ln -s ${mkModuleXml "com.mysql" "mysql-connector-java.jar"} $module_path/com/mysql/main/module.xml
-    ''}
-
-    for script in add-user-keycloak.sh add-user.sh domain.sh elytron-tool.sh jboss-cli.sh jconsole.sh jdr.sh standalone.sh wsconsume.sh wsprovide.sh; do
+  '';
+  preFixup = ''
+    rm -rf $out/bin/*.bat
+    for script in kcadm.sh kcreg.sh kc.sh; do
       wrapProgram $out/bin/$script --set JAVA_HOME ${jre}
     done
-    wrapProgram $out/bin/kcadm.sh --prefix PATH : ${jre}/bin
-    wrapProgram $out/bin/kcreg.sh --prefix PATH : ${jre}/bin
   '';
 
   passthru = {


### PR DESCRIPTION
###### Description of changes

This updates keycloak from 16.1.0 to 17.0.1, which is a more significant change involving a switch from wildfly to quarkus, necessitating a change in the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
