### PR TITLE
python3Packages.robomachine: fix by using pyparsing_2 

### DIFF
--- a/pkgs/development/python-modules/robomachine/default.nix
+++ b/pkgs/development/python-modules/robomachine/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonPackage, pyparsing, robotframework, allpairspy }:
+{ lib, fetchPypi, buildPythonPackage, pyparsing_2, robotframework, allpairspy }:
 
 buildPythonPackage rec {
   pname = "RoboMachine";
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     sha256 = "4251d405759a38f1e665acc245dcbcdec319376718169a73c57560183370fe0e";
   };
 
-  propagatedBuildInputs = [ pyparsing robotframework allpairspy ];
+  propagatedBuildInputs = [ pyparsing_2 robotframework allpairspy ];
 
   # Remove Windows .bat files
   postInstall = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7465,6 +7465,16 @@ in {
 
   pyparsing = callPackage ../development/python-modules/pyparsing { };
 
+  pyparsing_2 = self.pyparsing.overridePythonAttrs (old: rec {
+    version = "2.4.7";
+    src = pkgs.fetchFromGitHub {
+      owner = "pyparsing";
+      repo = "pyparsing";
+      rev = "pyparsing_${version}";
+      sha256 = "14pfy80q2flgzjcx8jkracvnxxnr59kjzp3kdm5nh232gk1v6g6h";
+    };
+  });
+
   pyparted = callPackage ../development/python-modules/pyparted { };
 
   pypass = callPackage ../development/python-modules/pypass { };


### PR DESCRIPTION
###### Description of changes
RoboMachine tests broke, this fixes it by using pyparsing_2 intead of default pyparsing (3.x).

Upstream issue: https://github.com/mkorpela/RoboMachine/issues/28

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
