### PR TITLE
Update http3 libraries

### DIFF
--- a/pkgs/development/libraries/nghttp3/default.nix
+++ b/pkgs/development/libraries/nghttp3/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nghttp3";
-  version = "unstable-2021-12-22";
+  version = "unstable-2022-04-10";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
-    rev = "8d8184acf850b06b53157bba39022bc7b7b5f1cd";
-    sha256 = "sha256-pV1xdQa5RBz17jDINC2uN1Q+jpa2edDwqTqf8D5VU3E=";
+    rev = "1e4bef2cc45b1fd3971ca3606d08a1e1d1567b1a";
+    sha256 = "sha256-DHNxtu4X0S8l1ADwRJC3yQ+Z1ja3FT0Zb/boRh6PvYw=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config file ];

--- a/pkgs/development/libraries/ngtcp2/default.nix
+++ b/pkgs/development/libraries/ngtcp2/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ngtcp2";
-  version = "unstable-2021-12-19";
+  version = "unstable-2022-04-11";
 
   src = fetchFromGitHub {
     owner = "ngtcp2";
     repo = pname;
-    rev = "20c710a8789ec910455ae4e588c72e9e39f8cec9";
-    sha256 = "sha256-uBmD26EYT8zxmHD5FuHCbEuTdWxer/3uhRp8PhUT87M=";
+    rev = "825899c051ea2a1f06a0c4617f41782f37009a18";
+    sha256 = "sha256-VoSy0tyIXWNTmcVdsaiM9ijXLq41AOaPBajvsEIrfjo=";
   };
 
   nativeBuildInputs = [ autoreconfHook pkg-config file ];

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -9,20 +9,15 @@
 , withPerl ? stdenv.hostPlatform == stdenv.buildPlatform
 }:
 
-assert (
-  lib.assertMsg (!withPerl -> stdenv.hostPlatform != stdenv.buildPlatform)
-  "withPerl should not be disabled unless cross compiling"
-);
-
 stdenv.mkDerivation rec {
   pname = "quictls";
-  version = "3.0.1+quick_unstable-2021-12.14";
+  version = "3.0.2+quick_unstable-2022-03.15";
 
   src = fetchFromGitHub {
     owner = "quictls";
     repo = "openssl";
-    rev = "ab8b87bdb436b11bf2a10a2a57a897722224f828";
-    sha256 = "sha256-835oZgoM1CTS+JLxPO3oGSTnhLmJXGT1cFaJhCJK++8=";
+    rev = "7f2ab56a2b842b8e6fefc7b9d20eb5ff9c6ef151";
+    sha256 = "sha256-We4ow0mGJFXqYM4PqbGn8qY5IYH/MtNaefrSaJreoRA=";
   };
 
   patches = [


### PR DESCRIPTION
###### Description of changes
Update packages:
- 3.0.1+quick_unstable-2021-12.14 > 3.0.2+quick_unstable-2022-03.15
- nghttp3: unstable-2021-12-22 -> unstable-2022-04-03
- ngtcp2: unstable-2021-12-19 -> unstable-2022-04-06

cc @c0bw3b
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
