### PR TITLE
lightning-loop: 0.17.0-beta -> 0.18.0-beta

### DIFF
--- a/pkgs/applications/blockchains/lightning-loop/default.nix
+++ b/pkgs/applications/blockchains/lightning-loop/default.nix
@@ -5,16 +5,16 @@
 
 buildGoModule rec {
   pname = "lightning-loop";
-  version = "0.17.0-beta";
+  version = "0.18.0-beta";
 
   src = fetchFromGitHub {
     owner = "lightninglabs";
     repo = "loop";
     rev = "v${version}";
-    sha256 = "0hjawagn1dfgj67i52bvf3phvm9f9708z3jqs6cvyz0w7vp107py";
+    sha256 = "1kg5nlvb4lb3cjn84wcylhq0l73d2n6rg4n1srnxmgs96v41y78f";
   };
 
-  vendorSha256 = "1fpc73hwdn3baz5ykrykvqdr5861gj9p6liy8qll5525kdv560f6";
+  vendorSha256 = "0q3wbjfaqdj29sjlhx6fhc0p4d12aa31s6ia36jalcvf659ybb0l";
 
   subPackages = [ "cmd/loop" "cmd/loopd" ];
 


### PR DESCRIPTION
###### Description of changes

No breaking changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

You can GPG verify the hash with [this script](https://gist.github.com/nixbitcoin/d51a554330d0ca93e3e0ed15eb21cae7). Just execute `./script 0.18.0-beta`
Tested with the [nix-bitcoin VM test](https://gist.github.com/nixbitcoin/6c8939a99a048a8f51d7165d7e01e6d8).

@prusnak 