### PR TITLE
gcc10: fix cross-compilation bug from aarch64-darwin host

### DIFF
--- a/pkgs/development/compilers/gcc/10/default.nix
+++ b/pkgs/development/compilers/gcc/10/default.nix
@@ -71,7 +71,12 @@ let majorVersion = "10";
       # Obtain latest patch with ../update-mcfgthread-patches.sh
       ++ optional (!crossStageStatic && targetPlatform.isMinGW) ./Added-mcf-thread-model-support-from-mcfgthread.patch
 
-      ++ [ ../libsanitizer-no-cyclades.patch ];
+      ++ [ ../libsanitizer-no-cyclades.patch ]
+
+      ++ optional (buildPlatform.system == "aarch64-darwin" && targetPlatform != buildPlatform) (fetchpatch {
+        url = "https://raw.githubusercontent.com/richard-vd/musl-cross-make/5e9e87f06fc3220e102c29d3413fbbffa456fcd6/patches/gcc-${version}/0008-darwin-aarch64-self-host-driver.patch";
+        sha256 = "sha256-XtykrPd5h/tsnjY1wGjzSOJ+AyyNLsfnjuOZ5Ryq9vA=";
+      });
 
     /* Cross-gcc settings (build == host != target) */
     crossMingw = targetPlatform != hostPlatform && targetPlatform.libc == "msvcrt";


### PR DESCRIPTION
This fixes a problem trying to cross-compile on an M1 mac (example user reports [here](https://github.com/richfelker/musl-cross-make/issues/116) and [here](https://github.com/riscv-software-src/homebrew-riscv/issues/47)). The symptom is a link failure like this:

    Undefined symbols for architecture arm64:
      "_host_hooks", referenced from:
          gt_pch_save(__sFILE*) in libbackend.a(ggc-common.o)
          gt_pch_restore(__sFILE*) in libbackend.a(ggc-common.o)
          toplev::main(int, char**) in libbackend.a(toplev.o)
    ld: symbol(s) not found for architecture arm64

###### Description of changes

This pulls in a [pre-existing patch](https://github.com/richard-vd/musl-cross-make/blob/master/patches/gcc-10.3.0/0008-darwin-aarch64-self-host-driver.patch) for gcc 10 from the [richard-vd/musl-cross-make](https://github.com/richard-vd/musl-cross-make) project. I've validated this fixes the problem on `aarch64-darwin`, and is benign on `{aarch64,x86_64}-linux`.

Right now, gcc10 is the default for aarch64-darwin, so this unblocks mainline cross-compilation today.

With an eye to the future, gcc11 currently has the same underlying problem. I tried covering that case too, using the corresponding patch for  [gcc 11.2.0](https://github.com/richard-vd/musl-cross-make/blob/master/patches/gcc-11.2.0/0006-apple-silicon.patch). Unfortunately that doesn't work: it fails to compose cleanly with the other patches already present, and (in either order) one of the patches always fails to apply.

I'm happy to prepare a hand-crafted patch to address gcc 11.2.0, that applies after the existing ones, but this customised patch would have to be committed to nixpkgs. So I'm asking for opinions first, in case there's a cleaner way.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
