### PR TITLE
mathematica: Support specifying a version via override

### DIFF
--- a/pkgs/applications/science/math/mathematica/11.nix
+++ b/pkgs/applications/science/math/mathematica/11.nix
@@ -19,6 +19,8 @@
 , libxml2
 , libuuid
 , lang ? "en"
+, majorVersion ? "11"
+, minorVersion ? null
 , libGL
 , libGLU
 }:
@@ -26,9 +28,7 @@
 let
   l10n =
     import ./l10ns.nix {
-      lib = lib;
-      inherit requireFile lang;
-      majorVersion = "11";
+      inherit lib majorVersion minorVersion requireFile lang;
     };
 in
 stdenv.mkDerivation rec {

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -105,6 +105,8 @@ in stdenv.mkDerivation {
     "--set USE_WOLFRAM_LD_LIBRARY_PATH 1"
     # Fix xkeyboard config path for Qt
     "--set QT_XKB_CONFIG_ROOT ${xkeyboard_config}/share/X11/xkb"
+    # Always use xcb as the QT backend, wayland doesn't work
+    "--set QT_QPA_PLATFORM xcb"
   ];
 
   unpackPhase = ''

--- a/pkgs/applications/science/math/mathematica/default.nix
+++ b/pkgs/applications/science/math/mathematica/default.nix
@@ -35,11 +35,13 @@
 , xorg
 , zlib
 , lang ? "en"
+, majorVersion ? "13"
+, minorVersion ? null
 }:
 
 let
   l10n = import ./l10ns.nix {
-    inherit lib requireFile lang;
+    inherit lib requireFile lang majorVersion minorVersion;
   };
 in stdenv.mkDerivation {
   inherit (l10n) version name src;


### PR DESCRIPTION
###### Description of changes

I had a download link to mathematica 13.0.0 and not 13.0.1, which made it problematic for me to run the installer. This PR makes it possible for users to specify an exact version, with the (now more exposed) `majorVersion` and the new `minorVersion` arguments to `mathematica.override`. Example:

```nix
  mathematica_my = mathematica.override {
    minorVersion = "0.0";
  };
```

This PR also changes a bit the nix code in `mathematica/l10ns.nix` file because now the `majorVersion` is not inferred if we want the latest, since even the latest major version has to be explicitly used when `import ./l10ns.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
