### PR TITLE
igraph: random improvements

### DIFF
--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -12,7 +12,9 @@
 , lapack
 , libxml2
 , libxslt
+, llvmPackages
 , pkg-config
+, plfit
 , python3
 , sourceHighlight
 , suitesparse
@@ -30,10 +32,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-SL9PcT18vFvykCv4VRXxXtlcDAcybmwEImnnKXMciFQ=";
   };
 
-  # Normally, igraph wants us to call bootstrap.sh, which will call
-  # tools/getversion.sh. Instead, we're going to put the version directly
-  # where igraph wants, and then let autoreconfHook do the rest of the
-  # bootstrap. ~ C.
   postPatch = ''
     echo "${version}" > IGRAPH_VERSION
   '' + lib.optionalString stdenv.isAarch64 ''
@@ -65,7 +63,10 @@ stdenv.mkDerivation rec {
     gmp
     lapack
     libxml2
+    plfit
     suitesparse
+  ] ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
   ];
 
   cmakeFlags = [
@@ -75,8 +76,10 @@ stdenv.mkDerivation rec {
     "-DIGRAPH_USE_INTERNAL_GLPK=OFF"
     "-DIGRAPH_USE_INTERNAL_CXSPARSE=OFF"
     "-DIGRAPH_USE_INTERNAL_GMP=OFF"
+    "-DIGRAPH_USE_INTERNAL_PLFIT=OFF"
     "-DIGRAPH_GLPK_SUPPORT=ON"
     "-DIGRAPH_GRAPHML_SUPPORT=ON"
+    "-DIGRAPH_OPENMP_SUPPORT=ON"
     "-DIGRAPH_ENABLE_LTO=AUTO"
     "-DIGRAPH_ENABLE_TLS=ON"
     "-DBUILD_SHARED_LIBS=ON"

--- a/pkgs/tools/misc/plfit/default.nix
+++ b/pkgs/tools/misc/plfit/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, python ? null
+, swig
+, llvmPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "plfit";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "ntamas";
+    repo = "plfit";
+    rev = version;
+    hash = "sha256-y4n6AlGtuuUuA+33oF7lGOYuKSqea4GMSJlv9PaSpQ8=";
+  };
+
+  patches = [
+    # https://github.com/ntamas/plfit/pull/41
+    (fetchpatch {
+      name = "use-cmake-install-full-dir.patch";
+      url = "https://github.com/ntamas/plfit/commit/d0e77c80e6e899298240e6be465cf580603f6ee2.patch";
+      hash = "sha256-wi3qCp6ZQtrKuM7XDA6xCXunCiqsyhnkxmg2eSmxjYM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals (!isNull python) [
+    python
+    swig
+  ];
+
+  cmakeFlags = [
+    "-DPLFIT_USE_OPENMP=ON"
+  ] ++ lib.optionals (!isNull python) [
+    "-DPLFIT_COMPILE_PYTHON_MODULE=ON"
+  ];
+
+  buildInputs = lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  meta = with lib; {
+    description = "Fitting power-law distributions to empirical data";
+    homepage = "https://github.com/ntamas/plfit";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9114,6 +9114,10 @@ with pkgs;
 
   pleroma = callPackage ../servers/pleroma { };
 
+  plfit = callPackage ../tools/misc/plfit {
+    python = null;
+  };
+
   ploticus = callPackage ../tools/graphics/ploticus {
     libpng = libpng12;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6374,6 +6374,10 @@ in {
 
   plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
 
+  plfit = toPythonModule (pkgs.plfit.override {
+    inherit (self) python;
+  });
+
   plone-testing = callPackage ../development/python-modules/plone-testing { };
 
   plotly = callPackage ../development/python-modules/plotly { };


### PR DESCRIPTION
###### Description of changes
* remove outdated comment
* use plfit from Nixpkgs
* unconditionally enable OpenMP

closes https://github.com/NixOS/nixpkgs/issues/166573
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @szhorvat