### PR TITLE
CloudCompare: unstable-2021-10-14 -> 2.12.0, add plugins

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -1,13 +1,16 @@
 { lib
 , mkDerivation
 , fetchFromGitHub
+, fetchpatch
 , cmake
-, dxflib
+, boost
+, cgal_5
 , eigen
 , flann
 , gdal
+, gmp
 , LASzip
-, libLAS
+, mpfr
 , pdal
 , pcl
 , qtbase
@@ -15,36 +18,43 @@
 , qttools
 , tbb
 , xercesc
+, wrapGAppsHook
 }:
 
 mkDerivation rec {
   pname = "cloudcompare";
-  # Released version(v2.11.3) doesn't work with packaged PCL.
-  version = "unstable-2021-10-14";
+  version = "2.12.0";
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
-    rev = "1f65ba63756e23291ae91ff52d04da468ade8249";
-    sha256 = "x1bDjFjXIl3r+yo1soWvRB+4KGP50/WBoGlrH013JQo=";
-    # As of writing includes (https://github.com/CloudCompare/CloudCompare/blob/a1c589c006fc325e8b560c77340809b9c7e7247a/.gitmodules):
-    # * libE57Format
-    # * PoissonRecon
-    # * CCCoreLib
+    rev = "v${version}";
+    sha256 = "sha256-hu3ckVocExi9lvxelHAwKb/MZacH4CcCE+vIzElgP/A=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # fix issues compiling on aarch64. remove once upgraded past 2.12.0
+    (fetchpatch {
+      url = "https://github.com/CloudCompare/CloudCompare/commit/7e71861fdbd6ea704add5ba69343f47d8fc3d5ae.patch";
+      sha256 = "sha256-CRUPjxtKUbsqOyYsjKF+dRZ+E3rqrv5mS3ZaOay2wk8=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
     eigen # header-only
+    wrapGAppsHook
   ];
 
   buildInputs = [
-    dxflib
+    boost
+    cgal_5
     flann
     gdal
+    gmp
     LASzip
-    libLAS
+    mpfr
     pdal
     pcl
     qtbase
@@ -72,8 +82,31 @@ mkDerivation rec {
     "-DPLUGIN_IO_QPHOTOSCAN=ON"
     "-DPLUGIN_IO_QRDB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
 
+    "-DCCCORELIB_USE_CGAL=ON" # enables Delauney triangulation support
     "-DPLUGIN_STANDARD_QPCL=ON" # Adds PCD import and export support
+    "-DPLUGIN_STANDARD_QANIMATION=ON"
+    "-DPLUGIN_STANDARD_QBROOM=ON"
+    "-DPLUGIN_STANDARD_QCANUPO=ON"
+    "-DPLUGIN_STANDARD_QCOMPASS=ON"
+    "-DPLUGIN_STANDARD_QCSF=ON"
+    "-DPLUGIN_STANDARD_QFACETS=ON"
+    "-DPLUGIN_STANDARD_QHOUGH_NORMALS=ON"
+    "-DEIGEN_ROOT_DIR=${eigen}/include/eigen3" # needed for hough normals
+    "-DPLUGIN_STANDARD_QHPR=ON"
+    "-DPLUGIN_STANDARD_QM3C2=ON"
+    "-DPLUGIN_STANDARD_QMPLANE=ON"
+    "-DPLUGIN_STANDARD_QPOISSON_RECON=ON"
+    "-DPLUGIN_STANDARD_QRANSAC_SD=ON"
+    "-DPLUGIN_STANDARD_QSRA=ON"
+    "-DPLUGIN_STANDARD_QCLOUDLAYERS=ON"
   ];
+
+  dontWrapGApps = true;
+
+  # fix file dialogs crashing on non-NixOS (and avoid double wrapping)
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   meta = with lib; {
     description = "3D point cloud and mesh processing software";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This updates CloudCompare to release 2.12.0 and enables most of the common plugins that would be found in a distribution version. I removed some inputs which are now vendored and/or used for no-longer-supported features. I've also added `wrapGAppsHook` to fix crashes with file dialogs when being used on non-NixOS.

Unfortunately, this version is still not ready for PDAL 2.4.0 (#165972) but I have poked upstream about it and I think they are slowly working on it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
