### PR TITLE
kubectx: enable tests

### DIFF
--- a/pkgs/development/tools/kubectx/default.nix
+++ b/pkgs/development/tools/kubectx/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-4sQaqC0BOsDfWH3cHy2EMQNMq6qiAcbV+RwxCdcSxsg=";
 
-  doCheck = false;
-
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''


### PR DESCRIPTION
kubectx: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   Test_parseArgs_new
=== RUN   Test_parseArgs_new/nil_Args
=== RUN   Test_parseArgs_new/empty_Args
=== RUN   Test_parseArgs_new/help_shorthand
=== RUN   Test_parseArgs_new/help_long_form
=== RUN   Test_parseArgs_new/current_shorthand
=== RUN   Test_parseArgs_new/current_long_form
=== RUN   Test_parseArgs_new/unset_shorthand
=== RUN   Test_parseArgs_new/unset_long_form
=== RUN   Test_parseArgs_new/switch_by_name
=== RUN   Test_parseArgs_new/switch_by_swap
=== RUN   Test_parseArgs_new/delete_-_without_contexts
=== RUN   Test_parseArgs_new/delete_-_current_context
=== RUN   Test_parseArgs_new/delete_-_multiple_contexts
=== RUN   Test_parseArgs_new/rename_context
=== RUN   Test_parseArgs_new/rename_context_with_old=current
=== RUN   Test_parseArgs_new/unrecognized_flag
=== RUN   Test_parseArgs_new/too_many_args
--- PASS: Test_parseArgs_new (0.00s)
    --- PASS: Test_parseArgs_new/nil_Args (0.00s)
    --- PASS: Test_parseArgs_new/empty_Args (0.00s)
    --- PASS: Test_parseArgs_new/help_shorthand (0.00s)
    --- PASS: Test_parseArgs_new/help_long_form (0.00s)
    --- PASS: Test_parseArgs_new/current_shorthand (0.00s)
    --- PASS: Test_parseArgs_new/current_long_form (0.00s)
    --- PASS: Test_parseArgs_new/unset_shorthand (0.00s)
    --- PASS: Test_parseArgs_new/unset_long_form (0.00s)
    --- PASS: Test_parseArgs_new/switch_by_name (0.00s)
    --- PASS: Test_parseArgs_new/switch_by_swap (0.00s)
    --- PASS: Test_parseArgs_new/delete_-_without_contexts (0.00s)
    --- PASS: Test_parseArgs_new/delete_-_current_context (0.00s)
    --- PASS: Test_parseArgs_new/delete_-_multiple_contexts (0.00s)
    --- PASS: Test_parseArgs_new/rename_context (0.00s)
    --- PASS: Test_parseArgs_new/rename_context_with_old=current (0.00s)
    --- PASS: Test_parseArgs_new/unrecognized_flag (0.00s)
    --- PASS: Test_parseArgs_new/too_many_args (0.00s)
=== RUN   TestPrintHelp
--- PASS: TestPrintHelp (0.00s)
=== RUN   Test_parseRenameSyntax
=== RUN   Test_parseRenameSyntax/no_equals_sign
=== RUN   Test_parseRenameSyntax/no_left_side
=== RUN   Test_parseRenameSyntax/no_right_side
=== RUN   Test_parseRenameSyntax/correct_format
=== RUN   Test_parseRenameSyntax/correct_format_with_current_context
--- PASS: Test_parseRenameSyntax (0.00s)
    --- PASS: Test_parseRenameSyntax/no_equals_sign (0.00s)
    --- PASS: Test_parseRenameSyntax/no_left_side (0.00s)
    --- PASS: Test_parseRenameSyntax/no_right_side (0.00s)
    --- PASS: Test_parseRenameSyntax/correct_format (0.00s)
    --- PASS: Test_parseRenameSyntax/correct_format_with_current_context (0.00s)
=== RUN   Test_readLastContext_nonExistingFile
--- PASS: Test_readLastContext_nonExistingFile (0.00s)
=== RUN   Test_readLastContext
--- PASS: Test_readLastContext (0.00s)
=== RUN   Test_writeLastContext_err
--- PASS: Test_writeLastContext_err (0.00s)
=== RUN   Test_writeLastContext
--- PASS: Test_writeLastContext (0.00s)
=== RUN   Test_kubectxFilePath
--- PASS: Test_kubectxFilePath (0.00s)
=== RUN   Test_kubectxFilePath_error
--- PASS: Test_kubectxFilePath_error (0.00s)
PASS
ok  	github.com/ahmetb/kubectx/cmd/kubectx	0.002s
=== RUN   Test_parseArgs_new
=== RUN   Test_parseArgs_new/nil_Args
=== RUN   Test_parseArgs_new/empty_Args
=== RUN   Test_parseArgs_new/help_shorthand
=== RUN   Test_parseArgs_new/help_long_form
=== RUN   Test_parseArgs_new/current_shorthand
=== RUN   Test_parseArgs_new/current_long_form
=== RUN   Test_parseArgs_new/switch_by_name
=== RUN   Test_parseArgs_new/switch_by_swap
=== RUN   Test_parseArgs_new/unrecognized_flag
=== RUN   Test_parseArgs_new/too_many_args
--- PASS: Test_parseArgs_new (0.00s)
    --- PASS: Test_parseArgs_new/nil_Args (0.00s)
    --- PASS: Test_parseArgs_new/empty_Args (0.00s)
    --- PASS: Test_parseArgs_new/help_shorthand (0.00s)
    --- PASS: Test_parseArgs_new/help_long_form (0.00s)
    --- PASS: Test_parseArgs_new/current_shorthand (0.00s)
    --- PASS: Test_parseArgs_new/current_long_form (0.00s)
    --- PASS: Test_parseArgs_new/switch_by_name (0.00s)
    --- PASS: Test_parseArgs_new/switch_by_swap (0.00s)
    --- PASS: Test_parseArgs_new/unrecognized_flag (0.00s)
    --- PASS: Test_parseArgs_new/too_many_args (0.00s)
=== RUN   TestNSFile
--- PASS: TestNSFile (0.00s)
=== RUN   TestNSFile_path_windows
--- PASS: TestNSFile_path_windows (0.00s)
=== RUN   Test_isWindows
--- PASS: Test_isWindows (0.00s)
PASS
ok  	github.com/ahmetb/kubectx/cmd/kubens	0.007s
=== RUN   TestPrintDeprecatedEnvWarnings_noDeprecatedVars
--- PASS: TestPrintDeprecatedEnvWarnings_noDeprecatedVars (0.00s)
=== RUN   TestPrintDeprecatedEnvWarnings_bgColors
--- PASS: TestPrintDeprecatedEnvWarnings_bgColors (0.00s)
=== RUN   Test_homeDir
=== RUN   Test_homeDir/don't_use_XDG_CACHE_HOME_as_homedir
=== RUN   Test_homeDir/HOME_over_USERPROFILE
=== RUN   Test_homeDir/only_USERPROFILE_available
=== RUN   Test_homeDir/none_available
--- PASS: Test_homeDir (0.00s)
    --- PASS: Test_homeDir/don't_use_XDG_CACHE_HOME_as_homedir (0.00s)
    --- PASS: Test_homeDir/HOME_over_USERPROFILE (0.00s)
    --- PASS: Test_homeDir/only_USERPROFILE_available (0.00s)
    --- PASS: Test_homeDir/none_available (0.00s)
PASS
ok  	github.com/ahmetb/kubectx/internal/cmdutil	0.001s
=== RUN   TestKubeconfig_DeleteContextEntry_errors
--- PASS: TestKubeconfig_DeleteContextEntry_errors (0.00s)
=== RUN   TestKubeconfig_DeleteContextEntry
--- PASS: TestKubeconfig_DeleteContextEntry (0.00s)
=== RUN   TestKubeconfig_ModifyCurrentContext_fieldExists
--- PASS: TestKubeconfig_ModifyCurrentContext_fieldExists (0.00s)
=== RUN   TestKubeconfig_ModifyCurrentContext_fieldMissing
--- PASS: TestKubeconfig_ModifyCurrentContext_fieldMissing (0.00s)
=== RUN   TestKubeconfig_ModifyContextName_noContextsEntryError
--- PASS: TestKubeconfig_ModifyContextName_noContextsEntryError (0.00s)
=== RUN   TestKubeconfig_ModifyContextName_contextsEntryNotSequenceError
--- PASS: TestKubeconfig_ModifyContextName_contextsEntryNotSequenceError (0.00s)
=== RUN   TestKubeconfig_ModifyContextName_noChange
--- PASS: TestKubeconfig_ModifyContextName_noChange (0.00s)
=== RUN   TestKubeconfig_ModifyContextName
--- PASS: TestKubeconfig_ModifyContextName (0.00s)
=== RUN   TestKubeconfig_ContextNames
--- PASS: TestKubeconfig_ContextNames (0.00s)
=== RUN   TestKubeconfig_ContextNames_noContextsEntry
--- PASS: TestKubeconfig_ContextNames_noContextsEntry (0.00s)
=== RUN   TestKubeconfig_ContextNames_nonArrayContextsEntry
--- PASS: TestKubeconfig_ContextNames_nonArrayContextsEntry (0.00s)
=== RUN   TestKubeconfig_CheckContextExists
--- PASS: TestKubeconfig_CheckContextExists (0.00s)
=== RUN   TestKubeconfig_GetCurrentContext
--- PASS: TestKubeconfig_GetCurrentContext (0.00s)
=== RUN   TestKubeconfig_GetCurrentContext_missingField
--- PASS: TestKubeconfig_GetCurrentContext_missingField (0.00s)
=== RUN   TestKubeconfig_UnsetCurrentContext
--- PASS: TestKubeconfig_UnsetCurrentContext (0.00s)
=== RUN   TestParse
--- PASS: TestParse (0.00s)
=== RUN   TestSave
--- PASS: TestSave (0.00s)
=== RUN   Test_kubeconfigPath
--- PASS: Test_kubeconfigPath (0.00s)
=== RUN   Test_kubeconfigPath_noEnvVars
--- PASS: Test_kubeconfigPath_noEnvVars (0.00s)
=== RUN   Test_kubeconfigPath_envOvveride
--- PASS: Test_kubeconfigPath_envOvveride (0.00s)
=== RUN   Test_kubeconfigPath_envOvverideDoesNotSupportPathSeparator
--- PASS: Test_kubeconfigPath_envOvverideDoesNotSupportPathSeparator (0.00s)
=== RUN   TestStandardKubeconfigLoader_returnsNotFoundErr
--- PASS: TestStandardKubeconfigLoader_returnsNotFoundErr (0.00s)
=== RUN   TestKubeconfig_NamespaceOfContext_ctxNotFound
--- PASS: TestKubeconfig_NamespaceOfContext_ctxNotFound (0.00s)
=== RUN   TestKubeconfig_NamespaceOfContext
--- PASS: TestKubeconfig_NamespaceOfContext (0.00s)
=== RUN   TestKubeconfig_SetNamespace
--- PASS: TestKubeconfig_SetNamespace (0.00s)
PASS
ok  	github.com/ahmetb/kubectx/internal/kubeconfig	0.002s
=== RUN   Test_useColors_forceColors
--- PASS: Test_useColors_forceColors (0.00s)
=== RUN   Test_useColors_disableColors
--- PASS: Test_useColors_disableColors (0.00s)
=== RUN   Test_useColors_default
--- PASS: Test_useColors_default (0.00s)
PASS
ok  	github.com/ahmetb/kubectx/internal/printer	0.001s

```