### PR TITLE
paperless-ngx: init at 1.6.0

### DIFF
--- a/nixos/modules/services/misc/paperless-ng.nix
+++ b/nixos/modules/services/misc/paperless-ng.nix
@@ -53,7 +53,6 @@ let
     PrivateNetwork = true;
     PrivateTmp = true;
     PrivateUsers = true;
-    ProcSubset = "pid";
     ProtectClock = true;
     # Breaks if the home dir of the user is in /home
     # Also does not add much value in combination with the TemporaryFileSystem.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -399,6 +399,7 @@ in
   pantalaimon = handleTest ./matrix/pantalaimon.nix {};
   pantheon = handleTest ./pantheon.nix {};
   paperless-ng = handleTest ./paperless-ng.nix {};
+  paperless-ngx = handleTest ./paperless-ngx.nix {};
   parsedmarc = handleTest ./parsedmarc {};
   pdns-recursor = handleTest ./pdns-recursor.nix {};
   peerflix = handleTest ./peerflix.nix {};

--- a/nixos/tests/paperless-ngx.nix
+++ b/nixos/tests/paperless-ngx.nix
@@ -1,0 +1,46 @@
+import ./make-test-python.nix ({ lib, ... }: {
+  name = "paperless-ngx";
+  meta.maintainers = with lib.maintainers; [ lukegb ];
+
+  nodes.machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ imagemagick jq ];
+    services.paperless-ng = {
+      enable = true;
+      package = pkgs.paperless-ngx;
+      passwordFile = builtins.toFile "password" "admin";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("paperless-ng-consumer.service")
+
+    with subtest("Create test doc"):
+        machine.succeed(
+            "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "
+            "-annotate +5+20 'hello world 16-10-2005' /var/lib/paperless/consume/doc.png"
+        )
+
+    with subtest("Web interface gets ready"):
+        machine.wait_for_unit("paperless-ng-web.service")
+        # Wait until server accepts connections
+        machine.wait_until_succeeds("curl -fs localhost:28981")
+
+    with subtest("Create web test doc"):
+        machine.succeed(
+            "convert -size 400x40 xc:white -font 'DejaVu-Sans' -pointsize 20 -fill black "
+            "-annotate +5+20 'hello web 16-10-2005' /tmp/webdoc.png"
+        )
+        machine.wait_until_succeeds("curl -u admin:admin -F document=@/tmp/webdoc.png -fs localhost:28981/api/documents/post_document/")
+
+    with subtest("Documents are consumed"):
+        machine.wait_until_succeeds(
+            "(($(curl -u admin:admin -fs localhost:28981/api/documents/ | jq .count) == 2))"
+        )
+        assert "2005-10-16" in machine.succeed(
+            "curl -u admin:admin -fs localhost:28981/api/documents/ | jq '.results | .[0] | .created'"
+        )
+        assert "2005-10-16" in machine.succeed(
+            "curl -u admin:admin -fs localhost:28981/api/documents/ | jq '.results | .[1] | .created'"
+        )
+  '';
+})

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -1,0 +1,193 @@
+{ lib
+, fetchurl
+, fetchpatch
+, nixosTests
+, python3
+, ghostscript
+, imagemagick
+, jbig2enc
+, optipng
+, pngquant
+, qpdf
+, tesseract4
+, unpaper
+, liberation_ttf
+}:
+
+let
+  py = python3.override {
+    packageOverrides = self: super: {
+      django = super.django_3;
+
+      # Incompatible with aioredis 2
+      aioredis = super.aioredis.overridePythonAttrs (oldAttrs: rec {
+        version = "1.3.1";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "0fi7jd5hlx8cnv1m97kv9hc4ih4l8v15wzkqwsp73is4n0qazy0m";
+        };
+      });
+    };
+  };
+
+  path = lib.makeBinPath [ ghostscript imagemagick jbig2enc optipng pngquant qpdf tesseract4 unpaper ];
+in
+py.pkgs.pythonPackages.buildPythonApplication rec {
+  pname = "paperless-ngx";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/paperless-ngx/paperless-ngx/releases/download/ngx-${version}/${pname}-${version}.tar.xz";
+    sha256 = "07mrxbwahkm00n9nvssd6d13p80w333g84cd38bzp0l34nzim5zl";
+  };
+
+  format = "other";
+
+  # Make bind address configurable
+  postPatch = ''
+    substituteInPlace gunicorn.conf.py --replace "bind = " "# bind = "
+  '';
+
+  propagatedBuildInputs = with py.pkgs.pythonPackages; [
+    aioredis
+    arrow
+    asgiref
+    async-timeout
+    attrs
+    autobahn
+    automat
+    blessed
+    certifi
+    cffi
+    channels-redis
+    channels
+    chardet
+    click
+    coloredlogs
+    concurrent-log-handler
+    constantly
+    cryptography
+    daphne
+    dateparser
+    django-cors-headers
+    django-extensions
+    django-filter
+    django-picklefield
+    django-q
+    django
+    djangorestframework
+    filelock
+    fuzzywuzzy
+    gunicorn
+    h11
+    hiredis
+    httptools
+    humanfriendly
+    hyperlink
+    idna
+    imap-tools
+    img2pdf
+    incremental
+    inotify-simple
+    inotifyrecursive
+    joblib
+    langdetect
+    lxml
+    msgpack
+    numpy
+    ocrmypdf
+    pathvalidate
+    pdfminer
+    pikepdf
+    pillow
+    pluggy
+    portalocker
+    psycopg2
+    pyasn1-modules
+    pyasn1
+    pycparser
+    pyopenssl
+    python-dateutil
+    python-dotenv
+    python-gnupg
+    python-Levenshtein
+    python_magic
+    pytz
+    pyyaml
+    redis
+    regex
+    reportlab
+    requests
+    scikit-learn
+    scipy
+    service-identity
+    six
+    sortedcontainers
+    sqlparse
+    threadpoolctl
+    tika
+    tqdm
+    twisted.extras.tls
+    txaio
+    tzlocal
+    urllib3
+    uvicorn
+    uvloop
+    watchdog
+    watchgod
+    wcwidth
+    websockets
+    whitenoise
+    whoosh
+    zope_interface
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -r . $out/lib/paperless-ngx
+    chmod +x $out/lib/paperless-ngx/src/manage.py
+    makeWrapper $out/lib/paperless-ngx/src/manage.py $out/bin/paperless-ngx \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --prefix PATH : "${path}"
+    ln -s $out/lib/paperless-ngx $out/lib/paperless-ng
+    ln -s $out/bin/paperless-ngx $out/bin/paperless-ng
+  '';
+
+  checkInputs = with py.pkgs.pythonPackages; [
+    pytest-django
+    pytest-env
+    pytest-sugar
+    pytest-xdist
+    factory_boy
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "src" ];
+
+  # The tests require:
+  # - PATH with runtime binaries
+  # - A temporary HOME directory for gnupg
+  # - XDG_DATA_DIRS with test-specific fonts
+  preCheck = ''
+    export PATH="${path}:$PATH"
+    export HOME=$(mktemp -d)
+    export XDG_DATA_DIRS="${liberation_ttf}/share:$XDG_DATA_DIRS"
+
+    # Disable unneeded code coverage test
+    substituteInPlace src/setup.cfg \
+      --replace "--cov --cov-report=html" ""
+  '';
+
+  passthru = {
+    # PYTHONPATH of all dependencies used by the package
+    pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
+    inherit path;
+  };
+
+  meta = with lib; {
+    description = "A supercharged version of paperless: scan, index, and archive all of your physical documents";
+    homepage = "https://paperless-ngx.readthedocs.io/en/latest/";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ lukegb ];
+  };
+}

--- a/pkgs/applications/office/paperless-ngx/default.nix
+++ b/pkgs/applications/office/paperless-ngx/default.nix
@@ -182,6 +182,8 @@ py.pkgs.pythonPackages.buildPythonApplication rec {
     # PYTHONPATH of all dependencies used by the package
     pythonPath = python3.pkgs.makePythonPath propagatedBuildInputs;
     inherit path;
+
+    tests = { inherit (nixosTests) paperless-ngx; };
   };
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8857,6 +8857,8 @@ with pkgs;
 
   paperless-ng = callPackage ../applications/office/paperless-ng { };
 
+  paperless-ngx = callPackage ../applications/office/paperless-ngx { };
+
   paperwork = callPackage ../applications/office/paperwork/paperwork-gtk.nix { };
 
   papertrail = callPackage ../tools/text/papertrail { };


### PR DESCRIPTION
###### Description of changes

paperless-ngx is a fork of paperless-ng, which is a fork of paperless. paperless-ngx is owned by an organisation rather than a single individual, and has cut a new release (and is the source of some of the patches included in the paperless-ng build in NixOS)

The `ProcSubset` is removed because it causes it to spew some (possibly non-fatal?) errors on startup.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
