### PR TITLE
nixos/setup-etc.pl: Cleanup setup-etc.pl

### DIFF
--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -1,10 +1,12 @@
 #! @perl@/bin/perl
 
 use strict;
-use File::Find;
-use File::Copy;
-use File::Path;
+use warnings;
+
 use File::Basename;
+use File::Copy;
+use File::Find;
+use File::Path;
 use File::Slurp;
 
 my $etc = $ARGV[0] or die;

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -1,3 +1,5 @@
+#! @perl@/bin/perl
+
 use strict;
 use File::Find;
 use File::Copy;

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -115,12 +115,12 @@ sub link {
     }
 
     if (-e "$_.mode") {
-        my $mode = read_file("$_.mode"); chomp $mode;
+        chomp(my $mode = read_file("$_.mode"));
         if ($mode eq "direct-symlink") {
             atomic_symlink readlink("$static/$fn"), $target or warn "could not create symlink $target";
         } else {
-            my $uid = read_file("$_.uid"); chomp $uid;
-            my $gid = read_file("$_.gid"); chomp $gid;
+            my $uid = read_file("$_.uid", { chomp => 1 });
+            my $gid = read_file("$_.gid", { chomp => 1 });
             copy "$static/$fn", "$target.tmp" or warn;
 
             # uid could either be an uid or an username, this gets the uid

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -85,7 +85,7 @@ find(\&cleanup, "/etc");
 
 # Use /etc/.clean to keep track of copied files.
 my @old_copied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
-open CLEAN, ">>/etc/.clean" or die("Couldn't open /etc/.clean");
+open(my $clean, ">>", "/etc/.clean") or die("Couldn't open /etc/.clean");
 
 
 # For every file in the etc tree, create a corresponding symlink in
@@ -140,7 +140,7 @@ sub link {
             }
         }
         push @copied, $fn;
-        print CLEAN "$fn\n";
+        print $clean "$fn\n";
     } elsif (-l "$_") {
         atomic_symlink "$static/$fn", $target or warn "could not create symlink $target";
     }
@@ -161,11 +161,11 @@ foreach my $fn (@old_copied) {
 
 
 # Rewrite /etc/.clean.
-close CLEAN or die("Couldn't close /etc/.clean");
+close($clean) or die("Couldn't close /etc/.clean");
 write_file("/etc/.clean", map { "$_\n" } sort @copied);
 
 # Create /etc/NIXOS tag if not exists.
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,
 # so we need to check and re-create it during activation.
-open TAG, ">>/etc/NIXOS" or die("Couldn't create /etc/NIXOS");
-close $TAG or die ("Couldn't close /etc/NIXOS");
+open(my $TAG, ">>", "/etc/NIXOS") or die("Couldn't create /etc/NIXOS");
+close($TAG) or die ("Couldn't close /etc/NIXOS");

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -46,9 +46,9 @@ sub is_static {
     }
 
     if (-d $path) {
-        opendir(my $dir, "$path") or return 0;
-        my @names = readdir($dir) or die("Failed reading directory `$dir`");
-        closedir($dir);
+        opendir(my $dh, $path) or return 0;
+        my @names = readdir($dh) or die("Failed reading directory `$dh`");
+        closedir($dh);
 
         foreach my $name (@names) {
             if ($name eq "." || $name eq "..") {
@@ -69,7 +69,7 @@ sub is_static {
 # (where all the NixOS sources live).
 sub cleanup {
     my $filename = $_;
-    if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq "/etc/static") {
+    if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq $static) {
         $File::Find::prune = 1;
         return;
     }
@@ -79,8 +79,8 @@ sub cleanup {
             my $x = $static . substr($File::Find::name, length("/etc/"));
             # Check if symlink is still present in new etc
             if (not (-l $x)) {
-                print(STDERR "removing obsolete symlink ‘$File::Find::name’...\n");
-                unlink("$filename");
+                warn("removing obsolete symlink ‘$File::Find::name’...\n");
+                unlink($filename);
             }
         }
     }
@@ -171,8 +171,8 @@ find(\&make_symlinks, $etc);
 foreach my $fn (@old_copied) {
     if (!defined $created{$fn}) {
         $fn = "/etc/$fn";
-        print(STDERR "removing obsolete file ‘$fn’...\n");
-        unlink("$fn");
+        warn("removing obsolete file ‘$fn’...\n");
+        unlink($fn);
     }
 }
 

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -67,17 +67,18 @@ sub is_static {
 # in the current one.  For efficiency, don't look under /etc/nixos
 # (where all the NixOS sources live).
 sub cleanup {
-    if ($File::Find::name eq "/etc/nixos") {
+    my $filename = $_;
+    if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq "/etc/static") {
         $File::Find::prune = 1;
         return;
     }
-    if (-l $_) {
-        my $target = readlink($_);
+    if (-l $filename) {
+        my $target = readlink($filename);
         if (substr($target, 0, length($static)) eq $static) {
             my $x = $static . substr($File::Find::name, length("/etc/"));
             if (not (-l $x)) {
                 print(STDERR "removing obsolete symlink ‘$File::Find::name’...\n");
-                unlink("$_");
+                unlink("$filename");
             }
         }
     }

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -47,12 +47,12 @@ sub is_static ($path) {
         my @names = read_dir($path);
         foreach my $name (@names) {
             if (not (is_static("$path/$name"))) {
-                return 0;
+                return;
             }
         }
         return 1;
     }
-    return 0;
+    return;
 }
 
 # Remove dangling symlinks that point to /etc/static.  These are

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -2,7 +2,7 @@
 
 use v5.34;
 use warnings;
-use experimental qw(signatures);
+use experimental qw(try signatures);
 
 use File::Basename qw(dirname);
 use File::Copy qw(copy);
@@ -15,24 +15,31 @@ if ($etc eq "") {
     die("This script must be called with an argument which expresses the new /etc directory in the nix store");
 }
 my $static = "/etc/static";
+my @cleanup_errors;
+my @symlink_errors;
+
 
 # Create a symlink atomically from argument 2 -> argument 1
 sub atomic_symlink ($source, $target) {
     my $tmp = "$target.tmp";
     unlink($tmp);
-    symlink($source, $tmp) or return 0;
-    if (rename($tmp, $target)) {
-        return 1;
-    } else {
-        unlink($tmp);
-        return 0;
+    if (-e $tmp) {
+        die("Failed to remove `$tmp` file before linking");
     }
+    symlink($source, $tmp) or die("Failed to create symlink `$tmp` -> `$source`: $!");
+    rename($tmp, $target) or die("Failed to move `$tmp` -> `$target`: $!");
 }
 
 
 # Atomically update /etc/static to point at the etc files of the
 # current configuration.
-atomic_symlink($etc, $static) or die("Failed to create symlink for /etc");
+try {
+    atomic_symlink($etc, $static);
+}
+catch ($e) {
+    die("Failed to create symlink for /etc: $e");
+}
+
 
 # Returns 1 if the argument points to the files in /etc/static.  That
 # means either argument is a symlink to a file in /etc/static or a
@@ -63,25 +70,35 @@ sub is_static ($path) {
 sub cleanup {
     my $filename = $_;
 
-    if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq $static) {
-        $File::Find::prune = 1;
-        return;
-    }
-    if (-l $filename) {
-        my $target = readlink($filename);
-        if (substr($target, 0, length($static)) eq $static) {
-            my $x = $static . substr($File::Find::name, length("/etc/"));
-            # Check if symlink is still present in new etc
-            if (not (-l $x)) {
-                warn("removing obsolete symlink ‘$File::Find::name’...\n");
-                unlink($filename);
+    try {
+        if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq $static) {
+            $File::Find::prune = 1;
+            return;
+        }
+        if (-l $filename) {
+            my $target = readlink($filename);
+            if (substr($target, 0, length($static)) eq $static) {
+                my $x = $static . substr($File::Find::name, length("/etc/"));
+                # Check if symlink is still present in new etc
+                if (not (-l $x)) {
+                    warn("removing obsolete symlink ‘$File::Find::name’...\n");
+                    unlink($filename) or die("Failed to remove `$filename`: $!");
+                }
             }
         }
+        return;
     }
-    return;
+    catch ($e) {
+        push(@cleanup_errors, $e);
+    }
 }
 
 find(\&cleanup, "/etc");
+if (@cleanup_errors) {
+    warn("Something went wrong while removing dangling symlinks:");
+    warn(map({ "- $_\n" } @cleanup_errors));
+    warn("Please remove these symlinks manually to prevent security implications.");
+}
 
 
 # Use /etc/.clean to keep track of copied files.
@@ -97,64 +114,65 @@ my @copied;
 sub make_symlinks {
     my $path_to_file = $_;
 
-    # This is needed to avoid a warning if we take the substr of the first
-    # directory, i.e., the /nix/store/.../etc itself
-    if (length($File::Find::name) == length($etc)) {
-        return;
-    }
-
-    # Strip away /nix/store/<hash>-etc/etc/ from filename
-    my $fn = substr($File::Find::name, length($etc) + 1) or return;
-
-    # nixos-enter sets up /etc/resolv.conf as a bind mount, so skip it.
-    if ($fn eq "resolv.conf" and $ENV{'IN_NIXOS_ENTER'}) {
-        return;
-    }
-
-    my $target = "/etc/$fn";
-    make_path(dirname($target));
-    $created{$fn} = 1;
-
-    # Rename doesn't work if target is directory.
-    if (-l $path_to_file && -d $target) {
-        if (is_static($target)) {
-            rmtree($target) or warn("Failed to remove $target");
-        } else {
-            warn("$target directory contains user files. Symlinking may fail.");
+    try {
+        # This is needed to avoid a warning if we take the substr of the first
+        # directory, i.e., the /nix/store/.../etc itself
+        if (length($File::Find::name) == length($etc)) {
+            return;
         }
-    }
 
-    # This will set uid/gid if the options were set in the nix config
-    if (-e "$path_to_file.mode") {
-        chomp(my $mode = read_file("$path_to_file.mode"));
-        if ($mode eq "direct-symlink") {
-            atomic_symlink(readlink("$static/$fn"), $target) or warn("Failed to symlink `$target`");
-        } else {
-            my $uid = read_file("$path_to_file.uid", { chomp => 1 });
-            my $gid = read_file("$path_to_file.gid", { chomp => 1 });
-            copy("$static/$fn", "$target.tmp") or warn("Copy failed: $!");
+        # Strip away /nix/store/<hash>-etc/etc/ from filename
+        my $fn = substr($File::Find::name, length($etc) + 1) or return;
 
-            # uid could either be an uid or an username, this gets the uid
-            if ($uid !~ /^\+/) {
-                $uid = getpwnam($uid) or warn("No user with name `$uid` found!");
-            }
-            if ($gid !~ /^\+/) {
-                $gid = getgrnam($gid) or warn("No group with name `$uid` found!");
-            }
+        # nixos-enter sets up /etc/resolv.conf as a bind mount, so skip it.
+        if ($fn eq "resolv.conf" and $ENV{'IN_NIXOS_ENTER'}) {
+            return;
+        }
 
-            chown(int($uid), int($gid), "$target.tmp") or warn("Chowning `$target` failed");
-            chmod(oct($mode), "$target.tmp") or warn("Chmod of `$target` failed");
-            unless (rename("$target.tmp", $target)) {
-                warn("Moving of `$target` failed");
-                unlink("$target.tmp");
+        my $target = "/etc/$fn";
+        make_path(dirname($target));
+        $created{$fn} = 1;
+
+        # Rename doesn't work if target is directory.
+        if (-l $path_to_file && -d $target) {
+            if (is_static($target)) {
+                rmtree($target) or die("Failed to remove directory `$target`: $!");
+            } else {
+                warn("$target directory contains user files. Symlinking may fail.");
             }
         }
-        push(@copied, $fn);
-    } elsif (-l $path_to_file) {
-        atomic_symlink("$static/$fn", $target) or warn("Atomic symlink failed for `$target`");
-    }
 
-    return;
+        # This will set uid/gid if the options were set in the nix config
+        if (-e "$path_to_file.mode") {
+            chomp(my $mode = read_file("$path_to_file.mode"));
+            if ($mode eq "direct-symlink") {
+                atomic_symlink(readlink("$static/$fn"), $target) or warn("Failed to symlink `$target`");
+            } else {
+                my $uid = read_file("$path_to_file.uid", { chomp => 1 });
+                my $gid = read_file("$path_to_file.gid", { chomp => 1 });
+                copy("$static/$fn", "$target.tmp") or warn("Copy failed: $!");
+
+                # uid could either be an uid or an username, this gets the uid
+                if ($uid !~ /^\+/) {
+                    $uid = getpwnam($uid) or warn("No user with name `$uid` found!");
+                }
+                if ($gid !~ /^\+/) {
+                    $gid = getgrnam($gid) or warn("No group with name `$uid` found!");
+                }
+
+                chown(int($uid), int($gid), "$target.tmp") or die("Chowning `$target` failed: $!");
+                chmod(oct($mode), "$target.tmp") or die("Chmod of `$target` failed: $!");
+                rename("$target.tmp", $target) or die("Moving of `$target` failed: $!");
+            }
+            push(@copied, $fn);
+        } elsif (-l $path_to_file) {
+            atomic_symlink("$static/$fn", $target) or warn("Atomic symlink failed for `$target`");
+        }
+        return;
+    }
+    catch ($e) {
+        push(@symlink_errors, $e);
+    }
 }
 
 find(\&make_symlinks, $etc);
@@ -178,3 +196,11 @@ write_file("/etc/.clean", { atomic => 1 }, map({ "$_\n" } sort @copied));
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,
 # so we need to check and re-create it during activation.
 write_file("/etc/NIXOS", { append => 1 }) or die("Couldn't create /etc/NIXOS");
+
+
+if (@symlink_errors) {
+    warn("Something went wrong while setting up the new /etc directory:");
+    warn(map({ "- $_\n" } @symlink_errors));
+    warn("The system is left in a potentially unsafe state!");
+    exit 1;
+}

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -183,5 +183,4 @@ write_file("/etc/.clean", { atomic => 1 }, map({ "$_\n" } sort @copied));
 # Create /etc/NIXOS tag if not exists.
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,
 # so we need to check and re-create it during activation.
-open(my $TAG, ">>", "/etc/NIXOS") or die("Couldn't create /etc/NIXOS");
-close($TAG) or die ("Couldn't close /etc/NIXOS");
+write_file("/etc/NIXOS", { append => 1 }) or die("Couldn't create /etc/NIXOS");

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -54,7 +54,6 @@ sub is_static {
         }
         return 1;
     }
-
     return 0;
 }
 
@@ -144,6 +143,8 @@ sub link {
     } elsif (-l "$_") {
         atomic_symlink "$static/$fn", $target or warn "could not create symlink $target";
     }
+
+    return;
 }
 
 find(\&link, $etc);

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -48,7 +48,7 @@ sub isStatic {
 
         foreach my $name (@names) {
             next if $name eq "." || $name eq "..";
-            unless (isStatic("$path/$name")) {
+            if (not (isStatic("$path/$name"))) {
                 return 0;
             }
         }
@@ -71,7 +71,7 @@ sub cleanup {
         my $target = readlink $_;
         if (substr($target, 0, length $static) eq $static) {
             my $x = $static . substr($File::Find::name, length "/etc/");
-            unless (-l $x) {
+            if (not (-l $x)) {
                 print STDERR "removing obsolete symlink ‘$File::Find::name’...\n";
                 unlink "$_";
             }
@@ -122,8 +122,15 @@ sub link {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
             copy "$static/$fn", "$target.tmp" or warn;
-            $uid = getpwnam $uid unless $uid =~ /^\+/;
-            $gid = getgrnam $gid unless $gid =~ /^\+/;
+
+            # uid could either be an uid or an username, this gets the uid
+            if ($uid !~ /^\+/) {
+                $uid = getpwnam $uid;
+            }
+            if ($gid !~ /^\+/) {
+                $gid = getgrnam $gid;
+            }
+
             chown int($uid), int($gid), "$target.tmp" or warn;
             chmod oct($mode), "$target.tmp" or warn;
             unless (rename "$target.tmp", $target) {

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -1,7 +1,8 @@
 #! @perl@/bin/perl
 
-use strict;
+use v5.34;
 use warnings;
+use experimental qw(signatures);
 
 use File::Basename qw(dirname);
 use File::Copy qw(copy);
@@ -16,8 +17,7 @@ if ($etc eq "") {
 my $static = "/etc/static";
 
 # Create a symlink atomically from argument 2 -> argument 1
-sub atomic_symlink {
-    my ($source, $target) = @_;
+sub atomic_symlink ($source, $target) {
     my $tmp = "$target.tmp";
     unlink($tmp);
     symlink($source, $tmp) or return 0;
@@ -37,9 +37,7 @@ atomic_symlink($etc, $static) or die("Failed to create symlink for /etc");
 # Returns 1 if the argument points to the files in /etc/static.  That
 # means either argument is a symlink to a file in /etc/static or a
 # directory with all children being static.
-sub is_static {
-    my $path = shift;
-
+sub is_static ($path) {
     if (-l $path) {
         my $target = readlink($path);
         return substr($target, 0, length($static)) eq $static;
@@ -69,6 +67,7 @@ sub is_static {
 # (where all the NixOS sources live).
 sub cleanup {
     my $filename = $_;
+
     if ($File::Find::name eq "/etc/nixos" || $File::Find::name eq $static) {
         $File::Find::prune = 1;
         return;

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -136,10 +136,10 @@ sub make_symlinks {
 
             # uid could either be an uid or an username, this gets the uid
             if ($uid !~ /^\+/) {
-                $uid = getpwnam($uid);
+                $uid = getpwnam($uid) or warn("No user with name `$uid` found!");
             }
             if ($gid !~ /^\+/) {
-                $gid = getgrnam($gid);
+                $gid = getgrnam($gid) or warn("No group with name `$uid` found!");
             }
 
             chown(int($uid), int($gid), "$target.tmp") or warn("Chowning `$target` failed");

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -38,7 +38,7 @@ sub isStatic {
 
     if (-l $path) {
         my $target = readlink $path;
-        return substr($target, 0, length "/etc/static/") eq "/etc/static/";
+        return substr($target, 0, length $static) eq $static;
     }
 
     if (-d $path) {
@@ -70,7 +70,7 @@ sub cleanup {
     if (-l $_) {
         my $target = readlink $_;
         if (substr($target, 0, length $static) eq $static) {
-            my $x = "/etc/static/" . substr($File::Find::name, length "/etc/");
+            my $x = $static . substr($File::Find::name, length "/etc/");
             unless (-l $x) {
                 print STDERR "removing obsolete symlink ‘$File::Find::name’...\n";
                 unlink "$_";

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -92,7 +92,6 @@ find(\&cleanup, "/etc");
 
 # Use /etc/.clean to keep track of copied files.
 my @old_copied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
-open(my $clean, ">>", "/etc/.clean") or die("Couldn't open /etc/.clean");
 
 
 # For every file in the etc tree, create a corresponding symlink in
@@ -157,7 +156,6 @@ sub make_symlinks {
             }
         }
         push(@copied, $fn);
-        print($clean "$fn\n");
     } elsif (-l "$path_to_file") {
         atomic_symlink("$static/$fn", $target) or warn("could not create symlink $target");
     }
@@ -180,8 +178,7 @@ foreach my $fn (@old_copied) {
 
 
 # Rewrite /etc/.clean.
-close($clean) or die("Couldn't close /etc/.clean");
-write_file("/etc/.clean", map({ "$_\n" } sort @copied));
+write_file("/etc/.clean", { atomic => 1 }, map({ "$_\n" } sort @copied));
 
 # Create /etc/NIXOS tag if not exists.
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -3,11 +3,11 @@
 use strict;
 use warnings;
 
-use File::Basename;
-use File::Copy;
-use File::Find;
-use File::Path;
-use File::Slurp;
+use File::Basename qw(dirname);
+use File::Copy qw(copy);
+use File::Find qw(find);
+use File::Path qw(make_path rmtree);
+use File::Slurp qw(read_file write_file);
 
 my $etc = $ARGV[0];
 if ($etc eq "") {

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -15,6 +15,7 @@ if ($etc eq "") {
 }
 my $static = "/etc/static";
 
+# Create a symlink atomically from argument 2 -> argument 1
 sub atomic_symlink {
     my ($source, $target) = @_;
     my $tmp = "$target.tmp";
@@ -76,6 +77,7 @@ sub cleanup {
         my $target = readlink($filename);
         if (substr($target, 0, length($static)) eq $static) {
             my $x = $static . substr($File::Find::name, length("/etc/"));
+            # Check if symlink is still present in new etc
             if (not (-l $x)) {
                 print(STDERR "removing obsolete symlink ‘$File::Find::name’...\n");
                 unlink("$filename");
@@ -129,6 +131,7 @@ sub make_symlinks {
         }
     }
 
+    # This will set uid/gid if the options were set in the nix config
     if (-e "$path_to_file.mode") {
         chomp(my $mode = read_file("$path_to_file.mode"));
         if ($mode eq "direct-symlink") {

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -101,7 +101,15 @@ my @copied;
 
 sub make_symlinks {
     my $path_to_file = $_;
-    my $fn = substr($File::Find::name, length($etc) + 1) or next;
+
+    # This is needed to avoid a warning if we take the substr of the first
+    # directory, i.e., the /nix/store/.../etc itself
+    if (length($File::Find::name) == length($etc)) {
+        return;
+    }
+
+    # Strip away /nix/store/<hash>-etc/etc/ from filename
+    my $fn = substr($File::Find::name, length($etc) + 1) or return;
 
     # nixos-enter sets up /etc/resolv.conf as a bind mount, so skip it.
     if ($fn eq "resolv.conf" and $ENV{'IN_NIXOS_ENTER'}) {

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -12,7 +12,7 @@ use File::Slurp;
 my $etc = $ARGV[0] or die;
 my $static = "/etc/static";
 
-sub atomicSymlink {
+sub atomic_symlink {
     my ($source, $target) = @_;
     my $tmp = "$target.tmp";
     unlink $tmp;
@@ -28,12 +28,12 @@ sub atomicSymlink {
 
 # Atomically update /etc/static to point at the etc files of the
 # current configuration.
-atomicSymlink $etc, $static or die;
+atomic_symlink $etc, $static or die;
 
 # Returns 1 if the argument points to the files in /etc/static.  That
 # means either argument is a symlink to a file in /etc/static or a
 # directory with all children being static.
-sub isStatic {
+sub is_static {
     my $path = shift;
 
     if (-l $path) {
@@ -48,7 +48,7 @@ sub isStatic {
 
         foreach my $name (@names) {
             next if $name eq "." || $name eq "..";
-            if (not (isStatic("$path/$name"))) {
+            if (not (is_static("$path/$name"))) {
                 return 0;
             }
         }
@@ -77,13 +77,14 @@ sub cleanup {
             }
         }
     }
+    return;
 }
 
 find(\&cleanup, "/etc");
 
 
 # Use /etc/.clean to keep track of copied files.
-my @oldCopied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
+my @old_copied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
 open CLEAN, ">>/etc/.clean";
 
 
@@ -107,7 +108,7 @@ sub link {
 
     # Rename doesn't work if target is directory.
     if (-l $_ && -d $target) {
-        if (isStatic $target) {
+        if (is_static $target) {
             rmtree $target or warn;
         } else {
             warn "$target directory contains user files. Symlinking may fail.";
@@ -117,7 +118,7 @@ sub link {
     if (-e "$_.mode") {
         my $mode = read_file("$_.mode"); chomp $mode;
         if ($mode eq "direct-symlink") {
-            atomicSymlink readlink("$static/$fn"), $target or warn "could not create symlink $target";
+            atomic_symlink readlink("$static/$fn"), $target or warn "could not create symlink $target";
         } else {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
@@ -141,7 +142,7 @@ sub link {
         push @copied, $fn;
         print CLEAN "$fn\n";
     } elsif (-l "$_") {
-        atomicSymlink "$static/$fn", $target or warn "could not create symlink $target";
+        atomic_symlink "$static/$fn", $target or warn "could not create symlink $target";
     }
 }
 
@@ -150,7 +151,7 @@ find(\&link, $etc);
 
 # Delete files that were copied in a previous version but not in the
 # current.
-foreach my $fn (@oldCopied) {
+foreach my $fn (@old_copied) {
     if (!defined $created{$fn}) {
         $fn = "/etc/$fn";
         print STDERR "removing obsolete file ‘$fn’...\n";

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -47,7 +47,9 @@ sub is_static {
         closedir(DIR);
 
         foreach my $name (@names) {
-            next if $name eq "." || $name eq "..";
+            if ($name eq "." || $name eq "..") {
+                next;
+            }
             if (not (is_static("$path/$name"))) {
                 return 0;
             }

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -85,7 +85,7 @@ find(\&cleanup, "/etc");
 
 # Use /etc/.clean to keep track of copied files.
 my @old_copied = read_file("/etc/.clean", chomp => 1, err_mode => 'quiet');
-open CLEAN, ">>/etc/.clean";
+open CLEAN, ">>/etc/.clean" or die("Couldn't open /etc/.clean");
 
 
 # For every file in the etc tree, create a corresponding symlink in
@@ -161,11 +161,11 @@ foreach my $fn (@old_copied) {
 
 
 # Rewrite /etc/.clean.
-close CLEAN;
+close CLEAN or die("Couldn't close /etc/.clean");
 write_file("/etc/.clean", map { "$_\n" } sort @copied);
 
 # Create /etc/NIXOS tag if not exists.
 # When /etc is not on a persistent filesystem, it will be wiped after reboot,
 # so we need to check and re-create it during activation.
-open TAG, ">>/etc/NIXOS";
-close TAG;
+open TAG, ">>/etc/NIXOS" or die("Couldn't create /etc/NIXOS");
+close $TAG or die ("Couldn't close /etc/NIXOS");


### PR DESCRIPTION
###### Description of changes

Cleanup of setup-etc.pl

Best reviewed by commit.

The etc test is still passing, but the next thing i'll do is expqnd this test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
