### PR TITLE
openvscode-server: 1.62.3 -> 1.66.0

### DIFF
--- a/pkgs/servers/openvscode-server/default.nix
+++ b/pkgs/servers/openvscode-server/default.nix
@@ -13,7 +13,8 @@ let
   vsBuildTarget = {
     x86_64-linux = "linux-x64";
     aarch64-linux = "linux-arm64";
-    x86_64-darwin = "darwin";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
   }.${system} or (throw "Unsupported system ${system}");
 
   # replaces esbuild's download script with a binary from nixpkgs
@@ -26,13 +27,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "openvscode-server";
-  version = "1.62.3";
+  version = "1.66.0";
 
   src = fetchFromGitHub {
     owner = "gitpod-io";
     repo = "openvscode-server";
     rev = "openvscode-server-v${version}";
-    sha256 = "0822181gbd6y8bzn65liv7prqv7pg067sbl8nac02zg7268qwi6j";
+    sha256 = "g5QaxZDVXvE/vOe2BjBXlqYLGZ2EG4nTKdUlLdt8H8A=";
   };
 
   yarnCache = stdenv.mkDerivation {
@@ -55,7 +56,7 @@ in stdenv.mkDerivation rec {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "0rmcixcn7lmrndb2pq0x895qp34hc271h1j0n3xq9rv603v1ayvk";
+    outputHash = "sha256-BeVJsruiRLReGMwThfcEm/ez4UFcr0oI4wwevJwxt58=";
   };
 
   # Extract the Node.js source code which is used to compile packages with
@@ -123,7 +124,7 @@ in stdenv.mkDerivation rec {
     patchShebangs ./remote/node_modules
 
     # put ripgrep binary into bin so postinstall does not try to download it
-    find -name vscode-ripgrep -type d \
+    find -path "*@vscode/ripgrep" -type d \
       -execdir mkdir -p {}/bin \; \
       -execdir ln -s ${ripgrep}/bin/rg {}/bin/rg \;
   '' + lib.optionalString stdenv.isDarwin ''
@@ -150,13 +151,9 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -p $out/libexec
-
-    cp -R -T ../vscode-reh-web-${vsBuildTarget} "$out/libexec"
-
-    ln -s ${nodejs}/bin/node $out/libexec
-
-    makeWrapper "$out/libexec/server.sh" "$out/bin/openvscode-server"
+    mkdir -p $out
+    cp -R -T ../vscode-reh-web-${vsBuildTarget} $out
+    ln -s ${nodejs}/bin/node $out
   '';
 
   meta = with lib; {
@@ -167,7 +164,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/gitpod-io/openvscode-server";
     license = licenses.mit;
-    maintainers = with maintainers; [ dguenther ghuntley ];
-    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    maintainers = with maintainers; [ dguenther ghuntley emilytrau ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
   };
 }

--- a/pkgs/servers/openvscode-server/remove-node-download.patch
+++ b/pkgs/servers/openvscode-server/remove-node-download.patch
@@ -1,15 +1,17 @@
---- ./build/gulpfile.reh.js
-+++ ./build/gulpfile.reh.js
-@@ -277,8 +277,6 @@
+diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
+index a44941a1e73..5fc924cb367 100644
+--- a/build/gulpfile.reh.js
++++ b/build/gulpfile.reh.js
+@@ -265,8 +265,6 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
  			.pipe(util.stripSourceMappingURL())
  			.pipe(jsFilter.restore);
  
--		const nodePath = `.build/node/v${nodeVersion}/${platform}-${platform === 'darwin' ? 'x64' : arch}`;
+-		const nodePath = `.build/node/v${nodeVersion}/${platform}-${arch}`;
 -		const node = gulp.src(`${nodePath}/**`, { base: nodePath, dot: true });
  
  		let web = [];
  		if (type === 'reh-web') {
-@@ -296,7 +294,6 @@
+@@ -284,7 +282,6 @@ function packageTask(type, platform, arch, sourceFolderName, destinationFolderNa
  			license,
  			sources,
  			deps,
@@ -17,11 +19,11 @@
  			...web
  		);
  
-@@ -376,7 +373,6 @@
+@@ -382,7 +379,6 @@ function tweakProductForServerWeb(product) {
  			const destinationFolderName = `vscode-${type}${dashed(platform)}${dashed(arch)}`;
  
  			const serverTaskCI = task.define(`vscode-${type}${dashed(platform)}${dashed(arch)}${dashed(minified)}-ci`, task.series(
--				gulp.task(`node-${platform}-${platform === 'darwin' ? 'x64' : arch}`),
+-				gulp.task(`node-${platform}-${arch}`),
  				util.rimraf(path.join(BUILD_ROOT, destinationFolderName)),
  				packageTask(type, platform, arch, sourceFolderName, destinationFolderName)
  			));


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumps openvscode-server version and enables support for aarch64-darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
