### PR TITLE
yubioath-desktop: 5.0.5 -> 5.1.0

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -1,27 +1,38 @@
-{ lib, stdenv, fetchurl, mkDerivation
-, qmake, qtbase, qtquickcontrols2, qtgraphicaleffects
-, python3, pyotherside
-, pcsclite, yubikey-personalization
-, yubikey-manager, makeWrapper }:
+{ lib
+, stdenv
+, fetchurl
+, mkDerivation
+, qmake
+, qtbase
+, qtquickcontrols2
+, qtgraphicaleffects
+, qtmultimedia
+, python3
+, pyotherside
+, pcsclite
+, yubikey-personalization
+, yubikey-manager
+, makeWrapper
+}:
 
 mkDerivation rec {
   pname = "yubioath-desktop";
-  version = "5.0.5";
+  version = "5.1.0";
 
   src = fetchurl {
     url = "https://developers.yubico.com/yubioath-desktop/Releases/yubioath-desktop-${version}.tar.gz";
-    sha256 = "05xs6xh9pi50h0668arirj0gnz11adpixgsdkds072077gasdm0g";
+    hash = "sha256-Lm9F4eaG9T5brAV7XDAkoj0WClmXEYIhuUzh2rk0oc0=";
   };
 
   doCheck = false;
 
-  buildInputs = [ qtbase qtquickcontrols2 qtgraphicaleffects python3 ];
+  buildInputs = [ qtbase qtquickcontrols2 qtgraphicaleffects qtmultimedia python3 ];
 
   nativeBuildInputs = [ qmake makeWrapper python3.pkgs.wrapPython ];
 
   postPatch = ''
-    substituteInPlace deployment.pri \
-      --replace '/usr/bin' "$out/bin"
+    substituteInPlace QZXing/QZXing-components.pri \
+      --replace 'target.path = $$PREFIX/lib' 'target.path = $$PREFIX/bin'
   '';
 
   pythonPath = [ yubikey-manager ];


### PR DESCRIPTION
###### Description of changes

New version released with support for Yubikey Bio.

Tried to add version tests also, unfortunately seems it fails without display, even though it is supposed to just print the version.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
