### PR TITLE
istioctl: enable tests

### DIFF
--- a/pkgs/applications/networking/cluster/istioctl/default.nix
+++ b/pkgs/applications/networking/cluster/istioctl/default.nix
@@ -12,8 +12,6 @@ buildGoModule rec {
   };
   vendorSha256 = "sha256-AOcWkcw+2DcgBxvxRO/sdb339a7hmI7Oy5I4kW4oE+k=";
 
-  doCheck = false;
-
   nativeBuildInputs = [ installShellFiles ];
 
   # Bundle release metadata


### PR DESCRIPTION
istioctl: enable tests

```
running tests
=== RUN   TestIstioctlMain
1.13.2
--- PASS: TestIstioctlMain (0.00s)
PASS
ok      istio.io/istio/istioctl/cmd/istioctl    0.035s
```

There is a single test for version, but new tests might be added later on upstream. So it is better to keep tests here enabled.