### PR TITLE
python3Packages.django-hijack: 2.1.10 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/django-hijack-admin/default.nix
+++ b/pkgs/development/python-modules/django-hijack-admin/default.nix
@@ -34,5 +34,8 @@ buildPythonPackage rec {
     homepage = "https://github.com/arteria/django-hijack-admin";
     license = licenses.mit;
     maintainers = with maintainers; [ lsix ];
+    # may be unmaintained, doesn't work with recent django-hijack:
+    # https://github.com/django-hijack/django-hijack-admin/issues/46
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/django-hijack/default.nix
+++ b/pkgs/development/python-modules/django-hijack/default.nix
@@ -1,34 +1,34 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python,
-  django, django_compat, django_nose
+{ lib
+, fetchPypi
+, buildPythonPackage
+, django
+, django_compat
+, pytest-django
+, pytestCheckHook
 }:
+
 buildPythonPackage rec {
   pname = "django-hijack";
-  version = "2.1.10";
+  version = "3.2.0";
 
-  # the pypi packages don't include everything required for the tests
-  src = fetchFromGitHub {
-    owner = "arteria";
-    repo = "django-hijack";
-    rev = "v${version}";
-    sha256 = "01fwkjdzvw0yx2spwi7zc1yy64ndq1y72bfmk7kxnq5x803m2ak6";
+  # the wheel comes with pre-built assets, allowing us to avoid fighting
+  # with npm/webpack/gettext to build them ourselves.
+  format = "wheel";
+  src = fetchPypi {
+    inherit version format;
+    pname = "django_hijack";
+    dist = "py3";
+    python = "py3";
+    sha256 = "1ixn7ppmbq1bgqahwv3z57hk80ql7sxpwl8jms7y8w5z1h91cn86";
   };
 
-  checkInputs = [ django_nose ];
   propagatedBuildInputs = [ django django_compat ];
 
-  checkPhase = ''
-    runHook preCheck
-
-    # we have to do a little bit of tinkering to convince the tests to run against the installed package, not the
-    # source directory
-    mkdir testbase
-    pushd testbase
-    mv ../runtests.py .
-    ${python.interpreter} runtests.py hijack
-    popd
-
-    runHook postCheck
+  checkInputs = [ pytestCheckHook pytest-django ];
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE='hijack.tests.test_app.settings'
   '';
+  pytestFlagsArray = [ "--pyargs" "hijack" ];
 
   meta = with lib; {
     description = "Allows superusers to hijack (=login as) and work on behalf of another user";


### PR DESCRIPTION
###### Description of changes

Overdue bump. Switch to using wheel for its pre-built assets.

cc @lsix I've marked `django-hijack-admin` as `broken = true` because of https://github.com/django-hijack/django-hijack-admin/issues/46

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
