### PR TITLE
python3Packages.graphviz: 0.19.1 -> 0.20

### DIFF
--- a/pkgs/development/python-modules/diagrams/default.nix
+++ b/pkgs/development/python-modules/diagrams/default.nix
@@ -27,8 +27,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'jinja2 = "^2.10"' 'jinja2 = "*"' \
-      --replace 'graphviz = ">=0.13.2,<0.17.0"' 'graphviz = "*"'
+      --replace 'graphviz = ">=0.13.2,<0.20.0"' 'graphviz = "*"'
   '';
 
   preConfigure = ''

--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "graphviz";
-  version = "0.19.2";
+  version = "0.20";
 
   disabled = pythonOlder "3.7";
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "xflr6";
     repo = "graphviz";
     rev = version;
-    hash = "sha256-LxXi0Es6ZJT/nSS6SjGg/3stmR25T4R7TZC34mbT+EA=";
+    hash = "sha256-QyZwXxRbcMushxh/Ypy+v4FOTM4H1u5b7IZMSVgLyEs=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -16,16 +16,16 @@
 
 buildPythonPackage rec {
   pname = "graphviz";
-  version = "0.19.1";
+  version = "0.19.2";
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   # patch does not apply to PyPI tarball due to different line endings
   src = fetchFromGitHub {
     owner = "xflr6";
     repo = "graphviz";
     rev = version;
-    sha256 = "sha256-pE1lsx/r/BjvW5W2niDx/UeRXxx4kvCyHzAUAG3bdGc=";
+    hash = "sha256-LxXi0Es6ZJT/nSS6SjGg/3stmR25T4R7TZC34mbT+EA=";
   };
 
   patches = [
@@ -65,6 +65,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Simple Python interface for Graphviz";
     homepage = "https://github.com/xflr6/graphviz";
+    changelog = "https://github.com/xflr6/graphviz/blob/${src.rev}/CHANGES.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
   };


### PR DESCRIPTION

###### Description of changes
https://github.com/xflr6/graphviz/blob/0.19.2/CHANGES.rst

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
