### PR TITLE
 python3Packages.cattrs: 1.10.0 -> 22.1.0 

### DIFF
--- a/pkgs/development/python-modules/cattrs/default.nix
+++ b/pkgs/development/python-modules/cattrs/default.nix
@@ -1,11 +1,13 @@
 { lib
 , attrs
 , buildPythonPackage
+, exceptiongroup
 , fetchFromGitHub
 , hypothesis
 , immutables
 , motor
 , msgpack
+, orjson
 , poetry-core
 , pytest-xdist
 , pytestCheckHook
@@ -18,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "cattrs";
-  version = "1.10.0";
+  version = "22.1.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -27,7 +29,7 @@ buildPythonPackage rec {
     owner = "python-attrs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-VbfQMMDO03eeUHAACxoX6a3DKmzoF9EfLuTpvaY6bWs=";
+    hash = "sha256-C8uIsewpgJfB1yYckWTwF5K32+2AAOrxFKB9I18RENg=";
   };
 
   nativeBuildInputs = [
@@ -38,6 +40,8 @@ buildPythonPackage rec {
     attrs
   ] ++ lib.optionals (pythonOlder "3.7") [
     typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    exceptiongroup
   ];
 
   checkInputs = [
@@ -45,6 +49,7 @@ buildPythonPackage rec {
     immutables
     motor
     msgpack
+    orjson
     pytest-xdist
     pytestCheckHook
     pyyaml
@@ -55,12 +60,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "-l --benchmark-sort=fullname --benchmark-warmup=true --benchmark-warmup-iterations=5  --benchmark-group-by=fullname" "" \
-      --replace 'orjson = "^3.5.2"' "" \
-      --replace "[tool.poetry.group.dev.dependencies]" "[tool.poetry.dev-dependencies]"
-    substituteInPlace tests/test_preconf.py \
-      --replace "from orjson import dumps as orjson_dumps" "" \
-      --replace "from orjson import loads as orjson_loads" ""
+      --replace "-l --benchmark-sort=fullname --benchmark-warmup=true --benchmark-warmup-iterations=5  --benchmark-group-by=fullname" ""
   '';
 
   preCheck = ''
@@ -76,8 +76,6 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # orjson is not available as it requires Rust nightly features to compile its requirements
-    "test_orjson"
     # tomlkit is pinned to an older version and newer versions raise InvalidControlChar exception
     "test_tomlkit"
   ];

--- a/pkgs/development/python-modules/pyclipper/default.nix
+++ b/pkgs/development/python-modules/pyclipper/default.nix
@@ -1,34 +1,45 @@
 { lib
-, fetchPypi
+, fetchFromGitHub
 , buildPythonPackage
 , setuptools-scm
 , cython
 , pytestCheckHook
-, unittest2
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "pyclipper";
-  version = "1.3.0";
+  version = "1.3.0.post2";
+  format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "zip";
-    sha256 = "48a1b5c585aea10e5b9c0b82d6abe2642fafd9ef158b9921852bc4af815ca20c";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "fonttools";
+    repo = pname;
+    rev = version;
+    hash = "sha256-AFdfzM1zdhmfh3Uu5fFVOMWStbuHxKS3FovZPTeuNFA=";
   };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   nativeBuildInputs = [
     setuptools-scm
     cython
   ];
 
-  checkInputs = [ pytestCheckHook unittest2 ];
-  pythonImportsCheck = [ "pyclipper" ];
+  checkInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyclipper"
+  ];
 
   meta = with lib; {
     description = "Cython wrapper for clipper library";
-    homepage    = "https://github.com/fonttools/pyclipper";
-    license     = licenses.mit;
+    homepage = "https://github.com/fonttools/pyclipper";
+    license = licenses.mit;
     maintainers = with maintainers; [ matthuszagh ];
   };
 }

--- a/pkgs/development/python-modules/statmake/default.nix
+++ b/pkgs/development/python-modules/statmake/default.nix
@@ -1,12 +1,14 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, poetry-core
 , attrs
+, buildPythonPackage
 , cattrs
+, fetchFromGitHub
 , fonttools
 , fs
+, importlib-metadata
+, poetry-core
 , pytestCheckHook
+, pythonOlder
 , ufo2ft
 , ufoLib2
 }:
@@ -14,14 +16,15 @@
 buildPythonPackage rec {
   pname = "statmake";
   version = "0.4.1";
-
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "daltonmaag";
-    repo = "statmake";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "OXhoQAD4LEh80iRUZE2z8sCtWJDv/bSo0bwHbOOPVE0=";
+    sha256 = "sha256-OXhoQAD4LEh80iRUZE2z8sCtWJDv/bSo0bwHbOOPVE0=";
   };
 
   nativeBuildInputs = [
@@ -34,6 +37,8 @@ buildPythonPackage rec {
     fonttools
     # required by fonttools[ufo]
     fs
+  ] ++ lib.optionals (pythonOlder "3.8") [
+    importlib-metadata
   ];
 
   checkInputs = [
@@ -46,8 +51,20 @@ buildPythonPackage rec {
     # https://github.com/daltonmaag/statmake/pull/41
     substituteInPlace pyproject.toml \
       --replace 'requires = ["poetry>=1.0.0"]' 'requires = ["poetry-core"]' \
-      --replace 'build-backend = "poetry.masonry.api"' 'build-backend = "poetry.core.masonry.api"'
+      --replace 'build-backend = "poetry.masonry.api"' 'build-backend = "poetry.core.masonry.api"' \
+      --replace 'cattrs = "^1.1"' 'cattrs = ">= 1.1"'
   '';
+
+  disabledTests = [
+    # cattrs.errors.IterableValidationError: While structuring typing.List[statmake.classes.Axis]
+    # https://github.com/daltonmaag/statmake/issues/42
+    "test_load_stylespace_broken_range"
+    "test_load_stylespace_broken_multilingual_no_en"
+  ];
+
+  pythonImportsCheck = [
+    "statmake"
+  ];
 
   meta = with lib; {
     description = "Applies STAT information from a Stylespace to a variable font";


### PR DESCRIPTION
###### Description of changes
https://github.com/python-attrs/cattrs/blob/main/HISTORY.rst#2210-2022-04-03
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
