### PR TITLE
unigine-tropics: init at 1.3

### DIFF
--- a/pkgs/applications/graphics/unigine-tropics/default.nix
+++ b/pkgs/applications/graphics/unigine-tropics/default.nix
@@ -1,0 +1,95 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, autoPatchelfHook
+, libX11
+, libXext
+, libXrandr
+, libXinerama
+, libglvnd
+, openal
+, glibc
+, makeDesktopItem
+, copyDesktopItems
+, imagemagick
+}:
+let
+  version = "1.3";
+in
+stdenv.mkDerivation {
+  pname = "unigine-tropics";
+  inherit version;
+
+  src = fetchurl {
+    url = "http://m12-assets.unigine.com/d/Unigine_Tropics-${version}.run";
+    sha256 = "0icasdp46fjnic7gk83pknjx0gpap9j202dm0llcfg5zin5kbq7x";
+  };
+
+  libPath = lib.makeLibraryPath [
+    libglvnd
+    openal
+    glibc
+  ];
+
+  installPhase = ''
+    bash $src --target $name
+
+    install -D -m 0755 $name/bin/libUnigine_x86.so $out/lib/unigine/tropics/bin/libUnigine_x86.so
+    install -D -m 0755 $name/bin/Tropics $out/lib/unigine/tropics/bin/Tropics
+    install -D -m 0755 $name/1024x768_windowed.sh $out/bin/Tropics
+
+    cp -R $name/data $out/lib/unigine/tropics
+
+    wrapProgram $out/bin/Tropics \
+      --prefix LD_LIBRARY_PATH : $libPath:$out/lib/unigine/tropics/bin \
+      --run "cd $out/lib/unigine/tropics"
+
+    convert -size 256x256 xc:Transparent -fill gradient:'dodgerblue-white' -stroke Transparent -draw "roundrectangle 0,0 256,256 50,50"  $name/icon.png
+    convert $name/icon.png -fill white -stroke white -draw "polygon  69.2564,84.1261 117.9,84.1261 117.9,206.56 138.1,206.56 138.1,84.1261 186.744,84.1261 186.744,65.9877 69.2564,65.9877 69.2564,84.1261" $name/icon.png
+
+    for RES in 16 24 32 48 64 128 256
+    do
+        mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
+        convert $name/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Tropics.png
+    done
+    convert $name/icon.png -resize 128x128 $out/share/icons/Tropics.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Tropics";
+      exec = "Tropics";
+      genericName = "A GPU Stress test tool from the UNIGINE";
+      icon = "Tropics";
+      desktopName = "Tropics Benchmark";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    imagemagick
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc
+    libX11
+    libXext
+    libXrandr
+    libXinerama
+  ];
+
+  dontUnpack = true;
+
+  meta = {
+    description = "The Unigine Heaven GPU benchmarking tool";
+    homepage = "https://benchmark.unigine.com/tropics";
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.BarinovMaxim ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -29677,6 +29677,8 @@ with pkgs;
 
   unigine-heaven = callPackage ../applications/graphics/unigine-heaven { };
 
+  unigine-tropics = pkgsi686Linux.callPackage ../applications/graphics/unigine-tropics { };
+
   unigine-superposition = libsForQt5.callPackage ../applications/graphics/unigine-superposition { };
 
   unipicker = callPackage ../applications/misc/unipicker { };


### PR DESCRIPTION
###### Description of changes

I want to add a new package unigine-tropics. It's a benchmarking tool from unigine. Nixos users will be able to install this package on their computers and benchmark gpu.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
