### PR TITLE
nagstamon: 3.2.1 -> 3.8.0

### DIFF
--- a/pkgs/tools/misc/nagstamon/default.nix
+++ b/pkgs/tools/misc/nagstamon/default.nix
@@ -1,27 +1,47 @@
-{ lib, fetchurl, pythonPackages }:
+{ lib, fetchFromGitHub, python39Packages, wrapQtAppsHook }:
 
-pythonPackages.buildPythonApplication rec {
+let
   pname = "nagstamon";
-  version = "3.2.1";
+  version = "v3.8.0";
+in python39Packages.buildPythonApplication rec {
+  inherit pname;
+  inherit version;
 
-  src = fetchurl {
-    url = "https://nagstamon.ifw-dresden.de/files/stable/Nagstamon-${version}.tar.gz";
-    sha256 = "1048x55g3nlyyggn6a36xmj24w4hv08llg58f4hzc0fwg074cd58";
+  src = fetchFromGitHub {
+    owner = "HenriWahl";
+    repo = "Nagstamon";
+    rev = "${version}";
+    sha256 = "0a8aqw44z58pabsgxlvndnmzzvc50wrb4g12yp6zgajn40b2l8pw";
   };
 
-  # Test assumes darwin
   doCheck = false;
 
-  propagatedBuildInputs = with pythonPackages; [ configparser pyqt5 psutil requests
-     beautifulsoup4 keyring requests-kerberos kerberos lxml ];
+  nativeBuildInputs = [ wrapQtAppsHook ];
+  postFixup = ''
+    wrapQtApp $out/bin/nagstamon.py
+  '';
+
+  propagatedBuildInputs = with python39Packages; [
+    beautifulsoup4
+    configparser
+    dateutil
+    kerberos
+    keyring
+    lxml
+    psutil
+    pyqt5_with_qtmultimedia
+    requests
+    requests-kerberos
+    setuptools
+    xlib
+  ];
 
   meta = with lib; {
     description = "A status monitor for the desktop";
     homepage = "https://nagstamon.ifw-dresden.de/";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ pSub ];
-    # fails to install with:
-    # TypeError: cannot unpack non-iterable bool object
-    broken = true;
+    maintainers = with maintainers; [ foosinn ];
+    inherit version;
   };
 }
+


### PR DESCRIPTION
###### Description of changes

Update of the nagstamon package to 3.8.0 which adds multiple new providers and a lot of bugfixes.

I'm new to this so please let me know if i missed something. Thanks!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
