### PR TITLE
saml2aws: enable tests

### DIFF
--- a/pkgs/tools/security/saml2aws/default.nix
+++ b/pkgs/tools/security/saml2aws/default.nix
@@ -15,8 +15,6 @@ buildGoModule rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];
 
-  doCheck = false;
-
   subPackages = [ "." "cmd/saml2aws" ];
 
   ldflags = [


### PR DESCRIPTION
saml2aws: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestExtractAWSAccounts
--- PASS: TestExtractAWSAccounts (0.00s)
=== RUN   TestAssignPrincipals
--- PASS: TestAssignPrincipals (0.00s)
=== RUN   TestLocateRole
--- PASS: TestLocateRole (0.00s)
=== RUN   TestParseRoles
--- PASS: TestParseRoles (0.00s)
=== RUN   TestProviderList_Keys
--- PASS: TestProviderList_Keys (0.00s)
=== RUN   TestProviderList_Mfas
--- PASS: TestProviderList_Mfas (0.00s)
=== RUN   TestExtractAwsRoles
--- PASS: TestExtractAwsRoles (0.00s)
=== RUN   TestExtractSessionDuration
--- PASS: TestExtractSessionDuration (0.00s)
=== RUN   TestExtractDestinationURL
--- PASS: TestExtractDestinationURL (0.00s)
=== RUN   TestExtractDestinationURL2
--- PASS: TestExtractDestinationURL2 (0.00s)
=== RUN   TestExtractMFATokenDuration
--- PASS: TestExtractMFATokenDuration (0.00s)
=== RUN   TestExtractMFATokenDuration2
    saml_test.go:62: parsing time "This-is-invalid-2016-09-10F32:59:39.387Z" as "2006-01-02T15:04:05Z07:00": cannot parse "This-is-invalid-2016-09-10F32:59:39.387Z" as "2006"
--- PASS: TestExtractMFATokenDuration2 (0.00s)
PASS
ok  	github.com/versent/saml2aws/v2	0.003s
?   	github.com/versent/saml2aws/v2/cmd/saml2aws	[no test files]
```