### PR TITLE
cod: fix tests

### DIFF
--- a/pkgs/tools/misc/cod/default.nix
+++ b/pkgs/tools/misc/cod/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildGoModule }:
+{ lib, fetchFromGitHub, buildGoModule, python3 }:
 
 buildGoModule rec {
   pname = "cod";
@@ -15,7 +15,16 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" "-X main.GitSha=${src.rev}" ];
 
-  doCheck = false;
+  checkInputs = [ python3 ];
+
+  preCheck = ''
+    pushd test/binaries/
+    for f in *.py; do
+      patchShebangs ''$f
+    done
+    popd
+    export COD_TEST_BINARY="''${NIX_BUILD_TOP}/go/bin/cod"
+  '';
 
   meta = with lib; {
     description = "Tool for generating Bash/Fish/Zsh autocompletions based on `--help` output";


### PR DESCRIPTION
cod: fix tests

Co-authored-by: @jnetod @thiagokokada

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
/build/source/test/binaries /build/source
patching script interpreter paths in argparse-subcommand.py
argparse-subcommand.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
patching script interpreter paths in cat.py
cat.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
patching script interpreter paths in default-subcommand.py
default-subcommand.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
patching script interpreter paths in foo_v1.py
foo_v1.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
patching script interpreter paths in foo_v2.py
foo_v2.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
patching script interpreter paths in naval-fate.py
naval-fate.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/9px00aaqzb6n5p03i9wd8rx3msg95y9r-python3-3.9.11/bin/python3"
/build/source
=== RUN   TestCanonizeExecutablePath
--- PASS: TestCanonizeExecutablePath (0.00s)
=== RUN   TestIsCommandMatchingContext
--- PASS: TestIsCommandMatchingContext (0.00s)
=== RUN   TestNewSqliteStorage
--- PASS: TestNewSqliteStorage (0.00s)
=== RUN   TestCRUD
--- PASS: TestCRUD (0.00s)
=== RUN   TestAddSamePage
--- PASS: TestAddSamePage (0.00s)
=== RUN   TestListCommands
--- PASS: TestListCommands (0.00s)
PASS
ok  	github.com/dim-an/cod/datastore	0.005s
=== RUN   TestParseArgparse
--- PASS: TestParseArgparse (0.00s)
=== RUN   TestParseArgparseContext
--- PASS: TestParseArgparseContext (0.00s)
=== RUN   TestParseDocker
--- PASS: TestParseDocker (0.00s)
=== RUN   TestParseUsageSubCommand
--- PASS: TestParseUsageSubCommand (0.00s)
=== RUN   TestIsJavaStyleFlag
--- PASS: TestIsJavaStyleFlag (0.00s)
=== RUN   TestParseCatHelp
2022/04/07 14:55:15 Parser argparse failed with error cannot find usage
--- PASS: TestParseCatHelp (0.00s)
=== RUN   TestParseQuWriteFileHelp
--- PASS: TestParseQuWriteFileHelp (0.00s)
=== RUN   TestParseLsHelp
2022/04/07 14:55:15 Parser argparse failed with error cannot find usage
--- PASS: TestParseLsHelp (0.00s)
=== RUN   TestMultipleFlagOccurrences
2022/04/07 14:55:15 Parser argparse failed with error error parsing usage: cannot tokenize: <flags>
--- PASS: TestMultipleFlagOccurrences (0.00s)
=== RUN   TestJavaStyleInclusion
2022/04/07 14:55:15 Parser argparse failed with error error parsing usage: cannot tokenize: <flags>
--- PASS: TestJavaStyleInclusion (0.00s)
=== RUN   TestJavaStyle
2022/04/07 14:55:15 Parser argparse failed with error error parsing usage: cannot tokenize: <flags>
--- PASS: TestJavaStyle (0.00s)
=== RUN   TestOptionInVeryBeginningOfLine
2022/04/07 14:55:15 Parser argparse failed with error error parsing usage: cannot tokenize: <flags>
--- PASS: TestOptionInVeryBeginningOfLine (0.00s)
=== RUN   TestFindIndentedParagraph
--- PASS: TestFindIndentedParagraph (0.00s)
PASS
ok  	github.com/dim-an/cod/parse_doc	0.003s
=== RUN   TestQuote
--- PASS: TestQuote (0.00s)
=== RUN   TestBashRemoveCompletions
--- PASS: TestBashRemoveCompletions (0.00s)
=== RUN   TestTokenizeStrings
--- PASS: TestTokenizeStrings (0.00s)
PASS
ok  	github.com/dim-an/cod/shells	0.002s
=== RUN   TestExampleConfiguration
--- PASS: TestExampleConfiguration (0.03s)
=== RUN   TestLearn
--- PASS: TestLearn (0.02s)
=== RUN   TestLearnBroken
--- PASS: TestLearnBroken (0.01s)
=== RUN   TestLearnUpdateShorter
--- PASS: TestLearnUpdateShorter (0.04s)
=== RUN   TestLearnFromPATH
--- PASS: TestLearnFromPATH (0.02s)
=== RUN   TestMergeLearn
--- PASS: TestMergeLearn (0.06s)
=== RUN   TestLearnArgparseSubCommand
--- PASS: TestLearnArgparseSubCommand (0.09s)
=== RUN   TestLearnDefaultSubCommand
--- PASS: TestLearnDefaultSubCommand (0.06s)
=== RUN   TestLearnList
--- PASS: TestLearnList (0.04s)
=== RUN   TestLearnListRemove
--- PASS: TestLearnListRemove (0.05s)
=== RUN   TestLearnListBasenameSelector
--- PASS: TestLearnListBasenameSelector (0.04s)
=== RUN   TestLearnListPathSelector
--- PASS: TestLearnListPathSelector (0.04s)
=== RUN   TestLearnListIdSelector
--- PASS: TestLearnListIdSelector (0.04s)
=== RUN   TestPollUpdates
--- PASS: TestPollUpdates (0.02s)
=== RUN   TestDaemonSmoke
--- PASS: TestDaemonSmoke (0.00s)
=== RUN   TestAttachDetach
2022/04/07 14:55:16 killing shell: 10540
--- PASS: TestAttachDetach (0.31s)
=== RUN   TestUpdateReplace
--- PASS: TestUpdateReplace (0.04s)
=== RUN   TestUpdateMerge
--- PASS: TestUpdateMerge (0.07s)
=== RUN   TestUpdateNoChange
--- PASS: TestUpdateNoChange (0.04s)
=== RUN   TestUpdateBroken
--- PASS: TestUpdateBroken (0.03s)
PASS
ok  	github.com/dim-an/cod/test	1.051s
=== RUN   TestGlobExpression_Match
--- PASS: TestGlobExpression_Match (0.00s)
PASS
ok  	github.com/dim-an/cod/util	0.001s
```


###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
