### PR TITLE
glab: install shell completions

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/glab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/glab/default.nix
@@ -26,13 +26,12 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall =
-    lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
-      for shell in bash zsh fish; do
-        $out/bin/glab completion -s $shell > glab.$shell
-        installShellCompletion glab.$shell
-      done
-    '';
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    installShellCompletion --cmd glab \
+      --bash <($out/bin/glab completion -s bash) \
+      --fish <($out/bin/glab completion -s fish) \
+      --zsh <($out/bin/glab completion -s zsh)
+  '';
 
   meta = with lib; {
     description = "An open-source GitLab command line tool";

--- a/pkgs/applications/version-management/git-and-tools/glab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/glab/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles, stdenv }:
 
 buildGoModule rec {
   pname = "glab";
@@ -23,6 +23,16 @@ buildGoModule rec {
   '';
 
   subPackages = [ "cmd/glab" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+      for shell in bash zsh fish; do
+        $out/bin/glab completion -s $shell > glab.$shell
+        installShellCompletion glab.$shell
+      done
+    '';
 
   meta = with lib; {
     description = "An open-source GitLab command line tool";


### PR DESCRIPTION
###### Description of changes

Added `glab` shell completions.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).