### PR TITLE
pre-commit: Add libiconv for tests on x86_64-darwin

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -6,6 +6,7 @@
 , dotnet-sdk
 , git
 , go
+, libiconv
 , nodejs
 }:
 
@@ -52,6 +53,11 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     re-assert
+  ];
+
+  buildInputs = [
+    # Required for rust test on x86_64-darwin
+    libiconv
   ];
 
   doCheck = true;


### PR DESCRIPTION
Note: not a checkInput, because we need
this dependency in the role of a _build_
input during tests: library path, etc.

Solves

    E                 = note: ld: library not found for -liconv
    E                         clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
    E
    E
    E               error: failed to compile `rust-hello-world v0.1.0 (/private/tmp/nix-build-python3.9-pre-commit-2.18.1.drv-1/pytest-of-nixbld4/pytest-0/popen-gw3/test_rust_hook0/0/.pre-commit/repomj5itq00)`, intermediate artifacts can be found at `/private/tmp/nix-build-python3.9-pre-commit-2.18.1.drv-1/pytest-of-nixbld4/pytest-0/popen-gw3/test_rust_hook0/0/.pre-commit/repomj5itq00/target`
    E
    E               Caused by:
    E                 could not compile `rust-hello-world` due to previous error

    pre_commit/util.py:146: CalledProcessError

in test case

    FAILED tests/repository_test.py::test_rust_hook

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
