### PR TITLE
invidious: unstable-2022-03-16 -> unstable-2022-05-04

### DIFF
--- a/pkgs/servers/invidious/lsquic.nix
+++ b/pkgs/servers/invidious/lsquic.nix
@@ -1,11 +1,19 @@
-{ lib, boringssl, stdenv, fetchgit, fetchFromGitHub, cmake, zlib, perl, libevent, gcc10Stdenv, buildGoModule }:
+{ lib, boringssl, stdenv, fetchgit, fetchFromGitHub, fetchurl, cmake, zlib, perl, libevent }:
 let
   versions = builtins.fromJSON (builtins.readFile ./versions.json);
 
-  buildGoModuleGcc10 = buildGoModule.override { stdenv = gcc10Stdenv; };
+  fetchGitilesPatch = { name, url, sha256 }:
+    fetchurl {
+      url = "${url}%5E%21?format=TEXT";
+      inherit name sha256;
+      downloadToTemp = true;
+      postFetch = ''
+        base64 -d < $downloadedFile > $out
+      '';
+    };
 
   # lsquic requires a specific boringssl version (noted in its README)
-  boringssl' = (boringssl.overrideAttrs (old: {
+  boringssl' = boringssl.overrideAttrs ({ preBuild, ... }: {
     version = versions.boringssl.rev;
     src = fetchgit {
       url = "https://boringssl.googlesource.com/boringssl";
@@ -15,10 +23,43 @@ let
     patches = [
       # Use /etc/ssl/certs/ca-certificates.crt instead of /etc/ssl/cert.pem
       ./use-etc-ssl-certs.patch
+
+      # because lsquic requires that specific boringssl version and that
+      # version does not yet include fixes for gcc11 build errors, they
+      # must be backported
+      (fetchGitilesPatch {
+        name = "fix-mismatch-between-header-and-implementation-of-bn_sqr_comba8.patch";
+        url = "https://boringssl.googlesource.com/boringssl/+/139adff9b27eaf0bdaac664ec4c9a7db2fe3f920";
+        sha256 = "05sp602dvh50v46jkzmh4sf4wqnq5bwy553596g2rhxg75bailjj";
+      })
+      (fetchGitilesPatch {
+        name = "use-an-unsized-helper-for-truncated-SHA-512-variants.patch";
+        url = "https://boringssl.googlesource.com/boringssl/+/a24ab549e6ae246b391155d7bed3790ac0e07de2";
+        sha256 = "0483jkpg4g64v23ln2blb74xnmzdjcn3r7w4zk7nfg8j3q5f9lxm";
+      })
+/*
+      # the following patch is too complex, so we will modify the build flags
+      # of crypto/fipsmodule/CMakeFiles/fipsmodule.dir/bcm.c.o in preBuild
+      # and turn off -Werror=stringop-overflow
+      (fetchGitilesPatch {
+        name = "make-md32_common.h-single-included-and-use-an-unsized-helper-for-SHA-256.patch";
+        url = "https://boringssl.googlesource.com/boringssl/+/597ffef971dd980b7de5e97a0c9b7ca26eec94bc";
+        sha256 = "1y0bkkdf1ccd6crx326agp01q22clm4ai4p982y7r6dkmxmh52qr";
+      })
+*/
+      (fetchGitilesPatch {
+        name = "fix-array-parameter-warnings.patch";
+        url = "https://boringssl.googlesource.com/boringssl/+/92c6fbfc4c44dc8462d260d836020d2b793e7804";
+        sha256 = "0h4sl95i8b0dj0na4ngf50wg54raxyjxl1zzwdc810abglp10vnv";
+      })
     ];
-  })).override {
-    buildGoModule = buildGoModuleGcc10;
-  };
+
+    preBuild = ''
+      ${preBuild}
+      sed -e '/^build crypto\/fipsmodule\/CMakeFiles\/fipsmodule\.dir\/bcm\.c\.o:/,/^ *FLAGS =/ s/^ *FLAGS = -Werror/& -Wno-error=stringop-overflow/' \
+          -i build.ninja
+    '';
+  });
 in
 stdenv.mkDerivation rec {
   pname = "lsquic";

--- a/pkgs/servers/invidious/shards.nix
+++ b/pkgs/servers/invidious/shards.nix
@@ -20,14 +20,14 @@
   exception_page = {
     owner = "crystal-loot";
     repo = "exception_page";
-    rev = "v0.2.0";
-    sha256 = "0nlgnh5iykbr1v2132342k2mz6s2laws6nkgqsqlwhhcr4gb4jcx";
+    rev = "v0.2.2";
+    sha256 = "1c8askb9b7621jjz5pjj6b8pdbhw3r1l3dym6swg1saspf5j3jwi";
   };
   kemal = {
     owner = "kemalcr";
     repo = "kemal";
-    rev = "v1.1.0";
-    sha256 = "07vlvddy4mba9li2bvskzqzywwq55cyvlgkz13q6dsl4zfgc96ca";
+    rev = "v1.1.2";
+    sha256 = "1149q4qw0zrws5asqqr4snrdi67xsmisdcq58zcrbgqgsxgly9d0";
   };
   kilt = {
     owner = "jeromegn";

--- a/pkgs/servers/invidious/update.sh
+++ b/pkgs/servers/invidious/update.sh
@@ -41,7 +41,7 @@ git -C "$git_dir" fetch origin "$git_branch"
 # because there might still be commits coming
 # use the day of the latest commit we picked as version
 new_rev=$(git -C "$git_dir" log -n 1 --format='format:%H' --before="${today}T00:00:00Z" "origin/$git_branch")
-new_version="unstable-$(git -C "$git_dir" log -n 1 --format='format:%cs' "$new_rev")"
+new_version="unstable-$(TZ=UTC git -C "$git_dir" log -n 1 --date='format-local:%Y-%m-%d' --format='%cd' "$new_rev")"
 info "latest commit before $today: $new_rev"
 
 if [ "$new_rev" = "$old_rev" ]; then

--- a/pkgs/servers/invidious/versions.json
+++ b/pkgs/servers/invidious/versions.json
@@ -4,15 +4,15 @@
     "sha256": "sha256-EU6T9yQCdOLx98Io8o01rEsgxDFF/Xoy42LgPopD2/A="
   },
   "invidious": {
-    "rev": "ed265cfdcd131b9df5398d899cc5d7036a5b7846",
-    "sha256": "0hhnq4s0slwbgxra7gxapl7dcz60a7k71cndi4crqcikmazzac3b",
-    "version": "unstable-2022-03-16"
+    "rev": "ca27e096f3249533cc7a9b123a8a8378f3312bb7",
+    "sha256": "0xjdzxnw6b5lk8pr82sjj60wfzxqkyamh0gpf2wxby52jvlbdcka",
+    "version": "unstable-2022-05-11"
   },
   "lsquic": {
     "sha256": "sha256-hG8cUvhbCNeMOsKkaJlgGpzUrIx47E/WhmPIdI5F3qM=",
     "version": "2.18.1"
   },
   "videojs": {
-    "sha256": "0b4vxd29kpvy60yhqm376r1872gds17s6wljqw0zlr16j762k50r"
+    "sha256": "0m09pc9acpzhfwwvc9dayl60nn28skmmglgvmlp48dlkqgfbgc27"
   }
 }


### PR DESCRIPTION
###### Description of changes

Upstream update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
