### PR TITLE
nixos: systemd: initrd: add support for luks

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1183,6 +1183,7 @@
   ./system/boot/systemd/initrd.nix
   ./system/boot/timesyncd.nix
   ./system/boot/tmp.nix
+  ./system/boot/initrd-systemd-udev.nix
   ./system/etc/etc-activation.nix
   ./tasks/auto-upgrade.nix
   ./tasks/bcache.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1184,6 +1184,7 @@
   ./system/boot/timesyncd.nix
   ./system/boot/tmp.nix
   ./system/boot/initrd-systemd-udev.nix
+  ./system/boot/initrd-systemd-luks.nix
   ./system/etc/etc-activation.nix
   ./tasks/auto-upgrade.nix
   ./tasks/bcache.nix

--- a/nixos/modules/system/boot/initrd-systemd-luks.nix
+++ b/nixos/modules/system/boot/initrd-systemd-luks.nix
@@ -1,0 +1,50 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  systemd = config.boot.initrd.systemd.package;
+  crypttab =
+    let
+      luksDevices = attrValues config.boot.initrd.luks.devices;
+      stringifyLuksDevice = { name, device, header, keyFile, keyFileSize, keyFileOffset, allowDiscards, ... }@fs:
+        let
+          opts =
+            optional allowDiscards "discard" ++
+            optional (keyFileOffset != null) "keyfile-offset=${keyFileOffset}" ++
+            optional (keyFileSize != null) "keyfile-size=${keyFileSize}" ++
+            optional (header != null) "header=${header}";
+          optsSection = lib.concatStringsSep "," opts;
+          keyFileSection = if keyFile == null then "-" else keyFile;
+        in
+        "${name} ${device} ${keyFileSection} ${optsSection}";
+    in
+    lib.concatMapStringsSep "\n" stringifyLuksDevice luksDevices;
+in
+{
+  config = {
+    boot.initrd.availableKernelModules =
+      [ "dm_mod" "dm_crypt" "cryptd" "input_leds" ]
+      ++ config.boot.initrd.luks.cryptoModules ++ [
+        "ecb"
+      ];
+
+    boot.initrd.systemd = {
+      additionalUpstreamUnits = [
+        "cryptsetup-pre.target"
+        "cryptsetup.target"
+        "remote-cryptsetup.target"
+      ];
+
+      initrdBin = [
+        pkgs.cryptsetup
+      ];
+
+      contents = {
+        "/etc/crypttab".text = crypttab;
+      };
+
+      storePaths = [
+        "${systemd}/lib/systemd/systemd-cryptsetup"
+      ];
+    };
+  };
+}

--- a/nixos/modules/system/boot/initrd-systemd-udev.nix
+++ b/nixos/modules/system/boot/initrd-systemd-udev.nix
@@ -40,8 +40,8 @@ let
         substituteInPlace $i \
           --replace \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
           --replace \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
-          --replace \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
-          --replace \"/bin/mount \"${pkgs.util-linux}/bin/mount \
+          --replace \"/sbin/blkid \"${systemd.util-linux}/sbin/blkid \
+          --replace \"/bin/mount \"${systemd.util-linux}/bin/mount \
           --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
           --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename
       done
@@ -133,7 +133,7 @@ in
 
   config = {
     boot.initrd.systemd = {
-      udev.path = [ pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.util-linux udev ];
+      udev.path = [ pkgs.coreutils pkgs.gnused pkgs.gnugrep systemd.util-linux udev ];
 
       contents = {
         "/etc/udev/rules.d".source = udevRules;
@@ -142,8 +142,8 @@ in
       storePaths = [
         "${pkgs.kmod}/bin/modprobe"
         "${pkgs.mdadm}/sbin/mdadm"
-        "${pkgs.util-linux}/sbin/blkid"
-        "${pkgs.util-linux}/bin/mount"
+        "${systemd.util-linux}/sbin/blkid"
+        "${systemd.util-linux}/bin/mount"
         "${pkgs.coreutils}/bin/readlink"
         "${pkgs.coreutils}/bin/basename"
       ];

--- a/nixos/modules/system/boot/initrd-systemd-udev.nix
+++ b/nixos/modules/system/boot/initrd-systemd-udev.nix
@@ -1,0 +1,152 @@
+{ lib, pkgs, config, ... }:
+let
+  cfg = config.boot.initrd.systemd.udev;
+
+  systemd = config.boot.initrd.systemd.package;
+  udev = systemd;
+
+  udevPath = pkgs.buildEnv {
+    name = "udev-path";
+    paths = cfg.path;
+    pathsToLink = [ "/bin" "/sbin" ];
+    ignoreCollisions = true;
+  };
+
+  # Perform substitutions in all udev rules files.
+  udevRules = pkgs.runCommand "udev-rules"
+    { preferLocalBuild = true;
+      allowSubstitutes = false;
+      packages = lib.unique (map toString cfg.packages);
+    }
+    ''
+      mkdir -p $out
+      shopt -s nullglob
+      set +o pipefail
+
+      # Set a reasonable $PATH for programs called by udev rules.
+      echo 'ENV{PATH}="${udevPath}/bin:${udevPath}/sbin"' > $out/00-path.rules
+
+      # Add the udev rules from other packages.
+      for i in $packages; do
+        echo "Adding rules for package $i"
+        for j in $i/{etc,lib}/udev/rules.d/*; do
+          echo "Copying $j to $out/$(basename $j)"
+          cat $j > $out/$(basename $j)
+        done
+      done
+
+      # Fix some paths in the standard udev rules.  Hacky.
+      for i in $out/*.rules; do
+        substituteInPlace $i \
+          --replace \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
+          --replace \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
+          --replace \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
+          --replace \"/bin/mount \"${pkgs.util-linux}/bin/mount \
+          --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
+          --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename
+      done
+
+      echo -n "Checking that all programs called by relative paths in udev rules exist in ${udev}/lib/udev... "
+      import_progs=$(grep 'IMPORT{program}="[^/$]' $out/* |
+        sed -e 's/.*IMPORT{program}="\([^ "]*\)[ "].*/\1/' | uniq)
+      run_progs=$(grep -v '^[[:space:]]*#' $out/* | grep 'RUN+="[^/$]' |
+        sed -e 's/.*RUN+="\([^ "]*\)[ "].*/\1/' | uniq)
+      for i in $import_progs $run_progs; do
+        if [[ ! -x ${udev}/lib/udev/$i && ! $i =~ socket:.* ]]; then
+          echo "FAIL"
+          echo "$i is called in udev rules but not installed by udev"
+          exit 1
+        fi
+      done
+      echo "OK"
+
+      echo -n "Checking that all programs called by absolute paths in udev rules exist... "
+      import_progs=$(grep 'IMPORT{program}="\/' $out/* |
+        sed -e 's/.*IMPORT{program}="\([^ "]*\)[ "].*/\1/' | uniq)
+      run_progs=$(grep -v '^[[:space:]]*#' $out/* | grep 'RUN+="/' |
+        sed -e 's/.*RUN+="\([^ "]*\)[ "].*/\1/' | uniq)
+      for i in $import_progs $run_progs; do
+        # if the path refers to /run/current-system/systemd, replace with systemd package
+        if [[ $i == /run/current-system/systemd* ]]; then
+          i="${systemd}/''${i#/run/current-system/systemd/}"
+        fi
+        if [[ ! -x $i ]]; then
+          echo "FAIL"
+          echo "$i is called in udev rules but is not executable or does not exist"
+          exit 1
+        fi
+      done
+      echo "OK"
+
+      filesToFixup="$(for i in "$out"/*; do
+        grep -l '\B\(/usr\)\?/s\?bin' "$i" || :
+      done)"
+
+      if [ -n "$filesToFixup" ]; then
+        echo "Consider fixing the following udev rules:"
+        echo "$filesToFixup" | while read localFile; do
+          remoteFile="origin unknown"
+          for i in ${toString cfg.packages}; do
+            for j in "$i"/*/udev/rules.d/*; do
+              [ -e "$out/$(basename "$j")" ] || continue
+              [ "$(basename "$j")" = "$(basename "$localFile")" ] || continue
+              remoteFile="originally from $j"
+              break 2
+            done
+          done
+          refs="$(
+            grep -o '\B\(/usr\)\?/s\?bin/[^ "]\+' "$localFile" \
+              | sed -e ':r;N;''${s/\n/ and /;br};s/\n/, /g;br'
+          )"
+          echo "$localFile ($remoteFile) contains references to $refs."
+        done
+        exit 1
+      fi
+    ''; # */
+in
+{
+  options = with lib; {
+    boot.initrd.systemd.udev = {
+      packages = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          List of packages containing <command>udev</command> rules.
+          All files found in
+          <filename><replaceable>pkg</replaceable>/etc/udev/rules.d</filename> and
+          <filename><replaceable>pkg</replaceable>/lib/udev/rules.d</filename>
+          will be included.
+        '';
+        apply = map getBin;
+      };
+
+      path = mkOption {
+        type = types.listOf types.path;
+        default = [];
+        description = ''
+          Packages added to the <envar>PATH</envar> environment variable when
+          executing programs from Udev rules.
+        '';
+      };
+    };
+  };
+
+  config = {
+    boot.initrd.systemd = {
+      udev.path = [ pkgs.coreutils pkgs.gnused pkgs.gnugrep pkgs.util-linux udev ];
+
+      contents = {
+        "/etc/udev/rules.d".source = udevRules;
+      };
+
+      storePaths = [
+        "${pkgs.kmod}/bin/modprobe"
+        "${pkgs.mdadm}/sbin/mdadm"
+        "${pkgs.util-linux}/sbin/blkid"
+        "${pkgs.util-linux}/bin/mount"
+        "${pkgs.coreutils}/bin/readlink"
+        "${pkgs.coreutils}/bin/basename"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
###### Description of changes

This adds luks support for systemd-initrd. Luks also requires adding udev rules into initrd, so this is added as well.

Note that this PR still requires tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
