### PR TITLE
asap: init at 5.2.0

### DIFF
--- a/pkgs/tools/audio/asap/default.nix
+++ b/pkgs/tools/audio/asap/default.nix
@@ -1,0 +1,53 @@
+{ stdenv
+, lib
+, fetchzip
+, SDL
+}:
+
+stdenv.mkDerivation rec {
+  pname = "asap";
+  version = "5.2.0";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/project/asap/asap/${version}/asap-${version}.tar.gz";
+    sha256 = "1riwfds5ipgh19i3ibsyqhxlh70xix9452y4wqih9xdkixmxqbqm";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  buildInputs = [
+    SDL
+  ];
+
+  enableParallelBuilding = true;
+
+  buildFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    # Only targets that don't need cito transpiler
+    "asapconv"
+    "asap-sdl"
+    "lib"
+  ];
+
+  installFlags = [
+    "prefix=${placeholder "dev"}"
+    "bindir=${placeholder "out"}/bin"
+    "install-asapconv"
+    "install-sdl"
+    "install-lib"
+  ];
+
+  meta = with lib; {
+    homepage = "http://asap.sourceforge.net/";
+    mainProgram = "asap-sdl";
+    description = "Another Slight Atari Player";
+    longDescription = ''
+      ASAP (Another Slight Atari Player) plays and converts 8-bit Atari POKEY
+      music (*.sap, *.cmc, *.mpt, *.rmt, *.tmc, ...) on modern computers and
+      mobile devices.
+    '';
+    maintainers = with maintainers; [ OPNA2608 ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24750,6 +24750,8 @@ with pkgs;
 
   inherit (atomPackages) atom atom-beta;
 
+  asap = callPackage ../tools/audio/asap { };
+
   aseprite = callPackage ../applications/editors/aseprite { };
   aseprite-unfree = aseprite.override { unfree = true; };
 


### PR DESCRIPTION
###### Description of changes

http://asap.sourceforge.net/

To test functionality:

1. Download SAP file from http://asma.atari.org/asmadb/search.php?details=4017
2. `asap-sdl /path/to/Candy_Mountain.sap`
3. Should produce audio like this: https://www.youtube.com/watch?v=1PYRhfeN0KQ

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
