### PR TITLE
blender: fix dependencies

### DIFF
--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -90,5 +90,5 @@ rec {
   # latest cudnn, nccl, cutensor, etc! It sometimes happens that CUDA versions
   # are released prior to compatibility with the rest of the ecosystem. And
   # don't forget to request a review from @NixOS/cuda-maintainers!
-  cudatoolkit_11 = cudatoolkit_11_5;
+  cudatoolkit_11 = cudatoolkit_11_4; # update to 11.5 or 11.6 when pytorch reaches 1.11
 }

--- a/pkgs/development/libraries/opencl-clew/default.nix
+++ b/pkgs/development/libraries/opencl-clew/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+# Used by opensubdiv and blender
+let
+  pname = "clew";
+  version = "0.10";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  nativeBuildInputs = [ cmake ];
+
+  src = fetchFromGitHub {
+    owner = "martijnberger";
+    repo = pname;
+    rev = version;
+    hash = "sha256-51HkWGHlvk0d7jayCqy+nInY7C/EUIex1+LO5FjL74c=";
+  };
+
+  meta = {
+    maintainers = [ lib.maintainers.SomeoneSerge ];
+    license = lib.licenses.boost;
+    changelog = "https://github.com/martijnberger/clew/releases/tag/${version}";
+    description = "The OpenCL Extension Wrangler Library";
+    homepage = "https://github.com/martijnberger/clew";
+    paltforms = lib.platforms.linux; # upstream mentions windows and darwin support too
+  };
+}

--- a/pkgs/development/libraries/opencl-clew/default.nix
+++ b/pkgs/development/libraries/opencl-clew/default.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation {
     changelog = "https://github.com/martijnberger/clew/releases/tag/${version}";
     description = "The OpenCL Extension Wrangler Library";
     homepage = "https://github.com/martijnberger/clew";
-    paltforms = lib.platforms.linux; # upstream mentions windows and darwin support too
+    platforms = lib.platforms.linux; # upstream mentions windows and darwin support too
   };
 }

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       "-DCLEW_INCLUDE_DIR=${clew}/include"
       "-DCLEW_LIBRARY=${clew}"
     ] ++ lib.optionals cudaSupport [
-      "-DOSD_CUDA_NVCC_FLAGS=--gpu-architecture=compute_30"
+      "-DOSD_CUDA_NVCC_FLAGS=--gpu-architecture=compute_80"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"
     ];
 

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -1,5 +1,6 @@
 { config, lib, stdenv, fetchFromGitHub, cmake, pkg-config, xorg, libGLU
 , libGL, glew, ocl-icd, python3
+, clew
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , darwin
 }:
@@ -36,6 +37,8 @@ stdenv.mkDerivation rec {
     ] ++ lib.optionals (!stdenv.isDarwin) [
       "-DGLEW_INCLUDE_DIR=${glew.dev}/include"
       "-DGLEW_LIBRARY=${glew.dev}/lib"
+      "-DCLEW_INCLUDE_DIR=${clew}/include"
+      "-DCLEW_LIBRARY=${clew}"
     ] ++ lib.optionals cudaSupport [
       "-DOSD_CUDA_NVCC_FLAGS=--gpu-architecture=compute_30"
       "-DCUDA_HOST_COMPILER=${cudatoolkit.cc}/bin/cc"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4629,7 +4629,7 @@ with pkgs;
     cudatoolkit_11_5
     cudatoolkit_11_6;
 
-  cudatoolkit = cudatoolkit_10;
+  cudatoolkit = cudatoolkit_11;
 
   cudnnPackages = callPackages ../development/libraries/science/math/cudnn { };
   inherit (cudnnPackages)
@@ -4652,7 +4652,7 @@ with pkgs;
     cudnn_8_3_cudatoolkit_11;
 
   # Make sure to keep this in sync with the `cudatoolkit` version!
-  cudnn = cudnn_8_3_cudatoolkit_10;
+  cudnn = cudnn_8_3_cudatoolkit_11;
 
   cutensorPackages = callPackages ../development/libraries/science/math/cutensor { };
   inherit (cutensorPackages)
@@ -4666,7 +4666,7 @@ with pkgs;
     cutensor_cudatoolkit_11_3
     cutensor_cudatoolkit_11_4;
 
-  cutensor = cutensor_cudatoolkit_10;
+  cutensor = cutensor_cudatoolkit_11;
 
   curie = callPackage ../data/fonts/curie { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -289,6 +289,8 @@ with pkgs;
 
   chrysalis = callPackage ../applications/misc/chrysalis { };
 
+  clew = callPackage ../development/libraries/opencl-clew { };
+
   clifm = callPackage ../applications/misc/clifm { };
 
   clj-kondo = callPackage ../development/tools/clj-kondo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8378,24 +8378,6 @@ in {
 
   pytorch = callPackage ../development/python-modules/pytorch {
     cudaSupport = pkgs.config.cudaSupport or false;
-
-    # TODO: next time pytorch is updated (to 1.11.0, currently in staging as of
-    # 2022-03-31), make the following changes:
-
-    # -> cudatoolk_11
-    cudatoolkit = pkgs.cudatoolkit_10;
-
-    # -> cudnn_8_3_cudatoolkit_11
-    cudnn = pkgs.cudnn_8_1_cudatoolkit_10;
-
-    # -> cutensor_cudatoolkit_11 (cutensor is a new dependency in v1.11.0)
-    # cutensor = pkgs.cutensor_cudatoolkit_11;
-
-    # -> setting a custom magma should be unnecessary with v1.11.0
-    magma = pkgs.magma.override { cudatoolkit = pkgs.cudatoolkit_10; };
-
-    # -> nccl_cudatoolkit_11
-    nccl = pkgs.nccl.override { cudatoolkit = pkgs.cudatoolkit_10; };
   };
 
   pytorch-bin = callPackage ../development/python-modules/pytorch/bin.nix { };


### PR DESCRIPTION
When assessing the state of cuda-enabled packages, we also want to ensure that `blender` builds successfully.
Blender has been rejecting to build: https://github.com/NixOS/nixpkgs/issues/167068
...with a [failing dependency](https://hercules-ci.com/accounts/github/SomeoneSerge/derivations/%2Fnix%2Fstore%2F6q4a99a0ww0vzll8q6212xzrsbipp76z-opensubdiv-3.4.4.drv/log?via-job=930fc1c2-1577-48e1-b532-c9252621fe60): `opensubdiv`.

The problems were:
- [x] `opensubdiv` failing to find CLEW in configurePhase
- [x] `opensubdiv` building cuda extensions with `arch=compute_30`, that has been removed in cuda 11 (which we want to make the [default](https://github.com/NixOS/nixpkgs/pull/167250#issuecomment-1088139725))


###### Description of changes

- Added CLEW package
  - I haven't tested OpenCL support and I'm not particularly familiar with it
  - I noticed that `blender` patches CLEW to look for absolute paths when searching for OpenCL:
    
    https://github.com/NixOS/nixpkgs/blob/4561be306455a4ed12c5c66408816298d14eb8f9/pkgs/applications/misc/blender/default.nix#L90

  Should I do the same for `clew`-the-package? What should I do for the other platforms?
  CC @abbradar (I understand you authored the linked code?) @veprbl @cillianderoiste
- `opensubdiv`: Replaced `compute_30` with `compute_80`
  - it would be still built with multiple gencodes, would it? CC @NixOS/cuda-maintainers
  - I'll test blender tomorrow

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux: https://hercules-ci.com/github/SomeoneSerge/nixpkgs-unfree/jobs/175
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

