### PR TITLE
obfs4: enable tests

### DIFF
--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -12,8 +12,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-xGCK8biTYcrmKbsl6ZyCjpRrVP9x5xGrC3VcMsR7ETo=";
 
-  doCheck = false;
-
   meta = with lib; {
     description = "A pluggable transport proxy";
     homepage = "https://www.torproject.org/projects/obfsproxy";


### PR DESCRIPTION
obfs4: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestNewKeypair
--- PASS: TestNewKeypair (0.00s)
=== RUN   TestHandshake
--- PASS: TestHandshake (0.00s)
PASS
ok  	gitlab.com/yawning/obfs4.git/common/ntor	0.002s
=== RUN   TestWeightedDist
--- PASS: TestWeightedDist (0.73s)
PASS
ok  	gitlab.com/yawning/obfs4.git/common/probdist	0.728s
=== RUN   TestReplayFilter
--- PASS: TestReplayFilter (0.00s)
PASS
ok  	gitlab.com/yawning/obfs4.git/common/replayfilter	0.001s
=== RUN   TestParseClientParameters
--- PASS: TestParseClientParameters (0.00s)
=== RUN   TestAuthInvalidVersion
--- PASS: TestAuthInvalidVersion (0.00s)
=== RUN   TestAuthInvalidNMethods
--- PASS: TestAuthInvalidNMethods (0.00s)
=== RUN   TestAuthNoneRequired
--- PASS: TestAuthNoneRequired (0.00s)
=== RUN   TestAuthUsernamePassword
--- PASS: TestAuthUsernamePassword (0.00s)
=== RUN   TestAuthBoth
--- PASS: TestAuthBoth (0.00s)
=== RUN   TestAuthUnsupported
--- PASS: TestAuthUnsupported (0.00s)
=== RUN   TestAuthUnsupported2
--- PASS: TestAuthUnsupported2 (0.00s)
=== RUN   TestRFC1929InvalidVersion
--- PASS: TestRFC1929InvalidVersion (0.00s)
=== RUN   TestRFC1929InvalidUlen
--- PASS: TestRFC1929InvalidUlen (0.00s)
=== RUN   TestRFC1929InvalidPlen
--- PASS: TestRFC1929InvalidPlen (0.00s)
=== RUN   TestRFC1929InvalidPTArgs
--- PASS: TestRFC1929InvalidPTArgs (0.00s)
=== RUN   TestRFC1929Success
--- PASS: TestRFC1929Success (0.00s)
=== RUN   TestRequestInvalidHdr
--- PASS: TestRequestInvalidHdr (0.00s)
=== RUN   TestRequestIPv4
--- PASS: TestRequestIPv4 (0.00s)
=== RUN   TestRequestIPv6
--- PASS: TestRequestIPv6 (0.00s)
=== RUN   TestRequestFQDN
--- PASS: TestRequestFQDN (0.00s)
=== RUN   TestResponseNil
--- PASS: TestResponseNil (0.00s)
PASS
ok  	gitlab.com/yawning/obfs4.git/common/socks5	0.002s
=== RUN   TestGenerateKeyOdd
--- PASS: TestGenerateKeyOdd (0.00s)
=== RUN   TestGenerateKeyEven
--- PASS: TestGenerateKeyEven (0.00s)
=== RUN   TestHandshake
--- PASS: TestHandshake (0.01s)
PASS
ok  	gitlab.com/yawning/obfs4.git/common/uniformdh	0.011s
=== RUN   TestHandshakeNtorClient
--- PASS: TestHandshakeNtorClient (2.10s)
=== RUN   TestHandshakeNtorServer
--- PASS: TestHandshakeNtorServer (2.00s)
PASS
ok  	gitlab.com/yawning/obfs4.git/transports/obfs4	4.098s
=== RUN   TestNewEncoder
--- PASS: TestNewEncoder (0.00s)
=== RUN   TestEncoder_Encode
--- PASS: TestEncoder_Encode (0.00s)
=== RUN   TestEncoder_Encode_Oversize
--- PASS: TestEncoder_Encode_Oversize (0.00s)
=== RUN   TestNewDecoder
--- PASS: TestNewDecoder (0.00s)
=== RUN   TestDecoder_Decode
--- PASS: TestDecoder_Decode (0.01s)
PASS
ok  	gitlab.com/yawning/obfs4.git/transports/obfs4/framing	0.008s
```

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
