### PR TITLE
rustracer: 2.1.48 -> 2.2.1

### DIFF
--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "racer";
-  version = "2.1.48";
+  version = "2.2.1";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-lat5s9+AMFI3VXiWqjLESZrtq3IwOZhlt+5BhYoonfA=";
+    sha256 = "sha256-uAVtJwOyhe1lPz+MUUFCgHJPVGuIk/lNUkQWiNdOZ5Y=";
   };
 
-  cargoSha256 = "sha256-jGsvCmrPGVzWdx7V3J4bBK+SF2o+icORmVKuwqYxdh4=";
+  cargoSha256 = "sha256-U2mI1y6t8CwxW/iPcPzxAafu61GNm/XLCKVGuyybV/4=";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = lib.optional stdenv.isDarwin Security;
@@ -32,6 +32,10 @@ rustPlatform.buildRustPackage rec {
     "--skip test_resolve_global_path_in_modules"
   ];
 
+  # [2022-04-06] Its test suite contains two function calls with the
+  # wrong number of arguments, breaking its build.
+  doCheck = false;
+
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/racer --version
@@ -42,7 +46,5 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/racer-rust/racer";
     license = licenses.mit;
     maintainers = with maintainers; [ jagajaga ];
-    # error[E0199]: implementing the trait `Step` is not unsafe
-    broken = true;
   };
 }


### PR DESCRIPTION
Update `rustracer` from 2.1.48 to 2.2.1 and unmark it as broken.

The breakage is now confined to its test suite, which therefore I disable.

###### Description of changes
* <https://github.com/racer-rust/racer/blob/master/CHANGELOG.md> (which is obsolete and not helpful)
* <https://github.com/racer-rust/racer/compare/v2.1.46...2.2.1> (versions 2.1.47 and 2.1.48 were not tagged)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [ ] Reviewed someone else's pull request

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
