### PR TITLE
asterisk: update all packages

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2205.section.xml
@@ -1456,6 +1456,15 @@
       </listitem>
       <listitem>
         <para>
+          The <literal>asterisk</literal> and
+          <literal>asterisk-stable</literal> packages were switched from
+          <literal>asterisk_18</literal> to the newly-packaged
+          <literal>asterisk_19</literal>. Asterisk 13 and 17 have been
+          removed as they have reached their end of life.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           The <literal>services.unifi.openPorts</literal> option default
           value of <literal>true</literal> is now deprecated and will be
           changed to <literal>false</literal> in 22.11. Configurations

--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -513,6 +513,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `programs.zsh.autosuggestions.strategy` now takes a list of strings instead of a string.
 
+- The `asterisk` and `asterisk-stable` packages were switched from `asterisk_18` to the newly-packaged `asterisk_19`. Asterisk 13 and 17 have been removed as they have reached their end of life.
+
 - The `services.unifi.openPorts` option default value of `true` is now deprecated and will be changed to `false` in 22.11.
   Configurations using this default will print a warning when rebuilt.
 

--- a/pkgs/servers/asterisk/default.nix
+++ b/pkgs/servers/asterisk/default.nix
@@ -100,17 +100,16 @@ let
   }) (lib.importJSON ./versions.json);
 
 in {
-  # Supported releases (as of 2020-10-26).
+  # Supported releases (as of 2022-04-05).
   # Source: https://wiki.asterisk.org/wiki/display/AST/Asterisk+Versions
   # Exact version can be found at https://www.asterisk.org/downloads/asterisk/all-asterisk-versions/
   #
   # Series  Type       Rel. Date   Sec. Fixes  EOL
-  # 13.x    LTS        2014-10-24  2020-10-24  2021-10-24
   # 16.x    LTS        2018-10-09  2022-10-09  2023-10-09
-  # 17.x    Standard   2019-10-28  2020-10-28  2021-10-28
   # 18.x    LTS        2020-10-20  2024-10-20  2025-10-20
+  # 19.x    Standard   2021-11-02  2022-11-02  2023-11-02
   asterisk-lts = versions.asterisk_18;
-  asterisk-stable = versions.asterisk_18;
-  asterisk = versions.asterisk_18;
+  asterisk-stable = versions.asterisk_19;
+  asterisk = versions.asterisk_19;
 
 } // versions

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,18 +1,14 @@
 {
-  "asterisk_13": {
-    "sha256": "478040705f5819259bb1d22cb4e27970092a5bfdb691d27d321c26235eea4bb3",
-    "version": "13.38.3"
-  },
   "asterisk_16": {
-    "sha256": "c34fc38287cea533c0d0a34959112119e47d12d8ea6ac11bdddf9265afda6d11",
-    "version": "16.19.1"
-  },
-  "asterisk_17": {
-    "sha256": "cc0d6b9ef1512d4e279b80ca8bf78032d69fe6e92492c95c22c44023d6c111fa",
-    "version": "17.9.4"
+    "sha256": "379c5529b9957c28734192999543486a0b0b24f6671b2e02e77cc809774e7ba9",
+    "version": "16.25.1"
   },
   "asterisk_18": {
-    "sha256": "e7d78716a0deeadf24b7d537cd24c11c2d9a096265eefc9470565c4da0fc54c7",
-    "version": "18.5.1"
+    "sha256": "9db0e94e005a91a5433fc11173247065a5c40c9a7ca946577908f65d130b888e",
+    "version": "18.11.1"
+  },
+  "asterisk_19": {
+    "sha256": "3e1fa31ef1de7813365dd8b98ef93744ff87902255472814d0232b955c794706",
+    "version": "19.3.1"
   }
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -81,7 +81,9 @@ mapAliases ({
   arora = throw "arora has been removed"; # Added 2020-09-09
   asciidocFull = throw "'asciidocFull' has been renamed to/replaced by 'asciidoc-full'"; # Converted to throw 2022-02-22
   asn1c = throw "asn1c has been removed: deleted by upstream"; # Added 2022-01-07
+  asterisk_13 = throw "asterisk_13: Asterisk 13 is end of life and has been removed"; # Added 2022-04-06
   asterisk_15 = throw "asterisk_15: Asterisk 15 is end of life and has been removed"; # Added 2020-10-07
+  asterisk_17 = throw "asterisk_17: Asterisk 17 is end of life and has been removed"; # Added 2022-04-06
   at_spi2_atk = throw "'at_spi2_atk' has been renamed to/replaced by 'at-spi2-atk'"; # Converted to throw 2022-02-22
   at_spi2_core = throw "'at_spi2_core' has been renamed to/replaced by 'at-spi2-core'"; # Converted to throw 2022-02-22
   aucdtect = throw "aucdtect: Upstream no longer provides download urls"; # Added 2020-12-26

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21211,7 +21211,7 @@ with pkgs;
 
   inherit (callPackages ../servers/asterisk { })
     asterisk asterisk-stable asterisk-lts
-    asterisk_13 asterisk_16 asterisk_17 asterisk_18;
+    asterisk_16 asterisk_18 asterisk_19;
 
   asterisk-module-sccp = callPackage ../servers/asterisk/sccp { };
 


### PR DESCRIPTION
###### Description of changes
This updates all Asterisk packages, drops the EOL versions 13 and 17 and adds the new 19. In all supported version this applies critical security fixes to pjsip (for CVE-2021-37706, CVE-2022-23608 and CVE-2022-21723).

###### Things done
I ran the update script and updated the version table and changed the package list in all-packages.nix.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
