### PR TITLE
nextdns: enable tests

### DIFF
--- a/pkgs/applications/networking/nextdns/default.nix
+++ b/pkgs/applications/networking/nextdns/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-6hWD05lXteqL7egj9tiRVHlevKM33i+a+zBUZs7PF7I=";
 
-  doCheck = false;
-
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   meta = with lib; {


### PR DESCRIPTION
nextdns: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   Test_isLocalhostMode
=== RUN   Test_isLocalhostMode/127.0.0.1:53
=== RUN   Test_isLocalhostMode/127.0.0.1:5353
=== RUN   Test_isLocalhostMode/10.0.0.1:53
=== RUN   Test_isLocalhostMode/127.0.0.1:53,10.0.0.1:53
=== RUN   Test_isLocalhostMode/10.0.0.1:53,127.0.0.1:53
--- PASS: Test_isLocalhostMode (0.00s)
    --- PASS: Test_isLocalhostMode/127.0.0.1:53 (0.00s)
    --- PASS: Test_isLocalhostMode/127.0.0.1:5353 (0.00s)
    --- PASS: Test_isLocalhostMode/10.0.0.1:53 (0.00s)
    --- PASS: Test_isLocalhostMode/127.0.0.1:53,10.0.0.1:53 (0.00s)
    --- PASS: Test_isLocalhostMode/10.0.0.1:53,127.0.0.1:53 (0.00s)
PASS
ok  	github.com/nextdns/nextdns	0.002s
=== RUN   TestConfigs_Get
=== RUN   TestConfigs_Get/PrefixMatch
=== RUN   TestConfigs_Get/MACMatch
--- PASS: TestConfigs_Get (0.00s)
    --- PASS: TestConfigs_Get/PrefixMatch (0.00s)
    --- PASS: TestConfigs_Get/MACMatch (0.00s)
=== RUN   TestByteParsing
=== RUN   TestByteParsing/42
=== RUN   TestByteParsing/42MB
=== RUN   TestByteParsing/42mb
=== RUN   TestByteParsing/42_MB
=== RUN   TestByteParsing/42_mb
=== RUN   TestByteParsing/42.5MB
=== RUN   TestByteParsing/42.5_MB
=== RUN   TestByteParsing/42M
=== RUN   TestByteParsing/42m
=== RUN   TestByteParsing/42_M
=== RUN   TestByteParsing/42_m
=== RUN   TestByteParsing/42.5M
=== RUN   TestByteParsing/42.5_M
=== RUN   TestByteParsing/1,234.03_MB
--- PASS: TestByteParsing (0.00s)
    --- PASS: TestByteParsing/42 (0.00s)
    --- PASS: TestByteParsing/42MB (0.00s)
    --- PASS: TestByteParsing/42mb (0.00s)
    --- PASS: TestByteParsing/42_MB (0.00s)
    --- PASS: TestByteParsing/42_mb (0.00s)
    --- PASS: TestByteParsing/42.5MB (0.00s)
    --- PASS: TestByteParsing/42.5_MB (0.00s)
    --- PASS: TestByteParsing/42M (0.00s)
    --- PASS: TestByteParsing/42m (0.00s)
    --- PASS: TestByteParsing/42_M (0.00s)
    --- PASS: TestByteParsing/42_m (0.00s)
    --- PASS: TestByteParsing/42.5M (0.00s)
    --- PASS: TestByteParsing/42.5_M (0.00s)
    --- PASS: TestByteParsing/1,234.03_MB (0.00s)
PASS
ok  	github.com/nextdns/nextdns/config	0.002s
?   	github.com/nextdns/nextdns/ctl/internal/winio	[no test files]
=== RUN   Test_readDHCPDLease
=== RUN   Test_readDHCPDLease/Valid_file
--- PASS: Test_readDHCPDLease (0.00s)
    --- PASS: Test_readDHCPDLease/Valid_file (0.00s)
=== RUN   Test_readDNSMasqLease
=== RUN   Test_readDNSMasqLease/Valid_file
--- PASS: Test_readDNSMasqLease (0.00s)
    --- PASS: Test_readDNSMasqLease/Valid_file (0.00s)
=== RUN   TestLookupStaticHost
=== RUN   TestLookupStaticHost/testdata/hosts
=== RUN   TestLookupStaticHost/testdata/singleline-hosts
=== RUN   TestLookupStaticHost/testdata/ipv4-hosts
=== RUN   TestLookupStaticHost/testdata/ipv6-hosts
=== RUN   TestLookupStaticHost/testdata/case-hosts
--- PASS: TestLookupStaticHost (0.00s)
    --- PASS: TestLookupStaticHost/testdata/hosts (0.00s)
    --- PASS: TestLookupStaticHost/testdata/singleline-hosts (0.00s)
    --- PASS: TestLookupStaticHost/testdata/ipv4-hosts (0.00s)
    --- PASS: TestLookupStaticHost/testdata/ipv6-hosts (0.00s)
    --- PASS: TestLookupStaticHost/testdata/case-hosts (0.00s)
=== RUN   TestLookupStaticAddr
=== RUN   TestLookupStaticAddr/testdata/hosts
=== RUN   TestLookupStaticAddr/testdata/singleline-hosts
=== RUN   TestLookupStaticAddr/testdata/ipv4-hosts
=== RUN   TestLookupStaticAddr/testdata/ipv6-hosts
=== RUN   TestLookupStaticAddr/testdata/case-hosts
--- PASS: TestLookupStaticAddr (0.00s)
    --- PASS: TestLookupStaticAddr/testdata/hosts (0.00s)
    --- PASS: TestLookupStaticAddr/testdata/singleline-hosts (0.00s)
    --- PASS: TestLookupStaticAddr/testdata/ipv4-hosts (0.00s)
    --- PASS: TestLookupStaticAddr/testdata/ipv6-hosts (0.00s)
    --- PASS: TestLookupStaticAddr/testdata/case-hosts (0.00s)
=== RUN   Test_readClientList
=== RUN   Test_readClientList/Empty
=== RUN   Test_readClientList/Empty_Line
=== RUN   Test_readClientList/One_host
=== RUN   Test_readClientList/With_Spaces
=== RUN   Test_readClientList/Two_hosts
=== RUN   Test_readClientList/Skip_Empty_Host
=== RUN   Test_readClientList/Invalid_format
=== RUN   Test_readClientList/Empty_items
--- PASS: Test_readClientList (0.00s)
    --- PASS: Test_readClientList/Empty (0.00s)
    --- PASS: Test_readClientList/Empty_Line (0.00s)
    --- PASS: Test_readClientList/One_host (0.00s)
    --- PASS: Test_readClientList/With_Spaces (0.00s)
    --- PASS: Test_readClientList/Two_hosts (0.00s)
    --- PASS: Test_readClientList/Skip_Empty_Host (0.00s)
    --- PASS: Test_readClientList/Invalid_format (0.00s)
    --- PASS: Test_readClientList/Empty_items (0.00s)
=== RUN   Test_isValidName
=== RUN   Test_isValidName/iPhone
=== RUN   Test_isValidName/Android_1
=== RUN   Test_isValidName/331e87e5-3018-5336-23f3-595cdea48d9b
=== RUN   Test_isValidName/CC_22_3D_E4_CE_FE
=== RUN   Test_isValidName/10-0-0-213
--- PASS: Test_isValidName (0.00s)
    --- PASS: Test_isValidName/iPhone (0.00s)
    --- PASS: Test_isValidName/Android_1 (0.00s)
    --- PASS: Test_isValidName/331e87e5-3018-5336-23f3-595cdea48d9b (0.00s)
    --- PASS: Test_isValidName/CC_22_3D_E4_CE_FE (0.00s)
    --- PASS: Test_isValidName/10-0-0-213 (0.00s)
PASS
ok  	github.com/nextdns/nextdns/discovery	0.002s
=== RUN   Test_diff
=== RUN   Test_diff/empty
=== RUN   Test_diff/new_interface
=== RUN   Test_diff/new_interface_inserted
=== RUN   Test_diff/interface_removed
=== RUN   Test_diff/interface_removed_head
=== RUN   Test_diff/interface_up
=== RUN   Test_diff/interface_down
--- PASS: Test_diff (0.00s)
    --- PASS: Test_diff/empty (0.00s)
    --- PASS: Test_diff/new_interface (0.00s)
    --- PASS: Test_diff/new_interface_inserted (0.00s)
    --- PASS: Test_diff/interface_removed (0.00s)
    --- PASS: Test_diff/interface_removed_head (0.00s)
    --- PASS: Test_diff/interface_up (0.00s)
    --- PASS: Test_diff/interface_down (0.00s)
=== RUN   Test_diffAddrs
=== RUN   Test_diffAddrs/addr_added
=== RUN   Test_diffAddrs/addr_removed
--- PASS: Test_diffAddrs (0.00s)
    --- PASS: Test_diffAddrs/addr_added (0.00s)
    --- PASS: Test_diffAddrs/addr_removed (0.00s)
PASS
ok  	github.com/nextdns/nextdns/netstatus	0.001s
=== RUN   Test_ptrIP
=== RUN   Test_ptrIP/b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.
=== RUN   Test_ptrIP/.8.b.d.0.1.0.0.2.ip6.arpa.
=== RUN   Test_ptrIP/8.16.155.10.in-addr.arpa.
=== RUN   Test_ptrIP/16.155.10.in-addr.arpa.
=== RUN   Test_ptrIP/.ip6.arpa.
=== RUN   Test_ptrIP/.in-addr.arpa.
=== RUN   Test_ptrIP/....ip6.arpa.
=== RUN   Test_ptrIP/....in-addr.arpa.
=== RUN   Test_ptrIP/.arpa.
--- PASS: Test_ptrIP (0.00s)
    --- PASS: Test_ptrIP/b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa. (0.00s)
    --- PASS: Test_ptrIP/.8.b.d.0.1.0.0.2.ip6.arpa. (0.00s)
    --- PASS: Test_ptrIP/8.16.155.10.in-addr.arpa. (0.00s)
    --- PASS: Test_ptrIP/16.155.10.in-addr.arpa. (0.00s)
    --- PASS: Test_ptrIP/.ip6.arpa. (0.00s)
    --- PASS: Test_ptrIP/.in-addr.arpa. (0.00s)
    --- PASS: Test_ptrIP/....ip6.arpa. (0.00s)
    --- PASS: Test_ptrIP/....in-addr.arpa. (0.00s)
    --- PASS: Test_ptrIP/.arpa. (0.00s)
=== RUN   Test_isPrivateReverse
=== RUN   Test_isPrivateReverse/IPv4/AlmostLoopback
=== RUN   Test_isPrivateReverse/IPv4/Private/192
=== RUN   Test_isPrivateReverse/IPv4/Private/Almost172
=== RUN   Test_isPrivateReverse/domain
=== RUN   Test_isPrivateReverse/IPv6/Private
=== RUN   Test_isPrivateReverse/IPv6/AlmostLoopback
=== RUN   Test_isPrivateReverse/IPv4/Public
=== RUN   Test_isPrivateReverse/IPv4/Loopback
=== RUN   Test_isPrivateReverse/IPv6/Public
=== RUN   Test_isPrivateReverse/IPv6/Loopback
=== RUN   Test_isPrivateReverse/IPv4/Private/10
=== RUN   Test_isPrivateReverse/IPv4/Private/Almost192
=== RUN   Test_isPrivateReverse/IPv4/Private/172
--- PASS: Test_isPrivateReverse (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/AlmostLoopback (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Private/192 (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Private/Almost172 (0.00s)
    --- PASS: Test_isPrivateReverse/domain (0.00s)
    --- PASS: Test_isPrivateReverse/IPv6/Private (0.00s)
    --- PASS: Test_isPrivateReverse/IPv6/AlmostLoopback (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Public (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Loopback (0.00s)
    --- PASS: Test_isPrivateReverse/IPv6/Public (0.00s)
    --- PASS: Test_isPrivateReverse/IPv6/Loopback (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Private/10 (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Private/Almost192 (0.00s)
    --- PASS: Test_isPrivateReverse/IPv4/Private/172 (0.00s)
PASS
ok  	github.com/nextdns/nextdns/proxy	0.002s
=== RUN   Test_cacheValue_AdjustedResponse
=== RUN   Test_cacheValue_AdjustedResponse/Empty_Record
=== RUN   Test_cacheValue_AdjustedResponse/Happy_Path
--- PASS: Test_cacheValue_AdjustedResponse (0.00s)
    --- PASS: Test_cacheValue_AdjustedResponse/Empty_Record (0.00s)
    --- PASS: Test_cacheValue_AdjustedResponse/Happy_Path (0.00s)
PASS
ok  	github.com/nextdns/nextdns/resolver	0.001s
=== RUN   TestManager_SteadyState
    manager_test.go:111: endpoint changed to https://a
--- PASS: TestManager_SteadyState (0.00s)
=== RUN   TestManager_ProviderError
    manager_test.go:123: provider err &{0xc0000a1010}: cannot load endpoints
    manager_test.go:111: endpoint changed to https://a
--- PASS: TestManager_ProviderError (0.00s)
=== RUN   TestManager_FirstFail
    manager_test.go:117: endpoint err https://a: roundtrip: a failed
    manager_test.go:111: endpoint changed to https://b
--- PASS: TestManager_FirstFail (0.00s)
=== RUN   TestManager_FirstAllThenRecover
    manager_test.go:117: endpoint err https://a: roundtrip: a failed
    manager_test.go:117: endpoint err https://b: roundtrip: b failed
    manager_test.go:111: endpoint changed to https://a
--- PASS: TestManager_FirstAllThenRecover (0.00s)
=== RUN   TestManager_AutoRecover
=== RUN   TestManager_AutoRecover/#0
=== CONT  TestManager_AutoRecover
    manager_test.go:111: endpoint changed to https://a
=== RUN   TestManager_AutoRecover/#1
=== RUN   TestManager_AutoRecover/#2
=== RUN   TestManager_AutoRecover/#3
=== RUN   TestManager_AutoRecover/#4
=== CONT  TestManager_AutoRecover
    manager_test.go:117: endpoint err https://a: roundtrip: a failed
    manager_test.go:111: endpoint changed to https://b
=== RUN   TestManager_AutoRecover/#5
=== RUN   TestManager_AutoRecover/#6
--- PASS: TestManager_AutoRecover (0.00s)
    --- PASS: TestManager_AutoRecover/#0 (0.00s)
    --- PASS: TestManager_AutoRecover/#1 (0.00s)
    --- PASS: TestManager_AutoRecover/#2 (0.00s)
    --- PASS: TestManager_AutoRecover/#3 (0.00s)
    --- PASS: TestManager_AutoRecover/#4 (0.00s)
    --- PASS: TestManager_AutoRecover/#5 (0.00s)
    --- PASS: TestManager_AutoRecover/#6 (0.00s)
=== RUN   TestManager_OpportunisticTest
--- SKIP: TestManager_OpportunisticTest (0.00s)
PASS
ok  	github.com/nextdns/nextdns/resolver/endpoint	0.002s
```