### PR TITLE
[DO NOT MERGE] memtest86+: update to 6.0, build EFI executable

### DIFF
--- a/pkgs/tools/misc/memtest86+/default.nix
+++ b/pkgs/tools/misc/memtest86+/default.nix
@@ -1,25 +1,28 @@
-{ lib, stdenv, fetchgit }:
+{ lib, stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "memtest86+";
-  version = "5.01-coreboot-002";
+  # FIXME: wait for stable release
+  version = "6.00-beta2";
 
-  src = fetchgit {
-    url = "https://review.coreboot.org/memtest86plus.git";
-    rev = "v002";
-    sha256 = "0cwx20yja24bfknqh1rjb5rl2c0kwnppzsisg1dibbak0l8mxchk";
+  src = fetchFromGitHub {
+    owner = "memtest86plus";
+    repo = "memtest86plus";
+    rev = "v${version}";
+    sha256 = "sha256-U3++iJa0Zj3g2SZTJ0jom7raAu+LGqiOKZEputs/YfM=";
   };
 
-  NIX_CFLAGS_COMPILE = "-I. -std=gnu90";
-
-  hardeningDisable = [ "all" ];
-
-  buildFlags = [ "memtest.bin" ];
-
-  doCheck = false; # fails
+  buildPhase = let
+    bits = if stdenv.is32bit then "32"
+           else if stdenv.is64bit then "64"
+           else throw "unsupported system!";
+  in ''
+    cd build${bits}
+    make memtest.bin memtest.efi
+  '';
 
   installPhase = ''
-    install -Dm0444 -t $out/ memtest.bin
+    install -Dm0444 -t $out/ memtest.bin memtest.efi
   '';
 
   meta = {


### PR DESCRIPTION
###### Description of changes

There's now an alive memtest86 fork again, with real EFI support and some more goodies. There's no stable release _yet_, but the current git version builds and works, and there should be one soon(ish).

Do not merge until a stable release is actually out and this is updated to match.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] i686-linux
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).