### PR TITLE
lib/strings: optimise hasInfix function

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -252,9 +252,8 @@ rec {
       hasInfix "foo" "abcd"
       => false
   */
-  hasInfix = infix:
-    let matchInfix = builtins.match ".*${escapeRegex infix}.*";
-    in content: matchInfix content != null;
+  hasInfix = infix: content:
+    builtins.match ".*${escapeRegex infix}.*" content != null;
 
   /* Convert a string to a list of characters (i.e. singleton strings).
      This allows you to, e.g., map a function over each character.  However,

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -252,15 +252,9 @@ rec {
       hasInfix "foo" "abcd"
       => false
   */
-  hasInfix = infix: content:
-    let
-      infixLength = stringLength infix;
-      contentLength = stringLength content;
-      stopAt = contentLength - infixLength;
-      hasInfix' = offset:
-        substring offset infixLength content == infix
-        || offset < stopAt && hasInfix' (offset + 1);
-    in hasInfix' 0;
+  hasInfix = infix:
+    let matchInfix = builtins.match ".*${escapeRegex infix}.*";
+    in content: matchInfix content != null;
 
   /* Convert a string to a list of characters (i.e. singleton strings).
      This allows you to, e.g., map a function over each character.  However,

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -254,9 +254,13 @@ rec {
   */
   hasInfix = infix: content:
     let
-      drop = x: substring 1 (stringLength x) x;
-    in hasPrefix infix content
-      || content != "" && hasInfix infix (drop content);
+      infixLength = stringLength infix;
+      contentLength = stringLength content;
+      stopAt = contentLength - infixLength;
+      hasInfix' = offset:
+        substring offset infixLength content == infix
+        || offset < stopAt && hasInfix' (offset + 1);
+    in hasInfix' 0;
 
   /* Convert a string to a list of characters (i.e. singleton strings).
      This allows you to, e.g., map a function over each character.  However,

--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -154,7 +154,7 @@ in
     hunspellDictionaries = with lib; filter isDerivation (unique (attrValues hunspellDicts));
     # These dicts contain identically-named dict files, so we only keep the
     # -large versions in case of clashes
-    largeDicts = with lib; filter (d: hasInfix "-large-wordlist" d) hunspellDictionaries;
+    largeDicts = with lib; filter (d: hasInfix "-large-wordlist" d.name) hunspellDictionaries;
     otherDicts = with lib; filter
       (d: !(hasAttr "dictFileName" d &&
         elem d.dictFileName (map (d: d.dictFileName) largeDicts)))


### PR DESCRIPTION
###### Description of changes

Made the definition of `hasInfix` more efficient.

I measured the improvement with `NIX_SHOW_STATS=1 NIX_COUNT_CALLS=1` for both the old and new definitions, searching for a 5 letter infix which was not present within a 10,000 character string. A summary of the results:

- 1.5× less CPU time
- 4× less thunks
- 2× less primop calls
- 5× less function calls
- 64× less total bytes allocated

Although the code is longer, I think this implementation is also easier to understand.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
