### PR TITLE
[21.11] element-{web,desktop}: 1.10.6 -> 1.10.8

### DIFF
--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop-package.json
@@ -2,7 +2,7 @@
   "name": "element-desktop",
   "productName": "Element",
   "main": "lib/electron-main.js",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "A feature-rich client for Matrix.org",
   "author": "Element",
   "repository": {
@@ -44,7 +44,7 @@
     "counterpart": "^0.18.6",
     "electron-store": "^6.0.1",
     "electron-window-state": "^5.0.3",
-    "minimist": "^1.2.3",
+    "minimist": "^1.2.6",
     "png-to-ico": "^2.1.1",
     "request": "^2.88.2"
   },

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.10.7",
-  "desktopSrcHash": "HkGny9t8dNzVGyyqgr4tABbFZgWV4xqGZt9xH4ejkew=",
-  "desktopYarnHash": "038rqg26dn8chzscck5mlhnw2viy6gr8pjb7zrcmi7ipx9h038a0",
-  "webHash": "0gim79a1zpfc56ca5fndp2whmlv9jz1s32z666i268xppn4z53k1"
+  "version": "1.10.8",
+  "desktopSrcHash": "S9MQIn773BzCH4dsTkD1DpIThDzoIGr4Heaie2Qs0jY=",
+  "desktopYarnHash": "1imx43qbpj08l6d0fji31kcxqshcpr0ch8dzfbbgxyjvblq2p8ln",
+  "webHash": "02i6l3armzr19kki3hgshhzkdpb3001nilh4h10hr3xw5z711ppr"
 }

--- a/pkgs/applications/networking/instant-messengers/element/pin.json
+++ b/pkgs/applications/networking/instant-messengers/element/pin.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.10.6",
-  "desktopSrcHash": "TJGYavawLDLbP9Sg7HxIcOkr7hcTfAwk4fyOOEv4KhI=",
+  "version": "1.10.7",
+  "desktopSrcHash": "HkGny9t8dNzVGyyqgr4tABbFZgWV4xqGZt9xH4ejkew=",
   "desktopYarnHash": "038rqg26dn8chzscck5mlhnw2viy6gr8pjb7zrcmi7ipx9h038a0",
-  "webHash": "1wax4h5gfcq4giyq1igsix748cngky487kwvf69zb1gz95hjds9r"
+  "webHash": "0gim79a1zpfc56ca5fndp2whmlv9jz1s32z666i268xppn4z53k1"
 }


### PR DESCRIPTION
###### Description of changes

Backport for #166274, #164279.
Closes #167011 
Closes #166352
Closes #164548

cc @genofire @sumnerevans going to merge as soon as CI is green!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
