### PR TITLE
treewide: update raspberrypi packages

### DIFF
--- a/pkgs/development/libraries/libraspberrypi/default.nix
+++ b/pkgs/development/libraries/libraspberrypi/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libraspberrypi";
-  version = "unstable-2021-10-25";
+  version = "unstable-2022-03-23";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "userland";
-    rev = "0093675e4aa6e152a3ffc318b51a124e96eb287b";
-    sha256 = "qpooQy9k2UZ94KaqlFwurV+tt0GrBSRffGdlvMcn1XU=";
+    rev = "c4fd1b8986c6d6d4ae5cd51e65a8bbeb495dfa4e";
+    hash = "sha256-sAfpfq7C9HXVS7ym3UFIO6bpEIWFCOfVCSN2n5q1RNg=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "2021-11-02";
+  version = "2021-12-06";
 
   srcs = [
     (fetchFromGitHub {
@@ -10,14 +10,14 @@ stdenv.mkDerivation {
       owner = "RPi-Distro";
       repo = "bluez-firmware";
       rev = "e7fd166981ab4bb9a36c2d1500205a078a35714d";
-      sha256 = "1dkg8mzn7n4afi50ibrda2s33nw2qj52jjjdv9w560q601gms47b";
+      hash = "sha256-6xBdXwAGA1N42k1KKYrEgtsxtFAtrwhKdIrYY39Fb7Y=";
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "54ffdd6e2ea6055d46656b78e148fe7def3ec9d8";
-      sha256 = "4WTrs/tUyOugufRrrh0qsEmhPclQD64ypYysxsnOyS8=";
+      rev = "99d5c588e95ec9c9b86d7e88d3cf85b4f729d2bc";
+      hash = "sha256-xg6fYQvg7t2ikyLI8/XfpiNaNTf7CNFQlAzpTldTz10=";
     })
   ];
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
 
   outputHashMode = "recursive";
   outputHashAlgo = "sha256";
-  outputHash = "l+7VOq7CV5QA8/FWjMBGDcxq8Qe7NFf6E2Y42htZEgE=";
+  outputHash = "sha256-Fw8EC1jzszWg9rNH01oaOIHnSYDuF6ov6ulmIAPuNz4=";
 
   meta = with lib; {
     description = "Firmware for builtin Wifi/Bluetooth devices in the Raspberry Pi 3+ and Zero W";

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -26,5 +26,6 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://github.com/raspberrypi/firmware";
     license = licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
     maintainers = with maintainers; [ dezgeg ];
+    broken = stdenvNoCC.isDarwin; # Hash mismatch on source, mystery.
   };
 }

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -1,16 +1,16 @@
-{ lib, stdenvNoCC, fetchurl, unzip }:
+{ lib, stdenvNoCC, fetchFromGitHub }:
 
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  version = "1.20220118";
+  version = "1.20220331";
 
-  src = fetchurl {
-    url = "https://github.com/raspberrypi/firmware/archive/${version}.zip";
-    sha256 = "sha256-98rbwKIuB7vb4MWbFCr7TYsvJB0HzPdH8Tw0+bktK/M=";
+  src = fetchFromGitHub {
+    owner = "raspberrypi";
+    repo = "firmware";
+    rev = version;
+    hash = "sha256-TxlpHPEJAtVJTtDghuJpx2mLjEPiKkcAr7S9Cd/cocE=";
   };
-
-  nativeBuildInputs = [ unzip ];
 
   installPhase = ''
     mkdir -p $out/share/raspberrypi/

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -2,9 +2,8 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "5.10.92";
-  tag = "1.20220118";
-  rev = "650082a559a570d6c9d2739ecc62843d6f951059";
+  modDirVersion = "5.15.32";
+  tag = "1.20220331";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -13,8 +12,8 @@ lib.overrideDerivation (buildLinux (args // {
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "linux";
-    inherit rev;
-    sha256 = "sha256-OSDx9dzqm8JnLUvdiv1aKqhRz80uWqfjXLd7m6ycXME=";
+    rev = tag;
+    hash = "sha256-dJtOXe4yvZz/iu0Ly5F9/E/2GbpTJF/9ZMU3rC1nKMw=";
   };
 
   defconfig = {

--- a/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
+++ b/pkgs/os-specific/linux/raspberrypi-eeprom/default.nix
@@ -3,18 +3,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "raspberrypi-eeprom";
-  version = "2021.12.02";
-  # From 3fdf703f3f7bbe57eacceada3b558031229a34b0 Mon Sep 17 00:00:00 2001
-  # From: Peter Harper <peter.harper@raspberrypi.com>
-  # Date: Mon, 13 Dec 2021 11:56:11 +0000
-  # Subject: [PATCH] 2021-12-02: Promote the 2021-12-02 beta release to LATEST/STABLE
-  commit = "3fdf703f3f7bbe57eacceada3b558031229a34b0";
+  version = "unstable-2022-03-10";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-eeprom";
-    rev = commit;
-    sha256 = "sha256-JTL2ziOkT0tnOrOS08ttNtxj3qegsacP73xZBVur7xM=";
+    rev = "e8927007e3800db3a72100ee6cd38b0d9b687c16";
+    hash = "sha256-/hn6l5gheh6E3zoANwU1SXYgdry2IjOT9Muw2jkrtCU=";
   };
 
   buildInputs = [ python3 ];


### PR DESCRIPTION
- raspberrypi-eeprom: 2021.12.02 -> unstable-2022-03-10
- raspberrypifw: 1.20220118 -> 1.20220331
- linux_rpi{1,2,3,4}: 1.20220118 -> 1.20220331
- raspberrypiWirelessFirmware: 2021-11-02 -> 2021-12-06
- libraspberrypi: unstable-2021-10-25 -> unstable-2022-03-23

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
