### PR TITLE
jetbrains.idea-ultimate: Patch remote-dev-server

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -303,7 +303,7 @@ in
     update-channel = "IntelliJ IDEA RELEASE";
   };
 
-  idea-ultimate = buildIdea rec {
+  idea-ultimate = (buildIdea rec {
     pname = "idea-ultimate";
     product = "IntelliJ IDEA";
     version = products.idea-ultimate.version;
@@ -315,7 +315,15 @@ in
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
-  };
+  }).overrideAttrs (attrs: {
+    patches = (attrs.patches or []) ++ optionals (stdenv.isLinux) [
+      ./patches/idea-ultimate-remote-dev-server.patch
+    ];
+    postPatch = (attrs.postPatch or "") + optionalString (stdenv.isLinux) ''
+      # NOTE: Assumes that the passed JDK is the JBR. How to validate?
+      ln -s ${jdk} jbr
+    '';
+  });
 
   mps = buildMps rec {
     pname = "mps";

--- a/pkgs/applications/editors/jetbrains/patches/idea-ultimate-remote-dev-server.patch
+++ b/pkgs/applications/editors/jetbrains/patches/idea-ultimate-remote-dev-server.patch
@@ -1,0 +1,49 @@
+--- idea-ultimate/plugins/remote-dev-server/bin/launcher.sh	2022-04-09 16:18:47.016261219 +0200
++++ idea-ultimate/plugins/remote-dev-server/bin/launcher.sh	2022-04-09 16:22:02.368749316 +0200
+@@ -219,35 +219,6 @@
+ mkdir -p "$IJ_HOST_CONFIG_DIR" || (echo "Failed to create $IJ_HOST_CONFIG_DIR" 1>&2; exit 1)
+ mkdir -p "$IJ_HOST_SYSTEM_DIR" || (echo "Failed to create $IJ_HOST_SYSTEM_DIR" 1>&2; exit 1)
+ 
+-# -------------------------------------------------------------------------------------
+-# Patch JBR to make self-contained JVM (requires nothing from host system except glibc)
+-# -------------------------------------------------------------------------------------
+-
+-SELFCONTAINED_LIBS="$REMOTE_DEV_SERVER_DIR/selfcontained/lib"
+-if [ ! -d "$SELFCONTAINED_LIBS" ]; then
+-  echo "ERROR! Unable to locate libraries for self-contained idea distribution. Directory not found: '$SELFCONTAINED_LIBS'." 1>&2
+-  exit 1
+-fi
+-
+-TEMP_JBR="$IJ_HOST_SYSTEM_DIR/pid.$$.temp.jbr"
+-rm -rf "$TEMP_JBR"
+-cp -r --symbolic-link "$IDE_HOME/jbr" "$TEMP_JBR"
+-
+-export "${IDE_PRODUCT_UC}_JDK"="$TEMP_JBR"
+-
+-patch_bin_file() {
+-  file="$1"
+-  mv "$file" "$file.bin"
+-  cat >"$file" <<EOT
+-#!/bin/sh
+-exec /lib64/ld-linux-x86-64.so.2 --library-path "$SELFCONTAINED_LIBS" "${file}.bin" "\$@"
+-EOT
+-  chmod 755 "$file"
+-}
+-
+-find -L "$TEMP_JBR/bin" -type f -executable | while IFS= read -r line; do patch_bin_file "$line"; done
+-find -L "$TEMP_JBR/lib" -type f -executable | while IFS= read -r line; do patch_bin_file "$line"; done
+-
+ # -----------------------------
+ # Display project trust warning
+ # -----------------------------
+@@ -314,10 +285,6 @@
+ # Replace only default Xmx since users may modify vmoptions file to e.g. make -Xmx even bigger
+ sed -i "s/$IDE_DEFAULT_XMX/-Xmx2048m/g" "$TEMP_VM_OPTIONS"
+ 
+-# Since TEMP_JBR is built on symlinks, java tries to resolve it and calculates java.home incorrectly
+-# Make sure java.home points to our patched JBR
+-echo "-Djava.home=$TEMP_JBR" >>"$TEMP_VM_OPTIONS"
+-
+ export "${IDE_PRODUCT_UC}_VM_OPTIONS"="${TEMP_VM_OPTIONS}"
+ 
+ if [ "${REMOTE_DEV_SERVER_JCEF_ENABLED:-}" = "1" ] || [ "${REMOTE_DEV_SERVER_JCEF_ENABLED:-}" = "true" ]; then


### PR DESCRIPTION
###### Description of changes

Resolves #153335

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
