### PR TITLE
Go: drop extra escape

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -176,7 +176,7 @@ let
         IFS=' ' read -r -a excludedArr <<<$excludedPackages
         printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
         excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
-        exclude+='\\|'"$excludedAlternates"
+        exclude+='\|'"$excludedAlternates"
       fi
       exclude+='\)'
 

--- a/pkgs/development/go-packages/generic/default.nix
+++ b/pkgs/development/go-packages/generic/default.nix
@@ -155,7 +155,7 @@ let
         IFS=' ' read -r -a excludedArr <<<$excludedPackages
         printf -v excludedAlternates '%s\\|' "''${excludedArr[@]}"
         excludedAlternates=''${excludedAlternates%\\|} # drop final \| added by printf
-        exclude+='\\|'"$excludedAlternates"
+        exclude+='\|'"$excludedAlternates"
       fi
       exclude+='\)'
 


### PR DESCRIPTION
###### Description of changes

Drops an extra/unnecessary `\` that was used in the exclusion regex

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Supersedes https://github.com/NixOS/nixpkgs/pull/166968, tested that prometheus was indeed broken before this commit and fixed afterwards.