### PR TITLE
musikcube: fix Darwin build

### DIFF
--- a/pkgs/applications/audio/musikcube/0001-apple-cmake.patch
+++ b/pkgs/applications/audio/musikcube/0001-apple-cmake.patch
@@ -1,0 +1,14 @@
+diff --git a/src/musikcube/CMakeLists.txt b/src/musikcube/CMakeLists.txt
+index f42748aa..ae339946 100644
+--- a/src/musikcube/CMakeLists.txt
++++ b/src/musikcube/CMakeLists.txt
+@@ -98,9 +98,6 @@ else()
+ endif()
+ 
+ if (APPLE)
+-    message(STATUS "[ncurses] detected Darwin, linking statically")
+-    set(CURSES_LIBRARY_NAME "lib${CURSES_LIBRARY_NAME}.a")
+-    set(PANEL_LIBRARY_NAME "lib${PANEL_LIBRARY_NAME}.a")
+ else()
+     message(STATUS "[ncurses] not Darwin! will attempt to link against libtinfo")
+     find_library(LIBTINFO NAMES tinfo)

--- a/pkgs/applications/audio/musikcube/default.nix
+++ b/pkgs/applications/audio/musikcube/default.nix
@@ -1,6 +1,5 @@
 { cmake
 , pkg-config
-, alsa-lib
 , boost
 , curl
 , fetchFromGitHub
@@ -11,12 +10,17 @@
 , libev
 , libmicrohttpd
 , ncurses
-, pulseaudio
 , lib
 , stdenv
 , taglib
+# Linux Dependencies
+, alsa-lib
+, pulseaudio
 , systemdSupport ? stdenv.isLinux
 , systemd
+# Darwin Dependencies
+, Cocoa
+, SystemConfiguration
 }:
 
 stdenv.mkDerivation rec {
@@ -38,14 +42,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/clangen/musikcube/commit/1240720e27232fdb199a4da93ca6705864442026.patch";
       sha256 = "0bhjgwnj6d24wb1m9xz1vi1k9xk27arba1absjbcimggn54pinid";
     })
+    ./0001-apple-cmake.patch
   ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
   ];
+
   buildInputs = [
-    alsa-lib
     boost
     curl
     ffmpeg
@@ -54,9 +59,14 @@ stdenv.mkDerivation rec {
     libev
     libmicrohttpd
     ncurses
-    pulseaudio
     taglib
-  ] ++ lib.optional systemdSupport systemd;
+  ] ++ lib.optional systemdSupport [
+    systemd
+  ] ++ lib.optional stdenv.isLinux [
+    alsa-lib pulseaudio
+  ] ++ lib.optional stdenv.isDarwin [
+    Cocoa SystemConfiguration
+  ];
 
   cmakeFlags = [
     "-DDISABLE_STRIP=true"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27047,7 +27047,9 @@ with pkgs;
 
   marker = callPackage ../applications/editors/marker { };
 
-  musikcube = callPackage ../applications/audio/musikcube {};
+  musikcube = callPackage ../applications/audio/musikcube {
+    inherit (darwin.apple_sdk.frameworks) Cocoa SystemConfiguration;
+  };
 
   libmt32emu = callPackage ../applications/audio/munt/libmt32emu.nix { };
 


### PR DESCRIPTION
###### Description of changes

ℹ️ This PR should be reviewed with the changes from #168169 in mind and merged only after #168169 has been merged.
**Update 20220430:** #168169 has been merged and this PR has been rebased onto master containing the changes from #168169.

* Add platform specific dependencies to `buildInputs` using `lib.options stdenv.is$PLATFORM`
* Add Darwin specific `CMakeLists.txt` patch to ensure `ncurses` from nixpkgs is found

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] **No packages depend on musikcube.** Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
