### PR TITLE
haskell.compiler.ghc8107BinaryMinimal: remove at 8.10.7

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -5,12 +5,6 @@
 , llvmPackages
 , coreutils
 , targetPackages
-
-  # minimal = true; will remove files that aren't strictly necessary for
-  # regular builds and GHC bootstrapping.
-  # This is "useful" for staying within hydra's output limits for at least the
-  # aarch64-linux architecture.
-, minimal ? false
 }:
 
 # Prebuilt only does native
@@ -356,18 +350,6 @@ stdenv.mkDerivation rec {
     for file in $(find "$out" -name setup-config); do
       substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
     done
-  '' +
-  lib.optionalString minimal ''
-    # Remove profiling files
-    find $out -type f -name '*.p_o' -delete
-    find $out -type f -name '*.p_hi' -delete
-    find $out -type f -name '*_p.a' -delete
-    # `-f` because e.g. musl bindist does not have this file.
-    rm -f $out/lib/ghc-*/bin/ghc-iserv-prof
-    # Hydra will redistribute this derivation, so we have to keep the docs for
-    # legal reasons (retaining the legal notices etc)
-    # As a last resort we could unpack the docs separately and symlink them in.
-    # They're in $out/share/{doc,man}.
   '';
 
   # In nixpkgs, musl based builds currently enable `pie` hardening by default

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -7,7 +7,6 @@ let
     "ghc8102Binary"
     "ghc8102BinaryMinimal"
     "ghc8107Binary"
-    "ghc8107BinaryMinimal"
     "ghcjs"
     "ghcjs810"
     "integer-simple"
@@ -71,11 +70,6 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
 
-    ghc8107BinaryMinimal = callPackage ../development/compilers/ghc/8.10.7-binary.nix {
-      llvmPackages = pkgs.llvmPackages_12;
-      minimal = true;
-    };
-
     ghc884 = callPackage ../development/compilers/ghc/8.8.4.nix {
       bootPkgs =
         # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
@@ -89,14 +83,7 @@ in {
       llvmPackages = pkgs.llvmPackages_7;
     };
     ghc8107 = callPackage ../development/compilers/ghc/8.10.7.nix {
-      bootPkgs =
-        # aarch64 ghc865Binary gets SEGVs due to haskell#15449 or similar
-        # the oldest ghc with aarch64-darwin support is 8.10.5
-        # Musl bindists do not exist for ghc 8.6.5, so we use 8.10.* for them
-        if stdenv.isAarch64 || stdenv.isAarch32 then
-          packages.ghc8107BinaryMinimal
-        else
-          packages.ghc8107Binary;
+      bootPkgs = packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and
@@ -106,25 +93,14 @@ in {
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc902 = callPackage ../development/compilers/ghc/9.0.2.nix {
-      bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        # the oldest ghc with aarch64-darwin support is 8.10.5
-        if stdenv.isAarch64 || stdenv.isAarch32 then
-          packages.ghc8107BinaryMinimal
-        else
-          packages.ghc8107Binary;
+      bootPkgs = packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       inherit (buildPackages.darwin) autoSignDarwinBinariesHook xattr;
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_12;
       llvmPackages = pkgs.llvmPackages_12;
     };
     ghc922 = callPackage ../development/compilers/ghc/9.2.2.nix {
-      bootPkgs =
-        # aarch64 ghc8107Binary exceeds max output size on hydra
-        if stdenv.isAarch64 || stdenv.isAarch32 then
-          packages.ghc8107BinaryMinimal
-        else
-          packages.ghc8107Binary;
+      bootPkgs = packages.ghc8107Binary;
       inherit (buildPackages.python3Packages) sphinx;
       # Need to use apple's patched xattr until
       # https://github.com/xattr/xattr/issues/44 and
@@ -200,12 +176,6 @@ in {
     ghc8107Binary = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc8107Binary;
       ghc = bh.compiler.ghc8107Binary;
-      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
-      packageSetConfig = bootstrapPackageSet;
-    };
-    ghc8107BinaryMinimal = callPackage ../development/haskell-modules {
-      buildHaskellPackages = bh.packages.ghc8107BinaryMinimal;
-      ghc = bh.compiler.ghc8107BinaryMinimal;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-8.10.x.nix { };
       packageSetConfig = bootstrapPackageSet;
     };


### PR DESCRIPTION
The 8.10.7 bindist is no longer affected by
https://gitlab.haskell.org/ghc/ghc/-/issues/17051, meaning we can use it
on Hydra to bootstrap all applicable package sets. See also
f2f10367b9e1b955d4f0fdf41ba6d44daac05a89 (in fact ghc8107Binary has been
bootstrapping ghcHEAD for quite a while).

---

Merge for next `haskell-updates` iteration, as it's a set rebuild.

###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
