### PR TITLE
nebula: enable tests

### DIFF
--- a/pkgs/tools/networking/nebula/default.nix
+++ b/pkgs/tools/networking/nebula/default.nix
@@ -13,8 +13,6 @@ buildGoModule rec {
 
   vendorSha256 = "5Yv2t5vdUNCcCo2KAm1xCkRVrt6gIasKHLqH7VVPDuU=";
 
-  doCheck = false;
-
   subPackages = [ "cmd/nebula" "cmd/nebula-cert" ];
 
   ldflags = [ "-X main.Build=${version}" ];


### PR DESCRIPTION
nebula: enable tests

```
@nix { "action": "setPhase", "phase": "checkPhase" }
running tests
?   	github.com/slackhq/nebula/cmd/nebula	[no test files]
=== RUN   Test_caSummary
--- PASS: Test_caSummary (0.00s)
=== RUN   Test_caHelp
--- PASS: Test_caHelp (0.00s)
=== RUN   Test_ca
--- PASS: Test_ca (0.00s)
=== RUN   Test_keygenSummary
--- PASS: Test_keygenSummary (0.00s)
=== RUN   Test_keygenHelp
--- PASS: Test_keygenHelp (0.00s)
=== RUN   Test_keygen
--- PASS: Test_keygen (0.00s)
=== RUN   Test_help
--- PASS: Test_help (0.00s)
=== RUN   Test_handleError
--- PASS: Test_handleError (0.00s)
=== RUN   Test_printSummary
--- PASS: Test_printSummary (0.00s)
=== RUN   Test_printHelp
--- PASS: Test_printHelp (0.00s)
=== RUN   Test_printCert
--- PASS: Test_printCert (0.00s)
=== RUN   Test_signSummary
--- PASS: Test_signSummary (0.00s)
=== RUN   Test_signHelp
--- PASS: Test_signHelp (0.00s)
=== RUN   Test_signCert
--- PASS: Test_signCert (0.00s)
=== RUN   Test_verifySummary
--- PASS: Test_verifySummary (0.00s)
=== RUN   Test_verifyHelp
--- PASS: Test_verifyHelp (0.00s)
=== RUN   Test_verify
--- PASS: Test_verify (0.00s)
PASS
ok  	github.com/slackhq/nebula/cmd/nebula-cert	0.007s
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
