### PR TITLE
openvpn: use update-systemd-resolved instead of vendoring it

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -1,26 +1,21 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , pkg-config
-, makeWrapper
-, runtimeShell
 , iproute2
 , lzo
 , openssl
 , pam
 , useSystemd ? stdenv.isLinux
 , systemd
+, update-systemd-resolved
 , util-linux
 , pkcs11Support ? false
 , pkcs11helper
 }:
 
-with lib;
 let
-  # Check if the script needs to have other binaries wrapped when changing this.
-  update-resolved = fetchurl {
-    url = "https://raw.githubusercontent.com/jonathanio/update-systemd-resolved/v1.3.0/update-systemd-resolved";
-    sha256 = "021qzv1k0zxgv1rmyfpqj3zlzqr28xa7zff1n7vrbjk36ijylpsc";
-  };
+  inherit (lib) versionOlder optional optionals optionalString;
 
   generic = { version, sha256 }:
     let
@@ -36,7 +31,7 @@ let
           inherit sha256;
         };
 
-        nativeBuildInputs = [ makeWrapper pkg-config ];
+        nativeBuildInputs = [ pkg-config ];
 
         buildInputs = [ lzo openssl ]
           ++ optional stdenv.isLinux pam
@@ -52,15 +47,15 @@ let
         ++ optional pkcs11Support "--enable-pkcs11"
         ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
 
+        # We used to vendor the update-systemd-resolved script inside libexec,
+        # but a separate package was made, that uses libexec/openvpn. Copy it
+        # into libexec in case any consumers expect it to be there even though
+        # they should use the update-systemd-resolved package instead.
         postInstall = ''
           mkdir -p $out/share/doc/openvpn/examples
-          cp -r sample/sample-config-files/ $out/share/doc/openvpn/examples
-          cp -r sample/sample-keys/ $out/share/doc/openvpn/examples
-          cp -r sample/sample-scripts/ $out/share/doc/openvpn/examples
+          cp -r sample/sample-{config-files,keys,scripts}/ $out/share/doc/openvpn/examples
         '' + optionalString useSystemd ''
-          install -Dm555 ${update-resolved} $out/libexec/update-systemd-resolved
-          wrapProgram $out/libexec/update-systemd-resolved \
-            --prefix PATH : ${makeBinPath [ runtimeShell iproute2 systemd util-linux ]}
+          install -Dm555 -t $out/libexec ${update-systemd-resolved}/libexec/openvpn/*
         '';
 
         enableParallelBuilding = true;
@@ -69,7 +64,7 @@ let
           description = "A robust and highly flexible tunneling application";
           downloadPage = "https://openvpn.net/community-downloads/";
           homepage = "https://openvpn.net/";
-          license = licenses.gpl2;
+          license = licenses.gpl2Only;
           maintainers = with maintainers; [ viric peterhoeg ];
           platforms = platforms.unix;
         };

--- a/pkgs/tools/networking/openvpn/update-systemd-resolved.nix
+++ b/pkgs/tools/networking/openvpn/update-systemd-resolved.nix
@@ -1,34 +1,42 @@
-{ lib, stdenv, fetchFromGitHub
-, makeWrapper
-, iproute2, systemd, coreutils, util-linux }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, iproute2
+, runtimeShell
+, systemd
+, coreutils
+, util-linux
+}:
 
 stdenv.mkDerivation rec {
   pname = "update-systemd-resolved";
+  # when updating this, check if additional binaries need injecting into PATH
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "jonathanio";
     repo = "update-systemd-resolved";
     rev = "v${version}";
-    sha256 = "19zhbpyms57yb70hi0ws5sbkpk2yqp9nnix3f86r36h1g93m70lm";
+    hash = "sha256-lYJTR3oBmpENcqNHa9PFXsw7ly6agwjBWf4UXf1d8Kc=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
-  buildFlags = [
-    "PREFIX=${placeholder "out"}/libexec/openvpn"
+  # set SCRIPT_NAME in case we are wrapped and inject PATH
+  patches = [
+    ./update-systemd-resolved.patch
   ];
 
-  installPhase = ''
-    wrapProgram $out/libexec/openvpn/update-systemd-resolved \
-      --prefix PATH : ${lib.makeBinPath [ iproute2 systemd coreutils util-linux ]}
+  PREFIX = "${placeholder "out"}/libexec/openvpn";
+
+  postInstall = ''
+    substituteInPlace ${PREFIX}/update-systemd-resolved \
+      --subst-var-by PATH ${lib.makeBinPath [ coreutils iproute2 runtimeShell systemd util-linux ]}
   '';
 
   meta = with lib; {
     description = "Helper script for OpenVPN to directly update the DNS settings of a link through systemd-resolved via DBus";
     homepage = "https://github.com/jonathanio/update-systemd-resolved";
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ eadwu ];
-    license = licenses.gpl3;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/openvpn/update-systemd-resolved.patch
+++ b/pkgs/tools/networking/openvpn/update-systemd-resolved.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 524b6b7..8a880f1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,6 @@ all: install info
+ 
+ install:
+ 	@install -Dm750 $(SRC) $(DEST)
+-	@install -Dm644 $(SRC).conf $(DEST).conf
+ 
+ info:
+ 	@printf 'Successfully installed %s to %s.\n' $(SRC) $(DEST)
+diff --git a/update-systemd-resolved b/update-systemd-resolved
+index 1452e1a..39641cb 100755
+--- a/update-systemd-resolved
++++ b/update-systemd-resolved
+@@ -29,7 +29,8 @@
+ DBUS_DEST="org.freedesktop.resolve1"
+ DBUS_NODE="/org/freedesktop/resolve1"
+ 
+-SCRIPT_NAME="${BASH_SOURCE[0]##*/}"
++PATH="@PATH@"
++SCRIPT_NAME="update-systemd-resolved"
+ 
+ log() {
+   logger -s -t "$SCRIPT_NAME" "$@"


### PR DESCRIPTION
###### Description of changes

Don't vendor `update-systemd-resolved` when we have it in nixpkgs.

Also, patch the `update-systemd-resolved` script to avoid having to wrap it which looks ugly in the logs.

Cc: @eadwu 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
