### PR TITLE
python3Packages.apsw: 3.37.0-r1 -> 3.38.1-r1

### DIFF
--- a/pkgs/development/python-modules/apsw/default.nix
+++ b/pkgs/development/python-modules/apsw/default.nix
@@ -4,12 +4,11 @@
 , fetchFromGitHub
 , sqlite
 , isPyPy
-, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "apsw";
-  version = "3.37.0-r1";
+  version = "3.38.1-r1";
   format = "setuptools";
 
   disabled = isPyPy;
@@ -18,42 +17,19 @@ buildPythonPackage rec {
     owner = "rogerbinns";
     repo = "apsw";
     rev = version;
-    sha256 = "0p6rlbk7p6hj5mbmk1a8phazw3ym6hf5103zkxzg4p1jgjgi0xpl";
+    sha256 = "sha256-pbb6wCu1T1mPlgoydB1Y1AKv+kToGkdVUjiom2vTqf4=";
   };
 
   buildInputs = [
     sqlite
   ];
 
-  checkInputs = [
-    pytestCheckHook
-  ];
-
-  # Works around the following error by dropping the call to that function
-  #     def print_version_info(write=write):
-  # >       write("                Python " + sys.executable + " " + str(sys.version_info) + "\n")
-  # E       TypeError: 'module' object is not callable
-  preCheck = ''
-    sed -i '/print_version_info(write)/d' tests.py
+  # Project uses custom test setup to exclude some tests by default, so using pytest
+  # requires more maintenance
+  # https://github.com/rogerbinns/apsw/issues/335
+  checkPhase = ''
+    python tests.py
   '';
-
-  pytestFlagsArray = [
-    "tests.py"
-  ];
-
-  disabledTests = [
-    "testCursor"
-    "testLoadExtension"
-    "testShell"
-    "testVFS"
-    "testVFSWithWAL"
-    "testdb"
-  ] ++ lib.optionals stdenv.isDarwin [
-    # This is https://github.com/rogerbinns/apsw/issues/277 but
-    # because we use pytestCheckHook we need to blacklist the test
-    # manually
-    "testzzForkChecker"
-  ];
 
   pythonImportsCheck = [
     "apsw"


### PR DESCRIPTION
###### Description of changes

Update to [latest version](https://github.com/rogerbinns/apsw/releases/tag/3.38.1-r1), which fixes https://github.com/NixOS/nixpkgs/issues/167626.

Additionally, in https://github.com/NixOS/nixpkgs/pull/147426 tests were moved to `pytest`. Normally this is a good thing, but from what I can tell upstream isn't really compatible with pytest. With this branch still using pytest, I get `AttributeError: 'APSW' object has no attribute 'testLargeObjects'`. I'm not entirely sure what's happening, but it seems pytest may collect and/or cache all methods of [`APSW` class in `tests.py`](https://github.com/rogerbinns/apsw/blob/25e9b5d7e839c3346f115119c9995e6bca1045ed/tests.py#L231), then [`tests.py::setup()` runs and deletes](https://github.com/rogerbinns/apsw/blob/25e9b5d7e839c3346f115119c9995e6bca1045ed/tests.py#L8590) some methods from `APSW`, such as [`testLargeObjects`](https://github.com/rogerbinns/apsw/blob/25e9b5d7e839c3346f115119c9995e6bca1045ed/tests.py#L3114). By the time pytest goes to run the tests `testLargeObjects` is unexpectedly missing. Upstream's [recommended way of running the tests is via `setup.py`](https://github.com/rogerbinns/apsw/blob/3.38.1-r1/doc/build.rst#testing), which runs a lot of logic that pytest doesn't (pytest runs the `test.py::setup()` but not `setup.py::run_tests()` or the `__main__` stuff in `tests.py`). By simply ditching pytest, 93 tests are run and pass, no skipping tests manually required.

So my rationale in ditching pytest is that it's less fighting upstream and having to mark new tests to skip manually as the large amount of custom logic we skip changes. It was also really confusing trying to figure out why a test/method that's clearly in the code wasn't there. The alternative is keep pytest and just add `testLargeObjects` to the skip array. I'm fine with either and I'm not sure what the initial reason was for changing to pytest in the first place so maybe I am missing something.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).