### PR TITLE
cudaPackages: fix hash mismatch for cuda=10.1 cudnn=7.6.5

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/extension.nix
+++ b/pkgs/development/libraries/science/math/cudnn/extension.nix
@@ -49,7 +49,7 @@ final: prev: let
       rec {
         fileVersion = "10.1";
         fullVersion = "7.6.5.32";
-        hash = "sha256-YAJn8squ0v1Y6yFLpmnY6jXzlqfRm5SCLms2+fcIjCA=";
+        hash = "sha256-fq7IA5osMKsLx1jTA1iHZ2k972v0myJIWiwAvy4TbLM=";
         url = "${urlPrefix}/v${majorMinorPatch fullVersion}/cudnn-${cudatoolkit.majorVersion}-linux-x64-v${fullVersion}.tgz";
         supportedCudaVersions = [ "10.1" ];
       }


### PR DESCRIPTION
Fixes

```
error: hash mismatch in fixed-output derivation '/nix/store/f6wrlm8wmnm133qc737svji6khpwlx04-cudnn-10.1-linux-x64-v7.6.5.32.tgz.drv':
         specified: sha256-YAJn8squ0v1Y6yFLpmnY6jXzlqfRm5SCLms2+fcIjCA=
            got:    sha256-fq7IA5osMKsLx1jTA1iHZ2k972v0myJIWiwAvy4TbLM=
error: 1 dependencies of derivation '/nix/store/a4h5iwazp6cw11489gbwh4fybgzhnsf5-cudatoolkit-10.1-cudnn-7.6.5.drv' failed to build
```

CC @NixOS/cuda-maintainers 