### PR TITLE
nixos/stage-1-systemd: Implement job scripts

### DIFF
--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -94,131 +94,133 @@ in rec {
 
   };
 
-  commonUnitOptions = { options = (sharedOptions // {
+  commonUnitOptions = {
+    options = sharedOptions // {
 
-    description = mkOption {
-      default = "";
-      type = types.singleLineStr;
-      description = "Description of this unit used in systemd messages and progress indicators.";
+      description = mkOption {
+        default = "";
+        type = types.singleLineStr;
+        description = "Description of this unit used in systemd messages and progress indicators.";
+      };
+
+      documentation = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        description = "A list of URIs referencing documentation for this unit or its configuration.";
+      };
+
+      requires = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          Start the specified units when this unit is started, and stop
+          this unit when the specified units are stopped or fail.
+        '';
+      };
+
+      wants = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          Start the specified units when this unit is started.
+        '';
+      };
+
+      after = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          If the specified units are started at the same time as
+          this unit, delay this unit until they have started.
+        '';
+      };
+
+      before = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          If the specified units are started at the same time as
+          this unit, delay them until this unit has started.
+        '';
+      };
+
+      bindsTo = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          Like ‘requires’, but in addition, if the specified units
+          unexpectedly disappear, this unit will be stopped as well.
+        '';
+      };
+
+      partOf = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          If the specified units are stopped or restarted, then this
+          unit is stopped or restarted as well.
+        '';
+      };
+
+      conflicts = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          If the specified units are started, then this unit is stopped
+          and vice versa.
+        '';
+      };
+
+      requisite = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          Similar to requires. However if the units listed are not started,
+          they will not be started and the transaction will fail.
+        '';
+      };
+
+      unitConfig = mkOption {
+        default = {};
+        example = { RequiresMountsFor = "/data"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Unit]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.unit</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
+      onFailure = mkOption {
+        default = [];
+        type = types.listOf unitNameType;
+        description = ''
+          A list of one or more units that are activated when
+          this unit enters the "failed" state.
+        '';
+      };
+
+      startLimitBurst = mkOption {
+         type = types.int;
+         description = ''
+           Configure unit start rate limiting. Units which are started
+           more than startLimitBurst times within an interval time
+           interval are not permitted to start any more.
+         '';
+      };
+
+      startLimitIntervalSec = mkOption {
+         type = types.int;
+         description = ''
+           Configure unit start rate limiting. Units which are started
+           more than startLimitBurst times within an interval time
+           interval are not permitted to start any more.
+         '';
+      };
+
     };
-
-    documentation = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      description = "A list of URIs referencing documentation for this unit or its configuration.";
-    };
-
-    requires = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        Start the specified units when this unit is started, and stop
-        this unit when the specified units are stopped or fail.
-      '';
-    };
-
-    wants = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        Start the specified units when this unit is started.
-      '';
-    };
-
-    after = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        If the specified units are started at the same time as
-        this unit, delay this unit until they have started.
-      '';
-    };
-
-    before = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        If the specified units are started at the same time as
-        this unit, delay them until this unit has started.
-      '';
-    };
-
-    bindsTo = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        Like ‘requires’, but in addition, if the specified units
-        unexpectedly disappear, this unit will be stopped as well.
-      '';
-    };
-
-    partOf = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        If the specified units are stopped or restarted, then this
-        unit is stopped or restarted as well.
-      '';
-    };
-
-    conflicts = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        If the specified units are started, then this unit is stopped
-        and vice versa.
-      '';
-    };
-
-    requisite = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        Similar to requires. However if the units listed are not started,
-        they will not be started and the transaction will fail.
-      '';
-    };
-
-    unitConfig = mkOption {
-      default = {};
-      example = { RequiresMountsFor = "/data"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Unit]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.unit</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
-    };
-
-    onFailure = mkOption {
-      default = [];
-      type = types.listOf unitNameType;
-      description = ''
-        A list of one or more units that are activated when
-        this unit enters the "failed" state.
-      '';
-    };
-
-    startLimitBurst = mkOption {
-       type = types.int;
-       description = ''
-         Configure unit start rate limiting. Units which are started
-         more than startLimitBurst times within an interval time
-         interval are not permitted to start any more.
-       '';
-    };
-
-    startLimitIntervalSec = mkOption {
-       type = types.int;
-       description = ''
-         Configure unit start rate limiting. Units which are started
-         more than startLimitBurst times within an interval time
-         interval are not permitted to start any more.
-       '';
-    };
-
-  }); };
+  };
 
   stage2CommonUnitOptions = {
     imports = [
@@ -250,131 +252,132 @@ in rec {
   };
   stage1CommonUnitOptions = commonUnitOptions;
 
-  serviceOptions = { name, config, ... }: { options = {
+  serviceOptions = { name, config, ... }: {
+    options = {
 
-    environment = mkOption {
-      default = {};
-      type = with types; attrsOf (nullOr (oneOf [ str path package ]));
-      example = { PATH = "/foo/bar/bin"; LANG = "nl_NL.UTF-8"; };
-      description = "Environment variables passed to the service's processes.";
+      environment = mkOption {
+        default = {};
+        type = with types; attrsOf (nullOr (oneOf [ str path package ]));
+        example = { PATH = "/foo/bar/bin"; LANG = "nl_NL.UTF-8"; };
+        description = "Environment variables passed to the service's processes.";
+      };
+
+      path = mkOption {
+        default = [];
+        type = with types; listOf (oneOf [ package str ]);
+        description = ''
+          Packages added to the service's <envar>PATH</envar>
+          environment variable.  Both the <filename>bin</filename>
+          and <filename>sbin</filename> subdirectories of each
+          package are added.
+        '';
+      };
+
+      serviceConfig = mkOption {
+        default = {};
+        example =
+          { RestartSec = 5;
+          };
+        type = types.addCheck (types.attrsOf unitOption) checkService;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Service]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.service</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
+      script = mkOption {
+        type = types.lines;
+        default = "";
+        description = "Shell commands executed as the service's main process.";
+      };
+
+      scriptArgs = mkOption {
+        type = types.str;
+        default = "";
+        description = "Arguments passed to the main process script.";
+      };
+
+      preStart = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Shell commands executed before the service's main process
+          is started.
+        '';
+      };
+
+      postStart = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Shell commands executed after the service's main process
+          is started.
+        '';
+      };
+
+      reload = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Shell commands executed when the service's main process
+          is reloaded.
+        '';
+      };
+
+      preStop = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Shell commands executed to stop the service.
+        '';
+      };
+
+      postStop = mkOption {
+        type = types.lines;
+        default = "";
+        description = ''
+          Shell commands executed after the service's main process
+          has exited.
+        '';
+      };
+
+      jobScripts = mkOption {
+        type = with types; coercedTo path singleton (listOf path);
+        internal = true;
+        description = "A list of all job script derivations of this unit.";
+        default = [];
+      };
+
     };
 
-    path = mkOption {
-      default = [];
-      type = with types; listOf (oneOf [ package str ]);
-      description = ''
-        Packages added to the service's <envar>PATH</envar>
-        environment variable.  Both the <filename>bin</filename>
-        and <filename>sbin</filename> subdirectories of each
-        package are added.
-      '';
-    };
-
-    serviceConfig = mkOption {
-      default = {};
-      example =
-        { RestartSec = 5;
-        };
-      type = types.addCheck (types.attrsOf unitOption) checkService;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Service]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.service</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
-    };
-
-    script = mkOption {
-      type = types.lines;
-      default = "";
-      description = "Shell commands executed as the service's main process.";
-    };
-
-    scriptArgs = mkOption {
-      type = types.str;
-      default = "";
-      description = "Arguments passed to the main process script.";
-    };
-
-    preStart = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Shell commands executed before the service's main process
-        is started.
-      '';
-    };
-
-    postStart = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Shell commands executed after the service's main process
-        is started.
-      '';
-    };
-
-    reload = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Shell commands executed when the service's main process
-        is reloaded.
-      '';
-    };
-
-    preStop = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Shell commands executed to stop the service.
-      '';
-    };
-
-    postStop = mkOption {
-      type = types.lines;
-      default = "";
-      description = ''
-        Shell commands executed after the service's main process
-        has exited.
-      '';
-    };
-
-    jobScripts = mkOption {
-      type = with types; coercedTo path singleton (listOf path);
-      internal = true;
-      description = "A list of all job script derivations of this unit.";
-      default = [];
-    };
-
-  };
-
-  config = mkMerge [
-    (mkIf (config.preStart != "") rec {
-      jobScripts = makeJobScript "${name}-pre-start" config.preStart;
-      serviceConfig.ExecStartPre = [ jobScripts ];
-    })
-    (mkIf (config.script != "") rec {
-      jobScripts = makeJobScript "${name}-start" config.script;
-      serviceConfig.ExecStart = jobScripts + " " + config.scriptArgs;
-    })
-    (mkIf (config.postStart != "") rec {
-      jobScripts = (makeJobScript "${name}-post-start" config.postStart);
-      serviceConfig.ExecStartPost = [ jobScripts ];
-    })
-    (mkIf (config.reload != "") rec {
-      jobScripts = makeJobScript "${name}-reload" config.reload;
-      serviceConfig.ExecReload = jobScripts;
-    })
-    (mkIf (config.preStop != "") rec {
-      jobScripts = makeJobScript "${name}-pre-stop" config.preStop;
-      serviceConfig.ExecStop = jobScripts;
-    })
-    (mkIf (config.postStop != "") rec {
-      jobScripts = makeJobScript "${name}-post-stop" config.postStop;
-      serviceConfig.ExecStopPost = jobScripts;
-    })
-  ];
+    config = mkMerge [
+      (mkIf (config.preStart != "") rec {
+        jobScripts = makeJobScript "${name}-pre-start" config.preStart;
+        serviceConfig.ExecStartPre = [ jobScripts ];
+      })
+      (mkIf (config.script != "") rec {
+        jobScripts = makeJobScript "${name}-start" config.script;
+        serviceConfig.ExecStart = jobScripts + " " + config.scriptArgs;
+      })
+      (mkIf (config.postStart != "") rec {
+        jobScripts = (makeJobScript "${name}-post-start" config.postStart);
+        serviceConfig.ExecStartPost = [ jobScripts ];
+      })
+      (mkIf (config.reload != "") rec {
+        jobScripts = makeJobScript "${name}-reload" config.reload;
+        serviceConfig.ExecReload = jobScripts;
+      })
+      (mkIf (config.preStop != "") rec {
+        jobScripts = makeJobScript "${name}-pre-stop" config.preStop;
+        serviceConfig.ExecStop = jobScripts;
+      })
+      (mkIf (config.postStop != "") rec {
+        jobScripts = makeJobScript "${name}-post-stop" config.postStop;
+        serviceConfig.ExecStopPost = jobScripts;
+      })
+    ];
 
   };
 
@@ -450,41 +453,43 @@ in rec {
   };
 
 
-  socketOptions = { options = {
+  socketOptions = {
+    options = {
 
-    listenStreams = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      example = [ "0.0.0.0:993" "/run/my-socket" ];
-      description = ''
-        For each item in this list, a <literal>ListenStream</literal>
-        option in the <literal>[Socket]</literal> section will be created.
-      '';
+      listenStreams = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        example = [ "0.0.0.0:993" "/run/my-socket" ];
+        description = ''
+          For each item in this list, a <literal>ListenStream</literal>
+          option in the <literal>[Socket]</literal> section will be created.
+        '';
+      };
+
+      listenDatagrams = mkOption {
+        default = [];
+        type = types.listOf types.str;
+        example = [ "0.0.0.0:993" "/run/my-socket" ];
+        description = ''
+          For each item in this list, a <literal>ListenDatagram</literal>
+          option in the <literal>[Socket]</literal> section will be created.
+        '';
+      };
+
+      socketConfig = mkOption {
+        default = {};
+        example = { ListenStream = "/run/my-socket"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Socket]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.socket</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
     };
 
-    listenDatagrams = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      example = [ "0.0.0.0:993" "/run/my-socket" ];
-      description = ''
-        For each item in this list, a <literal>ListenDatagram</literal>
-        option in the <literal>[Socket]</literal> section will be created.
-      '';
-    };
-
-    socketConfig = mkOption {
-      default = {};
-      example = { ListenStream = "/run/my-socket"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Socket]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.socket</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
-    };
-
-  }; };
+  };
 
   stage2SocketOptions = {
     imports = [
@@ -501,23 +506,25 @@ in rec {
   };
 
 
-  timerOptions = { options = {
+  timerOptions = {
+    options = {
 
-    timerConfig = mkOption {
-      default = {};
-      example = { OnCalendar = "Sun 14:00:00"; Unit = "foo.service"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Timer]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.timer</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> and
-        <citerefentry><refentrytitle>systemd.time</refentrytitle>
-        <manvolnum>7</manvolnum></citerefentry> for details.
-      '';
+      timerConfig = mkOption {
+        default = {};
+        example = { OnCalendar = "Sun 14:00:00"; Unit = "foo.service"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Timer]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.timer</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> and
+          <citerefentry><refentrytitle>systemd.time</refentrytitle>
+          <manvolnum>7</manvolnum></citerefentry> for details.
+        '';
+      };
+
     };
-
-  }; };
+  };
 
   stage2TimerOptions = {
     imports = [
@@ -534,21 +541,23 @@ in rec {
   };
 
 
-  pathOptions = { options = {
+  pathOptions = {
+    options = {
 
-    pathConfig = mkOption {
-      default = {};
-      example = { PathChanged = "/some/path"; Unit = "changedpath.service"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Path]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.path</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
+      pathConfig = mkOption {
+        default = {};
+        example = { PathChanged = "/some/path"; Unit = "changedpath.service"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Path]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.path</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
     };
-
-  }; };
+  };
 
   stage2PathOptions = {
     imports = [
@@ -565,49 +574,52 @@ in rec {
   };
 
 
-  mountOptions = { options = {
+  mountOptions = {
+    options = {
 
-    what = mkOption {
-      example = "/dev/sda1";
-      type = types.str;
-      description = "Absolute path of device node, file or other resource. (Mandatory)";
-    };
+      what = mkOption {
+        example = "/dev/sda1";
+        type = types.str;
+        description = "Absolute path of device node, file or other resource. (Mandatory)";
+      };
 
-    where = mkOption {
-      example = "/mnt";
-      type = types.str;
-      description = ''
-        Absolute path of a directory of the mount point.
-        Will be created if it doesn't exist. (Mandatory)
-      '';
-    };
+      where = mkOption {
+        example = "/mnt";
+        type = types.str;
+        description = ''
+          Absolute path of a directory of the mount point.
+          Will be created if it doesn't exist. (Mandatory)
+        '';
+      };
 
-    type = mkOption {
-      default = "";
-      example = "ext4";
-      type = types.str;
-      description = "File system type.";
-    };
+      type = mkOption {
+        default = "";
+        example = "ext4";
+        type = types.str;
+        description = "File system type.";
+      };
 
-    options = mkOption {
-      default = "";
-      example = "noatime";
-      type = types.commas;
-      description = "Options used to mount the file system.";
-    };
+      options = mkOption {
+        default = "";
+        example = "noatime";
+        type = types.commas;
+        description = "Options used to mount the file system.";
+      };
 
-    mountConfig = mkOption {
-      default = {};
-      example = { DirectoryMode = "0775"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Mount]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.mount</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
+      mountConfig = mkOption {
+        default = {};
+        example = { DirectoryMode = "0775"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Mount]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.mount</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
     };
-  }; };
+  };
 
   stage2MountOptions = {
     imports = [
@@ -623,29 +635,32 @@ in rec {
     ];
   };
 
-  automountOptions = { options = {
+  automountOptions = {
+    options = {
 
-    where = mkOption {
-      example = "/mnt";
-      type = types.str;
-      description = ''
-        Absolute path of a directory of the mount point.
-        Will be created if it doesn't exist. (Mandatory)
-      '';
-    };
+      where = mkOption {
+        example = "/mnt";
+        type = types.str;
+        description = ''
+          Absolute path of a directory of the mount point.
+          Will be created if it doesn't exist. (Mandatory)
+        '';
+      };
 
-    automountConfig = mkOption {
-      default = {};
-      example = { DirectoryMode = "0775"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Automount]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.automount</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
+      automountConfig = mkOption {
+        default = {};
+        example = { DirectoryMode = "0775"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Automount]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.automount</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
     };
-  }; };
+  };
 
   stage2AutomountOptions = {
     imports = [
@@ -661,21 +676,23 @@ in rec {
     ];
   };
 
-  sliceOptions = { options = {
+  sliceOptions = {
+    options = {
 
-    sliceConfig = mkOption {
-      default = {};
-      example = { MemoryMax = "2G"; };
-      type = types.attrsOf unitOption;
-      description = ''
-        Each attribute in this set specifies an option in the
-        <literal>[Slice]</literal> section of the unit.  See
-        <citerefentry><refentrytitle>systemd.slice</refentrytitle>
-        <manvolnum>5</manvolnum></citerefentry> for details.
-      '';
+      sliceConfig = mkOption {
+        default = {};
+        example = { MemoryMax = "2G"; };
+        type = types.attrsOf unitOption;
+        description = ''
+          Each attribute in this set specifies an option in the
+          <literal>[Slice]</literal> section of the unit.  See
+          <citerefentry><refentrytitle>systemd.slice</refentrytitle>
+          <manvolnum>5</manvolnum></citerefentry> for details.
+        '';
+      };
+
     };
-
-  }; };
+  };
 
   stage2SliceOptions = {
     imports = [

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -96,6 +96,7 @@ let
 
   enabledUpstreamUnits = filter (n: ! elem n cfg.suppressedUnits) upstreamUnits;
   enabledUnits = filterAttrs (n: v: ! elem n cfg.suppressedUnits) cfg.units;
+  jobScripts = concatLists (mapAttrsToList (_: unit: unit.jobScripts or []) (filterAttrs (_: v: v.enable) cfg.services));
 
   stage1Units = generateUnits {
     type = "initrd";
@@ -378,7 +379,7 @@ in {
 
         # so NSS can look up usernames
         "${pkgs.glibc}/lib/libnss_files.so"
-      ];
+      ] ++ jobScripts;
 
       targets.initrd.aliases = ["default.target"];
       units =


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Being able to set `script` makes it a lot easier to write services, just as with `systemd.services` in stage 2.
cc @roberth for the module stuff.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
