### PR TITLE
gnome.ghex: 4.beta.1 → 42.0

### DIFF
--- a/pkgs/desktops/gnome/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome/apps/ghex/default.nix
@@ -1,12 +1,10 @@
 { stdenv
 , lib
 , fetchurl
-, fetchpatch
 , pkg-config
 , gi-docgen
 , meson
 , ninja
-, python3
 , gnome
 , desktop-file-utils
 , appstream-glib
@@ -17,33 +15,19 @@
 , glib
 , atk
 , gobject-introspection
-, wrapGAppsHook
+, wrapGAppsHook4
 }:
 
 stdenv.mkDerivation rec {
   pname = "ghex";
-  version = "4.beta.1";
+  version = "42.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/ghex/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sBS/9cY++uHLGCbLeex8ZW697JJn3dK+HaM6tHBdwJ4=";
+    url = "mirror://gnome/sources/ghex/${lib.versions.major version}/${pname}-${version}.tar.xz";
+    sha256 = "Ly11VO8SimxoAJ2YY5TiBMMWeMU+HUpAnyGQmNS/ybs=";
   };
-
-  patches = [
-    # Fix build with -Werror=format-security
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/ghex/-/commit/3d35359f3a12b6abb4a3d8a12a0f39b7221be408.patch";
-      sha256 = "4z9nUd+/eBOUGwl3MErse+FKLzGqtWKwkIzej57CnYk=";
-    })
-    # Build devhelp index.
-    # https://gitlab.gnome.org/GNOME/ghex/-/merge_requests/25
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/ghex/-/commit/b26a7b1135ea2fe956a9bc0669b3b6ed818716c3.patch";
-      sha256 = "nYjjxds9GNWkW/RhXEe5zJzPF4TnLMsCELEqYR4dXTk=";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils
@@ -53,9 +37,8 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     gi-docgen
-    python3
     gobject-introspection
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -72,11 +55,6 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dgtk_doc=true"
   ];
-
-  postPatch = ''
-    chmod +x meson_post_install.py
-    patchShebangs meson_post_install.py
-  '';
 
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.

--- a/pkgs/desktops/gnome/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome/apps/ghex/default.nix
@@ -54,6 +54,9 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=true"
+  ] ++ lib.optionals stdenv.isDarwin [
+    # mremap does not exist on darwin
+    "-Dmmap-buffer-backend=false"
   ];
 
   postFixup = ''


### PR DESCRIPTION
###### Description of changes

https://gitlab.gnome.org/GNOME/ghex/-/compare/4.beta.1...42.0
Versioning scheme for app and lib has been splited.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
