### PR TITLE
xfsdump: init at 3.1.10

### DIFF
--- a/pkgs/tools/filesystems/xfsdump/default.nix
+++ b/pkgs/tools/filesystems/xfsdump/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchurl
+, attr
+, gettext
+, autoconf
+, automake
+, ncurses
+, libtool
+, libuuid
+, libxfs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xfsdump";
+  version = "3.1.10";
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/utils/fs/xfs/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "sha256-mqt6U6oFzUbtyXJp6/FFaqsrYKuMH/+q+KpJLwtfZRc=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    gettext
+    libtool
+  ];
+  buildInputs = [
+    attr
+    libuuid
+    libxfs
+    ncurses
+  ];
+
+  patchPhase = ''
+    substituteInPlace Makefile \
+      --replace "cp include/install-sh ." "cp -f include/install-sh ."
+  '';
+
+  # Conifigure scripts don't check PATH, see xfstests derviation
+  preConfigure = ''
+    export MAKE=$(type -P make)
+    export MSGFMT=$(type -P msgfmt)
+    export MSGMERGE=$(type -P msgmerge)
+    export XGETTEXT=$(type -P xgettext)
+
+    make configure
+    patchShebangs ./install-sh
+  '';
+
+  meta = with lib; {
+    description = "XFS filesystem incremental dump utility";
+    homepage = "https://git.kernel.org/pub/scm/fs/xfs/xfsdump-dev.git/tree/doc/CHANGES";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.lunik1 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11491,6 +11491,8 @@ with pkgs;
   xflux = callPackage ../tools/misc/xflux { };
   xflux-gui = python3Packages.callPackage ../tools/misc/xflux/gui.nix { };
 
+  xfsdump = callPackage ../tools/filesystems/xfsdump { };
+
   xfsprogs = callPackage ../tools/filesystems/xfsprogs { };
   libxfs = xfsprogs.dev;
 


### PR DESCRIPTION
###### Description of changes
Adds the `xfsdump` and `xfsrestore` utilities.

I'd appreciate a review from the other xfs utility maintainers @dezgeg @ajs124

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
