### PR TITLE
python3Packages.gremlinpython: 3.5.1 -> 3.6.0

### DIFF
--- a/pkgs/development/python-modules/gremlinpython/default.nix
+++ b/pkgs/development/python-modules/gremlinpython/default.nix
@@ -15,25 +15,18 @@
 
 buildPythonPackage rec {
   pname = "gremlinpython";
-  version = "3.5.1";
+  version = "3.6.0";
 
   # pypi tarball doesn't include tests
   src = fetchFromGitHub {
     owner = "apache";
     repo = "tinkerpop";
     rev = version;
-    sha256 = "1vlhxq0f2hanhkv6f17dxgbwr7gnbnh1kkkq0lxcwkbm2l0rdrlr";
+    sha256 = "0gyf3a0zbh1grc1vr9zzpqm5yfcjvn0f1akw9l1arq36isqwvydn";
   };
   sourceRoot = "source/gremlin-python/src/main/python";
   postPatch = ''
     substituteInPlace setup.py \
-      --replace 'aenum>=1.4.5,<3.0.0' 'aenum' \
-      --replace 'aiohttp>=3.7.0,<=3.7.4' 'aiohttp' \
-      --replace 'PyHamcrest>=1.9.0,<2.0.0' 'PyHamcrest' \
-      --replace 'radish-bdd==0.8.6' 'radish-bdd' \
-      --replace 'mock>=3.0.5,<4.0.0' 'mock' \
-      --replace 'pytest>=4.6.4,<5.0.0' 'pytest' \
-      --replace 'importlib-metadata<3.0.0' 'importlib-metadata' \
       --replace 'pytest-runner==5.2' ' '
   '';
 
@@ -59,6 +52,7 @@ buildPythonPackage rec {
   # disable custom pytest report generation
   preCheck = ''
     substituteInPlace setup.cfg --replace 'addopts' '#addopts'
+    export TEST_TRANSACTIONS='false'
   '';
 
   # many tests expect a running tinkerpop server


### PR DESCRIPTION
###### Description of changes

Standard bumpage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
