### PR TITLE
nfpm: enable tests

### DIFF
--- a/pkgs/tools/package-management/nfpm/default.nix
+++ b/pkgs/tools/package-management/nfpm/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-guJgLjmB29sOLIzs2+gKNp0WTWC3zS9Sb5DD5IistKY=";
 
-  doCheck = false;
-
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   meta = with lib; {


### PR DESCRIPTION
* nfpm: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestRegister
--- PASS: TestRegister (0.00s)
=== RUN   TestGet
--- PASS: TestGet (0.00s)
=== RUN   TestDefaultsVersion
--- PASS: TestDefaultsVersion (0.00s)
=== RUN   TestDefaults
--- PASS: TestDefaults (0.00s)
=== RUN   TestValidate
=== RUN   TestValidate/dirs
DEPRECATION WARNING: 'empty_folders' is deprecated and will be removed in a future version, create content with type 'dir' and directory name as 'dst' instead
=== RUN   TestValidate/config
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/dirs (0.00s)
    --- PASS: TestValidate/config (0.00s)
=== RUN   TestValidateError
=== RUN   TestValidateError/package_name_must_be_provided
=== RUN   TestValidateError/package_arch_must_be_provided
=== RUN   TestValidateError/package_version_must_be_provided
--- PASS: TestValidateError (0.00s)
    --- PASS: TestValidateError/package_name_must_be_provided (0.00s)
    --- PASS: TestValidateError/package_arch_must_be_provided (0.00s)
    --- PASS: TestValidateError/package_version_must_be_provided (0.00s)
=== RUN   TestParseFile
--- PASS: TestParseFile (0.00s)
=== RUN   TestParseEnhancedFile
--- PASS: TestParseEnhancedFile (0.00s)
=== RUN   TestParseEnhancedNestedGlobFile
--- PASS: TestParseEnhancedNestedGlobFile (0.00s)
=== RUN   TestParseEnhancedNestedNoGlob
--- PASS: TestParseEnhancedNestedNoGlob (0.00s)
=== RUN   TestOptionsFromEnvironment
=== RUN   TestOptionsFromEnvironment/version
=== RUN   TestOptionsFromEnvironment/release
=== RUN   TestOptionsFromEnvironment/maintainer
=== RUN   TestOptionsFromEnvironment/vendor
=== RUN   TestOptionsFromEnvironment/global_passphrase
=== RUN   TestOptionsFromEnvironment/specific_passphrases
=== RUN   TestOptionsFromEnvironment/packager
=== RUN   TestOptionsFromEnvironment/depends
--- PASS: TestOptionsFromEnvironment (0.00s)
    --- PASS: TestOptionsFromEnvironment/version (0.00s)
    --- PASS: TestOptionsFromEnvironment/release (0.00s)
    --- PASS: TestOptionsFromEnvironment/maintainer (0.00s)
    --- PASS: TestOptionsFromEnvironment/vendor (0.00s)
    --- PASS: TestOptionsFromEnvironment/global_passphrase (0.00s)
    --- PASS: TestOptionsFromEnvironment/specific_passphrases (0.00s)
    --- PASS: TestOptionsFromEnvironment/packager (0.00s)
    --- PASS: TestOptionsFromEnvironment/depends (0.00s)
=== RUN   TestOverrides
=== RUN   TestOverrides/apk
=== RUN   TestOverrides/deb
=== RUN   TestOverrides/rpm
=== RUN   TestOverrides/no_overrides
--- PASS: TestOverrides (0.00s)
    --- PASS: TestOverrides/apk (0.00s)
    --- PASS: TestOverrides/deb (0.00s)
    --- PASS: TestOverrides/rpm (0.00s)
    --- PASS: TestOverrides/no_overrides (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2	0.004s
=== RUN   TestCreateBuilderData
--- PASS: TestCreateBuilderData (0.00s)
=== RUN   TestCombineToApk
--- PASS: TestCombineToApk (0.00s)
=== RUN   TestPathsToCreate
=== RUN   TestPathsToCreate/pathToTest:_'/usr/share/doc/whatever/foo.md'
=== RUN   TestPathsToCreate/pathToTest:_'/var/moises'
=== RUN   TestPathsToCreate/pathToTest:_'/'
--- PASS: TestPathsToCreate (0.00s)
    --- PASS: TestPathsToCreate/pathToTest:_'/usr/share/doc/whatever/foo.md' (0.00s)
    --- PASS: TestPathsToCreate/pathToTest:_'/var/moises' (0.00s)
    --- PASS: TestPathsToCreate/pathToTest:_'/' (0.00s)
=== RUN   TestDefaultWithArch
=== RUN   TestDefaultWithArch/386
=== RUN   TestDefaultWithArch/amd64
--- PASS: TestDefaultWithArch (0.00s)
    --- PASS: TestDefaultWithArch/386 (0.00s)
    --- PASS: TestDefaultWithArch/amd64 (0.00s)
=== RUN   TestNoInfo
--- PASS: TestNoInfo (0.00s)
=== RUN   TestFileDoesNotExist
--- PASS: TestFileDoesNotExist (0.00s)
=== RUN   TestNoFiles
--- PASS: TestNoFiles (0.00s)
=== RUN   TestCreateBuilderControl
--- PASS: TestCreateBuilderControl (0.00s)
=== RUN   TestCreateBuilderControlScripts
--- PASS: TestCreateBuilderControlScripts (0.00s)
=== RUN   TestControl
--- PASS: TestControl (0.00s)
=== RUN   TestSignature
--- PASS: TestSignature (0.01s)
=== RUN   TestSignatureError
--- PASS: TestSignatureError (0.00s)
=== RUN   TestDisableGlobbing
--- PASS: TestDisableGlobbing (0.00s)
=== RUN   TestAPKConventionalFileName
--- PASS: TestAPKConventionalFileName (0.00s)
=== RUN   TestPackageSymlinks
--- PASS: TestPackageSymlinks (0.00s)
=== RUN   TestDirectories
--- PASS: TestDirectories (0.00s)
=== RUN   TestNoDuplicateAutocreatedDirectories
--- PASS: TestNoDuplicateAutocreatedDirectories (0.00s)
=== RUN   TestNoDuplicateDirectories
--- PASS: TestNoDuplicateDirectories (0.00s)
=== RUN   TestNoDuplicateContents
--- PASS: TestNoDuplicateContents (0.00s)
=== RUN   TestArches
=== RUN   TestArches/arm7
=== RUN   TestArches/arm64
=== RUN   TestArches/ppc64le
=== RUN   TestArches/s390
=== RUN   TestArches/386
=== RUN   TestArches/amd64
=== RUN   TestArches/arm6
=== RUN   TestArches/override
--- PASS: TestArches (0.00s)
    --- PASS: TestArches/arm7 (0.00s)
    --- PASS: TestArches/arm64 (0.00s)
    --- PASS: TestArches/ppc64le (0.00s)
    --- PASS: TestArches/s390 (0.00s)
    --- PASS: TestArches/386 (0.00s)
    --- PASS: TestArches/amd64 (0.00s)
    --- PASS: TestArches/arm6 (0.00s)
    --- PASS: TestArches/override (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/apk	0.018s
=== RUN   TestDeb
=== RUN   TestDeb/386
=== RUN   TestDeb/amd64
--- PASS: TestDeb (0.00s)
    --- PASS: TestDeb/386 (0.00s)
    --- PASS: TestDeb/amd64 (0.00s)
=== RUN   TestDebVersionWithDash
--- PASS: TestDebVersionWithDash (0.00s)
=== RUN   TestDebVersion
--- PASS: TestDebVersion (0.00s)
=== RUN   TestDebVersionWithRelease
--- PASS: TestDebVersionWithRelease (0.00s)
=== RUN   TestDebVersionWithPrerelease
--- PASS: TestDebVersionWithPrerelease (0.00s)
=== RUN   TestDebVersionWithReleaseAndPrerelease
--- PASS: TestDebVersionWithReleaseAndPrerelease (0.00s)
=== RUN   TestDebVersionWithVersionMetadata
--- PASS: TestDebVersionWithVersionMetadata (0.00s)
=== RUN   TestControl
--- PASS: TestControl (0.00s)
=== RUN   TestSpecialFiles
--- PASS: TestSpecialFiles (0.00s)
=== RUN   TestNoJoinsControl
--- PASS: TestNoJoinsControl (0.00s)
=== RUN   TestDebFileDoesNotExist
--- PASS: TestDebFileDoesNotExist (0.00s)
=== RUN   TestDebNoFiles
--- PASS: TestDebNoFiles (0.00s)
=== RUN   TestDebNoInfo
--- PASS: TestDebNoInfo (0.00s)
=== RUN   TestConffiles
--- PASS: TestConffiles (0.00s)
=== RUN   TestPathsToCreate
=== RUN   TestPathsToCreate/path:_'/usr/share/doc/whatever/foo.md'
=== RUN   TestPathsToCreate/path:_'/var/moises'
=== RUN   TestPathsToCreate/path:_'/'
--- PASS: TestPathsToCreate (0.00s)
    --- PASS: TestPathsToCreate/path:_'/usr/share/doc/whatever/foo.md' (0.00s)
    --- PASS: TestPathsToCreate/path:_'/var/moises' (0.00s)
    --- PASS: TestPathsToCreate/path:_'/' (0.00s)
=== RUN   TestMinimalFields
--- PASS: TestMinimalFields (0.00s)
=== RUN   TestDebEpoch
--- PASS: TestDebEpoch (0.00s)
=== RUN   TestDebRules
--- PASS: TestDebRules (0.00s)
=== RUN   TestMultilineFields
--- PASS: TestMultilineFields (0.00s)
=== RUN   TestDEBConventionalFileName
--- PASS: TestDEBConventionalFileName (0.00s)
=== RUN   TestDebChangelogControl
--- PASS: TestDebChangelogControl (0.00s)
=== RUN   TestDebNoChangelogControlWithoutChangelogConfigured
--- PASS: TestDebNoChangelogControlWithoutChangelogConfigured (0.00s)
=== RUN   TestDebChangelogData
--- PASS: TestDebChangelogData (0.00s)
=== RUN   TestDebNoChangelogDataWithoutChangelogConfigured
--- PASS: TestDebNoChangelogDataWithoutChangelogConfigured (0.00s)
=== RUN   TestDebTriggers
--- PASS: TestDebTriggers (0.00s)
=== RUN   TestDebNoTriggersInControlIfNoneProvided
--- PASS: TestDebNoTriggersInControlIfNoneProvided (0.00s)
=== RUN   TestSymlink
--- PASS: TestSymlink (0.00s)
=== RUN   TestEnsureRelativePrefixInTarballs
--- PASS: TestEnsureRelativePrefixInTarballs (0.00s)
=== RUN   TestMD5Sums
--- PASS: TestMD5Sums (0.00s)
=== RUN   TestDirectories
--- PASS: TestDirectories (0.00s)
=== RUN   TestNoDuplicateContents
--- PASS: TestNoDuplicateContents (0.00s)
=== RUN   TestDebsigsSignature
--- PASS: TestDebsigsSignature (0.09s)
=== RUN   TestDebsigsSignatureError
--- PASS: TestDebsigsSignatureError (0.00s)
=== RUN   TestDisableGlobbing
--- PASS: TestDisableGlobbing (0.00s)
=== RUN   TestNoDuplicateAutocreatedDirectories
--- PASS: TestNoDuplicateAutocreatedDirectories (0.00s)
=== RUN   TestNoDuplicateDirectories
--- PASS: TestNoDuplicateDirectories (0.00s)
=== RUN   TestCompressionAlgorithms
=== RUN   TestCompressionAlgorithms/gzip
=== RUN   TestCompressionAlgorithms/#00
=== RUN   TestCompressionAlgorithms/xz
=== RUN   TestCompressionAlgorithms/none
--- PASS: TestCompressionAlgorithms (0.01s)
    --- PASS: TestCompressionAlgorithms/gzip (0.00s)
    --- PASS: TestCompressionAlgorithms/#00 (0.00s)
    --- PASS: TestCompressionAlgorithms/xz (0.00s)
    --- PASS: TestCompressionAlgorithms/none (0.00s)
=== RUN   TestEmptyButRequiredDebFields
DEPRECATION WARNING: Leaving the 'maintainer' field unset will not be allowed in a future version
--- PASS: TestEmptyButRequiredDebFields (0.00s)
=== RUN   TestArches
=== RUN   TestArches/arm5
=== RUN   TestArches/arm6
=== RUN   TestArches/arm7
=== RUN   TestArches/mipsle
=== RUN   TestArches/mips64le
=== RUN   TestArches/ppc64le
=== RUN   TestArches/s390
=== RUN   TestArches/386
=== RUN   TestArches/override
--- PASS: TestArches (0.00s)
    --- PASS: TestArches/arm5 (0.00s)
    --- PASS: TestArches/arm6 (0.00s)
    --- PASS: TestArches/arm7 (0.00s)
    --- PASS: TestArches/mipsle (0.00s)
    --- PASS: TestArches/mips64le (0.00s)
    --- PASS: TestArches/ppc64le (0.00s)
    --- PASS: TestArches/s390 (0.00s)
    --- PASS: TestArches/386 (0.00s)
    --- PASS: TestArches/override (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/deb	0.132s
=== RUN   TestNotice
DEPRECATION WARNING: before--- PASS: TestNotice (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/deprecation	0.002s
=== RUN   TestBasicDecode
    files_test.go:39: &files.Content{Source:"a", Destination:"b", Type:"", Packager:"", FileInfo:(*files.ContentFileInfo)(nil)}
    files_test.go:39: &files.Content{Source:"a", Destination:"b", Type:"config|noreplace", Packager:"rpm", FileInfo:(*files.ContentFileInfo)(0xc000012500)}
--- PASS: TestBasicDecode (0.00s)
=== RUN   TestDeepPathsWithGlob
--- PASS: TestDeepPathsWithGlob (0.00s)
=== RUN   TestDeepPathsWithoutGlob
--- PASS: TestDeepPathsWithoutGlob (0.00s)
=== RUN   TestFileInfoDefault
--- PASS: TestFileInfoDefault (0.00s)
=== RUN   TestFileInfo
--- PASS: TestFileInfo (0.00s)
=== RUN   TestSymlinksInDirectory
--- PASS: TestSymlinksInDirectory (0.00s)
=== RUN   TestRace
--- PASS: TestRace (0.00s)
=== RUN   TestCollision
=== RUN   TestCollision/collision_between_files_for_all_packagers
=== RUN   TestCollision/no_collision_due_to_different_per-file_packagers
=== RUN   TestCollision/collision_between_file_for_all_packagers_and_file_for_specific_packager
--- PASS: TestCollision (0.00s)
    --- PASS: TestCollision/collision_between_files_for_all_packagers (0.00s)
    --- PASS: TestCollision/no_collision_due_to_different_per-file_packagers (0.00s)
    --- PASS: TestCollision/collision_between_file_for_all_packagers_and_file_for_specific_packager (0.00s)
=== RUN   TestDisableGlobbing
=== RUN   TestDisableGlobbing/0
=== RUN   TestDisableGlobbing/1
=== RUN   TestDisableGlobbing/2
=== RUN   TestDisableGlobbing/3
--- PASS: TestDisableGlobbing (0.00s)
    --- PASS: TestDisableGlobbing/0 (0.00s)
    --- PASS: TestDisableGlobbing/1 (0.00s)
    --- PASS: TestDisableGlobbing/2 (0.00s)
    --- PASS: TestDisableGlobbing/3 (0.00s)
=== RUN   TestGlobbingWhenFilesHaveBrackets
--- PASS: TestGlobbingWhenFilesHaveBrackets (0.00s)
=== RUN   TestGlobbingFilesWithDifferentSizesWithFileInfo
--- PASS: TestGlobbingFilesWithDifferentSizesWithFileInfo (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/files	0.003s
=== RUN   TestLongestCommonPrefix
--- PASS: TestLongestCommonPrefix (0.00s)
=== RUN   TestGlob
=== RUN   TestGlob/simple
=== RUN   TestGlob/to_parent
=== RUN   TestGlob/single_file
=== RUN   TestGlob/double_star
=== RUN   TestGlob/nil_value
=== RUN   TestGlob/no_matches
=== RUN   TestGlob/escaped_brace
=== RUN   TestGlob/no_glob
--- PASS: TestGlob (0.00s)
    --- PASS: TestGlob/simple (0.00s)
    --- PASS: TestGlob/to_parent (0.00s)
    --- PASS: TestGlob/single_file (0.00s)
    --- PASS: TestGlob/double_star (0.00s)
    --- PASS: TestGlob/nil_value (0.00s)
    --- PASS: TestGlob/no_matches (0.00s)
    --- PASS: TestGlob/escaped_brace (0.00s)
    --- PASS: TestGlob/no_glob (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/internal/glob	0.002s
=== RUN   TestPGPSignerAndVerify
=== RUN   TestPGPSignerAndVerify/protected
=== RUN   TestPGPSignerAndVerify/unprotected
=== RUN   TestPGPSignerAndVerify/armored_protected
=== RUN   TestPGPSignerAndVerify/armored_unprotected
=== RUN   TestPGPSignerAndVerify/gpg_subkey_unprotected
=== RUN   TestPGPSignerAndVerify/protected-with-key-id
=== RUN   TestPGPSignerAndVerify/unprotected-with-key-id
=== RUN   TestPGPSignerAndVerify/armored_protected-with-key-id
=== RUN   TestPGPSignerAndVerify/armored_unprotected-with-key-id
=== RUN   TestPGPSignerAndVerify/gpg_subkey_unprotected-with-key-id
--- PASS: TestPGPSignerAndVerify (0.38s)
    --- PASS: TestPGPSignerAndVerify/protected (0.09s)
    --- PASS: TestPGPSignerAndVerify/unprotected (0.00s)
    --- PASS: TestPGPSignerAndVerify/armored_protected (0.09s)
    --- PASS: TestPGPSignerAndVerify/armored_unprotected (0.00s)
    --- PASS: TestPGPSignerAndVerify/gpg_subkey_unprotected (0.00s)
    --- PASS: TestPGPSignerAndVerify/protected-with-key-id (0.09s)
    --- PASS: TestPGPSignerAndVerify/unprotected-with-key-id (0.00s)
    --- PASS: TestPGPSignerAndVerify/armored_protected-with-key-id (0.09s)
    --- PASS: TestPGPSignerAndVerify/armored_unprotected-with-key-id (0.00s)
    --- PASS: TestPGPSignerAndVerify/gpg_subkey_unprotected-with-key-id (0.00s)
=== RUN   TestArmoredDetachSignAndVerify
=== RUN   TestArmoredDetachSignAndVerify/protected
=== RUN   TestArmoredDetachSignAndVerify/unprotected
=== RUN   TestArmoredDetachSignAndVerify/armored_protected
=== RUN   TestArmoredDetachSignAndVerify/armored_unprotected
=== RUN   TestArmoredDetachSignAndVerify/gpg_subkey_unprotected
=== RUN   TestArmoredDetachSignAndVerify/protected-with-key-id
=== RUN   TestArmoredDetachSignAndVerify/unprotected-with-key-id
=== RUN   TestArmoredDetachSignAndVerify/armored_protected-with-key-id
=== RUN   TestArmoredDetachSignAndVerify/armored_unprotected-with-key-id
=== RUN   TestArmoredDetachSignAndVerify/gpg_subkey_unprotected-with-key-id
--- PASS: TestArmoredDetachSignAndVerify (0.38s)
    --- PASS: TestArmoredDetachSignAndVerify/protected (0.09s)
    --- PASS: TestArmoredDetachSignAndVerify/unprotected (0.00s)
    --- PASS: TestArmoredDetachSignAndVerify/armored_protected (0.09s)
    --- PASS: TestArmoredDetachSignAndVerify/armored_unprotected (0.00s)
    --- PASS: TestArmoredDetachSignAndVerify/gpg_subkey_unprotected (0.00s)
    --- PASS: TestArmoredDetachSignAndVerify/protected-with-key-id (0.09s)
    --- PASS: TestArmoredDetachSignAndVerify/unprotected-with-key-id (0.00s)
    --- PASS: TestArmoredDetachSignAndVerify/armored_protected-with-key-id (0.09s)
    --- PASS: TestArmoredDetachSignAndVerify/armored_unprotected-with-key-id (0.00s)
    --- PASS: TestArmoredDetachSignAndVerify/gpg_subkey_unprotected-with-key-id (0.00s)
=== RUN   TestPGPSignerError
--- PASS: TestPGPSignerError (0.00s)
=== RUN   TestNoSigningKey
--- PASS: TestNoSigningKey (0.00s)
=== RUN   TestMultipleKeys
--- PASS: TestMultipleKeys (0.00s)
=== RUN   TestWrongPass
--- PASS: TestWrongPass (0.04s)
=== RUN   TestEmptyPass
--- PASS: TestEmptyPass (0.00s)
=== RUN   TestReadArmoredKey
--- PASS: TestReadArmoredKey (0.09s)
=== RUN   TestReadKey
--- PASS: TestReadKey (0.09s)
=== RUN   TestIsASCII
--- PASS: TestIsASCII (0.00s)
=== RUN   TestRSASignAndVerify
=== RUN   TestRSASignAndVerify/unprotected
=== RUN   TestRSASignAndVerify/protected
--- PASS: TestRSASignAndVerify (0.00s)
    --- PASS: TestRSASignAndVerify/unprotected (0.00s)
    --- PASS: TestRSASignAndVerify/protected (0.00s)
=== RUN   TestWrongPassphrase
--- PASS: TestWrongPassphrase (0.00s)
=== RUN   TestNoPassphrase
--- PASS: TestNoPassphrase (0.00s)
=== RUN   TestInvalidHash
--- PASS: TestInvalidHash (0.00s)
=== RUN   TestRSAVerifyWrongKey
--- PASS: TestRSAVerifyWrongKey (0.00s)
=== RUN   TestRSAVerifyWrongSignature
--- PASS: TestRSAVerifyWrongSignature (0.00s)
=== RUN   TestRSAVerifyWrongPublicKeyFormat
--- PASS: TestRSAVerifyWrongPublicKeyFormat (0.00s)
=== RUN   TestRSAVerifyWrongSecretKeyFormat
--- PASS: TestRSAVerifyWrongSecretKeyFormat (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/internal/sign	0.998s
=== RUN   TestRPM
--- PASS: TestRPM (0.00s)
=== RUN   TestRPMGroup
--- PASS: TestRPMGroup (0.00s)
=== RUN   TestRPMCompression
=== RUN   TestRPMCompression/gzip:-1
=== RUN   TestRPMCompression/gzip:0
=== RUN   TestRPMCompression/gzip:1
=== RUN   TestRPMCompression/gzip:2
=== RUN   TestRPMCompression/gzip:3
=== RUN   TestRPMCompression/gzip:4
=== RUN   TestRPMCompression/gzip:5
=== RUN   TestRPMCompression/gzip:6
=== RUN   TestRPMCompression/gzip:7
=== RUN   TestRPMCompression/gzip:8
=== RUN   TestRPMCompression/gzip:9
=== RUN   TestRPMCompression/lzma
=== RUN   TestRPMCompression/xz
=== RUN   TestRPMCompression/zstd:-1
=== RUN   TestRPMCompression/zstd:0
=== RUN   TestRPMCompression/zstd:1
=== RUN   TestRPMCompression/zstd:2
=== RUN   TestRPMCompression/zstd:3
=== RUN   TestRPMCompression/zstd:4
=== RUN   TestRPMCompression/zstd:5
=== RUN   TestRPMCompression/zstd:6
=== RUN   TestRPMCompression/zstd:7
=== RUN   TestRPMCompression/zstd:8
=== RUN   TestRPMCompression/zstd:9
--- PASS: TestRPMCompression (0.10s)
    --- PASS: TestRPMCompression/gzip:-1 (0.00s)
    --- PASS: TestRPMCompression/gzip:0 (0.00s)
    --- PASS: TestRPMCompression/gzip:1 (0.00s)
    --- PASS: TestRPMCompression/gzip:2 (0.00s)
    --- PASS: TestRPMCompression/gzip:3 (0.00s)
    --- PASS: TestRPMCompression/gzip:4 (0.00s)
    --- PASS: TestRPMCompression/gzip:5 (0.00s)
    --- PASS: TestRPMCompression/gzip:6 (0.00s)
    --- PASS: TestRPMCompression/gzip:7 (0.00s)
    --- PASS: TestRPMCompression/gzip:8 (0.00s)
    --- PASS: TestRPMCompression/gzip:9 (0.00s)
    --- PASS: TestRPMCompression/lzma (0.00s)
    --- PASS: TestRPMCompression/xz (0.00s)
    --- PASS: TestRPMCompression/zstd:-1 (0.00s)
    --- PASS: TestRPMCompression/zstd:0 (0.00s)
    --- PASS: TestRPMCompression/zstd:1 (0.00s)
    --- PASS: TestRPMCompression/zstd:2 (0.00s)
    --- PASS: TestRPMCompression/zstd:3 (0.00s)
    --- PASS: TestRPMCompression/zstd:4 (0.01s)
    --- PASS: TestRPMCompression/zstd:5 (0.00s)
    --- PASS: TestRPMCompression/zstd:6 (0.01s)
    --- PASS: TestRPMCompression/zstd:7 (0.00s)
    --- PASS: TestRPMCompression/zstd:8 (0.02s)
    --- PASS: TestRPMCompression/zstd:9 (0.03s)
=== RUN   TestRPMSummary
--- PASS: TestRPMSummary (0.00s)
=== RUN   TestRPMPackager
--- PASS: TestRPMPackager (0.00s)
=== RUN   TestWithRPMTags
--- PASS: TestWithRPMTags (0.00s)
=== RUN   TestRPMVersion
--- PASS: TestRPMVersion (0.00s)
=== RUN   TestRPMVersionWithRelease
--- PASS: TestRPMVersionWithRelease (0.00s)
=== RUN   TestRPMVersionWithPrerelease
--- PASS: TestRPMVersionWithPrerelease (0.00s)
=== RUN   TestRPMVersionWithReleaseAndPrerelease
--- PASS: TestRPMVersionWithReleaseAndPrerelease (0.00s)
=== RUN   TestRPMVersionWithVersionMetadata
--- PASS: TestRPMVersionWithVersionMetadata (0.00s)
=== RUN   TestWithInvalidEpoch
--- PASS: TestWithInvalidEpoch (0.00s)
=== RUN   TestRPMScripts
--- PASS: TestRPMScripts (0.00s)
=== RUN   TestRPMFileDoesNotExist
--- PASS: TestRPMFileDoesNotExist (0.00s)
=== RUN   TestArches
=== RUN   TestArches/all
=== RUN   TestArches/amd64
=== RUN   TestArches/arm64
=== RUN   TestArches/mipsle
=== RUN   TestArches/386
=== RUN   TestArches/arm5
=== RUN   TestArches/arm6
=== RUN   TestArches/arm7
=== RUN   TestArches/mips
=== RUN   TestArches/override
--- PASS: TestArches (0.00s)
    --- PASS: TestArches/all (0.00s)
    --- PASS: TestArches/amd64 (0.00s)
    --- PASS: TestArches/arm64 (0.00s)
    --- PASS: TestArches/mipsle (0.00s)
    --- PASS: TestArches/386 (0.00s)
    --- PASS: TestArches/arm5 (0.00s)
    --- PASS: TestArches/arm6 (0.00s)
    --- PASS: TestArches/arm7 (0.00s)
    --- PASS: TestArches/mips (0.00s)
    --- PASS: TestArches/override (0.00s)
=== RUN   TestConfigNoReplace
--- PASS: TestConfigNoReplace (0.00s)
=== RUN   TestRPMConventionalFileName
--- PASS: TestRPMConventionalFileName (0.00s)
=== RUN   TestRPMChangelog
--- PASS: TestRPMChangelog (0.00s)
=== RUN   TestRPMNoChangelogTagsWithoutChangelogConfigured
--- PASS: TestRPMNoChangelogTagsWithoutChangelogConfigured (0.00s)
=== RUN   TestSymlink
--- PASS: TestSymlink (0.00s)
=== RUN   TestRPMSignature
--- PASS: TestRPMSignature (0.18s)
=== RUN   TestRPMSignatureError
--- PASS: TestRPMSignatureError (0.04s)
=== RUN   TestRPMGhostFiles
--- PASS: TestRPMGhostFiles (0.00s)
=== RUN   TestDisableGlobbing
--- PASS: TestDisableGlobbing (0.00s)
=== RUN   TestDirectories
--- PASS: TestDirectories (0.00s)
PASS
ok  	github.com/goreleaser/nfpm/v2/rpm	0.357s
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
