### PR TITLE
getoptions: init at 3.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7758,6 +7758,12 @@
     githubId = 1711539;
     name = "matklad";
   };
+  matrss = {
+    name = "Matthias Riße";
+    email = "matthias.risze@t-online.de";
+    github = "matrss";
+    githubId = 9308656;
+  };
   matt-snider = {
     email = "matt.snider@protonmail.com";
     github = "matt-snider";

--- a/pkgs/tools/misc/getoptions/default.nix
+++ b/pkgs/tools/misc/getoptions/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, fetchFromGitHub, shellcheck, shellspec, busybox-sandbox-shell, ksh, mksh, yash, zsh }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "getoptions";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ko1nksm";
+    repo = "getoptions";
+    rev = "v${version}";
+    hash = "sha256-kUQ0dPjPr/A/btgFQu13ZLklnI284Ij74hCYbGgzF3A=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  doCheck = true;
+
+  checkInputs = [ shellcheck shellspec busybox-sandbox-shell ksh mksh yash zsh ];
+
+  preCheck = ''
+    sed -i '/shellspec -s posh/d' Makefile
+  '';
+
+  checkTarget = "check testall";
+
+  meta = with lib; {
+    description = "An elegant option/argument parser for shell scripts (full support for bash and all POSIX shells)";
+    homepage = "https://github.com/ko1nksm/getoptions";
+    license = licenses.cc0;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ matrss ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5818,6 +5818,8 @@ with pkgs;
 
   getopt = callPackage ../tools/misc/getopt { };
 
+  getoptions = callPackage ../tools/misc/getoptions { };
+
   gexiv2 = callPackage ../development/libraries/gexiv2 { };
 
   gftp = callPackage ../applications/networking/ftp/gftp {


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`getoptions` is "An elegant option parser for shell scripts".

upstream: https://github.com/ko1nksm/getoptions

Notes:
- I had to disable one test, because `posh` does not seem to be packaged in nixpkgs
- I am not sure if `platforms.all` is the best choice here


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
