### PR TITLE
headscale: Add restricted_nameservers option to configure SplitDNS.

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -204,6 +204,23 @@ in
           '';
         };
 
+        restrictedNameservers = mkOption {
+          type = with types; attrsOf (listOf str);
+          default = {};
+          description = ''
+            A list of search domains and the DNS to query for each one.
+            See <link xlink:href="https://tailscale.com/kb/1054/dns">Split DNS</link>.
+          '';
+          example = lib.literalExpression ''
+            {
+              "foo.bar.com" = [
+                "1.1.1.1"
+                "8.8.8.8"
+              ];
+            }
+            '';
+        };
+
         domains = mkOption {
           type = types.listOf types.str;
           default = [ ];
@@ -371,6 +388,7 @@ in
 
       dns_config = {
         nameservers = mkDefault cfg.dns.nameservers;
+        restricted_nameservers = mkDefault cfg.dns.restrictedNameservers;
         domains = mkDefault cfg.dns.domains;
         magic_dns = mkDefault cfg.dns.magicDns;
         base_domain = mkDefault cfg.dns.baseDomain;


### PR DESCRIPTION
###### Description of changes

This adds the `restricted_nameservers` to the headscale configuration which allows us to configure [SplitDNS](https://tailscale.com/kb/1054/dns/).
The default is an empty attribute set, i.e. no SplitDNS is setup, which should not break any existing setup.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
