### PR TITLE
Fix python3Packages.astroquery

### DIFF
--- a/pkgs/development/python-modules/astroquery/default.nix
+++ b/pkgs/development/python-modules/astroquery/default.nix
@@ -6,8 +6,12 @@
 , keyring
 , beautifulsoup4
 , html5lib
+, matplotlib
+, pillow
 , pytest
 , pytest-astropy
+, pytestCheckHook
+, pyvo
 , astropy-helpers
 , isPy3k
 }:
@@ -24,20 +28,38 @@ buildPythonPackage rec {
 
   disabled = !isPy3k;
 
-  propagatedBuildInputs = [ astropy requests keyring beautifulsoup4 html5lib ];
+  propagatedBuildInputs = [
+    astropy
+    requests
+    keyring
+    beautifulsoup4
+    html5lib
+    pyvo
+  ];
 
   nativeBuildInputs = [ astropy-helpers ];
 
-  # Tests disabled until pytest-astropy has been updated to include pytest-astropy-header
-  doCheck = false;
-  checkInputs = [ pytest pytest-astropy ];
+  # Disable automatic update of the astropy-helper module
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "auto_use = True" "auto_use = False"
+  '';
+
+  checkInputs = [
+    matplotlib
+    pillow
+    pytest
+    pytest-astropy
+    pytestCheckHook
+  ];
 
   # Tests must be run in the build directory. The tests create files
   # in $HOME/.astropy so we need to set HOME to $TMPDIR.
-  checkPhase = ''
+  preCheck = ''
+    export HOME=$TMPDIR
     cd build/lib
-    HOME=$TMPDIR pytest
   '';
+
+  pythonImportsCheck = [ "astroquery" ];
 
   meta = with pkgs.lib; {
     description = "Functions and classes to access online data resources";

--- a/pkgs/development/python-modules/pyvo/default.nix
+++ b/pkgs/development/python-modules/pyvo/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, astropy
+, pillow
+, pythonOlder
+, pytestCheckHook
+, pytest-astropy
+, requests
+, requests-mock
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "pyvo";
+  version = "1.3";
+
+  disabled = pythonOlder "3.8"; # according to setup.cfg
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "846a54a05a8ddb47a8c2cc3077434779b0e4ccc1b74a7a5408593cb673307d67";
+  };
+
+  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    astropy
+    requests
+  ];
+
+  checkInputs = [
+    pillow
+    pytestCheckHook
+    pytest-astropy
+    requests-mock
+  ];
+
+  disabledTestPaths = [
+    # touches network
+    "pyvo/dal/tests/test_datalink.py"
+  ];
+
+  pythonImportsCheck = [ "pyvo" ];
+
+  meta = with lib; {
+    description = "Astropy affiliated package for accessing Virtual Observatory data and services";
+    homepage = "github.com/astropy/pyvo";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ smaret ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8490,6 +8490,8 @@ in {
 
   pyvmomi = callPackage ../development/python-modules/pyvmomi { };
 
+  pyvo = callPackage ../development/python-modules/pyvo { };
+
   pyvolumio = callPackage ../development/python-modules/pyvolumio { };
 
   pyvoro = callPackage ../development/python-modules/pyvoro { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

python3Packages.astroquery has been broken since the last automatic update, because of a missing dependency (pyvo). This PR adds the missing dependency and fix astroquery build. The tests for astroquery have been restored.

Note that this requires #167922 to be merged first in order to build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
