### PR TITLE
Jetbrains update script fixes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -681,6 +681,12 @@
     github = "an-empty-string";
     githubId = 681716;
   };
+  AnatolyPopov = {
+    email = "aipopov@live.ru";
+    github = "AnatolyPopov";
+    githubId = 2312534;
+    name = "Anatolii Popov";
+  };
   andehen = {
     email = "git@andehen.net";
     github = "andehen";

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -260,7 +260,7 @@ in
       sha256 = products.clion.sha256;
     };
     wmClass = "jetbrains-clion";
-    update-channel = "CLion RELEASE"; # channel's id as in http://www.jetbrains.com/updates/updates.xml
+    update-channel = products.clion.update-channel;
   };
 
   datagrip = buildDataGrip rec {
@@ -273,7 +273,7 @@ in
       sha256 = products.datagrip.sha256;
     };
     wmClass = "jetbrains-datagrip";
-    update-channel = "DataGrip RELEASE";
+    update-channel = products.datagrip.update-channel;
   };
 
   goland = buildGoland rec {
@@ -286,7 +286,7 @@ in
       sha256 = products.goland.sha256;
     };
     wmClass = "jetbrains-goland";
-    update-channel = "GoLand RELEASE";
+    update-channel = products.goland.update-channel;
   };
 
   idea-community = buildIdea rec {
@@ -300,7 +300,7 @@ in
       sha256 = products.idea-community.sha256;
     };
     wmClass = "jetbrains-idea-ce";
-    update-channel = "IntelliJ IDEA RELEASE";
+    update-channel = products.idea-community.update-channel;
   };
 
   idea-ultimate = buildIdea rec {
@@ -314,12 +314,12 @@ in
       sha256 = products.idea-ultimate.sha256;
     };
     wmClass = "jetbrains-idea";
-    update-channel = "IntelliJ IDEA RELEASE";
+    update-channel = products.idea-ultimate.update-channel;
   };
 
   mps = buildMps rec {
     pname = "mps";
-    product = "MPS ${products.mps.version-major-minor}";
+    product = "MPS ${products.mps.version}";
     version = products.mps.version;
     description = "Create your own domain-specific language";
     license = lib.licenses.asl20;
@@ -328,7 +328,7 @@ in
       sha256 = products.mps.sha256;
     };
     wmClass = "jetbrains-mps";
-    update-channel = "MPS RELEASE";
+    update-channel = products.mps.update-channel;
   };
 
   phpstorm = buildPhpStorm rec {
@@ -341,7 +341,7 @@ in
       sha256 = products.phpstorm.sha256;
     };
     wmClass = "jetbrains-phpstorm";
-    update-channel = "PhpStorm RELEASE";
+    update-channel = products.phpstorm.update-channel;
   };
 
   pycharm-community = buildPycharm rec {
@@ -355,7 +355,7 @@ in
       sha256 = products.pycharm-community.sha256;
     };
     wmClass = "jetbrains-pycharm-ce";
-    update-channel = "PyCharm RELEASE";
+    update-channel = products.pycharm-community.update-channel;
   };
 
   pycharm-professional = buildPycharm rec {
@@ -369,7 +369,7 @@ in
       sha256 = products.pycharm-professional.sha256;
     };
     wmClass = "jetbrains-pycharm";
-    update-channel = "PyCharm RELEASE";
+    update-channel = products.pycharm-professional.update-channel;
   };
 
   rider = buildRider rec {
@@ -382,7 +382,7 @@ in
       sha256 = products.rider.sha256;
     };
     wmClass = "jetbrains-rider";
-    update-channel = "Rider RELEASE";
+    update-channel = products.rider.update-channel;
   };
 
   ruby-mine = buildRubyMine rec {
@@ -395,7 +395,7 @@ in
       sha256 = products.ruby-mine.sha256;
     };
     wmClass = "jetbrains-rubymine";
-    update-channel = "RubyMine RELEASE";
+    update-channel = products.ruby-mine.update-channel;
   };
 
   webstorm = buildWebStorm rec {
@@ -408,7 +408,7 @@ in
       sha256 = products.webstorm.sha256;
     };
     wmClass = "jetbrains-webstorm";
-    update-channel = "WebStorm RELEASE";
+    update-channel = products.webstorm.update-channel;
   };
 
 }

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -124,7 +124,7 @@ let
           with JUnit, TestNG, popular SCMs, Ant & Maven. Also known
           as IntelliJ.
         '';
-        maintainers = with maintainers; [ edwtjo gytis-ivaskevicius steinybot ];
+        maintainers = with maintainers; [ edwtjo gytis-ivaskevicius steinybot AnatolyPopov ];
         platforms = ideaPlatforms;
       };
     });


### PR DESCRIPTION
###### Description of changes
Fixing issues caused by this [PR](https://github.com/NixOS/nixpkgs/pull/160115). More specifically:
1. Proper sha256 validation without downloading all the IDEs
2. Proper support of update-channels allowing to upgrade to EAP versions easily.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
