### PR TITLE
kubescape: 2.0.150 -> 2.0.152

### DIFF
--- a/pkgs/tools/security/kubescape/default.nix
+++ b/pkgs/tools/security/kubescape/default.nix
@@ -6,31 +6,38 @@
 
 buildGoModule rec {
   pname = "kubescape";
-  version = "2.0.150";
+  version = "2.0.152";
 
   src = fetchFromGitHub {
     owner = "armosec";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-1D/ixtZI7/H05MD6zRtZCF8yhW1FhvRpdPWieAPwxHs=";
+    hash = "sha256-hibXmA2JerfnkGiSnBUCMHGPm4Tefnsl/x2VAS5z0Fo=";
   };
+  vendorSha256 = "sha256-HfsQfoz1n3FEd2eVBBz3Za2jYCSrozXpL34Z8CgQsTA=";
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
-  modRoot = "cmd";
-  vendorSha256 = "sha256-Nznf793OMQ7ZCWb5voVcLyMiBa1Z8Dswp7Tdn1AzlJA=";
-
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/armosec/kubescape/core/cautils.BuildNumber=v${version}"
+    "-X github.com/armosec/kubescape/v2/core/cautils.BuildNumber=v${version}"
   ];
 
-  postBuild = ''
-    # kubescape/cmd should be called kubescape
-    mv $GOPATH/bin/{cmd,kubescape}
+  subPackages = [ "." ];
+
+  preCheck = ''
+    # Feed in all but the integration tests for testing
+    # This is because subPackages above limits what is built to just what we
+    # want but also limits the tests
+    # Skip httphandler tests - the checkPhase doesn't care about excludedPackages
+    getGoDirs() {
+      go list ./... | grep -v httphandler
+    }
+
+    rm core/pkg/resourcehandler/{repositoryscanner,urlloader}_test.go
   '';
 
   postInstall = ''
@@ -44,6 +51,8 @@ buildGoModule rec {
   installCheckPhase = ''
     runHook preInstallCheck
     $out/bin/kubescape --help
+    # `--version` vs `version` shows the version without checking for latest
+    # if the flag is missing the BuildNumber may have moved
     $out/bin/kubescape --version | grep "v${version}"
     runHook postInstallCheck
   '';


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump kubescape to `2.0.152`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
