### PR TITLE
Run `lib/tests/misc.nix` on ofborg

### DIFF
--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -235,6 +235,7 @@ runTests {
           list = isStorePath [];
           int = isStorePath 42;
         };
+        storeDir = isStorePath builtins.storeDir;
       };
     expected = {
       storePath = true;
@@ -248,6 +249,7 @@ runTests {
         list = false;
         int = false;
       };
+      storeDir = false;
     };
   };
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -189,7 +189,10 @@ runTests {
     expected = [ "A" "B" ];
   };
 
-  testSplitStringsDerivation = {
+  testSplitStringsDerivation =
+  if builtins.storeDir != "/nix/store"
+  then { expr = null; expected = null; }
+  else {
     expr = take 3  (strings.splitString "/" (derivation {
       name = "name";
       builder = "builder";
@@ -219,7 +222,9 @@ runTests {
             "${builtins.storeDir}/d945ibfx9x185xf04b890y4f9g3cbb63-python-2.7.11";
       in {
         storePath = isStorePath goodPath;
-        storePathDerivation = isStorePath (import ../.. { system = "x86_64-linux"; }).hello;
+        # This should work, but let's keep it lean.
+        # storePathDerivation = isStorePath (import ../.. { system = "x86_64-linux"; }).hello;
+        storePathDerivation = isStorePath (derivation { system = "x86_64-linux"; name = "bogus"; builder = "/nope"; });
         storePathAppendix = isStorePath
           "${goodPath}/bin/python";
         nonAbsolute = isStorePath (concatStrings (tail (stringToCharacters goodPath)));

--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -36,5 +36,13 @@ pkgs.runCommand "nixpkgs-lib-tests" {
     echo "Running lib/tests/sources.sh"
     TEST_LIB=$PWD/lib bash lib/tests/sources.sh
 
+    echo "Running lib/tests/misc.nix"
+    nix-instantiate --show-trace --eval --strict lib/tests/misc.nix >misc-out
+    if ! cmp <(echo "[ ]") misc-out; then
+      echo "lib/tests/misc.nix failed:"
+      cat misc-out
+      exit 1
+    fi
+
     touch $out
 ''


### PR DESCRIPTION
###### Description of changes

Run `lib/tests/misc.nix` on ofborg

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
