### PR TITLE
rustfmt: stop pretending we're on nightly

### DIFF
--- a/pkgs/development/compilers/rust/rustfmt.nix
+++ b/pkgs/development/compilers/rust/rustfmt.nix
@@ -18,8 +18,8 @@ rustPlatform.buildRustPackage rec {
 
   # As of rustc 1.45.0, these env vars are required to build rustfmt (due to
   # https://github.com/rust-lang/rust/pull/72001)
-  CFG_RELEASE = "${rustPlatform.rust.rustc.version}-nightly";
-  CFG_RELEASE_CHANNEL = "nightly";
+  CFG_RELEASE = rustPlatform.rust.rustc.version;
+  CFG_RELEASE_CHANNEL = "stable";
 
   meta = with lib; {
     description = "A tool for formatting Rust code according to style guidelines";

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -3,6 +3,7 @@
 , lib
 , rustPlatform
 , rustfmt
+, protobuf
 }:
 let
   src = fetchFromGitHub {
@@ -30,7 +31,9 @@ in
 
     buildAndTestSubdir = "server";
 
-    nativeBuildInputs = [ rustfmt ];
+    PROTOC = "${protobuf}/bin/protoc";
+
+    nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 
     # test rely on libindradb and it can't be found
     # failure at https://github.com/indradb/indradb/blob/master/server/tests/plugins.rs#L63
@@ -44,7 +47,9 @@ in
 
     cargoSha256 = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
 
-    nativeBuildInputs = [ rustfmt ];
+    PROTOC = "${protobuf}/bin/protoc";
+
+    nativeBuildInputs = [ rustfmt rustPlatform.bindgenHook ];
 
     buildAndTestSubdir = "client";
   };


### PR DESCRIPTION
###### Description of changes

Fixes build after #161726.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
