### PR TITLE
gnome.hitori: 3.38.3 -> 3.38.4

### DIFF
--- a/pkgs/desktops/gnome/games/hitori/default.nix
+++ b/pkgs/desktops/gnome/games/hitori/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -15,26 +14,16 @@
 , gettext
 , itstool
 , desktop-file-utils
-, adwaita-icon-theme
 }:
 
 stdenv.mkDerivation rec {
   pname = "hitori";
-  version = "3.38.3";
+  version = "3.38.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/hitori/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "99cQPLBjP7ATcwExqYw646IWK5+5SZ/H8ZUS1YG/ZWk=";
+    sha256 = "iZPMkfuSN4jjieA+wqp4dtFcErrZIEz2Wy/6DtOSL30=";
   };
-
-  patches = [
-    # Fix build with meson 0.61
-    # data/meson.build:3:0: ERROR: Function does not take positional arguments.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/hitori/-/commit/d25728e122f1d7b985029a5ba96810c3e57c27f7.patch";
-      sha256 = "LwBpFFr+vLacLTpto7PwvO1p2lku6epyEv9YZvUvW+g=";
-    })
-  ];
 
   nativeBuildInputs = [
     meson
@@ -52,7 +41,6 @@ stdenv.mkDerivation rec {
     glib
     gtk3
     cairo
-    adwaita-icon-theme
   ];
 
   postPatch = ''


### PR DESCRIPTION


###### Description of changes

https://gitlab.gnome.org/GNOME/hitori/-/compare/3.38.3...3.38.4


- Initial support for playing the game with a keyboard
- Bugs fixed:
  - <a href="https://gitlab.gnome.org/GNOME/hitori/merge_requests/34">!34</a> Make game playable with keyboard (bare minimum)
  - <a href="https://gitlab.gnome.org/GNOME/hitori/merge_requests/35">!35</a> build: Drop positional arguments from i18n.merge_file() calls
  - <a href="https://gitlab.gnome.org/GNOME/hitori/merge_requests/36">!36</a> interface: Fix a minor leak
  - <a href="https://gitlab.gnome.org/GNOME/hitori/merge_requests/37">!37</a> snap: Add itstool to image
  - <a href="https://gitlab.gnome.org/GNOME/hitori/merge_requests/38">!38</a> Move appdata screenshot to git

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
