### PR TITLE
haskell.compiler.ghcjs: fix build with aeson 2.0 

### DIFF
--- a/pkgs/development/compilers/ghcjs/8.10/common-overrides.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/common-overrides.nix
@@ -1,8 +1,37 @@
-{ haskellLib }:
+{ haskellLib, fetchpatch, buildPackages }:
 
-let inherit (haskellLib) addBuildTools appendConfigureFlag dontHaddock doJailbreak;
+let inherit (haskellLib) addBuildTools appendConfigureFlag dontHaddock doJailbreak markUnbroken overrideCabal;
 in self: super: {
-  ghcjs = doJailbreak (super.ghcjs.overrideScope (self: super: {
+  ghcjs = overrideCabal (drv: {
+    # Jailbreak and patch can be dropped after https://github.com/ghcjs/ghcjs/pull/833
+    jailbreak = true;
+    patches = drv.patches or [] ++ [
+      (fetchpatch {
+        name = "ghcjs-aeson-2.0.patch";
+        url = "https://github.com/ghcjs/ghcjs/commit/9ef1f92d740e8503d15d91699f57db147f0474cc.patch";
+        sha256 = "0cgxcy6b5870bv4kj54n3bzcqinh4gl4w4r78dg43h2mblhkzbnj";
+      })
+    ];
+  }) (super.ghcjs.overrideScope (self: super: {
     optparse-applicative = self.optparse-applicative_0_15_1_0;
+    webdriver = overrideCabal (drv: {
+      patches = drv.patches or [] ++ [
+        # Patch for aeson 2.0 which adds a lower bound on it, so we don't apply it globally
+        # Pending https://github.com/kallisti-dev/hs-webdriver/pull/183
+        (fetchpatch {
+          name = "webdriver-aeson-2.0.patch";
+          url = "https://github.com/georgefst/hs-webdriver/commit/90ded63218da17fc0bd9f9b208b0b3f60b135757.patch";
+          sha256 = "1xvkk51r2v020xlmci5n1fd1na8raa332lrj7r9f0ijsyfvnqlv0";
+          excludes = [ "webdriver.cabal" ];
+        })
+      ];
+      # Fix line endings so patch applies
+      prePatch = drv.prePatch or "" + ''
+        find . -name '*.hs' | xargs "${buildPackages.dos2unix}/bin/dos2unix"
+      '';
+
+      jailbreak = true;
+      broken = false;
+    }) super.webdriver;
   }));
 }

--- a/pkgs/development/compilers/ghcjs/8.10/default.nix
+++ b/pkgs/development/compilers/ghcjs/8.10/default.nix
@@ -2,6 +2,7 @@
 , pkgsHostHost
 , callPackage
 , fetchgit
+, fetchpatch
 , ghcjsSrcJson ? null
 , ghcjsSrc ? fetchgit (lib.importJSON ghcjsSrcJson)
 , bootPkgs
@@ -36,7 +37,7 @@ let
       })
 
       (callPackage ./common-overrides.nix {
-        inherit haskellLib;
+        inherit haskellLib fetchpatch buildPackages;
       })
       ghcjsDepOverrides
     ]);

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -129,7 +129,18 @@ let
   jobs = recursiveUpdateMany [
     (mapTestOn {
       haskellPackages = packagePlatforms pkgs.haskellPackages;
-      haskell.compiler = packagePlatforms pkgs.haskell.compiler;
+      haskell.compiler = packagePlatforms pkgs.haskell.compiler // (lib.genAttrs [
+        "ghcjs"
+        "ghcjs810"
+      ] (ghcjsName: {
+        # We can't build ghcjs itself, since it exceeds 3GB (Hydra's output limit) due
+        # to the size of its bundled libs. We can however save users a bit of compile
+        # time by building the bootstrap ghcjs on Hydra. For this reason, we overwrite
+        # the ghcjs attributes in haskell.compiler with a reference to the bootstrap
+        # ghcjs attribute in their bootstrap package set (exposed via passthru) which
+        # would otherwise be ignored by Hydra.
+        bootGhcjs = (packagePlatforms pkgs.haskell.compiler.${ghcjsName}.passthru).bootGhcjs;
+      }));
 
       tests.haskell = packagePlatforms pkgs.tests.haskell;
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
