### PR TITLE
firefox{,-bin}: 98.0.2 -> 99.0; firefox-esr: 91.7.1esr -> 91.8.0esr; rust-cbindgen: 0.20 -> 0.21

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,985 +1,985 @@
 {
-  version = "98.0.2";
+  version = "99.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ach/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ach/firefox-99.0.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "e40a11afbb7a464eb7817457cf360ec2b4e0d77b8d5db5d7856c5b79cdb1425e";
+      sha256 = "86cf773e1637f17ce85810712c6fae9a2e5d9d7ee0bf7b265a30f4a469c87215";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/af/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/af/firefox-99.0.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "8d0570e82ec73708933cbe2cacd53d89503cdc7d1e97cc57edaa066960340a1c";
+      sha256 = "72e525fee2e85110b77057178e77ddb277dd9c58609befbad04653e40cba6842";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/an/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/an/firefox-99.0.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "04403b0d68911dde99880c76d1e87f1315d1c463a63711e37e0f40abbfd9c2eb";
+      sha256 = "373700cebfc90fad01f5add0d5a0ff49ccab3ce8286adf3b3c91f2d69c51a18a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ar/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ar/firefox-99.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "57ab64dfa19fead2a828333456921465cd77e37a36d2030f81b7c022062fe215";
+      sha256 = "50dcb4b8bf1a6df6fd17975c9f5c3a2b54b23697191c853d48e08a01429ea102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ast/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ast/firefox-99.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "3dfb8f3c288e6c910d929da7c0228c52c490e33a1fbc99ce90c231e81cd9896d";
+      sha256 = "947401a336c715809de254d7e6381b902dc663e350bc1f89bf4ad08819a1f811";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/az/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/az/firefox-99.0.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "b5fc1a8d7decd2372026f9e4d4d8bb4d5fd839b165168f01e08a9641c0d7f92e";
+      sha256 = "87115f184011114f54110b3dcdbe2c7833a90be44f38294395274971710f6162";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/be/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/be/firefox-99.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "8b1fffc493c20318533879ecf9a006d0215d7c6f2323134fadecdfea68aaaa6f";
+      sha256 = "ea0844501b10ece23edc98781a2428de1f9a1b012a06c062765b1558c0d66706";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/bg/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/bg/firefox-99.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "852016bb71423b058a195d1b8631331a6da144a20c0d74b641d6189c93730ad5";
+      sha256 = "9cf618bfc8f46e9ec787274b320879d56bb1437685b3a8d057def285a1ab3621";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/bn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/bn/firefox-99.0.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "748e7303d01ca41fed55dc31d0bb57458c69180499bb5915ca4c835f7fdb56c4";
+      sha256 = "c41c3fd72734b6f81e4b92682a2b004058dab570e29721d227cc32719c5d7433";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/br/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/br/firefox-99.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "efc2e20d5201621c76411ffc3c7df227c9462bb6994f7ad19d735c986c362aa1";
+      sha256 = "627f1cf6109a6c529cabd537ac47a4ba907b7f4a2c2b565f715535d08696d8f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/bs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/bs/firefox-99.0.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "adb507af1a64e2c72193942b2c3a839576ca7d493541bdfed06b0f838f3bef43";
+      sha256 = "283f229ea9b0430613988fce636ee11a91d73e1e5caba2671965b57df39127ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ca-valencia/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ca-valencia/firefox-99.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "1cb7d989fcb1ca726d022a2e20523427d9aa0718d2129cea5102971624edff61";
+      sha256 = "1fb7e3474af461ea33769c8ac2bf3f0c7d6376caf7d8de549f11987fd83be198";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ca/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ca/firefox-99.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "0d746e8c8ca233d4f4161134f920a44e1a3593a2277101e20184087f76a443b5";
+      sha256 = "68045b6c2fae1024fd85c759e3da18857a7ab335da055c105c428244ef98127c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/cak/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/cak/firefox-99.0.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "fac629e27bb9e60fef81fa58268f9367a95af59b299a628ffe692731fd5ae4c8";
+      sha256 = "b6bd14470ec62436e99d72097e7f82566cefe70a2a0d57be729b9e3665070004";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/cs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/cs/firefox-99.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "7f6f30ea9afac44b1d1fde8abe2701f8f83b3014aa1c98fba1e2c4ae6c841140";
+      sha256 = "ad005d5e99575a0773882f933344453a73478e58c7d48769735a69ed39ca59f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/cy/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/cy/firefox-99.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "63c2b0bf442365c7db1cf96f192db016c4ddd4233a32190d657779a254871a2f";
+      sha256 = "6f22fe5b3bc4649b4f73220530571140d94291f69c4fd7c512b88a3471291e3c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/da/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/da/firefox-99.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f7d18039814a6310ce4a4e37d10d131639868a6f5ae85c4718ca1f9ceb90ae13";
+      sha256 = "2b1b37cd8e270f410a1bfa1e0e04dfb5acb17853d4f9a184eb52655b79f9d29b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/de/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/de/firefox-99.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "736f10e89507455708e40c9cdbd093fb1cb802ada7dd5d3e0d612cb0e11db096";
+      sha256 = "a115c9b1a29baa75579dd6fea40f7f498177dba0ba901f4c6de35a07fbcbb9a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/dsb/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/dsb/firefox-99.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "50ca85b163011ebdda69be8772a76ff4a912653a03d527784b18bbffd7c63a16";
+      sha256 = "ecdf01b499c393e06caeba03be7e3c89303a3f770859f228155bceb8c1a9c49b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/el/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/el/firefox-99.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "4b3a28670c6a7577f65dba7f857e8c68009a8d1e80089707d8d830e02a5f7fa3";
+      sha256 = "0205616cbfa802c67abff6cbb8e23e26b45fb8b224b5d7c02dece0ff3da4b924";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/en-CA/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/en-CA/firefox-99.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "f3a7c9de172b6ec0673d2600537ab9265cf3cde3e2fa614424e9f4c08986eb7c";
+      sha256 = "764ed326f89e0e3ef0cab0252cbfafe8b1b739268f787f5893d1110e4cfde4b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/en-GB/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/en-GB/firefox-99.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "49f044b0b5f841d5e42b9c6275dc7c78e2b2f903aa28f0d6a02a25a41d781d23";
+      sha256 = "dcfe8088136427476353c2797ee9ca159414f60b09fffe126eeb009ea041ebdd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/en-US/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/en-US/firefox-99.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "07c5f3dad0850a92d5c609278fb1fe682b2562fa55e6733c09a6b4da7373bfcc";
+      sha256 = "b6d895047c8911a49d944f78f710718091957f0057344cea735096ab4a8c07d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/eo/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/eo/firefox-99.0.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "98626ef3b514d1ddf0d9d530ef7b3ac8bb504717eb633f036fe9cb9437d8ea56";
+      sha256 = "acdf7d24ac1c91802938e8151c2876765532d935c3add9028a15ff47e0dedb38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/es-AR/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/es-AR/firefox-99.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "86a57a29b086fbc1d59731f94b792d1116a358e4735d9a8d08c022a2d5c7d0d6";
+      sha256 = "6d350750f744ff633168008d364b70a07a3becae1eb102c73bd2ddb6ddd8fbf5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/es-CL/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/es-CL/firefox-99.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "834bbbe0388631cae1e87e464c0b4e0151c37341828d71dd99fccc2d56c179c2";
+      sha256 = "9a4720bdf50e13bea6c98ba2e48b85dcca13683594e7b4d1e280649ac069ac3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/es-ES/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/es-ES/firefox-99.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "590efa38b4a374ccac89128a0e84de77492f1a8702e70b3b13d9a456575963f6";
+      sha256 = "cb78b97c05002db97bd15038b2c34f582199934302c1157912f95a7304112536";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/es-MX/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/es-MX/firefox-99.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f64ac621daa5f891541d836727d91cb56d5eb8db6093aa7f83af19adfc49ffc9";
+      sha256 = "10965923df9ed49c0dbe7a00154f70eb7fcc2254de77d0eacb115a0466881dbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/et/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/et/firefox-99.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "08374c6ae7b8eff3b6ce748c87f18136c86f73abf6238383ba3c4b1555f8a003";
+      sha256 = "dafe509497714b9fa6d97ff279cb0f79b8ab0ddec1a1ca0f538301875acbf22c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/eu/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/eu/firefox-99.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "3ce288c26201feca071bfd56f66fca69da7a68b3a468405ff6a665cb666cd799";
+      sha256 = "fa3098d1dc3fe3a4775fb431465ff9f1d6bea286cd0753afe373b907a09a7a41";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/fa/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/fa/firefox-99.0.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "3bfac0751b251dbd3ddb253973bb1ad7afe58f7cb824bef59d4f6c7dc5acec78";
+      sha256 = "cc7374de92c433d30e98f01e0cc742bb0fe3ec90894953423ead3e756b2377aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ff/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ff/firefox-99.0.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "2b962a0442a12c7f2dd7d2c716fbac0ad9435debf06d1c1e9f95fcb62fb90d50";
+      sha256 = "41765b0971f3185b0124726983de84dbfa6ce9f2018ba53cdb69703302ee50f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/fi/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/fi/firefox-99.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "705b21bdfa9826563042d0014a9225870c87b3351b9920cca35e203d1375f9b6";
+      sha256 = "b34ac17ab0e2aa8dfce3dbf4f3f50fcc748ad57cb2c5dcfc5026e74243df4b54";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/fr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/fr/firefox-99.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "e1d9cbb1c529508bb8262b0498506c30c7932b17a7d86d9b5877f44877cea60e";
+      sha256 = "62c1a24620ab6010c4a279d3e440e654fb446f8a8cd2c2906253d623d3d6a2a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/fy-NL/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/fy-NL/firefox-99.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "c1b40fb366281b9df839083af4aaaaa7a264e1ce380f9ffe46a2fe181bddd3f7";
+      sha256 = "34c6bd8a1400f35f970ba5cad69c32826550e3d429e63002a1c34ef5f9c0c98a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ga-IE/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ga-IE/firefox-99.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "466ff81e255bed9c03669c974581ee2cfc796e77456dea25af75adb501855c54";
+      sha256 = "0e4954e566f128fe93a970d41df9a05c631fc22fd500b7cae43559ba836c1bba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/gd/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/gd/firefox-99.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "0e1de18ab0b75b43ee8caff97c2963b7047f1000fa8dfdcc4e3fe87f29794c17";
+      sha256 = "1dd639f39a95a50d41a7759a43ac0eabea36e1ff80c557222d6b4e8dcf85701c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/gl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/gl/firefox-99.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "56f259c9f2f13d3f366e921aae1fbd069f00d59131cd3a3b31cb0f3e16f2ad74";
+      sha256 = "ba2525bc4c25c74b0aaaa77dae6c05dd4a7519086d756d34fc462ea907840b8e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/gn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/gn/firefox-99.0.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "b532c79002184bb13a3f197b5c0faf4a24e0b71f737de31c242f9fd286f05aa9";
+      sha256 = "6566afd98454031eca6ad3020323b82e1a8beb20a0e1f1ceacd3785a6e53725a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/gu-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/gu-IN/firefox-99.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "12ec5c968d852a7a72221373813fca48a4e524e552d22aca50ae99111a7128fa";
+      sha256 = "afc0da597d00fe408574e4036d2e928c644ff57857f6bf4b3182947e119cde73";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/he/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/he/firefox-99.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "3c1c1222a4ffcac6679849c94da395440d417284a922cae16b5edd1cf4ba678d";
+      sha256 = "5ec824f60e9b8df7a570eae973489751a2167e423fccdf750ee9320b9a1dee2d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/hi-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/hi-IN/firefox-99.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "6ae96b87b251917d2c11684ae58ac3df54496cf047b115145a5f85cfb1575b9a";
+      sha256 = "6640405a9361c4f080b552a4da9757cd7b81030fec328a96793a7cc752e00371";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/hr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/hr/firefox-99.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "4a77fb11f0d27a4abfc1426136d93404baaa730ffea2a31fe337f11ad92bcc8a";
+      sha256 = "75072debad6b291a051dc2af60a52554e9db3e5d87cc3fca2ea2974adfa3c3d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/hsb/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/hsb/firefox-99.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "725e2f719720c84ba06a28c5f025a16a951642c1102f7fe5faa41baede1b6a5d";
+      sha256 = "8ce2a5cf8e65d3d5de31105a7db1280c0379c77186af8deae17e6c23c6bd3edf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/hu/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/hu/firefox-99.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "4a128951a5466189b703fbf3055a9e65af64f08a7fcd979448611b91a63bb456";
+      sha256 = "595be31ce2c0671916bf8ad66f03e81bd8e53d7136d4e62d50fc7f250629bd05";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/hy-AM/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/hy-AM/firefox-99.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "70e44a8105ef260b3e10271f1a9c36a5149a485130d5a1219397aff93500639a";
+      sha256 = "2a3bcd22400dfe87e6dfcb38b0d4e970a49b9b4386c3d7bb3598299fbdd06c6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ia/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ia/firefox-99.0.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "a121636fb2513557f8e7e0a1b30e3d855202db14f997437cc5a6d7863214d385";
+      sha256 = "d13f9cb95fc78bf4f744ada47f2758c61d85ed231b2195ea579635c2aca4c749";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/id/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/id/firefox-99.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "eccb423ef76aab7725cd21efda222ed63c030d494c294998f4e9837ecccbbf06";
+      sha256 = "b6e02073e442960c773a5b77f66d54685dc617f3f6c9ad085caa923e84be5b4c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/is/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/is/firefox-99.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "86aac8ae944846967e472d6fd893c40ac988c25a2c2ee9af40485e216bb67b2d";
+      sha256 = "c6f45c0ea25b560e1f3f5a8f4c38d3732e7a944fbaf7ea766eef1a6162830631";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/it/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/it/firefox-99.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "f0ccf0977b3f3e05ed0d07980eca2179a808e0f62930690fb33f17b68c3bdca7";
+      sha256 = "adf2da8dce907f184cfbcad8ee7cc645fe707b0fb2ccec480f5baf503a03ed0d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ja/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ja/firefox-99.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "217159ae769b050bf9ff1b04ed80ad85a384625e2ccbf0d9f98c0786dc2e6c5a";
+      sha256 = "6698d549fdc42794372a32d6a435ebb90300ba42594de94d9ffeaf5aca53002f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ka/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ka/firefox-99.0.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c4aa9e994cad797afc081d2031296cac780e76966a7f231e6a0e3187d9e8aef2";
+      sha256 = "a16e4e6b86c9d1f62f6267417711a668d8899c2ed3414e32da13ac592bbc70c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/kab/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/kab/firefox-99.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "cc8333cb75f48ea82b752023162a270f18e33cbec610571624a38919737b00c7";
+      sha256 = "2ee4c463d31a388d22a4039365ed18103b4b56a3b584d32ebe393cfb956b34ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/kk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/kk/firefox-99.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "3482645b2581284503f72569caedc750706c439346917c07673ed0a27b0bbf36";
+      sha256 = "f4d9a8d6e6fec7f38664dd3c1fa9512dcf734481ffa20029295a86c4944c7b23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/km/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/km/firefox-99.0.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "b70fcfa2b4b4bed16d4fe8af2d57d8b7a4af346f321ece425895c10f7ac058d1";
+      sha256 = "04fd804bbd428f8441ff1900d356104160dda63ac5c6bdcc54c5fd6ada23185a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/kn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/kn/firefox-99.0.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "63550bf8572312f3c69c90f65de89423fc0ac926736723be3034d5d441ceb1e4";
+      sha256 = "ab8a5e9c60a9bbe1d44ad4c997491e7fed9cdfe7a2c83dbfeda60d7f1a90e1ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ko/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ko/firefox-99.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "de17cda5324ca6d179b9d576b62cde0ed21718b72896b161631513b654540cf0";
+      sha256 = "bf741c3962de3277a00c5aed83e45af14743767000365153a28cbc558a6778d6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/lij/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/lij/firefox-99.0.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "67cafe6a9f0c01aadb1fb55afe273fb58e4baeb38be2b472ed90a83c72b07ed6";
+      sha256 = "bd40f1f0126d60e539baeb2264b275a0983d83ab56dd8881c838f1d40a7299b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/lt/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/lt/firefox-99.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "135773dc11e691c20f20b0a1d37e2b25d92062c573846127c113896708e649d8";
+      sha256 = "29f3ea64fbe0e8fd4c53789de1819c29d497688180c5573fadeedd48182d5044";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/lv/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/lv/firefox-99.0.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "44bfaf12e5d34e1b8e281d00c7d9a26c2d0aa0a8ffbd74df9a5026e15ac12b66";
+      sha256 = "f1a6dbf6fb72733e681c000c1ee96b895ad28bd14925185c1f1ba4445e589513";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/mk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/mk/firefox-99.0.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "94d7db6bc2ba9de25207a058d29d8abc57e967dfaf59c3388438953098da9580";
+      sha256 = "bc8826ad43d8c51379f4479366b1c52635c69660b7bcc3bcb9897e6be15fc370";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/mr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/mr/firefox-99.0.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "e2ef6708ed116e40d3cc776c483d3cd42c91988673b91d2d29f4da8ea996f1c0";
+      sha256 = "7ef006861e0b17df49a08ebd877e91ea78d741c6966569df95554b813d0ad615";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ms/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ms/firefox-99.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "e376a479d170ff881d6de21f9c03ffc7a4968fccde7347e9fa261de7bb11e427";
+      sha256 = "2ffd658538429e5dbee797c12a95f5c294622bf110a607bf5cb0219680bde05b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/my/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/my/firefox-99.0.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "a1143bce18aaadd340b69403f064574664f202765ee5a8553ac6d3372ab33134";
+      sha256 = "0d533237d125a3c73d36d8a86d58026daf8338df3034cef661510c387109b774";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/nb-NO/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/nb-NO/firefox-99.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "eebdd022202cb7140db46995a3925c990e614233f3e15b850e5176b1f2c07907";
+      sha256 = "aeef86125435a840bfc23c23d9648e1d49a51079bda1e63276495512c8164391";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ne-NP/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ne-NP/firefox-99.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "084a278fe0b67a51126518d9aa62cae7cf78d96e3f6cf5b191f136a5c20acf84";
+      sha256 = "30618d33a48ac7cf990e669ff009b36d4ca491f266fb7d917ad64b213d0e47ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/nl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/nl/firefox-99.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "fdae25ccd979bdb5b4bb23f4e9e82e432df98059d82732ee187f37c8cb3547d4";
+      sha256 = "fa30128a44619961b3144b338612b8677bec82c5bb4a3ee37dfda9bc0d54f5bd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/nn-NO/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/nn-NO/firefox-99.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "7ec4c099c7a282a5b38df9a124ea6f2ee3a1704746aa308431aa8c356a57bec5";
+      sha256 = "96e31471625624ab0bfeecd2abec6b78bc4414a451ae3b5488ff09fecfac23d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/oc/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/oc/firefox-99.0.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "7f6d8ed3a7511d6af408c47c626a3e141425925df364f26a622a088491d7fe5d";
+      sha256 = "3802cce7288bf14780f78e117c528324611683dc1e8bf4db7f4c875958dd5610";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/pa-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/pa-IN/firefox-99.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "9fa3699918286b6f9f8829beac8cd45e59f35f389a09e0cbb34dc393885ec8f6";
+      sha256 = "177241ad04a1d18154657e753c7058e709d260af767bc53d786f5ca76ff2250a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/pl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/pl/firefox-99.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "e2ebf0346fb5b626a048a720782e325eefd04f1fe62de5c57826ebdd3ab1bec5";
+      sha256 = "1691326be5d01826c8ebd207a2fe3f00021a8edfcf3b44ab7f28024466118ebb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/pt-BR/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/pt-BR/firefox-99.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "dc79e634319ffc7221245e2a081cf6bfc15ddcd4bd8bf110d5dc15732aaab33f";
+      sha256 = "6b789a430c5c7b80f230fff69b20429a9329deb6c30f174882d71c80e3af9e02";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/pt-PT/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/pt-PT/firefox-99.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "f94ba01eca76939d1ecbfccfd9647c96244effb080df98b4e04d3edfd80ffa48";
+      sha256 = "e45567074b0573a3023e6c70241e0203cb8707e4d8c8a250d42aa29f207a969c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/rm/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/rm/firefox-99.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "6b27aee9330a94e659da34f17213522687859263ed8500daf1d62fc496cff033";
+      sha256 = "8e4ca7411436f910d6a2c271924fd61deb295081d7a1218cd19023635f76b18e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ro/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ro/firefox-99.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "b6029f72497173e8aef444cb42437d6035354fe4a2bfe6359c50eefa4d6e1850";
+      sha256 = "9df7c85feafd6611c29c38ca25371b224e36fbbd602e74a986c26ef1f6f7c361";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ru/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ru/firefox-99.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "73cbafa190a5083cfeba8ad0971d28eaaa228b9a9345ddc72d4f5d6490ebbad1";
+      sha256 = "61015fdab4d7791a2eae09a99440df7a65828a5092d04a7376049dd7f1b5c062";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sco/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sco/firefox-99.0.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "dd2d86ddcd270d2bb58c7152d15072341460a09b2da1639a76ac70afc9a714e6";
+      sha256 = "0481eec6bbe61c586c0a14416d7fc03df661432f2e2ad10c342fd6f6a6132e29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/si/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/si/firefox-99.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "0cf0281b2d082b3861947e5002f843df050586e96027ec30acba2913ce588daf";
+      sha256 = "1443ac2cfcea8fc577e341efc3d87406c01c94af9fadcf9672fd5283794d0107";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sk/firefox-99.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "8853372fdbe0834f6322e2e1c03d909b2c21f60496d7e679266dfc35e5835191";
+      sha256 = "4ffc688b2c38af18d28c7110f51a7a910b6671612b3a9ab657b579fabf9fb7f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sl/firefox-99.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "ce97423a4ad380fb019b3e4c8d57a44bb15ca0b0afc7778a10fd23cb9382c143";
+      sha256 = "7eba5fe498e694650047a2d5a9bcd0ef12f65b32c554ddb64fe79ba16a097927";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/son/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/son/firefox-99.0.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "468b642210c8c52ef5a8b91ddf81b9ff9c25768d7b0481f361e7c95861dfa5d0";
+      sha256 = "3dec0e49c906b0923229789fac38927a19e43c27a7a6004223f50bf267fb83e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sq/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sq/firefox-99.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "8a079436e4be7ceb82b56f02d50054066906b2f819b787ba964d20c64ba731d1";
+      sha256 = "c2f9c4ad474223a18b11f8b0f7453b0e2a8800030ae506c7c6aabe56440e9677";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sr/firefox-99.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "e9f0f1a8d6bf3bcb6df32a27560e952e3373d712cee08fb97e1c41b76052d370";
+      sha256 = "87d70164fa38d2c8ce13bb7af9c86c84d546bba9e2bd9f37ea345664edb27a76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/sv-SE/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/sv-SE/firefox-99.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "eb4b4092f1f667661afbce19e0d3ef75301976689f1ea2ee11104d11fea2ddd0";
+      sha256 = "e6a167e9b9e10232ca338560f80eeeedc4b32854893905e97881102c718f8ef7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/szl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/szl/firefox-99.0.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "29c9fcd787fafc93480fabb59573dd500d557847079f032a6f3ca6e9c4422c80";
+      sha256 = "49ca939d4a7f714ae4318a13c1229c1f6f5e8b903cba2a31f4ebd98469f6bb14";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ta/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ta/firefox-99.0.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "f07b8a79048b55d6fd8f7d19858ea2f1b5f53bde782c65ea7fb3f34d9cd5ac40";
+      sha256 = "5f8951a89a1dbe81d5327597373738a87bc5316601714ec759a4dd9d020e7ab6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/te/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/te/firefox-99.0.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "14882f8a3c425dd512c37f80fd45bdf9d34c4d7163454e1533c6306713935d36";
+      sha256 = "ad4b82cdacbd019a06acdcc7f76385edcd167efa8127a5bb6456ba53bc879298";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/th/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/th/firefox-99.0.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "c91bb2249cd2b22ae86b1b51fe6c34062a4da7772eab97b1e39915a2c2782488";
+      sha256 = "cbd3ecc7e51e35aad4ab16f91e014e502005903b2a1d2fc3bebcac987e033ba3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/tl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/tl/firefox-99.0.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "1c6fe06f19821a7a77a26bedf38ed3fea20561df0589c672027b2108e080e6b3";
+      sha256 = "b0466b793df5feb08eb8ff8f53b70e7d58c56602acf6c7b1dc1c97c96a881348";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/tr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/tr/firefox-99.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "c06881993063dcdf6fbfebe139f9fdafe2ca37667375683ae85497603517b5a0";
+      sha256 = "9ef3e70378c059075017ab8e3c104651e4845ceb6a981d9da85278881ea05b18";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/trs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/trs/firefox-99.0.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "fcfd9120933339006f1868b27e0fff1d60f562a3d11e826bbf9996f69d4256ae";
+      sha256 = "c31471dd116db01c888753a77bdd3078a84ad2bbc19d93b91e54ab79fb4b7de7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/uk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/uk/firefox-99.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "01cabeeb98988d4478d381b34e7c0e6cde887d2ea83feeb349763ee454760924";
+      sha256 = "4fde8729334a29c38d8bccad9d6632b8ba99a4faa769ce34d59b748aded50a93";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/ur/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/ur/firefox-99.0.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "db7de84fed953da53998ae6ff2456a02de833de22d13d1aa7e16f53d3bcb7fb1";
+      sha256 = "b1476c1b0bdbcc9cc6722db50f12b7fc92dcab3848478a184b6879a927e38d3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/uz/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/uz/firefox-99.0.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9fe0fc4851f005160de9562123e48c19216cb013dcdd2b8bd2b745d7838062ea";
+      sha256 = "3efae069d67253c450de209a3b028910aa3a3d0c14aae259d8096414d86d6ab5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/vi/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/vi/firefox-99.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "e335f20bd5a63c2fa17ce15fdebe0c5af5c6787d37bd49ad2da156b450383ae3";
+      sha256 = "d781e5fd73bb219fdfeb9be8e6fc861886724c48aaa4bf480605e1d641ff1c80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/xh/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/xh/firefox-99.0.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "9cd953e87b70c979a8c03fde8c989f626a23f62a7d59be8796a09c8a8950127f";
+      sha256 = "1db80ed81fd431373338693ea81961089e0251dadeeaf9f4e5179b0f5abd657a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/zh-CN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/zh-CN/firefox-99.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "2c7d059be4474164fddd349fc3f18d1f380af5f9ba82f8e01b04e2f18bcd09e8";
+      sha256 = "b0c1d1cb71947cdab88859e08c09910120a2117440c03ea29f1c2d0b40d29918";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-x86_64/zh-TW/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-x86_64/zh-TW/firefox-99.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "37b5a0275b137b0ef578591ccf5a54518bdbb449915f4ad50c276952a0bcccd8";
+      sha256 = "d4807ad378d61e01d8dcf53530deec5d4fad7b8d7df50f3df0918d2b591e6d46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ach/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ach/firefox-99.0.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "b3b734eb8d62112f7983e86dbd49d2d3be3ed6d2f80fd2d7bc189f12e03ab0b6";
+      sha256 = "79b90de5371b68c404db32c4498b4866b4ed6b10dbf58f9a2e4ebcc6d7b17478";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/af/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/af/firefox-99.0.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "fcf6a355f70392606ec2ed5853b1d14e8d5923fd92c10774c776c43e6c8a6cdb";
+      sha256 = "2a6f75faef4006c878b8a5156412a490c667dd970779d48a891b4d898c664e27";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/an/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/an/firefox-99.0.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "388532ad380bf43c287ca3e7e29a3a6f97fbbc0e02c2ae5207ac07587c3faa2d";
+      sha256 = "613f776853c37115f610206f6769f36adff86ed3b5b46cbe81a2ccece469cacd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ar/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ar/firefox-99.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "178a38e6bec65a59679944fdd6882774d23bb15e62f2e697cf369742bc4c8196";
+      sha256 = "a436337365e0865801fab136f710cb3134dfcf93896cf59aa78bf28bd70bb5a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ast/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ast/firefox-99.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "5fa0aea769c7f7fba13168fb404f03b2cb8f6df5ab733054118df67015ab665f";
+      sha256 = "85a937e65ac45dde5235e85194c9764056fcbf531f53a443c849fc727bfc5b8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/az/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/az/firefox-99.0.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "62816d95c32f04090a5e23bc38ebc774355ac77dfdd1a41a2d6e10ce983c53ac";
+      sha256 = "7a154cf0086ee80e03d88740f3b05d3de288dcab25ac151bc5ebc81af30e1220";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/be/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/be/firefox-99.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "918447a5f57647ed5d846a0a0bbbcbaa55559722de7b8dca2ed2e744eb14ce36";
+      sha256 = "c05628994a45f2bebd6b912175b012aca3af563ec70b85c93f65106ccfa5b4f6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/bg/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/bg/firefox-99.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "74851892da2c6c0a9a75d822aeef2c0a275fb5bbc32b88abb28e67f9310bb2ba";
+      sha256 = "9fc5b8266fb107b6ace769a0a75ed47bc4af5a9de6e215c4e0cd59e0f99c0711";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/bn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/bn/firefox-99.0.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "2a6f53aa3fec578a76368120bca30240bb631db9767159aedb3b5480c1ab661a";
+      sha256 = "3010fdb412c86b282b6a6bb9531124e8e06c409c64f3738d7c142be7d83277f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/br/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/br/firefox-99.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "5d1d9478f459bcc3e6b148ff42d6f9f589b8fb395672e3b8ce8f333832b523dd";
+      sha256 = "acf68c7dbc8f702f1280136f2443effbc8af793bc8be8621e617a757440c6f72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/bs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/bs/firefox-99.0.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "ed99ea471d6e30c0304bbb27bbdf88b479fee4df7f8cbba481d03de13954131a";
+      sha256 = "233b6b37d7e4f15bc971d48c1a0d55be146bdd430bb281472367a5526867f8af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ca-valencia/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ca-valencia/firefox-99.0.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "5dd1447b3fea23f08551b2ab5a80581c3e0e09f5602709cbdce751d491faa60a";
+      sha256 = "ee80548107642ed65feacfe480c7fa219b77ec6376244865e0deda14ffea8a7e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ca/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ca/firefox-99.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "21f6c622de4016a8e372ae7d249a07800b4393ba02ab59994356869a01cef571";
+      sha256 = "244107e338a2a290987d452953b93049642eb5008c897216d952851895011adc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/cak/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/cak/firefox-99.0.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "e9895877763157132e390f31c859b561c7d62adb011e209ab9cc0092ecfccb1a";
+      sha256 = "8db4e710b982e6f4f0c5e09b170884a8bd44db72a01ebb69f1eb899772132538";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/cs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/cs/firefox-99.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "13c94b8b12fcbee4d41c6f7289f0cf2f199ef3d750628cc0ea11a60534ab6954";
+      sha256 = "768976418cae1fdeddd8ebbbc53edda46c7b05b997db813573705bcb6dc80d80";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/cy/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/cy/firefox-99.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "c21d9e83d14ac46effb9e12a5210d7b56e3d765eef877f8ac4ed5104582d2631";
+      sha256 = "26705ed485b8436861032e74da2ef27b06b0d4471b6f019003175b8ef99e411b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/da/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/da/firefox-99.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "74a4a14ae8d8f64c56ce4409851f3e8e51bac61e2223c022f40d56d341fdcc65";
+      sha256 = "2828700cbc12e6d349b862bc49258752602ad9ea74a8ad1b52a8171caff3e0ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/de/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/de/firefox-99.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "d3449eec8075f3b6d07b2e6d7adecbec60a7e29b12c2016f642a90c5555971ed";
+      sha256 = "b27bf803ca3ac8f4530339f648c2c7248e674f5e52a327d4d62d5dc8055c8683";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/dsb/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/dsb/firefox-99.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "0dfac7916796d4ec7943963e28d7ca65f78661b6f22c226afb2dd00db47917e0";
+      sha256 = "b3a31746bf575bf2c06227eb01cd07013b59ec2e17f6603babacc3be76222254";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/el/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/el/firefox-99.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "c2769489e0947a7eeb0cb1f9d99d51317fd037e2a7bb06134403df1d4560a767";
+      sha256 = "b220df0d42dee179c02066677db3edc3526d1f91df9399d6555f79dc96212ae6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/en-CA/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/en-CA/firefox-99.0.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "87bb7162b58f7632ddf733fbdd4f195d75a9a6d467355c2625344171c72f4e9f";
+      sha256 = "a87252dfa797e7777823a84e80d6f9d8de6d1f17d29f8d2ee4ece46ab8d1b917";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/en-GB/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/en-GB/firefox-99.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "89bbf10bb75effa9e8064b6c42d0a4d7fd21ac2cd6e4ed3625d92c6b55ba1ee6";
+      sha256 = "37001a756bf9ea4e042ec043339e86eba4abaa4bc248bc699836ac8338f56ff8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/en-US/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/en-US/firefox-99.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "888db6752eb5703af5fe5ab4b1575f2a35dbd204614552fbe3a276042a3509d5";
+      sha256 = "c6e074e4083c366793dbc6d96968fd323fe0ffec1b8629be16e7c984ab1c3bef";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/eo/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/eo/firefox-99.0.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "a2004dc59269fb2b37e568767593bcc0a7862a109df18f548eb1a0b829cf4293";
+      sha256 = "a5b6b630d5e58e20d6af73d6646954f0842ef537f8e0fdd4a424e6d34ccd2d7c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/es-AR/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/es-AR/firefox-99.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "9e2c0f6cb231c469660cc7fe63489e69a2616553d17c52f5e7a2a86a171bc6e9";
+      sha256 = "84f7042e098eecf4974fef594c3640bd0e4c1c9fdab373c287ed580b2bac0a8b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/es-CL/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/es-CL/firefox-99.0.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "dfe6f1229a6f80b6fab3a22fc8a8a6ecf3137b31805339a489ec53e5af63f040";
+      sha256 = "15a9ee9c9765ad5e0303cd94d22c61af50c723ba5241102d327e88eed2e8110e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/es-ES/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/es-ES/firefox-99.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "01020488ee2ad2e2357bbaf83857a2ad0820fb9f97302d1447cf4148b22d2bd4";
+      sha256 = "acd612f04297eed5f09b47615412e3b19099610c7a62ea8468382fdbfccf7d1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/es-MX/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/es-MX/firefox-99.0.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "3c7bacc6f703cdff7adb9097bfc39f52a67aa6a9814d7a8f451d4ef50c591714";
+      sha256 = "e86c3e1a68e7b33413b0c97ac1ad63535faa618228db207abd1d0fbdae4f5f08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/et/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/et/firefox-99.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "f2bc8e4200c89cf74ae6c984543e97b2523782dae70ecf6135f47943a01f1d83";
+      sha256 = "dcb820763848a5bbe5b32dba6be949877bc38e123c9d7553ed569316ed1d436e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/eu/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/eu/firefox-99.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "62bf0d826adb66d755f38bf25199eaf3850c37bfddca627b597802a20f8d3367";
+      sha256 = "dd1b5cbb48ea9aef8d3acab9f6a4c8de44128584b9d95fd50b2ed1b1ca79d367";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/fa/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/fa/firefox-99.0.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "9d4dfff33db462c71eb12067f56f2e20b0a557f9cbf1234b617e1c2ab5832ea8";
+      sha256 = "e4e66fb13ac850712bfa9946c05b97bc69f1d750037f8524ad766d6fcde67d86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ff/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ff/firefox-99.0.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "5b3a271207003e25776a55b7ee6adba2f83e844d4b0a738209d21be7db82ac33";
+      sha256 = "a793ad05230d98cfb4a003263082a64de86998eb5148ab3827b3e999e242a758";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/fi/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/fi/firefox-99.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "50a9408303ac8fc7c22da96f993b0b251407261d35598b4fe06f1c545788ef0b";
+      sha256 = "0567d3400a281bd569c81c406b462a101d3dcf041c4ec4e0e9753301ec0aa629";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/fr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/fr/firefox-99.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "65db55f518be2abd8da5b52654bdf0efecd94b21ab843b76a6ad9e9ccb516a55";
+      sha256 = "fbb0392b310297e0ee974486092f7e6ed74f63d1f190218c63796bedf4e2b90d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/fy-NL/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/fy-NL/firefox-99.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "b3da8b5a077e4955bf2c662840005adaba2dd77af4724e965403da3139b5fb3f";
+      sha256 = "8eccc6e66de2b523e4e811d5d57b8eb17496ea9c5566c29ae7fedeb751876bf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ga-IE/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ga-IE/firefox-99.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "f4812b90fa0a0391d2a372e7bf45a3393d59714209046618e7b1ed72f1889e2f";
+      sha256 = "239f4dfc4e5fc29b32a75ce0c4397a8785f3cc0b5e10b61b08565b6902342cbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/gd/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/gd/firefox-99.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "769c42c86d5b3866f9ad38bc833f5f1f1b01c7f5ed6898eba064ce6f31c9f550";
+      sha256 = "312c89bee7911e74fb87ce7cd128d55c7e4b0f706dba5950e7b45d39cfd5a817";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/gl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/gl/firefox-99.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "b75ed9efccd63053589a3f60fbabb6ce5fc1c027a1a00789ff23b6971b0ebad5";
+      sha256 = "98d7ee9fb9dc4442d475db37925128858d807f3e686e9624902e62a872322a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/gn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/gn/firefox-99.0.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "bf60ba48f5d5a18ef9aeaf631d564412788ca102990b69b176ac66c1b8e3535c";
+      sha256 = "5d1e387fc779d0226347dbc6abfa9acd5ed5c39f30da22f36789dc1b2d68326e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/gu-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/gu-IN/firefox-99.0.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "19f568337cfba71d7e1626099b1c6cee4d69a0332065779e5375da648d70a3f4";
+      sha256 = "51f5f582d2b2bda10ac528a2b0842ca86b29d20421ba83ae56493d791613bbc0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/he/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/he/firefox-99.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "7d6a55d76f74d85e2f9da77ee071df31aed1c37f9fb139e448624a105b6ef19d";
+      sha256 = "d0192b6ad1508b1ebae13cbd3bc3d7fbf5b5e222d5f5cba1857d2b3d73c1c048";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/hi-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/hi-IN/firefox-99.0.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "12451d7cc49ca2629ffedeebd1d77f8ac96d5839ed165ea91f55a249427ebf09";
+      sha256 = "9bf5814ada09f878d484ccd4a37d56054316372caf9766b8da70cd81f817f208";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/hr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/hr/firefox-99.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "b2197d6d51847848cd849fef446e8b84725fc2b9539824e65719c4fd1d7f29ba";
+      sha256 = "4c2453a9ac74a71d7f5dfea3474ae68cd5fc2d4a85aeb04e367116d80df9cdbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/hsb/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/hsb/firefox-99.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "5000e21630440a446416de3cc38bcfc7c22bb8bc8d1a1a027c14b9548acff74a";
+      sha256 = "c3904c1a8b1ecedded23ceef7d8168865a0f18f08b81600e013f7cfebc5d5ce7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/hu/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/hu/firefox-99.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "dee75736596f5f0dc1d6952327274d07f927ff42e7c9a0ed8c8ba8dc78a6b3f9";
+      sha256 = "e05debfc803f3752dfaffef6b30e0079f5af44107217c362325e1e5922eb18a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/hy-AM/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/hy-AM/firefox-99.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "4b7dcb46864b058bdbeb35404de32c88e2822dd0315f105e95f61be857288282";
+      sha256 = "364a7408f1d2a150f04ab759da6a45021fad3bca5ba2811931df46960671c1ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ia/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ia/firefox-99.0.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "e89e07b1d71e1b2ccfd4d412dabea164bae8448f57a5f99a07ab04f9dcaa0bab";
+      sha256 = "5dc2a481ce5e9bd54241363fb88b62a655584293fd9d3f7ddf13dd0195d8cea0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/id/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/id/firefox-99.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "398ee6ed278cec1ceb489dd06d8f4c2671309a3e0d61f3202fd5280a5b596ca7";
+      sha256 = "b9d5b10461130d5c2895b04604be7eccf8979b87c4e8acc03173709979185eb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/is/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/is/firefox-99.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "a3531b8f68ee22452390ff8e1c70d7f6b842e10ab60ca6666f79fd958284d099";
+      sha256 = "6e4506fd90b7f3ee316a500f5e2fd3e2063fbeea79f3a86dcfc8573b8c355469";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/it/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/it/firefox-99.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "fe8fd2e7b0e87cb3b12ab6d8d973c422ef763d9d3a78620fe5a9f374455ccecc";
+      sha256 = "2bdc9c8aa3f8b0b86b0310a95e4f3aa74de418aef7dadd7ef3c24af51c4bf0ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ja/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ja/firefox-99.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "5d52ec4afd7de44806b804b5de6e597228d7061c10b0cc8d6fabeca505a0b207";
+      sha256 = "8e035fa783b64ec5e8503bf329346799aec628df03b013319586cf04969d36f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ka/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ka/firefox-99.0.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "902abc9df459c6dd2168050764cb2301ffee566f4deb11b2ef7c694cf429cc58";
+      sha256 = "59d2b9eaed8a898be979286d7ecf963e4f2241dfcbed9ac8e0d0b1821fb9e2fd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/kab/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/kab/firefox-99.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "aa96307da2c832df7ea7ea418d3dae6dd9f2aed56432a8ed6e43fabe71aa9828";
+      sha256 = "2506702d67e1576df307bfcfcb9e20809352a37be3650c9a454e906a5d78fd2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/kk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/kk/firefox-99.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "addb689db7bb19f28db963ca61dd0ece3813f5ca21f3437c1320c3f972e19029";
+      sha256 = "df0e505fd8552384ea55024531378e7228e35d9a40b66288631f524a565b94c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/km/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/km/firefox-99.0.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "7a982cdb847d162c6cedf724adebfab904cfacdbe3d4e48ee9af3e644e74cc14";
+      sha256 = "fc2202caadc90364dca89329a335869dd9bc8a2240fb95d5b3c6fcfdd6586be1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/kn/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/kn/firefox-99.0.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "d2cb6eb8c004d9c0e0929d8047d93902a2235b5068b86672c693edef1a2b8911";
+      sha256 = "8b4fe5e47aeaf7d1f15fa00d74088689f40a9d92df893b79d6c3c950f182c234";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ko/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ko/firefox-99.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "63770f2a873b520e5b1c1bece82ea4a987a2ae6535f9c4047e99b68f62c91748";
+      sha256 = "ce2a3f64b6d2b4ca319ed020ef621974977216aa468811609431a618aee9b77e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/lij/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/lij/firefox-99.0.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "ff130a01dc266b5b49f39f9c4355a6576211c0008cd5008290266daff222e18d";
+      sha256 = "6b8ebcebb1c9ffec9993663ef6040007909136d99dc9a2f724d16d9b9dc1f647";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/lt/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/lt/firefox-99.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "04105e0614b660d0e156b0aa2307af9d0d11236119b6667718d7f0f1f13ae505";
+      sha256 = "798c36f256f173fc5662d5edca6c4eaa55bc0c4f794a481524871aebabcf9b0f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/lv/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/lv/firefox-99.0.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "50dd34d558800dafc84d714f5cf08a26eb4970c3aa6b8850430aa156d8869549";
+      sha256 = "4ea59a53fcbfd93959540edd12b4760586ca3f0a26fcdbdafa13cad70db7ca0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/mk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/mk/firefox-99.0.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8ca0b1cc9ff39757f2cc513d61a77d1d95a607862ea654d6743bf4a8f7bde99c";
+      sha256 = "c4bab25688564f1dc34b14d96695bb03881af3e2551040a8cd3e4543d8107338";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/mr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/mr/firefox-99.0.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "b24884486692dfcad578026498a3654d34ae78cd39e977b3708053bd7754d37b";
+      sha256 = "e440be0dcd8714e7f08dad0800ccb642677e98444fd115c9a8ee5684f6b619e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ms/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ms/firefox-99.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "c43f2f10d928a3cf875e81afb54c09c1ef49ff8457069c054df2f62e0a43979f";
+      sha256 = "4d09e9925b2c67c1ea082b895f62db8f1282dbad073a851504187ff9b1725e74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/my/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/my/firefox-99.0.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "296d3860c2224deaa43184fa85dfce21eb9fc9b11d080d7f71cc189c4a790ed3";
+      sha256 = "be56fa7ae49aa26d174633d7e2bf426fb6931901176d8ecd26fdcc6e02749b6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/nb-NO/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/nb-NO/firefox-99.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "b0ce5e0157ff9f64434b38cf9338960870bbf6bdb4b75494b82c8ba871868ff3";
+      sha256 = "52a14a147126a49314425fb9ce2c964786cf409e176e1fc949ecf9a1c67627aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ne-NP/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ne-NP/firefox-99.0.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "58b7a719e7fb10bf7bfbe23f4ffcf002434652f792a3a1ffbadb13a5e06a04ba";
+      sha256 = "25fa25a6d63008badc2bdab5242c0620520b427df68de45fab873c230f7e948f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/nl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/nl/firefox-99.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "2951dae0cbb3bec0e47ae44b70e6796ace16c8fbac18d7d04da84a51ded6a650";
+      sha256 = "0d751560dfd83afdbe69aab576449ab25a3b2b66ebed28ff4d13ddfefe520f9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/nn-NO/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/nn-NO/firefox-99.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "6f44201f301931e3b51144d57a79c484b776c37cb29dda93b57795c0a756c62f";
+      sha256 = "baf6b5ae7d2848344648fe3b3fa95991ccea45d2302eec5c657671a5736cbc7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/oc/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/oc/firefox-99.0.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "899a48b47dd642a64de0ac9226b4655e74bba9f0f6d1eccebc1c1875e1d3ea12";
+      sha256 = "bcf9df67acd24f0bdd4794820863f91b60bfe745471b0e88d29a22a225922665";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/pa-IN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/pa-IN/firefox-99.0.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "392b6e6cb3ca1ef3e17f73ca327bf7fd49d453ee0216f922dfc3bfc7b2ce18da";
+      sha256 = "c0d8aaab99ddfa3b0be3bc323483f99094feaa67aa3d94bab4f5cf2ca8612fb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/pl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/pl/firefox-99.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "f4f6124c3520c58ee00b7f4f00a39a904657b21072fe3d822a17b072c8e69473";
+      sha256 = "df2d1ba0a3db60f32c9031db067d14a56f06ebb8a3e04b540d4d7f15e2bc4367";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/pt-BR/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/pt-BR/firefox-99.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "b19e3aee72fb779ab139535295d3279cd06c125349fb5ee71c12737ab2aff733";
+      sha256 = "8f038e619e5380491b2002909930ac254a60f92215ba922a7fb2ec0895047a91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/pt-PT/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/pt-PT/firefox-99.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "0924bc137f6eaaf6686249f59540eadfd9b09aa843a071bd7db5d62f742258af";
+      sha256 = "749ba7ce1e93dad3a95f28f5ec6bb81e9bcf63a7c4d436487422126d2f04d8c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/rm/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/rm/firefox-99.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "ea9b082ba495a19162c0945b865eae6f66c689962807873bf27ad59a3e83c85e";
+      sha256 = "1b3ff965145535d0c3275366c27c4ed3a0d95a47e42d8baa7088dcdd58fb5e13";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ro/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ro/firefox-99.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "3bbd902b4ace383d914f51553bce3de83c2ca4f6366e3f2dc42268795c7bf72b";
+      sha256 = "51640a0f3792d962a31ab494fe9c8f6a31cb6c2093d06f2293b2d2614d82e17a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ru/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ru/firefox-99.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "84296b00a3646cf8d0e7ba3ec6cbc90592b8fe8b2dcc36b8c904d1e15c264575";
+      sha256 = "01e25d1e39ad93fdaad2382039dbf3b0d9a7e1c6f7993ebe6088a7f0d6545ad1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sco/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sco/firefox-99.0.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "8f966e6fa33e9e0242dd422818c9c46c5ffe37ebeb34e01a7eb57258e0aea481";
+      sha256 = "cf27b720e94a69df2a18ff9846108672bfe757224b71625a1ff1445ab11d5489";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/si/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/si/firefox-99.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "3ce96976ec5e920b20fdb1ff7fa8d20db2a67c0797ac4307f7e387db91306719";
+      sha256 = "4e64606407dfb9d9bbd44dc8eeb493208d546cb8d79c526a3e261a18b899b050";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sk/firefox-99.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "1a4d37ac6777185230343dceb4902b55e0adad62d144347d09f031228583370c";
+      sha256 = "7917d08b5870a3e02c7d2393a9bfae39e9bc45114ce37c1e2cebbe81d6ed3f60";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sl/firefox-99.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "e1875f0077c3c03f34d7fa33e807d0297f831d451a045cd55accc493c3dce366";
+      sha256 = "12c7b3b525fc7fa1ab76f12bb837f481ccb30b317202f185cf5e71bda80048d8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/son/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/son/firefox-99.0.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "1d13d9d3f9d8cfc03e5e45cd1c62a08b24437ed9feeb27ce42b07a75f0aefc04";
+      sha256 = "b0d0d04af3623eca737b8325e607e330636531525b92e23150d05204b29ba7e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sq/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sq/firefox-99.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "e2ae3fa32c56258069cdb95231a5d3b44218d32f0b10afc4174ac204bda7acf5";
+      sha256 = "4ee2854ec755ef5c1e4f4761819cd7125bbcff832d7c8ce6f3ee96e92c343b8c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sr/firefox-99.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "96a5178bdbca9f6d1434610aa0d35c32b6eb542d6d3e760ce778a8e4181515f7";
+      sha256 = "6a2e415702701fb082beacababab5cf9368790a9876114eb2186f5691f32d265";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/sv-SE/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/sv-SE/firefox-99.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "fabe9274a8ac78ba84a394a7a5e7cfa22c41e3b58c8e6b94496fda6490bad644";
+      sha256 = "cdae3c72e5f79fb2a5ed988d39eac0f21e321feebe9ca67d8b7362c80160d7d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/szl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/szl/firefox-99.0.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "d77505b5fe04946002e5d1a28081c7e2933ce910a8d67f4e5ed31508808cfd41";
+      sha256 = "d39ec7a68195af2bded9826a251904b5f501c58dcb3c92789a2ab5251fe2618f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ta/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ta/firefox-99.0.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "a34e5b28526f9861bdc7af910e0a3418404f4316ad5792607493a698f480c9a1";
+      sha256 = "a7220a78f600010125b20c22205865169330c45bb9eacf4496c26ccf780257d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/te/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/te/firefox-99.0.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "c3b8653af6ed8f4cf7e9f3e5a4a0c622a163f7c45dd0d1ddcb3936e1504ea1af";
+      sha256 = "8c4973de96cda2a3448a30ec4776e488ceac9b27a9f5142f2256b92ac5c31102";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/th/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/th/firefox-99.0.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "a6456037b76bf2adaa6a6d68f8b20f293f8a4fdbbc3e533c8a6a22aedcc3bf4d";
+      sha256 = "aefbf224abd9b77303b90437a5ab87bacd4f04334d84c29c3d41c4b9922282e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/tl/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/tl/firefox-99.0.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "51ff115845f3d70a9fb08f08fcd3c1f86a41b3570f81f460c24a5a87605a779d";
+      sha256 = "d0c1e4c099482fbcbfdea2f45b3f6e1ec6744b3073d5c0ab840ed6eab129aa26";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/tr/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/tr/firefox-99.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "3ccb5735a16622dafe6ae465ba167ea164843c85df436e7cd20cf6e7a4fbb610";
+      sha256 = "97b7f1c90fe846a4eb8c1a0dbef7eb9fa8f3a536f8e37b24565b4cb42ede27bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/trs/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/trs/firefox-99.0.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "7d1a71033460524506082087ce1b3ddc424207ea3ade6e0bbdbb00310e74cfea";
+      sha256 = "3910053c3e0ab255cd595cdebbbb0e0720a32cc1f20d6e74b5fdd3427fbb5137";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/uk/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/uk/firefox-99.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "6db06ed2f126c5307ef6380dff4dae14cc39ca58d23b827835d3e702acf33c72";
+      sha256 = "4736b57b2beea7f6a09a289b3ce6921082541acf20faf9d6165658ba96e06dc2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/ur/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/ur/firefox-99.0.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "d00bcd6b3c70919999e748046b3291279d313f850c3daedae37259b695cb351d";
+      sha256 = "072b4f58064362f74eef2984c94cf42302bff9e61d0f9d8adf13124cef699386";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/uz/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/uz/firefox-99.0.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "1d77240a5f6d7542a7035fd32fd73e07bee1e1e880800cabd01e357a3da30907";
+      sha256 = "42f99dd9d61f29491ba55edb806131a4768768145676b42c886b5848d09dd451";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/vi/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/vi/firefox-99.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "9469a1c6613ea83a8e367c0e25e188ea9b9fddcc1497725a3ebb008fb5d5d73e";
+      sha256 = "d9c9cf96117b7e759291d7731fb53b51fc9f7d07b95ec7d479f6a03c34227b9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/xh/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/xh/firefox-99.0.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "af3144bfcb52df706182fa04badf39be51e5774335af21d8ec38dcbebe3bdf13";
+      sha256 = "929005cf3eba0a59e13e9af9f1595e218757a1d08c7c9a50cfc2323cd8d2de1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/zh-CN/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/zh-CN/firefox-99.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "fe6fc7bda0e52d64abcef8cbfc5e8576c64067b8746605e80790bde6dcd9b03d";
+      sha256 = "06bef0564337cfeab47ce84a095e9bcd347df4f6c821eb5d0404d984689c9e6d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/98.0.2/linux-i686/zh-TW/firefox-98.0.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/99.0/linux-i686/zh-TW/firefox-99.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "18da6dcf61bba9a22b5487f695793d65b952cfc7065ff334b0faf8e7ec82d90f";
+      sha256 = "7eda1a1131117ceb3b513dc345c62397542bcb58cda1e97ade47fedb4fe704c9";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -32,10 +32,10 @@ rec {
 
   firefox-esr-91 = common rec {
     pname = "firefox-esr";
-    version = "91.7.1esr";
+    version = "91.8.0esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "c56aa38e9d706ff1f1838d2639dac82109dcffb54a7ea17326ae306604d78967ac32da13676756999bc1aa0bf50dc4e7072936ceb16e2e834bea48382ae4b48c";
+      sha512 = "edea2c7d4d3d0322091b20b623019ef041090d9f89f33c8e3140f66a54624261f278257393db70d2038154de8ee02da0bee6ecf85c281f3558338da71fc173c3";
     };
 
     meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -7,10 +7,10 @@ in
 rec {
   firefox = common rec {
     pname = "firefox";
-    version = "98.0.2";
+    version = "99.0";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "b567b53fcdc08491063d535545f558ea56ec5be02ca540661de116986245b79f509e0103cea5661faf9f4b3d30b67758ebdb4b30401e260ee27cbb300203f36e";
+      sha512 = "08f6d5a668140c4275aba6df463ed3af596043dfe5f27573583afbc1e9f6b27ebca79a52ce2c9598261c631b400b5378744e9e70f51ef9c4098b419e9904aa7c";
     };
 
     meta = {


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/99.0/releasenotes/
https://www.mozilla.org/en-US/firefox/91.8.0/releasenotes/

Targeting staging-next, due to the nss 3.76 requirement.

> ERROR: Requested 'nss >= 3.76' but version of NSS is 3.75.0

The rust-cbindgen update is just so we stay ahead of the curve.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
