### PR TITLE
bugdom: Enable on Darwin

### DIFF
--- a/pkgs/games/bugdom/default.nix
+++ b/pkgs/games/bugdom/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, SDL2, IOKit, Foundation, cmake, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "bugdom";
@@ -12,8 +12,18 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Expects SDL2.framework in specific location, which we don't have
+    # Passing this in cmakeFlags doesn't work because the path is hard-coded for Darwin
+    substituteInPlace cmake/FindSDL2.cmake \
+      --replace 'set(SDL2_LIBRARIES' 'set(SDL2_LIBRARIES "${SDL2}/lib/libSDL2.dylib") #'
+  '';
+
   buildInputs = [
     SDL2
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    IOKit
+    Foundation
   ];
 
   nativeBuildInputs = [
@@ -21,13 +31,25 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
+    # Expects SDL2.framework in specific location, which we don't have
+    "-DSDL2_INCLUDE_DIRS=${SDL2.dev}/include/SDL2"
+  ];
+
   installPhase = ''
     runHook preInstall
 
+  '' + (if stdenv.hostPlatform.isDarwin then ''
+    mkdir -p $out/{bin,Applications}
+    mv {,$out/Applications/}Bugdom.app
+    ln -s $out/{Applications/Bugdom.app/Contents/MacOS,bin}/Bugdom
+  '' else ''
     mkdir -p $out/share/bugdom
     mv Data $out/share/bugdom
     install -Dm755 {.,$out/bin}/Bugdom
     wrapProgram $out/bin/Bugdom --run "cd $out/share/bugdom"
+  '') + ''
 
     runHook postInstall
   '';
@@ -39,6 +61,6 @@ stdenv.mkDerivation rec {
       cc-by-sa-40
     ];
     maintainers = with maintainers; [ lux ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31003,7 +31003,9 @@ with pkgs;
 
   btanks = callPackage ../games/btanks { };
 
-  bugdom = callPackage ../games/bugdom { };
+  bugdom = callPackage ../games/bugdom {
+    inherit (darwin.apple_sdk.frameworks) IOKit Foundation;
+  };
 
   bzflag = callPackage ../games/bzflag {
     inherit (darwin.apple_sdk.frameworks) Carbon CoreServices;


### PR DESCRIPTION
###### Description of changes

Fixes required to build on Darwin. Moved to separate PR according to https://github.com/NixOS/nixpkgs/pull/152454#issuecomment-1088604295.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
