### PR TITLE
stellar-core: 17.0.0 -> 18.5.0

### DIFF
--- a/pkgs/applications/blockchains/stellar-core/default.nix
+++ b/pkgs/applications/blockchains/stellar-core/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "stellar-core";
-  version = "17.0.0";
+  version = "18.5.0";
 
   src = fetchFromGitHub {
     owner = "stellar";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1ngl8yjqb8xzhdwzlxzzxf14q2hgwy2ysb17sn5380rrn0jswin1";
+    sha256 = "sha256-wEi22R4zb8d5CJV5eWb776Yob8B6Ok4FrbYI0SGM0H8=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/blockchains/stellar-core/default.nix
+++ b/pkgs/applications/blockchains/stellar-core/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoconf, libtool, automake, pkg-config, git
-, bison, flex, postgresql, ripgrep }:
+, bison, flex, postgresql, ripgrep, libunwind }:
 
 stdenv.mkDerivation rec {
   pname = "stellar-core";
@@ -13,9 +13,11 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ automake autoconf git libtool pkg-config ripgrep ];
+  nativeBuildInputs = [ automake autoconf git libtool pkg-config ripgrep libunwind ];
 
   propagatedBuildInputs = [ bison flex postgresql ];
+
+  enableParallelBuilding = true;
 
   preConfigure = ''
     # Due to https://github.com/NixOS/nixpkgs/issues/8567 we cannot rely on

--- a/pkgs/applications/blockchains/stellar-core/default.nix
+++ b/pkgs/applications/blockchains/stellar-core/default.nix
@@ -13,7 +13,9 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ automake autoconf git libtool pkg-config ripgrep libunwind ];
+  nativeBuildInputs = [ automake autoconf git libtool pkg-config ripgrep ];
+
+  buildInputs = [ libunwind ];
 
   propagatedBuildInputs = [ bison flex postgresql ];
 


### PR DESCRIPTION
###### Description of changes

Update stellar-core to latest version (see https://github.com/stellar/stellar-core/releases/tag/v18.5.0).
Made as a replacement of https://github.com/NixOS/nixpkgs/pull/159781 due to that version being both unable to build with glibc >= 2.34 and it no longer being the latest version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
