### PR TITLE
nixos/test-driver: shellopts with execute + timeout

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -159,23 +159,8 @@ The following methods are available on machine objects:
 `execute`
 
 :   Execute a shell command, returning a list `(status, stdout)`.
-    If the command detaches, it must close stdout, as `execute` will wait
-    for this to consume all output reliably. This can be achieved by
-    redirecting stdout to stderr `>&2`, to `/dev/console`, `/dev/null` or
-    a file. Examples of detaching commands are `sleep 365d &`, where the
-    shell forks a new process that can write to stdout and `xclip -i`, where
-    the `xclip` command itself forks without closing stdout.
-    Takes an optional parameter `check_return` that defaults to `True`.
-    Setting this parameter to `False` will not check for the return code
-    and return -1 instead. This can be used for commands that shut down
-    the VM and would therefore break the pipe that would be used for
-    retrieving the return code.
 
-`succeed`
-
-:   Execute a shell command, raising an exception if the exit status is
-    not zero, otherwise returning the standard output. Commands are run
-    with `set -euo pipefail` set:
+    Commands are run with `set -euo pipefail` set:
 
     -   If several commands are separated by `;` and one fails, the
         command as a whole will fail.
@@ -183,10 +168,33 @@ The following methods are available on machine objects:
     -   For pipelines, the last non-zero exit status will be returned
         (if there is one, zero will be returned otherwise).
 
-    -   Dereferencing unset variables fail the command.
+    -   Dereferencing unset variables fails the command.
 
-    -   It will wait for stdout to be closed. See `execute` for the
-        implications.
+    -   It will wait for stdout to be closed.
+
+    If the command detaches, it must close stdout, as `execute` will wait
+    for this to consume all output reliably. This can be achieved by
+    redirecting stdout to stderr `>&2`, to `/dev/console`, `/dev/null` or
+    a file. Examples of detaching commands are `sleep 365d &`, where the
+    shell forks a new process that can write to stdout and `xclip -i`, where
+    the `xclip` command itself forks without closing stdout.
+
+    Takes an optional parameter `check_return` that defaults to `True`.
+    Setting this parameter to `False` will not check for the return code
+    and return -1 instead. This can be used for commands that shut down
+    the VM and would therefore break the pipe that would be used for
+    retrieving the return code.
+
+    A timeout for the command can be specified (in seconds) using the optional
+    `timeout` parameter, e.g., `execute(cmd, timeout=10)` or
+    `execute(cmd, timeout=None)`. The default is 900 seconds.
+
+`succeed`
+
+:   Execute a shell command, raising an exception if the exit status is
+    not zero, otherwise returning the standard output. Similar to `execute`,
+    except that the timeout is `None` by default. See `execute` for details on
+    command execution.
 
 `fail`
 
@@ -196,10 +204,13 @@ The following methods are available on machine objects:
 `wait_until_succeeds`
 
 :   Repeat a shell command with 1-second intervals until it succeeds.
+    Has a default timeout of 900 seconds which can be modified, e.g.
+    `wait_until_succeeds(cmd, timeout=10)`. See `execute` for details on
+    command execution.
 
 `wait_until_fails`
 
-:   Repeat a shell command with 1-second intervals until it fails.
+:   Like `wait_until_succeeds`, but repeating the command until it fails.
 
 `wait_for_unit`
 

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -166,7 +166,7 @@ The following methods are available on machine objects:
         command as a whole will fail.
 
     -   For pipelines, the last non-zero exit status will be returned
-        (if there is one, zero will be returned otherwise).
+        (if there is one; otherwise zero will be returned).
 
     -   Dereferencing unset variables fails the command.
 

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -291,8 +291,8 @@ start_all()
             <listitem>
               <para>
                 For pipelines, the last non-zero exit status will be
-                returned (if there is one, zero will be returned
-                otherwise).
+                returned (if there is one; otherwise zero will be
+                returned).
               </para>
             </listitem>
             <listitem>

--- a/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
+++ b/nixos/doc/manual/from_md/development/writing-nixos-tests.section.xml
@@ -274,35 +274,9 @@ start_all()
         <listitem>
           <para>
             Execute a shell command, returning a list
-            <literal>(status, stdout)</literal>. If the command
-            detaches, it must close stdout, as
-            <literal>execute</literal> will wait for this to consume all
-            output reliably. This can be achieved by redirecting stdout
-            to stderr <literal>&gt;&amp;2</literal>, to
-            <literal>/dev/console</literal>,
-            <literal>/dev/null</literal> or a file. Examples of
-            detaching commands are <literal>sleep 365d &amp;</literal>,
-            where the shell forks a new process that can write to stdout
-            and <literal>xclip -i</literal>, where the
-            <literal>xclip</literal> command itself forks without
-            closing stdout. Takes an optional parameter
-            <literal>check_return</literal> that defaults to
-            <literal>True</literal>. Setting this parameter to
-            <literal>False</literal> will not check for the return code
-            and return -1 instead. This can be used for commands that
-            shut down the VM and would therefore break the pipe that
-            would be used for retrieving the return code.
+            <literal>(status, stdout)</literal>.
           </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>
-          <literal>succeed</literal>
-        </term>
-        <listitem>
           <para>
-            Execute a shell command, raising an exception if the exit
-            status is not zero, otherwise returning the standard output.
             Commands are run with <literal>set -euo pipefail</literal>
             set:
           </para>
@@ -323,16 +297,57 @@ start_all()
             </listitem>
             <listitem>
               <para>
-                Dereferencing unset variables fail the command.
+                Dereferencing unset variables fails the command.
               </para>
             </listitem>
             <listitem>
               <para>
-                It will wait for stdout to be closed. See
-                <literal>execute</literal> for the implications.
+                It will wait for stdout to be closed.
               </para>
             </listitem>
           </itemizedlist>
+          <para>
+            If the command detaches, it must close stdout, as
+            <literal>execute</literal> will wait for this to consume all
+            output reliably. This can be achieved by redirecting stdout
+            to stderr <literal>&gt;&amp;2</literal>, to
+            <literal>/dev/console</literal>,
+            <literal>/dev/null</literal> or a file. Examples of
+            detaching commands are <literal>sleep 365d &amp;</literal>,
+            where the shell forks a new process that can write to stdout
+            and <literal>xclip -i</literal>, where the
+            <literal>xclip</literal> command itself forks without
+            closing stdout.
+          </para>
+          <para>
+            Takes an optional parameter <literal>check_return</literal>
+            that defaults to <literal>True</literal>. Setting this
+            parameter to <literal>False</literal> will not check for the
+            return code and return -1 instead. This can be used for
+            commands that shut down the VM and would therefore break the
+            pipe that would be used for retrieving the return code.
+          </para>
+          <para>
+            A timeout for the command can be specified (in seconds)
+            using the optional <literal>timeout</literal> parameter,
+            e.g., <literal>execute(cmd, timeout=10)</literal> or
+            <literal>execute(cmd, timeout=None)</literal>. The default
+            is 900 seconds.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <literal>succeed</literal>
+        </term>
+        <listitem>
+          <para>
+            Execute a shell command, raising an exception if the exit
+            status is not zero, otherwise returning the standard output.
+            Similar to <literal>execute</literal>, except that the
+            timeout is <literal>None</literal> by default. See
+            <literal>execute</literal> for details on command execution.
+          </para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -353,7 +368,10 @@ start_all()
         <listitem>
           <para>
             Repeat a shell command with 1-second intervals until it
-            succeeds.
+            succeeds. Has a default timeout of 900 seconds which can be
+            modified, e.g.
+            <literal>wait_until_succeeds(cmd, timeout=10)</literal>. See
+            <literal>execute</literal> for details on command execution.
           </para>
         </listitem>
       </varlistentry>
@@ -363,8 +381,8 @@ start_all()
         </term>
         <listitem>
           <para>
-            Repeat a shell command with 1-second intervals until it
-            fails.
+            Like <literal>wait_until_succeeds</literal>, but repeating
+            the command until it fails.
           </para>
         </listitem>
       </varlistentry>

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -526,10 +526,14 @@ class Machine:
         self.run_callbacks()
         self.connect()
 
-        if timeout is not None:
-            command = "timeout {} sh -c {}".format(timeout, shlex.quote(command))
+        # Always run command with shell opts
+        command = f"set -euo pipefail; {command}"
 
-        out_command = f"( set -euo pipefail; {command} ) | (base64 --wrap 0; echo)\n"
+        if timeout is not None:
+            command = f"timeout {timeout} sh -c {shlex.quote(command)}"
+
+        out_command = f"({command}) | (base64 --wrap 0; echo)\n"
+
         assert self.shell
         self.shell.send(out_command.encode())
 

--- a/nixos/lib/test-driver/test_driver/machine.py
+++ b/nixos/lib/test-driver/test_driver/machine.py
@@ -529,10 +529,13 @@ class Machine:
         # Always run command with shell opts
         command = f"set -euo pipefail; {command}"
 
+        timeout_str = ""
         if timeout is not None:
-            command = f"timeout {timeout} sh -c {shlex.quote(command)}"
+            timeout_str = f"timeout {timeout}"
 
-        out_command = f"({command}) | (base64 --wrap 0; echo)\n"
+        out_command = (
+            f"{timeout_str} sh -c {shlex.quote(command)} | (base64 --wrap 0; echo)\n"
+        )
 
         assert self.shell
         self.shell.send(out_command.encode())


### PR DESCRIPTION
###### Description of changes

In the test-driver, setting the shell opts in the `machine.execute()` command is inconsistent: When no timeout is used, shellopts `set -euo pipefail` are applied to the command as expected. When a timeout is specified, the shellopts are not applied to the command itself but rather to the `timeout` command (because the user command is called inside a `sh -c` that doesn't inherit the shellopts).

Using the example of `pipefail`, this leads to the following behavior (all commands succeed):

```python
cmd = "false | true"

machine.fail(cmd)
machine.succeed(cmd, timeout=1)
machine.wait_until_succeeds(cmd) # --> indirectly adds a timeout
```

Expected behavior would be:

```python
cmd = "false | true"

machine.fail(cmd)
machine.fail(cmd, timeout=1)
machine.wait_until_fails(cmd) # --> indirectly adds a timeout
```

In addition to the fix in this PR, the documentation has been adapted to clarify that the shellopts are set in every `execute` call and that the `timeout` parameter can be used in `execute`, `succeed` and `wait_until_succeeds` as well.


###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
