### PR TITLE
cdo: 1.9.10 -> 2.0.5 and add eccodes dependency for GRIB files

### DIFF
--- a/pkgs/development/libraries/cdo/default.nix
+++ b/pkgs/development/libraries/cdo/default.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "cdo";
-  version = "1.9.10";
+  version = "2.0.5";
 
   # Dependencies
   buildInputs = [ curl netcdf hdf5 ];
 
   src = fetchurl {
-    url = "https://code.mpimet.mpg.de/attachments/download/24638/${pname}-${version}.tar.gz";
-    sha256 = "sha256-zDnIm7tIHXs5RaBsVqhJIEcjX0asNjxPDZgPzN3mZ34=";
+    url = "https://code.mpimet.mpg.de/attachments/download/26823/${pname}-${version}.tar.gz";
+    sha256 = "sha256-7e678cOxofDGQtrmvIx2JODFS6vkYQZNxcfaykpbDc4=";
   };
 
  # Configure phase

--- a/pkgs/development/libraries/cdo/default.nix
+++ b/pkgs/development/libraries/cdo/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, curl, hdf5, netcdf
+{ lib, stdenv, fetchurl, curl, hdf5, netcdf, eccodes
 , # build, install and link to a CDI library [default=no]
   enable_cdi_lib ? false
 , # build a completely statically linked CDO binary
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
  # Configure phase
  configureFlags = [
-   "--with-netcdf=${netcdf}" "--with-hdf5=${hdf5}"]
+   "--with-netcdf=${netcdf}" "--with-hdf5=${hdf5}" "--with-eccodes=${eccodes}" ]
    ++ lib.optional (enable_cdi_lib) "--enable-cdi-lib"
    ++ lib.optional (enable_all_static) "--enable-all-static"
    ++ lib.optional (enable_cxx) "--enable-cxx";

--- a/pkgs/development/libraries/cdo/default.nix
+++ b/pkgs/development/libraries/cdo/default.nix
@@ -19,12 +19,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7e678cOxofDGQtrmvIx2JODFS6vkYQZNxcfaykpbDc4=";
   };
 
- # Configure phase
  configureFlags = [
-   "--with-netcdf=${netcdf}" "--with-hdf5=${hdf5}" "--with-eccodes=${eccodes}" ]
-   ++ lib.optional (enable_cdi_lib) "--enable-cdi-lib"
-   ++ lib.optional (enable_all_static) "--enable-all-static"
-   ++ lib.optional (enable_cxx) "--enable-cxx";
+    "--with-netcdf=${netcdf}"
+    "--with-hdf5=${hdf5}"
+    "--with-eccodes=${eccodes}"
+  ]
+   ++ lib.optional enable_cdi_lib "--enable-cdi-lib"
+   ++ lib.optional enable_all_static "--enable-all-static"
+   ++ lib.optional enable_cxx "--enable-cxx";
 
   meta = with lib; {
     description = "Collection of command line Operators to manipulate and analyse Climate and NWP model Data";


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Latest changelog: https://code.mpimet.mpg.de/news/521

Some versions are skipped, more changelogs can be found here: https://code.mpimet.mpg.de/projects/cdo/news

The second commit adds eccodes as a dependency because it is needed for GRIB files.
This makes the package comply with its longDescription, which explicitly mentions GRIB 1/2.
I am not sure if this should be a separate PR, but it is such a small change that I decided against that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
