### PR TITLE
haskell: don't lose packageOverrides for native-bignum and integer-simple

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -245,29 +245,43 @@ in {
 
     # The integer-simple attribute set contains package sets for all the GHC compilers
     # using integer-simple instead of integer-gmp.
-    integer-simple = let
-      integerSimpleGhcNames = pkgs.lib.filter
-        (name: ! builtins.elem name integerSimpleExcludes)
-        (pkgs.lib.attrNames packages);
-    in pkgs.lib.genAttrs integerSimpleGhcNames (name: packages.${name}.override {
-      ghc = bh.compiler.integer-simple.${name};
-      buildHaskellPackages = bh.packages.integer-simple.${name};
-      overrides = _self : _super : {
-        integer-simple = null;
-        integer-gmp = null;
-      };
-    });
+    integer-simple =
+      let
+        integerSimpleGhcNames = pkgs.lib.filter
+          (name: ! builtins.elem name integerSimpleExcludes)
+          (pkgs.lib.attrNames packages);
+      in
+      pkgs.lib.genAttrs integerSimpleGhcNames
+        (name:
+          packages.${name}.override (oldAttrs: {
+            ghc = bh.compiler.integer-simple.${name};
+            buildHaskellPackages = bh.packages.integer-simple.${name};
+            overrides =
+              pkgs.lib.composeExtensions
+                (oldAttrs.overrides or (_: _: {}))
+                (_: _: {
+                  integer-simple = null;
+                  integer-gmp = null;
+                });
+          })
+        );
 
-    native-bignum = let
-      nativeBignumGhcNames = pkgs.lib.filter
-        (name: builtins.elem name nativeBignumIncludes)
-        (pkgs.lib.attrNames compiler);
-    in pkgs.lib.genAttrs nativeBignumGhcNames (name: packages.${name}.override {
-      ghc = bh.compiler.native-bignum.${name};
-      buildHaskellPackages = bh.packages.native-bignum.${name};
-      overrides = _self : _super : {
-        integer-gmp = null;
-      };
-    });
+    native-bignum =
+      let
+        nativeBignumGhcNames = pkgs.lib.filter
+          (name: builtins.elem name nativeBignumIncludes)
+          (pkgs.lib.attrNames compiler);
+      in
+      pkgs.lib.genAttrs nativeBignumGhcNames
+        (name:
+          packages.${name}.override (oldAttrs: {
+            ghc = bh.compiler.native-bignum.${name};
+            buildHaskellPackages = bh.packages.native-bignum.${name};
+            overrides =
+              pkgs.lib.composeExtensions
+                (oldAttrs.overrides or (_: _: {}))
+                (_: _: { integer-gmp = null; });
+          })
+        );
   };
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -259,10 +259,7 @@ in {
             overrides =
               pkgs.lib.composeExtensions
                 (oldAttrs.overrides or (_: _: {}))
-                (_: _: {
-                  integer-simple = null;
-                  integer-gmp = null;
-                });
+                (_: _: { integer-simple = null; });
           })
         );
 
@@ -274,14 +271,10 @@ in {
       in
       pkgs.lib.genAttrs nativeBignumGhcNames
         (name:
-          packages.${name}.override (oldAttrs: {
+          packages.${name}.override {
             ghc = bh.compiler.native-bignum.${name};
             buildHaskellPackages = bh.packages.native-bignum.${name};
-            overrides =
-              pkgs.lib.composeExtensions
-                (oldAttrs.overrides or (_: _: {}))
-                (_: _: { integer-gmp = null; });
-          })
+          }
         );
   };
 }


### PR DESCRIPTION
###### Description of changes

This updates `haskell.packages.{native-bignum,integer-simple}.*` so that the new haskell packages added to `packageOverrides` are kept in the native-bignum and integer-simple package sets.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
