### PR TITLE
nixos/doc: add notes on additional drivers or firmware

### DIFF
--- a/nixos/doc/manual/development/building-nixos.chapter.md
+++ b/nixos/doc/manual/development/building-nixos.chapter.md
@@ -30,6 +30,37 @@ To check the content of an ISO image, mount it like so:
 # mount -o loop -t iso9660 ./result/iso/cd.iso /mnt/iso
 ```
 
+## Additional drivers or firmware {#sec-building-image-drivers}
+
+If you need additional (non-distributable) drivers or firmware in the
+installer, you might want to extend these configurations.
+
+For example, to build the GNOME graphical installer ISO, but with support for
+certain WiFi adapters present in some MacBooks, you can create the following
+file at `modules/installer/cd-dvd/installation-cd-graphical-gnome-macbook.nix`:
+
+```nix
+{ config, ... }:
+
+{
+  imports = [ ./installation-cd-graphical-gnome.nix ];
+
+  boot.initrd.kernelModules = [ "wl" ];
+
+  boot.kernelModules = [ "kvm-intel" "wl" ];
+  boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+}
+```
+
+Then build it like in the example above:
+
+```ShellSession
+$ git clone https://github.com/NixOS/nixpkgs.git
+$ cd nixpkgs/nixos
+$ export NIXPKGS_ALLOW_UNFREE=1
+$ nix-build -A config.system.build.isoImage -I nixos-config=modules/installer/cd-dvd/installation-cd-graphical-gnome-macbook.nix default.nix
+```
+
 ## Technical Notes {#sec-building-image-tech-notes}
 
 The config value enforcement is implemented via `mkImageMediaOverride = mkOverride 60;`

--- a/nixos/doc/manual/from_md/development/building-nixos.chapter.xml
+++ b/nixos/doc/manual/from_md/development/building-nixos.chapter.xml
@@ -45,6 +45,40 @@ $ nix-build -A config.system.build.isoImage -I nixos-config=modules/installer/cd
 # mount -o loop -t iso9660 ./result/iso/cd.iso /mnt/iso
 </programlisting>
   </section>
+  <section xml:id="sec-building-image-drivers">
+    <title>Additional drivers or firmware</title>
+    <para>
+      If you need additional (non-distributable) drivers or firmware in
+      the installer, you might want to extend these configurations.
+    </para>
+    <para>
+      For example, to build the GNOME graphical installer ISO, but with
+      support for certain WiFi adapters present in some MacBooks, you
+      can create the following file at
+      <literal>modules/installer/cd-dvd/installation-cd-graphical-gnome-macbook.nix</literal>:
+    </para>
+    <programlisting language="bash">
+{ config, ... }:
+
+{
+  imports = [ ./installation-cd-graphical-gnome.nix ];
+
+  boot.initrd.kernelModules = [ &quot;wl&quot; ];
+
+  boot.kernelModules = [ &quot;kvm-intel&quot; &quot;wl&quot; ];
+  boot.extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
+}
+</programlisting>
+    <para>
+      Then build it like in the example above:
+    </para>
+    <programlisting>
+$ git clone https://github.com/NixOS/nixpkgs.git
+$ cd nixpkgs/nixos
+$ export NIXPKGS_ALLOW_UNFREE=1
+$ nix-build -A config.system.build.isoImage -I nixos-config=modules/installer/cd-dvd/installation-cd-graphical-gnome-macbook.nix default.nix
+</programlisting>
+  </section>
   <section xml:id="sec-building-image-tech-notes">
     <title>Technical Notes</title>
     <para>


### PR DESCRIPTION
This describes how to build your own installer medium with some custom
firmware/drivers, using an Intel MacBook as an example - on which WiFi
doesn't work out of the box, due to it being nonfree.

Fixes #15162.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
