### PR TITLE
tests formats: fix due to tomlkit output change

### DIFF
--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -165,9 +165,6 @@ in runBuildTests {
 
       [attrs]
       foo = "foo"
-
-      [level1]
-      [level1.level2]
       [level1.level2.level3]
       level4 = "deep"
     '';


### PR DESCRIPTION
should fix https://github.com/NixOS/nixpkgs/issues/167681
not sure if we relied on the old behavior of generating TOML