### PR TITLE
python3Packages.asdf: 2.10.1 -> 2.11.0

### DIFF
--- a/pkgs/development/python-modules/asdf-standard/default.nix
+++ b/pkgs/development/python-modules/asdf-standard/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, importlib-resources
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "asdf-standard";
+  version = "1.0.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "asdf_standard";
+    inherit version;
+    hash = "sha256-HK8GceEm9K7DETreG1BjhYNpp2klXPu7vNLWfazFtZI=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ];
+
+  # Circular dependency on asdf
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "asdf_standard"
+  ];
+
+  meta = with lib; {
+    description = "Standards document describing ASDF";
+    homepage = "https://github.com/asdf-format/asdf-standard";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/asdf-transform-schemas/default.nix
+++ b/pkgs/development/python-modules/asdf-transform-schemas/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, asdf-standard
+, buildPythonPackage
+, fetchPypi
+, importlib-resources
+, pythonOlder
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "asdf-transform-schemas";
+  version = "0.2.2";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    pname = "asdf_transform_schemas";
+    inherit version;
+    hash = "sha256-9xqTCe0+vQmxk3roV8lM7JKIeHBEDrPphou77XJlaxU=";
+  };
+
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    asdf-standard
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ];
+
+  # Circular dependency on asdf
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "asdf_transform_schemas"
+  ];
+
+  meta = with lib; {
+    description = "ASDF schemas for validating transform tags";
+    homepage = "https://github.com/asdf-format/asdf-transform-schemas";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/asdf/default.nix
+++ b/pkgs/development/python-modules/asdf/default.nix
@@ -1,10 +1,13 @@
 { lib
+, asdf-standard
+, asdf-transform-schemas
 , astropy
 , buildPythonPackage
 , fetchPypi
 , importlib-resources
 , jmespath
 , jsonschema
+, lz4
 , numpy
 , packaging
 , pytest-astropy
@@ -17,18 +20,23 @@
 
 buildPythonPackage rec {
   pname = "asdf";
-  version = "2.10.1";
-  disabled = pythonOlder "3.6";
+  version = "2.11.0";
   format = "pyproject";
+
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-9+Vp8ps3I5Oe/sgWTrLtcnS91ICwsoPXWDPw9Z0QhAk=";
+    hash = "sha256-FEWXGSkneduhO9+YlzrZvpJHUsI7TeagVLwBdMEIRvw=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  nativeBuildInputs = [
+    setuptools-scm
+  ];
 
   propagatedBuildInputs = [
+    asdf-standard
+    asdf-transform-schemas
     jmespath
     jsonschema
     numpy
@@ -40,8 +48,9 @@ buildPythonPackage rec {
   ];
 
   checkInputs = [
-    pytest-astropy
     astropy
+    lz4
+    pytest-astropy
     pytestCheckHook
   ];
 
@@ -49,11 +58,13 @@ buildPythonPackage rec {
     export PY_IGNORE_IMPORTMISMATCH=1
   '';
 
-  pythonImportsCheck = [ "asdf" ];
+  pythonImportsCheck = [
+    "asdf"
+  ];
 
   meta = with lib; {
     description = "Python tools to handle ASDF files";
-    homepage = "https://github.com/spacetelescope/asdf";
+    homepage = "https://github.com/asdf-format/asdf";
     license = licenses.bsd3;
     maintainers = with maintainers; [ costrouc ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -645,6 +645,8 @@ in {
 
   asdf-standard = callPackage ../development/python-modules/asdf-standard { };
 
+  asdf-transform-schemas = callPackage ../development/python-modules/asdf-transform-schemas { };
+
   ase = callPackage ../development/python-modules/ase { };
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -643,6 +643,8 @@ in {
 
   asdf = callPackage ../development/python-modules/asdf { };
 
+  asdf-standard = callPackage ../development/python-modules/asdf-standard { };
+
   ase = callPackage ../development/python-modules/ase { };
 
   asgi-csrf = callPackage ../development/python-modules/asgi-csrf { };


### PR DESCRIPTION
###### Description of changes
https://github.com/asdf-format/asdf/releases/tag/2.11.0

Fix build (https://hydra.nixos.org/build/172224165)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
