### PR TITLE
`formats.javaProperties`: add type coercions

### DIFF
--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -1,6 +1,10 @@
 { lib, pkgs }:
+let
+  inherit (lib) types;
+  inherit (types) attrsOf oneOf coercedTo str bool int float package;
+in
 {
-  javaProperties = { comment ? "Generated with Nix" }: {
+  javaProperties = { comment ? "Generated with Nix", boolToString ? lib.boolToString }: {
 
     # Design note:
     # A nested representation of inevitably leads to bad UX:
@@ -25,7 +29,21 @@
     # We _can_ choose to support hierarchical config files
     # via nested attrsets, but the module author should
     # make sure that problem (2) does not occur.
-    type = lib.types.attrsOf lib.types.str;
+    type = let
+      elemType =
+        oneOf ([
+          # `package` isn't generalized to `path` because path values
+          # are ambiguous. Are they host path strings (toString /foo/bar)
+          # or should they be added to the store? ("${/foo/bar}")
+          # The user must decide.
+          (coercedTo package toString str)
+
+          (coercedTo bool boolToString str)
+          (coercedTo int toString str)
+          (coercedTo float toString str)
+        ])
+        // { description = "string, package, bool, int or float"; };
+      in attrsOf elemType;
 
     generate = name: value:
       pkgs.runCommandLocal name

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -77,7 +77,8 @@ stdenv.mkDerivation {
   src = lib.sourceByRegex ./. [
     ".*\.java"
   ];
-  LANG = "C.UTF-8";
+  # On Linux, this can be C.UTF-8, but darwin + zulu requires en_US.UTF-8
+  LANG = "en_US.UTF-8";
   buildPhase = ''
     javac Main.java
   '';

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -5,6 +5,12 @@
 , lib
 , stdenv
 }:
+
+# This test primarily tests correct escaping.
+# See also testJavaProperties in
+# pkgs/pkgs-lib/tests/formats.nix, which tests
+# type coercions and is a bit easier to read.
+
 let
   inherit (lib) concatStrings attrValues mapAttrs;
 

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -18,8 +18,11 @@ let
       }) [ def ]);
     in formatSet.generate "test-format-file" config;
 
-  runBuildTest = name: { drv, expected }: pkgs.runCommand name {} ''
-    if diff -u '${builtins.toFile "expected" expected}' '${drv}'; then
+  runBuildTest = name: { drv, expected }: pkgs.runCommand name {
+    passAsFile = ["expected"];
+    inherit expected drv;
+  } ''
+    if diff -u "$expectedPath" "$drv"; then
       touch "$out"
     else
       echo

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -176,11 +176,21 @@ in runBuildTests {
     '';
   };
 
-  # See also java-properties/default.nix for more complete tests
+  # This test is responsible for
+  #   1. testing type coercions
+  #   2. providing a more readable example test
+  # Whereas java-properties/default.nix tests the low level escaping, etc.
   testJavaProperties = {
     drv = evalFormat formats.javaProperties {} {
+      floaty = 3.1415;
+      tautologies = true;
+      contradictions = false;
       foo = "bar";
-      "1" = "2";
+      # # Disallowed at eval time, because it's ambiguous:
+      # # add to store or convert to string?
+      # root = /root;
+      "1" = 2;
+      package = pkgs.hello;
       "ütf 8" = "dûh";
       # NB: Some editors (vscode) show this _whole_ line in right-to-left order
       "الجبر" = "أكثر من مجرد أرقام";
@@ -189,7 +199,11 @@ in runBuildTests {
       # Generated with Nix
 
       1 = 2
+      contradictions = false
+      floaty = 3.141500
       foo = bar
+      package = ${pkgs.hello}
+      tautologies = true
       \u00fctf\ 8 = d\u00fbh
       \u0627\u0644\u062c\u0628\u0631 = \u0623\u0643\u062b\u0631 \u0645\u0646 \u0645\u062c\u0631\u062f \u0623\u0631\u0642\u0627\u0645
     '';


### PR DESCRIPTION
###### Description of changes

 - Allow the use of unambiguously convertible types, as a user may expect to be able to.

 - Fix test on darwin (preexisting problem)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
