### PR TITLE
nixos: shellhub-agent: support more options

### DIFF
--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -12,14 +12,7 @@ in
 
     services.shellhub-agent = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Whether to enable the ShellHub Agent daemon, which allows
-          secure remote logins.
-        '';
-      };
+      enable = mkEnableOption "ShellHub Agent daemon";
 
       package = mkOption {
         type = types.package;

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -95,8 +95,6 @@ in
         ExecStart = "${cfg.package}/bin/agent";
       };
     };
-
-    environment.systemPackages = [ cfg.package ];
   };
 }
 

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -68,9 +68,9 @@ in
         "time-sync.target"
       ];
 
-      environment.SERVER_ADDRESS = cfg.server;
-      environment.PRIVATE_KEY = cfg.privateKey;
-      environment.TENANT_ID = cfg.tenantId;
+      environment.SHELLHUB_SERVER_ADDRESS = cfg.server;
+      environment.SHELLHUB_PRIVATE_KEY = cfg.privateKey;
+      environment.SHELLHUB_TENANT_ID = cfg.tenantId;
 
       serviceConfig = {
         # The service starts sessions for different users.

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -23,6 +23,16 @@ in
         '';
       };
 
+      keepAliveInterval = mkOption {
+        type = types.int;
+        default = 30;
+        description = ''
+          Determine the interval to send the keep alive message to
+          the server. This has a direct impact of the bandwidth
+          used by the device.
+        '';
+      };
+
       tenantId = mkOption {
         type = types.str;
         example = "ba0a880c-2ada-11eb-a35e-17266ef329d6";
@@ -71,6 +81,7 @@ in
       environment.SHELLHUB_SERVER_ADDRESS = cfg.server;
       environment.SHELLHUB_PRIVATE_KEY = cfg.privateKey;
       environment.SHELLHUB_TENANT_ID = cfg.tenantId;
+      environment.SHELLHUB_KEEPALIVE_INTERVAL = toString cfg.keepAliveInterval;
 
       serviceConfig = {
         # The service starts sessions for different users.

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -14,14 +14,7 @@ in
 
       enable = mkEnableOption "ShellHub Agent daemon";
 
-      package = mkOption {
-        type = types.package;
-        default = pkgs.shellhub-agent;
-        defaultText = literalExpression "pkgs.shellhub-agent";
-        description = ''
-          Which ShellHub Agent package to use.
-        '';
-      };
+      package = mkPackageOption pkgs "shellhub-agent" { };
 
       preferredHostname = mkOption {
         type = types.str;

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -80,11 +80,13 @@ in
         "time-sync.target"
       ];
 
-      environment.SHELLHUB_SERVER_ADDRESS = cfg.server;
-      environment.SHELLHUB_PRIVATE_KEY = cfg.privateKey;
-      environment.SHELLHUB_TENANT_ID = cfg.tenantId;
-      environment.SHELLHUB_PREFERRED_HOSTNAME = cfg.preferredHostname;
-      environment.SHELLHUB_KEEPALIVE_INTERVAL = toString cfg.keepAliveInterval;
+      environment = {
+        SHELLHUB_SERVER_ADDRESS = cfg.server;
+        SHELLHUB_PRIVATE_KEY = cfg.privateKey;
+        SHELLHUB_TENANT_ID = cfg.tenantId;
+        SHELLHUB_KEEPALIVE_INTERVAL = toString cfg.keepAliveInterval;
+        SHELLHUB_PREFERRED_HOSTNAME = cfg.preferredHostname;
+      };
 
       serviceConfig = {
         # The service starts sessions for different users.

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -23,6 +23,15 @@ in
         '';
       };
 
+      preferredHostname = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Set the device preferred hostname. This provides a hint to
+          the server to use this as hostname if it is available.
+        '';
+      };
+
       keepAliveInterval = mkOption {
         type = types.int;
         default = 30;
@@ -81,6 +90,7 @@ in
       environment.SHELLHUB_SERVER_ADDRESS = cfg.server;
       environment.SHELLHUB_PRIVATE_KEY = cfg.privateKey;
       environment.SHELLHUB_TENANT_ID = cfg.tenantId;
+      environment.SHELLHUB_PREFERRED_HOSTNAME = cfg.preferredHostname;
       environment.SHELLHUB_KEEPALIVE_INTERVAL = toString cfg.keepAliveInterval;
 
       serviceConfig = {

--- a/nixos/modules/services/networking/shellhub-agent.nix
+++ b/nixos/modules/services/networking/shellhub-agent.nix
@@ -1,10 +1,11 @@
 { config, lib, pkgs, ... }:
 
 with lib;
+
 let
   cfg = config.services.shellhub-agent;
-in {
-
+in
+{
   ###### interface
 
   options = {
@@ -89,3 +90,4 @@ in {
     environment.systemPackages = [ cfg.package ];
   };
 }
+


### PR DESCRIPTION
###### Description of changes

Rework of existing module and addition of new options.

###### Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
