### PR TITLE
python3.pkgs.numba: added optional CUDA support

### DIFF
--- a/pkgs/development/python-modules/numba/cuda_path.patch
+++ b/pkgs/development/python-modules/numba/cuda_path.patch
@@ -1,0 +1,79 @@
+diff --git a/numba/cuda/cuda_paths.py b/numba/cuda/cuda_paths.py
+index b9988bc..a642680 100644
+--- a/numba/cuda/cuda_paths.py
++++ b/numba/cuda/cuda_paths.py
+@@ -24,10 +24,7 @@ def _find_valid_path(options):
+ 
+ def _get_libdevice_path_decision():
+     options = [
+-        ('Conda environment', get_conda_ctk()),
+-        ('CUDA_HOME', get_cuda_home('nvvm', 'libdevice')),
+-        ('System', get_system_ctk('nvvm', 'libdevice')),
+-        ('Debian package', get_debian_pkg_libdevice()),
++        ('Nix store', get_nix_ctk('nvvm', 'libdevice')),
+     ]
+     by, libdir = _find_valid_path(options)
+     return by, libdir
+@@ -35,18 +32,16 @@ def _get_libdevice_path_decision():
+ 
+ def _nvvm_lib_dir():
+     if IS_WIN32:
+-        return 'nvvm', 'bin'
++        return 'bin',
+     elif IS_OSX:
+-        return 'nvvm', 'lib'
++        return 'lib',
+     else:
+-        return 'nvvm', 'lib64'
++        return 'lib64',
+ 
+ 
+ def _get_nvvm_path_decision():
+     options = [
+-        ('Conda environment', get_conda_ctk()),
+-        ('CUDA_HOME', get_cuda_home(*_nvvm_lib_dir())),
+-        ('System', get_system_ctk(*_nvvm_lib_dir())),
++        ('Nix store', get_nix_ctk(*_nvvm_lib_dir())),        
+     ]
+     by, path = _find_valid_path(options)
+     return by, path
+@@ -74,14 +69,12 @@ def _cudalib_path():
+     elif IS_OSX:
+         return 'lib'
+     else:
+-        return 'lib64'
++        return 'lib'
+ 
+ 
+ def _get_cudalib_dir_path_decision():
+     options = [
+-        ('Conda environment', get_conda_ctk()),
+-        ('CUDA_HOME', get_cuda_home(_cudalib_path())),
+-        ('System', get_system_ctk(_cudalib_path())),
++        ('Nix store', get_nix_lib_ctk(_cudalib_path())),
+     ]
+     by, libdir = _find_valid_path(options)
+     return by, libdir
+@@ -92,6 +85,22 @@ def _get_cudalib_dir():
+     return _env_path_tuple(by, libdir)
+ 
+ 
++def get_nix_ctk(*subdirs):
++    """Return path to nix store cudatoolkit; or, None if it doesn't exist.
++    """
++    base = '@cuda_toolkit_path@'
++    if os.path.exists(base):
++        return os.path.join(base, *subdirs)
++
++
++def get_nix_lib_ctk(*subdirs):
++    """Return path to nix store cudatoolkit-lib; or, None if it doesn't exist.
++    """
++    base = '@cuda_toolkit_lib_path@'
++    if os.path.exists(base):
++        return os.path.join(base, *subdirs)
++
++
+ def get_system_ctk(*subdirs):
+     """Return path to system-wide cudatoolkit; or, None if it doesn't exist.
+     """

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5676,7 +5676,14 @@ in {
 
   num2words = callPackage ../development/python-modules/num2words { };
 
-  numba = callPackage ../development/python-modules/numba { };
+  numba = callPackage ../development/python-modules/numba {
+    cudaSupport = pkgs.config.cudaSupport or false;
+    cudatoolkit = tensorflow_compat_cudatoolkit;
+  };
+
+  numbaWithCuda = self.numba.override {
+    cudaSupport = true;
+  };
 
   numba-scipy = callPackage ../development/python-modules/numba-scipy { };
 


### PR DESCRIPTION
CUDA support for **numba**, unchanged version

###### Description of changes

Added `cudatoolkit` inclusion in `numba`, triggered by enabling `cudaSupport`, consistent with jaxlib and tensorflow. Added package `numbaWithCuda` forcing CUDA support, as is done with jaxlib etc.

`cuda_paths.py` is patched inside `numba` to force nix store paths in place of dynamic resolution. `nvvm` paths seem to have changed from `cudatoolkit` 10 to 11, so `nvvm` resolution is patched from `nvvm/lib64` to just `lib64` in the toolkit. This will NOT work with `cudatoolkit_10`.

Additionally, removed obsolete substitutions (@FRidh , check it makes sense pls - for me they only generate not found warnings)

Did a short test in a non-NixOS shell, seems to work.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
