### PR TITLE
assh: enable tests

### DIFF
--- a/pkgs/tools/networking/assh/default.nix
+++ b/pkgs/tools/networking/assh/default.nix
@@ -1,8 +1,10 @@
 { lib
+, stdenv
 , buildGoModule
 , fetchFromGitHub
 , openssh
 , makeWrapper
+, ps
 }:
 
 buildGoModule rec {
@@ -18,13 +20,13 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-xLsiYM0gZL5O+Y3IkiMmzJReNW7XFN3Xejz2CkCqp5M=";
 
-  doCheck = false;
-
   ldflags = [
     "-s" "-w" "-X moul.io/assh/v2/pkg/version.Version=${version}"
   ];
 
   nativeBuildInputs = [ makeWrapper ];
+
+  checkInputs = lib.optionals stdenv.isDarwin [ ps ];
 
   postInstall = ''
     wrapProgram "$out/bin/assh" \


### PR DESCRIPTION
assh: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestComputeHost

  Testing computeHost() ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


16 total assertions

--- PASS: TestComputeHost (0.00s)
=== RUN   Test_runProxy

  Testing proxyCommand() ✔✔test from proxyCommand
✔test from proxyCommand
✔✔✔


22 total assertions

--- PASS: Test_runProxy (0.00s)
=== RUN   Test_hostPrepare

  Testing hostPrepare() ✔✔✔✔✔✔✔✔✔✔✔✔✔


35 total assertions

--- PASS: Test_hostPrepare (0.00s)
PASS
ok  	moul.io/assh/v2/pkg/commands	0.005s
=== RUN   TestNew

  Testing New() ✔✔✔✔


4 total assertions

--- PASS: TestNew (0.00s)
=== RUN   TestConfig

  Testing dummyConfig ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


32 total assertions

--- PASS: TestConfig (0.00s)
=== RUN   TestConfig_LoadConfig

  Testing Config.LoadConfig 
    standard ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


51 total assertions

--- PASS: TestConfig_LoadConfig (0.00s)
=== RUN   TestConfig_JSONString

  Testing Config.JSONString 
    dummyConfig ✔✔
    yamlConfig ✔✔✔


56 total assertions

--- PASS: TestConfig_JSONString (0.00s)
=== RUN   TestComputeHost

  Testing computeHost() ✔
    Standard ✔
    Expand variables in HostName ✔✔✔✔✔✔✔✔✔
    Do not expand variables twice ✔✔✔✔✔
    Expand variables using environment ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


88 total assertions

--- PASS: TestComputeHost (0.00s)
=== RUN   TestConfig_getHostByName

  Testing Config.getHostByName 
    Without gateway ✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    With gateway ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


118 total assertions

--- PASS: TestConfig_getHostByName (0.00s)
=== RUN   TestConfig_GetGatewaySafe

  Testing Config.GetGatewaySafe 
    Without gateway ✔✔✔✔
    With gateway ✔✔✔✔✔✔✔


129 total assertions

--- PASS: TestConfig_GetGatewaySafe (0.00s)
=== RUN   TestConfig_needsARebuildForTarget

  Testing Config.needsARebuildForTarget ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


153 total assertions

--- PASS: TestConfig_needsARebuildForTarget (0.00s)
=== RUN   TestConfig_LoadFiles

  Testing Config.LoadFiles ✔✔
    Loading a simple file ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    Loading the same file again ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    Expand includes environment ✔✔✔✔✔✔✔✔✔✔✔✔✔✔


223 total assertions

--- PASS: TestConfig_LoadFiles (0.00s)
=== RUN   TestConfig_getHostByPath

  Testing Config.getHostByPath 
    Without gateway ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    With gateway ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


261 total assertions

--- PASS: TestConfig_getHostByPath (0.00s)
=== RUN   TestConfig_GetHost

  Testing Config.GetHost 
    Without gateway ✔✔✔✔✔✔✔✔✔
    With gateway ✔✔✔✔✔✔✔✔✔
    Inheritance ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
    Aliases ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


311 total assertions

--- PASS: TestConfig_GetHost (0.00s)
=== RUN   TestConfig_GetHostSafe

  Testing Config.GetHostSafe 
    Without gateway ✔✔✔✔✔✔✔
    With gateway ✔✔✔✔✔✔✔


325 total assertions

--- PASS: TestConfig_GetHostSafe (0.00s)
=== RUN   TestConfig_String

  Testing Config.String ✔


326 total assertions

--- PASS: TestConfig_String (0.00s)
=== RUN   TestConfig_WriteSSHConfig

  Testing Config.WriteSSHConfig ✔✔


328 total assertions


  Testing very long string comment ✔✔


330 total assertions


  Testing very long slice comment ✔✔


332 total assertions

--- PASS: TestConfig_WriteSSHConfig (0.00s)
=== RUN   TestConfig_ValidateSummary

  Testing Config.ValidateSummary ✔✔✔✔


336 total assertions

--- PASS: TestConfig_ValidateSummary (0.00s)
=== RUN   TestBoolVal

  Testing BoolVal ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


351 total assertions

--- PASS: TestBoolVal (0.00s)
=== RUN   TestHost_ApplyDefaults

  Testing Host.ApplyDefaults 
    Standard configuration ✔✔✔✔✔✔✔✔✔
    Empty configuration ✔✔✔✔✔✔✔✔✔


369 total assertions

--- PASS: TestHost_ApplyDefaults (0.00s)
=== RUN   TestHost_ExpandString

  Testing Host.ExpandString() ✔✔✔✔✔✔


375 total assertions

--- PASS: TestHost_ExpandString (0.00s)
=== RUN   TestHost_Clone

  Testing Host.Clone() ✔✔✔✔✔


380 total assertions

--- PASS: TestHost_Clone (0.00s)
=== RUN   TestHost_Prototype

  Testing Host.Prototype() ✔✔✔


383 total assertions

--- PASS: TestHost_Prototype (0.00s)
=== RUN   TestHost_Matches

  Testing Host.Matches() ✔✔✔✔✔✔✔✔✔✔✔✔✔✔


397 total assertions

--- PASS: TestHost_Matches (0.00s)
=== RUN   TestHost_Validate

  Testing Host.Validate() ✔✔✔✔✔✔✔✔✔✔✔✔✔


410 total assertions

--- PASS: TestHost_Validate (0.00s)
=== RUN   TestHost_Options

  Testing Host.Options() ✔✔✔✔


414 total assertions

--- PASS: TestHost_Options (0.00s)
=== RUN   TestHostsListToList

  Testing HostsList.ToList() ✔


415 total assertions

--- PASS: TestHostsListToList (0.00s)
=== RUN   TestHostsListSortedList

  Testing HostsList.SortedList() ✔✔✔✔


419 total assertions

--- PASS: TestHostsListSortedList (0.00s)
=== RUN   TestOptionString

  Testing Option.String() ✔


420 total assertions

--- PASS: TestOptionString (0.00s)
=== RUN   TestOptionsListToStringList

  Testing OptionsList.ToStringList() ✔


421 total assertions

--- PASS: TestOptionsListToStringList (0.00s)
=== RUN   TestOptionsListRemove

  Testing OptionsList.Remove() ✔✔✔✔✔✔✔


428 total assertions

--- PASS: TestOptionsListRemove (0.00s)
PASS
ok  	moul.io/assh/v2/pkg/config	0.011s
=== RUN   TestGraph

  Testing Graph() ✔✔digraph G {
	"aaa"->"bbb"[ color=red, label=1 ];
	"bbb"->"ccc"[ color=red, label=1 ];
	"bbb"->"aaa"[ color=red, label=2 ];
	"ccc"->"eee"[ color=red, label=1 ];
	"fff"->"eee"[ color=red, label=1 ];
	"aaa" [ color=blue ];
	"bbb" [ color=blue ];
	"ccc" [ color=blue ];
	"eee" [ color=blue ];
	"fff" [ color=blue ];

}

✔


3 total assertions


  Testing Graph() with isolated hosts ✔✔digraph G {
	"fff"->"eee"[ color=red, label=1 ];
	"aaa"->"bbb"[ color=red, label=1 ];
	"bbb"->"ccc"[ color=red, label=1 ];
	"bbb"->"aaa"[ color=red, label=2 ];
	"ccc"->"eee"[ color=red, label=1 ];
	"aaa" [ color=blue ];
	"bbb" [ color=blue ];
	"ccc" [ color=blue ];
	"ddd" [ color=blue ];
	"eee" [ color=blue ];
	"fff" [ color=blue ];
	"ggg" [ color=blue ];

}

✔


6 total assertions

--- PASS: TestGraph (0.00s)
PASS
ok  	moul.io/assh/v2/pkg/config/graphviz	0.003s
=== RUN   TestLogLevelFromParentSSHProcess

  Testing LogLevelFromParentSSHProcess() ✔


1 total assertion

--- PASS: TestLogLevelFromParentSSHProcess (0.01s)
PASS
ok  	moul.io/assh/v2/pkg/logger	0.014s
=== RUN   TestGetHomeDir

  Testing GetHomeDir ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


20 total assertions

--- PASS: TestGetHomeDir (0.00s)
=== RUN   TestExpandUser

  Testing ExpandUser ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔


62 total assertions

--- PASS: TestExpandUser (0.00s)
PASS
ok  	moul.io/assh/v2/pkg/utils	0.002s
=== RUN   Test

  Testing version ✔✔


2 total assertions

--- PASS: Test (0.00s)
PASS
ok  	moul.io/assh/v2/pkg/version	0.002s
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
-  [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
