### PR TITLE
cassowary: enable tests

### DIFF
--- a/pkgs/tools/networking/cassowary/default.nix
+++ b/pkgs/tools/networking/cassowary/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "sha256-hGpiL88x2roFEjJJM4CKyt3k66VK1pEnpOwvhDPDp6M=";
 
-  doCheck = false;
-
   ldflags = [ "-s" "-w" "-X main.version=${version}" ];
 
   meta = with lib; {


### PR DESCRIPTION
cassowary: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
=== RUN   TestBoxPlot
--- PASS: TestBoxPlot (0.03s)
=== RUN   TestPutCloudwatchMetrics
--- PASS: TestPutCloudwatchMetrics (0.00s)
=== RUN   TestValidURL
--- PASS: TestValidURL (0.00s)
=== RUN   TestSplitHeaders
--- PASS: TestSplitHeaders (0.00s)
=== RUN   TestTLSScheme
--- PASS: TestTLSScheme (0.00s)
=== RUN   TestSuffixes
--- PASS: TestSuffixes (0.00s)
=== RUN   TestBins
--- PASS: TestBins (0.00s)
=== RUN   TestHistOutput
--- PASS: TestHistOutput (0.03s)
=== RUN   TestLoadCoordinate
--- PASS: TestLoadCoordinate (0.00s)
=== RUN   TestLoadCoordinateURLPaths
--- PASS: TestLoadCoordinateURLPaths (0.00s)
=== RUN   TestCoordinateTLSConfig
--- PASS: TestCoordinateTLSConfig (0.04s)
=== RUN   TestPromGwPush
--- PASS: TestPromGwPush (0.00s)
=== RUN   TestCalcMean
--- PASS: TestCalcMean (0.00s)
=== RUN   TestCalcMedian
--- PASS: TestCalcMedian (0.00s)
=== RUN   TestCalcVariance
--- PASS: TestCalcVariance (0.00s)
=== RUN   TestCalcStdDev
--- PASS: TestCalcStdDev (0.00s)
=== RUN   Test95Percentile
--- PASS: Test95Percentile (0.00s)
=== RUN   TestFailedRequests
--- PASS: TestFailedRequests (0.00s)
PASS
ok  	github.com/rogerwelin/cassowary/pkg/client	0.100s
```

Runned on x86_64-linux.