### PR TITLE
nixos/systemd: remove duplicate definition of `systemd.user.timers`

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -573,14 +573,6 @@ in
         })
         (filterAttrs (name: service: service.enable && service.startAt != []) cfg.services);
 
-    # Generate timer units for all services that have a ‘startAt’ value.
-    systemd.user.timers =
-      mapAttrs (name: service:
-        { wantedBy = [ "timers.target" ];
-          timerConfig.OnCalendar = service.startAt;
-        })
-        (filterAttrs (name: service: service.startAt != []) cfg.user.services);
-
     # Some overrides to upstream units.
     systemd.services."systemd-backlight@".restartIfChanged = false;
     systemd.services."systemd-fsck@".restartIfChanged = false;


### PR DESCRIPTION
#### Copy of commit msg
It's already defined in `systemd/user.nix`.
This is a leftover from #164016 where all `systemd.user` settings were moved to `systemd/user.nix`.

cc: @bobvanderlinden, @flokli, @dasJ, @mweinelt