### PR TITLE
python3Packages.recordlinkage: init at 0.14

### DIFF
--- a/pkgs/development/python-modules/recordlinkage/default.nix
+++ b/pkgs/development/python-modules/recordlinkage/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, bottleneck
+, buildPythonPackage
+, fetchPypi
+, jellyfish
+, joblib
+, networkx
+, numexpr
+, numpy
+, pandas
+, pyarrow
+, pytest
+, scikit-learn
+, scipy
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "recordlinkage";
+  version = "0.14";
+
+  disabled = pythonOlder "3.7";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-kuY2MUuwaLb228kwkJmOnnU+OolZcvGlhKTTiama+T4=";
+  };
+
+  propagatedBuildInputs = [
+    pyarrow
+    jellyfish
+    numpy
+    pandas
+    scipy
+    scikit-learn
+    joblib
+    networkx
+    bottleneck
+    numexpr
+  ];
+
+  # pytestCheckHook does not work
+  # Reusing their CI setup which involves 'rm -rf recordlinkage' in preCheck phase do not work too.
+  checkInputs = [ pytest ];
+
+  pythonImportsCheck = [ "recordlinkage" ];
+
+  meta = with lib; {
+    description = "Library to link records in or between data sources";
+    homepage = "https://recordlinkage.readthedocs.io/";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.raitobezarius ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8837,6 +8837,8 @@ in {
 
   recommonmark = callPackage ../development/python-modules/recommonmark { };
 
+  recordlinkage = callPackage ../development/python-modules/recordlinkage { };
+
   redbaron = callPackage ../development/python-modules/redbaron { };
 
   redis = callPackage ../development/python-modules/redis { };


### PR DESCRIPTION
###### Description of changes

This library enables record linkage in Python (see https://github.com/J535D165/recordlinkage) ; it enables deduplication, indexing, etc. with the ability to use machine learning classification, etc.

~~Depends on #169149 to pass tests.~~
https://github.com/NixOS/nixpkgs/pull/170107 fixed it.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).