### PR TITLE
faiss: use the redistributable cuda

### DIFF
--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -1,10 +1,31 @@
 { lib
+, config
 , fetchFromGitHub
 , stdenv
 , cmake
+, pkg-config
+, cudaSupport ? config.cudaSupport or false
 , cudaPackages
 , symlinkJoin
+, enableOpenmp ? true
+, enableTbb ? false
+, tbb
+, hostSystem ? "CPP"
+, deviceSystem ? let
+    devices = lib.optional cudaSupport "CUDA"
+      ++ lib.optional enableTbb "TBB"
+      ++ lib.optional enableOpenmp "OMP"
+      ++ [ "CPP" ];
+  in
+  builtins.head devices
 }:
+
+assert builtins.elem deviceSystem [ "CPP" "OMP" "TBB" "CUDA" ];
+assert builtins.elem hostSystem [ "CPP" "OMP" "TBB" ];
+assert (deviceSystem == "CUDA") -> cudaSupport;
+assert (builtins.elem "TBB" [ deviceSystem hostSystem ]) -> enableTbb;
+assert (builtins.elem "OMP" [ deviceSystem hostSystem ]) -> enableOpenmp;
+
 let
   pname = "nvidia-thrust";
   version = "1.16.0";
@@ -30,12 +51,15 @@ stdenv.mkDerivation {
     hash = "sha256-/EyznxWKuHuvHNjq+SQg27IaRbtkjXR2zlo2YgCWmUQ=";
   };
 
+  buildInputs = lib.optional enableTbb tbb;
+
   nativeBuildInputs = [
     cmake
-
+    pkg-config
+  ] ++ lib.optionals cudaSupport [
     # goes in native build inputs because thrust looks for headers
     # in a path relative to nvcc...
-    #
+
     # Works when build=host, but we only support
     # cuda on x86_64 anyway
 
@@ -45,8 +69,14 @@ stdenv.mkDerivation {
   ];
 
   cmakeFlags = [
-    "-DTHRUST_INCLUDE_CUB_CMAKE=ON"
+    "-DTHRUST_INCLUDE_CUB_CMAKE=${if cudaSupport then "ON" else "OFF"}"
+    "-DTHRUST_DEVICE_SYSTEM=${deviceSystem}"
+    "-DTHRUST_HOST_SYSTEM=${hostSystem}"
   ];
+
+  passthru = {
+    inherit cudaSupport cudaPackages;
+  };
 
   meta = with lib; {
     description = ''

--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -7,12 +7,20 @@
 , cudaPackages
 , symlinkJoin
 , tbb
-  # Upstream defaults:
 , hostSystem ? "CPP"
-, deviceSystem ? if config.cudaSupport or false then "CUDA" else "CPP"
+, deviceSystem ? if config.cudaSupport or false then "CUDA" else "OMP"
 }:
 
-assert builtins.elem deviceSystem [ "CPP" "OMP" "TBB" "CUDA" ];
+# Policy for device_vector<T>
+assert builtins.elem deviceSystem [
+  "CPP" # Serial on CPU
+  "OMP" # Parallel with OpenMP
+  "TBB" # Parallel with Intel TBB
+  "CUDA" # Parallel on GPU
+];
+
+# Policy for host_vector<T>
+# Always lives on CPU, but execution can be made parallel
 assert builtins.elem hostSystem [ "CPP" "OMP" "TBB" ];
 
 let

--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -1,0 +1,61 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, cmake
+, cudaPackages
+, symlinkJoin
+}:
+let
+  pname = "nvidia-thrust";
+  version = "1.16.0";
+
+  # TODO: Would like to use this:
+  cudaJoined = symlinkJoin {
+    name = "cuda-packages-unsplit";
+    paths = with cudaPackages; [
+      cuda_nvcc
+      cuda_cudart # cuda_runtime.h
+      libcublas
+    ];
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "thrust";
+    rev = version;
+    fetchSubmodules = true;
+    hash = "sha256-/EyznxWKuHuvHNjq+SQg27IaRbtkjXR2zlo2YgCWmUQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+
+    # goes in native build inputs because thrust looks for headers
+    # in a path relative to nvcc...
+    #
+    # Works when build=host, but we only support
+    # cuda on x86_64 anyway
+
+    # TODO: but instead using this
+    # cudaJoined
+    cudaPackages.cudatoolkit
+  ];
+
+  cmakeFlags = [
+    "-DTHRUST_INCLUDE_CUB_CMAKE=ON"
+  ];
+
+  meta = with lib; {
+    description = ''
+      A high-level C++ parallel algorithms library
+      that builds on top of CUDA, TBB, OpenMP, etc.
+    '';
+    homepage = "https://github.com/NVIDIA/thrust";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ SomeoneSerge ];
+  };
+}

--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -71,10 +71,7 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = ''
-      A high-level C++ parallel algorithms library
-      that builds on top of CUDA, TBB, OpenMP, etc.
-    '';
+    description = "A high-level C++ parallel algorithms library that builds on top of CUDA, TBB, OpenMP, etc";
     homepage = "https://github.com/NVIDIA/thrust";
     license = licenses.asl20;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/nvidia-thrust/default.nix
+++ b/pkgs/development/libraries/nvidia-thrust/default.nix
@@ -4,7 +4,7 @@
 , stdenv
 , cmake
 , pkg-config
-, cudaPackages
+, cudaPackages ? { }
 , symlinkJoin
 , tbb
 , hostSystem ? "CPP"
@@ -27,6 +27,9 @@ let
   pname = "nvidia-thrust";
   version = "1.16.0";
 
+  inherit (cudaPackages) backendStdenv cudaFlags;
+  cudaCapabilities = map cudaFlags.dropDot cudaFlags.cudaCapabilities;
+
   tbbSupport = builtins.elem "TBB" [ deviceSystem hostSystem ];
   cudaSupport = deviceSystem == "CUDA";
 
@@ -35,9 +38,13 @@ let
     name = "cuda-packages-unsplit";
     paths = with cudaPackages; [
       cuda_nvcc
+      cuda_nvrtc # symbols: cudaLaunchDevice, &c; notice postBuild
       cuda_cudart # cuda_runtime.h
       libcublas
     ];
+    postBuild = ''
+      ln -s $out/lib $out/lib64
+    '';
   };
 in
 stdenv.mkDerivation {
@@ -51,6 +58,15 @@ stdenv.mkDerivation {
     hash = "sha256-/EyznxWKuHuvHNjq+SQg27IaRbtkjXR2zlo2YgCWmUQ=";
   };
 
+  # NVIDIA's "compiler hacks" seem like work-arounds for legacy toolchains and
+  # cause us errors such as:
+  # > Thrust's test harness uses CMAKE_CXX_COMPILER for the CUDA host compiler.
+  # > Refusing to overwrite specified CMAKE_CUDA_HOST_COMPILER
+  # So we un-fix cmake after them:
+  postPatch = ''
+    echo > cmake/ThrustCompilerHacks.cmake
+  '';
+
   buildInputs = lib.optionals tbbSupport [ tbb ];
 
   nativeBuildInputs = [
@@ -59,23 +75,21 @@ stdenv.mkDerivation {
   ] ++ lib.optionals cudaSupport [
     # Goes in native build inputs because thrust looks for headers
     # in a path relative to nvcc...
-
-    # Works when build=host, but we only support
-    # cuda on x86_64 anyway
-
-    # TODO: but instead using this
-    # cudaJoined
-    cudaPackages.cudatoolkit
+    cudaJoined
   ];
 
   cmakeFlags = [
     "-DTHRUST_INCLUDE_CUB_CMAKE=${if cudaSupport then "ON" else "OFF"}"
     "-DTHRUST_DEVICE_SYSTEM=${deviceSystem}"
     "-DTHRUST_HOST_SYSTEM=${hostSystem}"
-  ];
+    "-DTHRUST_AUTO_DETECT_COMPUTE_ARCHS=OFF"
+    "-DTHRUST_DISABLE_ARCH_BY_DEFAULT=ON"
+  ] ++ lib.optionals cudaFlags.enableForwardCompat [
+    "-DTHRUST_ENABLE_COMPUTE_FUTURE=ON"
+  ] ++ map (sm: "THRUST_ENABLE_COMPUTE_${sm}") cudaCapabilities;
 
   passthru = {
-    inherit cudaSupport cudaPackages;
+    inherit cudaSupport cudaPackages cudaJoined;
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -16,8 +16,8 @@
 , addOpenGLRunpath
 , optLevel ? let
     optLevels =
-      lib.optional stdenv.hostPlatform.avx2Support "avx2"
-      ++ lib.optional stdenv.hostPlatform.sse4_1Support "sse4"
+      lib.optionals stdenv.hostPlatform.avx2Support [ "avx2" ]
+      ++ lib.optionals stdenv.hostPlatform.sse4_1Support [ "sse4" ]
       ++ [ "generic" ];
   in
   # Choose the maximum available optimization level

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -42,11 +42,14 @@ let
       cuda_cudart # cuda_runtime.h
       libcublas
       libcurand
-      cuda_nvprof # cuda_profiler_api.h
     ] ++ lib.optionals useThrustSourceBuild [
       nvidia-thrust
     ] ++ lib.optionals (!useThrustSourceBuild) [
       cuda_cccl
+    ] ++ lib.optionals (cudaPackages ? cuda_profiler_api) [
+      cuda_profiler_api # cuda_profiler_api.h
+    ] ++ lib.optionals (!(cudaPackages ? cuda_profiler_api)) [
+      cuda_nvprof # cuda_profiler_api.h
     ];
   };
 in

--- a/pkgs/development/libraries/science/math/faiss/default.nix
+++ b/pkgs/development/libraries/science/math/faiss/default.nix
@@ -6,8 +6,9 @@
 , cmake
 , cudaPackages ? { }
 , cudaSupport ? config.cudaSupport or false
-, pythonSupport ? true
 , nvidia-thrust
+, useThrustSourceBuild ? true
+, pythonSupport ? true
 , pythonPackages
 , llvmPackages
 , boost
@@ -42,6 +43,10 @@ let
       libcublas
       libcurand
       cuda_nvprof # cuda_profiler_api.h
+    ] ++ lib.optionals useThrustSourceBuild [
+      nvidia-thrust
+    ] ++ lib.optionals (!useThrustSourceBuild) [
+      cuda_cccl
     ];
   };
 in
@@ -68,7 +73,6 @@ stdenv.mkDerivation {
     llvmPackages.openmp
   ] ++ lib.optionals cudaSupport [
     cudaJoined
-    nvidia-thrust
   ];
 
   propagatedBuildInputs = lib.optionals pythonSupport [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10306,6 +10306,8 @@ with pkgs;
 
   nvfetcher = haskell.lib.compose.justStaticExecutables haskellPackages.nvfetcher;
 
+  nvidia-thrust = callPackage ../development/libraries/nvidia-thrust { };
+
   miller = callPackage ../tools/text/miller { };
 
   milu = callPackage ../applications/misc/milu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10308,6 +10308,14 @@ with pkgs;
 
   nvidia-thrust = callPackage ../development/libraries/nvidia-thrust { };
 
+  nvidia-thrust-intel = callPackage ../development/libraries/nvidia-thrust {
+    enableTbb = true;
+  };
+
+  nvidia-thrust-cuda = callPackage ../development/libraries/nvidia-thrust {
+    cudaSupport = true;
+  };
+
   miller = callPackage ../tools/text/miller { };
 
   milu = callPackage ../applications/misc/milu { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10309,11 +10309,12 @@ with pkgs;
   nvidia-thrust = callPackage ../development/libraries/nvidia-thrust { };
 
   nvidia-thrust-intel = callPackage ../development/libraries/nvidia-thrust {
-    enableTbb = true;
+    hostSystem = "TBB";
+    deviceSystem = if config.cudaSupport or false then "CUDA" else "TBB";
   };
 
   nvidia-thrust-cuda = callPackage ../development/libraries/nvidia-thrust {
-    cudaSupport = true;
+    deviceSystem = "CUDA";
   };
 
   miller = callPackage ../tools/text/miller { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -37804,6 +37804,11 @@ with pkgs;
     swig = swig4;
   };
 
+  faissWithCuda = faiss.override {
+    cudaSupport = true;
+    nvidia-thrust = nvidia-thrust-cuda;
+  };
+
   fityk = callPackage ../applications/science/misc/fityk { };
 
   galario = callPackage ../development/libraries/galario { };


### PR DESCRIPTION
###### Description of changes

This is a follow-up (or an alternative) to https://github.com/NixOS/nixpkgs/pull/168197.
This PR is meant as an experiment in using the split `cudaPackages` that come from [redistributable archives instead of the `.run` files](https://github.com/NixOS/nixpkgs/pull/167016)

With this PR, `faiss` only uses the redistributable parts of cuda, although `cudatoolkit` is still part of the closure (I haven't managed to build Thrust without it)

I'm using the `symlinkJoin` approach:

```nix
  cudaJoined = symlinkJoin {
    name = "cuda-packages-unsplit";
    paths = with cudaPackages; [
      cuda_cudart # cuda_runtime.h
      libcublas
      libcurand
      cuda_nvprof # cuda_profiler_api.h
    ];
  };
```

And exposing it to cmake via `-DCUDAToolkit_INCLUDE_DIR` flag, which is part of [FindCUDAToolkit.cmake](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html) (the module appears to be "the standard" way of discovering cuda today).

Unfortunately, Thrust is not using this module (or maybe using some internal parts, but ignores the public variables, and discovers cuda through PATH and nvcc)

New attributes:

```
faissWithCuda
nvidia-thrust
nvidia-thrust-cuda
nvidia-thrust-intel
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


CC @NixOS/cuda-maintainers 