### PR TITLE
octoprint: fix tomli build issue with black

### DIFF
--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -44,6 +44,9 @@ let
                 hash = "sha256-d7gPaTpWni5SeVhFljTxjfmwuiYluk4MLV2lvkLm8rM=";
               };
               doCheck = false;
+              postPatch = ''
+                substituteInPlace setup.py --replace "tomli>=0.2.6,<2.0.0" "tomli"
+                '';
             });
           }
         )
@@ -174,6 +177,8 @@ let
               };
               disabledTestPaths = [
                 "t/unit/backends/test_mongodb.py"
+                # needs cassandra
+                "t/unit/backends/test_cassandra.py"
               ];
             });
           }
@@ -235,6 +240,7 @@ let
               #pytestFlagsArray = [ "-W ignore::DeprecationWarning" ];
               disabledTestPaths = oldAttrs.disabledTestPaths ++ [
                 "tests/asgi/test_asgi_servers.py"
+                "tests/test_wsgi_servers.py"
               ];
             });
           }
@@ -249,6 +255,8 @@ let
                 "test_cookies.py"
                 # requires network
                 "test_worker.py"
+                # fails on aarch64
+                "test_server_events.py"
               ];
             });
           }


### PR DESCRIPTION
Octoprint currently fails to build, because:

- octoprint relies on black 21.12b0
- black21.12b0 relies in tomli <=2.0.0

Since the update to tomli 2.0.1, octoprint doesn't build anymore.

This relaxes the constrain in black (which was removed later on upstream anyway)

Signed-off-by: Florian Brandes <florian.brandes@posteo.de>

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
