### PR TITLE
stellar-horizon: init at 2.16.0

### DIFF
--- a/pkgs/applications/blockchains/stellar-horizon/default.nix
+++ b/pkgs/applications/blockchains/stellar-horizon/default.nix
@@ -1,0 +1,44 @@
+#with import <nixpkgs> {};
+
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+
+let
+  # A list of binaries to put into separate outputs
+  bins = [
+    "horizon"
+  ];
+
+in buildGoModule rec {
+  pname = "stellar-horizon";
+  version = "2.16.0";
+
+  src = fetchFromGitHub {
+    owner = "stellar";
+    repo = "go";
+    rev = "horizon-v${version}";
+    sha256 = "sha256-5Q2H+z+1JoDeoMTyczJfLul4k/wyB1mv/Q3tICdMaE8=";
+  };
+
+  vendorSha256 = "sha256-Vrfc4nrUjoP2xOXZW1QBBktAQdD1ksCN6Ye86l+Y9Uo=";
+  proxyVendor = true;
+
+  outputs = [ "out" ] ++ bins;
+
+  # Move binaries to separate outputs and symlink them back to $out
+  postInstall = lib.concatStringsSep "\n" (
+    builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
+  );
+
+  ldflags = [ "-X github.com/stellar/go/support/app.version=${version}" ];
+
+  subPackages = [
+    "services/horizon"
+  ];
+
+  meta = with lib; {
+    homepage = "https://stellar.org/";
+    description = "Client facing API server for the Stellar ecosystem.";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/applications/blockchains/stellar-horizon/default.nix
+++ b/pkgs/applications/blockchains/stellar-horizon/default.nix
@@ -1,14 +1,14 @@
-#with import <nixpkgs> {};
+with import <nixpkgs> {};
 
-{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+#{ lib, stdenv, buildGoModule, fetchFromGitHub }:
 
-let
-  # A list of binaries to put into separate outputs
-  bins = [
-    "horizon"
-  ];
+#let
+#  # A list of binaries to put into separate outputs
+#  bins = [
+#    "horizon"
+#  ];
 
-in buildGoModule rec {
+buildGoModule rec {
   pname = "stellar-horizon";
   version = "2.16.0";
 
@@ -22,12 +22,12 @@ in buildGoModule rec {
   vendorSha256 = "sha256-Vrfc4nrUjoP2xOXZW1QBBktAQdD1ksCN6Ye86l+Y9Uo=";
   proxyVendor = true;
 
-  outputs = [ "out" ] ++ bins;
+  #outputs = [ "out" ] ++ bins;
 
   # Move binaries to separate outputs and symlink them back to $out
-  postInstall = lib.concatStringsSep "\n" (
-    builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
-  );
+  #postInstall = lib.concatStringsSep "\n" (
+  #  builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
+  #);
 
   ldflags = [ "-X github.com/stellar/go/support/app.version=${version}" ];
 

--- a/pkgs/applications/blockchains/stellar-horizon/default.nix
+++ b/pkgs/applications/blockchains/stellar-horizon/default.nix
@@ -1,6 +1,6 @@
-with import <nixpkgs> {};
+#with import <nixpkgs> {};
 
-#{ lib, stdenv, buildGoModule, fetchFromGitHub }:
+{ lib, stdenv, buildGoModule, fetchFromGitHub }:
 
 #let
 #  # A list of binaries to put into separate outputs


### PR DESCRIPTION
###### Description of changes

Add Stellar Horizon as a package. A client facing API for the Stellar (blockchain) ecosystem.
It's a complementary package to the already available stellar-core package.

Release notes available at: https://github.com/stellar/go/releases

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
