### PR TITLE
chromiumBeta: 101.0.4951.15 -> 101.0.4951.26

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/get-commit-message.py
+++ b/pkgs/applications/networking/browsers/chromium/get-commit-message.py
@@ -38,9 +38,9 @@ for entry in feed.entries:
     else:
         print('chromium: TODO -> ' + version + '\n')
     print(url)
-    if fixes := re.search(r'This update includes .+ security fixes\.', content).group(0):
-        zero_days = re.search(r'Google is aware( of reports)? th(e|at) .+ in the wild\.', content)
-        if zero_days:
+    if fixes := re.search(r'This update includes .+ security fixes\.', content):
+        fixes = fixes.group(0)
+        if zero_days := re.search(r'Google is aware( of reports)? th(e|at) .+ in the wild\.', content):
             fixes += " " + zero_days.group(0)
         print('\n' + '\n'.join(textwrap.wrap(fixes, width=72)))
     if cve_list := re.findall(r'CVE-[^: ]+', content):

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -19,9 +19,9 @@
     }
   },
   "beta": {
-    "version": "101.0.4951.15",
-    "sha256": "1gm70mz6gzildh1g082q4dg5q9namm9kvxfj5qrdcj67gvz5m66y",
-    "sha256bin64": "0z2rx7mw9wg5ly8wmxkflk8f9gifq4cxqvi224v9dr11qqj8gwm2",
+    "version": "101.0.4951.26",
+    "sha256": "1wpdi5l0bic0z9ydvx5vj35z6fh21b3n8dsxyvcbm0rq4fca5zcg",
+    "sha256bin64": "13mx2jxq5pjzp6dxvnzkfs83krhvpbw0pim7z4c7hhyphjc4fhzr",
     "deps": {
       "gn": {
         "version": "2022-03-14",


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
