### PR TITLE
PCMSolver Glibc Compatibility

### DIFF
--- a/pkgs/development/libraries/pcmsolver/default.nix
+++ b/pkgs/development/libraries/pcmsolver/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, perl, gfortran, python2
+{ lib, stdenv, fetchFromGitHub, cmake, perl, gfortran, python3
 , boost, eigen, zlib
 } :
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     cmake
     gfortran
     perl
-    python2
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/pcmsolver/default.nix
+++ b/pkgs/development/libraries/pcmsolver/default.nix
@@ -13,6 +13,13 @@ stdenv.mkDerivation rec {
     sha256= "0jrxr8z21hjy7ik999hna9rdqy221kbkl3qkb06xw7g80rc9x9yr";
   };
 
+  # Glibc 2.34 changed SIGSTKSZ to a dynamic value, which breaks
+  # PCMsolver. Replace SIGSTKZ by the backward-compatible _SC_SIGSTKSZ.
+  postPatch = ''
+    substituteInPlace external/Catch/catch.hpp \
+      --replace SIGSTKSZ _SC_SIGSTKSZ
+  '';
+
   nativeBuildInputs = [
     cmake
     gfortran


### PR DESCRIPTION
###### Description of changes
The Glibc update to 2.34 broke the PCMSolver, by changing `SIGSTKSZ` to a dynamic value, which leads to type errors in PCMSolvers' C++ code. I've opened [an issue upstream](https://github.com/PCMSolver/pcmsolver/issues/197#issuecomment-1094644716), but PCMSolver is broken in current `master`, `nixos-unstable`, and soon probably `nixpkgs-unstable`. The current workaround just replaces `SIGSTKSZ` by `_SC_SIGSTKSZ`, which is provided for backwards-compatibility.
I've also replaced the `python2` build dependency by `python3`.


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).