### PR TITLE
geekbench: init at 4.4.4

### DIFF
--- a/pkgs/tools/misc/geekbench/4.nix
+++ b/pkgs/tools/misc/geekbench/4.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, fetchurl, makeWrapper, ocl-icd, vulkan-loader, linuxPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "geekbench";
+  version = "4.4.4";
+
+  src = fetchurl {
+    url = "https://cdn.geekbench.com/Geekbench-${version}-Linux.tar.gz";
+    sha256 = "sha256-KVsBE0ueWewmoVY/vzxX2sKhRTzityPNR+wmTwZBWiI=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib
+    cp -r geekbench.plar geekbench4 geekbench_x86_64 $out/bin
+
+    # needed for compute benchmark
+    ln -s ${linuxPackages.nvidia_x11}/lib/libcuda.so $out/lib/
+    ln -s ${ocl-icd}/lib/libOpenCL.so $out/lib/
+    ln -s ${ocl-icd}/lib/libOpenCL.so.1 $out/lib/
+    ln -s ${vulkan-loader}/lib/libvulkan.so $out/lib/
+    ln -s ${vulkan-loader}/lib/libvulkan.so.1 $out/lib/
+
+    for f in geekbench4 geekbench_x86_64 ; do
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) $out/bin/$f
+      wrapProgram $out/bin/$f --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}:$out/lib/"
+    done
+  '';
+
+  meta = with lib; {
+    description = "Cross-platform benchmark";
+    homepage = "https://geekbench.com/";
+    license = licenses.unfree;
+    maintainers = [ maintainers.michalrus ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3248,7 +3248,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  geekbench = callPackage ../tools/misc/geekbench { };
+  geekbench4 = callPackage ../tools/misc/geekbench/4.nix { };
+  geekbench5 = callPackage ../tools/misc/geekbench { };
+  geekbench = geekbench5;
 
   gencfsm = callPackage ../tools/security/gencfsm { };
 


### PR DESCRIPTION
###### Description of changes

Adds older version again since it's still supported and useful for comparison with older benchmark results.

###### Things done

Tested CPU and OpenCL (on Nvidia GPU) benchmark.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

