### PR TITLE
whoogle-search: create new package

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -6,7 +6,7 @@
 
 ## New Services {#sec-release-23.11-new-services}
 
-- Create the first release note entry in this section!
+- [whoogle-search](https://github.com/benbusby/whoogle-search), a self-hosted, ad-free, privacy-respecting metasearch engine. Available as [services.whoogle-search](options.html#opt-services.whoogle-search.enable).
 
 - [acme-dns](https://github.com/joohoi/acme-dns), a limited DNS server to handle ACME DNS challenges easily and securely. Available as [services.acme-dns](#opt-services.acme-dns.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1068,6 +1068,7 @@
   ./services/networking/webhook.nix
   ./services/networking/wg-quick.nix
   ./services/networking/wgautomesh.nix
+  ./services/networking/whoogle-search.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix
   ./services/networking/wstunnel.nix

--- a/nixos/modules/services/networking/whoogle-search.nix
+++ b/nixos/modules/services/networking/whoogle-search.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+
+let
+  cfg = config.services.whoogle-search;
+  stateDir = "/var/lib/whoogle-search";
+in
+{
+  options = with lib; {
+    services.whoogle-search = {
+      enable = mkEnableOption (mdDoc "whoogle-search service");
+
+      port = mkOption {
+        type = types.port;
+        default = 5000;
+        description = mdDoc "Port to listen on.";
+      };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = mdDoc "Address to listen on for the web interface.";
+      };
+
+      dataDir = mkOption {
+        type = types.path;
+        default = stateDir;
+        description = mdDoc ''
+          The directory where whoogle-search will create session files.
+
+          If left as the default value this directory will automatically be
+          created before whoogle-search starts, otherwise the sysadmin is
+          responsible for ensuring the directory exists with appropriate
+          ownership and permissions.
+        '';
+      };
+
+      httpsOnly = mkOption {
+        type = types.bool;
+        default = false;
+        description = mdDoc "Enforce HTTPS redirects for all requests.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    systemd.services.whoogle-search = {
+      description = "Whoogle Search";
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.whoogle-search ];
+
+      preStart = ''
+        if [ ! -d '${cfg.dataDir}/static' ]; then
+          cp -r '${pkgs.whoogle-search}/${pkgs.python3.sitePackages}/app/static_runtime' '${cfg.dataDir}/static'
+        fi
+
+        # The build directory must be writable to store the session static files
+        chmod 0755 '${cfg.dataDir}/static/build'
+      '';
+
+      environment = {
+        CONFIG_VOLUME = cfg.dataDir;
+      };
+
+      serviceConfig = lib.mkMerge [
+        {
+          Type = "simple";
+          DynamicUser = true;
+          ExecStart = "${pkgs.whoogle-search}/bin/whoogle-search"
+            + " --host '${cfg.listenAddress}'"
+            + " --port '${builtins.toString cfg.port}'"
+            + lib.optionalString (cfg.httpsOnly) " --https-only";
+          ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+          PrivateTmp = true;
+          ProtectSystem = true;
+          ProtectHome = true;
+          Restart = "on-failure";
+          RestartSec = "5s";
+
+          ReadWritePaths = [ cfg.dataDir ];
+        }
+        (lib.mkIf (cfg.dataDir == stateDir) {
+          StateDirectory = "whoogle-search";
+          StateDirectoryMode = "0750";
+        })
+      ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ seberm ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -821,6 +821,7 @@ in {
   warzone2100 = handleTest ./warzone2100.nix {};
   wasabibackend = handleTest ./wasabibackend.nix {};
   webhook = runTest ./webhook.nix;
+  whoogle-search = handleTest ./whoogle-search.nix {};
   wiki-js = handleTest ./wiki-js.nix {};
   wine = handleTest ./wine.nix {};
   wireguard = handleTest ./wireguard {};

--- a/nixos/tests/whoogle-search.nix
+++ b/nixos/tests/whoogle-search.nix
@@ -1,0 +1,20 @@
+import ./make-test-python.nix ({ pkgs, lib, ...} : {
+  name = "whoogle-search";
+  meta.maintainers = with lib.maintainers; [ seberm ];
+
+  nodes.machine = { pkgs, ... }: {
+    services.whoogle-search = {
+      enable = true;
+      port = 5000;
+      listenAddress = "127.0.0.1";
+      httpsOnly = false;
+    };
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("whoogle-search.service")
+    machine.wait_for_open_port(5000)
+    machine.wait_until_succeeds("curl --fail --show-error --silent --location localhost:5000/")
+  '';
+})

--- a/pkgs/applications/networking/whoogle-search/default.nix
+++ b/pkgs/applications/networking/whoogle-search/default.nix
@@ -1,0 +1,78 @@
+{ lib
+, python3
+, fetchPypi
+, nixosTests
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "whoogle-search";
+  version = "0.8.2";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-r/DrI1xugKU3pxTA/5h2Oo9ubyVngZSVQmswbqOq3uQ=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    setuptools
+    attrs
+    brotli
+    cachelib
+    certifi
+    certifi
+    chardet
+    click
+    idna
+    itsdangerous
+    jinja2
+    markupsafe
+    more-itertools
+    packaging
+    pluggy
+    pycparser
+    pyopenssl
+    pyparsing
+    pysocks
+    python-dateutil
+    soupsieve
+    wcwidth
+    werkzeug
+    python-dotenv
+    beautifulsoup4
+    cssutils
+    cryptography
+    defusedxml
+    flask
+    python-dotenv
+    requests
+    stem
+    waitress
+  ];
+
+  pythonRemoveDeps = [
+    "pytest"
+    "pycodestyle"
+  ];
+
+  postInstall = ''
+    mv $out/${python3.sitePackages}/app/static $out/${python3.sitePackages}/app/static_runtime
+
+    # FIXME: Is it possible to specify dataDir from service configuration here?
+    ln -s /var/lib/whoogle-search/static $out/${python3.sitePackages}/app/static
+  '';
+
+  # Require network
+  doCheck = false;
+
+  passthru.tests = {
+    inherit (nixosTests) whoogle-search;
+  };
+
+  meta = {
+    homepage = "https://github.com/benbusby/whoogle-search";
+    description = "A self-hosted, ad-free, privacy-respecting metasearch engine";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ seberm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40752,6 +40752,8 @@ with pkgs;
 
   wifi-password = callPackage ../os-specific/darwin/wifi-password { };
 
+  whoogle-search = callPackage ../applications/networking/whoogle-search { };
+
   qubes-core-vchan-xen = callPackage ../applications/qubes/qubes-core-vchan-xen { };
 
   coz = callPackage ../development/tools/analysis/coz { };


### PR DESCRIPTION
###### Description of changes
A self-hosted, ad-free, privacy-respecting metasearch engine.

- https://github.com/NixOS/nixpkgs/issues/167245
- https://github.com/benbusby/whoogle-search

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
