### PR TITLE
weechat-otr: Fix build and knownVulnerabilities

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/default.nix
@@ -24,6 +24,9 @@ let
 
     buildInputs = [ gmp ];
 
+    # Tests are relying on old Python 2 modules.
+    doCheck = false;
+
     preConfigure = ''
       sed -i 's,/usr/include,/no-such-dir,' configure
       sed -i "s!,'/usr/include/'!!" setup.py
@@ -66,5 +69,9 @@ in stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ oxzi ];
     description = "WeeChat script for Off-the-Record messaging";
+    knownVulnerabilities = [
+      "There is no upstream release since 2018-03."
+      "Utilizes deprecated and vulnerable pycrypto library with Debian patches from 2020-04."
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

First, this closes #167972 by explicitly disabling Python tests for the
backported pycrypto library. Those tests were written for Python 2 only.

Furthermore, the meta.knownVulnerabilities attribute was added as the
last weechat-otr upstream release was in 2018-03 [0] and the backported
Debian package of pycrypto is from 2020-04 [1]. As there are no known
vulnerabilities for weechat-otr itself, pycrypto "is unmaintained,
obsolete, and contains security vulnerabilities" [2]. Even with Debian's
patches, this is no good situation.

As weechat-otr being a security and privacy related software, it should
be made obvious, that its code base is old and unmaintained.

[0] https://github.com/mmb/weechat-otr/releases/tag/v1.9.2
[1] https://salsa.debian.org/sramacher/python-crypto/-/tags/debian%2F2.6.1-13.1
[2] https://www.pycrypto.org/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
