### PR TITLE
chromiumDev: 102.0.4972.0 -> 102.0.4987.0

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/get-commit-message.py
+++ b/pkgs/applications/networking/browsers/chromium/get-commit-message.py
@@ -38,7 +38,7 @@ for entry in feed.entries:
     else:
         print('chromium: TODO -> ' + version + '\n')
     print(url)
-    if fixes := re.search(r'This update includes .+ security fixes\.', content):
+    if fixes := re.search(r'This update includes .+ security fix(es)?\.', content):
         fixes = fixes.group(0)
         if zero_days := re.search(r'Google is aware( of reports)? th(e|at) .+ in the wild\.', content):
             fixes += " " + zero_days.group(0)

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.json
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.json
@@ -32,15 +32,15 @@
     }
   },
   "dev": {
-    "version": "102.0.4972.0",
-    "sha256": "1aihdym7h8sd52wiybnrgjrd618f3yby4bpbkc26xyrl8gviz31d",
-    "sha256bin64": "0mb67cfr397aclkiy0v9xqga07c166qdylq257k2kmhj7df1gcvn",
+    "version": "102.0.4987.0",
+    "sha256": "0rs6smmda0wlhwbvmhmyz0vi43rkb9gyfbm49bn2084bd1x3qpzy",
+    "sha256bin64": "1knrnjhn98bln81qf3646gz9znn848kgjayyjl5ik0x0fimx524x",
     "deps": {
       "gn": {
-        "version": "2022-03-29",
+        "version": "2022-04-05",
         "url": "https://gn.googlesource.com/gn",
-        "rev": "e39d5251c25155b9dfdb96adeab31b795095fd3b",
-        "sha256": "1clr0f847rmwwpmsl9zv4q6rw1shn09my775666v480szpahj9pk"
+        "rev": "5eb3845ec2d8296b4f41da4eca85302eb111fe69",
+        "sha256": "04yy4d77bw3bhb32q1szlqn6lmif6qaah2c0ns6by0cbnkliyaza"
       }
     }
   },


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
