### PR TITLE
quivira: init at 4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13238,6 +13238,12 @@
     githubId = 3521180;
     name = "Tom Sydney Kerckhove";
   };
+  nosewings = {
+    name = "Nicholas Coltharp";
+    email = "coltharpnicholas@gmail.com";
+    github = "nosewings";
+    githubId = 24929858;
+  };
   NotAShelf = {
     name = "NotAShelf";
     email = "raf@notashelf.dev";

--- a/pkgs/data/fonts/quivira/default.nix
+++ b/pkgs/data/fonts/quivira/default.nix
@@ -1,0 +1,29 @@
+{ lib, fetchurl }:
+let
+  pname = "quivira";
+  version = "4.1";
+in fetchurl {
+  name = "${pname}-${version}";
+  url = "http://www.quivira-font.com/files/Quivira.otf";
+
+  # Download the source file to a temporary directory so that $out can be a
+  # directory with the expected structure.
+  downloadToTemp = true;
+  # recursiveHash needs to be true because $out is going to be a directory.
+  recursiveHash = true;
+  postFetch = ''
+    install -D $downloadedFile $out/share/fonts/opentype/Quivira.otf
+  '';
+
+  sha256 = "Hhl+0Oc5DDohOpBbEARMunMYCpr6nn4X6RgpQeEksNo=";
+  meta = {
+    description = "a free Unicode font in the OpenType format which is supported by every usual office program or printer";
+    homepage = "http://www.quivira-font.com/";
+    license = lib.licenses.publicDomain;
+    maintainers = [ lib.maintainers.nosewings ];
+    # From the homepage: "If you try to install Quivira on a Mac,
+    # you will get an error message about the 'post table
+    # usability'."
+    platforms = lib.filter (platform: !lib.hasInfix "darwin" platform) lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29998,6 +29998,8 @@ with pkgs;
 
   quattrocento-sans = callPackage ../data/fonts/quattrocento-sans { };
 
+  quivira = callPackage ../data/fonts/quivira { };
+
   raleway = callPackage ../data/fonts/raleway { };
 
   recursive = callPackage ../data/fonts/recursive { };


### PR DESCRIPTION
###### Description of changes

Adds the Quivira font.

Note that this does not build on Darwin platforms.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
