### PR TITLE
openboard: fix compile with poppler >= 22.01

### DIFF
--- a/pkgs/applications/graphics/openboard/default.nix
+++ b/pkgs/applications/graphics/openboard/default.nix
@@ -33,11 +33,10 @@ in mkDerivation rec {
   };
 
   patches = [
-    # Poppler requires at least C++17
+    # Fix build with poppler >= 22.01
     (fetchpatch {
-      name = "use-c-17-for-pdf-on-linux-builds";
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/use-c-17-for-pdf-on-linux-builds.patch?h=openboard";
-      sha256 = "sha256-M6HigpOo8ul7qaub4cd7/ATUc85HezEyKyDuzsrZvC8=";
+      url = "https://github.com/OpenBoard-org/OpenBoard/commit/3a9b043e0fafec08e4123f362dcb7750f7476b59.patch";
+      sha256 = "sha256-yD163FK79HBU1W7m6sLxhfsRo4r/38zYTFWgeyqwU1o=";
     })
   ];
 


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Basically a copy of these changes https://aur.archlinux.org/cgit/aur.git/commit/?h=openboard&id=c39644d53595b4d1974460ae6318e6194f4cc4cd.

The new patch fixes build. While we are preemptively pinning ffmpeg before the default changes to ffmpg_5? (I'm not too sure if I should do this or if this is a treewide operation which needs to be done)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
