### PR TITLE
brave: 1.37.109 -> 1.37.111

### DIFF
--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -91,11 +91,11 @@ in
 
 stdenv.mkDerivation rec {
   pname = "brave";
-  version = "1.37.109";
+  version = "1.37.111";
 
   src = fetchurl {
     url = "https://github.com/brave/brave-browser/releases/download/v${version}/brave-browser_${version}_amd64.deb";
-    sha256 = "fL3vuCqUnzq38JD0bzM/DxLVb5P31iChbMVY2eax9RE=";
+    sha256 = "qkb3/SiyjPbsHAqLCtbe5lumgUG2fMMeBpQwk/BuBkI=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
###### Description of changes
https://github.com/brave/brave-browser/blob/master/CHANGELOG_DESKTOP.md#137111

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).