### PR TITLE
cudatoolkit: 10.2 -> 11.5

### DIFF
--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "http://caffe.berkeleyvision.org/";
     maintainers = with maintainers; [ ];
+    broken = pythonSupport && (python.isPy310);
     license = licenses.bsd2;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -62,6 +62,12 @@ stdenv.mkDerivation rec {
     rm "$out"/lib/*.a
   '';
 
+  # used to mark cudaSupport in python310Packages.mxnet as broken;
+  # other attributes exposed for consistency
+  passthru = {
+    inherit cudaSupport cudnnSupport cudatoolkit cudnn;
+  };
+
   meta = with lib; {
     description = "Lightweight, Portable, Flexible Distributed/Mobile Deep Learning with Dynamic, Mutation-aware Dataflow Dep Scheduler";
     homepage = "https://mxnet.incubator.apache.org/";

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -2,6 +2,7 @@
 , opencv3, gtest, blas, gomp, llvmPackages, perl
 , cudaSupport ? config.cudaSupport or false, cudatoolkit, nvidia_x11
 , cudnnSupport ? cudaSupport, cudnn
+, cudaCapabilities ? [ "3.7" "5.0" "6.0" "7.0" "7.5" "8.0" "8.6" ]
 }:
 
 assert cudnnSupport -> cudaSupport;
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
       "-DUSE_OLDCMAKECUDA=ON"  # see https://github.com/apache/incubator-mxnet/issues/10743
       "-DCUDA_ARCH_NAME=All"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
+      "-DMXNET_CUDA_ARCH=${lib.concatStringsSep ";" cudaCapabilities}"
     ] else [ "-DUSE_CUDA=OFF" ])
     ++ lib.optional (!cudnnSupport) "-DUSE_CUDNN=OFF";
 

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -90,5 +90,5 @@ rec {
   # latest cudnn, nccl, cutensor, etc! It sometimes happens that CUDA versions
   # are released prior to compatibility with the rest of the ecosystem. And
   # don't forget to request a review from @NixOS/cuda-maintainers!
-  cudatoolkit_11 = cudatoolkit_11_6;
+  cudatoolkit_11 = cudatoolkit_11_5; # update me to 11_6 when cudnn>=8.3.3
 }

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -90,5 +90,5 @@ rec {
   # latest cudnn, nccl, cutensor, etc! It sometimes happens that CUDA versions
   # are released prior to compatibility with the rest of the ecosystem. And
   # don't forget to request a review from @NixOS/cuda-maintainers!
-  cudatoolkit_11 = cudatoolkit_11_5;
+  cudatoolkit_11 = cudatoolkit_11_4; # update to 11.5 or 11.6 when pytorch reaches 1.11
 }

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -90,5 +90,5 @@ rec {
   # latest cudnn, nccl, cutensor, etc! It sometimes happens that CUDA versions
   # are released prior to compatibility with the rest of the ecosystem. And
   # don't forget to request a review from @NixOS/cuda-maintainers!
-  cudatoolkit_11 = cudatoolkit_11_4; # update to 11.5 or 11.6 when pytorch reaches 1.11
+  cudatoolkit_11 = cudatoolkit_11_6;
 }

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -15,7 +15,6 @@
 , cudatoolkit_11_3
 , cudatoolkit_11_4
 , cudatoolkit_11_5
-, cudatoolkit_11_6
 , fetchurl
 , lib
 }:
@@ -90,7 +89,7 @@ rec {
     cudatoolkit = cudatoolkit_10_2;
     # See https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-832/support-matrix/index.html#cudnn-cuda-hardware-versions.
     minCudaVersion = "10.2.00000";
-    maxCudaVersion = "11.6.00001";
+    maxCudaVersion = "11.5.99999";
     mkSrc = cudatoolkit:
       let v = if lib.versions.majorMinor cudatoolkit.version == "10.2" then "10.2" else "11.5"; in
       fetchurl {
@@ -109,7 +108,6 @@ rec {
   cudnn_8_3_cudatoolkit_11_3 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_3; };
   cudnn_8_3_cudatoolkit_11_4 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_4; };
   cudnn_8_3_cudatoolkit_11_5 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_5; };
-  cudnn_8_3_cudatoolkit_11_6 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_6; };
 
   cudnn_8_3_cudatoolkit_10 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_10; };
   cudnn_8_3_cudatoolkit_11 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11; };

--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -15,6 +15,7 @@
 , cudatoolkit_11_3
 , cudatoolkit_11_4
 , cudatoolkit_11_5
+, cudatoolkit_11_6
 , fetchurl
 , lib
 }:
@@ -89,7 +90,7 @@ rec {
     cudatoolkit = cudatoolkit_10_2;
     # See https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-832/support-matrix/index.html#cudnn-cuda-hardware-versions.
     minCudaVersion = "10.2.00000";
-    maxCudaVersion = "11.5.99999";
+    maxCudaVersion = "11.6.00001";
     mkSrc = cudatoolkit:
       let v = if lib.versions.majorMinor cudatoolkit.version == "10.2" then "10.2" else "11.5"; in
       fetchurl {
@@ -108,6 +109,7 @@ rec {
   cudnn_8_3_cudatoolkit_11_3 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_3; };
   cudnn_8_3_cudatoolkit_11_4 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_4; };
   cudnn_8_3_cudatoolkit_11_5 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_5; };
+  cudnn_8_3_cudatoolkit_11_6 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11_6; };
 
   cudnn_8_3_cudatoolkit_10 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_10; };
   cudnn_8_3_cudatoolkit_11 = cudnn_8_3_cudatoolkit_10_2.override { cudatoolkit = cudatoolkit_11; };

--- a/pkgs/development/python-modules/chainer/default.nix
+++ b/pkgs/development/python-modules/chainer/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildPythonPackage, fetchFromGitHub, isPy3k
+{ config, lib, buildPythonPackage, fetchFromGitHub, isPy3k
 , filelock, protobuf, numpy, pytestCheckHook, mock, typing-extensions
-, cupy, cudaSupport ? false
+, cupy, cudaSupport ? config.cudaSupport or false
 }:
 
 buildPythonPackage rec {
@@ -39,6 +39,8 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A flexible framework of neural networks for deep learning";
     homepage = "https://chainer.org/";
+    # Un-break me when updating chainer next time!
+    broken = cudaSupport && (lib.versionAtLeast cupy.version "8.0.0");
     license = licenses.mit;
     maintainers = with maintainers; [ hyphon81 ];
   };

--- a/pkgs/development/python-modules/mxnet/default.nix
+++ b/pkgs/development/python-modules/mxnet/default.nix
@@ -6,10 +6,11 @@
 , graphviz
 , python
 , isPy3k
+, isPy310
 }:
 
 buildPythonPackage {
-  inherit (pkgs.mxnet) pname version src meta;
+  inherit (pkgs.mxnet) pname version src;
 
   buildInputs = [ pkgs.mxnet ];
   propagatedBuildInputs = [ requests numpy graphviz ];
@@ -32,4 +33,7 @@ buildPythonPackage {
     ln -s ${pkgs.mxnet}/lib/libmxnet.so $out/${python.sitePackages}/mxnet
   '';
 
+  meta = pkgs.mxnet.meta // {
+    broken = (pkgs.mxnet.broken or false) || (isPy310 && pkgs.mxnet.cudaSupport);
+  };
 }

--- a/pkgs/tools/security/truecrack/default.nix
+++ b/pkgs/tools/security/truecrack/default.nix
@@ -33,6 +33,7 @@ gccStdenv.mkDerivation rec {
   meta = with lib; {
     description = "TrueCrack is a brute-force password cracker for TrueCrypt volumes. It works on Linux and it is optimized for Nvidia Cuda technology.";
     homepage = "https://gitlab.com/kalilinux/packages/truecrack";
+    broken = cudaSupport;
     license = licenses.gpl3Plus;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ethancedwards8 ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26406,7 +26406,10 @@ with pkgs;
 
   gpsprune = callPackage ../applications/misc/gpsprune { };
 
-  gpu-screen-recorder = callPackage ../applications/video/gpu-screen-recorder { };
+  gpu-screen-recorder = callPackage ../applications/video/gpu-screen-recorder {
+    # rm me as soon as this package gains the support for cuda 11
+    cudatoolkit = cudatoolkit_10;
+  };
 
   gpu-screen-recorder-gtk = callPackage ../applications/video/gpu-screen-recorder/gpu-screen-recorder-gtk.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4625,7 +4625,7 @@ with pkgs;
     cudatoolkit_11_5
     cudatoolkit_11_6;
 
-  cudatoolkit = cudatoolkit_10;
+  cudatoolkit = cudatoolkit_11;
 
   cudnnPackages = callPackages ../development/libraries/science/math/cudnn { };
   inherit (cudnnPackages)
@@ -4648,7 +4648,7 @@ with pkgs;
     cudnn_8_3_cudatoolkit_11;
 
   # Make sure to keep this in sync with the `cudatoolkit` version!
-  cudnn = cudnn_8_3_cudatoolkit_10;
+  cudnn = cudnn_8_3_cudatoolkit_11;
 
   cutensorPackages = callPackages ../development/libraries/science/math/cutensor { };
   inherit (cutensorPackages)
@@ -4662,7 +4662,7 @@ with pkgs;
     cutensor_cudatoolkit_11_3
     cutensor_cudatoolkit_11_4;
 
-  cutensor = cutensor_cudatoolkit_10;
+  cutensor = cutensor_cudatoolkit_11;
 
   curie = callPackage ../data/fonts/curie { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8375,24 +8375,6 @@ in {
 
   pytorch = callPackage ../development/python-modules/pytorch {
     cudaSupport = pkgs.config.cudaSupport or false;
-
-    # TODO: next time pytorch is updated (to 1.11.0, currently in staging as of
-    # 2022-03-31), make the following changes:
-
-    # -> cudatoolk_11
-    cudatoolkit = pkgs.cudatoolkit_10;
-
-    # -> cudnn_8_3_cudatoolkit_11
-    cudnn = pkgs.cudnn_8_1_cudatoolkit_10;
-
-    # -> cutensor_cudatoolkit_11 (cutensor is a new dependency in v1.11.0)
-    # cutensor = pkgs.cutensor_cudatoolkit_11;
-
-    # -> setting a custom magma should be unnecessary with v1.11.0
-    magma = pkgs.magma.override { cudatoolkit = pkgs.cudatoolkit_10; };
-
-    # -> nccl_cudatoolkit_11
-    nccl = pkgs.nccl.override { cudatoolkit = pkgs.cudatoolkit_10; };
   };
 
   pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix { };


### PR DESCRIPTION
also downgrade cudatoolkit_11: 11.5 -> 11.4 until pytorch 1.11 passes staging

###### Description of changes

As discussed in: https://github.com/NixOS/nixpkgs/pull/166784/#issuecomment-1086762659
The motivation is to build as many packages as possible with the "defaults": sharing cuda, cudnn, magma, and nccl instances and simplifying overlays.
This is a major bump for cuda version, but a small step in pruning this garden:)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] [x86_64-linux](https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/169)
- [ ] (inprogress) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

CC @NixOS/cuda-maintainers 