### PR TITLE
libwebsockets: 4.3.0 -> 4.3.1

### DIFF
--- a/pkgs/development/libraries/libwebsockets/default.nix
+++ b/pkgs/development/libraries/libwebsockets/default.nix
@@ -5,12 +5,13 @@
 , openssl
 , zlib
 , libuv
+, fetchpatch
 # External poll is required for e.g. mosquitto, but discouraged by the maintainer.
 , withExternalPoll ? false
 }:
 
 let
-  generic = { version, sha256 }: stdenv.mkDerivation rec {
+  generic = { version, sha256, patches ? [] }: stdenv.mkDerivation rec {
     pname = "libwebsockets";
     inherit version;
 
@@ -20,6 +21,8 @@ let
       rev = "v${version}";
       inherit sha256;
     };
+
+    inherit patches;
 
     buildInputs = [ openssl zlib libuv ];
 
@@ -76,7 +79,15 @@ in {
   };
 
   libwebsockets_4_3 = generic {
-    version = "4.3.0";
-    sha256 = "13lxb487mqlzbsbv6fbj50r1717mfwdy87ps592lgfy3307yqpr4";
+    version = "4.3.1";
+    sha256 = "sha256-lB3JHh058cQc5rycLnHk3JAOgtku0nRCixN5U6lPKq8=";
+    patches = [
+      # fixes the propagated cmake files, fixing the build of ttyd
+      # see also https://github.com/tsl0922/ttyd/issues/918
+      (fetchpatch {
+        url = "https://github.com/warmcat/libwebsockets/commit/99a8b9c4422bed45c8b7412a1e121056f2a6132a.patch";
+        hash = "sha256-zHBo2ZEayvibM+jzeVaZqySxghaOLUglpSFwuGhl6HM=";
+      })
+    ];
   };
 }


### PR DESCRIPTION
###### Description of changes

<s>I think this is the only change?
- https://libwebsockets.org/git/libwebsockets/commit?id=91f0b3bc0f6530f74e4961b9ae49fba6bee8f7b6

(Can't find an official changelog)</s>

Changes (no changelog was written AFAICT):
- https://github.com/warmcat/libwebsockets/compare/v4.3.0...v4.3.1

I'm considering dropping all older libwebsockets versions, since they've been unused for a while in nixpkgs now.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package failed to build:</summary>
  <ul>
    <li>ttyd</li>
  </ul>
</details>
<details>
  <summary>7 packages built:</summary>
  <ul>
    <li>ardour</li>
    <li>collectd</li>
    <li>domoticz</li>
    <li>driftnet</li>
    <li>janus-gateway</li>
    <li>libwebsockets</li>
    <li>mosquitto</li>
  </ul>
</details>
