### PR TITLE
ocamlPackages.torch: Mark as broken with pytorch >= 1.11

### DIFF
--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -56,5 +56,6 @@ buildDunePackage rec {
     description = "Ocaml bindings to Pytorch";
     maintainers = [ maintainers.bcdarwin ];
     license = licenses.asl20;
+    broken = lib.versionAtLeast pytorch.version "1.11";
   };
 }


### PR DESCRIPTION
###### Description of changes

ocaml-torch is currently broken after the pytorch upgrade (#162538).  I don't have the expertise to fix ocaml-torch, but here's the build error for reference:


```
these derivations will be built:
  /nix/store/3hfssk467v4k60wcjj9ikp1sa54vs12i-ocaml4.13.1-torch-0.14.drv
building '/nix/store/3hfssk467v4k60wcjj9ikp1sa54vs12i-ocaml4.13.1-torch-0.14.drv'...
unpacking sources
unpacking source archive /nix/store/zn939m1n8vyslp42jz2qhyigx96d2pbn-source
source root is source
patching sources
configuring
no configure script, doing nothing
building
         gcc src/wrapper/torch_api.o (exit 1)
(cd _build/default/src/wrapper && /nix/store/j0lglxsmvrd3zyv9dlabffc0n0xnxbia-gcc-wrapper-10.3.0/bin/gcc -std=c++14 -fPIC -D_GLIBCXX_USE_CXX11_ABI=1 -isystem /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include -isystem /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/api/include -g -I /nix/store/l1n38x82vbl4xlq1rplsg4pgzz2g7czl-ocaml-4.13.1/lib/ocaml -I /nix/store/bp5lgi8n0555nwap13l0bp6nl743mxmx-ocaml4.13.1-integers-0.5.1/lib/ocaml/4.13.1/site-lib/integers -I /nix/store/br2p6gfgpl045ilm48vwjj00ichcv2n3-ocaml4.13.1-bigarray-compat-1.1.0/lib/ocaml/4.13.1/site-lib/bigarray-compat -I /nix/store/fkkjr0yk9q7x5dqwbd6kjhmw23pfxwfa-ocaml-findlib-1.9.1/lib/ocaml/4.13.1/site-lib/bytes -I /nix/store/l1n38x82vbl4xlq1rplsg4pgzz2g7czl-ocaml-4.13.1/lib/ocaml/threads -I /nix/store/vzmy6m6gvxrz3q5wks121pqxsf011lxw-ocaml4.13.1-ctypes-0.18.0/lib/ocaml/4.13.1/site-lib/ctypes -o torch_api.o -c torch_api.cpp)
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg__baddbmm_mkl_(at::Tensor**, tensor, tensor, tensor)':
torch_api_generated.cpp.h:238:29: error: '_baddbmm_mkl_' is not a member of 'torch'
  238 |     auto outputs__ = torch::_baddbmm_mkl_(*self, *batch1, *batch2);
      |                             ^~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__conv_depthwise2d_backward(at::Tensor**, tensor, tensor, tensor, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t*, int)':
torch_api_generated.cpp.h:378:29: error: '_conv_depthwise2d_backward_out' is not a member of 'torch'
  378 |     auto outputs__ = torch::_conv_depthwise2d_backward_out(*grad_input, *grad_weight, *grad_output, *self, *weight, torch::IntArrayRef(kernel_size_data, kernel_size_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(dilation_data, dilation_len));
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__convolution_nogroup(at::Tensor**, tensor, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int, int64_t*, int)':
torch_api_generated.cpp.h:428:29: error: '_convolution_nogroup' is not a member of 'torch'
  428 |     auto outputs__ = torch::_convolution_nogroup(*input, *weight, (bias ? *bias : torch::Tensor()), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(dilation_data, dilation_len), (bool)transposed, torch::IntArrayRef(output_padding_data, output_padding_len));
      |                             ^~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__inverse_helper(at::Tensor**, tensor)':
torch_api_generated.cpp.h:744:29: error: '_inverse_helper' is not a member of 'torch'
  744 |     auto outputs__ = torch::_inverse_helper(*self);
      |                             ^~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__log_softmax_backward_data(at::Tensor**, tensor, tensor, int64_t, tensor)':
torch_api_generated.cpp.h:773:84: error: cannot convert 'at::Tensor' to 'c10::ScalarType'
  773 |     auto outputs__ = torch::_log_softmax_backward_data(*grad_output, *output, dim, *self);
      |                                                                                    ^~~~~
      |                                                                                    |
      |                                                                                    at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:215,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/_log_softmax_backward_data.h:26:143: note:   initializing argument 4 of 'at::Tensor at::_log_softmax_backward_data(const at::Tensor&, const at::Tensor&, int64_t, c10::ScalarType)'
   26 | TORCH_API inline at::Tensor _log_softmax_backward_data(const at::Tensor & grad_output, const at::Tensor & output, int64_t dim, at::ScalarType input_dtype) {
      |                                                                                                                                ~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg__log_softmax_backward_data_out(at::Tensor**, tensor, tensor, tensor, int64_t, tensor)':
torch_api_generated.cpp.h:780:94: error: cannot convert 'at::Tensor' to 'c10::ScalarType'
  780 |     auto outputs__ = torch::_log_softmax_backward_data_out(*out, *grad_output, *output, dim, *self);
      |                                                                                              ^~~~~
      |                                                                                              |
      |                                                                                              at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:215,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/_log_softmax_backward_data.h:31:167: note:   initializing argument 5 of 'at::Tensor& at::_log_softmax_backward_data_out(at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, c10::ScalarType)'
   31 | TORCH_API inline at::Tensor & _log_softmax_backward_data_out(at::Tensor & out, const at::Tensor & grad_output, const at::Tensor & output, int64_t dim, at::ScalarType input_dtype) {
      |                                                                                                                                                        ~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg__nnpack_spatial_convolution_backward_input(at::Tensor**, tensor, tensor, tensor, int64_t*, int)':
torch_api_generated.cpp.h:880:29: error: '_nnpack_spatial_convolution_backward_input' is not a member of 'torch'
  880 |     auto outputs__ = torch::_nnpack_spatial_convolution_backward_input(*input, *grad_output, *weight, torch::IntArrayRef(padding_data, padding_len));
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__nnpack_spatial_convolution_backward_weight(at::Tensor**, tensor, int64_t*, int, tensor, int64_t*, int)':
torch_api_generated.cpp.h:887:29: error: '_nnpack_spatial_convolution_backward_weight' is not a member of 'torch'
  887 |     auto outputs__ = torch::_nnpack_spatial_convolution_backward_weight(*input, torch::IntArrayRef(weightsize_data, weightsize_len), *grad_output, torch::IntArrayRef(padding_data, padding_len));
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg__softmax_backward_data(at::Tensor**, tensor, tensor, int64_t, tensor)':
torch_api_generated.cpp.h:1031:80: error: cannot convert 'at::Tensor' to 'c10::ScalarType'
 1031 |     auto outputs__ = torch::_softmax_backward_data(*grad_output, *output, dim, *self);
      |                                                                                ^~~~~
      |                                                                                |
      |                                                                                at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:253,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/_softmax_backward_data.h:26:139: note:   initializing argument 4 of 'at::Tensor at::_softmax_backward_data(const at::Tensor&, const at::Tensor&, int64_t, c10::ScalarType)'
   26 | TORCH_API inline at::Tensor _softmax_backward_data(const at::Tensor & grad_output, const at::Tensor & output, int64_t dim, at::ScalarType input_dtype) {
      |                                                                                                                            ~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg__softmax_backward_data_out(at::Tensor**, tensor, tensor, tensor, int64_t, tensor)':
torch_api_generated.cpp.h:1038:97: error: cannot convert 'at::Tensor' to 'c10::ScalarType'
 1038 |     auto outputs__ = torch::_softmax_backward_data_out(*grad_input, *grad_output, *output, dim, *self);
      |                                                                                                 ^~~~~
      |                                                                                                 |
      |                                                                                                 at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:253,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/_softmax_backward_data.h:31:170: note:   initializing argument 5 of 'at::Tensor& at::_softmax_backward_data_out(at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, c10::ScalarType)'
   31 | TORCH_API inline at::Tensor & _softmax_backward_data_out(at::Tensor & grad_input, const at::Tensor & grad_output, const at::Tensor & output, int64_t dim, at::ScalarType input_dtype) {
      |                                                                                                                                                           ~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg__svd_helper(at::Tensor**, tensor, int, int)':
torch_api_generated.cpp.h:1221:29: error: '_svd_helper' is not a member of 'torch'
 1221 |     auto outputs__ = torch::_svd_helper(*self, (bool)some, (bool)compute_uv);
      |                             ^~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_conv_depthwise3d_backward(at::Tensor**, tensor, tensor, tensor, tensor, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t*, int)':
torch_api_generated.cpp.h:3428:29: error: 'conv_depthwise3d_backward_out' is not a member of 'torch'
 3428 |     auto outputs__ = torch::conv_depthwise3d_backward_out(*grad_input, *grad_weight, *grad_bias, *grad_output, *self, *weight, torch::IntArrayRef(kernel_size_data, kernel_size_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(dilation_data, dilation_len));
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_backward_input(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int, int)':
torch_api_generated.cpp.h:3696:29: error: 'cudnn_convolution_backward_input' is not a member of 'torch'
 3696 |     auto outputs__ = torch::cudnn_convolution_backward_input(torch::IntArrayRef(self_size_data, self_size_len), *grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic, (bool)allow_tf32);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_backward_weight(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int, int)':
torch_api_generated.cpp.h:3703:29: error: 'cudnn_convolution_backward_weight' is not a member of 'torch'
 3703 |     auto outputs__ = torch::cudnn_convolution_backward_weight(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic, (bool)allow_tf32);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_deprecated(at::Tensor**, tensor, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:3710:69: error: could not convert '((bias != 0) ? at::Tensor((*(const at::Tensor*)bias)) : at::Tensor())' from 'at::Tensor' to 'c10::IntArrayRef' {aka 'c10::ArrayRef<long int>'}
 3710 |     auto outputs__ = torch::cudnn_convolution(*self, *weight, (bias ? *bias : torch::Tensor()), torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                                                               ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                     |
      |                                                                     at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_deprecated2(at::Tensor**, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:3717:248: error: too few arguments to function 'at::Tensor at::cudnn_convolution(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, int64_t, bool, bool, bool)'
 3717 |     auto outputs__ = torch::cudnn_convolution(*self, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                                                                                                                                                                                                                                                        ^
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:469,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/cudnn_convolution.h:26:29: note: declared here
   26 | TORCH_API inline at::Tensor cudnn_convolution(const at::Tensor & self, const at::Tensor & weight, at::IntArrayRef padding, at::IntArrayRef stride, at::IntArrayRef dilation, int64_t groups, bool benchmark, bool deterministic, bool allow_tf32) {
      |                             ^~~~~~~~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_transpose_backward_input(at::Tensor**, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int, int)':
torch_api_generated.cpp.h:3738:29: error: 'cudnn_convolution_transpose_backward_input' is not a member of 'torch'
 3738 |     auto outputs__ = torch::cudnn_convolution_transpose_backward_input(*grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic, (bool)allow_tf32);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_transpose_backward_weight(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int, int)':
torch_api_generated.cpp.h:3745:29: error: 'cudnn_convolution_transpose_backward_weight' is not a member of 'torch'
 3745 |     auto outputs__ = torch::cudnn_convolution_transpose_backward_weight(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic, (bool)allow_tf32);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_transpose_deprecated(at::Tensor**, tensor, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:3752:79: error: could not convert '((bias != 0) ? at::Tensor((*(const at::Tensor*)bias)) : at::Tensor())' from 'at::Tensor' to 'c10::IntArrayRef' {aka 'c10::ArrayRef<long int>'}
 3752 |     auto outputs__ = torch::cudnn_convolution_transpose(*self, *weight, (bias ? *bias : torch::Tensor()), torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(output_padding_data, output_padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                                                                         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                               |
      |                                                                               at::Tensor
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_cudnn_convolution_transpose_deprecated2(at::Tensor**, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:3759:319: error: too few arguments to function 'at::Tensor at::cudnn_convolution_transpose(const at::Tensor&, const at::Tensor&, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, c10::IntArrayRef, int64_t, bool, bool, bool)'
 3759 |     auto outputs__ = torch::cudnn_convolution_transpose(*self, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(output_padding_data, output_padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                                                                                                                                                                                                                                                                                                                               ^
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:472,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/cudnn_convolution_transpose.h:26:29: note: declared here
   26 | TORCH_API inline at::Tensor cudnn_convolution_transpose(const at::Tensor & self, const at::Tensor & weight, at::IntArrayRef padding, at::IntArrayRef output_padding, at::IntArrayRef stride, at::IntArrayRef dilation, int64_t groups, bool benchmark, bool deterministic, bool allow_tf32) {
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg_grid_sampler_2d_backward(at::Tensor**, tensor, tensor, tensor, int64_t, int64_t, int)':
torch_api_generated.cpp.h:5673:136: error: too few arguments to function 'std::tuple<at::Tensor, at::Tensor> at::grid_sampler_2d_backward(const at::Tensor&, const at::Tensor&, const at::Tensor&, int64_t, int64_t, bool, std::array<bool, 2>)'
 5673 |     auto outputs__ = torch::grid_sampler_2d_backward(*grad_output, *input, *grid, interpolation_mode, padding_mode, (bool)align_corners);
      |                                                                                                                                        ^
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:609,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/grid_sampler_2d_backward.h:26:54: note: declared here
   26 | TORCH_API inline ::std::tuple<at::Tensor,at::Tensor> grid_sampler_2d_backward(const at::Tensor & grad_output, const at::Tensor & input, const at::Tensor & grid, int64_t interpolation_mode, int64_t padding_mode, bool align_corners, ::std::array<bool,2> output_mask) {
      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg_miopen_convolution_backward_bias(at::Tensor**, tensor)':
torch_api_generated.cpp.h:8155:29: error: 'miopen_convolution_backward_bias' is not a member of 'torch'
 8155 |     auto outputs__ = torch::miopen_convolution_backward_bias(*grad_output);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_convolution_backward_input(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8162:29: error: 'miopen_convolution_backward_input' is not a member of 'torch'
 8162 |     auto outputs__ = torch::miopen_convolution_backward_input(torch::IntArrayRef(self_size_data, self_size_len), *grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_convolution_backward_weight(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8169:29: error: 'miopen_convolution_backward_weight' is not a member of 'torch'
 8169 |     auto outputs__ = torch::miopen_convolution_backward_weight(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_convolution_transpose_backward_input(at::Tensor**, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8183:29: error: 'miopen_convolution_transpose_backward_input' is not a member of 'torch'
 8183 |     auto outputs__ = torch::miopen_convolution_transpose_backward_input(*grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_convolution_transpose_backward_weight(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8190:29: error: 'miopen_convolution_transpose_backward_weight' is not a member of 'torch'
 8190 |     auto outputs__ = torch::miopen_convolution_transpose_backward_weight(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_depthwise_convolution_backward_input(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8204:29: error: 'miopen_depthwise_convolution_backward_input' is not a member of 'torch'
 8204 |     auto outputs__ = torch::miopen_depthwise_convolution_backward_input(torch::IntArrayRef(self_size_data, self_size_len), *grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_miopen_depthwise_convolution_backward_weight(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int, int)':
torch_api_generated.cpp.h:8211:29: error: 'miopen_depthwise_convolution_backward_weight' is not a member of 'torch'
 8211 |     auto outputs__ = torch::miopen_depthwise_convolution_backward_weight(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)benchmark, (bool)deterministic);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_mkldnn_convolution_backward_input(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int)':
torch_api_generated.cpp.h:8278:29: error: 'mkldnn_convolution_backward_input' is not a member of 'torch'
 8278 |     auto outputs__ = torch::mkldnn_convolution_backward_input(torch::IntArrayRef(self_size_data, self_size_len), *grad_output, *weight, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)bias_defined);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_mkldnn_convolution_backward_weights(at::Tensor**, int64_t*, int, tensor, tensor, int64_t*, int, int64_t*, int, int64_t*, int, int64_t, int)':
torch_api_generated.cpp.h:8285:29: error: 'mkldnn_convolution_backward_weights' is not a member of 'torch'
 8285 |     auto outputs__ = torch::mkldnn_convolution_backward_weights(torch::IntArrayRef(weight_size_data, weight_size_len), *grad_output, *self, torch::IntArrayRef(padding_data, padding_len), torch::IntArrayRef(stride_data, stride_len), torch::IntArrayRef(dilation_data, dilation_len), groups, (bool)bias_defined);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
torch_api_generated.cpp.h: In function 'void atg_softplus_backward(at::Tensor**, tensor, tensor, scalar, scalar, tensor)':
torch_api_generated.cpp.h:10929:94: error: too many arguments to function 'at::Tensor at::softplus_backward(const at::Tensor&, const at::Tensor&, const c10::Scalar&, const c10::Scalar&)'
10929 |     auto outputs__ = torch::softplus_backward(*grad_output, *self, *beta, *threshold, *output);
      |                                                                                              ^
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:1015,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/softplus_backward.h:36:29: note: declared here
   36 | TORCH_API inline at::Tensor softplus_backward(const at::Tensor & grad_output, const at::Tensor & self, const at::Scalar & beta, const at::Scalar & threshold) {
      |                             ^~~~~~~~~~~~~~~~~
In file included from torch_api.cpp:7:
torch_api_generated.cpp.h: In function 'void atg_softplus_backward_grad_input(at::Tensor**, tensor, tensor, tensor, scalar, scalar, tensor)':
torch_api_generated.cpp.h:10936:111: error: too many arguments to function 'at::Tensor& at::softplus_backward_out(at::Tensor&, const at::Tensor&, const at::Tensor&, const c10::Scalar&, const c10::Scalar&)'
10936 |     auto outputs__ = torch::softplus_backward_out(*grad_input, *grad_output, *self, *beta, *threshold, *output);
      |                                                                                                               ^
torch_api.h:14:5: note: in definition of macro 'PROTECT'
   14 |     x \
      |     ^
In file included from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/Functions.h:1015,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/input_metadata.h:10,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/function.h:7,
                 from /nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/torch/csrc/autograd/engine.h:11,
                 from torch_api.cpp:1:
/nix/store/jx2b9p7pjyby47ky7m8915agaswrw1bk-python3.9-pytorch-1.11.0-dev/include/ATen/ops/softplus_backward.h:26:31: note: declared here
   26 | TORCH_API inline at::Tensor & softplus_backward_out(at::Tensor & grad_input, const at::Tensor & grad_output, const at::Tensor & self, const at::Scalar & beta, const at::Scalar & threshold) {
      |                               ^~~~~~~~~~~~~~~~~~~~~

builder for '/nix/store/3hfssk467v4k60wcjj9ikp1sa54vs12i-ocaml4.13.1-torch-0.14.drv' failed with exit code 1
error: build of '/nix/store/3hfssk467v4k60wcjj9ikp1sa54vs12i-ocaml4.13.1-torch-0.14.drv' failed

```