### PR TITLE
gopass: enable tests

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -28,8 +28,6 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  doCheck = false;
-
   ldflags = [ "-s" "-w" "-X main.version=${version}" "-X main.commit=${src.rev}" ];
 
   wrapperPath = lib.makeBinPath (


### PR DESCRIPTION
gopass: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestVersionPrinter
=== PAUSE TestVersionPrinter
=== RUN   TestGetVersion
=== PAUSE TestGetVersion
=== RUN   TestSetupApp
--- PASS: TestSetupApp (0.00s)
=== RUN   TestGetCommands
foo
_gopass_bash_autocomplete() {
     local cur opts base
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
     local IFS=$'\n'
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0
 }

complete -F _gopass_bash_autocomplete gopass.test
#compdef gopass.test

_gopass.test () {
    local cmd
    if (( CURRENT > 2)); then
	cmd=${words[2]}
	curcontext="${curcontext%:*:*}:gopass.test-$cmd"
	(( CURRENT-- ))
	shift words
	case "${cmd}" in
	  *)
	      _gopass.test_complete_passwords
	      ;;
	esac
    else
	local -a subcommands
	subcommands=(
	)
	_describe -t command 'gopass.test' subcommands
	_arguments : 
	_gopass.test_complete_passwords
    fi
}

_gopass.test_complete_keys () {
    local IFS=$'\n'
    _values 'gpg keys' $(gpg2 --list-secret-keys --with-colons 2> /dev/null | cut -d : -f 10 | sort -u | sed '/^$/d')
}

_gopass.test_complete_passwords () {
    local IFS=$'\n'
    _arguments : \
	"--clip[Copy the first line of the secret into the clipboard]"
    _values 'passwords' $(gopass.test ls --flat)
}

_gopass.test_complete_folders () {
    local -a folders
    folders=("${(@f)$(gopass.test ls --folders --flat)}")
    _describe -t folders "folders" folders -qS /
}

_gopass.test
#!/usr/bin/env fish
set PROG 'gopass.test'

function __fish_gopass.test_needs_command
  set -l cmd (commandline -opc)
  if [ (count $cmd) -eq 1 -a $cmd[1] = $PROG ]
    return 0
  end
  return 1
end

function __fish_gopass.test_uses_command
  set cmd (commandline -opc)
  if [ (count $cmd) -gt 1 ]
    if [ $argv[1] = $cmd[2] ]
      return 0
    end
  end
  return 1
end

function __fish_gopass.test_print_gpg_keys
  gpg2 --list-keys | grep uid | sed 's/.*&lt;\(.*\)>/\1/'
end

function __fish_gopass.test_print_entries
  gopass.test ls --flat
end

function __fish_gopass.test_print_dir
  for i in (gopass.test ls --flat)
	  echo (dirname $i)
	end | sort -u
end

# erase any existing completions for gopass.test
complete -c $PROG -e
complete -c $PROG -f -n '__fish_gopass.test_needs_command' -a "(__fish_gopass.test_print_entries)"
complete -c $PROG -f -s c -l clip -r -a "(__fish_gopass.test_print_entries)"

PASS_LIST=$(gopass ls -f)
set -A complete_gopass -- $PASS_LIST 
autoclip
autoimport
cliptimeout
exportkeys
nopager
notifications
parsing
path
remote
safecontent
foo
foo
foo
foo
foo
foo
foo
foo
foo
foo
foo
gopass
└── foo

foo
foo
foo
fAgQnuuNZcm7 
JhF4PNrYjErx 
mvNFg9HoBfgk 
xvnxCdK556b3 
FmvpTGI5Tz2Z 
Hyc6e9EtWdru 
grvnetON5drx 
UWYnn1Xl5viw 
SkM2K8aAPjqy 
hE9AYosC17W6 
0xDEADBEEF
gopass
└── 0xDEADBEEF

foo
foo
gopass

gopass.test version 
<root>     - plain 0.0.0 -   fs 0.0.0
Available Crypto Backends: age, gpgcli, plain
Available Storage Backends: fossilfs, fs, gitfs
--- PASS: TestGetCommands (0.00s)
=== RUN   TestInitContext
--- PASS: TestInitContext (0.00s)
=== CONT  TestVersionPrinter
=== CONT  TestGetVersion
--- PASS: TestGetVersion (0.00s)
--- PASS: TestVersionPrinter (0.00s)
PASS
ok  	github.com/gopasspw/gopass	0.047s
```