### PR TITLE
sparrow: init at 1.6.4

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -1,0 +1,232 @@
+{ stdenv
+, lib
+, makeWrapper
+, fetchurl
+, makeDesktopItem
+, copyDesktopItems
+, autoPatchelfHook
+, openjdk17
+, gtk3
+, gsettings-desktop-schemas
+, writeScript
+, bash
+, gnugrep
+, tor
+, zlib
+, openimajgrabber
+, hwi
+, imagemagick
+}:
+
+let
+  pname = "sparrow";
+  version = "1.6.4";
+
+  src = fetchurl {
+    url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "1wdibpbhv3g6qk42ddfc5vyqkkwprczy45w5wi115qg3g1rf1in7";
+  };
+
+  launcher = writeScript "sparrow" ''
+    #! ${bash}/bin/bash
+    params=(
+      --module-path @out@/lib:@jdkModules@/modules
+      --add-opens javafx.graphics/com.sun.javafx.css=org.controlsfx.controls
+      --add-opens javafx.graphics/javafx.scene=org.controlsfx.controls
+      --add-opens javafx.controls/com.sun.javafx.scene.control.behavior=org.controlsfx.controls
+      --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=org.controlsfx.controls
+      --add-opens javafx.graphics/com.sun.javafx.scene.traversal=org.controlsfx.controls
+      --add-opens javafx.base/com.sun.javafx.event=org.controlsfx.controls
+      --add-opens javafx.controls/javafx.scene.control.cell=com.sparrowwallet.sparrow
+      --add-opens org.controlsfx.controls/impl.org.controlsfx.skin=com.sparrowwallet.sparrow
+      --add-opens org.controlsfx.controls/impl.org.controlsfx.skin=javafx.fxml
+      --add-opens javafx.graphics/com.sun.javafx.tk=centerdevice.nsmenufx
+      --add-opens javafx.graphics/com.sun.javafx.tk.quantum=centerdevice.nsmenufx
+      --add-opens javafx.graphics/com.sun.glass.ui=centerdevice.nsmenufx
+      --add-opens javafx.controls/com.sun.javafx.scene.control=centerdevice.nsmenufx
+      --add-opens javafx.graphics/com.sun.javafx.menu=centerdevice.nsmenufx
+      --add-opens javafx.graphics/com.sun.glass.ui=com.sparrowwallet.sparrow
+      --add-opens javafx.graphics/com.sun.javafx.application=com.sparrowwallet.sparrow
+      --add-opens java.base/java.net=com.sparrowwallet.sparrow
+      --add-opens java.base/java.io=com.google.gson
+      --add-reads com.sparrowwallet.merged.module=java.desktop
+      --add-reads com.sparrowwallet.merged.module=java.sql
+      --add-reads com.sparrowwallet.merged.module=com.sparrowwallet.sparrow
+      --add-reads com.sparrowwallet.merged.module=logback.classic
+      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.databind
+      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.annotation
+      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.core
+      --add-reads com.sparrowwallet.merged.module=co.nstant.in.cbor
+      -m com.sparrowwallet.sparrow
+    )
+
+    XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS ${openjdk17}/bin/java ''${params[@]} $@
+  '';
+
+  torWrapper = writeScript "tor-wrapper" ''
+    #! ${bash}/bin/bash
+
+    exec ${tor}/bin/tor "$@"
+  '';
+
+  jdk-modules = stdenv.mkDerivation {
+    name = "jdk-modules";
+    nativeBuildInputs = [ openjdk17 ];
+    dontUnpack = true;
+
+    buildPhase = ''
+      # Extract the JDK's JIMAGE and generate a list of modules.
+      mkdir modules
+      pushd modules
+      jimage extract ${openjdk17}/lib/openjdk/lib/modules
+      ls | xargs -d " " -- echo > ../manifest.txt
+      popd
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp manifest.txt $out/
+      cp -r modules/ $out/
+    '';
+  };
+
+  sparrow-modules = stdenv.mkDerivation {
+    pname = "sparrow-modules";
+    inherit version src;
+    nativeBuildInputs = [ makeWrapper gnugrep openjdk17 autoPatchelfHook stdenv.cc.cc.lib zlib ];
+
+    buildPhase = ''
+      # Extract Sparrow's JIMAGE and generate a list of them.
+      mkdir modules
+      pushd modules
+      jimage extract ../lib/runtime/lib/modules
+
+      # Delete JDK modules
+      cat ${jdk-modules}/manifest.txt | xargs -I {} -- rm -fR {}
+
+      # Delete unneeded native libs.
+
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/freebsd-x86
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-aarch64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-arm
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-armel
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-mips64el
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-ppc64le
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-s390x
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/linux-x86
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/openbsd-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/openbsd-x86
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-sparc
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-sparcv9
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-x86-64
+      rm -fR com.sparrowwallet.merged.module/com/sun/jna/sunos-x86
+      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_armel
+      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_armhf
+      rm -fR com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_x86
+      rm com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_x64/OpenIMAJGrabber.so
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_arm32_armel
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_armel
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_armhf
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/linux_x86
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x64
+      rm -fR com.nativelibs4java.bridj/org/bridj/lib/sunos_x86
+      rm -fR com.sparrowwallet.merged.module/linux-aarch64
+      rm -fR com.sparrowwallet.merged.module/linux-arm
+      rm -fR com.sparrowwallet.merged.module/linux-x86
+      rm com.sparrowwallet.sparrow/native/linux/x64/hwi
+
+      ls | xargs -d " " -- echo > ../manifest.txt
+      find . | grep "\.so$" | xargs -- chmod ugo+x
+      popd
+
+      # Replace the embedded Tor binary (which is in a Tar archive)
+      # with one from Nixpkgs.
+      cp ${torWrapper} ./tor
+      tar -cJf tor.tar.xz tor
+      cp tor.tar.xz modules/netlayer.jpms/native/linux/x64/tor.tar.xz
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp manifest.txt $out/
+      cp -r modules/ $out/
+      ln -s ${openimajgrabber}/lib/OpenIMAJGrabber.so $out/modules/com.github.sarxos.webcam.capture/com/github/sarxos/webcam/ds/buildin/lib/linux_x64/OpenIMAJGrabber.so
+      ln -s ${hwi}/bin/hwi $out/modules/com.sparrowwallet.sparrow/native/linux/x64/hwi
+    '';
+  };
+
+  # To use the udev rules for connected hardware wallets,
+  # add "pkgs.sparrow" to "services.udev.packages" and add user accounts to the user group "plugdev".
+  udev-rules = stdenv.mkDerivation {
+    name = "sparrow-udev";
+
+    src = let version = "2.0.2"; in
+      fetchurl {
+        url = "https://github.com/bitcoin-core/HWI/releases/download/${version}/hwi-${version}.tar.gz";
+        sha256 = "sha256-di1fRsMbwpHcBFNTCVivfxpwhUoUKLA3YTnJxKq/jHM=";
+      };
+
+    installPhase = ''
+      mkdir -p $out/etc/udev/rules.d
+      cp -a hwilib/udev/* $out/etc/udev/rules.d
+      rm $out/etc/udev/rules.d/README.md
+    '';
+  };
+in
+stdenv.mkDerivation rec {
+  inherit pname version src;
+  nativeBuildInputs = [ makeWrapper copyDesktopItems ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Sparrow";
+      exec = pname;
+      icon = pname;
+      desktopName = "Sparrow Bitcoin Wallet";
+      genericName = "Bitcoin Wallet";
+      categories = [ "Finance" ];
+    })
+  ];
+
+  sparrow-icons = stdenv.mkDerivation {
+    inherit version src;
+    pname = "sparrow-icons";
+    nativeBuildInputs = [ imagemagick ];
+
+    installPhase = ''
+      for n in 16 24 32 48 64 96 128 256; do
+        size=$n"x"$n
+        mkdir -p $out/hicolor/$size/apps
+        convert lib/Sparrow.png -resize $size $out/hicolor/$size/apps/sparrow.png
+        done;
+    '';
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out
+    ln -s ${sparrow-modules}/modules $out/lib
+    install -D -m 777 ${launcher} $out/bin/sparrow
+    substituteAllInPlace $out/bin/sparrow
+    substituteInPlace $out/bin/sparrow --subst-var-by jdkModules ${jdk-modules}
+
+    mkdir -p $out/share/icons
+    ln -s ${sparrow-icons}/hicolor $out/share/icons
+
+    mkdir -p $out/etc/udev
+    ln -s ${udev-rules}/etc/udev/rules.d $out/etc/udev/rules.d
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A modern desktop Bitcoin wallet application supporting most hardware wallets and built on common standards such as PSBT, with an emphasis on transparency and usability.";
+    homepage = "https://sparrowwallet.com";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ emmanuelrosa _1000101 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/blockchains/sparrow/openimajgrabber.nix
+++ b/pkgs/applications/blockchains/sparrow/openimajgrabber.nix
@@ -1,0 +1,40 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, libv4l
+}:
+stdenv.mkDerivation rec {
+  pname = "openimajgrabber";
+  version = "1.3.10";
+
+  src = fetchFromGitHub {
+    owner = "openimaj";
+    repo = "openimaj";
+    rev = "openimaj-${version}";
+    sha256 = "sha256-Y8707ovE7f6Fk3cJ+PtwvzNpopgH5vlF55m2Xm4hjYM=";
+  };
+
+  buildInputs = [ libv4l ];
+
+  # These build instructions come from build.sh
+  buildPhase = ''
+    pushd hardware/core-video-capture/src-native/linux
+    g++ -fPIC -g -c OpenIMAJGrabber.cpp
+    g++ -fPIC -g -c capture.cpp
+    g++ -shared -Wl,-soname,OpenIMAJGrabber.so -o OpenIMAJGrabber.so OpenIMAJGrabber.o capture.o -lv4l2 -lrt -lv4lconvert
+    popd
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp hardware/core-video-capture/src-native/linux/OpenIMAJGrabber.so $out/lib
+  '';
+
+  meta = with lib; {
+    description = "A collection of libraries and tools for multimedia (images, text, video, audio, etc.) content analysis and content generation. This package only builds the OpenIMAJGrabber for Linux.";
+    homepage = "http://www.openimaj.org";
+    license = licenses.bsd0;
+    maintainers = with maintainers; [ emmanuelrosa _1000101 ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10454,6 +10454,10 @@ with pkgs;
 
   sozu = callPackage ../servers/sozu { };
 
+  sparrow = callPackage ../applications/blockchains/sparrow {
+    openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix {};
+  };
+
   sparsehash = callPackage ../development/libraries/sparsehash { };
 
   spectre-meltdown-checker = callPackage ../tools/security/spectre-meltdown-checker { };


### PR DESCRIPTION
###### Description of changes

This change adds a package for Sparrow, a Bitcoin wallet.

I've had this package in a Nix Flake for about 4 months, and the application has been working. There were two remaining issues which were recently fixed:

 - QR code scanning did not work. `patchelf` didn't work with OpenIMAJWrapper.so, so I now compile only that library.
 - Tor connectivity using the built-in Tor. However, keep in mind that Sparrow hard-codes the Tor proxy port 9050. So if you have a Tor proxy already running on that port, the you'll need to use that proxy instead of using the built-in Tor.

This change also includes (generic) helper functions to generate desktop icons; Java applications don't usually install icons. They work similar to makeDesktopItem, and make a good companion. Let me know if these functions would be useful for other packages, so that I know to submit a future PR to make them available. In fact, I'd like to update my Bisq package to use them.

Note that with certain window managers, such as bspwm, there are issues when clicking on the menu items. This is a JDK/JFX issue. See https://github.com/sparrowwallet/sparrow/issues/170

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
