### PR TITLE
makeWrapper to nativeBuildInputs

### DIFF
--- a/pkgs/applications/graphics/imgbrd-grabber/default.nix
+++ b/pkgs/applications/graphics/imgbrd-grabber/default.nix
@@ -33,12 +33,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     openssl
-    makeWrapper
     libpulseaudio
     typescript
   ];
 
   nativeBuildInputs = [
+    makeWrapper
     qtmultimedia
     qtbase
     qtdeclarative

--- a/pkgs/applications/graphics/jpegrescan/default.nix
+++ b/pkgs/applications/graphics/jpegrescan/default.nix
@@ -28,8 +28,12 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ perlPackages.FileSlurp ];
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
   buildInputs = [
-    perl libjpeg_turbo makeWrapper
+    perl libjpeg_turbo
   ];
 
   meta = with lib; {

--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -103,10 +103,10 @@ stdenv.mkDerivation {
 
   preConfigure = "./bootstrap.sh";
 
-  nativeBuildInputs = [ pkg-config autoreconfHook gettext ];
+  nativeBuildInputs = [ pkg-config autoreconfHook gettext makeWrapper ];
   buildInputs = [
     ETL boost cairo glibmm gtk3 gtkmm3 imagemagick intltool
-    libjack2 libsigcxx libxmlxx makeWrapper mlt-qt5
+    libjack2 libsigcxx libxmlxx mlt-qt5
     synfig which gnome.adwaita-icon-theme
   ];
 

--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
 
   patches = [ ./hivex-syms.patch ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ makeWrapper pkg-config ];
   buildInputs = [
-    autoreconfHook makeWrapper libxml2
+    autoreconfHook libxml2
   ]
   ++ (with perlPackages; [ perl IOStringy ])
   ++ lib.optionals stdenv.isDarwin [ libiconv ];

--- a/pkgs/development/libraries/hivex/default.nix
+++ b/pkgs/development/libraries/hivex/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
 
   patches = [ ./hivex-syms.patch ];
 
-  nativeBuildInputs = [ makeWrapper pkg-config ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkg-config ];
   buildInputs = [
-    autoreconfHook libxml2
+    libxml2
   ]
   ++ (with perlPackages; [ perl IOStringy ])
   ++ lib.optionals stdenv.isDarwin [ libiconv ];

--- a/pkgs/development/tools/phantomjs2/default.nix
+++ b/pkgs/development/tools/phantomjs2/default.nix
@@ -25,11 +25,10 @@ in stdenv.mkDerivation rec {
     sha256 = "1zsbpk1sgh9a16f1a5nx3qvk77ibjn812wqkxqck8n6fia85m5iq";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [ qmake makeWrapper ];
   buildInputs = [
     bison flex fontconfig freetype gperf icu openssl
     libjpeg libpng perl python2 ruby sqlite qtwebkit qtbase
-    makeWrapper
   ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
     AGL ApplicationServices AppKit Cocoa OpenGL
     darwin.libobjc fakeClang cups

--- a/pkgs/os-specific/linux/pam_usb/default.nix
+++ b/pkgs/os-specific/linux/pam_usb/default.nix
@@ -41,8 +41,12 @@ stdenv.mkDerivation rec {
     sha256 = "1g1w0s9d8mfld8abrn405ll5grv3xgs0b0hsganrz6qafdq9j7q1";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
     # pam_usb dependencies
     dbus libxml2 pam pmount pkg-config
     # pam_usb's tools dependencies

--- a/pkgs/servers/monitoring/munin/default.nix
+++ b/pkgs/servers/monitoring/munin/default.nix
@@ -13,8 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-p273O5JLFX1dA2caV3lVVL9YNTcGMSrC7DWieUfUmqI=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
+  ];
+
+  buildInputs = [
     which
     coreutils
     rrdtool

--- a/pkgs/servers/owncast/default.nix
+++ b/pkgs/servers/owncast/default.nix
@@ -15,7 +15,7 @@ buildGoModule rec {
 
   propagatedBuildInputs = [ ffmpeg ];
 
-  buildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
   preInstall = ''
     mkdir -p $out

--- a/pkgs/servers/rt/default.nix
+++ b/pkgs/servers/rt/default.nix
@@ -18,10 +18,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    makeWrapper
   ];
 
   buildInputs = [
-    makeWrapper
     perl
     (buildEnv {
       name = "rt-perl-deps";

--- a/pkgs/tools/X11/obconf/default.nix
+++ b/pkgs/tools/X11/obconf/default.nix
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
+    makeWrapper
     pkg-config
   ];
 
@@ -22,7 +23,6 @@ stdenv.mkDerivation rec {
     libSM
     libstartup_notification
     libxml2
-    makeWrapper
     openbox
   ];
 

--- a/pkgs/tools/misc/kisslicer/default.nix
+++ b/pkgs/tools/misc/kisslicer/default.nix
@@ -27,8 +27,11 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     makeWrapper
+  ];
+
+  buildInputs = [
     libGLU libGL
     libX11
   ];

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -26,8 +26,12 @@ let this = stdenv.mkDerivation rec {
   dontStrip         = true;
   dontPatchShebangs = true;
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
   buildInputs = [
-    makeWrapper jre
+    jre
   ];
 
   installPhase = ''

--- a/pkgs/tools/misc/logstash/7.x.nix
+++ b/pkgs/tools/misc/logstash/7.x.nix
@@ -41,8 +41,11 @@ let
     dontStrip = true;
     dontPatchShebangs = true;
 
-    buildInputs = [
+    nativeBuildInputs = [
       makeWrapper
+    ];
+
+    buildInputs = [
       jre
     ];
 


### PR DESCRIPTION
###### Description of changes

Move makeWrapper to nativeBuildInputs for a couple of packages.

Note that this doesn't fix cross-compilation for most of these packages, it just prevents an (unclear) eval failure. It's also generally more correct.

###### Things done

- [x] Verify eval failure doesn't happen anymore due to makeWrapper in wrong input list

For some packages an eval failure still happens, this seems to be related with something regarding qt5 wrapping. Still need to figure that out :).