### PR TITLE
ocamlPackages.gen_js_api: init at 1.0.9

### DIFF
--- a/pkgs/development/ocaml-modules/gen_js_api/default.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/default.nix
@@ -1,0 +1,41 @@
+{ buildDunePackage
+, lib
+, ppxlib
+, fetchFromGitHub
+, ojs
+, js_of_ocaml-compiler
+, nodejs
+}:
+
+buildDunePackage rec {
+  pname = "gen_js_api";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = "LexiFi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1qx6if1avr484bl9x1h0cksdc6gqw5i4pwzdr27h46hppnnvi8y8";
+  };
+
+  minimalOCamlVersion = "4.08";
+
+  propagatedBuildInputs = [ ojs ppxlib ];
+  checkInputs = [ js_of_ocaml-compiler nodejs ];
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/LexiFi/gen_js_api";
+    description = "Easy OCaml bindings for JavaScript libraries";
+    longDescription = ''
+      gen_js_api aims at simplifying the creation of OCaml bindings for
+      JavaScript libraries. Authors of bindings write OCaml signatures for
+      JavaScript libraries and the tool generates the actual binding code with a
+      combination of implicit conventions and explicit annotations.
+
+      gen_js_api is to be used with the js_of_ocaml compiler.
+    '';
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bcc32 ];
+  };
+}

--- a/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
+++ b/pkgs/development/ocaml-modules/gen_js_api/ojs.nix
@@ -1,0 +1,21 @@
+{ buildDunePackage
+, gen_js_api
+}:
+
+buildDunePackage rec {
+  pname = "ojs";
+
+  inherit (gen_js_api) version src;
+
+  doCheck = false; # checks depend on gen_js_api, which is a cycle
+
+  minimalOCamlVersion = "4.08";
+
+  meta = {
+    inherit (gen_js_api.meta) homepage license maintainers;
+    description = "Runtime Library for gen_js_api generated libraries";
+    longDescription = ''
+      To be used in conjunction with gen_js_api
+    '';
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -508,6 +508,8 @@ let
 
     gapi_ocaml = callPackage ../development/ocaml-modules/gapi-ocaml { };
 
+    gen_js_api = callPackage ../development/ocaml-modules/gen_js_api { };
+
     gg = callPackage ../development/ocaml-modules/gg { };
 
     git = callPackage ../development/ocaml-modules/git {
@@ -997,6 +999,8 @@ let
     odoc = callPackage ../development/ocaml-modules/odoc { };
 
     odoc-parser = callPackage ../development/ocaml-modules/odoc-parser { };
+
+    ojs = callPackage ../development/ocaml-modules/gen_js_api/ojs.nix { };
 
     omd = callPackage ../development/ocaml-modules/omd { };
 


### PR DESCRIPTION
I chose 1.0.9 instead of the latest 1.1.0, to avoid having to upgrade
js_of_ocaml first.

###### Description of changes

https://github.com/LexiFi/gen_js_api generates binding code for JavaScript libraries for use in js_of_ocaml-compiled OCaml code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
