### PR TITLE
nitter: unstable-2022-02-11 -> unstable-2022-03-21

### DIFF
--- a/pkgs/servers/nitter/default.nix
+++ b/pkgs/servers/nitter/default.nix
@@ -2,14 +2,14 @@
 
 nimPackages.buildNimPackage rec {
   pname = "nitter";
-  version = "unstable-2022-02-11";
+  version = "unstable-2022-03-21";
   nimBinOnly = true;
 
   src = fetchFromGitHub {
     owner = "zedeus";
     repo = "nitter";
-    rev = "6695784050605c77a301c0a66764fa9a9580a2f5";
-    sha256 = "1lddzf6m74bw5kkv465cp211xxqbwnfacav7ia3y9i38rrnqwk6m";
+    rev = "6884f05041a9b8619ec709afacdfdd6482a120a0";
+    sha256 = "1mnc6jqljpqp9lgcrxxvf3aiswssr34v139cxfbwlmj45swmsazh";
   };
 
   buildInputs = with nimPackages; [

--- a/pkgs/servers/nitter/update.sh
+++ b/pkgs/servers/nitter/update.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl jq nix nix-prefetch-git patchutils
+set -euo pipefail
+
+info() {
+    if [ -t 2 ]; then
+        set -- '\033[32m%s\033[39m\n' "$@"
+    else
+        set -- '%s\n' "$@"
+    fi
+    printf "$@" >&2
+}
+
+nitter_old_version=$(nix-instantiate --eval --strict --json -A nitter.version . | jq -r .)
+nitter_old_rev=$(nix-instantiate --eval --strict --json -A nitter.src.rev . | jq -r .)
+today=$(LANG=C date -u +'%Y-%m-%d')
+
+# use latest commit before today, we should not call the version *today*
+# because there might still be commits coming
+# use the day of the latest commit we picked as version
+commit=$(curl -Sfs "https://api.github.com/repos/zedeus/nitter/compare/$nitter_old_rev~1...master" \
+    | jq '.commits | map(select(.commit.committer.date < $today) | {sha, date: .commit.committer.date}) | .[-1]' --arg today "$today")
+nitter_new_rev=$(jq -r '.sha' <<< "$commit")
+nitter_new_version="unstable-$(jq -r '.date[0:10]' <<< "$commit")"
+info "latest commit before $today: $nitter_new_rev ($(jq -r '.date' <<< "$commit"))"
+
+if [ "$nitter_new_rev" = "$nitter_old_rev" ]; then
+    info "nitter is up-to-date."
+    exit
+fi
+
+if curl -Sfs "https://github.com/zedeus/nitter/compare/$nitter_old_rev...$nitter_new_rev.patch" \
+| lsdiff | grep -Fxe 'a/nitter.nimble' -e 'b/nitter.nimble' > /dev/null; then
+    info "nitter.nimble changed, some dependencies probably need updating."
+fi
+
+nitter_new_sha256=$(nix-prefetch-git --rev "$nitter_new_rev" "https://github.com/zedeus/nitter.git" | jq -r .sha256)
+update-source-version nitter "$nitter_new_version" "$nitter_new_sha256" --rev="$nitter_new_rev"
+git commit --all --verbose --message "nitter: $nitter_old_version -> $nitter_new_version"
+info "Updated nitter to $nitter_new_version."


### PR DESCRIPTION
###### Description of changes

Add simple update script. The script only updates version, rev, and sha256 and warns the user if there are changes to nitter.nimble, which should mean changes to its dependencies that need to be resolved manually.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
