### PR TITLE
qFlipper: 0.8.2 -> 1.0.1

### DIFF
--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -21,10 +21,10 @@
 , qtwayland
 }:
 let
-  version = "0.8.2";
+  version = "1.0.1";
   timestamp = "99999999999";
   commit = "nix-${version}";
-  hash = "sha256-BaqKlF2SZueykFhtj91McP39oXYAx+lz8eXhn5eouqg=";
+  hash = "sha256-vHBlrtQ06kjjXXGL/jSdpAPHgqb7Vn1c6jXZVXwxHPQ=";
 
   udev_rules = ''
     #Flipper Zero serial port
@@ -50,13 +50,13 @@ mkDerivation {
     pkg-config
     qmake
     qttools
+    wrapQtAppsHook
   ];
 
   buildInputs = [
     zlib
     libusb1
     libGL
-    wrapQtAppsHook
 
     qtbase
     qt3d
@@ -70,39 +70,30 @@ mkDerivation {
     qtwayland
   ];
 
-  preBuild = ''
+  qmakeFlags = [
+    "DEFINES+=DISABLE_APPLICATION_UPDATES"
+    "CONFIG+=qtquickcompiler"
+  ];
+
+  postPatch = ''
     substituteInPlace qflipper_common.pri \
         --replace 'GIT_VERSION = unknown' 'GIT_VERSION = "${version}"' \
         --replace 'GIT_TIMESTAMP = 0' 'GIT_TIMESTAMP = ${timestamp}' \
         --replace 'GIT_COMMIT = unknown' 'GIT_COMMIT = "${commit}"'
     cat qflipper_common.pri
-
   '';
 
-  installPhase = ''
-    runHook preInstall
-
+  postInstall = ''
     mkdir -p $out/bin
-    ${lib.optionalString stdenv.isLinux ''
-      install -Dm755 qFlipper $out/bin/qFlipper
-    ''}
     ${lib.optionalString stdenv.isDarwin ''
-      install -Dm755 qFlipper.app/Contents/MacOS/qFlipper $out/bin/qFlipper
+    cp qFlipper.app/Contents/MacOS/qFlipper $out/bin
     ''}
-    cp qFlipperTool $out/bin
-
-    mkdir -p $out/share/applications
-    cp installer-assets/appimage/qFlipper.desktop $out/share/applications
-
-    mkdir -p $out/share/icons
-    cp application/assets/icons/qFlipper.png $out/share/icons
+    cp qFlipper-cli $out/bin
 
     mkdir -p $out/etc/udev/rules.d
     tee $out/etc/udev/rules.d/42-flipperzero.rules << EOF
     ${udev_rules}
     EOF
-
-    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Description of changes

qFlipper package bump, and related build fixes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
