### PR TITLE
leveldb: fix static building

### DIFF
--- a/pkgs/development/libraries/leveldb/default.nix
+++ b/pkgs/development/libraries/leveldb/default.nix
@@ -38,12 +38,8 @@ stdenv.mkDerivation rec {
     "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
     "-DLEVELDB_BUILD_TESTS=OFF"
+    "-DLEVELDB_BUILD_BENCHMARKS=OFF"
   ];
-
-  postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
-    # remove shared objects from "all" target
-    sed -i '/^all:/ s/$(SHARED_LIBS) $(SHARED_PROGRAMS)//' Makefile
-  '';
 
   postInstall = ''
     substituteInPlace "$out"/lib/cmake/leveldb/leveldbTargets.cmake \


### PR DESCRIPTION
###### Description of changes

1. The Makefile is long gone and the patch in not needed anymore.

2. For some reason LEVELDB_BUILD_BENCHMARKS=OFF is necessary
   when building statically. (Note: this has always been of
   for the shared build)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
