### PR TITLE
gscan2pdf: 2.12.5 -> 2.12.6

### DIFF
--- a/pkgs/applications/graphics/gscan2pdf/default.nix
+++ b/pkgs/applications/graphics/gscan2pdf/default.nix
@@ -10,11 +10,11 @@ with lib;
 
 perlPackages.buildPerlPackage rec {
   pname = "gscan2pdf";
-  version = "2.12.5";
+  version = "2.12.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/gscan2pdf/gscan2pdf-${version}.tar.xz";
-    sha256 = "sha256-MFWW9DTJ/svtgN3fbw+zeGpgg3pgIoC9jZ1HkG5p6sc=";
+    sha256 = "sha256-9ntpUEM3buT3EhneXz9G8bibvzOnEK6Xt0jJcTvLKT0=";
   };
 
   nativeBuildInputs = [ wrapGAppsHook ];
@@ -111,8 +111,6 @@ perlPackages.buildPerlPackage rec {
     # # Looks like you failed 1 test of 1.
     # t/169_import_scan.t ........................... Dubious, test returned 1 (wstat 256, 0x100)
     rm t/169_import_scan.t
-    # t/1604_import_multipage_DjVu.t ................ Dubious, test returned 255 (wstat 65280, 0xff00)
-    rm t/1604_import_multipage_DjVu.t
 
     # Disable a test which passes but reports an incorrect status
     # t/0601_Dialog_Scan.t .......................... All 14 subtests passed


### PR DESCRIPTION
###### Description of changes

Updating `pkgs.gscan2pdf` to the latest version.
Also re-enabling a no-longer failing test.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

