### PR TITLE
errcheck: 1.6.0 -> unstable-2022-03-26

### DIFF
--- a/pkgs/development/tools/errcheck/default.nix
+++ b/pkgs/development/tools/errcheck/default.nix
@@ -2,22 +2,23 @@
 
 buildGoModule rec {
   pname = "errcheck";
-  version = "1.6.0";
+  version = "unstable-2022-03-26";
 
   src = fetchFromGitHub {
     owner = "kisielk";
     repo = "errcheck";
-    rev = "v${version}";
-    sha256 = "sha256-Przf2c2jFNdkUq7IOUD7ChXHiSayAz4xTsNzajycYZ0=";
+    rev = "e62617a91f7bd1abab2cbe7f28966188dd85eee0";
+    sha256 = "sha256-RoPv6Odh8l9DF1S50pNEomLtI4uTDNjveOXZd4S52c0=";
   };
 
-  vendorSha256 = "sha256-rluaBdW+w2zPThELlBwX/6LXDgc2aIk/ucbrsrABpVc=";
+  vendorSha256 = "sha256-fDugaI9Fh0L27yKSFNXyjYLMMDe6CRgE6kVLiJ3+Kyw=";
+
+  subPackages = [ "." ];
 
   meta = with lib; {
-    description = "Program for checking for unchecked errors in go programs";
+    description = "Checks for unchecked errors in go programs";
     homepage = "https://github.com/kisielk/errcheck";
     license = licenses.mit;
     maintainers = with maintainers; [ kalbasit ];
-    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3095,7 +3095,9 @@ with pkgs;
 
   envsubst = callPackage ../tools/misc/envsubst { };
 
-  errcheck = callPackage ../development/tools/errcheck { };
+  errcheck = callPackage ../development/tools/errcheck {
+    buildGoModule = buildGo118Module;
+  };
 
   eschalot = callPackage ../tools/security/eschalot { };
 


### PR DESCRIPTION
###### Description of changes

This updates errcheck to a newer version which has go1.18 support.

There's no tagged release yet for this, but without this change, this
package breaks under go1.18, so it seems worth updating before upstream
tags.

Related to #164320

The switch to 'subPackages' was added because 'testdata' contains a
'main_test.go' file which is not meant to be actually tested, and the
default checkPhase will try to run 'cd testdata && go test' unless you
do _something_ to override it. Since checkPhase doesn't respect
'excludedPackages', but does respect 'subPackages', this seemed like a
reasonable way to do that.

###### Changelog

There's no actual changelog, but here's the diff:

https://github.com/kisielk/errcheck/compare/v1.6.0...e62617a91f7bd1abab2cbe7f28966188dd85eee0

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).