### PR TITLE
Add espeakup and pyttsx3 packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3849,6 +3849,13 @@
     githubId = 222467;
     name = "Dmitry Ivanov";
   };
+  ethindp = {
+    name = "Ethin Probst";
+    email = "harlydavidsen@gmail.com";
+    matrix = "@ethindp:the-gdn.net";
+    github = "ethindp";
+    githubId = 8030501;
+  };
   Etjean = {
     email = "et.jean@outlook.fr";
     github = "Etjean";

--- a/pkgs/applications/accessibility/espeakup/default.nix
+++ b/pkgs/applications/accessibility/espeakup/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, meson
+, ninja
+, espeak-ng
+, fetchFromGitHub
+, pkg-config
+, ronn
+, alsa-lib
+, systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "espeakup";
+  version = "0.90";
+
+  src = fetchFromGitHub {
+    owner = "linux-speakup";
+    repo = "espeakup";
+    rev = "v${version}";
+    sha256 = "0lmjwafvfxy07zn18v3dzjwwpnid2xffgvy2dzlwkbns8gb60ds2";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    ronn
+  ];
+
+  buildInputs = [
+    espeak-ng
+    alsa-lib
+    systemd
+  ];
+
+  PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+
+  meta = with lib; {
+    homepage = "https://github.com/linux-speakup/espeakup";
+    description = "Lightweight connector for espeak-ng and speakup";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ ethindp ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/development/python-modules/pyttsx3/default.nix
+++ b/pkgs/development/python-modules/pyttsx3/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, espeak-ng }:
+
+buildPythonPackage rec {
+  pname = "pyttsx3";
+  version = "2.90";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit pname version format;
+    sha256 = "a585b6d8cffc19bd92db1e0ccbd8aa9c6528dd2baa5a47045d6fed542a44aa19";
+    dist = "py3";
+    python = "py3";
+  };
+
+  # This package has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Offline text-to-speech synthesis library";
+    homepage = "https://github.com/nateshmbhat/pyttsx3";
+    license = licenses.mpl20;
+    maintainers = [ maintainers.ethindp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25838,6 +25838,8 @@ with pkgs;
 
   espeakedit = callPackage ../applications/audio/espeak/edit.nix { };
 
+  espeakup = callPackage ../applications/accessibility/espeakup { };
+
   etebase-server = with python3Packages; toPythonApplication etebase-server;
 
   etesync-dav = callPackage ../applications/misc/etesync-dav {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8471,6 +8471,8 @@ in {
 
   pytricia = callPackage ../development/python-modules/pytricia { };
 
+  pyttsx3 = callPackage ../development/python-modules/pyttsx3 { };
+
   pytube = callPackage ../development/python-modules/pytube { };
 
   pytun = callPackage ../development/python-modules/pytun { };


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds two packages:

* espeakup: espeakup is a console-based screen reader that bridges the espeak-ng package and the speakup Linux kernel modules, which implement the actual screen reading functionality. The screen reader is minimal: it resides as a kernel module (speakup_soft, or any number of other speech synthesis modules) and, through the module you choose to load, communicates with the given speech synthesis engine. espeakup connects to speakup to provide software-based speech synthesis functionality.
* pyttsx3: see https://github.com/nateshmbhat/pyttsx3


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
