### PR TITLE
nethogs: 0.8.6 -> 0.8.7

### DIFF
--- a/pkgs/tools/networking/nethogs/default.nix
+++ b/pkgs/tools/networking/nethogs/default.nix
@@ -1,25 +1,15 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, libpcap }:
+{ lib, stdenv, fetchFromGitHub, ncurses, libpcap }:
 
 stdenv.mkDerivation rec {
   pname = "nethogs";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchFromGitHub {
     owner = "raboof";
     repo = "nethogs";
     rev = "v${version}";
-    sha256 = "0sn1sdp86akwlm4r1vmkxjjl50c0xaisk91bbz57z7kcsaphxna9";
+    sha256 = "10shdwvfj90lp2fxz9260342a1c2n1jbw058qy5pyq5kh3xwr9b8";
   };
-
-  patches = [
-    # Pull upstream patch for ncurses-6.3 support:
-    #  https://github.com/raboof/nethogs/pull/210
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/raboof/nethogs/commit/455daf357da7f394763e5b93b11b3defe1f82ed1.patch";
-      sha256 = "0wkp0yr6qg1asgvmsn7blf7rq48sh5k4n3w0nxf5869hxvkhnnzs";
-    })
-  ];
 
   buildInputs = [ ncurses libpcap ];
 


### PR DESCRIPTION
###### Description of changes

Bump nethogs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)