### PR TITLE
openafs: Patch for Linux kernel 5.17

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -11,6 +11,7 @@
 , perl
 , libtool_2
 , libkrb5
+, fetchpatch
 }:
 
 with (import ./srcs.nix {
@@ -20,6 +21,10 @@ with (import ./srcs.nix {
 let
   modDestDir = "$out/lib/modules/${kernel.modDirVersion}/extra/openafs";
   kernelBuildDir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  fetchBase64Patch = args: (fetchpatch args).overrideAttrs (o: {
+    postFetch = "mv $out p; base64 -d p > $out; " + o.postFetch;
+  });
 
 in
 stdenv.mkDerivation {
@@ -31,6 +36,34 @@ stdenv.mkDerivation {
     ++ kernel.moduleBuildDependencies;
 
   buildInputs = [ libkrb5 ];
+
+  patches = [
+    # Add autoconf-archive to src/external
+    (fetchBase64Patch {
+      url = "https://gerrit.openafs.org/changes/14942/revisions/006616bd8e88b2d386a5ddc23973cf3e625cb80d/patch";
+      hash = "sha256-55sc2sKy5XkQHAv6ysVxi69+0xVsHnN2TS144UTeLHU=";
+    })
+    # Import of code from autoconf-archive
+    (fetchBase64Patch {
+      url = "https://gerrit.openafs.org/changes/14943/revisions/d3782b1d4e6fd81c5432e95112eb44305f07f272/patch";
+      hash = "sha256-ohkjSux+S3+6slh6uZIw5UJXlvhy9UUDpDlP0YFRwmw=";
+    })
+    # Use autoconf-archive m4 from src/external
+    (fetchBase64Patch {
+      url = "https://gerrit.openafs.org/changes/14944/revisions/ea2a0e128d71802f61b8da2e44de3c6325c5f328/patch";
+      hash = "sha256-PAUk/MXL5p8xwhn40/UGmo3UIhvl1PB2FwgqhmqsjJ4=";
+    })
+    # Linux-5.17: kernel func complete_and_exit renamed
+    (fetchBase64Patch {
+      url = "https://gerrit.openafs.org/changes/14945/revisions/a714e865efe41aa1112f6f9c8479112660dacd6f/patch";
+      hash = "sha256-zvyR/GOPJeAbG6ySRRMp44oT5tPujUwybyU0XR/5Xyc=";
+    })
+    # Linux-5.17: Kernel build uses -Wcast-function-type
+    (fetchBase64Patch {
+      url = "https://gerrit.openafs.org/changes/14946/revisions/449d1faf87e2841e80be38cf2b4a5cf5ff4df2d8/patch";
+      hash = "sha256-3bRTHYeMRIleLhob56m2Xt0dWzIMDo3QrytY0K1/q7c=";
+    })
+  ];
 
   hardeningDisable = [ "pic" ];
 
@@ -70,6 +103,6 @@ stdenv.mkDerivation {
     license = licenses.ipl10;
     platforms = platforms.linux;
     maintainers = with maintainers; [ maggesi spacefrogg ];
-    broken = kernel.kernelAtLeast "5.17" || kernel.isHardened;
+    broken = kernel.isHardened;
   };
 }


### PR DESCRIPTION
###### Description of changes

Cherry-pick [patches from upstream Gerrit](https://gerrit.openafs.org/#/q/project:openafs+branch:openafs-stable-1_8_x+topic:Linux-5.17) needed to build with Linux kernel 5.17.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
