### PR TITLE
talosctl: provide path to UEFI firmware

### DIFF
--- a/pkgs/applications/networking/cluster/talosctl/0001-qemu-provisioner-hardcode-path-to-OVMF.patch
+++ b/pkgs/applications/networking/cluster/talosctl/0001-qemu-provisioner-hardcode-path-to-OVMF.patch
@@ -1,0 +1,55 @@
+From 0329d29be24c17eb668b7178e391015eb4ad34ac Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Fri, 8 Apr 2022 08:09:46 +0200
+Subject: [PATCH] qemu provisioner: hardcode path to OVMF
+
+The qemu provisioner needs UEFI firmware, which doesn't live in
+/usr/share/ovmf or /usr/share/qemu-efi-aarch64 on NixOS.
+
+Avoid having to specify `--extra-uefi-search-paths` on every
+`talosctl cluster create` invocation, by also adding a nix-provided path
+to the list of search paths.
+
+Keep the existing search paths intact, so people running a nix-built
+talosctl on non-NixOS can still pick up UEFI firmware that's not
+(yet) provided by Nix - such as the aarch64 OVMF firmware for the
+x86_64-linux talosctl binary.
+---
+ pkg/provision/providers/qemu/arch.go | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/pkg/provision/providers/qemu/arch.go b/pkg/provision/providers/qemu/arch.go
+index 49a298a1..3c1c27c9 100644
+--- a/pkg/provision/providers/qemu/arch.go
++++ b/pkg/provision/providers/qemu/arch.go
+@@ -74,7 +74,12 @@ type PFlash struct {
+ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlash {
+ 	switch arch {
+ 	case ArchArm64:
+-		uefiSourcePaths := []string{"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd", "/usr/share/OVMF/QEMU_EFI.fd"}
++		uefiSourcePaths := []string{
++			"@ovmf@/QEMU_EFI.fd",
++			"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
++			"/usr/share/OVMF/QEMU_EFI.fd",
++		}
++
+ 		for _, p := range extraUEFISearchPaths {
+ 			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "QEMU_EFI.fd"))
+ 		}
+@@ -93,7 +98,12 @@ func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlas
+ 			return nil
+ 		}
+ 
+-		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd"}
++		uefiSourcePaths := []string{
++			"@ovmf@/OVMF.fd",
++			"/usr/share/ovmf/OVMF.fd",
++			"/usr/share/OVMF/OVMF.fd",
++		}
++
+ 		for _, p := range extraUEFISearchPaths {
+ 			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "OVMF.fd"))
+ 		}
+-- 
+2.35.1
+

--- a/pkgs/applications/networking/cluster/talosctl/default.nix
+++ b/pkgs/applications/networking/cluster/talosctl/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, OVMF, substituteAll }:
 let
   # look for GO_LDFLAGS getting set in the Makefile
   version = "1.0.1";
@@ -18,6 +18,13 @@ buildGoModule rec {
     rev = "v${version}";
     inherit sha256;
   };
+
+  patches = [
+    (substituteAll {
+      src = ./0001-qemu-provisioner-hardcode-path-to-OVMF.patch;
+      ovmf = "${OVMF.fd}/FV";
+    })
+  ];
 
   ldflags =
     let


### PR DESCRIPTION
By default, a `talosctl cluster create` will spin up VMs with UEFI.
For this to work, an UEFI firmware binary needs to be passed to qemu.
`talosctl` looks for these in various places in `/usr/share`.

On NixOS, these paths don't exist. While it's possible to pass
additional search paths (via the `--extra-uefi-search-paths` cmdline
arg), it's much more convenient to automatically have a Nix-built OVMF
firmware in the search paths.

Right now, we only do this for the "native" OVMF binaries - so if you
run an x86_64-linux talosctl binary, you can spin up a x86_64 VM out of
the box, but you won't be able to start a aarch64-linux VM without
explicitly setting `--extra-uefi-search-paths` to a aarch64 firmware
path - this is mostly due to the OVMF package not properly
crosscompiling.

We only add to the default search paths, not replace them, so people
running talosctl on non-NixOS have more search paths available.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
