### PR TITLE
stripe-cli: 1.8.4 -> 1.8.8

### DIFF
--- a/pkgs/tools/admin/stripe-cli/default.nix
+++ b/pkgs/tools/admin/stripe-cli/default.nix
@@ -1,27 +1,68 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, stdenv }:
 
 buildGoModule rec {
   pname = "stripe-cli";
-  version = "1.8.4";
+  version = "1.8.8";
 
   src = fetchFromGitHub {
     owner = "stripe";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-TP366SozSNfxUGYXIOObfIul0BhQtIGQYZLwH/TPFs0=";
+    sha256 = "sha256-frVQ2nqOflY26ZZWVYJGMNMOdbLuIojQDu/79kLilBk=";
   };
-
   vendorSha256 = "sha256-1c+YtfRy1ey0z117YHHkrCnpb7g+DmM+LR1rjn1YwMQ=";
 
-  subPackages = [
-    "cmd/stripe"
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/stripe/stripe-cli/pkg/version.Version=${version}"
   ];
+
+  preCheck = ''
+    # the tests expect the Version ldflag not to be set
+    unset ldflags
+  '' + lib.optionalString (
+      # delete plugin tests on all platforms but exact matches
+      # https://github.com/stripe/stripe-cli/issues/850
+      ! lib.lists.any
+        (platform: lib.meta.platformMatch stdenv.hostPlatform platform)
+        [ "x86_64-linux" "x86_64-darwin" ]
+  ) ''
+    rm pkg/plugins/plugin_test.go
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd stripe \
+      --bash <($out/bin/stripe completion --write-to-stdout --shell bash) \
+      --zsh <($out/bin/stripe completion --write-to-stdout --shell zsh)
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/stripe --help
+    $out/bin/stripe --version | grep "${version}"
+    runHook postInstallCheck
+  '';
 
   meta = with lib; {
     homepage = "https://stripe.com/docs/stripe-cli";
+    changelog = "https://github.com/stripe/stripe-cli/releases/tag/v${version}";
     description = "A command-line tool for Stripe";
+    longDescription = ''
+      The Stripe CLI helps you build, test, and manage your Stripe integration
+      right from the terminal.
+
+      With the CLI, you can:
+      Securely test webhooks without relying on 3rd party software
+      Trigger webhook events or resend events for easy testing
+      Tail your API request logs in real-time
+      Create, retrieve, update, or delete API objects.
+    '';
     license = with licenses; [ asl20 ];
-    maintainers = with maintainers; [ RaghavSood ];
+    maintainers = with maintainers; [ RaghavSood jk ];
     mainProgram = "stripe";
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumps `stripe-cli` to `1.8.8`

also:

Added ldflags
  -s -w makes the binary 2MB smaller
  -X ... adds the version details (without a v prefix like the official release, see screenshot)
![image](https://user-images.githubusercontent.com/9866621/162069568-3153ee66-b382-4db1-897f-4fb431df0bc5.png)
Added the tests
Added shell completions
Added changelog and longDescription
Added myself as a maintainer


cc: @RaghavSood

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
