### PR TITLE
tusd: init at 1.8.0

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1389,6 +1389,7 @@ in
   tuptime = handleTest ./tuptime.nix { };
   turbovnc-headless-server = handleTest ./turbovnc-headless-server.nix { };
   turn-rs = handleTest ./turn-rs.nix { };
+  tusd = runTest ./tusd/default.nix;
   tuxguitar = runTest ./tuxguitar.nix;
   twingate = runTest ./twingate.nix;
   typesense = handleTest ./typesense.nix { };

--- a/nixos/tests/tusd/default.nix
+++ b/nixos/tests/tusd/default.nix
@@ -1,0 +1,50 @@
+{ pkgs, lib, ... }:
+
+let
+  port = 1080;
+
+  client =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  server =
+    { pkgs, ... }:
+    {
+      # tusd does not have a NixOS service yet.
+      systemd.services.tusd = {
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          ExecStart = ''${pkgs.tusd}/bin/tusd -port "${toString port}" -upload-dir=/data'';
+        };
+      };
+      networking.firewall.allowedTCPPorts = [ port ];
+    };
+in
+{
+  name = "tusd";
+  meta.maintainers = with lib.maintainers; [
+    nh2
+    kalbasit
+  ];
+
+  nodes = {
+    inherit server;
+    inherit client;
+  };
+
+  testScript = ''
+    server.wait_for_unit("tusd.service")
+    server.wait_for_open_port(${toString port})
+
+    # Create large file.
+    client.succeed("${pkgs.coreutils}/bin/truncate --size=100M file-100M.bin")
+
+    # Upload it.
+    client.succeed("${./tus-curl-upload.sh} file-100M.bin http://server:${toString port}/files/")
+
+    print("Upload succeeded")
+  '';
+}

--- a/nixos/tests/tusd/tus-curl-upload.sh
+++ b/nixos/tests/tusd/tus-curl-upload.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Adapted from:
+# - https://github.com/tus/tus.io/issues/96
+
+if [ ! -f "${1}" ]; then
+  echo -e "\n\033[1;31m✘\033[0m First argument needs to be an existing file.\n"
+  exit 1
+fi
+
+if [ -z "${2}" ]; then
+  echo -e "\n\033[1;31m✘\033[0m Second argument needs to be the TUS server's URL.\n"
+  exit 1
+fi
+
+file=${1}
+TUS_URL=${2}
+filename=$(basename "${file}" | base64)
+filesize="$(wc -c <"${file}")"
+
+# Apparently 'Location: ..' is terminated by CRLF. grep and awk faithfully
+# preserve the line ending, and the shell's $() substitution strips off the
+# final LF leaving you with a string that just ends with a CR.
+#
+# When the CR is printed, the cursor moves to the beginning of the line and
+# whatever gets printed next overwrites what was there.
+# ... | tr -d '\015'
+location=$(curl \
+  --silent --show-error \
+  -I \
+  -X POST \
+  -H "Tus-Resumable: 1.0.0" \
+  -H "Content-Length: 0" \
+  -H "Upload-Length: ${filesize}" \
+  -H "Upload-Metadata: name ${filename}" \
+  "${TUS_URL}" | grep 'Location:' | awk '{print $2}' | tr -d '\015')
+
+if [ -n "${location}" ]; then
+  curl \
+    -X PATCH \
+    -H "Tus-Resumable: 1.0.0" \
+    -H "Upload-Offset: 0" \
+    -H "Content-Length: ${filesize}" \
+    -H "Content-Type: application/offset+octet-stream" \
+    --data-binary "@${file}" \
+    "${location}" -v
+else
+  echo -e "\n\033[1;31m✘\033[0m File creation failed..\n"
+  exit 1
+fi

--- a/pkgs/by-name/tu/tusd/package.nix
+++ b/pkgs/by-name/tu/tusd/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+}:
+
+buildGoModule rec {
+  pname = "tusd";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "tus";
+    repo = "tusd";
+    tag = "v${version}";
+    hash = "sha256-OzXBeLDjaJk4NVgsauR/NUATh7qHbuEfWNdhytZmd0A=";
+  };
+
+  vendorHash = "sha256-YununGyB72zE0tmqO3BREJeMTjCuy/1fhPHC5r8OLjg=";
+
+  # Tests need the path to the binary:
+  # https://github.com/tus/tusd/blob/0e52ad650abed02ec961353bb0c3c8bc36650d2c/internal/e2e/e2e_test.go#L37
+  preCheck = ''
+    export TUSD_BINARY=$PWD/../go/bin/tusd
+  '';
+
+  passthru.tests.tusd = nixosTests.tusd;
+
+  meta = {
+    description = "Reference server implementation in Go of tus: the open protocol for resumable file uploads";
+    license = lib.licenses.mit;
+    homepage = "https://tus.io/";
+    maintainers = with lib.maintainers; [
+      nh2
+      kalbasit
+    ];
+  };
+}


### PR DESCRIPTION
###### Description of changes

* Packages `tusd`, the reference server implementation of https://tus.io
* As requested on https://github.com/tus/tusd/issues/683
* Also a NixOS VM test
* The `curl`-based test upload script is from https://github.com/tus/tus.io/issues/96#issuecomment-312036573

I would like to have co-maintainers for this, since I'm just trying out `tusd` currently.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

