### PR TITLE
python39Packages.pycurl: disable failing tests, add SuperSandro2000 as maintainer

### DIFF
--- a/pkgs/development/python-modules/pycurl/default.nix
+++ b/pkgs/development/python-modules/pycurl/default.nix
@@ -71,12 +71,17 @@ buildPythonPackage rec {
     "test_libcurl_ssl_gnutls"
     # AssertionError: assert 'crypto' in ['curl']
     "test_ssl_in_static_libs"
+    # pycurl.error: (27, '')
+    "test_getinfo_raw_certinfo"
+    "test_request_with_certinfo"
+    "test_request_with_verifypeer"
+    "test_request_without_certinfo"
   ];
 
   meta = with lib; {
     homepage = "http://pycurl.io/";
     description = "Python Interface To The cURL library";
     license = with licenses; [ lgpl2Only mit ];
-    maintainers = with maintainers; [];
+    maintainers = with maintainers; [ SuperSandro2000 ];
   };
 }


### PR DESCRIPTION
(cherry picked from commit c270defab79e46b4c98039b09ab6209d1a69ffb3)

###### Description of changes

cherry-pick #166335 to `master` to workaround #167971 until #167993 hits master from `stagin` / `staging-next`. As discussed in https://github.com/NixOS/nixpkgs/pull/167993#issuecomment-1094300347, this causes many "re"builds, but **only those** that are **currently (transitively) failing** to build on `master` due to the `pycurl` build problem, _anyway_. Thus it should be OK to target `master`.

This will be partially reverted by 32f4270 (i.e., the now-failing tests will be re-enabled), which will get introduced from `stagin` / `staging-next` to `master` _together_ with the fix-proper from #167993 that shall make those tests pass again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

  Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
  <details>
  <summary>1 package marked as broken and skipped:</summary>
  <ul>
    <li>python310Packages.bugwarrior</li>
  </ul>
  </details>
  <details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>udocker</li>
  </ul>
  </details>
  <details>
  <summary>15 packages built:</summary>
  <ul>
    <li>moonraker</li>
    <li>nvchecker (python39Packages.nvchecker)</li>
    <li>nvfetcher</li>
    <li>pyCA</li>
    <li>python310Packages.nvchecker</li>
    <li>python310Packages.osc</li>
    <li>python310Packages.pycurl</li>
    <li>python310Packages.urlgrabber</li>
    <li>python310Packages.wfuzz</li>
    <li>python39Packages.bugwarrior</li>
    <li>python39Packages.osc</li>
    <li>python39Packages.pycurl</li>
    <li>python39Packages.urlgrabber</li>
    <li>wfuzz (python39Packages.wfuzz)</li>
    <li>system-config-printer</li>
  </ul>
  </details>
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - The only executable binary from above seems to be `moonraker`. I have no idea how to test that. If I launch it without arguments, it fails with `FileNotFoundError: [Errno 2] No such file or directory: '/home/das-g/moonraker.conf'` but that's hardly to be blamed on `pycurl`.
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).