### PR TITLE
pomodoro: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+let
+  pname = "pomodoro";
+  version = "0.1.0-git";
+in
+rustPlatform.buildRustPackage {
+  inherit pname;
+  inherit version;
+  src = fetchFromGitHub {
+    owner = "SanderJSA";
+    repo = pname;
+    rev = "c833b9551ed0b09e311cdb369cc8226c5b9cac6a";
+    sha256 = "0x5apv5q0dhjrmjrmfzclsgd3ynyjd68llyk2yad8wa9hpanl3b4";
+  };
+
+  cargoSha256 = "0nwf2f6xywirz70kr5xxly5rbp493idfsv8y7bqgnwrp9y63v2q8";
+
+  meta = with lib; {
+    description = "A simple CLI pomodoro timer using desktop notifications written in Rust";
+    homepage = "https://github.com/SanderJSA/Pomodoro";
+    license = licenses.mit;
+    maintainers = with maintainers; [ wamserma ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28555,6 +28555,8 @@ with pkgs;
     electron = electron_9;
   };
 
+  pomodoro = callPackage ../applications/misc/pomodoro { };
+
   pond = callPackage ../applications/networking/instant-messengers/pond { };
 
   ponymix = callPackage ../applications/audio/ponymix { };


### PR DESCRIPTION
A simple CLI pomodoro timer using desktop notifications written in Rust.
https://github.com/SanderJSA/Pomodoro

There is no tag/release on GH, but cargho.toml carries a version number.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
