### PR TITLE
phpExtensions.openswoole: init at 4.11.1

### DIFF
--- a/pkgs/development/php-packages/openswoole/default.nix
+++ b/pkgs/development/php-packages/openswoole/default.nix
@@ -1,0 +1,22 @@
+{ lib, stdenv, buildPecl, php, valgrind, pcre2 }:
+let
+  pname = "openswoole";
+  version = "4.11.1";
+in
+buildPecl {
+  inherit pname version;
+
+  sha256 = "sha256-Rhoa4ny86dwB3e86/1W30AlDGRUDYjK8RusquKF5Izg=";
+
+  buildInputs = [ pcre2 ] ++ lib.optionals (!stdenv.isDarwin) [ valgrind ];
+  internalDeps = lib.optionals (lib.versionOlder php.version "7.4") [ php.extensions.hash ];
+
+  meta = with lib; {
+    changelog = "https://pecl.php.net/package/openswoole/${version}";
+    description = "Coroutine-based concurrency library and high performance programmatic server for PHP";
+    homepage = "https://www.openswoole.com/";
+    license = licenses.asl20;
+    longDescription = "Open Swoole allows you to build high-performance, async multi-tasking webservices and applications using an easy to use Coroutine API.\nOpen Swoole is a complete async solution that has built-in support for async programming via coroutines.\nIt offers a range of multi-threaded I/O modules (HTTP Server, WebSockets, TaskWorkers, Process Pools) out of the box and support for popular PHP clients like PDO for MySQL, and CURL.\nYou can use the sync or async, Coroutine API to write whole applications or create thousands of light weight Coroutines within one Linux process.";
+    maintainers = teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -209,6 +209,8 @@ lib.makeScope pkgs.newScope (self: with self; {
       sha256 = "108ds92620dih5768z19hi0jxfa7wfg5hdvyyvpapir87c0ap914";
     });
 
+    openswoole = callPackage ../development/php-packages/openswoole { };
+
     pdlib = callPackage ../development/php-packages/pdlib { };
 
     pcov = callPackage ../development/php-packages/pcov { };


### PR DESCRIPTION
###### Description of changes

Request to add openswoole: https://pecl.php.net/package/openswoole

Open Swoole is a fork of [Swoole](https://github.com/johanjanssens/nixpkgs/tree/master/pkgs/development/php-packages/swoole). It is actively maintained by some of the original developers and has growing community. 

- https://github.com/openswoole
- https://openswoole.com/
- https://openswoole.com/community

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).