### PR TITLE
cldr-annotations: 40.0 -> 41.0

### DIFF
--- a/pkgs/data/misc/cldr-annotations/default.nix
+++ b/pkgs/data/misc/cldr-annotations/default.nix
@@ -1,18 +1,18 @@
 { lib, fetchzip }:
 
 let
-  version = "40.0";
+  version = "41.0";
 in fetchzip rec {
   name = "cldr-annotations-${version}";
 
-  url = "https://unicode.org/Public/cldr/40/cldr-common-${version}.zip";
+  url = "https://unicode.org/Public/cldr/${lib.versions.major version}/cldr-common-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/unicode/cldr
     unzip -d $out/share/unicode/cldr $downloadedFile 'common/annotations/*' 'common/annotationsDerived/*'
   '';
 
-  sha256 = "sha256-L4NSMNFYKJWV3qKQhio9eMABtDlLieT9VeMZfzeAkbM=";
+  sha256 = "sha256-3dHVZGx3FmR97fzhlTSx/xp6YTAV+sMExl6gpLzl1MY=";
 
   meta = with lib; {
     description = "Names and keywords for Unicode characters from the Common Locale Data Repository";


### PR DESCRIPTION
###### Description of changes
https://cldr.unicode.org/index/downloads/cldr-41

There are minimal changes to annotations in this CLDR release. I've successfully rebuilt ibus with it to make sure nothing is unexpectedly broken. 

###### Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
