### PR TITLE
deltachat-desktop: 1.28.1 -> 1.28.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/default.nix
@@ -47,13 +47,13 @@ let
   });
 in nodejs-14_x.pkgs.deltachat-desktop.override rec {
   pname = "deltachat-desktop";
-  version = "1.28.1";
+  version = "1.28.2";
 
   src = fetchFromGitHub {
     owner = "deltachat";
     repo = "deltachat-desktop";
     rev = "v${version}";
-    hash = "sha256-i2Cb2HfapYTaxg5IUl4pGWYUM6o/4mWgMO7QsBqDHoU=";
+    hash = "sha256-jhtriDnt8Yl8eCmUTEyoPjccZV8RNAchMykkkiRpF60=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/deltachat-desktop/package.json
+++ b/pkgs/applications/networking/instant-messengers/deltachat-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "dependencies": {
     "@blueprintjs/core": "^3.22.3",
     "@deltachat/message_parser_wasm": "^0.3.0",
@@ -51,7 +51,7 @@
     "@types/react-window": "^1.8.4",
     "@types/react-window-infinite-loader": "^1.0.4",
     "@types/url-parse": "^1.4.3",
-    "electron": "^14.2.6",
+    "electron": "^14.2.9",
     "esbuild": "^0.12.29",
     "glob-watcher": "^5.0.5",
     "sass": "^1.26.5",


### PR DESCRIPTION
###### Description of changes
https://github.com/deltachat/deltachat-desktop/releases/tag/v1.28.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @Jikstra @Simon-Laux