### PR TITLE
ocamlPackages.coin: 0.1.3 → 0.1.4

### DIFF
--- a/pkgs/development/ocaml-modules/coin/default.nix
+++ b/pkgs/development/ocaml-modules/coin/default.nix
@@ -1,20 +1,19 @@
 { buildDunePackage
-, fetchzip
+, fetchurl
 , findlib
 , lib
-, menhir
 , ocaml
 , re
 }:
 
 buildDunePackage rec {
   pname = "coin";
-  version = "0.1.3";
+  version = "0.1.4";
   minimalOCamlVersion = "4.03";
 
-  src = fetchzip {
-    url = "https://github.com/mirage/coin/releases/download/v${version}/coin-v${version}.tbz";
-    sha256 = "06bfidvglyp9hzvr2xwbdx8wf26is2xrzc31fldzjf5ab0vd076p";
+  src = fetchurl {
+    url = "https://github.com/mirage/coin/releases/download/v${version}/coin-${version}.tbz";
+    sha256 = "sha256:0069qqswd1ik5ay3d5q1v1pz0ql31kblfsnv0ax0z8jwvacp3ack";
   };
 
   postPatch = ''
@@ -22,9 +21,7 @@ buildDunePackage rec {
       'ocaml} -I ${findlib}/lib/ocaml/${ocaml.version}/site-lib '
   '';
 
-  useDune2 = true;
-
-  nativeBuildInputs = [ menhir findlib ];
+  nativeBuildInputs = [ findlib ];
   buildInputs = [ re ];
 
   strictDeps = true;


### PR DESCRIPTION
###### Description of changes

Drop `menhir` dependency.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
