### PR TITLE
b43Firmware: support cross compile

### DIFF
--- a/pkgs/os-specific/linux/firmware/b43-firmware-cutter/default.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware-cutter/default.nix
@@ -11,7 +11,10 @@ stdenv.mkDerivation rec {
 
   patches = [ ./no-root-install.patch ];
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
   meta = {
     description = "Firmware extractor for cards supported by the b43 kernel module";

--- a/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/5.1.138.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0vz4ka8gycf72gmnaq61k8rh8y17j1wm2k3fidxvcqjvmix0drzi";
   };
 
-  buildInputs = [ b43FirmwareCutter ];
+  nativeBuildInputs = [ b43FirmwareCutter ];
 
   installPhase = ''
     mkdir -p $out/lib/firmware

--- a/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
+++ b/pkgs/os-specific/linux/firmware/b43-firmware/6.30.163.46.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0baw6gcnrhxbb447msv34xg6rmlcj0gm3ahxwvdwfcvq4xmknz50";
   };
 
-  buildInputs = [ b43FirmwareCutter ];
+  nativeBuildInputs = [ b43FirmwareCutter ];
 
   sourceRoot = ".";
 


### PR DESCRIPTION
###### Description of changes
Adds support for cross compiling the following derivations:

`b43FirmwareCutter`
`b43Firmware_5_1_138`
`b43Firmware_6_30_163_46`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
