### PR TITLE
elmPackages.elm-format: build using hspec-tasty 1.1.6, hspec-golden 0.1.0.3

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -80,6 +80,9 @@ let
       # We need attoparsec < 0.14 to build elm for now
       attoparsec = self.attoparsec_0_13_2_5;
 
+      # aeson 2.0.3.0 does not build with attoparsec_0_13_2_5
+      aeson = self.aeson_1_5_6_0;
+
       # Needed for elm-format
       indents = self.callPackage ./packages/indents.nix {};
       bimap = self.callPackage ./packages/bimap.nix {};

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -85,6 +85,15 @@ let
       bimap = self.callPackage ./packages/bimap.nix {};
       avh4-lib = doJailbreak (self.callPackage ./packages/avh4-lib.nix {});
       elm-format-lib = doJailbreak (self.callPackage ./packages/elm-format-lib.nix {});
+      # We need tasty-hspec < 1.1.7 and hspec-golden < 0.2 to build elm-format-lib
+      tasty-hspec = self.tasty-hspec_1_1_6;
+      hspec-golden = self.hspec-golden_0_1_0_3;
+
+      # We need hspec hspec_core, hspec_discover < 2.8 for tasty-hspec == 1.1.6
+      hspec = self.hspec_2_7_10;
+      hspec-core = self.hspec-core_2_7_10;
+      hspec-discover = self.hspec-discover_2_7_10;
+
       elm-format-test-lib = self.callPackage ./packages/elm-format-test-lib.nix {};
       elm-format-markdown = self.callPackage ./packages/elm-format-markdown.nix {};
     };

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -129,6 +129,11 @@ extra-packages:
   - relude == 0.7.0.0                   # 2022-02-25: Needed for ema 0.6
   - SVGFonts < 1.8                      # 2022-03-19: Needed for Chart-diagrams 1.9.3
   - clay < 0.14                         # 2022-03-20: Needed for neuron 1.0.0.0
+  - hspec-golden == 0.1.*               # 2022-04-07: Needed for elm-format
+  - tasty-hspec == 1.1.6                # 2022-04-07: Needed for elm-format
+  - hspec < 2.8                         # 2022-04-07: Needed for tasty-hspec 1.1.6
+  - hspec-core < 2.8                    # 2022-04-07: Needed for tasty-hspec 1.1.6
+  - hspec-discover < 2.8                # 2022-04-07: Needed for tasty-hspec 1.1.6
 
 package-maintainers:
   abbradar:


### PR DESCRIPTION
###### Description of changes

elm-format depends on elm-format-lib which failed to build with
hspec-tasty 1.1.7 and hspec-golden 0.2.0.0.

hspec-tasty 1.1.6 and hspec-golden 0.1.0.3 had been removed in
cd67b4fcbb81d07477746a138d6dbb9d01a81450.

hspec-tasty 1.1.6 in turn pulls in older dependencies for hspec,
hspec-core and hspec-discover.

Fixes #167533.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
