### PR TITLE
ocaml 4.00 – 4.09: make compatible with glibc-2.34

### DIFF
--- a/pkgs/development/compilers/ocaml/4.00.1.nix
+++ b/pkgs/development/compilers/ocaml/4.00.1.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ncurses, xlibsWrapper }:
+{ lib, stdenv, fetchurl, fetchpatch, ncurses, xlibsWrapper }:
 
 let
    useX11 = !stdenv.isAarch32 && !stdenv.isMips;
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
     url = "https://caml.inria.fr/pub/distrib/ocaml-4.00/${pname}-${version}.tar.bz2";
     sha256 = "33c3f4acff51685f5bfd7c260f066645e767d4e865877bf1613c176a77799951";
   };
+
+  # Compatibility with Glibc 2.34
+  patches = [ (fetchpatch {
+    url = "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch";
+    sha256 = "sha256:07g9q9sjk4xsbqix7jxggfp36v15pmqw4bms80g5car0hfbszirn";
+  })];
 
   prefixKey = "-prefix ";
   configureFlags = [ "-no-tk" ] ++ optionals useX11 [ "-x11lib" xlibsWrapper ];

--- a/pkgs/development/compilers/ocaml/4.01.0.nix
+++ b/pkgs/development/compilers/ocaml/4.01.0.nix
@@ -2,6 +2,12 @@ import ./generic.nix {
   major_version = "4";
   minor_version = "01";
   patch_version = "0";
-  patches = [ ./fix-clang-build-on-osx.diff ];
+  patches = [
+    ./fix-clang-build-on-osx.diff
+
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch";
+      sha256 = "sha256:08mpy7lsiwv8m5qrqc4xzyiv2hri5713gz2qs1nfz02hz1bd79mc"; }
+  ];
   sha256 = "03d7ida94s1gpr3gadf4jyhmh5rrszd5s4m4z59daaib25rvfyv7";
 }

--- a/pkgs/development/compilers/ocaml/4.02.nix
+++ b/pkgs/development/compilers/ocaml/4.02.nix
@@ -2,6 +2,12 @@ import ./generic.nix {
   major_version = "4";
   minor_version = "02";
   patch_version = "3";
-  patches = [ ./ocamlbuild.patch ];
+  patches = [
+    ./ocamlbuild.patch
+
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch";
+      sha256 = "sha256:12sw512kpwk0xf2g6j0h5vqgd8xcmgrvgyilx6fxbd6bnfv1yib9"; }
+  ];
   sha256 = "1qwwvy8nzd87hk8rd9sm667nppakiapnx4ypdwcrlnav2dz6kil3";
 }

--- a/pkgs/development/compilers/ocaml/4.03.nix
+++ b/pkgs/development/compilers/ocaml/4.03.nix
@@ -3,4 +3,10 @@ import ./generic.nix {
   minor_version = "03";
   patch_version = "0";
   sha256 = "09p3iwwi55r6rbrpyp8f0wmkb0ppcgw67yxw6yfky60524wayp39";
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch";
+      sha256 = "sha256:1rrknmrk86xrj2k3hznnjk1gwnliyqh125zabg1hvy6dlvml9b0x"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.04.nix
+++ b/pkgs/development/compilers/ocaml/4.04.nix
@@ -6,4 +6,10 @@ import ./generic.nix {
 
   # If the executable is stipped it does not work
   dontStrip = true;
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch";
+      sha256 = "sha256:1hd45f7mwwrrym2y4dbcwklpv0g94avbz7qrn81l7w8mrrj3bngi"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.05.nix
+++ b/pkgs/development/compilers/ocaml/4.05.nix
@@ -6,4 +6,10 @@ import ./generic.nix {
 
   # If the executable is stipped it does not work
   dontStrip = true;
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch";
+      sha256 = "sha256:0ck9b2dpgg5k2p9ndbgniql24h35pn1bbpxjvk69j715lswzy4mh"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.06.nix
+++ b/pkgs/development/compilers/ocaml/4.06.nix
@@ -6,4 +6,10 @@ import ./generic.nix {
 
   # If the executable is stipped it does not work
   dontStrip = true;
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch";
+      sha256 = "sha256:0izsf6rm3677vbbx0snkmn9pkfcsayrdwz3ipiml5wjiaysnchjz"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.07.nix
+++ b/pkgs/development/compilers/ocaml/4.07.nix
@@ -6,4 +6,10 @@ import ./generic.nix {
 
   # If the executable is stripped it does not work
   dontStrip = true;
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch";
+      sha256 = "sha256:02cfya5ff5szx0fsl5x8ax76jyrla9zmf3qxavf3adhwq5ssrfcv"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.08.nix
+++ b/pkgs/development/compilers/ocaml/4.08.nix
@@ -9,4 +9,10 @@ import ./generic.nix {
 
   # Breaks build with Clang
   hardeningDisable = [ "strictoverflow" ];
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch";
+      sha256 = "sha256:1b3jc6sj2k23yvfwrv6nc1f4x2n2biqbhbbp74aqb6iyqyjsq35n"; }
+  ];
 }

--- a/pkgs/development/compilers/ocaml/4.09.nix
+++ b/pkgs/development/compilers/ocaml/4.09.nix
@@ -6,4 +6,10 @@ import ./generic.nix {
 
   # Breaks build with Clang
   hardeningDisable = [ "strictoverflow" ];
+
+  patches = [
+    # Compatibility with Glibc 2.34
+    { url = "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch";
+      sha256 = "sha256:1b3jc6sj2k23yvfwrv6nc1f4x2n2biqbhbbp74aqb6iyqyjsq35n"; }
+  ];
 }


### PR DESCRIPTION
###### Description of changes

Recent glibc update broke (in nixpkgs) all versions of OCaml below 4.09. This PR applies upstream patches.

Thanks Vladimír for the report and Théo for showing a path towards a fix.

cc @vcunat @Zimmi48

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
