### PR TITLE
graphene: 1.10.6 -> 1.10.8

### DIFF
--- a/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
+++ b/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
@@ -1,12 +1,12 @@
-From 57bed86429db9d871f1442c94f14e94e38972ca3 Mon Sep 17 00:00:00 2001
+From d68fcb793d70032e978ecf8e0577eea955a741cf Mon Sep 17 00:00:00 2001
 From: worldofpeace <worldofpeace@protonmail.ch>
-Date: Thu, 16 May 2019 21:15:15 -0400
+Date: Sun, 10 Apr 2022 12:02:10 +0800
 Subject: [PATCH] meson: add options for tests installation dirs
 
 ---
  meson_options.txt |  6 ++++++
- tests/meson.build | 23 ++++++++++++++++-------
- 2 files changed, 22 insertions(+), 7 deletions(-)
+ tests/meson.build | 13 +++++++++++--
+ 2 files changed, 17 insertions(+), 2 deletions(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
 index b9a2fb5..4b8629f 100644
@@ -23,7 +23,7 @@ index b9a2fb5..4b8629f 100644
 +       value: '',
 +       description: 'Installation directory for binary files in tests')
 diff --git a/tests/meson.build b/tests/meson.build
-index 77281f5..7522456 100644
+index 2b925e7..3276849 100644
 --- a/tests/meson.build
 +++ b/tests/meson.build
 @@ -21,8 +21,17 @@ unit_tests = [
@@ -32,66 +32,20 @@ index 77281f5..7522456 100644
  
 -installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_api_path)
 -installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_api_path)
-+test_suffix = join_paths('installed-tests', graphene_api_path)
++installed_test_suffix = join_paths('installed-tests', graphene_api_path)
 +
-+test_datadir = join_paths(get_option('installed_test_datadir'), test_suffix)
-+if test_datadir == ''
-+    test_datadir = join_paths(get_option('prefix'), get_option('datadir'), test_suffix)
++installed_test_datadir = join_paths(get_option('installed_test_datadir'), installed_test_suffix)
++if installed_test_datadir == ''
++  installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), installed_test_suffix)
 +endif
 +
-+test_bindir = join_paths(get_option('installed_test_bindir'), test_suffix)
-+if test_bindir == ''
-+    test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), test_suffix)
++installed_test_bindir = join_paths(get_option('installed_test_bindir'), installed_test_suffix)
++if installed_test_bindir == ''
++  installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), installed_test_suffix)
 +endif
  
  # Make tests conditional on having mutest-1 installed system-wide, or
  # available as a subproject
-@@ -40,13 +49,13 @@ if mutest_dep.found()
-       output: wrapper,
-       command: [
-         gen_installed_test,
--        '--testdir=@0@'.format(installed_test_bindir),
-+        '--testdir=@0@'.format(test_bindir),
-         '--testname=@0@'.format(unit),
-         '--outdir=@OUTDIR@',
-         '--outfile=@0@'.format(wrapper),
-       ],
-       install: get_option('installed_tests'),
--      install_dir: installed_test_datadir,
-+      install_dir: test_datadir,
-     )
- 
-     test(unit,
-@@ -55,7 +64,7 @@ if mutest_dep.found()
-         include_directories: graphene_inc,
-         c_args: common_cflags,
-         install: get_option('installed_tests'),
--        install_dir: installed_test_bindir,
-+        install_dir: test_bindir,
-       ),
-       env: ['MUTEST_OUTPUT=tap'],
-       protocol: 'tap',
-@@ -66,17 +75,18 @@ endif
- if build_gir and host_system == 'linux' and not meson.is_cross_build()
-   foreach unit: ['introspection.py']
-     wrapper = '@0@.test'.format(unit)
-+    install_data(unit, install_dir: test_bindir)
-     custom_target(wrapper,
-       output: wrapper,
-       command: [
-         gen_installed_test,
--        '--testdir=@0@'.format(installed_test_bindir),
-+        '--testdir=@0@'.format(test_bindir),
-         '--testname=@0@'.format(unit),
-         '--outdir=@OUTDIR@',
-         '--outfile=@0@'.format(wrapper),
-       ],
-       install: get_option('installed_tests'),
--      install_dir: installed_test_datadir,
-+      install_dir: test_datadir,
-     )
- 
-     test(unit,
 -- 
-2.31.1
+2.35.1
 

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -1,5 +1,7 @@
-{ lib, stdenv
+{ stdenv
+, lib
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , pkg-config
 , meson
@@ -17,7 +19,7 @@
 
 stdenv.mkDerivation rec {
   pname = "graphene";
-  version = "1.10.6";
+  version = "1.10.8";
 
   outputs = [ "out" ]
     ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" "installedTests" ];
@@ -26,12 +28,21 @@ stdenv.mkDerivation rec {
     owner = "ebassi";
     repo = pname;
     rev = version;
-    sha256 = "v6YH3fRMTzhp7wmU8in9ukcavzHmOAW54EK9ZwQyFxc=";
+    sha256 = "P6JQhSktzvyMHatP/iojNGXPmcsxsFxdYerXzS23ojI=";
   };
 
   patches = [
     # Add option for changing installation path of installed tests.
     ./0001-meson-add-options-for-tests-installation-dirs.patch
+
+    # Disable flaky simd_operators_reciprocal test
+    # https://github.com/ebassi/graphene/issues/246
+    (fetchpatch {
+      url = "https://github.com/ebassi/graphene/commit/4fbdd07ea3bcd0964cca3966010bf71cb6fa8209.patch";
+      sha256 = "uFkkH0u4HuQ/ua1mfO7sJZ7MPrQdV/JON7mTYB4DW80=";
+      includes = [ "tests/simd.c" ];
+      revert = true;
+    })
   ];
 
   depsBuildBuild = [


### PR DESCRIPTION
###### Description of changes

https://github.com/ebassi/graphene/releases/tag/1.10.8
https://github.com/ebassi/graphene/compare/1.10.6...1.10.8

I updated the patch because of https://github.com/ebassi/graphene/commit/2a16dfafb3653ef47a1cce3eb1153aa711f316ac

###### Things done

- On x86_64-linux:
  - [x] Built `graphene.passthru.tests` `gnome.mutter.passthru.tests` on 83178f1b6ef26c825f43f7c5d95e253fd1f89cf3.
  - [x] Built `pkgsCross.aarch64-multiplatform.graphene` on 3d00b96148da49d08641488ad9f6d67d904b86dc.
