### PR TITLE
gnome.gnome-nettool: 3.8.1 → 42.0

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-nettool/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-nettool/default.nix
@@ -1,28 +1,78 @@
-{ lib, stdenv, fetchurl, pkg-config, gnome, gtk3, wrapGAppsHook
-, libgtop, intltool, itstool, libxml2, nmap, inetutils }:
+{ stdenv
+, lib
+, fetchurl
+, fetchpatch
+, desktop-file-utils
+, itstool
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook
+, glib
+, gtk3
+, libgtop
+, dnsutils
+, iputils
+, nmap
+, inetutils
+, gnome
+}:
 
 stdenv.mkDerivation rec {
   pname = "gnome-nettool";
-  version = "3.8.1";
+  version = "42.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1c9cvzvyqgfwa5zzyvp7118pkclji62fkbb33g4y9sp5kw6m397h";
+    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    sha256 = "pU8p7vIDiu5pVRyLGcpPdY5eueIJCkvGtWM9/wGIdR8=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    gtk3 wrapGAppsHook libgtop intltool itstool libxml2
-    gnome.adwaita-icon-theme
+  patches = [
+    # Fix build with meson 0.61
+    # https://gitlab.gnome.org/GNOME/gnome-nettool/-/merge_requests/3
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/gnome-nettool/-/commit/1124c3e1fdb8472d30b7636500229aa16cdc1244.patch";
+      sha256 = "fbpfL8Xb1GsadpQzAdmu8FSPs++bsGCVdcwnzQWttGY=";
+    })
   ];
 
-  propagatedUserEnvPkgs = [ nmap inetutils ];
+  nativeBuildInputs = [
+    desktop-file-utils
+    itstool
+    meson
+    ninja
+    pkg-config
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libgtop
+  ];
+
+  postPatch = ''
+    chmod +x postinstall.py
+    patchShebangs postinstall.py
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [
+        dnsutils # for dig
+        iputils # for ping
+        nmap # for nmap
+        inetutils # for ping6, traceroute, whois
+      ]}"
+    )
+  '';
 
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;
       attrPath = "gnome.${pname}";
-      versionPolicy = "none";
     };
   };
 
@@ -30,7 +80,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/GNOME/gnome-nettool";
     description = "A collection of networking tools";
     maintainers = teams.gnome.members;
-    license = licenses.gpl2;
+    license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Description of changes

3.8.1 is released in 2013, and is added to Nixpkgs in https://github.com/NixOS/nixpkgs/commit/f11d41666626624adeaf9222ce5253a26c5b1f9a. I think I was not even a linux user when 3.8.1 is out.

https://gitlab.gnome.org/GNOME/gnome-nettool/-/compare/gnome-nettool-3-8-1...gnome-nettool-42-0

Actually I am not sure if this is still being developed... :crying_cat_face:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
