### PR TITLE
helix: 0.6.0 -> 22.03

### DIFF
--- a/pkgs/applications/editors/helix/default.nix
+++ b/pkgs/applications/editors/helix/default.nix
@@ -2,17 +2,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "helix";
-  version = "0.6.0";
+  version = "22.03";
 
   src = fetchFromGitHub {
     owner = "helix-editor";
     repo = pname;
-    rev = "v${version}";
+    rev = version;
     fetchSubmodules = true;
-    sha256 = "sha256-d/USOtcPLjdgzN7TBCouBRmoSDH5LZD4R5Qq7lUrWZw=";
+    sha256 = "anUYKgr61QQmdraSYpvFY/2sG5hkN3a2MwplNZMEyfI=";
   };
 
-  cargoSha256 = "sha256-/EATU7HsGNB35YOBp8sofbPd1nl4d3Ggj1ay3QuHkCI=";
+  cargoSha256 = "zJQ+KvO+6iUIb0eJ+LnMbitxaqTxfqgu7XXj3j0GiX4=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -24,11 +24,16 @@ rustPlatform.buildRustPackage rec {
     wrapProgram $out/bin/hx --set HELIX_RUNTIME $out/lib/runtime
   '';
 
+  # This tries to fetch the tree-sitter grammars over the Internet:
+  # https://github.com/helix-editor/helix/blob/f8c83f98859fd618980141eb95e7927dcdf074d7/helix-loader/src/grammar.rs#L140-L185
+  # TODO: Download the grammars through Nix so that they can be enabled.
+  HELIX_DISABLE_AUTO_GRAMMAR_BUILD = true;
+
   meta = with lib; {
     description = "A post-modern modal text editor";
     homepage = "https://helix-editor.com";
     license = licenses.mpl20;
     mainProgram = "hx";
-    maintainers = with maintainers; [ yusdacra ];
+    maintainers = with maintainers; [ danth yusdacra ];
   };
 }

--- a/pkgs/applications/editors/helix/default.nix
+++ b/pkgs/applications/editors/helix/default.nix
@@ -1,15 +1,15 @@
-{ fetchFromGitHub, lib, rustPlatform, makeWrapper }:
+{ fetchzip, lib, rustPlatform, makeWrapper }:
 
 rustPlatform.buildRustPackage rec {
   pname = "helix";
   version = "22.03";
 
-  src = fetchFromGitHub {
-    owner = "helix-editor";
-    repo = pname;
-    rev = version;
-    fetchSubmodules = true;
-    sha256 = "anUYKgr61QQmdraSYpvFY/2sG5hkN3a2MwplNZMEyfI=";
+  # This release tarball includes source code for the tree-sitter grammars,
+  # which is not ordinarily part of the repository.
+  src = fetchzip {
+    url = "https://github.com/helix-editor/helix/releases/download/${version}/helix-${version}-source.tar.xz";
+    sha256 = "DP/hh6JfnyHdW2bg0cvhwlWvruNDvL9bmXM46iAUQzA=";
+    stripRoot = false;
   };
 
   cargoSha256 = "zJQ+KvO+6iUIb0eJ+LnMbitxaqTxfqgu7XXj3j0GiX4=";
@@ -23,11 +23,6 @@ rustPlatform.buildRustPackage rec {
   postFixup = ''
     wrapProgram $out/bin/hx --set HELIX_RUNTIME $out/lib/runtime
   '';
-
-  # This tries to fetch the tree-sitter grammars over the Internet:
-  # https://github.com/helix-editor/helix/blob/f8c83f98859fd618980141eb95e7927dcdf074d7/helix-loader/src/grammar.rs#L140-L185
-  # TODO: Download the grammars through Nix so that they can be enabled.
-  HELIX_DISABLE_AUTO_GRAMMAR_BUILD = true;
 
   meta = with lib; {
     description = "A post-modern modal text editor";


### PR DESCRIPTION
###### Description of changes

Updated Helix to version 22.03. [See the changelog.](https://github.com/helix-editor/helix/blob/master/CHANGELOG.md#2203-2022-03-28)

I've disabled the new tree-sitter grammar system because it tries to download things during the build phase.
If the compiled grammars were included as part of the older package we may wish to get this enabled again before merging.

(Also added myself as a maintainer for this package.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
