### PR TITLE
p4c: init at 1.2.2.1

### DIFF
--- a/pkgs/development/compilers/p4c/default.nix
+++ b/pkgs/development/compilers/p4c/default.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, boehmgc
+, bison
+, flex
+, protobuf
+, gmp
+, boost
+, python3
+, doxygen
+, graphviz
+, libbpf
+, libllvm
+, enableDocumentation ? true
+, enableBPF ? true
+, enableDPDK ? true
+, enableBMV2 ? true
+, enableGraphBackend ? true
+, enableP4Tests ? true
+, enableGTests ? true
+, enableMultithreading ? false
+}:
+let
+  toCMakeBoolean = v: if v then "ON" else "OFF";
+in
+stdenv.mkDerivation rec {
+  pname = "p4c";
+  version = "1.2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "p4lang";
+    repo = "p4c";
+    rev = "v${version}";
+    sha256 = "sha256-XIZ7Cm5zfr5XA+s0aSG1WwWHCPjAYv/YoBWTRaXi9rQ=";
+    fetchSubmodules = true;
+  };
+
+  postFetch = ''
+    rm -rf backends/ebpf/runtime/contrib/libbpf
+    rm -rf control-plane/p4runtime
+  '';
+
+  cmakeFlags = [
+    "-DENABLE_BMV2=${toCMakeBoolean enableBMV2}"
+    "-DENABLE_EBPF=${toCMakeBoolean enableBPF}"
+    "-DENABLE_UBPF=${toCMakeBoolean enableBPF}"
+    "-DENABLE_DPDK=${toCMakeBoolean enableDPDK}"
+    "-DENABLE_P4C_GRAPHS=${toCMakeBoolean enableGraphBackend}"
+    "-DENABLE_P4TEST=${toCMakeBoolean enableP4Tests}"
+    "-DENABLE_DOCS=${toCMakeBoolean enableDocumentation}"
+    "-DENABLE_GC=ON"
+    "-DENABLE_GTESTS=${toCMakeBoolean enableGTests}"
+    "-DENABLE_PROTOBUF_STATIC=ON"
+    "-DENABLE_MULTITHREAD=${toCMakeBoolean enableMultithreading}"
+    "-DENABLE_GMP=ON"
+  ];
+
+  checkTarget = "check";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bison
+    flex
+    cmake
+    python3
+  ]
+  ++ lib.optional enableDocumentation [ doxygen graphviz ]
+  ++ lib.optional enableBPF [ libllvm libbpf ];
+
+  buildInputs = [
+    protobuf
+    boost
+    boehmgc
+    gmp
+    flex
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/p4lang/p4c";
+    description = "Reference compiler for the P4 programming language";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ raitobezarius ];
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8768,6 +8768,8 @@ with pkgs;
 
   p3x-onenote = callPackage ../applications/office/p3x-onenote { };
 
+  p4c = callPackage ../development/compilers/p4c { };
+
   p7zip = callPackage ../tools/archivers/p7zip { };
 
   packagekit = callPackage ../tools/package-management/packagekit { nix = nixVersions.nix_2_6; };


### PR DESCRIPTION
###### Description of changes

This adds the [P4 programming language](https://p4.org) compiler to nixpkgs.

I was not really able to split the outputs as it seems that CMake is ignoring the `MANDIR` vars passed, it might require some haul to upstream or patch downstream, docs makes up 128MB of the closure while binaries looks like this:
```
$ du -hs result/bin/*
4,0K	result/bin/p4c
28M	result/bin/p4c-bm2-psa
28M	result/bin/p4c-bm2-ss
28M	result/bin/p4c-dpdk
22M	result/bin/p4c-ebpf
20M	result/bin/p4c-graphs
27M	result/bin/p4c-ubpf
27M	result/bin/p4test
```

Some of them relies on BMv2 to be available, which will come in another PR (`p4c-bm2-*`). Tests do not seem to run, unsure why, I tested basic functionality, and it works fine, but I did not test ubpf/dpdk/ebpf backends yet.

I think it might work on `x86_64-darwin` but I have no machine to test.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).