### PR TITLE
hashlink: init at 1.11

### DIFF
--- a/pkgs/development/interpreters/hashlink/default.nix
+++ b/pkgs/development/interpreters/hashlink/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, libpng
+, libjpeg_turbo
+, libvorbis
+, openal
+, SDL2
+, mbedtls
+, libuv
+, libGLU
+}:
+
+stdenv.mkDerivation rec {
+  pname = "hashlink";
+  version = "1.11";
+
+  src = fetchFromGitHub {
+    owner = "HaxeFoundation";
+    repo = "hashlink";
+    rev = version;
+    sha256 = "Mw0AMPK4fdaAdq+BjnFDpo0B9qhTrecD8roLA/JF/a0=";
+  };
+
+  buildInputs = [ libpng libjpeg_turbo libvorbis openal SDL2 mbedtls libuv libGLU ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with lib; {
+    description = "A virtual machine for Haxe";
+    homepage = "https://hashlink.haxe.org/";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ iblech ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6427,6 +6427,8 @@ with pkgs;
 
   httplab = callPackage ../tools/networking/httplab { };
 
+  hashlink = callPackage ../development/interpreters/hashlink { };
+
   lucky-cli = callPackage ../development/web/lucky-cli { };
 
   partclone = callPackage ../tools/backup/partclone { };


### PR DESCRIPTION
###### Description of changes

Closes #168248. Hashlink is a virtual machine for the Haxe language. We already ship Haxe and a couple of Haxe packages, but didn't yet ship Hashlink.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc some people who did previous packaging work on Haxe (quick and incomplete selection): @MarcWeber @locallycompact @vbgl @sternenseemann

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
