### PR TITLE
basiliskii: init at unstable-2022-04-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10186,6 +10186,12 @@
     githubId = 115877;
     name = "Kenny Shen";
   };
+  quag = {
+    email = "quaggy@gmail.com";
+    github = "quag";
+    githubId = 35086;
+    name = "Jonathan Wright";
+  };
   queezle = {
     email = "git@queezle.net";
     github = "qzle";

--- a/pkgs/applications/emulators/basiliskii/default.nix
+++ b/pkgs/applications/emulators/basiliskii/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, autoconf, automake, pkg-config, SDL2, gtk2 }:
+stdenv.mkDerivation {
+  pname = "basiliskii";
+  version = "unstable-2022-04-05";
+
+  src = fetchFromGitHub {
+    owner = "kanjitalk755";
+    repo = "macemu";
+    rev = "d4baa318e49a29d7ea5fc71a637191d6c470546f";
+    sha256 = "jBKTC2fIPJ6mSkMABNxcd2ujXJ+duCXw291iz5ZmiVg=";
+  };
+  sourceRoot = "source/BasiliskII/src/Unix";
+  patches = [ ./remove-redhat-6-workaround-for-scsi-sg.h.patch ];
+  nativeBuildInputs = [ autoconf automake pkg-config ];
+  buildInputs = [ SDL2 gtk2 ];
+  preConfigure = ''
+    NO_CONFIGURE=1 ./autogen.sh
+  '';
+  configureFlags = [ "--enable-sdl-video" "--enable-sdl-audio" "--with-bincue" ];
+
+  meta = with lib; {
+    description = "68k Macintosh emulator";
+    homepage = "https://basilisk.cebix.net/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ quag ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/emulators/basiliskii/remove-redhat-6-workaround-for-scsi-sg.h.patch
+++ b/pkgs/applications/emulators/basiliskii/remove-redhat-6-workaround-for-scsi-sg.h.patch
@@ -1,0 +1,10 @@
+diff --git a/Linux/scsi_linux.cpp b/Linux/scsi_linux.cpp
+--- a/Linux/scsi_linux.cpp
++++ b/Linux/scsi_linux.cpp
+@@ -22,5 +22,5 @@
+ #include <sys/ioctl.h>
+ #include <linux/param.h>
+-#include <linux/../scsi/sg.h>	// workaround for broken RedHat 6.0 /usr/include/scsi
++#include <scsi/sg.h>
+ #include <unistd.h>
+ #include <errno.h>

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33200,6 +33200,8 @@ with pkgs;
 
   avell-unofficial-control-center = python3Packages.callPackage ../applications/misc/avell-unofficial-control-center { };
 
+  basiliskii = callPackage ../applications/emulators/basiliskii { };
+
   beep = callPackage ../misc/beep { };
 
   bees = callPackage ../tools/filesystems/bees { };


### PR DESCRIPTION
###### Description of changes

> Basilisk II is an Open Source 68k Macintosh (1984-1993) emulator. That is, it allows you to run 68k MacOS software on your computer, even if you are using a different operating system. However, you still need a copy of MacOS and a Macintosh ROM image to use Basilisk II.

[https://basilisk.cebix.net/](https://basilisk.cebix.net/)

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).