### PR TITLE
tinygo: 0.16.0 -> 0.23.0

### DIFF
--- a/pkgs/development/compilers/tinygo/clang-env.patch
+++ b/pkgs/development/compilers/tinygo/clang-env.patch
@@ -1,0 +1,46 @@
+diff --git builder/builtins.go builder/builtins.go
+index 479b541d..4e697d1e 100644
+--- builder/builtins.go
++++ builder/builtins.go
+@@ -164,7 +164,7 @@ var aeabiBuiltins = []string{
+ var CompilerRT = Library{
+ 	name: "compiler-rt",
+ 	cflags: func(target, headerPath string) []string {
+-		return []string{"-Werror", "-Wall", "-std=c11", "-nostdlibinc"}
++		return []string{"-Werror", "-Wall", "-std=c11", "-isystem", "@libclang_inc@"}
+ 	},
+ 	sourceDir: func() string {
+ 		llvmDir := filepath.Join(goenv.Get("TINYGOROOT"), "llvm-project/compiler-rt/lib/builtins")
+diff --git builder/picolibc.go builder/picolibc.go
+index f1b061ae..dd1aa3fe 100644
+--- builder/picolibc.go
++++ builder/picolibc.go
+@@ -27,7 +27,7 @@ var Picolibc = Library{
+ 			"-D_COMPILING_NEWLIB",
+ 			"-DHAVE_ALIAS_ATTRIBUTE",
+ 			"-DTINY_STDIO",
+-			"-nostdlibinc",
++			"-isystem", "@libclang_inc@",
+ 			"-isystem", picolibcDir + "/include",
+ 			"-I" + picolibcDir + "/tinystdio",
+ 			"-I" + headerPath,
+diff --git compileopts/config.go compileopts/config.go
+index b30e653e..22a95d71 100644
+--- compileopts/config.go
++++ compileopts/config.go
+@@ -288,6 +288,7 @@ func (c *Config) CFlags() []string {
+ 		path, _ := c.LibcPath("picolibc")
+ 		cflags = append(cflags,
+ 			"--sysroot="+path,
++			"-isystem", "@libclang_inc@",
+ 			"-isystem", filepath.Join(path, "include"), // necessary for Xtensa
+ 			"-isystem", filepath.Join(picolibcDir, "include"),
+ 			"-isystem", filepath.Join(picolibcDir, "tinystdio"),
+@@ -297,7 +298,6 @@ func (c *Config) CFlags() []string {
+ 		path, _ := c.LibcPath("musl")
+ 		arch := MuslArchitecture(c.Triple())
+ 		cflags = append(cflags,
+-			"-nostdlibinc",
+ 			"-isystem", filepath.Join(path, "include"),
+ 			"-isystem", filepath.Join(root, "lib", "musl", "arch", arch),
+ 			"-isystem", filepath.Join(root, "lib", "musl", "include"),

--- a/pkgs/development/compilers/tinygo/go.mod
+++ b/pkgs/development/compilers/tinygo/go.mod
@@ -1,14 +1,18 @@
 module github.com/tinygo-org/tinygo
 
-go 1.11
+go 1.15
 
 require (
+	github.com/aykevl/go-wasm v0.0.2-0.20211119014117-0761b1ddcd1a
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
-	github.com/chromedp/cdproto v0.0.0-20200709115526-d1f6fc58448b
-	github.com/chromedp/chromedp v0.5.4-0.20200303084119-2bb39134ab9e
+	github.com/gofrs/flock v0.8.1
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/marcinbor85/gohex v0.0.0-20200531091804-343a4b548892
-	go.bug.st/serial v1.0.0
-	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2
-	tinygo.org/x/go-llvm v0.0.0-20201104183921-570e7a6841d9
+	github.com/mattn/go-colorable v0.1.8
+	go.bug.st/serial v1.1.3
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/tools v0.1.6-0.20210813165731-45389f592fe9
+	google.golang.org/appengine v1.6.7
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	tinygo.org/x/go-llvm v0.0.0-20220420140351-512c94c1e71f
 )

--- a/pkgs/development/compilers/tinygo/main.go
+++ b/pkgs/development/compilers/tinygo/main.go
@@ -3,10 +3,14 @@ package main
 import (
 	"fmt"
 
+	_ "github.com/aykevl/go-wasm"
 	_ "github.com/blakesmith/ar"
+	_ "github.com/gofrs/flock"
 	_ "github.com/google/shlex"
 	_ "github.com/marcinbor85/gohex"
+	_ "github.com/mattn/go-colorable"
 	_ "go.bug.st/serial"
+	_ "go.bug.st/serial/enumerator"
 	_ "golang.org/x/tools/go/ast/astutil"
 	_ "golang.org/x/tools/go/ssa"
 	_ "google.golang.org/appengine"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13879,7 +13879,7 @@ with pkgs;
   tinycc = callPackage ../development/compilers/tinycc { };
 
   tinygo = callPackage ../development/compilers/tinygo {
-    inherit (llvmPackages_10) llvm clang-unwrapped lld;
+    inherit (llvmPackages_14) llvm clang-unwrapped lld;
     avrgcc = pkgsCross.avr.buildPackages.gcc;
   };
 


### PR DESCRIPTION
Notable changes:
- Fix for missing version information in Go 1.17 and later.
- Add -isystem to libclang includes.
- nixpkgs-fmt TinyGo default.nix file.
- Upgrade to LLVM 11.

TinyGo supports LLVM 12 and 13, but may result in weird errors when
building:

error: could not parse executable for stack size analysis: could not decode .debug_frame bytecode op 0x9 (for address 0x8012a4a)

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
