### PR TITLE
gitea: patch for CVE-2022-0905, CVE-2022-1058

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoPackage
 , fetchurl
+, fetchpatch
 , makeWrapper
 , git
 , bash
@@ -33,6 +34,16 @@ buildGoPackage rec {
 
   patches = [
     ./static-root-path.patch
+    (fetchpatch {
+      name = "CVE-2022-0905.patch";
+      url = "https://github.com/go-gitea/gitea/commit/1314f38b59748397b3429fb9bc9f9d6bac85d2f2.patch";
+      sha256 = "1hq16rmv69lp9w2qyrrhj04mmmqkdc361n2cls460pnzqk88wj0g";
+    })
+    (fetchpatch {
+      name = "CVE-2022-1058.patch";
+      url = "https://github.com/go-gitea/gitea/commit/e3d8e92bdc67562783de9a76b5b7842b68daeb48.patch";
+      sha256 = "0vvaqqhmx3gkw8fa64ifk2x546zsvlmf65grk29lhzsw1y148sy9";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Description of changes

Patch gitea for known vulnerabilities: https://github.com/NixOS/nixpkgs/issues/166640

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested with `nixosTests.gitea`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
