### PR TITLE
lib/generators: uninline recursion depth tracking

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -309,9 +309,7 @@ rec {
   showDefs = defs: concatMapStrings (def:
     let
       # Pretty print the value for display, if successful
-      prettyEval = builtins.tryEval
-        (lib.generators.toPretty { }
-          (lib.generators.withRecursion { depthLimit = 10; throwOnDepthLimit = false; } def.value));
+      prettyEval = builtins.tryEval (lib.generators.toPretty { maxDepth = 5; } def.value);
       # Split it into its lines
       lines = filter (v: ! isList v) (builtins.split "\n" prettyEval.value);
       # Only display the first 5 lines, and indent them for better visibility

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -126,6 +126,20 @@ rec {
     # List of input strings
     list: concatStringsSep sep (lib.imap1 f list);
 
+  /* Generate a string by repeating a given string a given number of times.
+
+     Type: repeat :: string -> int -> string
+
+     Example:
+       repeat "Nix" 3
+       => "NixNixNix"
+  */
+  repeat =
+    # Number of times to repeat the string
+    n:
+    # String to repeat
+    s: concatMapStrings (lib.const s) (lib.range 0 (n - 1));
+
   /* Construct a Unix-style, colon-separated search path consisting of
      the given `subDir` appended to each of the given paths.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -154,6 +154,21 @@ runTests {
     expected = "a,b,c";
   };
 
+  testRepeat = {
+    expr = strings.repeat 5 "nix";
+    expected = "nixnixnixnixnix";
+  };
+
+  testRepeatZeroTimes = {
+    expr = strings.repeat 0 "A";
+    expected = "";
+  };
+
+  testRepeatEmptyString = {
+    expr = strings.repeat 1000 "";
+    expected = "";
+  };
+
   testSplitStringsSimple = {
     expr = strings.splitString "." "a.b.c.d";
     expected = [ "a" "b" "c" "d" ];

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -614,18 +614,16 @@ runTests {
       a.b = 1;
       a.c = a;
     in {
-      expr = generators.toPretty { } (generators.withRecursion { throwOnDepthLimit = false; depthLimit = 2; } a);
-      expected = "{\n  b = 1;\n  c = {\n    b = \"<unevaluated>\";\n    c = {\n      b = \"<unevaluated>\";\n      c = \"<unevaluated>\";\n    };\n  };\n}";
-    };
-
-  testToPrettyLimitThrow =
-    let
-      a.b = 1;
-      a.c = a;
-    in {
-      expr = (builtins.tryEval
-        (generators.toPretty { } (generators.withRecursion { depthLimit = 2; } a))).success;
-      expected = false;
+      expr = generators.toPretty { maxDepth = 2; } a;
+      expected = ''
+        {
+          b = 1;
+          c = {
+            b = <...>;
+            c = <...>;
+          };
+        }'';
+        # ^ important: toPretty does not include a trailing newline
     };
 
   testToPrettyMultiline = {


### PR DESCRIPTION
As cute as it is, it breaks in "interesting" ways when combined with nixpkgs' magic __functor attribute and friends.

This has notably caused pretty-printing `pkgs.rust` to fail, making at least two users (me included) extremely confused.

There's probably a better approach here involving more nasty self-recursion and a wrapper, but let's cross that bridge when we come to it.

To reproduce: `pkgs.lib.options.showDefs [ { file = "foo"; value = pkgs.rust.packages.stable.buildRustPackages; } ]`.

###### Description of changes

Removed the `withRecursive` wrapper, moved all the step-counting into `toPretty`, lowered the default depth to a more reasonable amount.

Ping @Profpatsch and @Ma27 as originators of the function.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).