### PR TITLE
dockutil 2.0.5 -> 3.0.2

### DIFF
--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -1,25 +1,29 @@
-{ lib, stdenv, fetchFromGitHub }:
+{ lib, stdenv, fetchurl, xar, cpio, pbzx }:
 
 stdenv.mkDerivation rec {
   pname = "dockutil";
-  version = "2.0.5";
+  version = "3.0.2";
 
-  src = fetchFromGitHub {
-    owner  = "kcrawford";
-    repo   = "dockutil";
-    rev    = version;
-    sha256 = "sha256-8tDkueCTCtvxc7owp3K9Tsrn4hL79CM04zBNv7AcHgA=";
-  };
+  src = fetchurl {
+      url    = "https://github.com/kcrawford/dockutil/releases/download/${version}/dockutil-${version}.pkg";
+      sha256 = "175137ea747e83ed221d60b18b712b256ed31531534cde84f679487d337668fd";
+    };
 
   dontBuild = true;
 
+  nativeBuildInputs = [ xar cpio ];
+
+  unpackPhase = ''
+    xar -x -f $src
+  '';
+
   installPhase = ''
-    runHook preInstall
-
     mkdir -p $out/bin
-    install -Dm755 scripts/dockutil -t $out/bin
-
-    runHook postInstall
+    mkdir -p $out/usr/local/bin
+    mv ./Payload ./Payload.gz
+    gzip -cd ./Payload.gz | cpio -idm
+    cp ./usr/local/bin/dockutil $out/usr/local/bin
+    ln -rs $out/usr/local/bin/dockutil $out/bin/dockutil
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -4,9 +4,10 @@ stdenv.mkDerivation rec {
   version = "3.0.2";
 
   src = fetchurl {
-      url    = "https://github.com/kcrawford/dockutil/releases/download/${version}/dockutil-${version}.pkg";
-      sha256 = "175137ea747e83ed221d60b18b712b256ed31531534cde84f679487d337668fd";
-    };
+    url =
+      "https://github.com/kcrawford/dockutil/releases/download/${version}/dockutil-${version}.pkg";
+    sha256 = "175137ea747e83ed221d60b18b712b256ed31531534cde84f679487d337668fd";
+  };
 
   dontBuild = true;
 

--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -1,5 +1,4 @@
-{ lib, stdenv, fetchurl, xar, cpio, gzip }:
-
+{ lib, stdenv, fetchurl, libarchive, p7zip }:
 stdenv.mkDerivation rec {
   pname = "dockutil";
   version = "3.0.2";
@@ -11,19 +10,20 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  nativeBuildInputs = [ xar cpio gzip ];
+  nativeBuildInputs = [ libarchive p7zip ];
 
   unpackPhase = ''
-    xar -x -f $src
+    7z x $src
+    bsdtar -xf Payload~
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
     mkdir -p $out/usr/local/bin
-    mv ./Payload ./Payload.gz
-    gzip -cd ./Payload.gz | cpio -idm
-    cp ./usr/local/bin/dockutil $out/usr/local/bin
+    install -Dm755 usr/local/bin/dockutil -t $out/usr/local/bin
     ln -rs $out/usr/local/bin/dockutil $out/bin/dockutil
+    runHook postInstall
   '';
 
   meta = with lib; {

--- a/pkgs/os-specific/darwin/dockutil/default.nix
+++ b/pkgs/os-specific/darwin/dockutil/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, xar, cpio, pbzx }:
+{ lib, stdenv, fetchurl, xar, cpio, gzip }:
 
 stdenv.mkDerivation rec {
   pname = "dockutil";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  nativeBuildInputs = [ xar cpio ];
+  nativeBuildInputs = [ xar cpio gzip ];
 
   unpackPhase = ''
     xar -x -f $src


### PR DESCRIPTION
###### Description of changes

Updates the package for dockutil from version 2.0.5 to 3.0.2, change-sets for this update are as described [here](https://github.com/kcrawford/dockutil/compare/2.0.5...3.0.2) notably including a rewrite by the author to a swift version in order to enable users of MacOS 12.3+ where python is no longer packaged by default.

This pull request should close https://github.com/NixOS/nixpkgs/issues/167449 :+1: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
