### PR TITLE
popcorntime: init at 0.4.9

### DIFF
--- a/pkgs/applications/video/popcorntime/default.nix
+++ b/pkgs/applications/video/popcorntime/default.nix
@@ -1,0 +1,80 @@
+{ autoPatchelfHook
+, fetchurl
+, gcc-unwrapped
+, gsettings-desktop-schemas
+, gtk3
+, lib
+, makeDesktopItem
+, makeWrapper
+, nwjs
+, stdenv
+, unzip
+, udev
+, wrapGAppsHook
+, copyDesktopItems
+}:
+
+stdenv.mkDerivation rec {
+  pname = "popcorntime";
+  version = "0.4.9";
+
+  src = fetchurl {
+    url = "https://github.com/popcorn-official/popcorn-desktop/releases/download/v${version}/Popcorn-Time-${version}-linux64.zip";
+    sha256 = "sha256-cbKL5bgweZD/yfi/8KS0L7Raha8PTHqIm4qSPFidjUc=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    unzip
+    wrapGAppsHook
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    gcc-unwrapped
+    gsettings-desktop-schemas
+    gtk3
+    nwjs
+    udev
+  ];
+
+  sourceRoot = ".";
+
+  dontWrapGApps = true;
+  dontUnpack = true;
+
+  makeWrapperArgs = [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gcc-unwrapped.lib gtk3 udev ]}"
+    "--prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}"
+  ];
+
+  # Extract and copy executable in $out/bin
+  installPhase = ''
+    mkdir -p $out/share/applications $out/bin $out/opt/bin $out/share/icons/hicolor/scalable/apps/
+    # we can't unzip it in $out/lib, because nw.js will start with
+    # an empty screen. Therefore it will be unzipped in a non-typical
+    # folder and symlinked.
+    unzip -q $src -d $out/opt/popcorntime
+
+    ln -s $out/opt/popcorntime/Popcorn-Time $out/bin/popcorntime
+
+    ln -s $out/opt/popcorntime/src/app/images/icon.png $out/share/icons/hicolor/scalable/apps/popcorntime.png
+  '';
+
+  # GSETTINGS_SCHEMAS_PATH is not set in installPhase
+  preFixup = ''
+    wrapProgram $out/bin/popcorntime \
+      ''${makeWrapperArgs[@]} \
+      ''${gappsWrapperArgs[@]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/popcorn-official/popcorn-desktop";
+    description = "An application that streams movies and TV shows from torrents";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.gpl3;
+    maintainers = with maintainers; [ onny ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30351,6 +30351,8 @@ with pkgs;
 
   ponymix = callPackage ../applications/audio/ponymix { };
 
+  popcorntime = callPackage ../applications/video/popcorntime {};
+
   pothos = libsForQt5.callPackage ../applications/radio/pothos { };
 
   potrace = callPackage ../applications/graphics/potrace {};


### PR DESCRIPTION
###### Description of changes

This PR adds the p2p video player [popcorntime](https://github.com/popcorn-official/popcorn-desktop) at version 0.4.9.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
