### PR TITLE
gnome.eog: Hardcode library path in gir

### DIFF
--- a/pkgs/desktops/gnome/core/eog/default.nix
+++ b/pkgs/desktops/gnome/core/eog/default.nix
@@ -38,6 +38,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-+zW/tRZ6QhIfWae5t6wNdbvQUXua/W2Rgx6E01c13fg=";
   };
 
+  patches = [
+    # Fix path to libeog.so in the gir file.
+    # We patch gobject-introspection to hardcode absolute paths but
+    # our Meson patch will only pass the info when install_dir is absolute as well.
+    ./fix-gir-lib-path.patch
+  ];
+
   nativeBuildInputs = [
     meson
     ninja

--- a/pkgs/desktops/gnome/core/eog/fix-gir-lib-path.patch
+++ b/pkgs/desktops/gnome/core/eog/fix-gir-lib-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/meson.build b/src/meson.build
+index cc9d3856..f909836d 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -165,7 +165,7 @@ libeog = shared_library(
+   link_args: ldflags,
+   link_depends: symbol_map,
+   install: true,
+-  install_dir: eog_pkglibdir,
++  install_dir: eog_prefix / eog_pkglibdir,
+ )
+ 
+ libeog_dep = declare_dependency(


### PR DESCRIPTION
###### Description of changes

By default, gobject-introspection refers to libraries using their file name in the GIR file. Since we do not have FHS to reliably find libraries by their name, we are patching gobject-introspection to use absolute paths.

This works fine for libraries installed to "$out/lib" but when a different path is used, the hard-coded absolute path will be incorrect. To deal with this case, we also patch Meson to be able to pass the install_dir to gobject-introspection. But it currently only passes the data for targets that have absolute install_dir set.

To have correct libeog path, we therefore need to absolutize the install_dir.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
